### PR TITLE
Rectify: Anomaly Detection Observed-Model Self-Comparison & Scanner Budget Exhaustion — PART A ONLY

### DIFF
--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -307,11 +307,7 @@ def flush_session_log(
         )
 
     effective_model_id = model_identifier or _primary_model_identifier(token_usage)
-    _observed = (
-        model_identifier
-        if model_identifier
-        else (_primary_model_identifier(token_usage) if token_usage else "")
-    )
+    _observed = _primary_model_identifier(token_usage) if token_usage else ""
     anomalies.extend(detect_model_drift(model_identifier, _observed, profile_name=profile_name))
 
     # Write anomalies.jsonl (only if anomalies exist)

--- a/tests/arch/test_model_identity_contract.py
+++ b/tests/arch/test_model_identity_contract.py
@@ -76,28 +76,33 @@ def test_drift_call_site_uses_independent_observed_source():
     assert observed_var_name is not None, "detect_model_drift call not found in flush_session_log"
 
     for node in ast.walk(flush_func):
-        if (
-            isinstance(node, ast.Assign)
-            and len(node.targets) == 1
-            and isinstance(node.targets[0], ast.Name)
-            and node.targets[0].id == observed_var_name
-        ):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
             rhs = node.value
-            rhs_dump = ast.dump(rhs)
-            assert "_primary_model_identifier" in rhs_dump, (
-                f"{observed_var_name} must be assigned from _primary_model_identifier() — "
-                "the observed model must come from token_usage, not from the configured model"
-            )
-            for ifexp in ast.walk(rhs):
-                if isinstance(ifexp, ast.IfExp):
-                    for branch in (ifexp.body, ifexp.orelse):
-                        assert not (
-                            isinstance(branch, ast.Name) and branch.id == "model_identifier"
-                        ), (
-                            f"{observed_var_name} must not be assigned from model_identifier "
-                            "in any ternary branch — this collapses configured and observed to "
-                            "the same source and permanently disables drift detection"
-                        )
-            return
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            target = node.target
+            rhs = node.value
+        else:
+            continue
+
+        if not (isinstance(target, ast.Name) and target.id == observed_var_name):
+            continue
+
+        rhs_dump = ast.dump(rhs)
+        assert "_primary_model_identifier" in rhs_dump, (
+            f"{observed_var_name} must be assigned from _primary_model_identifier() — "
+            "the observed model must come from token_usage, not from the configured model"
+        )
+        for ifexp in ast.walk(rhs):
+            if isinstance(ifexp, ast.IfExp):
+                for branch in (ifexp.body, ifexp.orelse):
+                    assert not (
+                        isinstance(branch, ast.Name) and branch.id == "model_identifier"
+                    ), (
+                        f"{observed_var_name} must not be assigned from model_identifier "
+                        "in any ternary branch — this collapses configured and observed to "
+                        "the same source and permanently disables drift detection"
+                    )
+        return
 
     pytest.fail(f"No assignment to {observed_var_name!r} found in flush_session_log body")

--- a/tests/arch/test_model_identity_contract.py
+++ b/tests/arch/test_model_identity_contract.py
@@ -17,6 +17,7 @@ pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 
 SRC = Path(__file__).resolve().parents[2] / "src" / "autoskillit"
 ANOMALY_DETECTION = SRC / "execution" / "anomaly_detection.py"
+SESSION_LOG = SRC / "execution" / "session_log.py"
 
 
 def test_detect_model_drift_uses_normalize_model_id():
@@ -36,3 +37,67 @@ def test_detect_model_drift_uses_normalize_model_id():
             )
             return
     pytest.fail("detect_model_drift not found in anomaly_detection.py")
+
+
+def test_drift_call_site_uses_independent_observed_source():
+    """_observed passed to detect_model_drift must come from _primary_model_identifier.
+
+    Prevents regression where the call site collapses both arguments to the same
+    source (model_identifier), causing detect_model_drift(X, X) which can never
+    detect drift.
+    """
+    source = SESSION_LOG.read_text()
+    tree = ast.parse(source)
+
+    flush_func = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "flush_session_log":
+            flush_func = node
+            break
+    assert flush_func is not None, "flush_session_log not found in session_log.py"
+
+    observed_var_name = None
+    for node in ast.walk(flush_func):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "detect_model_drift"
+        ):
+            assert len(node.args) >= 2, (
+                "detect_model_drift call must have at least 2 positional args"
+            )
+            second_arg = node.args[1]
+            assert isinstance(second_arg, ast.Name), (
+                "second arg to detect_model_drift must be a Name node"
+            )
+            observed_var_name = second_arg.id
+            break
+
+    assert observed_var_name is not None, "detect_model_drift call not found in flush_session_log"
+
+    for node in ast.walk(flush_func):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == observed_var_name
+        ):
+            rhs = node.value
+            rhs_dump = ast.dump(rhs)
+            assert "_primary_model_identifier" in rhs_dump, (
+                f"{observed_var_name} must be assigned from _primary_model_identifier() — "
+                "the observed model must come from token_usage, not from the configured model"
+            )
+            for ifexp in ast.walk(rhs):
+                if isinstance(ifexp, ast.IfExp):
+                    for branch in (ifexp.body, ifexp.orelse):
+                        assert not (
+                            isinstance(branch, ast.Name) and branch.id == "model_identifier"
+                        ), (
+                            f"{observed_var_name} must not be assigned from model_identifier "
+                            "in any ternary branch — this collapses configured and observed to "
+                            "the same source and permanently disables drift detection"
+                        )
+            return
+
+    pytest.fail(f"No assignment to {observed_var_name!r} found in flush_session_log body")

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -1264,7 +1264,8 @@ def test_primary_model_identifier_parent_wins_on_output_tokens():
 
 def test_primary_model_identifier_argmax_returns_subagent_when_dominant():
     """Raw argmax returns subagent model when subagent output_tokens exceed parent.
-    This is expected — flush_session_log bypasses argmax when model_identifier is available."""
+    This is the value flush_session_log uses as the observed model for drift detection —
+    model_identifier does not override it."""
     from autoskillit.execution.session_log import _primary_model_identifier
 
     token_usage = {
@@ -1309,8 +1310,10 @@ def test_flush_session_log_configured_model_written_to_token_usage(tmp_path):
 
 
 def test_flush_session_log_no_false_drift_with_configured_model(tmp_path):
-    """When model_identifier is provided, drift detection compares it against itself,
-    NOT against argmax. No false positive drift anomaly."""
+    """When model_identifier matches the dominant model in model_breakdown, no drift anomaly fires.
+
+    The configured and API-observed models genuinely agree.
+    """
     _flush(
         tmp_path,
         session_id="no-false-drift-001",
@@ -1318,8 +1321,7 @@ def test_flush_session_log_no_false_drift_with_configured_model(tmp_path):
         model_identifier="claude-opus-4-6",
         token_usage={
             "model_breakdown": {
-                "claude-sonnet-4-6": {"input_tokens": 20000, "output_tokens": 8000},
-                "claude-opus-4-6": {"input_tokens": 5000, "output_tokens": 2000},
+                "claude-opus-4-6": {"input_tokens": 20000, "output_tokens": 8000},
             },
         },
     )

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -1374,12 +1374,11 @@ def test_flush_session_log_genuine_drift_with_configured_model(tmp_path):
     )
     anomalies_path = tmp_path / "sessions" / "genuine-drift-001" / "anomalies.jsonl"
     assert anomalies_path.exists(), "anomalies.jsonl must be written when drift is detected"
-    drift_entries = [
-        json.loads(line)
-        for line in anomalies_path.read_text().strip().splitlines()
-        if json.loads(line).get("kind") == "model_drift"
-    ]
-    assert len(drift_entries) == 1
+    all_entries = [json.loads(line) for line in anomalies_path.read_text().strip().splitlines()]
+    drift_entries = [e for e in all_entries if e.get("kind") == "model_drift"]
+    assert len(drift_entries) == 1, (
+        f"expected 1 model_drift entry, got {len(drift_entries)}: {drift_entries}"
+    )
     assert drift_entries[0]["detail"]["configured_model"] == "claude-opus-4-6"
     assert drift_entries[0]["detail"]["observed_model"] == "claude-sonnet-4-6"
 

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -1356,6 +1356,32 @@ def test_flush_session_log_bracket_suffix_no_drift(tmp_path):
     assert len(drift) == 0
 
 
+def test_flush_session_log_genuine_drift_with_configured_model(tmp_path):
+    """When model_identifier differs from the dominant model in model_breakdown, a MODEL_DRIFT anomaly fires."""
+    _flush(
+        tmp_path,
+        session_id="genuine-drift-001",
+        proc_snapshots=None,
+        model_identifier="claude-opus-4-6",
+        token_usage={
+            "model_breakdown": {
+                "claude-sonnet-4-6": {"input_tokens": 20000, "output_tokens": 8000},
+                "claude-opus-4-6": {"input_tokens": 1000, "output_tokens": 200},
+            },
+        },
+    )
+    anomalies_path = tmp_path / "sessions" / "genuine-drift-001" / "anomalies.jsonl"
+    assert anomalies_path.exists(), "anomalies.jsonl must be written when drift is detected"
+    drift_entries = [
+        json.loads(line)
+        for line in anomalies_path.read_text().strip().splitlines()
+        if json.loads(line).get("kind") == "model_drift"
+    ]
+    assert len(drift_entries) == 1
+    assert drift_entries[0]["detail"]["configured_model"] == "claude-opus-4-6"
+    assert drift_entries[0]["detail"]["observed_model"] == "claude-sonnet-4-6"
+
+
 def test_flush_session_log_argmax_fallback_prefers_output_tokens(tmp_path):
     """When model_identifier is empty, flush_session_log uses output-token-weighted
     argmax, not total-token argmax."""


### PR DESCRIPTION
## Summary

Commit `a5a68f49` introduced a regression in `session_log.py` where the `_observed` model variable is set to `model_identifier` (the configured model) when `model_identifier` is non-empty. This causes `detect_model_drift(model_identifier, model_identifier)` — comparing the configured model against itself — which permanently disables MODEL_DRIFT detection for all sessions with a configured model. The existing test `test_flush_session_log_no_false_drift_with_configured_model` validates this broken behavior as correct, and the AST guard in `test_model_identity_contract.py` only covers `detect_model_drift` internals, not the call site in `session_log.py`.

The architectural weakness is that `_observed` is computed at the call site with no structural enforcement that it must come from a different data source than `configured_model`. The detection function `detect_model_drift(configured, observed)` has a two-value comparison contract, but the call site collapsed both values to the same source. No test asserts the positive case (real drift fires through `flush_session_log`), and no AST guard prevents future regressions at the call site.

Part A fixes the `_observed` computation bug plus adds the tests and AST guard that make this class of regression structurally impossible. Part B will cover scanner-level improvements.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-171650-060527/.autoskillit/temp/rectify/rectify_anomaly_detection_observed_model_self_comparison_2026-05-30_172500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 2.9k | 23.7k | 3.7M | 132.2k | 339 | 210.3k | 20m 18s |
| review_approach* | sonnet | 1 | 9.9k | 7.8k | 198.5k | 53.9k | 112 | 42.9k | 6m 16s |
| dry_walkthrough* | opus | 1 | 39 | 7.0k | 571.8k | 62.5k | 76 | 46.3k | 3m 48s |
| implement* | sonnet | 1 | 1.1k | 12.8k | 1.1M | 58.6k | 76 | 42.7k | 5m 1s |
| audit_impl* | sonnet | 1 | 70 | 8.7k | 235.1k | 36.5k | 27 | 28.9k | 3m 5s |
| prepare_pr* | sonnet | 1 | 99.5k | 4.1k | 247.6k | 30.9k | 25 | 43.8k | 1m 55s |
| compose_pr* | sonnet | 1 | 39.4k | 1.6k | 182.8k | 30.9k | 14 | 15.6k | 48s |
| review_pr* | sonnet | 1 | 214 | 28.6k | 1.3M | 76.4k | 64 | 60.9k | 6m 39s |
| resolve_review* | opus | 1 | 35 | 5.4k | 904.2k | 67.3k | 37 | 72.0k | 6m 46s |
| **Total** | | | 153.1k | 99.7k | 8.4M | 132.2k | | 563.2k | 54m 41s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 109 | 9832.7 | 391.6 | 117.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 60 | 15070.6 | 1200.2 | 89.8 |
| **Total** | **169** | 49809.7 | 3332.6 | 589.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.9k | 23.7k | 3.7M | 210.3k | 20m 18s |
| sonnet | 6 | 150.1k | 63.6k | 3.3M | 234.6k | 23m 47s |
| opus | 2 | 74 | 12.3k | 1.5M | 118.3k | 10m 35s |