### PR TITLE
Rectify: Architectural Constraint Catalog Discovery Immunity

### DIFF
--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -409,7 +409,7 @@ the Task tool (`model: "sonnet"`).
 - `ACCEPT` — the reviewer identified a real issue; a code fix is warranted
 - `REJECT` — the reviewer is factually wrong (misread a guard, misunderstood an API,
   failed to recognize an intentional design pattern), OR the proposed change violates
-  a project-wide architectural constraint enforced by `tests/arch/` or `tests/recipe/`
+  a project-wide architectural constraint enforced by any test in the suite
   (see Architectural Constraint Catalog below — use category `arch_violation`);
   do NOT change the code
 - `DISCUSS` — the comment raises a valid design question that requires a human decision;
@@ -443,15 +443,17 @@ fall back to reading the file at `±30 lines` from the flagged line.
 
 **Architectural Constraint Catalog — consult before classifying ACCEPT:**
 
-The following project-wide constraints are enforced exclusively by pytest tests in
-`tests/arch/` and `tests/recipe/`. They are NOT caught by pre-commit. A suggestion
-that violates any of these must be classified `REJECT` with `category: "arch_violation"`.
+The following project-wide constraints are enforced by pytest tests across the test suite
+(primarily `tests/arch/`, `tests/recipe/`, `tests/workspace/`, and `tests/server/`).
+They are NOT caught by pre-commit. A suggestion that violates any of these must be
+classified `REJECT` with `category: "arch_violation"`.
 
 | Constraint | Enforced by | What is prohibited |
 |---|---|---|
 | Regex import | `test_regex_import.py` | `import re` or `from re import` in `src/` outside `hooks/` and `core/` — must use `import regex as re` |
 | Atomic writes | `test_ast_rules.py` (REQ-AST-002) | `.write_text()` / `.write_bytes()` in `src/` — must use `_atomic_write()` |
 | No print | `test_ast_rules.py` (ARCH-001) | `print()` in production `src/` code |
+| No StrEnum-to-string compare | `test_ast_rules.py` (ARCH-010) | Comparing StrEnum fields to raw string literals |
 | Dataclass slots | `test_dataclass_slots.py` | `dataclass(frozen=True)` decorator without `slots=True` |
 | Import layer ordering | `test_layer_enforcement.py` | Importing from a higher IL layer (e.g., IL-2 recipe/ imported by IL-0 core/) |
 | Anyio migration | `test_anyio_migration.py` | `asyncio.sleep`, `asyncio.Event`, `asyncio.to_thread` in `execution/process.py` |
@@ -461,7 +463,31 @@ that violates any of these must be classified `REJECT` with `category: "arch_vio
 | No hardcoded temp paths | `test_python_no_hardcoded_temp.py` | Literal `{{AUTOSKILLIT_TEMP}}` path string in Python outside whitelist |
 | SkillResult kill_reason | `test_skill_result_construction_guard.py` | `SkillResult()` without `kill_reason=` kwarg |
 | Never-raises contracts | `test_never_raises_contracts.py` | `mcp.tool()` handlers without top-level `try/except` and "Never raises" docstring |
-| No StrEnum-to-string compare | `test_ast_rules.py` (ARCH-010) | Comparing StrEnum fields to raw string literals |
+| ClaudeFlags isolation | `test_backend_flag_isolation.py` | `ClaudeFlags` referenced in `_session_launch.py` — backend flags belong in backend layer only |
+| Boot step symmetry | `test_boot_step_symmetry.py` | Both boot functions must call all required boot steps in the right order |
+| BackendCapabilities consumed | `test_capability_consumption.py` | Every `BackendCapabilities` field must have a production consumer — unused capability fields are prohibited |
+| BackendCapabilities documented | `test_capability_docstrings.py` | `BackendCapabilities` class and every field must have docstrings |
+| Channel B timeout floor | `test_channel_b_timeout_guard.py` | Channel B calls with `timeout` below `TimeoutTier.CHANNEL_B` minimum |
+| Clone network timeouts | `test_clone_timeouts.py` | `subprocess.run()` with git network subcommands (clone/fetch/pull/push/ls-remote) in `clone.py` without `timeout=` |
+| Dispatch timeout resolver | `test_dispatch_timeout_guard.py` | `_run_dispatch` using hardcoded timeout instead of `resolve_dispatch_timeout()` |
+| Doctor read-only | `test_doctor_readonly.py` | `run_doctor()` performing filesystem writes (REQ-DOCTOR-READONLY) |
+| No requestId dedup in flush | `test_flush_no_rid_guard.py` | Inline `seen_request_ids` dedup in `session_log.py` or `tool_sequence_analysis.py` — dedup is pre-applied |
+| GFM table rendering | `test_gfm_rendering_guard.py` | GFM table rendering bypassing `_render_gfm_table()` — all table output must route through it |
+| CLI prompts via timed_prompt | `test_input_tty_contracts.py` | `input()` calls in `src/autoskillit/cli/` not routed through `timed_prompt()` |
+| Interactive ordering gate | `test_interactive_ordering_gate.py` | Interactive launch sites that skip `assert_interactive_ordering()` before `_session_launch` |
+| Kitchen guard scoping | `test_kitchen_guard_scoping.py` | `any_kitchen_open()` call sites not passing `project_path` — must use scoped check |
+| Model identity contract | `test_model_identity_contract.py` | `detect_model_drift()` using raw string comparison instead of `normalize_model_id()` and `_models_match()` |
+| No error-dict returns | `test_no_error_dict_return.py` | `load_and_validate()` returning `{"error": ...}` dict — errors must propagate via exceptions |
+| No inline requestId dedup | `test_no_inline_jsonl_request_id_dedup.py` | `seen_request_ids` variable in `session_log.py` or `tool_sequence_analysis.py` |
+| No Path.cwd() in server tools | `test_no_path_cwd_in_tools.py` | `Path.cwd()` in server tool handlers — use injected project path instead |
+| No raw SIGTERM handler | `test_no_raw_signal_handler.py` | `signal.signal(SIGTERM, ...)` in `cli/app.py` — must use `anyio.open_signal_receiver` |
+| PTY coherence | `test_pty_coherence.py` | Dispatch paths that allocate PTY without respecting dispatch-type `pty_override=False` |
+| Registry key casing | `test_registry_key_casing.py` | Uppercase keys in `FEATURE_REGISTRY`, `RETIRED_FEATURES`, or `PACK_REGISTRY` |
+| Turn ID resolution | `test_resolve_turn_id_guard.py` | Direct `request_id` dict `.get()` outside `_resolve_turn_id()` — all turn ID resolution must go through the single resolver |
+| No hardcoded @-mentions in SKILL.md | `test_skills.py` | `@word` tokens at word-boundary in SKILL.md prose — includes Python decorator examples (`@dataclass`, `@mcp`); use prose descriptions or remove the `@` prefix |
+| FastMCP tag hygiene | `test_transforms_hygiene.py` | Test fixtures touching `mcp._transforms` without using the canonical `ALL_VISIBILITY_TAGS` constant |
+| Watcher dispatch marker | `test_watcher_signal_consistency.py` | Process watchers that skip `_has_active_dispatch_marker()` check |
+| Write restriction enforcement | `test_write_restriction_coverage.py` | Skills with prose write restrictions (`never modify source`, `read-only`, `output dir`) lacking runtime `WriteBehaviorSpec` enforcement |
 
 When a reviewer suggestion would cause a change matching any row above, classify
 the finding as `REJECT` with `category: "arch_violation"` and `evidence` referencing

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -167,6 +167,7 @@ to directory-level cascade — no error is raised. Refresh cadence:
 tests/
 ├── CLAUDE.md                            # Universal test guidelines (this file)
 ├── __init__.py
+├── _arch_constraint_discovery.py        # Discover arch constraint tests by docstring convention for catalog staleness guards
 ├── _helpers.py
 ├── _subprocess_ready.py
 ├── _test_filter.py                      # Test filter manifest: glob-to-test-directory mapping

--- a/tests/_arch_constraint_discovery.py
+++ b/tests/_arch_constraint_discovery.py
@@ -25,14 +25,26 @@ ARCH_CONSTRAINT_PREFIXES: tuple[str, ...] = (
 
 def discover_constraint_tests() -> dict[str, Path]:
     """Return {filename: path} for all test files whose module docstring
-    starts with a recognized constraint prefix."""
+    starts with a recognized constraint prefix.
+
+    Uses basename as key for catalog lookup compatibility.  If two files
+    share a basename, the one with the longer (deeper) relative path wins
+    so the collision is deterministic and logged via ValueError.
+    """
     results: dict[str, Path] = {}
     for test_file in sorted(TESTS_ROOT.rglob("test_*.py")):
         try:
             tree = ast.parse(test_file.read_text())
-        except SyntaxError:
+        except (SyntaxError, UnicodeDecodeError, OSError):
             continue
         docstring = ast.get_docstring(tree)
         if docstring and docstring.startswith(ARCH_CONSTRAINT_PREFIXES):
-            results[test_file.name] = test_file
+            name = test_file.name
+            if name in results and results[name] != test_file:
+                raise ValueError(
+                    f"Basename collision: {name} found at both "
+                    f"{results[name].relative_to(TESTS_ROOT)} and "
+                    f"{test_file.relative_to(TESTS_ROOT)}"
+                )
+            results[name] = test_file
     return results

--- a/tests/_arch_constraint_discovery.py
+++ b/tests/_arch_constraint_discovery.py
@@ -1,0 +1,38 @@
+"""Discover architectural constraint tests by module docstring convention.
+
+Tests that enforce project-wide invariants follow a docstring prefix convention:
+their module docstring starts with one of ARCH_CONSTRAINT_PREFIXES. This module
+provides a discovery function used by staleness guards to validate catalog
+completeness without hardcoded file lists.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+TESTS_ROOT = Path(__file__).parent
+
+ARCH_CONSTRAINT_PREFIXES: tuple[str, ...] = (
+    "Architectural invariant",
+    "Architectural guard",
+    "Architectural enforcement",
+    "Structural guard",
+    "Structural enforcement",
+    "AST guard",
+)
+
+
+def discover_constraint_tests() -> dict[str, Path]:
+    """Return {filename: path} for all test files whose module docstring
+    starts with a recognized constraint prefix."""
+    results: dict[str, Path] = {}
+    for test_file in sorted(TESTS_ROOT.rglob("test_*.py")):
+        try:
+            tree = ast.parse(test_file.read_text())
+        except SyntaxError:
+            continue
+        docstring = ast.get_docstring(tree)
+        if docstring and docstring.startswith(ARCH_CONSTRAINT_PREFIXES):
+            results[test_file.name] = test_file
+    return results

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -46,6 +46,7 @@ BUCKET_A_PATTERNS: frozenset[str] = frozenset(
     {
         "tests/conftest.py",
         "tests/_helpers.py",
+        "tests/_arch_constraint_discovery.py",
         "tests/arch/_helpers.py",
         "tests/arch/_rules.py",
         "pyproject.toml",

--- a/tests/recipe/test_anti_pattern_guards.py
+++ b/tests/recipe/test_anti_pattern_guards.py
@@ -1,4 +1,4 @@
-"""Guards against orchestrator anti-patterns re-emerging in bundled recipes."""
+"""Structural guard: orchestrator anti-patterns must not re-emerge in bundled recipes."""
 
 from __future__ import annotations
 

--- a/tests/server/test_no_path_cwd_in_tools.py
+++ b/tests/server/test_no_path_cwd_in_tools.py
@@ -1,6 +1,4 @@
-"""Regression guard: Path.cwd() must not appear in server tool handlers.
-
-This test prevents reintroduction of Path.cwd() call sites.
+"""Structural guard: Path.cwd() must not appear in server tool handlers.
 
 The one allowed site (_reload_session_handler in tools_kitchen.py) is excluded
 because it uses cwd to find the server's own log directory, not the project root.

--- a/tests/skills/CLAUDE.md
+++ b/tests/skills/CLAUDE.md
@@ -40,7 +40,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 | `test_resolve_failures_ci_aware.py` | Contract guards for resolve-failures CI-awareness: verdict decision tree |
 | `test_resolve_failures_guards.py` | Guards for resolve-failures SKILL.md: polling-cascade and output-bloat fixes |
 | `test_resolve_research_review_guards.py` | Behavioral guards for resolve-research-review/SKILL.md |
-| `test_resolve_review_arch_constraint_awareness.py` | Structural guard: resolve-review SKILL.md must contain an architectural constraint catalog for intent validation subagents |
+| `test_resolve_review_arch_constraint_awareness.py` | Structural guard: resolve-review SKILL.md architectural constraint catalog completeness via docstring-convention discovery |
 | `test_resolve_review_guards.py` | Guards for resolve-review SKILL.md: blind git add prevention |
 | `test_resolve_review_diff_context_consumption.py` | Guards: resolve-review loads and uses diff_context handoff file from review-pr |
 | `test_resolve_review_diff_hunk_preference.py` | Guards: resolve-review Step 3.5 prefers diff_hunk over source file reads |

--- a/tests/skills/test_resolve_review_arch_constraint_awareness.py
+++ b/tests/skills/test_resolve_review_arch_constraint_awareness.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._arch_constraint_discovery import discover_constraint_tests
+
 SKILL_PATH = (
     Path(__file__).parent.parent.parent
     / "src"
@@ -19,12 +21,65 @@ SKILL_PATH = (
 
 ARCH_DIR = Path(__file__).parent.parent / "arch"
 
+# Tests whose constraints cannot be violated by reviewer suggestions
+# (they guard test infrastructure, CI config, or test file structure).
+_CATALOG_EXCLUSIONS: frozenset[str] = frozenset(
+    {
+        # Test-infrastructure guards (guard test file splits, not production code):
+        "test_headless_split.py",
+        "test_doctor_split.py",
+        "test_update_checks_split.py",
+        "test_tools_kitchen_gate_split.py",
+        "test_tools_dispatch_split.py",
+        "test_tools_git_split.py",
+        "test_api_split_integrity.py",
+        # CI/infra guards (not violable by code review suggestions):
+        "test_ci_dev_config.py",
+        "test_session_type_exemption_enforcement.py",
+        "test_session_scope_enforcement.py",
+        "test_skill_exemption_enforcement.py",
+        # The catalog guard itself:
+        "test_resolve_review_arch_constraint_awareness.py",
+        # SKILL.md content guards (guard skill prose structure, not production code;
+        # reviewer suggestions don't change SKILL.md structure):
+        "test_audit_impl_diff_discipline.py",
+        "test_conflict_resolution_guards.py",
+        "test_deletion_regression_guards.py",
+        "test_open_research_pr_decomposition.py",
+        "test_resolve_design_review_contracts.py",
+        "test_resolve_review_intent_validation.py",
+        "test_resolve_review_token_optimizations.py",
+        "test_review_pr_inline_comment_guards.py",
+        # Execution/server test-infrastructure guards:
+        "test_conftest_import_guard.py",
+        "test_flush_completeness_guard.py",
+        "test_smoke_recipe_scope_guard.py",
+        # Internal structural guards (guard conftest/env patterns, not production code):
+        "test_conftest_env_coverage.py",
+        "test_make_context_env_boundary.py",
+        "test_command_guard_completeness.py",
+        "test_interactive_subprocess_contracts.py",
+    }
+)
+
 
 @pytest.fixture(scope="module")
 def skill_text():
     if not SKILL_PATH.exists():
         pytest.fail(f"SKILL.md not found at {SKILL_PATH}")
     return SKILL_PATH.read_text()
+
+
+# --- Discovery utility self-test ---
+
+
+def test_discovery_finds_known_constraints():
+    """Constraint discovery must find tests from multiple directories."""
+    discovered = discover_constraint_tests()
+    # These three are in different directories (arch/, workspace/, recipe/)
+    assert "test_regex_import.py" in discovered, "test_regex_import.py not found"
+    assert "test_clone_timeouts.py" in discovered, "test_clone_timeouts.py not found"
+    assert "test_anti_pattern_guards.py" in discovered, "test_anti_pattern_guards.py not found"
 
 
 # --- Catalog presence ---
@@ -36,25 +91,6 @@ def test_arch_constraint_catalog_section_exists(skill_text):
         "resolve-review SKILL.md must contain an 'Architectural Constraint Catalog' "
         "section for intent validation subagents"
     )
-
-
-# --- Catalog references key arch tests ---
-
-
-def test_catalog_references_key_constraint_tests(skill_text):
-    """The catalog must reference the most commonly violated constraint
-    enforcement test filenames — from tests/arch/ and tests/recipe/."""
-    key_test_files = [
-        "test_regex_import.py",  # tests/arch/
-        "test_ast_rules.py",  # tests/arch/
-        "test_dataclass_slots.py",  # tests/arch/
-        "test_layer_enforcement.py",  # tests/arch/
-        "test_anti_pattern_guards.py",  # tests/recipe/
-    ]
-    for test_file in key_test_files:
-        assert test_file in skill_text, (
-            f"Architectural Constraint Catalog must reference {test_file} by name"
-        )
 
 
 # --- REJECT criteria include arch violation ---
@@ -75,7 +111,7 @@ def test_reject_criteria_includes_arch_violation(skill_text):
     ), (
         "Classification criteria prose for REJECT must include language about "
         "architecturally prohibited changes (locally correct but violating "
-        "project-wide constraints enforced by tests/arch/)"
+        "project-wide constraints enforced by tests)"
     )
 
 
@@ -131,53 +167,57 @@ def test_never_block_prohibits_ignoring_arch_constraints(skill_text):
 
 
 def test_catalog_forward_references_valid(skill_text):
-    """Every arch test file referenced in the catalog must actually exist
-    in tests/arch/ or tests/recipe/."""
-    catalog_idx = skill_text.lower().find("architectural constraint catalog")
+    """Every test file cited in the catalog must actually exist in tests/."""
+    catalog_idx = skill_text.lower().find(
+        "architectural constraint catalog — consult before classifying accept"
+    )
     if catalog_idx == -1:
         pytest.fail("Architectural Constraint Catalog section not found in SKILL.md")
-    catalog_section = skill_text[catalog_idx : catalog_idx + 3000]
-    if not ARCH_DIR.is_dir():
-        pytest.fail(f"tests/arch/ not found at {ARCH_DIR}")
-    arch_test_files = {f.name for f in ARCH_DIR.glob("test_*.py")}
-    recipe_test_dir = ARCH_DIR.parent / "recipe"
-    recipe_test_files = (
-        {f.name for f in recipe_test_dir.glob("test_*.py")} if recipe_test_dir.exists() else set()
-    )
-    all_test_files = arch_test_files | recipe_test_files
+    catalog_section = skill_text[catalog_idx : catalog_idx + 6000]
+    # Build a set of ALL test filenames across the entire test tree
+    all_test_files = {f.name for f in Path(__file__).parent.parent.rglob("test_*.py")}
     referenced_files = set(re.findall(r"`(test_\w+\.py)`", catalog_section))
     for ref in referenced_files:
         assert ref in all_test_files, (
-            f"Catalog references {ref} but it does not exist in tests/arch/ or tests/recipe/"
+            f"Catalog references {ref} but it does not exist anywhere in tests/"
         )
 
 
 def test_catalog_reverse_coverage(skill_text):
-    """High-risk arch test files must be referenced in the catalog.
-    When a new arch test is added that enforces a constraint violable by
-    reviewer suggestions, this test ensures the catalog is updated."""
-    high_risk_test_files = {
-        "test_regex_import.py",
-        "test_ast_rules.py",
-        "test_dataclass_slots.py",
-        "test_layer_enforcement.py",
-        "test_never_raises_contracts.py",
-        "test_no_backend_name_bypass.py",
-        "test_subpackage_isolation.py",
-        "test_anyio_migration.py",
-        "test_python_no_hardcoded_temp.py",
-        "test_skill_result_construction_guard.py",
-        "test_anti_pattern_guards.py",
-    }
-    for test_file in high_risk_test_files:
-        arch_path = ARCH_DIR / test_file
-        recipe_path = ARCH_DIR.parent / "recipe" / test_file
-        if not arch_path.exists() and not recipe_path.exists():
-            continue
-        assert test_file in skill_text, (
-            f"High-risk arch test {test_file} exists but is not referenced "
-            f"in the Architectural Constraint Catalog. Update the catalog."
-        )
+    """Every discoverable constraint test (minus exclusions) must be
+    referenced in the Architectural Constraint Catalog."""
+    all_constraints = discover_constraint_tests()
+    catalogable = {name for name in all_constraints if name not in _CATALOG_EXCLUSIONS}
+    catalog_idx = skill_text.lower().find(
+        "architectural constraint catalog — consult before classifying accept"
+    )
+    assert catalog_idx != -1
+    catalog_section = skill_text[catalog_idx : catalog_idx + 6000]
+    missing = {name for name in catalogable if name not in catalog_section}
+    assert missing == set(), (
+        f"Constraint tests not in catalog: {sorted(missing)}. "
+        "Add them to the Architectural Constraint Catalog in "
+        "resolve-review/SKILL.md or add to _CATALOG_EXCLUSIONS with a reason."
+    )
+
+
+def test_catalog_completeness_via_discovery(skill_text):
+    """Bidirectional catalog guard: all constraint tests violable by reviewer
+    suggestions must appear in the Architectural Constraint Catalog."""
+    all_constraints = discover_constraint_tests()
+    catalogable = {name for name in all_constraints if name not in _CATALOG_EXCLUSIONS}
+    catalog_idx = skill_text.lower().find(
+        "architectural constraint catalog — consult before classifying accept"
+    )
+    if catalog_idx == -1:
+        pytest.fail("Architectural Constraint Catalog section not found in SKILL.md")
+    catalog_section = skill_text[catalog_idx : catalog_idx + 6000]
+    missing = {name for name in catalogable if name not in catalog_section}
+    assert missing == set(), (
+        f"Constraint tests not in catalog: {sorted(missing)}. "
+        "Add them to the Architectural Constraint Catalog in "
+        "resolve-review/SKILL.md or add to _CATALOG_EXCLUSIONS with a reason."
+    )
 
 
 # --- arch_violation category ---

--- a/tests/skills/test_resolve_review_arch_constraint_awareness.py
+++ b/tests/skills/test_resolve_review_arch_constraint_awareness.py
@@ -201,25 +201,6 @@ def test_catalog_reverse_coverage(skill_text):
     )
 
 
-def test_catalog_completeness_via_discovery(skill_text):
-    """Bidirectional catalog guard: all constraint tests violable by reviewer
-    suggestions must appear in the Architectural Constraint Catalog."""
-    all_constraints = discover_constraint_tests()
-    catalogable = {name for name in all_constraints if name not in _CATALOG_EXCLUSIONS}
-    catalog_idx = skill_text.lower().find(
-        "architectural constraint catalog — consult before classifying accept"
-    )
-    if catalog_idx == -1:
-        pytest.fail("Architectural Constraint Catalog section not found in SKILL.md")
-    catalog_section = skill_text[catalog_idx : catalog_idx + 6000]
-    missing = {name for name in catalogable if name not in catalog_section}
-    assert missing == set(), (
-        f"Constraint tests not in catalog: {sorted(missing)}. "
-        "Add them to the Architectural Constraint Catalog in "
-        "resolve-review/SKILL.md or add to _CATALOG_EXCLUSIONS with a reason."
-    )
-
-
 # --- arch_violation category ---
 
 

--- a/tests/skills/test_resolve_review_arch_constraint_awareness.py
+++ b/tests/skills/test_resolve_review_arch_constraint_awareness.py
@@ -10,6 +10,22 @@ import pytest
 
 from tests._arch_constraint_discovery import discover_constraint_tests
 
+_CATALOG_HEADING = "architectural constraint catalog — consult before classifying accept"
+
+
+def _extract_catalog_section(skill_text: str) -> str:
+    """Extract the catalog section up to the next markdown heading or rule."""
+    catalog_idx = skill_text.lower().find(_CATALOG_HEADING)
+    if catalog_idx == -1:
+        pytest.fail("Architectural Constraint Catalog section not found in SKILL.md")
+    end_idx = len(skill_text)
+    for delimiter in ("\n## ", "\n---"):
+        pos = skill_text.find(delimiter, catalog_idx + len(_CATALOG_HEADING))
+        if pos != -1 and pos < end_idx:
+            end_idx = pos
+    return skill_text[catalog_idx:end_idx]
+
+
 SKILL_PATH = (
     Path(__file__).parent.parent.parent
     / "src"
@@ -168,13 +184,7 @@ def test_never_block_prohibits_ignoring_arch_constraints(skill_text):
 
 def test_catalog_forward_references_valid(skill_text):
     """Every test file cited in the catalog must actually exist in tests/."""
-    catalog_idx = skill_text.lower().find(
-        "architectural constraint catalog — consult before classifying accept"
-    )
-    if catalog_idx == -1:
-        pytest.fail("Architectural Constraint Catalog section not found in SKILL.md")
-    catalog_section = skill_text[catalog_idx : catalog_idx + 6000]
-    # Build a set of ALL test filenames across the entire test tree
+    catalog_section = _extract_catalog_section(skill_text)
     all_test_files = {f.name for f in Path(__file__).parent.parent.rglob("test_*.py")}
     referenced_files = set(re.findall(r"`(test_\w+\.py)`", catalog_section))
     for ref in referenced_files:
@@ -188,11 +198,7 @@ def test_catalog_reverse_coverage(skill_text):
     referenced in the Architectural Constraint Catalog."""
     all_constraints = discover_constraint_tests()
     catalogable = {name for name in all_constraints if name not in _CATALOG_EXCLUSIONS}
-    catalog_idx = skill_text.lower().find(
-        "architectural constraint catalog — consult before classifying accept"
-    )
-    assert catalog_idx != -1
-    catalog_section = skill_text[catalog_idx : catalog_idx + 6000]
+    catalog_section = _extract_catalog_section(skill_text)
     missing = {name for name in catalogable if name not in catalog_section}
     assert missing == set(), (
         f"Constraint tests not in catalog: {sorted(missing)}. "

--- a/tests/workspace/test_clone_timeouts.py
+++ b/tests/workspace/test_clone_timeouts.py
@@ -1,4 +1,4 @@
-"""Static analysis: git network commands in clone.py must have timeouts."""
+"""Structural guard: git network commands in clone.py must have timeouts."""
 
 from __future__ import annotations
 

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -1,4 +1,4 @@
-"""Tests for skill resolution hierarchy."""
+"""Structural guard: skill resolution hierarchy and @-mention enforcement."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

The resolve-review skill's Architectural Constraint Catalog is a manually curated table in SKILL.md that lists pytest-enforced constraints. Its staleness guard (`test_catalog_reverse_coverage`) uses a hardcoded file set and only searches `tests/arch/` and `tests/recipe/`. This means new constraint tests added to any other directory (e.g., `tests/workspace/`, `tests/server/`, `tests/execution/`) silently go uncatalogued. The @-mention guard (`test_no_hardcoded_username_mentions_in_skill_mds` in `tests/workspace/test_skills.py`) is the immediate victim, but the pattern failure is broader: 52 structural/architectural guard tests exist across 7 directories (expanding to 56 tests across 9 directories after docstring normalization), the catalog lists only 13, and the staleness guard can only ever see tests in 2 of those directories.

The architectural solution: replace the manually curated catalog and its manually curated staleness guard with **docstring-convention-based automatic discovery**. The codebase already has a strong convention — most constraint tests use one of a small set of docstring prefixes. A discovery test can find all constraint tests by convention, validate the catalog covers them, and fail immediately when a new constraint test is added anywhere without a catalog entry.

Closes #3331

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-174543-571962/.autoskillit/temp/rectify/rectify_arch_constraint_catalog_discovery_2026-05-30_175800.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 80 | 26.3k | 3.0M | 125.7k | 375 | 117.0k | 30m 20s |
| review_approach* | sonnet | 1 | 62 | 7.4k | 242.8k | 53.7k | 91 | 41.5k | 5m 41s |
| dry_walkthrough* | opus | 1 | 58 | 20.1k | 1.2M | 65.0k | 125 | 48.8k | 9m 44s |
| implement* | sonnet | 1 | 1.6k | 29.6k | 1.9M | 85.7k | 104 | 70.5k | 8m 18s |
| audit_impl* | sonnet | 1 | 70 | 12.1k | 234.5k | 40.9k | 45 | 38.0k | 6m 21s |
| prepare_pr* | sonnet | 1 | 195.7k | 3.8k | 355.6k | 27.6k | 31 | 15.8k | 1m 55s |
| compose_pr* | sonnet | 1 | 57.8k | 1.6k | 162.5k | 27.6k | 16 | 15.5k | 49s |
| review_pr* | sonnet | 3 | 684 | 150.9k | 5.6M | 108.9k | 222 | 344.8k | 40m 51s |
| resolve_review* | opus | 2 | 113 | 24.3k | 2.3M | 78.5k | 105 | 160.0k | 20m 11s |
| **Total** | | | 256.2k | 276.0k | 15.0M | 125.7k | | 851.8k | 2h 4m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 244 | 7868.1 | 289.0 | 121.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 67 | 34472.4 | 2387.4 | 363.1 |
| **Total** | **311** | 48129.9 | 2739.0 | 887.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 80 | 26.3k | 3.0M | 117.0k | 30m 20s |
| sonnet | 6 | 256.0k | 205.3k | 8.5M | 526.1k | 1h 3m |
| opus | 2 | 171 | 44.4k | 3.5M | 208.7k | 29m 56s |