### PR TITLE
Add SendMessage continuation protocol to plan-review subagent dispatches

### DIFF
--- a/src/autoskillit/agents/plan-registry-tracer.md
+++ b/src/autoskillit/agents/plan-registry-tracer.md
@@ -3,7 +3,7 @@ name: plan-registry-tracer
 description: "Registry and artifact auditor for implementation plans. Finds every file referencing a renamed or added symbol via grep and LSP, and checks if the plan updates it. Use when reviewing a draft plan before finalization."
 tools: [Read, Grep, Glob, Bash, LSP]
 model: sonnet
-maxTurns: 40
+maxTurns: 80
 color: green
 ---
 

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -185,6 +185,13 @@ a `## Adversarial Review` heading:
 
    The Foundation Auditor performs step-by-step control-flow analysis: enumerates functions, draws control flow with scope levels, builds reachability tables, audits guard coverage, and applies exploit-first verification. It must NOT suggest scope expansion — only identify gaps in what the plan already claims to do.
 
+**SendMessage continuation protocol:** If the subagent returns with a continuation hint (truncated at maxTurns), use `SendMessage` to resume it:
+- `to`: the `agentId` from the continuation hint
+- `message`: `"Finalize your analysis and provide your complete findings report."`
+- `summary`: `"Continue plan review subagent to finalize findings"`
+
+The `summary` field is **required** when `message` is a string — omitting it causes `InputValidationError`. If the resumed agent still returns truncated, proceed without its findings rather than retrying further.
+
 7. **Interface Mapping** - Spawn 1 Interface Mapper via `Agent(subagent_type="autoskillit:plan-interface-mapper")`. Pass the full draft plan text and the codebase root. Prepend the contrastive frame to the prompt:
 
    > "A junior reviewer found this plan's variable usage correct — what did they miss?"
@@ -193,6 +200,13 @@ a `## Adversarial Review` heading:
 
    **RULES FOR APPLYING INTERFACE MAPPING FINDINGS:** When the interface mapper identifies the correct variable for a step, apply the correction to ALL fields that consume that variable — cwd, skill_command arguments, branch references, SHA captures, output paths. Do not split the correct variable across some fields while leaving other fields on the wrong variable.
 
+**SendMessage continuation protocol:** If the subagent returns with a continuation hint (truncated at maxTurns), use `SendMessage` to resume it:
+- `to`: the `agentId` from the continuation hint
+- `message`: `"Finalize your analysis and provide your complete findings report."`
+- `summary`: `"Continue plan review subagent to finalize findings"`
+
+The `summary` field is **required** when `message` is a string — omitting it causes `InputValidationError`. If the resumed agent still returns truncated, proceed without its findings rather than retrying further.
+
 8. **Registry Trace** - Spawn 1 Registry Tracer via `Agent(subagent_type="autoskillit:plan-registry-tracer")`. Pass the full draft plan text and the codebase root. Prepend the contrastive frame to the prompt:
 
    > "A junior reviewer found this plan's registry coverage complete — what did they miss?"
@@ -200,6 +214,13 @@ a `## Adversarial Review` heading:
    The Registry Tracer uses three-layer tracing (LSP primary, tree-sitter structural, grep fallback) to find every file referencing symbols the plan touches. It checks participation in registry-sync patterns (RETIRED NAME SETS, RE-EXPORT CHAINS, TOOL REGISTRIES, RULE REGISTRATION, DUAL-COPY CONSTANTS, IMPORT LAYER CONSTRAINTS, TYPED ALIASES, DERIVED ARTIFACTS), then performs a two-layer completeness check (source-code layer vs. test/fixture layer). It must NOT suggest scope expansion — only identify gaps in what the plan already claims to do.
 
    **RULES FOR APPLYING REGISTRY TRACE FINDINGS:** Verify BOTH fixture/test completeness AND registry completeness before finalizing. A plan that addresses only one interpretation of a rename (manifest-focused OR workspace-focused) and misses the cross-cutting update is incomplete. Apply the two-family check: if references appear in only one layer (source-code or test/fixture), perform targeted follow-up searches in the other layer before concluding.
+
+**SendMessage continuation protocol:** If the subagent returns with a continuation hint (truncated at maxTurns), use `SendMessage` to resume it:
+- `to`: the `agentId` from the continuation hint
+- `message`: `"Finalize your analysis and provide your complete findings report."`
+- `summary`: `"Continue plan review subagent to finalize findings"`
+
+The `summary` field is **required** when `message` is a string — omitting it causes `InputValidationError`. If the resumed agent still returns truncated, proceed without its findings rather than retrying further.
 
 9. **Plan Revision** - Read all available adversarial reports (0, 1, 2, or 3
    depending on the complexity gate decision in Step 5e). For each valid finding (where the agent identified a real gap, not a hypothetical):

--- a/src/autoskillit/skills_extended/rectify/SKILL.md
+++ b/src/autoskillit/skills_extended/rectify/SKILL.md
@@ -176,6 +176,13 @@ Spawn 1 Foundation Auditor via `Agent(subagent_type="autoskillit:plan-foundation
 
 The Foundation Auditor performs step-by-step control-flow analysis: enumerates functions, draws control flow with scope levels, builds reachability tables, audits guard coverage, and applies exploit-first verification. It must NOT suggest scope expansion — only identify gaps in what the plan already claims to do.
 
+**SendMessage continuation protocol:** If the subagent returns with a continuation hint (truncated at maxTurns), use `SendMessage` to resume it:
+- `to`: the `agentId` from the continuation hint
+- `message`: `"Finalize your analysis and provide your complete findings report."`
+- `summary`: `"Continue plan review subagent to finalize findings"`
+
+The `summary` field is **required** when `message` is a string — omitting it causes `InputValidationError`. If the resumed agent still returns truncated, proceed without its findings rather than retrying further.
+
 After reading the agent's findings, revise the draft plan by incorporating all valid findings (real gaps, not hypotheticals) before proceeding to Step 6.
 
 ### Step 6: Interface Mapping
@@ -188,6 +195,13 @@ The Interface Mapper traces variable SET/READ points with full hop-by-hop proven
 
 **RULES FOR APPLYING INTERFACE MAPPING FINDINGS:** When the interface mapper identifies the correct variable for a step, apply the correction to ALL fields that consume that variable — cwd, skill_command arguments, branch references, SHA captures, output paths. Do not split the correct variable across some fields while leaving other fields on the wrong variable.
 
+**SendMessage continuation protocol:** If the subagent returns with a continuation hint (truncated at maxTurns), use `SendMessage` to resume it:
+- `to`: the `agentId` from the continuation hint
+- `message`: `"Finalize your analysis and provide your complete findings report."`
+- `summary`: `"Continue plan review subagent to finalize findings"`
+
+The `summary` field is **required** when `message` is a string — omitting it causes `InputValidationError`. If the resumed agent still returns truncated, proceed without its findings rather than retrying further.
+
 After reading the agent's findings, revise the draft plan by incorporating all valid findings before proceeding to Step 7.
 
 ### Step 7: Registry Trace
@@ -199,6 +213,13 @@ Spawn 1 Registry Tracer via `Agent(subagent_type="autoskillit:plan-registry-trac
 The Registry Tracer uses three-layer tracing (LSP primary, tree-sitter structural, grep fallback) to find every file referencing symbols the plan touches. It checks participation in registry-sync patterns (RETIRED NAME SETS, RE-EXPORT CHAINS, TOOL REGISTRIES, RULE REGISTRATION, DUAL-COPY CONSTANTS, IMPORT LAYER CONSTRAINTS, TYPED ALIASES, DERIVED ARTIFACTS), then performs a two-layer completeness check (source-code layer vs. test/fixture layer). It must NOT suggest scope expansion — only identify gaps in what the plan already claims to do.
 
 **RULES FOR APPLYING REGISTRY TRACE FINDINGS:** Verify BOTH fixture/test completeness AND registry completeness before finalizing. A plan that addresses only one interpretation of a rename (manifest-focused OR workspace-focused) and misses the cross-cutting update is incomplete. Apply the two-family check: if references appear in only one layer (source-code or test/fixture), perform targeted follow-up searches in the other layer before concluding.
+
+**SendMessage continuation protocol:** If the subagent returns with a continuation hint (truncated at maxTurns), use `SendMessage` to resume it:
+- `to`: the `agentId` from the continuation hint
+- `message`: `"Finalize your analysis and provide your complete findings report."`
+- `summary`: `"Continue plan review subagent to finalize findings"`
+
+The `summary` field is **required** when `message` is a string — omitting it causes `InputValidationError`. If the resumed agent still returns truncated, proceed without its findings rather than retrying further.
 
 After reading the agent's findings, apply all valid findings. The plan is now fully reviewed and ready for file write.
 

--- a/src/autoskillit/skills_extended/rectify/SKILL.md
+++ b/src/autoskillit/skills_extended/rectify/SKILL.md
@@ -179,7 +179,7 @@ The Foundation Auditor performs step-by-step control-flow analysis: enumerates f
 **SendMessage continuation protocol:** If the subagent returns with a continuation hint (truncated at maxTurns), use `SendMessage` to resume it:
 - `to`: the `agentId` from the continuation hint
 - `message`: `"Finalize your analysis and provide your complete findings report."`
-- `summary`: `"Continue plan review subagent to finalize findings"`
+- `summary`: `"Continue rectify subagent to finalize findings"`
 
 The `summary` field is **required** when `message` is a string — omitting it causes `InputValidationError`. If the resumed agent still returns truncated, proceed without its findings rather than retrying further.
 
@@ -198,7 +198,7 @@ The Interface Mapper traces variable SET/READ points with full hop-by-hop proven
 **SendMessage continuation protocol:** If the subagent returns with a continuation hint (truncated at maxTurns), use `SendMessage` to resume it:
 - `to`: the `agentId` from the continuation hint
 - `message`: `"Finalize your analysis and provide your complete findings report."`
-- `summary`: `"Continue plan review subagent to finalize findings"`
+- `summary`: `"Continue rectify subagent to finalize findings"`
 
 The `summary` field is **required** when `message` is a string — omitting it causes `InputValidationError`. If the resumed agent still returns truncated, proceed without its findings rather than retrying further.
 
@@ -217,7 +217,7 @@ The Registry Tracer uses three-layer tracing (LSP primary, tree-sitter structura
 **SendMessage continuation protocol:** If the subagent returns with a continuation hint (truncated at maxTurns), use `SendMessage` to resume it:
 - `to`: the `agentId` from the continuation hint
 - `message`: `"Finalize your analysis and provide your complete findings report."`
-- `summary`: `"Continue plan review subagent to finalize findings"`
+- `summary`: `"Continue rectify subagent to finalize findings"`
 
 The `summary` field is **required** when `message` is a string — omitting it causes `InputValidationError`. If the resumed agent still returns truncated, proceed without its findings rather than retrying further.
 

--- a/tests/server/test_tools_agents.py
+++ b/tests/server/test_tools_agents.py
@@ -432,6 +432,27 @@ def test_pipeline_health_scanner_agent_exists():
     )
 
 
+# DIAG_C7: plan-registry-tracer maxTurns >= 80
+def test_plan_registry_tracer_max_turns_sufficient() -> None:
+    """plan-registry-tracer.md maxTurns must be >= 80."""
+    import yaml
+
+    from autoskillit.core import pkg_root
+
+    agent_path = pkg_root() / "agents" / "plan-registry-tracer.md"
+    assert agent_path.is_file(), f"plan-registry-tracer.md not found at {agent_path}"
+    content = agent_path.read_text()
+
+    parts = content.split("---", 2)
+    assert len(parts) >= 3, "plan-registry-tracer.md must have YAML frontmatter"
+    frontmatter = yaml.safe_load(parts[1]) or {}
+    max_turns = frontmatter.get("maxTurns")
+    assert max_turns is not None and max_turns >= 80, (
+        f"plan-registry-tracer maxTurns must be >= 80 (got {max_turns}); "
+        "80 minimum: tracer needs > 40 turns for multi-pass LSP + tree-sitter + grep analysis"
+    )
+
+
 # DIAG_C10: all agent definitions have structured output contracts
 AGENTS_WITHOUT_STRUCTURED_OUTPUT: frozenset[str] = frozenset()
 

--- a/tests/skills/CLAUDE.md
+++ b/tests/skills/CLAUDE.md
@@ -8,7 +8,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 |------|---------|
 | `__init__.py` | empty |
 | `conftest.py` | Skill test fixtures |
-| `test_adversarial_review_contracts.py` | Contract tests verifying adversarial review agents exist in make-plan and rectify SKILL.md files |
+| `test_adversarial_review_contracts.py` | Contract tests verifying adversarial review agents, maxTurns sufficiency, and SendMessage continuation protocol in make-plan and rectify SKILL.md files |
 | `test_analyze_prs_contracts.py` | Contract tests for analyze-prs SKILL.md batch branch naming convention |
 | `test_arch_lens_context_path.py` | Tests that all arch-lens skills have ## Arguments section and context_path handling |
 | `test_audit_arch_preflight_contracts.py` | Audit-arch skill preflight contract tests |

--- a/tests/skills/test_adversarial_review_contracts.py
+++ b/tests/skills/test_adversarial_review_contracts.py
@@ -302,3 +302,47 @@ def test_rectify_sequential_revision_pattern(rectify_text: str) -> None:
     im_section = rectify_text[im_idx:rt_idx].lower()
     assert "revis" in fa_section, "Foundation Audit step must include revision instruction"
     assert "revis" in im_section, "Interface Mapping step must include revision instruction"
+
+
+def test_make_plan_adversarial_steps_contain_continuation_protocol(make_plan_text: str) -> None:
+    """Each adversarial step in make-plan must include SendMessage continuation protocol."""
+    planning_idx = make_plan_text.find("## Planning Steps")
+    assert planning_idx != -1
+    step6_idx = make_plan_text.find("**Foundation Audit", planning_idx)
+    step7_idx = make_plan_text.find("**Interface Mapping", planning_idx)
+    step8_idx = make_plan_text.find("**Registry Trace", planning_idx)
+    step9_idx = make_plan_text.find("**Plan Revision", planning_idx)
+    assert all(i != -1 for i in (step6_idx, step7_idx, step8_idx, step9_idx))
+
+    for label, start, end in [
+        ("Step 6 (Foundation Audit)", step6_idx, step7_idx),
+        ("Step 7 (Interface Mapping)", step7_idx, step8_idx),
+        ("Step 8 (Registry Trace)", step8_idx, step9_idx),
+    ]:
+        section = make_plan_text[start:end].lower()
+        assert "sendmessage" in section, f"{label} must mention SendMessage"
+        assert "summary" in section, f"{label} must mention required summary field"
+        assert "continuation" in section, f"{label} must mention continuation"
+
+
+def test_rectify_adversarial_steps_contain_continuation_protocol(rectify_text: str) -> None:
+    """Each adversarial step in rectify must include SendMessage continuation protocol."""
+    workflow_idx = rectify_text.find("## Rectify Workflow")
+    assert workflow_idx != -1
+    fa_idx = rectify_text.find("Foundation Audit", workflow_idx)
+    im_idx = rectify_text.find("Interface Mapping", workflow_idx)
+    rt_idx = rectify_text.find("Registry Trace", workflow_idx)
+    assert all(i != -1 for i in (fa_idx, im_idx, rt_idx))
+
+    next_heading = rectify_text.find("\n## ", rt_idx)
+    rt_end = next_heading if next_heading != -1 else len(rectify_text)
+
+    for label, start, end in [
+        ("Step 5 (Foundation Audit)", fa_idx, im_idx),
+        ("Step 6 (Interface Mapping)", im_idx, rt_idx),
+        ("Step 7 (Registry Trace)", rt_idx, rt_end),
+    ]:
+        section = rectify_text[start:end].lower()
+        assert "sendmessage" in section, f"{label} must mention SendMessage"
+        assert "summary" in section, f"{label} must mention required summary field"
+        assert "continuation" in section, f"{label} must mention continuation"


### PR DESCRIPTION
## Summary

When a plan-review subagent (foundation auditor, interface mapper, or registry tracer) exhausts its `maxTurns` limit, the Claude Code harness returns a continuation hint with an `agentId`. Neither rectify nor make-plan SKILL.md files provide guidance for this case, causing orchestrators to improvise — and get the `SendMessage` schema wrong (omitting the required `summary` field). This plan bumps the registry tracer's `maxTurns` from 40 to 80 (reducing continuation frequency) and adds an explicit SendMessage continuation protocol to every adversarial subagent dispatch step in both skills.

Closes #3350

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260530-183836-227844/.autoskillit/temp/make-plan/rectify-make-plan-sendmessage-continuation-protocol-missing_plan_2026-05-30_184600.md`

## Changed Files

- `src/autoskillit/agents/plan-registry-tracer.md`
- `src/autoskillit/skills_extended/make-plan/SKILL.md`
- `src/autoskillit/skills_extended/rectify/SKILL.md`
- `tests/server/test_tools_agents.py`
- `tests/skills/CLAUDE.md`
- `tests/skills/test_adversarial_review_contracts.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.2k | 14.2k | 1.2M | 102.0k | 118 | 69.4k | 11m 20s |
| verify* | sonnet | 1 | 86 | 8.1k | 371.2k | 48.3k | 53 | 32.4k | 3m 41s |
| implement* | sonnet | 1 | 634.6k | 7.7k | 579.4k | 27.6k | 58 | 78.9k | 3m 5s |
| audit_impl* | sonnet | 1 | 68 | 9.4k | 232.4k | 36.0k | 28 | 27.3k | 4m 3s |
| prepare_pr* | sonnet | 1 | 65.8k | 2.9k | 223.3k | 33.0k | 22 | 23.9k | 1m 35s |
| compose_pr* | sonnet | 1 | 47.4k | 1.7k | 190.2k | 27.6k | 14 | 15.6k | 49s |
| review_pr* | sonnet | 2 | 274 | 81.0k | 1.7M | 86.3k | 107 | 179.9k | 17m 19s |
| resolve_review* | sonnet | 1 | 197 | 16.1k | 1.3M | 69.5k | 74 | 54.3k | 6m 41s |
| **Total** | | | 749.6k | 141.1k | 5.8M | 102.0k | | 481.5k | 48m 37s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 111 | 5219.5 | 710.4 | 69.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 213414.8 | 9049.3 | 2678.5 |
| **Total** | **117** | 49665.8 | 4115.2 | 1205.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.2k | 14.2k | 1.2M | 69.4k | 11m 20s |
| sonnet | 7 | 748.4k | 126.8k | 4.6M | 412.1k | 37m 16s |