### PR TITLE
Rectify: Test Filter Manifest Missing Workspace for SKILL.md Changes — PART A ONLY

### DIFF
--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -63,12 +63,15 @@ src/autoskillit/recipe/block_budgets.yaml:
 src/autoskillit/skills/*/SKILL.md:
   - skills/
   - contracts/
+  - workspace/
 
 src/autoskillit/skills_extended/*/SKILL.md:
   - skills/
   - contracts/
   - recipe/
   - skills_extended/
+  - workspace/
+  - planner/
 
 src/autoskillit/config/defaults.yaml:
   - config/
@@ -78,6 +81,7 @@ src/autoskillit/config/defaults.yaml:
 
 src/autoskillit/hooks/registry.sha256:
   - infra/
+  - hooks/
 
 src/autoskillit/.claude-plugin/plugin.json:
   - contracts/
@@ -92,6 +96,7 @@ src/autoskillit/agents/**:
   - server/
   - arch/
   - contracts/
+  - planner/
 
 .github/workflows/*.yml:
   - infra/
@@ -123,6 +128,7 @@ README.md:
 
 src/autoskillit/assets/**/*:
   - assets/
+  - contracts/
 
 tests/recipe/fixtures/*:
   - recipe/

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -91,6 +91,7 @@ ALWAYS_RUN_AGGRESSIVE: frozenset[str] = frozenset(
 _INFRA_UNCONDITIONAL_FILES: frozenset[str] = frozenset(
     {
         "test_manifest_completeness.py",
+        "test_manifest_directory_completeness.py",
         "test_guard_coverage.py",
         "test_session_scope_enforcement.py",
         "test_filter_activation.py",
@@ -1456,7 +1457,7 @@ def build_test_scope(
         else:
             direct_test_files.add(str(tests_root / "docs" / "test_doc_counts.py"))
 
-        # REQ-TIER-003: 6 infra + 3 hooks structural files always; full infra dir only on trigger
+        # REQ-TIER-003: 7 infra + 3 hooks structural files always; full infra dir only on trigger
         for fname in _INFRA_UNCONDITIONAL_FILES:
             direct_test_files.add(str(tests_root / "infra" / fname))
         for fname in _HOOKS_UNCONDITIONAL_FILES:

--- a/tests/infra/CLAUDE.md
+++ b/tests/infra/CLAUDE.md
@@ -32,6 +32,7 @@ CI/CD configuration, security, guard coverage, and release sanity tests.
 | `test_guard_coverage.py` | Structural test: destructive tools have PreToolUse hook coverage |
 | `test_skill_orchestration_guard.py` | Tests for skill_orchestration_guard.py PreToolUse hook |
 | `test_manifest_completeness.py` | Manifest completeness and orphan detection tests for the test-filter manifest |
+| `test_manifest_directory_completeness.py` | Manifest directory completeness: validates each manifest pattern's test directory list includes all dependent test directories |
 | `test_mcp_health_advisor.py` | Tests for mcp_health_advisor PreToolUse hook |
 | `test_open_kitchen_guard.py` | Phase 2 tests: open_kitchen_guard PreToolUse hook |
 | `test_planner_gh_discovery_guard.py` | Tests for the planner_gh_discovery_guard PreToolUse hook |

--- a/tests/infra/test_manifest_completeness.py
+++ b/tests/infra/test_manifest_completeness.py
@@ -145,3 +145,30 @@ def test_manifest_pattern_matches_real_file(pattern: str) -> None:
         f"Manifest pattern {pattern!r} matches no tracked files — it may be stale "
         "or misspelled. Remove it from .autoskillit/test-filter-manifest.yaml."
     )
+
+
+def _all_manifest_paths() -> list[tuple[str, str]]:
+    """Return (pattern, entry) pairs for all manifest directory/file entries."""
+    manifest = load_manifest(_MANIFEST_PATH)
+    pairs = []
+    for pattern, entries in manifest.items():
+        if isinstance(entries, list):
+            for entry in entries:
+                pairs.append((pattern, entry))
+        elif isinstance(entries, str):
+            pairs.append((pattern, entries))
+    return pairs
+
+
+@pytest.mark.parametrize("pattern,entry", _all_manifest_paths())
+def test_manifest_entry_path_exists(pattern: str, entry: str) -> None:
+    """Every test path listed in a manifest entry must exist under tests/.
+
+    Catches typos (e.g., 'planer/' instead of 'planner/') and stale
+    references after test directory renames. Handles both directory entries
+    (e.g., 'planner/') and file-level entries (e.g., 'workspace/test_skills.py').
+    """
+    target = _REPO_ROOT / "tests" / entry.rstrip("/")
+    assert target.exists(), (
+        f"Manifest entry for {pattern!r} references {entry!r} but {target} does not exist."
+    )

--- a/tests/infra/test_manifest_directory_completeness.py
+++ b/tests/infra/test_manifest_directory_completeness.py
@@ -1,0 +1,119 @@
+"""Manifest directory completeness tests for the test-filter manifest.
+
+Validates the pattern-to-directory axis: every manifest pattern must list all
+test directories that consume the matched source files.
+
+The SOURCE_DEPENDENCIES registry maps test directory names to the manifest
+patterns whose source files those tests consume. A parametrized test cross-
+references each declared dependency against the manifest's directory lists,
+catching any missing directory at test collection time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from autoskillit._test_filter import load_manifest
+
+pytestmark = [pytest.mark.layer("infra")]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MANIFEST_PATH = _REPO_ROOT / ".autoskillit" / "test-filter-manifest.yaml"
+
+# Registry: test directory name -> frozenset of manifest patterns that directory's
+# tests consume. Each entry declares a dependency that the manifest must satisfy.
+SOURCE_DEPENDENCIES: dict[str, frozenset[str]] = {
+    "workspace": frozenset(
+        {
+            "src/autoskillit/skills/*/SKILL.md",
+            "src/autoskillit/skills_extended/*/SKILL.md",
+        }
+    ),
+    "planner": frozenset(
+        {
+            "src/autoskillit/skills_extended/*/SKILL.md",
+            "src/autoskillit/agents/**",
+        }
+    ),
+    "contracts": frozenset(
+        {
+            "src/autoskillit/assets/**/*",
+        }
+    ),
+    "hooks": frozenset(
+        {
+            "src/autoskillit/hooks/registry.sha256",
+        }
+    ),
+}
+
+
+def _dir_is_covered(test_dir: str, manifest_entries: Sequence[str]) -> bool:
+    """Check if test_dir is represented in manifest_entries.
+
+    Handles three manifest entry formats:
+    - Trailing-slash directory: "planner/" -> strip slash, compare to "planner"
+    - Bare directory: "planner" -> compare directly
+    - File-level: "workspace/test_skills.py" -> extract first path component
+    """
+    for entry in manifest_entries:
+        normalized = entry.rstrip("/")
+        if normalized == test_dir:
+            return True
+        if "/" in normalized and normalized.split("/")[0] == test_dir:
+            return True
+    return False
+
+
+def _dependency_pairs() -> list[tuple[str, str]]:
+    pairs = []
+    for test_dir, patterns in SOURCE_DEPENDENCIES.items():
+        for pattern in sorted(patterns):
+            pairs.append((test_dir, pattern))
+    return pairs
+
+
+def _all_dependency_patterns() -> list[str]:
+    patterns: set[str] = set()
+    for pat_set in SOURCE_DEPENDENCIES.values():
+        patterns.update(pat_set)
+    return sorted(patterns)
+
+
+@pytest.mark.parametrize("test_dir,pattern", _dependency_pairs())
+def test_manifest_includes_dependent_directory(test_dir: str, pattern: str) -> None:
+    """Each declared dependency must appear in the manifest pattern's directory list.
+
+    Failure means a manifest entry routes source file changes to an incomplete set
+    of test directories, silently skipping tests that read those source files.
+    Fix: add the missing directory (e.g., 'workspace/') to the manifest entry for
+    that pattern in .autoskillit/test-filter-manifest.yaml.
+    """
+    manifest = load_manifest(_MANIFEST_PATH)
+    entries = manifest.get(pattern, [])
+    if isinstance(entries, str):
+        entries = [entries]
+    assert _dir_is_covered(test_dir, entries), (
+        f"Manifest pattern {pattern!r} is missing test directory {test_dir!r}. "
+        f"Current entries: {entries}. "
+        f"Add {test_dir + '/'!r} (or a file-level entry like {test_dir + '/test_file.py'!r}) "
+        f"to the manifest entry."
+    )
+
+
+@pytest.mark.parametrize("pattern", _all_dependency_patterns())
+def test_source_dependency_pattern_exists_in_manifest(pattern: str) -> None:
+    """Each pattern referenced in SOURCE_DEPENDENCIES must exist in the manifest.
+
+    Failure means a SOURCE_DEPENDENCIES entry is stale — the pattern was removed
+    or renamed in the manifest without updating this registry.
+    Fix: update SOURCE_DEPENDENCIES to reference the current manifest pattern, or
+    re-add the pattern to .autoskillit/test-filter-manifest.yaml.
+    """
+    manifest = load_manifest(_MANIFEST_PATH)
+    assert pattern in manifest, (
+        f"SOURCE_DEPENDENCIES references pattern {pattern!r} but it is not a key in the manifest."
+    )

--- a/tests/infra/test_manifest_directory_completeness.py
+++ b/tests/infra/test_manifest_directory_completeness.py
@@ -3,7 +3,7 @@
 Validates the pattern-to-directory axis: every manifest pattern must list all
 test directories that consume the matched source files.
 
-The SOURCE_DEPENDENCIES registry maps test directory names to the manifest
+The _SOURCE_DEPENDENCIES registry maps test directory names to the manifest
 patterns whose source files those tests consume. A parametrized test cross-
 references each declared dependency against the manifest's directory lists,
 catching any missing directory at test collection time.
@@ -25,7 +25,7 @@ _MANIFEST_PATH = _REPO_ROOT / ".autoskillit" / "test-filter-manifest.yaml"
 
 # Registry: test directory name -> frozenset of manifest patterns that directory's
 # tests consume. Each entry declares a dependency that the manifest must satisfy.
-SOURCE_DEPENDENCIES: dict[str, frozenset[str]] = {
+_SOURCE_DEPENDENCIES: dict[str, frozenset[str]] = {
     "workspace": frozenset(
         {
             "src/autoskillit/skills/*/SKILL.md",
@@ -70,7 +70,7 @@ def _dir_is_covered(test_dir: str, manifest_entries: Sequence[str]) -> bool:
 
 def _dependency_pairs() -> list[tuple[str, str]]:
     pairs = []
-    for test_dir, patterns in SOURCE_DEPENDENCIES.items():
+    for test_dir, patterns in _SOURCE_DEPENDENCIES.items():
         for pattern in sorted(patterns):
             pairs.append((test_dir, pattern))
     return pairs
@@ -78,7 +78,7 @@ def _dependency_pairs() -> list[tuple[str, str]]:
 
 def _all_dependency_patterns() -> list[str]:
     patterns: set[str] = set()
-    for pat_set in SOURCE_DEPENDENCIES.values():
+    for pat_set in _SOURCE_DEPENDENCIES.values():
         patterns.update(pat_set)
     return sorted(patterns)
 
@@ -106,14 +106,14 @@ def test_manifest_includes_dependent_directory(test_dir: str, pattern: str) -> N
 
 @pytest.mark.parametrize("pattern", _all_dependency_patterns())
 def test_source_dependency_pattern_exists_in_manifest(pattern: str) -> None:
-    """Each pattern referenced in SOURCE_DEPENDENCIES must exist in the manifest.
+    """Each pattern referenced in _SOURCE_DEPENDENCIES must exist in the manifest.
 
-    Failure means a SOURCE_DEPENDENCIES entry is stale — the pattern was removed
+    Failure means a _SOURCE_DEPENDENCIES entry is stale — the pattern was removed
     or renamed in the manifest without updating this registry.
-    Fix: update SOURCE_DEPENDENCIES to reference the current manifest pattern, or
+    Fix: update _SOURCE_DEPENDENCIES to reference the current manifest pattern, or
     re-add the pattern to .autoskillit/test-filter-manifest.yaml.
     """
     manifest = load_manifest(_MANIFEST_PATH)
     assert pattern in manifest, (
-        f"SOURCE_DEPENDENCIES references pattern {pattern!r} but it is not a key in the manifest."
+        f"_SOURCE_DEPENDENCIES references pattern {pattern!r} but it is not a key in the manifest."
     )

--- a/tests/test_test_filter_tiered_always_run.py
+++ b/tests/test_test_filter_tiered_always_run.py
@@ -117,8 +117,8 @@ class TestTieredAlwaysRun:
             assert d in dir_names, f"fail-open: {d} must be present for empty changeset"
 
     def test_unconditional_files_constants_have_correct_counts(self) -> None:
-        """_INFRA_UNCONDITIONAL_FILES has 6 entries; _HOOKS_UNCONDITIONAL_FILES has 3 entries."""
-        assert len(_INFRA_UNCONDITIONAL_FILES) == 6
+        """_INFRA_UNCONDITIONAL_FILES has 7 entries; _HOOKS_UNCONDITIONAL_FILES has 3 entries."""
+        assert len(_INFRA_UNCONDITIONAL_FILES) == 7
         assert len(_HOOKS_UNCONDITIONAL_FILES) == 3
 
     def test_infra_unconditional_files_resolve_under_infra_dir(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

The test filter manifest maps non-Python file patterns to test directories, but the directory lists are never validated for completeness. The manifest correctly *matches* SKILL.md files to *some* test directories, but silently omits `workspace/` (11 sensitive tests) and `planner/` (6 contract tests). The root architectural weakness is that `test_manifest_completeness.py` validates only the pattern-to-file axis (every file has a pattern, every pattern has a file) but not the pattern-to-test-directory axis (every pattern lists all test directories that consume the matched files). This makes the manifest a manually-curated, unvalidated routing table where drift is invisible.

The architectural fix introduces a **reverse-dependency declaration** mechanism: a `SOURCE_DEPENDENCIES` registry in a new test module maps test directories to manifest patterns they consume, and parametrized tests cross-reference these declarations against the manifest's directory lists — catching any missing directory at test collection time.

Part B will cover broader manifest audit tooling and automated dependency discovery.

## Requirements


## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.


## Changed Files

### New (★):
- `tests/infra/test_manifest_directory_completeness.py`

### Modified (●):
- `.autoskillit/test-filter-manifest.yaml`
- `tests/_test_filter.py`
- `tests/infra/CLAUDE.md`
- `tests/infra/test_manifest_completeness.py`
- `tests/test_test_filter_tiered_always_run.py`

Closes #3332

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-185817-415989/.autoskillit/temp/rectify/rectify_test_filter_manifest_directory_completeness_2026-05-30_190500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillIt
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 3.2k | 22.9k | 1.2M | 95.8k | 292 | 140.3k | 24m 51s |
| dry_walkthrough* | opus | 1 | 5.2k | 12.5k | 1.7M | 77.2k | 233 | 61.0k | 7m 21s |
| implement* | sonnet | 1 | 2.9k | 13.3k | 1.5M | 61.1k | 81 | 45.7k | 5m 44s |
| audit_impl* | sonnet | 1 | 62 | 8.1k | 201.8k | 37.7k | 36 | 30.7k | 3m 16s |
| prepare_pr* | sonnet | 1 | 169.5k | 5.7k | 331.1k | 27.6k | 31 | 40.6k | 2m 6s |
| compose_pr* | sonnet | 1 | 60.6k | 1.8k | 217.8k | 27.6k | 19 | 15.6k | 46s |
| review_pr* | sonnet | 1 | 140 | 33.7k | 787.3k | 77.0k | 57 | 61.8k | 7m 26s |
| resolve_review* | opus | 1 | 42 | 5.8k | 776.6k | 60.1k | 34 | 44.3k | 3m 23s |
| **Total** | | | 241.7k | 103.8k | 6.8M | 95.8k | | 440.0k | 54m 56s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 160 | 9566.7 | 285.3 | 83.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 16 | 48537.6 | 2771.4 | 362.4 |
| **Total** | **176** | 38605.7 | 2499.9 | 589.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 3.2k | 22.9k | 1.2M | 140.3k | 24m 51s |
| opus | 2 | 5.2k | 18.3k | 2.5M | 105.4k | 10m 44s |
| sonnet | 5 | 233.2k | 62.5k | 3.1M | 194.3k | 19m 20s |