### PR TITLE
Add MODULE_CASCADE_CORE Entries for 5 Unclassified Core Modules

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -233,6 +233,17 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "_type_session_env": frozenset({"core", "cli"}),
     "_type_capture": frozenset({"core", "fleet", "recipe", "cli"}),
     "_type_token": frozenset({"core", "execution"}),
+    "_type_constants_env": frozenset(
+        {"cli", "config", "core", "execution", "recipe", "server", "smoke_utils", "workspace"}
+    ),
+    "_type_constants_features": frozenset(
+        {"cli", "config", "core", "fleet", "recipe", "server", "workspace"}
+    ),
+    "_type_constants_registries": frozenset(
+        {"cli", "config", "core", "pipeline", "recipe", "server", "workspace"}
+    ),
+    "_type_exceptions": frozenset({"core", "fleet", "recipe", "server"}),
+    "_step_context": frozenset({"core", "execution", "pipeline", "server"}),
 }
 
 # Narrow per-module cascade for execution/. Modules not listed here fall through

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -679,6 +679,9 @@ class TestCoreStemCompleteness:
     def test_all_core_stems_classified(self) -> None:
         core_root = Path("src/autoskillit/core")
         actual_stems = {p.stem for p in core_root.rglob("*.py") if p.stem != "__init__"}
+        assert actual_stems, (
+            f"No .py files found under {core_root} — is pytest running from the project root?"
+        )
         classified = set(_CORE_UNIVERSAL_MODULES) | set(MODULE_CASCADE_CORE)
         unclassified = actual_stems - classified
         assert not unclassified, (

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -101,6 +101,11 @@ class TestModuleCascadeCore:
             "_type_session_env",
             "_type_capture",
             "_type_token",
+            "_type_constants_env",
+            "_type_constants_features",
+            "_type_constants_registries",
+            "_type_exceptions",
+            "_step_context",
         }
         assert set(MODULE_CASCADE_CORE.keys()) == expected_stems
 
@@ -174,6 +179,31 @@ class TestModuleCascadeCore:
     def test_json_cascade(self) -> None:
         assert MODULE_CASCADE_CORE["_json"] == frozenset(
             {"core", "execution", "pipeline", "recipe", "server"}
+        )
+
+    def test_type_constants_env_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_type_constants_env"] == frozenset(
+            {"cli", "config", "core", "execution", "recipe", "server", "smoke_utils", "workspace"}
+        )
+
+    def test_type_constants_features_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_type_constants_features"] == frozenset(
+            {"cli", "config", "core", "fleet", "recipe", "server", "workspace"}
+        )
+
+    def test_type_constants_registries_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_type_constants_registries"] == frozenset(
+            {"cli", "config", "core", "pipeline", "recipe", "server", "workspace"}
+        )
+
+    def test_type_exceptions_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_type_exceptions"] == frozenset(
+            {"core", "fleet", "recipe", "server"}
+        )
+
+    def test_step_context_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_step_context"] == frozenset(
+            {"core", "execution", "pipeline", "server"}
         )
 
 
@@ -548,6 +578,113 @@ class TestBuildTestScopeCoreCascade:
             assert pkg in dir_names, f"narrow cascade should include {pkg}"
         for excluded in ["config", "fleet", "migration", "workspace", "cli", "planner"]:
             assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
+
+    def test_type_constants_env_narrow_cascade(self, tmp_path: Path) -> None:
+        """_type_constants_env → narrow cascade (smoke_utils silently dropped, no test dir)."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_constants_env.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "cli", "config", "execution", "recipe", "server", "workspace"]:
+            assert pkg in dir_names, f"_type_constants_env cascade should include {pkg}"
+        for excluded in ["fleet", "pipeline", "migration", "planner", "hooks"]:
+            assert excluded not in dir_names, (
+                f"_type_constants_env cascade should not include {excluded}"
+            )
+
+    def test_type_constants_features_narrow_cascade(self, tmp_path: Path) -> None:
+        """_type_constants_features → narrow cascade of 7 dirs."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_constants_features.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "cli", "config", "fleet", "recipe", "server", "workspace"]:
+            assert pkg in dir_names, f"_type_constants_features cascade should include {pkg}"
+        for excluded in ["execution", "pipeline", "migration", "planner", "hooks"]:
+            assert excluded not in dir_names, (
+                f"_type_constants_features cascade should not include {excluded}"
+            )
+
+    def test_type_constants_registries_narrow_cascade(self, tmp_path: Path) -> None:
+        """_type_constants_registries → narrow cascade of 7 dirs."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_constants_registries.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "cli", "config", "pipeline", "recipe", "server", "workspace"]:
+            assert pkg in dir_names, f"_type_constants_registries cascade should include {pkg}"
+        for excluded in ["execution", "fleet", "migration", "planner", "hooks"]:
+            assert excluded not in dir_names, (
+                f"_type_constants_registries cascade should not include {excluded}"
+            )
+
+    def test_type_exceptions_narrow_cascade(self, tmp_path: Path) -> None:
+        """_type_exceptions → narrow cascade of 4 dirs."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_exceptions.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "fleet", "recipe", "server"]:
+            assert pkg in dir_names, f"_type_exceptions cascade should include {pkg}"
+        for excluded in [
+            "cli",
+            "config",
+            "execution",
+            "pipeline",
+            "migration",
+            "workspace",
+            "hooks",
+        ]:
+            assert excluded not in dir_names, (
+                f"_type_exceptions cascade should not include {excluded}"
+            )
+
+    def test_step_context_narrow_cascade(self, tmp_path: Path) -> None:
+        """_step_context → narrow cascade of 4 dirs."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/_step_context.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "execution", "pipeline", "server"]:
+            assert pkg in dir_names, f"_step_context cascade should include {pkg}"
+        for excluded in ["cli", "config", "fleet", "migration", "workspace", "recipe", "hooks"]:
+            assert excluded not in dir_names, (
+                f"_step_context cascade should not include {excluded}"
+            )
+
+
+class TestCoreStemCompleteness:
+    """REQ-FILT-007: every core/ .py stem must be classified."""
+
+    def test_all_core_stems_classified(self) -> None:
+        core_root = Path("src/autoskillit/core")
+        actual_stems = {p.stem for p in core_root.rglob("*.py") if p.stem != "__init__"}
+        classified = set(_CORE_UNIVERSAL_MODULES) | set(MODULE_CASCADE_CORE)
+        unclassified = actual_stems - classified
+        assert not unclassified, (
+            f"Unclassified core stems (will fall through to full 18-dir cascade): "
+            f"{sorted(unclassified)}"
+        )
 
 
 class TestClosureCoreNarrowCascade:


### PR DESCRIPTION
## Summary

Add 5 missing `MODULE_CASCADE_CORE` entries in `tests/_test_filter.py` for core modules created by the monolithic file split (May 24) and GitHub API log rectification (May 29). These modules currently fall through to the full 18-directory cascade instead of narrowed cascades matching their actual import consumers. Also add a completeness guard test (REQ-FILT-007) to prevent future regressions when new core modules are created.

**Files changed:** `tests/_test_filter.py`, `tests/test_test_filter_core_cascade.py`

## Requirements

- REQ-FILT-001: Add `_type_constants_env` to `MODULE_CASCADE_CORE` with cascade `{cli, config, core, execution, recipe, server, smoke_utils, workspace}`
- REQ-FILT-002: Add `_type_constants_features` to `MODULE_CASCADE_CORE` with cascade `{cli, config, core, fleet, recipe, server, workspace}`
- REQ-FILT-003: Add `_type_constants_registries` to `MODULE_CASCADE_CORE` with cascade `{cli, config, core, pipeline, recipe, server, workspace}`
- REQ-FILT-004: Add `_type_exceptions` to `MODULE_CASCADE_CORE` with cascade `{core, fleet, recipe, server}`
- REQ-FILT-005: Add `_step_context` to `MODULE_CASCADE_CORE` with cascade `{core, execution, pipeline, server}`
- REQ-FILT-006: Add companion test assertions in `tests/test_test_filter_core_cascade.py` for all 5 entries (both value assertions and routing tests)
- REQ-FILT-007: Consider adding a completeness guard test that scans `src/autoskillit/core/` for `.py` file stems and asserts each appears in either `_CORE_UNIVERSAL_MODULES` or `MODULE_CASCADE_CORE` — this prevents future monolithic file splits from silently falling through to the full cascade

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260530-195159-043829/.autoskillit/temp/make-plan/add_module_cascade_core_entries_plan_2026-05-30_195500.md`

Closes #3368

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 87 | 17.7k | 1.7M | 101.6k | 168 | 128.1k | 17m 50s |
| verify* | opus[1m] | 1 | 47 | 10.3k | 490.5k | 67.1k | 137 | 50.9k | 5m 35s |
| implement* | opus[1m] | 1 | 73.8k | 36.3k | 6.7M | 0 | 249 | 0 | 5m 31s |
| audit_impl* | opus[1m] | 1 | 34 | 7.4k | 211.8k | 38.2k | 60 | 29.1k | 3m 41s |
| prepare_pr* | opus[1m] | 1 | 59.6k | 2.5k | 138.1k | 27.6k | 18 | 42.5k | 1m 15s |
| compose_pr* | opus[1m] | 1 | 53.9k | 1.5k | 224.5k | 0 | 18 | 0 | 54s |
| review_pr* | opus[1m] | 1 | 41 | 15.9k | 603.0k | 60.9k | 36 | 46.1k | 4m 4s |
| resolve_review* | opus[1m] | 1 | 50 | 4.4k | 648.4k | 51.9k | 32 | 36.0k | 3m 22s |
| **Total** | | | 187.5k | 96.1k | 10.7M | 101.6k | | 332.8k | 42m 16s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 148 | 44946.8 | 0.0 | 245.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 3 | 216145.7 | 12016.0 | 1463.7 |
| **Total** | **151** | 70660.0 | 2204.2 | 636.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 8 | 187.5k | 96.1k | 10.7M | 332.8k | 42m 16s |