### PR TITLE
Standardize SKILL.md subagent spawn instructions for cross-provider compatibility

### DIFF
--- a/.autoskillit/skills/audit-feature-gates/SKILL.md
+++ b/.autoskillit/skills/audit-feature-gates/SKILL.md
@@ -43,7 +43,7 @@ to enumerate features.
 - Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Issue all 6 Task calls in a single message to maximize parallelism
 - Subagents must NOT create their own files — they return findings in response text only
 

--- a/.claude/skills/chart-course/SKILL.md
+++ b/.claude/skills/chart-course/SKILL.md
@@ -115,7 +115,7 @@ If `compass_path` was provided:
 
 #### Step 1.3: Launch Parallel Exploration Subagents
 
-Launch ALL concurrently in a single message. Every subagent uses `model: "sonnet"`.
+Launch ALL concurrently in a single message. Every subagent is spawned via `Agent(model="sonnet")`.
 
 **Subagent A: Architecture & Extension Points**
 Explore protocol definitions, plugin points, layering (L0/L1/L2/L3),
@@ -209,7 +209,7 @@ For each direction, launch targeted analysis:
 - What existing capabilities does it build on?
 - What would it conflict with or make harder?
 
-**Subagent: External Research** (`model: "sonnet"`, web search)
+**Subagent: External Research** (via `Agent(model="sonnet")`, web search)
 - How do other projects in this space handle this?
 - Are there standards, libraries, or patterns to adopt?
 - What pitfalls have others encountered?

--- a/.claude/skills/chart-course/SKILL.md
+++ b/.claude/skills/chart-course/SKILL.md
@@ -59,7 +59,7 @@ incorporate the issue content as additional strategic context.
 - Proceed past a checkpoint without user response
 
 **ALWAYS:**
-- Use `model: "sonnet"` for all Task tool subagent calls
+- Spawn all subagents via `Agent(model="sonnet")`
 - Initialize code-index via `set_project_path` before exploration (Phase 1)
 - Ask the user before moving to the next phase
 - Generate at least one diagram per direction explored
@@ -202,7 +202,7 @@ From the user's description, extract:
 
 For each direction, launch targeted analysis:
 
-**Subagent: Codebase Fit Analysis** (`model: "sonnet"`)
+**Subagent: Codebase Fit Analysis** via `Agent(model="sonnet")`
 - Where in the architecture would this connect?
 - What existing protocols, abstractions, or extension points support it?
 - What would need to change to accommodate it?

--- a/.claude/skills/check-bearing/SKILL.md
+++ b/.claude/skills/check-bearing/SKILL.md
@@ -71,7 +71,7 @@ hooks:
   direction X" — most changes are genuinely NEUTRAL to most directions
 
 **ALWAYS:**
-- Use `model: "sonnet"` for all Task tool subagent calls
+- Spawn all subagents via `Agent(model="sonnet")`
 - Initialize code-index via `set_project_path` before exploration (Step 0.5)
 - Parse the `---compass-data---` block before launching any analysis subagents
 - Provide specific file-level evidence for every non-NEUTRAL assessment

--- a/.claude/skills/promote-to-main/SKILL.md
+++ b/.claude/skills/promote-to-main/SKILL.md
@@ -126,7 +126,7 @@ EOF
 
 ### Phase 1: Pre-flight Checks (parallel, blocking)
 
-Spawn three parallel Task subagents (model: sonnet) to validate promotion readiness.
+Spawn three parallel subagents via `Agent(model="sonnet")` to validate promotion readiness.
 All three must pass before analysis proceeds. If any fails, report the failure clearly
 and exit 1. Do NOT create a PR when pre-flight fails.
 #### Subagent 1A: CI and Branch Status
@@ -191,7 +191,7 @@ treat as a warning (non-blocking) and note it in the report.
 
 ### Phase 2: Change Inventory (parallel subagents)
 
-Spawn four parallel Task subagents (model: sonnet).
+Spawn four parallel subagents via `Agent(model="sonnet")`.
 
 #### Subagent 2A: Commit Categorization
 
@@ -312,7 +312,7 @@ Return JSON:
 
 #### Step 3.1: Select Arch-Lens Lenses
 
-Spawn a Task subagent (model: sonnet) with the `changed_files` list and this lens menu:
+Spawn a subagent via `Agent(model="sonnet")` with the `changed_files` list and this lens menu:
 
 ```
 c4-container, concurrency, data-lineage, deployment, development,
@@ -381,7 +381,7 @@ new/modified nodes, add to `validated_diagrams`. Otherwise discard.
 
 #### Step 4.1: Release Notes Synthesis
 
-Spawn one Task subagent (model: sonnet) with results from Phase 2 ONLY (no domain
+Spawn one subagent via `Agent(model="sonnet")` with results from Phase 2 ONLY (no domain
 analysis or quality assessment data).
 The subagent receives:
 - Commit categorization from Subagent 2A

--- a/.claude/skills/review-promotion/SKILL.md
+++ b/.claude/skills/review-promotion/SKILL.md
@@ -137,7 +137,7 @@ Store as `domain_pr_numbers`.
 
 #### Step 1.5: Parallel Domain Analysis Subagents
 
-For each domain `D` in `domain_diffs`, spawn a Task subagent (model: sonnet) in a
+For each domain `D` in `domain_diffs`, spawn a subagent via `Agent(model="sonnet")` in a
 single parallel message.
 
 Each subagent receives:
@@ -164,7 +164,7 @@ Each subagent returns ONLY a JSON object:
 
 #### Step 1.6: Cross-Domain Dependency Analysis
 
-Spawn one Task subagent (model: sonnet) with ALL domain summaries from Step 1.5.
+Spawn one subagent via `Agent(model="sonnet")` with ALL domain summaries from Step 1.5.
 
 Analyze cross-domain dependencies:
 - Do recipe schema changes require corresponding server tool updates?
@@ -183,7 +183,7 @@ Return JSON:
 
 ### Phase 2: Quality Assessment (parallel subagents)
 
-Spawn three parallel Task subagents (model: sonnet).
+Spawn three parallel subagents via `Agent(model="sonnet")`.
 
 #### Subagent 2A: Test Coverage Delta
 
@@ -265,7 +265,7 @@ Return JSON:
 
 ### Phase 3: Review Summary Synthesis
 
-Spawn one Task subagent (model: sonnet) with ALL results from Phases 1–2.
+Spawn one subagent via `Agent(model="sonnet")` with ALL results from Phases 1–2.
 
 The subagent synthesizes a reviewer-focused verdict based on:
 - Domain risk scores from Phase 1

--- a/.claude/skills/validate-audit/SKILL.md
+++ b/.claude/skills/validate-audit/SKILL.md
@@ -47,7 +47,7 @@ signal downstream processing.
 - Do NOT include VALID BUT EXCEPTION WARRANTED findings in the validated report body — they belong in the validation summary only
 
 **ALWAYS:**
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Issue all Task calls in a single message to maximize parallelism
 - Write `validated: true` as the **first line** of the validated report file
 - Respect interactive vs headless mode for the approval step (Step 6)

--- a/src/autoskillit/skills_extended/analyze-prs/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-prs/SKILL.md
@@ -35,7 +35,7 @@ complexity, and produce machine-readable output for the `merge-prs` recipe.
 
 **ALWAYS:**
 - Use subagents to fetch PR data in parallel
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Abort clearly if `gh` CLI is not authenticated
 - Include every open PR targeting base_branch in the output — no PR is silently dropped (blocked PRs appear in ci_blocked_prs / review_blocked_prs arrays, not in the ordered prs list)
 - **Default to parallel batch processing**: When multiple PRs are present, ALWAYS process

--- a/src/autoskillit/skills_extended/audit-claims/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-claims/SKILL.md
@@ -118,7 +118,7 @@ Do not output any prose between subagent dispatches. Immediately proceed to the 
 Divide the diff by top-level markdown section: `## Executive Summary`, `## Results`,
 `## Methodology`, `## Discussion`, `## Limitations`, and any other top-level `##` section.
 
-Launch one Task tool subagent (`model: "sonnet"`) per section containing `+` diff lines.
+Launch one subagent via `Agent(model="sonnet")` per section containing `+` diff lines.
 Each subagent returns a JSON array of extracted claims:
 
 ```json
@@ -165,7 +165,7 @@ Aggregate all extracted claims from all subagents. Save to
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-Group extracted claims by `claim_type`. Launch one Task tool subagent (`model: "sonnet"`)
+Group extracted claims by `claim_type`. Launch one subagent via `Agent(model="sonnet")`
 per non-empty group. Each subagent receives the claim list and the full PR diff, and
 returns findings:
 

--- a/src/autoskillit/skills_extended/audit-claims/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-claims/SKILL.md
@@ -56,7 +56,7 @@ comments and emits a verdict for recipe routing.
 - Output `verdict=` on the final line
 - Exit 0 in all normal cases; verdict drives recipe routing via on_result, not exit code
 - Exit non-zero only for unrecoverable errors (e.g., gh CLI truly unavailable after graceful degradation)
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Deduplicate findings by (file, line) pairs before posting
 - Issue all Task calls in a single message to maximize parallelism
 

--- a/src/autoskillit/skills_extended/audit-impl/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-impl/SKILL.md
@@ -58,7 +58,7 @@ requirements, scope creep, and unexpected changes. Produces a GO or NO GO verdic
 **ALWAYS:**
 - Use Explore subagents for file reads and diff retrieval in Steps 1, 2, and 2.5
 - Use `Agent(subagent_type="autoskillit:audit-impl-slice-auditor")` for Step 3 audit slices
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Resolve all plan files before starting (abort early if any are missing)
 - Write `Dry-walkthrough verified = TRUE` as the absolute first line of any remediation file
 - Issue all Task calls in a single message to maximize parallelism

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -183,7 +183,7 @@ Do not output any prose between subagent dispatches. Immediately proceed to the 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 1. Group candidates into batches of ~10. Launch **parallel Sonnet subagents**
-   (`model: "sonnet"`) per batch.
+   via `Agent(model="sonnet")` per batch.
 
 2. Each Sonnet agent receives its candidate batch and, for each candidate:
    - If `path` is set: reads the file and surrounding context.

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -51,7 +51,7 @@ Space-separated issue numbers (required, minimum 2), plus optional flags:
 
 **ALWAYS:**
 - Use parallel subagents (up to 8) for issue fetching in Step 1
-- Use `model: "sonnet"` for all subagents
+- Spawn all subagents via `Agent(model="sonnet")`
 - Write both JSON and markdown report outputs to `{{AUTOSKILLIT_TEMP}}/build-execution-map/`
 - Emit `execution_map` and `execution_map_report` tokens with absolute paths (use `$(pwd)` to resolve the working directory prefix)
 - Emit structured output tokens as the final lines of text output (plain text, no markdown decorators)

--- a/src/autoskillit/skills_extended/download-data/SKILL.md
+++ b/src/autoskillit/skills_extended/download-data/SKILL.md
@@ -57,7 +57,7 @@ immediately.
 - Execute `depends_on` before `acquisition` for the same entry
 - Verify each download using the entry's `verification` criteria
 - Write the download report before emitting the verdict token
-- Use `model: "sonnet"` for all subagents
+- Spawn all subagents via `Agent(model="sonnet")`
 
 ## Workflow
 

--- a/src/autoskillit/skills_extended/download-data/SKILL.md
+++ b/src/autoskillit/skills_extended/download-data/SKILL.md
@@ -48,6 +48,7 @@ immediately.
 - Write files outside `{{AUTOSKILLIT_TEMP}}/download-data/`
 - Fabricate or hallucinate download results — only report actual command output
 - Attribute a missing or partial file to a completed download
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Read the `data_manifest` frontmatter section of the experiment plan
@@ -58,6 +59,7 @@ immediately.
 - Verify each download using the entry's `verification` criteria
 - Write the download report before emitting the verdict token
 - Spawn all subagents via `Agent(model="sonnet")`
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 

--- a/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
+++ b/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
@@ -53,7 +53,7 @@ The plan file must remain a **clean, self-contained implementation instruction s
 
 **ALWAYS:**
 - Keep the plan as clean implementation instructions only (information/background helpful to implementation is okay)
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Report all findings to terminal output (your response text)
 - Fix issues by directly updating the plan content
 - Verify assumptions against actual codebase

--- a/src/autoskillit/skills_extended/enrich-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/enrich-issues/SKILL.md
@@ -102,7 +102,7 @@ If no candidates remain after filtering, emit the result block immediately and e
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-Process up to 8 candidates in parallel using subagents (`model: "sonnet"`).
+Process up to 8 candidates in parallel using subagents via `Agent(model="sonnet")`.
 For each candidate:
 
 #### 5a. Fetch Full Content

--- a/src/autoskillit/skills_extended/enrich-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/enrich-issues/SKILL.md
@@ -242,6 +242,6 @@ After processing all candidates, emit to stdout:
 **ALWAYS:**
 - Respect `--dry-run`: never call `gh issue edit` when this flag is set
 - Verify codebase claims before incorporating them into requirements
-- Use `model: "sonnet"` for per-issue analysis subagents
+- Spawn all subagents via `Agent(model="sonnet")`
 - Emit the `---enrich-issues-result---` block as the final output
 - Issue all Task calls in a single message to maximize parallelism

--- a/src/autoskillit/skills_extended/generate-report/SKILL.md
+++ b/src/autoskillit/skills_extended/generate-report/SKILL.md
@@ -82,7 +82,7 @@ In addition to the arguments above, this skill reads from the worktree:
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Write the report to `research/` in the worktree root
 - Include experiment scripts inline as fenced code blocks for reproducibility
 - Commit the report to the worktree before returning

--- a/src/autoskillit/skills_extended/implement-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-experiment/SKILL.md
@@ -126,7 +126,7 @@ branch_name = ${BRANCH_NAME}
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-Before implementing anything, launch subagents (model: "sonnet") to understand
+Before implementing anything, launch subagents via `Agent(model="sonnet")` to understand
 the codebase context needed for the experiment. The following are **minimum
 required** — launch as many additional subagents as needed.
 

--- a/src/autoskillit/skills_extended/implement-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-experiment/SKILL.md
@@ -59,7 +59,7 @@ tokens after the skill name for the first path-like token (starts with `/`,
 **ALWAYS:**
 - Create a new worktree from the current branch
 - Use subagents to deeply understand the codebase context BEFORE implementing
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Follow the implementation phases from the experiment plan
 - Put all experiment artifacts in one self-contained `research/` subfolder
 - Commit per phase with descriptive messages

--- a/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
@@ -48,7 +48,7 @@ The worktree is left intact for the orchestrator to test and merge separately.
 **ALWAYS:**
 - Create a new worktree from the current branch
 - Use subagents to deeply understand affected systems BEFORE implementing
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Implement one phase at a time
 - Commit per phase with descriptive messages
 - Leave the worktree intact when done

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -41,7 +41,7 @@ Implement a provided plan in an isolated git worktree branched from the current 
 **ALWAYS:**
 - Create a new worktree from the current branch
 - Use subagents to deeply understand affected systems BEFORE implementing
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Implement one phase at a time
 - Run the project's test suite after implementation
 - Rebase onto base branch before completion (ready for squash-and-merge)

--- a/src/autoskillit/skills_extended/investigate/SKILL.md
+++ b/src/autoskillit/skills_extended/investigate/SKILL.md
@@ -36,7 +36,7 @@ Deep analysis mode is activated when ANY of the following conditions are met:
 
 ### Model
 
-When deep analysis mode is active, all subagents spawned via the Task tool always use `model: "sonnet"`. The main skill session model is controlled by the recipe or user — typically `opus[1m]` for the main session in deep mode.
+When deep analysis mode is active, all subagents are spawned via `Agent(model="sonnet")`. The main skill session model is controlled by the recipe or user — typically `opus[1m]` for the main session in deep mode.
 
 ### When NOT Activated
 
@@ -82,7 +82,7 @@ tool **before** beginning any analysis. Use the returned `content` field as the 
 - Use subagents for parallel exploration
 - Issue all Task calls in a single message to maximize parallelism
 - Limit total subagent spawns to 9 across all batches (standard and deep mode). If the investigation requires more exploration vectors, consolidate related questions into fewer, broader subagent prompts rather than spawning additional agents.
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Write findings as a markdown report with unique name to `{{AUTOSKILLIT_TEMP}}/investigate/` directory (relative to the current working directory)
 - After writing the investigation report, emit the **absolute path** as a structured output
   token as your final output. Resolve the relative `{{AUTOSKILLIT_TEMP}}/investigate/...`
@@ -222,7 +222,7 @@ Cross-reference: if a commit message references the same error type, component n
 
 #### Part C: Conditional Analysis (only if history found)
 
-If Part A or Part B found matches, spawn a single subagent (using `model: "sonnet"` via the Task tool) to:
+If Part A or Part B found matches, spawn a single subagent via `Agent(model="sonnet")` to:
 
 - Read the prior fix diffs via `git show {commit_hash}`
 - Read any prior investigation report files discovered during log scanning
@@ -337,7 +337,7 @@ Parse the investigation target (same as Step 1). Then propose an adaptive batch 
 
 ### Step D2: Batch 1 — Broad Parallel Exploration
 
-Launch a minimum of 5 parallel subagents (model: "sonnet") covering:
+Launch a minimum of 5 parallel subagents via `Agent(model="sonnet")` covering:
 
 - **Code path tracing**: Trace execution paths through the primary affected components
 - **Log and history analysis**: Scan session logs and git history for prior occurrences
@@ -366,7 +366,7 @@ For each subsequent batch (Batch 2, Batch 3, ...):
 
 Fires when ANY finding across any batch is marked NEEDS-EVIDENCE.
 
-Spawn one adversarial subagent (model: "sonnet") whose role is to disconfirm the primary hypothesis:
+Spawn one adversarial subagent via `Agent(model="sonnet")` whose role is to disconfirm the primary hypothesis:
 
 - Provide the primary hypothesis and all supporting evidence collected so far
 - Task: find counterevidence — code paths, behaviors, or data that contradict the hypothesis
@@ -380,7 +380,7 @@ Spawn one adversarial subagent (model: "sonnet") whose role is to disconfirm the
 
 **Issue ALL blast radius subagent calls in a single message — one per candidate — so they execute in parallel. Do not iterate across multiple turns.**
 
-Spawn solution-space subagents to enumerate candidate fixes. For each candidate, spawn one blast radius subagent (model: "sonnet") to assess:
+Spawn solution-space subagents to enumerate candidate fixes. For each candidate, spawn one blast radius subagent via `Agent(model="sonnet")` to assess:
 
 - Which components would be affected by this fix
 - What tests would need to be added or modified
@@ -388,7 +388,7 @@ Spawn solution-space subagents to enumerate candidate fixes. For each candidate,
 
 After blast radius analysis, converge to a single recommendation — the highest-confidence, lowest-blast-radius candidate with direct code evidence. Kill alternative options and document why each was rejected.
 
-**Adversarial Breakage Analysis:** After converging to a single recommendation, assess whether it proposes removal, replacement, or any action whose execution would eliminate, reduce, or supersede the function of an existing mechanism. If so, spawn one adversarial breakage subagent (model: "sonnet") per such recommendation:
+**Adversarial Breakage Analysis:** After converging to a single recommendation, assess whether it proposes removal, replacement, or any action whose execution would eliminate, reduce, or supersede the function of an existing mechanism. If so, spawn one adversarial breakage subagent via `Agent(model="sonnet")` per such recommendation:
 
 1. Receive the recommendation and the mechanism it targets, along with the Design Intent findings for that mechanism
 2. Trace the mechanism's full dependency chain through code: callers, importers, flag consumers
@@ -401,7 +401,7 @@ If the recommendation does not propose removal or change of an existing mechanis
 
 ### Step D6: Post-Report Validation
 
-After writing the report (Step 4), spawn 2–3 independent validator subagents (model: "sonnet") with distinct roles:
+After writing the report (Step 4), spawn 2–3 independent validator subagents via `Agent(model="sonnet")` with distinct roles:
 
 - **Validator 1 — Factual accuracy**: Cross-check every claim in the report against actual code/evidence. Flag any factual inaccuracy.
 - **Validator 2 — Recommendation soundness**: Assess whether the single recommendation is implementable, safe, and correctly scoped.

--- a/src/autoskillit/skills_extended/make-groups/SKILL.md
+++ b/src/autoskillit/skills_extended/make-groups/SKILL.md
@@ -64,7 +64,7 @@ tool **before** beginning any analysis. Use the returned `content` field as the 
 
 **ALWAYS:**
 - Use subagents to verify codebase structure before finalizing groups
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Include every requirement from the source document in exactly one group
 - Assign each group a sequential suffix: groupA, groupB, ... groupZ
 - State dependencies between groups explicitly

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -314,7 +314,7 @@ Before writing the final plan, verify:
   plan_parts = /absolute/cwd/{{AUTOSKILLIT_TEMP}}/make-plan/{filename}.md
   ```
   This token is MANDATORY — the pipeline cannot capture the output without it.
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Recommend the single best technical solution
 - Ground decisions in design quality and correctness
 - Include verification steps

--- a/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
@@ -192,7 +192,7 @@ Empty results are stored as empty lists.
 
 ### Step 4g: Run Parallel Domain Analysis Subagents
 
-For each domain `D` in `domain_diffs`, spawn a Task subagent (model: sonnet) in a single
+For each domain `D` in `domain_diffs`, spawn a subagent via `Agent(model="sonnet")` in a single
 parallel message. **Issue all Task calls in a single message** to maximize parallelism.
 **Skip domains with no diff content** (not in `domain_diffs`) — do not spawn subagents for them.
 
@@ -224,7 +224,7 @@ The 7 canonical domain names are: **Server/MCP Tools**, **Pipeline/Execution**,
 
 ### Step 5: Select Arch-Lens Lenses
 
-Spawn a subagent (Task tool, model: sonnet) with `changed_files` and the same lens
+Spawn a subagent via `Agent(model="sonnet")` with `changed_files` and the same lens
 menu as `open-pr`. Instruct it to return 1–3 lens names using the same `development`
 lens guard.
 

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -112,7 +112,7 @@ Detect and read inputs:
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-Launch subagents (model: "sonnet") to assess feasibility. The following are
+Launch subagents via `Agent(model="sonnet")` to assess feasibility. The following are
 **minimum required** — launch as many additional subagents as needed to fill
 information gaps and produce the best possible experiment plan.
 

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -68,7 +68,7 @@ incorporate the feedback before writing the plan.
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Write output to `{{AUTOSKILLIT_TEMP}}/plan-experiment/` directory
 - State hypotheses as falsifiable claims with measurable outcomes
 - Define metrics before describing the method

--- a/src/autoskillit/skills_extended/plan-visualization/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-visualization/SKILL.md
@@ -41,7 +41,7 @@ outputs, and synthesizes a complete visualization plan.
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Write a vis-lens context file for each selected lens before invoking it
 - Log every conflict resolution decision in the Conflict Resolution Log table
 - Emit `visualization_plan_path` and `report_plan_path` tokens as your final output

--- a/src/autoskillit/skills_extended/planner-assess-review-approach/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-assess-review-approach/SKILL.md
@@ -67,7 +67,7 @@ established conventions. This context informs whether a WP is "following establi
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-Spawn 1–2 subagents (model: "sonnet") to evaluate WPs in parallel batches. For each WP,
+Spawn 1–2 subagents via `Agent(model="sonnet")` to evaluate WPs in parallel batches. For each WP,
 evaluate against these signals:
 
 **Benefit signals (recommend: true):**

--- a/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
@@ -60,7 +60,7 @@ Read `refined_wps.json` from $1 and `refined_plan.json` from $2. Extract:
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-Spawn 1-2 subagents (model: "sonnet"):
+Spawn 1-2 subagents via `Agent(model="sonnet")`:
 
 **Subagent A — Phase alignment:**
 Provide the task description and all phase goals/scopes. Ask: "For each phase, does its

--- a/src/autoskillit/skills_extended/prepare-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-pr/SKILL.md
@@ -95,7 +95,7 @@ Read all plan files and extract the first `# ` heading line from each, strip the
 and strip any trailing `— PART [A-Z] ONLY` suffix.
 
 - **Single plan:** Use the heading directly as `task_title`.
-- **Multiple plans:** Spawn a subagent (Task tool, model: sonnet) with all extracted
+- **Multiple plans:** Spawn a subagent via `Agent(model="sonnet")` with all extracted
   headings. Instruct it to synthesize a single concise PR title (under 70 characters).
 
 **PR Title Prefix (derived from run_name):**
@@ -133,7 +133,7 @@ Store as separate lists: `new_files` (added, ★) and `modified_files` (modified
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-Spawn a subagent (Task tool, model: sonnet) with the list of changed file paths and the
+Spawn a subagent via `Agent(model="sonnet")` with the list of changed file paths and the
 following lens menu:
 
 ```

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -57,7 +57,7 @@ issues upfront, load recipe, execute session, collect result, report.
   transitions are fully automated.
 - Emit `---process-issues-result---` result block on completion (success or failure)
 - Write the summary report to `{{AUTOSKILLIT_TEMP}}/process-issues/` (relative to the current working directory)
-- Use `model: "sonnet"` when spawning subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Issue all Task calls in a single message to maximize parallelism
 - Use `gh` CLI for all GitHub operations (not raw API calls)
 - Include `--force` in all `gh label create` calls

--- a/src/autoskillit/skills_extended/promote-to-main/SKILL.md
+++ b/src/autoskillit/skills_extended/promote-to-main/SKILL.md
@@ -170,7 +170,7 @@ EOF
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-Spawn three parallel Task subagents (model: sonnet) to validate promotion readiness.
+Spawn three parallel subagents via `Agent(model="sonnet")` to validate promotion readiness.
 All three must pass before analysis proceeds. If any fails, report the failure clearly
 and exit 1. Do NOT create a PR when pre-flight fails.
 
@@ -236,7 +236,7 @@ treat as a warning (non-blocking) and note it in the report.
 
 ### Phase 2: Change Inventory (parallel subagents)
 
-Spawn four parallel Task subagents (model: sonnet).
+Spawn four parallel subagents via `Agent(model="sonnet")`.
 
 #### Subagent 2A: Commit Categorization
 
@@ -360,7 +360,7 @@ Using ONLY classDef styles from the mermaid skill (no invented colors).
 
 #### Step 3.1: Select Arch-Lens Lenses
 
-Spawn a Task subagent (model: sonnet) with the `changed_files` list and this lens menu:
+Spawn a subagent via `Agent(model="sonnet")` with the `changed_files` list and this lens menu:
 
 ```
 c4-container, concurrency, data-lineage, deployment, development,
@@ -429,7 +429,7 @@ new/modified nodes, add to `validated_diagrams`. Otherwise discard.
 
 #### Step 4.1: Release Notes Synthesis
 
-Spawn one Task subagent (model: sonnet) with results from Phase 2 ONLY (no domain
+Spawn one subagent via `Agent(model="sonnet")` with results from Phase 2 ONLY (no domain
 analysis or quality assessment data).
 
 The subagent receives:

--- a/src/autoskillit/skills_extended/rectify/SKILL.md
+++ b/src/autoskillit/skills_extended/rectify/SKILL.md
@@ -45,7 +45,7 @@ Do not change any code.
 
 **ALWAYS:**
 - Use subagents for parallel exploration
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Focus on architectural immunity over direct fixes
 - Identify how tests missed the issue and similar/related bugs
 - Map the components and their connections thoroughly

--- a/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
@@ -216,7 +216,7 @@ codebase and git history. This analysis phase runs entirely before code changes 
 (`citations`, `methodology`, `comparisons`, `unknown`).
 This is dimension-based grouping, NOT file-path grouping.
 
-Launch one parallel subagent (Task tool, `model: "sonnet"`) per non-empty dimension
+Launch one parallel subagent via `Agent(model="sonnet")` per non-empty dimension
 group. Each subagent receives:
 - Its list of findings (path, line, body, diff_hunk, dimension)
 - Instructions to read the actual content at each flagged line (±30 lines context)

--- a/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
@@ -84,7 +84,7 @@ Do not output any prose between subagent dispatches. Immediately proceed to the 
 
 This is the analysis phase. It runs entirely before any guidance is generated.
 
-Group findings; launch one parallel Task subagent per finding (model: "sonnet").
+Group findings; launch one parallel subagent per finding via `Agent(model="sonnet")`.
 Each subagent receives: finding metadata + full plan text.
 Each subagent classifies the finding as:
 
@@ -123,7 +123,7 @@ A finding is **goalposts-moving** when:
 - The pattern is: the plan improved to satisfy the prior concern, but the reviewer
   raised the bar on the same theme
 
-Detection heuristic — launch one subagent (model: "sonnet") per ADDRESSABLE finding.
+Detection heuristic — launch one subagent via `Agent(model="sonnet")` per ADDRESSABLE finding.
 Each subagent receives: current finding + all prior guidance entries. It returns:
 
 ```json

--- a/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
@@ -197,7 +197,7 @@ codebase and git history. This analysis phase runs entirely before code changes 
 (`statistical`, `methodology`, `reproducibility`, `reporting`, `hygiene`, `unknown`).
 This is dimension-based grouping, NOT file-path grouping.
 
-Launch one parallel subagent (Task tool, `model: "sonnet"`) per non-empty dimension
+Launch one parallel subagent via `Agent(model="sonnet")` per non-empty dimension
 group. Each subagent receives:
 - Its list of findings (path, line, body, diff_hunk, dimension)
 - Instructions to read the actual code at each flagged line (±30 lines context)

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -368,8 +368,8 @@ source files if a comment explicitly references code outside the hunk or the
 `diff_hunk` is missing. The classification criteria and output format are
 identical to the sub-agent path.
 
-This produces 3–6 groups on a typical PR. Launch one parallel sub-agent per group using
-the Task tool (`model: "sonnet"`).
+This produces 3–6 groups on a typical PR. Launch one parallel sub-agent per group via
+`Agent(model="sonnet")`.
 
 **Context resolution hierarchy** (applied per finding):
 1. **`diff_context_map` code_region** — richest context (±50 annotated diff lines); used when review-pr ran in the same pipeline and wrote the handoff file.

--- a/src/autoskillit/skills_extended/retry-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/retry-worktree/SKILL.md
@@ -49,7 +49,7 @@ Continue implementing a plan in an **existing** git worktree. This skill is used
 
 **ALWAYS:**
 - Use the provided worktree path (do NOT create a new one)
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Start by assessing what has already been implemented
 - Continue from where the previous session left off
 - Run the project's test suite from the worktree directory

--- a/src/autoskillit/skills_extended/review-approach/SKILL.md
+++ b/src/autoskillit/skills_extended/review-approach/SKILL.md
@@ -33,7 +33,7 @@ Research modern solutions, approaches, and strategies relevant to the issues or 
 
 **ALWAYS:**
 - Use subagents with web search for parallel research
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Keep findings concise and actionable
 - Present options with trade-offs
 - Make recommendations based on technical merit and project fit

--- a/src/autoskillit/skills_extended/review-design/SKILL.md
+++ b/src/autoskillit/skills_extended/review-design/SKILL.md
@@ -53,7 +53,7 @@ best available plan.
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Issue all Task calls in a single message to maximize parallelism
 - Write output to `{{AUTOSKILLIT_TEMP}}/review-design/` (relative to the current working directory)
 - After writing output files, emit the **absolute paths** as structured output tokens

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -309,7 +309,7 @@ in parallel. Do NOT iterate through dimensions across multiple turns.**
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-Each subagent (model: sonnet) receives only the PR diff content (not the full codebase) and
+Each subagent via `Agent(model="sonnet")` receives only the PR diff content (not the full codebase) and
 returns findings in JSON format:
 
 ```json

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -55,7 +55,7 @@ by the recipe pipeline after `open_pr_step` opens the PR.
 - Exit 0 in all normal cases; verdict drives recipe routing via on_result, not exit code
 - Exit non-zero only for unrecoverable errors (e.g., gh CLI truly unavailable after graceful degradation has already output verdict=approved)
 - Tag the authenticated GitHub user (`gh api user -q .login`) in escalation comments (`needs_human` verdict) — omit the mention silently if username derivation fails
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Deduplicate findings by (file, line) pairs before posting
 - Issue all Task calls in a single message to maximize parallelism
 

--- a/src/autoskillit/skills_extended/review-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-research-pr/SKILL.md
@@ -55,7 +55,7 @@ a summary verdict. Called by the recipe pipeline after `open_research_pr` opens 
 - Exit 0 in all normal cases; verdict drives recipe routing via on_result, not exit code
 - Exit non-zero only for unrecoverable errors (e.g., gh CLI truly unavailable after graceful degradation has already output verdict=approved)
 - Tag the authenticated GitHub user (`gh api user -q .login`) in escalation comments (`needs_human` verdict) — omit the mention silently if username derivation fails
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Deduplicate findings by (file, line) pairs before posting
 
 ## Workflow

--- a/src/autoskillit/skills_extended/review-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-research-pr/SKILL.md
@@ -134,7 +134,7 @@ validation. `VALID_LINE_RANGES` is used as fallback for interval checking.
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-Spawn parallel subagents (Task tool, model: sonnet) for each research audit dimension.
+Spawn parallel subagents via `Agent(model="sonnet")` for each research audit dimension.
 Each subagent receives only the PR diff content (not the full codebase) and returns
 findings in JSON format:
 

--- a/src/autoskillit/skills_extended/run-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/run-experiment/SKILL.md
@@ -98,7 +98,7 @@ Before running the experiment:
 3. If `--adjust` flag is set, read previous results from
    `{{AUTOSKILLIT_TEMP}}/run-experiment/` and identify what went wrong.
 
-Launch subagents (model: "sonnet") if needed to investigate the experiment
+Launch subagents via `Agent(model="sonnet")` if needed to investigate the experiment
 setup, resolve dependencies, or research how to use specific tools mentioned
 in the plan.
 

--- a/src/autoskillit/skills_extended/run-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/run-experiment/SKILL.md
@@ -55,7 +55,7 @@ plan, executes what the plan describes, and reports what happened.
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Write results to `{{AUTOSKILLIT_TEMP}}/run-experiment/` in the worktree (disk only, never committed)
 - Report failures with enough detail for the `--adjust` retry to fix them
 - Issue all Task calls in a single message to maximize parallelism

--- a/src/autoskillit/skills_extended/scope/SKILL.md
+++ b/src/autoskillit/skills_extended/scope/SKILL.md
@@ -73,7 +73,7 @@ text is supplementary context.
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-Launch subagents via the Task tool (model: "sonnet") to explore in parallel.
+Launch subagents via `Agent(model="sonnet")` to explore in parallel.
 You **must launch at least 5 subagents**. Select from the suggested menu below,
 define entirely custom subagents, or use any combination. The menu is a guide,
 not a mandate — you are free to skip entries that are not relevant and substitute

--- a/src/autoskillit/skills_extended/scope/SKILL.md
+++ b/src/autoskillit/skills_extended/scope/SKILL.md
@@ -53,7 +53,7 @@ text is supplementary context.
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Write output to `{{AUTOSKILLIT_TEMP}}/scope/` directory
 - Clearly separate facts (what the code does) from hypotheses (what might be true)
 - Include a known/unknown matrix in the output

--- a/src/autoskillit/skills_extended/select-vis-lenses/SKILL.md
+++ b/src/autoskillit/skills_extended/select-vis-lenses/SKILL.md
@@ -43,7 +43,7 @@ consumption. Does NOT invoke the vis-lens skills — that is handled by the
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Write a vis-lens context file for each selected lens before emitting tokens
 - Issue all Task calls in a single message to maximize parallelism
 

--- a/src/autoskillit/skills_extended/setup-environment/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-environment/SKILL.md
@@ -47,7 +47,7 @@ PASS and WARN proceed to `decompose_phases`; FAIL escalates immediately.
 - Parse `environment.type` from the experiment plan first
 - Try Docker before falling back to micromamba
 - Write the environment setup report before emitting the verdict token
-- Use `model: "sonnet"` for all subagents
+- Spawn all subagents via `Agent(model="sonnet")`
 
 ## Workflow
 

--- a/src/autoskillit/skills_extended/setup-environment/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-environment/SKILL.md
@@ -42,12 +42,14 @@ PASS and WARN proceed to `decompose_phases`; FAIL escalates immediately.
 - Write files outside `{{AUTOSKILLIT_TEMP}}/setup-environment/`
 - Skip the Docker availability probe before attempting a build
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
 - Parse `environment.type` from the experiment plan first
 - Try Docker before falling back to micromamba
 - Write the environment setup report before emitting the verdict token
 - Spawn all subagents via `Agent(model="sonnet")`
+- Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
 

--- a/src/autoskillit/skills_extended/setup-project/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-project/SKILL.md
@@ -47,7 +47,7 @@ Explore a target project and generate tailored recipes and AutoSkillit config th
 
 **ALWAYS:**
 - Read the target project using Glob, Read, and Grep — no shell commands against target
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Detect language, test framework, build system, and CI from actual files
 - Present candidate workflows one by one for user approval before generating scripts
 - Show a summary confirmation gate before writing anything to disk

--- a/src/autoskillit/skills_extended/stage-data/SKILL.md
+++ b/src/autoskillit/skills_extended/stage-data/SKILL.md
@@ -59,7 +59,7 @@ compute on doomed downloads.
 - Create data directories for every entry whose `location` field is non-null,
   using `mkdir -p`
 - Write the resource feasibility report before emitting the verdict token
-- Use `model: "sonnet"` for all subagents
+- Spawn all subagents via `Agent(model="sonnet")`
 - Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow

--- a/src/autoskillit/skills_extended/triage-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/triage-issues/SKILL.md
@@ -40,7 +40,7 @@ Analyze open GitHub issues, classify each into a recipe route, group them into p
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
 **ALWAYS:**
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Issue all Task calls in a single message to maximize parallelism
 - Pause for human input on ambiguous classifications
 - Write the triage report and manifest to `{{AUTOSKILLIT_TEMP}}/triage-issues/` (relative to the current working directory)
@@ -133,7 +133,7 @@ Launch parallel subagents (up to 8) to analyze each issue. Each subagent receive
 - **File paths** — explicitly mentioned files or files inferred from the description
 - **Dependencies** — explicit issue references (`#N`) or inferred dependencies from content overlap
 
-Use `model: "sonnet"` for all subagents.
+Spawn all subagents via `Agent(model="sonnet")`.
 
 ### Step 3: Recipe Classification
 

--- a/src/autoskillit/skills_extended/triage-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/triage-issues/SKILL.md
@@ -89,7 +89,7 @@ Do not output any prose between subagent dispatches. Immediately proceed to the 
 
 Before codebase analysis, run `issue-splitter` for every open issue to detect mixed-concern issues and expand the working set.
 
-Launch up to 8 subagents in parallel (`model: "sonnet"`), one per issue. Each subagent invokes:
+Launch up to 8 subagents in parallel via `Agent(model="sonnet")`, one per issue. Each subagent invokes:
 
 ```
 /autoskillit:issue-splitter --issue {N} --repo {owner/repo} [--no-label if --no-label was passed] [--dry-run if --dry-run was passed]

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -60,7 +60,7 @@ validated report carries a `validated: true` marker to signal downstream process
 - Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Issue all Task calls in a single message to maximize parallelism
 - Write `validated: true` as the **first line** of the validated report file
 - Respect interactive vs headless mode for the approval step (Step 6)

--- a/src/autoskillit/skills_extended/validate-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-review-decisions/SKILL.md
@@ -58,7 +58,7 @@ severities. The validated report carries a `validated: true` marker to signal do
 - Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Issue all Task calls in a single message to maximize parallelism
 - Write `validated: true` as the **first line** of the validated report file
 - Respect interactive vs headless mode for the approval step (Step 9)

--- a/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
@@ -53,7 +53,7 @@ signal downstream processing.
 - Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
-- Use `model: "sonnet"` when spawning all subagents via the Task tool
+- Spawn all subagents via `Agent(model="sonnet")`
 - Issue all Task calls in a single message to maximize parallelism
 - Write `validated: true` as the **first line** of the validated report file
 - Respect interactive vs headless mode for the approval step (Step 9)

--- a/tests/skills/CLAUDE.md
+++ b/tests/skills/CLAUDE.md
@@ -65,6 +65,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 | `test_skill_body_cleanliness.py` | Assert that no SKILL.md body references %%ORDER_UP%% |
 | `test_skill_compliance.py` | SKILL.md compliance tests: structural invariants for skill composition safety |
 | `test_skill_genericization.py` | Verify skill SKILL.md files contain no project-specific AutoSkillit internals |
+| `test_skill_md_spawn_syntax.py` | Regression guard: SKILL.md subagent spawn instructions must use unambiguous Agent(model="sonnet") syntax (issue #3367) |
 | `test_skill_output_compliance.py` | Tests that all SKILL.md output path instructions use HHMMSS-precision timestamps |
 | `test_skill_placeholder_contracts.py` | Validate that no SKILL.md bash code block uses an undefined {placeholder} token |
 | `test_skill_preambles.py` | Tests that critical SKILL.md preamble patterns are present (FRICT-1B-1, FRICT-1C-2) |

--- a/tests/skills/test_investigate_deep_mode_contracts.py
+++ b/tests/skills/test_investigate_deep_mode_contracts.py
@@ -68,9 +68,9 @@ def test_deep_mode_not_default(deep_mode_section: str) -> None:
 
 
 def test_deep_mode_subagents_use_sonnet(deep_mode_section: str) -> None:
-    """Deep mode section must specify that subagents use model: sonnet."""
-    assert 'model: "sonnet"' in deep_mode_section, (
-        "Deep Analysis Mode section must specify 'model: \"sonnet\"' for all subagents"
+    """Deep mode section must specify that subagents use Agent(model="sonnet")."""
+    assert 'Agent(model="sonnet")' in deep_mode_section, (
+        "Deep Analysis Mode section must specify 'Agent(model=\"sonnet\")' for all subagents"
     )
 
 

--- a/tests/skills/test_open_integration_pr_domain_analysis.py
+++ b/tests/skills/test_open_integration_pr_domain_analysis.py
@@ -42,8 +42,7 @@ def test_skill_defines_step_4g_parallel_subagents(skill_text: str) -> None:
 
 
 def test_skill_spawns_parallel_subagents_for_domains(skill_text: str) -> None:
-    assert "Task tool" in skill_text
-    assert "model: sonnet" in skill_text
+    assert 'Agent(model="sonnet")' in skill_text
 
 
 def test_skill_has_at_least_seven_domain_names(skill_text: str) -> None:

--- a/tests/skills/test_skill_md_spawn_syntax.py
+++ b/tests/skills/test_skill_md_spawn_syntax.py
@@ -1,0 +1,51 @@
+"""Regression guard: SKILL.md subagent spawn instructions must use unambiguous syntax."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_AMBIGUOUS_PATTERNS = [
+    # "(Task tool, model: ..." or "(Task tool, `model:" parenthetical
+    re.compile(r"\(\s*Task\s+tool\s*,\s*`?model:"),
+    # "Task subagent(s) (" — wrong tool name as subagent label
+    re.compile(r"\bTask\s+subagents?\s*\("),
+    # Standalone "(model: sonnet)" or '(model: "sonnet")' or '(`model: "sonnet"`)' —
+    # no Agent context
+    re.compile(r'\(\s*`?model:\s*"?sonnet"?\s*`?\s*\)'),
+    # "Task tool subagent" phrasing
+    re.compile(r"\bTask\s+tool\s+subagent"),
+]
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SKILL_DIRS = [
+    _REPO_ROOT / "src" / "autoskillit" / "skills",
+    _REPO_ROOT / "src" / "autoskillit" / "skills_extended",
+    _REPO_ROOT / ".claude" / "skills",
+]
+
+
+def _collect_violations() -> list[str]:
+    violations: list[str] = []
+    for d in _SKILL_DIRS:
+        if not d.exists():
+            continue
+        for md in sorted(d.rglob("SKILL.md")):
+            for i, line in enumerate(md.read_text().splitlines(), 1):
+                for pat in _AMBIGUOUS_PATTERNS:
+                    if pat.search(line):
+                        rel = md.relative_to(_REPO_ROOT)
+                        violations.append(f"  {rel}:{i}: {line.strip()}")
+                        break
+    return violations
+
+
+def test_no_ambiguous_spawn_model_parameter() -> None:
+    """SKILL.md files must not use ambiguous (Task tool, model: sonnet) patterns.
+
+    See: https://github.com/TalonT-Org/AutoSkillit/issues/3367
+    """
+    violations = _collect_violations()
+    assert not violations, "Ambiguous subagent spawn patterns found (issue #3367):\n" + "\n".join(
+        violations
+    )

--- a/tests/skills/test_skill_md_spawn_syntax.py
+++ b/tests/skills/test_skill_md_spawn_syntax.py
@@ -15,6 +15,8 @@ _AMBIGUOUS_PATTERNS = [
     re.compile(r'\(\s*`?model:\s*"?sonnet"?\s*`?\s*\)'),
     # "Task tool subagent" phrasing
     re.compile(r"\bTask\s+tool\s+subagent"),
+    # "Use `model: "sonnet"`" directive — old ALWAYS-block phrasing
+    re.compile(r'Use\s+`model:\s*"sonnet"'),
 ]
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent


### PR DESCRIPTION
## Summary

Update ~45 ambiguous subagent spawn instruction lines across 24 SKILL.md files to use unambiguous `Agent(model="sonnet")` Python-call syntax. This eliminates the `(Task tool, model: sonnet)` prose pattern that MiniMax-M2.7-highspeed misinterpreted as `subagent_type="sonnet"`, wasting one API round-trip. Adds a regression test to prevent reintroduction. Documents REQ-SPW-2 audit findings (additional ambiguous patterns in ~55+ files) for follow-up.

**Root cause:** The Claude Code `Agent` tool has separate `subagent_type` and `model` parameters. SKILL.md files used prose like `(Task tool, model: sonnet)` that conflates them — non-Anthropic providers interpret "sonnet" as the agent type rather than the model.

**Target syntax:** Replace all ambiguous patterns with backtick-wrapped Python-call form `Agent(model="sonnet")` — matching the established Form A convention already used by `audit-impl/SKILL.md`, `make-plan/SKILL.md`, and `rectify/SKILL.md` for their `Agent(subagent_type=...)` calls.

## Requirements

### Problem

SKILL.md files use an ambiguous prose pattern for subagent spawn instructions — `(Task tool, model: sonnet)` — that Anthropic models interpret correctly but MiniMax-M2.7-highspeed misreads as `subagent_type="sonnet"`, causing an immediate error followed by self-correction.

### Observed Failure

In the remediation pipeline run on 2026-05-30 (kitchen `7b421c49`, session `4b142a26`), the `prepare_pr` step (routed to MiniMax via `step_overrides`) hit this sequence:

1. **SKILL.md line 136** says: `Spawn a subagent (Task tool, model: sonnet)`
2. MiniMax called `Agent(subagent_type="sonnet")` — conflating `model:` with `subagent_type:`
3. Claude Code returned `Agent type 'sonnet' not found` (is_error: true)
4. MiniMax self-corrected on the next turn: `Agent(subagent_type="general-purpose", model="sonnet")`
5. The corrected subagent returned a misspelled slug `module-dependance` (caught and silently corrected by MiniMax's thinking block)

**Cost:** One wasted API round-trip (~5 seconds). No data loss or downstream impact — fully self-healed.

### Root Cause

The Claude Code `Agent` tool has two separate parameters:
- `subagent_type` — which agent type to spawn (e.g., `"general-purpose"`, `"Explore"`)
- `model` — which LLM model to use (e.g., `"sonnet"`, `"opus"`, `"haiku"`)

The phrasing `(Task tool, model: sonnet)` is ambiguous prose that can be parsed as either:
- "Use the Task/Agent tool, requesting the sonnet model" (intended)
- "Pass sonnet as the type/model parameter" (MiniMax interpretation)

### Scope of the Gap

The ambiguous pattern appears in **~20 spawn instruction lines across 10 SKILL.md files** — plus 12 additional files discovered during adversarial review.

### Historical Context

PR #1971 (2026-05-05) introduced MiniMax routing for `prepare_pr`, `compose_pr`, and `diagnose_ci`. It acknowledged MiniMax's "thoughtful disobedience" pattern and applied mitigations (directive descriptions, step renumbering) but did not audit spawn instruction phrasing. This is the first observed instance of the `subagent_type="sonnet"` misfire.

### MiniMax Routing Config

From `~/.autoskillit/config.yaml`:
```yaml
providers:
  step_overrides:
    compose_pr:  minimax
    diagnose_ci: minimax
    prepare_pr:  minimax
```

Any step in this list that contains the ambiguous phrasing and spawns subagents is at risk.

### Requirements

RE-1: Standardize spawn instruction syntax

Update all SKILL.md files that use the ambiguous `(Task tool, model: sonnet)` pattern to use the unambiguous form that explicitly separates `subagent_type` from `model`.

**Target phrasing:** `Spawn a subagent (Agent tool, subagent_type: "general-purpose", model: "sonnet")` — or equivalent unambiguous syntax that makes the parameter separation explicit.

**Scope:** ~20 lines across 10 files listed in the tables above.

RE-2: Verify no other ambiguous parameter patterns

Audit all SKILL.md files for other Agent tool parameter patterns that could confuse non-Anthropic providers — not just `model:` vs `subagent_type:`, but any parameter phrased as prose that a model could misparse as a tool parameter value (e.g., `"Explore"` used as a type name in prose without explicit `subagent_type:` annotation).

## Architecture Impact

### Operational Lens Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    subgraph SkillLayer ["SKILL.MD INSTRUCTION LAYER"]
        direction TB
        SKILL["● SKILL.md Files<br/>━━━━━━━━━━<br/>20 src/ + 4 .claude/<br/>Spawn instructions"]
        SPAWN["● Spawn Instructions<br/>━━━━━━━━━━<br/>Parenthetical params<br/>e.g. (Task tool, model: sonnet)"]
    end

    subgraph Interpretation ["MODEL INTERPRETATION"]
        direction TB
        CLAUDE["Anthropic Models<br/>━━━━━━━━━━<br/>Correct parse:<br/>model='sonnet'"]
        MINIMAX["Non-Anthropic Models<br/>━━━━━━━━━━<br/>Misparse:<br/>subagent_type='sonnet'"]
    end

    subgraph Fix ["★ STANDARDIZED SYNTAX"]
        direction TB
        NEWFORM["★ Agent&#40;model=sonnet&#41;<br/>━━━━━━━━━━<br/>Python-call syntax<br/>Explicit named param"]
        REGTEST["★ Regression Test<br/>━━━━━━━━━━<br/>test_skill_md_spawn_syntax<br/>4-pattern scanner"]
    end

    subgraph Execution ["AGENT TOOL EXECUTION"]
        direction TB
        AGENT["Agent Tool<br/>━━━━━━━━━━<br/>subagent_type: general-purpose<br/>model: sonnet"]
    end

    SKILL --> SPAWN
    SPAWN -->|"ambiguous"| CLAUDE
    SPAWN -->|"ambiguous"| MINIMAX
    CLAUDE -->|"correct"| AGENT
    MINIMAX -->|"subagent_type=sonnet ERROR"| AGENT
    NEWFORM -->|"unambiguous"| AGENT
    REGTEST -->|"prevents regression"| SKILL

    class SKILL,SPAWN phase;
    class CLAUDE stateNode;
    class MINIMAX gap;
    class NEWFORM,REGTEST newComponent;
    class AGENT handler;
```

**Color Legend:**

| Color | Category | Description |
|-------|----------|-------------|
| Purple | Config | SKILL.md instruction files (modified) |
| Teal | State | Correct model interpretation path |
| Orange/Yellow | Gap | Incorrect model interpretation path |
| Green | New | Standardized syntax and regression test |
| Orange | Handler | Agent tool execution layer |

**Lens Used:** Operational — the changes affect how SKILL.md operational instructions are parsed and dispatched by models invoking the Agent tool.

Closes #3367

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/standardize_skill_md_spawn_syntax_plan_2026-05-30_195500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 83 | 51.3k | 1.2M | 130.4k | 260 | 156.2k | 25m 28s |
| review_approach* | opus | 1 | 2.9k | 5.2k | 341.4k | 45.5k | 44 | 29.2k | 3m 11s |
| verify* | opus | 1 | 57 | 13.0k | 1.2M | 68.6k | 125 | 52.4k | 6m 5s |
| implement* | opus | 1 | 133.5k | 10.3k | 1.2M | 19.3k | 176 | 0 | 4m 54s |
| audit_impl* | opus | 1 | 1.8k | 15.9k | 261.0k | 50.1k | 92 | 48.7k | 6m 16s |
| prepare_pr* | opus | 1 | 57.0k | 4.5k | 194.4k | 0 | 16 | 0 | 1m 18s |
| compose_pr* | opus | 1 | 49.8k | 4.8k | 369.4k | 0 | 28 | 0 | 58s |
| review_pr* | opus | 1 | 55 | 30.2k | 1.0M | 97.9k | 84 | 136.5k | 11m 25s |
| resolve_review* | opus | 1 | 87 | 22.3k | 3.8M | 93.9k | 164 | 80.3k | 26m 56s |
| **Total** | | | 245.3k | 157.3k | 9.5M | 130.4k | | 503.3k | 1h 26m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 144 | 8203.8 | 0.0 | 71.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 80 | 46947.6 | 1003.7 | 278.7 |
| **Total** | **224** | 42405.4 | 2246.9 | 702.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 83 | 51.3k | 1.2M | 156.2k | 25m 28s |
| opus | 8 | 245.2k | 106.1k | 8.3M | 347.1k | 1h 1m |