### PR TITLE
Rectify: Channel B Resume-Boundary False-Fire

### DIFF
--- a/src/autoskillit/execution/process/_process_monitor.py
+++ b/src/autoskillit/execution/process/_process_monitor.py
@@ -294,11 +294,14 @@ async def _session_log_monitor(
     try:
         _initial_content = session_file.read_text(errors="replace")
         scan_pos = len(_initial_content)
+        last_size = len(_initial_content.encode("utf-8"))
     except OSError:
+        logger.warning(
+            "session_log_phase2_init_read_failed",
+            file=str(session_file),
+            fallback_scan_pos=0,
+        )
         scan_pos = 0
-    try:
-        last_size = session_file.stat().st_size
-    except OSError:
         last_size = 0
     last_change = _time.monotonic()
     logger.debug(

--- a/src/autoskillit/execution/process/_process_monitor.py
+++ b/src/autoskillit/execution/process/_process_monitor.py
@@ -284,9 +284,29 @@ async def _session_log_monitor(
     _session_id = session_file.stem
 
     # Phase 2: Monitor the session log
-    last_size = 0
+    # Initialize scan offset from file state at discovery. On resumed sessions,
+    # the JSONL already contains records (including completion markers) from the
+    # prior session. Starting at the current file boundary ensures Phase 2 only
+    # scans content written AFTER monitoring began.
+    #
+    # The two reads are in separate try/except blocks so that a transient
+    # stat() failure does not discard a correctly computed scan_pos.
+    try:
+        _initial_content = session_file.read_text(errors="replace")
+        scan_pos = len(_initial_content)
+    except OSError:
+        scan_pos = 0
+    try:
+        last_size = session_file.stat().st_size
+    except OSError:
+        last_size = 0
     last_change = _time.monotonic()
-    scan_pos = 0
+    logger.debug(
+        "session_log_phase2_init",
+        file=str(session_file),
+        initial_scan_pos=scan_pos,
+        initial_last_size=last_size,
+    )
     os_error_count = 0
     suppression_start: float | None = None
     _last_record_type: str | None = None

--- a/src/autoskillit/execution/process/_process_monitor.py
+++ b/src/autoskillit/execution/process/_process_monitor.py
@@ -288,9 +288,6 @@ async def _session_log_monitor(
     # the JSONL already contains records (including completion markers) from the
     # prior session. Starting at the current file boundary ensures Phase 2 only
     # scans content written AFTER monitoring began.
-    #
-    # The two reads are in separate try/except blocks so that a transient
-    # stat() failure does not discard a correctly computed scan_pos.
     try:
         _initial_content = session_file.read_text(errors="replace")
         scan_pos = len(_initial_content)
@@ -300,6 +297,7 @@ async def _session_log_monitor(
             "session_log_phase2_init_read_failed",
             file=str(session_file),
             fallback_scan_pos=0,
+            exc_info=True,
         )
         scan_pos = 0
         last_size = 0

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -380,10 +380,9 @@ class TestChannelBFullPipelineAdjudication:
         - timeout=180s: guards against the outer wall-clock expiring under xdist -n 4 load.
           _phase1_timeout=360 must exceed outer timeout so Phase 1 never fires STALE before
           the outer guard when subprocess startup is slow under WSL2 + xdist load.
-        - _session_id_timeout=0.5s: Script writes system record to stdout immediately;
-          the session ID is extracted from the heartbeat reader before Phase 1 starts.
-          0.5s is generous for session ID extraction while ensuring Phase 1 starts before
-          the JSONL marker is written (at t~0.25s from subprocess start).
+        - _session_id_timeout=0.5s: the script writes the JSONL marker at t~0.25s from
+          subprocess start. 0.5s is generous for session ID extraction (from stdout)
+          while ensuring Phase 1 starts before the marker arrives.
         """
         from autoskillit.execution.headless import _build_skill_result
 

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -130,9 +130,8 @@ PROCESS_EXIT_THEN_CHANNEL_B_FIRES_SCRIPT = textwrap.dedent("""\
                 "content": "working..."}}
         f.write(json.dumps(init) + "\\n")
         f.flush()
-    # Delay must exceed _phase1_poll (1.0s in test) so Phase 2 initializes
-    # before the marker is written. Phase 1 discovers the file, Phase 2 sets
-    # scan_pos from discovery boundary, then the marker arrives as new content.
+    # Delay must exceed session_id_timeout + Phase 1 poll so Phase 2 initializes
+    # scan_pos from discovery boundary before the marker arrives.
     time.sleep(2.0)
     with open(jsonl_path, "a") as f:
         record = {"type": "assistant", "message": {"role": "assistant",

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -33,7 +33,9 @@ CHANNEL_B_THEN_A_CONFIRM_SCRIPT = textwrap.dedent("""\
                 "content": "working..."}}
         f.write(json.dumps(init) + "\\n")
         f.flush()
-    time.sleep(0.15)
+    # Delay must exceed session_id_timeout + Phase 1 poll so Phase 2 initializes
+    # scan_pos from discovery boundary before the marker arrives.
+    time.sleep(1.0)
     with open(jsonl_path, "a") as f:
         record = {"type": "assistant", "message": {"role": "assistant",
                   "content": "%%ORDER_UP%%"}}
@@ -93,7 +95,9 @@ CHANNEL_B_THEN_A_EMPTY_RESULT_SCRIPT = textwrap.dedent("""\
                 "content": "working..."}}
         f.write(json.dumps(init) + "\\n")
         f.flush()
-    time.sleep(0.15)
+    # Delay must exceed _session_id_timeout + Phase 1 poll so the monitor
+    # discovers the file and initializes Phase 2 before the marker arrives.
+    time.sleep(1.0)
     with open(jsonl_path, "a") as f:
         record = {"type": "assistant", "message": {"role": "assistant",
                   "content": "%%ORDER_UP%%"}}
@@ -126,7 +130,10 @@ PROCESS_EXIT_THEN_CHANNEL_B_FIRES_SCRIPT = textwrap.dedent("""\
                 "content": "working..."}}
         f.write(json.dumps(init) + "\\n")
         f.flush()
-    time.sleep(0.15)
+    # Delay must exceed _phase1_poll (1.0s in test) so Phase 2 initializes
+    # before the marker is written. Phase 1 discovers the file, Phase 2 sets
+    # scan_pos from discovery boundary, then the marker arrives as new content.
+    time.sleep(2.0)
     with open(jsonl_path, "a") as f:
         record = {"type": "assistant", "message": {"role": "assistant",
                   "content": "%%ORDER_UP%%"}}
@@ -269,11 +276,8 @@ class TestChannelBDrainWait:
         natural_exit_grace_seconds=0.1: script never exits naturally (time.sleep(3600)),
         so shorten grace window to reduce total test time and avoid asyncio-waitpid
         thread contention under CI load (default 3.0s grace + 3.0s kill = 6s total).
-        _session_id_timeout=30.0: increased from 0.5s → 3.0s → 30.0s — under
-        heavy xdist load the event loop may not schedule the monitor coroutine
-        before the timeout expires, preventing Phase 1 from starting and causing
-        a spurious timed_out result; 30.0s gives adequate headroom within the
-        pytest.mark.timeout(150) outer guard.
+        _session_id_timeout=0.01: script never writes stdout, so session ID timeout
+        should expire immediately to let Phase 1 start before the marker is written.
         """
         session_dir = tmp_path / "session"
         session_dir.mkdir()
@@ -290,7 +294,7 @@ class TestChannelBDrainWait:
             natural_exit_grace_seconds=0.1,
             _phase1_poll=0.01,
             _phase2_poll=0.05,
-            _session_id_timeout=30.0,
+            _session_id_timeout=0.01,
             _phase1_timeout=250,
         )
 
@@ -377,9 +381,10 @@ class TestChannelBFullPipelineAdjudication:
         - timeout=180s: guards against the outer wall-clock expiring under xdist -n 4 load.
           _phase1_timeout=360 must exceed outer timeout so Phase 1 never fires STALE before
           the outer guard when subprocess startup is slow under WSL2 + xdist load.
-        - _session_id_timeout=5.0s: Python startup under WSL2 + xdist -n 4 heavy load
-          can take several seconds; generous timeout prevents session monitor from missing
-          the session ID and failing to watch the JSONL file.
+        - _session_id_timeout=0.5s: Script writes system record to stdout immediately;
+          the session ID is extracted from the heartbeat reader before Phase 1 starts.
+          0.5s is generous for session ID extraction while ensuring Phase 1 starts before
+          the JSONL marker is written (at t~0.25s from subprocess start).
         """
         from autoskillit.execution.headless import _build_skill_result
 
@@ -400,7 +405,7 @@ class TestChannelBFullPipelineAdjudication:
             _phase1_poll=0.01,
             _phase2_poll=0.05,
             _heartbeat_poll=0.05,
-            _session_id_timeout=5.0,
+            _session_id_timeout=0.5,
         )
         skill_result = _build_skill_result(
             result,
@@ -504,24 +509,12 @@ class TestPostExitDrainWindow:
     @pytest.mark.timeout(180)
     @pytest.mark.anyio
     async def test_drain_window_allows_channel_b_to_deposit(self, tmp_path):
-        """Process exits before Phase 1 polls; drain window lets Channel B detect marker.
+        """Process exits after writing marker; drain window lets Channel B detect it.
 
-        Uses _phase1_poll=1.0 to guarantee the process exits (~100ms) before the
-        first Phase 1 poll fires. The drain window (completion_drain_timeout=30.0)
-        gives the session monitor enough time to complete its poll and detect the
-        marker in the JSONL file, producing CHANNEL_B confirmation.
+        The script writes initial content, waits for Phase 1 to discover the file,
+        then writes the marker and exits. The drain window gives Channel B time to
+        complete its Phase 2 poll and detect the marker, producing CHANNEL_B confirmation.
 
-        Timing rationale for completion_drain_timeout=30.0:
-        - Before channel_b_ready can be set, _watch_session_log must:
-            1. Wait up to _session_id_timeout for stdout_session_id_ready (default 1.0s, tests pass 0.01s)
-            2. Sleep _phase1_poll=1.0s before Phase 1's first check
-            3. Sleep _phase2_poll=0.05s before Phase 2's first check
-          Total minimum: ~2.05s under normal conditions.
-        - Under xdist -n 4 load, asyncio.sleep() can overrun significantly.
-          With 10x jitter on Phase 1 alone (1.0s → 10s) the total exceeds 5.0s.
-          30.0s provides ~15x headroom against Phase 1 jitter alone.
-        - The test does NOT take 30s: channel_b_ready is set within ~2s normally
-          and move_on_after exits as soon as the event fires.
         timeout=120 / _phase1_timeout=250: _phase1_timeout must exceed the outer timeout
         so Phase 1 never fires STALE before the outer guard under WSL2 + xdist load.
         """
@@ -538,7 +531,7 @@ class TestPostExitDrainWindow:
             completion_marker="%%ORDER_UP%%",
             completion_drain_timeout=60.0,
             _phase1_timeout=250,
-            _phase1_poll=1.0,
+            _phase1_poll=0.01,
             _phase2_poll=0.05,
             _heartbeat_poll=0.05,
             _session_id_timeout=0.01,
@@ -605,7 +598,9 @@ CHANNEL_B_SUB_SKILL_COLLISION_SCRIPT = textwrap.dedent("""\
                 "content": "working..."}}
         f.write(json.dumps(init) + "\\n")
         f.flush()
-    time.sleep(0.15)
+    # Delay must exceed session_id_timeout + Phase 1 poll so Phase 2 initializes
+    # scan_pos from discovery boundary before sub-skill marker arrives.
+    time.sleep(1.0)
     with open(jsonl_path, "a") as f:
         # Sub-skill emits static marker — should NOT trigger completion
         sub_skill_record = {"type": "assistant", "message": {"role": "assistant",
@@ -638,9 +633,9 @@ class TestChannelBSubSkillCollision:
 
         timeout=300s / _phase1_timeout=600: _phase1_timeout must exceed the outer timeout so
         Phase 1 never fires STALE before the outer guard under WSL2 + xdist load.
-        _session_id_timeout=5.0 gives the stdout reader enough headroom under
-        heavy parallel load so Channel B monitoring always starts before the
-        JSONL markers are written.
+        _session_id_timeout=0.5: script writes system record to stdout immediately;
+        0.5s is generous for session ID extraction while ensuring Phase 1 starts
+        before the JSONL markers are written.
 
         Timeouts are set at 3x the isolation baseline (~14s) to absorb event-loop
         slowdowns under 4-worker xdist load on WSL2, where anyio.sleep() can run
@@ -663,7 +658,7 @@ class TestChannelBSubSkillCollision:
             _phase1_poll=0.05,
             _phase2_poll=0.05,
             _heartbeat_poll=0.05,
-            _session_id_timeout=5.0,
+            _session_id_timeout=0.5,
         )
 
         assert result.termination == TerminationReason.COMPLETED

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -27,7 +27,14 @@ CHANNEL_B_THEN_A_CONFIRM_SCRIPT = textwrap.dedent("""\
     sys.stdout.flush()
     # Small delay to ensure file ctime > spawn_time recorded in run_managed_async
     time.sleep(0.1)
-    with open(os.path.join(session_dir, "session.jsonl"), "w") as f:
+    jsonl_path = os.path.join(session_dir, "session.jsonl")
+    with open(jsonl_path, "w") as f:
+        init = {"type": "assistant", "message": {"role": "assistant",
+                "content": "working..."}}
+        f.write(json.dumps(init) + "\\n")
+        f.flush()
+    time.sleep(0.15)
+    with open(jsonl_path, "a") as f:
         record = {"type": "assistant", "message": {"role": "assistant",
                   "content": "%%ORDER_UP%%"}}
         f.write(json.dumps(record) + "\\n")
@@ -50,7 +57,14 @@ CHANNEL_B_NO_STDOUT_SCRIPT = textwrap.dedent("""\
     session_dir = sys.argv[1]
     os.makedirs(session_dir, exist_ok=True)
     time.sleep(0.1)
-    with open(os.path.join(session_dir, "session.jsonl"), "w") as f:
+    jsonl_path = os.path.join(session_dir, "session.jsonl")
+    with open(jsonl_path, "w") as f:
+        init = {"type": "assistant", "message": {"role": "assistant",
+                "content": "working..."}}
+        f.write(json.dumps(init) + "\\n")
+        f.flush()
+    time.sleep(0.15)
+    with open(jsonl_path, "a") as f:
         record = {"type": "assistant", "message": {"role": "assistant",
                   "content": "%%ORDER_UP%%"}}
         f.write(json.dumps(record) + "\\n")
@@ -73,7 +87,14 @@ CHANNEL_B_THEN_A_EMPTY_RESULT_SCRIPT = textwrap.dedent("""\
     sys.stdout.flush()
     # Small delay to ensure file ctime > spawn_time recorded in run_managed_async
     time.sleep(0.1)
-    with open(os.path.join(session_dir, "session.jsonl"), "w") as f:
+    jsonl_path = os.path.join(session_dir, "session.jsonl")
+    with open(jsonl_path, "w") as f:
+        init = {"type": "assistant", "message": {"role": "assistant",
+                "content": "working..."}}
+        f.write(json.dumps(init) + "\\n")
+        f.flush()
+    time.sleep(0.15)
+    with open(jsonl_path, "a") as f:
         record = {"type": "assistant", "message": {"role": "assistant",
                   "content": "%%ORDER_UP%%"}}
         f.write(json.dumps(record) + "\\n")
@@ -99,7 +120,14 @@ PROCESS_EXIT_THEN_CHANNEL_B_FIRES_SCRIPT = textwrap.dedent("""\
     sys.stdout.flush()
     # Small delay ensures file ctime > spawn_time recorded in run_managed_async
     time.sleep(0.1)
-    with open(os.path.join(session_dir, "session.jsonl"), "w") as f:
+    jsonl_path = os.path.join(session_dir, "session.jsonl")
+    with open(jsonl_path, "w") as f:
+        init = {"type": "assistant", "message": {"role": "assistant",
+                "content": "working..."}}
+        f.write(json.dumps(init) + "\\n")
+        f.flush()
+    time.sleep(0.15)
+    with open(jsonl_path, "a") as f:
         record = {"type": "assistant", "message": {"role": "assistant",
                   "content": "%%ORDER_UP%%"}}
         f.write(json.dumps(record) + "\\n")
@@ -571,13 +599,21 @@ CHANNEL_B_SUB_SKILL_COLLISION_SCRIPT = textwrap.dedent("""\
     sys.stdout.write(json.dumps({"type": "system", "session_id": "session"}) + "\\n")
     sys.stdout.flush()
     time.sleep(0.1)
-    with open(os.path.join(session_dir, "session.jsonl"), "w") as f:
+    jsonl_path = os.path.join(session_dir, "session.jsonl")
+    with open(jsonl_path, "w") as f:
+        init = {"type": "assistant", "message": {"role": "assistant",
+                "content": "working..."}}
+        f.write(json.dumps(init) + "\\n")
+        f.flush()
+    time.sleep(0.15)
+    with open(jsonl_path, "a") as f:
         # Sub-skill emits static marker — should NOT trigger completion
         sub_skill_record = {"type": "assistant", "message": {"role": "assistant",
                   "content": "%%ORDER_UP%%"}}
         f.write(json.dumps(sub_skill_record) + "\\n")
         f.flush()
-        time.sleep(0.3)
+    time.sleep(0.3)
+    with open(jsonl_path, "a") as f:
         # Parent emits its unique marker — SHOULD trigger completion
         parent_record = {"type": "assistant", "message": {"role": "assistant",
                   "content": unique_marker}}

--- a/tests/execution/test_process_heartbeat.py
+++ b/tests/execution/test_process_heartbeat.py
@@ -516,24 +516,40 @@ class TestOrphanedToolResultDetection:
         spawn_time = time.time() - 1
 
         session_file = log_dir / "sess_orphaned.jsonl"
-        session_file.write_text(
-            json.dumps({"type": "assistant", "message": {"content": "working..."}})
-            + "\n"
-            + json.dumps({"type": "user", "message": {"content": [{"type": "tool_result"}]}})
-            + "\n"
-        )
+        session_file.write_text("")
 
-        result = await _session_log_monitor(
-            log_dir,
-            "%%AUTOSKILLIT_COMPLETE%%",
-            stale_threshold=0.15,
-            spawn_time=spawn_time,
-            _phase1_poll=0.01,
-            _phase2_poll=0.04,
-        )
+        async def append_records():
+            await anyio.sleep(0.05)
+            with session_file.open("a") as f:
+                f.write(
+                    json.dumps({"type": "assistant", "message": {"content": "working..."}})
+                    + "\n"
+                    + json.dumps(
+                        {"type": "user", "message": {"content": [{"type": "tool_result"}]}}
+                    )
+                    + "\n"
+                )
 
-        assert result.status == ChannelBStatus.STALE
-        assert result.orphaned_tool_result is True
+        result_box: list = []
+
+        async def run_monitor():
+            result_box.append(
+                await _session_log_monitor(
+                    log_dir,
+                    "%%AUTOSKILLIT_COMPLETE%%",
+                    stale_threshold=0.3,
+                    spawn_time=spawn_time,
+                    _phase1_poll=0.01,
+                    _phase2_poll=0.04,
+                )
+            )
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(run_monitor)
+            tg.start_soon(append_records)
+
+        assert result_box[0].status == ChannelBStatus.STALE
+        assert result_box[0].orphaned_tool_result is True
 
     @pytest.mark.anyio
     async def test_no_false_positive_when_last_record_is_assistant(self, tmp_path):
@@ -545,24 +561,38 @@ class TestOrphanedToolResultDetection:
         spawn_time = time.time() - 1
 
         session_file = log_dir / "sess_assistant.jsonl"
-        session_file.write_text(
-            json.dumps({"type": "user", "message": {"content": "do something"}})
-            + "\n"
-            + json.dumps({"type": "assistant", "message": {"content": "thinking..."}})
-            + "\n"
-        )
+        session_file.write_text("")
 
-        result = await _session_log_monitor(
-            log_dir,
-            "%%AUTOSKILLIT_COMPLETE%%",
-            stale_threshold=0.15,
-            spawn_time=spawn_time,
-            _phase1_poll=0.01,
-            _phase2_poll=0.04,
-        )
+        async def append_records():
+            await anyio.sleep(0.05)
+            with session_file.open("a") as f:
+                f.write(
+                    json.dumps({"type": "user", "message": {"content": "do something"}})
+                    + "\n"
+                    + json.dumps({"type": "assistant", "message": {"content": "thinking..."}})
+                    + "\n"
+                )
 
-        assert result.status == ChannelBStatus.STALE
-        assert result.orphaned_tool_result is False
+        result_box: list = []
+
+        async def run_monitor():
+            result_box.append(
+                await _session_log_monitor(
+                    log_dir,
+                    "%%AUTOSKILLIT_COMPLETE%%",
+                    stale_threshold=0.3,
+                    spawn_time=spawn_time,
+                    _phase1_poll=0.01,
+                    _phase2_poll=0.04,
+                )
+            )
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(run_monitor)
+            tg.start_soon(append_records)
+
+        assert result_box[0].status == ChannelBStatus.STALE
+        assert result_box[0].orphaned_tool_result is False
 
     @pytest.mark.anyio
     async def test_orphaned_false_on_completion(self, tmp_path):
@@ -574,29 +604,43 @@ class TestOrphanedToolResultDetection:
         spawn_time = time.time() - 1
 
         session_file = log_dir / "sess_complete.jsonl"
-        session_file.write_text(
-            json.dumps({"type": "user", "message": {"content": "do something"}})
-            + "\n"
-            + json.dumps(
-                {
-                    "type": "assistant",
-                    "message": {"content": "done\n%%AUTOSKILLIT_COMPLETE%%"},
-                }
+        session_file.write_text("")
+
+        async def append_records():
+            await anyio.sleep(0.05)
+            with session_file.open("a") as f:
+                f.write(
+                    json.dumps({"type": "user", "message": {"content": "do something"}})
+                    + "\n"
+                    + json.dumps(
+                        {
+                            "type": "assistant",
+                            "message": {"content": "done\n%%AUTOSKILLIT_COMPLETE%%"},
+                        }
+                    )
+                    + "\n"
+                )
+
+        result_box: list = []
+
+        async def run_monitor():
+            result_box.append(
+                await _session_log_monitor(
+                    log_dir,
+                    "%%AUTOSKILLIT_COMPLETE%%",
+                    stale_threshold=5.0,
+                    spawn_time=spawn_time,
+                    _phase1_poll=0.01,
+                    _phase2_poll=0.04,
+                )
             )
-            + "\n"
-        )
 
-        result = await _session_log_monitor(
-            log_dir,
-            "%%AUTOSKILLIT_COMPLETE%%",
-            stale_threshold=5.0,
-            spawn_time=spawn_time,
-            _phase1_poll=0.01,
-            _phase2_poll=0.04,
-        )
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(run_monitor)
+            tg.start_soon(append_records)
 
-        assert result.status == ChannelBStatus.COMPLETION
-        assert result.orphaned_tool_result is False
+        assert result_box[0].status == ChannelBStatus.COMPLETION
+        assert result_box[0].orphaned_tool_result is False
 
 
 class TestHeartbeatStreamParser:

--- a/tests/execution/test_process_session_log_monitor.py
+++ b/tests/execution/test_process_session_log_monitor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 
 import anyio
@@ -32,7 +33,6 @@ class TestSessionLogMonitor:
     @pytest.mark.anyio
     async def test_session_log_monitor_detects_completion(self, tmp_path):
         """Session log with completion marker in assistant record returns 'completion'."""
-        import json
 
         log_dir = tmp_path / "session_logs"
         log_dir.mkdir()
@@ -86,7 +86,6 @@ class TestSessionLogMonitor:
     @pytest.mark.anyio
     async def test_session_log_monitor_detects_staleness(self, tmp_path):
         """Session log that stops being written to returns 'stale'."""
-        import json
 
         log_dir = tmp_path / "session_logs"
         log_dir.mkdir()
@@ -116,7 +115,6 @@ class TestSessionLogMonitor:
     @pytest.mark.anyio
     async def test_staleness_resets_on_activity(self, tmp_path):
         """Session log that keeps getting written to does not fire staleness."""
-        import json
 
         log_dir = tmp_path / "session_logs"
         log_dir.mkdir()
@@ -175,7 +173,6 @@ class TestSessionLogMonitor:
         the completion marker) into a queue-operation/enqueue record at byte 0.
         The monitor should ignore it. Only an assistant-type record triggers.
         """
-        import json
 
         log_dir = tmp_path / "session_logs"
         log_dir.mkdir()
@@ -250,7 +247,6 @@ class TestSessionLogMonitor:
 
         Only record 3 should trigger completion.
         """
-        import json
 
         log_dir = tmp_path / "session_logs"
         log_dir.mkdir()
@@ -330,7 +326,6 @@ class TestSessionLogMonitorSessionId:
     @pytest.mark.anyio
     async def test_session_log_monitor_returns_session_id_from_filename(self, tmp_path):
         """_session_log_monitor returns the JSONL filename stem as session_id."""
-        import json
 
         session_uuid = "d9adcc78-3098-4c3e-8720-ddcf3da35fff"
         jsonl_file = tmp_path / f"{session_uuid}.jsonl"
@@ -372,7 +367,6 @@ class TestSessionLogMonitorSessionId:
     @pytest.mark.anyio
     async def test_session_log_monitor_returns_session_id_on_stale(self, tmp_path):
         """Even stale sessions capture the session ID from the discovered file."""
-        import json
 
         session_uuid = "abc12345-dead-beef-cafe-123456789abc"
         jsonl_file = tmp_path / f"{session_uuid}.jsonl"
@@ -415,7 +409,6 @@ class TestSessionLogMonitorSessionId:
     @pytest.mark.anyio
     async def test_session_log_monitor_status_is_channel_b_status_enum(self, tmp_path):
         """SessionMonitorResult.status is a ChannelBStatus enum member."""
-        import json
 
         from autoskillit.core.types import ChannelBStatus
 
@@ -460,7 +453,6 @@ class TestWatchSessionLogSessionId:
     @pytest.mark.anyio
     async def test_watch_session_log_deposits_session_id(self, tmp_path):
         """_watch_session_log writes channel_b_session_id to the accumulator."""
-        import json
 
         acc = RaceAccumulator()
         trigger = anyio.Event()
@@ -507,7 +499,6 @@ class TestSessionIdBasedSelection:
     @pytest.mark.anyio
     async def test_session_id_selects_correct_file_over_newer(self, tmp_path):
         """When expected_session_id is provided, selects matching file regardless of ctime."""
-        import json
 
         session_a = "session-aaa-target"
         session_b = "session-bbb-newer"
@@ -558,7 +549,6 @@ class TestSessionIdBasedSelection:
     @pytest.mark.anyio
     async def test_session_id_falls_back_to_recency_when_no_match(self, tmp_path):
         """When expected_session_id doesn't match any file, falls back to newest."""
-        import json
 
         session_b = "session-bbb-only"
         file_b = tmp_path / f"{session_b}.jsonl"
@@ -630,7 +620,6 @@ class TestResumeBoundary:
         Reproduces the resume-boundary false-fire: on `claude --resume`, the JSONL
         file already contains the completion marker from the prior session.
         """
-        import json
 
         log_dir = tmp_path / "session_logs"
         log_dir.mkdir()
@@ -698,7 +687,6 @@ class TestResumeBoundary:
     async def test_monitor_fires_on_new_marker_after_preexisting_content(self, tmp_path):
         """Phase 2 fires on a new marker written after monitoring starts,
         even when the file has substantial pre-existing content."""
-        import json
 
         log_dir = tmp_path / "session_logs"
         log_dir.mkdir()
@@ -756,9 +744,7 @@ class TestResumeBoundary:
 
     @pytest.mark.anyio
     async def test_phase2_no_spurious_read_on_preexisting_content(self, tmp_path):
-        """When file has pre-existing content and no new writes occur,
-        Phase 2 should go stale without ever triggering a content read."""
-        import json
+        """Pre-existing content with no new writes triggers STALE within threshold."""
 
         log_dir = tmp_path / "session_logs"
         log_dir.mkdir()

--- a/tests/execution/test_process_session_log_monitor.py
+++ b/tests/execution/test_process_session_log_monitor.py
@@ -444,7 +444,7 @@ class TestSessionLogMonitorSessionId:
             tg.start_soon(run_monitor)
             tg.start_soon(append_marker)
 
-        assert isinstance(result_box[0].status, ChannelBStatus)
+        assert result_box[0].status == ChannelBStatus.COMPLETION
 
 
 class TestWatchSessionLogSessionId:

--- a/tests/execution/test_process_session_log_monitor.py
+++ b/tests/execution/test_process_session_log_monitor.py
@@ -335,24 +335,39 @@ class TestSessionLogMonitorSessionId:
         session_uuid = "d9adcc78-3098-4c3e-8720-ddcf3da35fff"
         jsonl_file = tmp_path / f"{session_uuid}.jsonl"
         jsonl_file.write_text(
-            json.dumps(
-                {
-                    "type": "assistant",
-                    "message": {"content": "done\n\nCOMPLETION_MARKER"},
-                }
+            json.dumps({"type": "assistant", "message": {"content": "initial"}}) + "\n"
+        )
+
+        async def append_marker():
+            await anyio.sleep(0.2)
+            with jsonl_file.open("a") as f:
+                f.write(
+                    json.dumps(
+                        {"type": "assistant", "message": {"content": "done\n\nCOMPLETION_MARKER"}}
+                    )
+                    + "\n"
+                )
+
+        result_box: list[SessionMonitorResult] = []
+
+        async def run_monitor():
+            result_box.append(
+                await _session_log_monitor(
+                    tmp_path,
+                    "COMPLETION_MARKER",
+                    stale_threshold=10.0,
+                    spawn_time=time.time() - 1,
+                    _phase1_poll=0.01,
+                    _phase2_poll=0.05,
+                )
             )
-            + "\n"
-        )
 
-        result = await _session_log_monitor(
-            tmp_path,
-            "COMPLETION_MARKER",
-            stale_threshold=10.0,
-            spawn_time=time.time() - 1,
-        )
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(run_monitor)
+            tg.start_soon(append_marker)
 
-        assert result.status == ChannelBStatus.COMPLETION
-        assert result.session_id == session_uuid
+        assert result_box[0].status == ChannelBStatus.COMPLETION
+        assert result_box[0].session_id == session_uuid
 
     @pytest.mark.anyio
     async def test_session_log_monitor_returns_session_id_on_stale(self, tmp_path):
@@ -407,15 +422,36 @@ class TestSessionLogMonitorSessionId:
         session_uuid = "enum-check-session"
         jsonl_file = tmp_path / f"{session_uuid}.jsonl"
         jsonl_file.write_text(
-            json.dumps({"type": "assistant", "message": {"content": "done\n\nMARKER"}}) + "\n"
+            json.dumps({"type": "assistant", "message": {"content": "initial"}}) + "\n"
         )
-        result = await _session_log_monitor(
-            tmp_path,
-            "MARKER",
-            stale_threshold=10.0,
-            spawn_time=time.time() - 1,
-        )
-        assert isinstance(result.status, ChannelBStatus)
+
+        async def append_marker():
+            await anyio.sleep(0.2)
+            with jsonl_file.open("a") as f:
+                f.write(
+                    json.dumps({"type": "assistant", "message": {"content": "done\n\nMARKER"}})
+                    + "\n"
+                )
+
+        result_box: list[SessionMonitorResult] = []
+
+        async def run_monitor():
+            result_box.append(
+                await _session_log_monitor(
+                    tmp_path,
+                    "MARKER",
+                    stale_threshold=10.0,
+                    spawn_time=time.time() - 1,
+                    _phase1_poll=0.01,
+                    _phase2_poll=0.05,
+                )
+            )
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(run_monitor)
+            tg.start_soon(append_marker)
+
+        assert isinstance(result_box[0].status, ChannelBStatus)
 
 
 class TestWatchSessionLogSessionId:
@@ -476,28 +512,48 @@ class TestSessionIdBasedSelection:
         session_a = "session-aaa-target"
         session_b = "session-bbb-newer"
 
-        # Create session A first
+        # Create session A first with non-marker content
         file_a = tmp_path / f"{session_a}.jsonl"
         file_a.write_text(
-            json.dumps({"type": "assistant", "message": {"content": "done\n\nMARKER"}}) + "\n"
+            json.dumps({"type": "assistant", "message": {"content": "initial"}}) + "\n"
         )
 
         # Create session B slightly later (newer by ctime)
         await anyio.sleep(0.05)
         file_b = tmp_path / f"{session_b}.jsonl"
         file_b.write_text(
-            json.dumps({"type": "assistant", "message": {"content": "done\n\nMARKER"}}) + "\n"
+            json.dumps({"type": "assistant", "message": {"content": "initial"}}) + "\n"
         )
 
-        result = await _session_log_monitor(
-            tmp_path,
-            "MARKER",
-            stale_threshold=10.0,
-            spawn_time=time.time() - 2,
-            expected_session_id=session_a,
-        )
-        assert result.status == ChannelBStatus.COMPLETION
-        assert result.session_id == session_a
+        async def append_marker():
+            await anyio.sleep(0.2)
+            with file_a.open("a") as f:
+                f.write(
+                    json.dumps({"type": "assistant", "message": {"content": "done\n\nMARKER"}})
+                    + "\n"
+                )
+
+        result_box: list[SessionMonitorResult] = []
+
+        async def run_monitor():
+            result_box.append(
+                await _session_log_monitor(
+                    tmp_path,
+                    "MARKER",
+                    stale_threshold=10.0,
+                    spawn_time=time.time() - 2,
+                    expected_session_id=session_a,
+                    _phase1_poll=0.01,
+                    _phase2_poll=0.05,
+                )
+            )
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(run_monitor)
+            tg.start_soon(append_marker)
+
+        assert result_box[0].status == ChannelBStatus.COMPLETION
+        assert result_box[0].session_id == session_a
 
     @pytest.mark.anyio
     async def test_session_id_falls_back_to_recency_when_no_match(self, tmp_path):
@@ -507,18 +563,38 @@ class TestSessionIdBasedSelection:
         session_b = "session-bbb-only"
         file_b = tmp_path / f"{session_b}.jsonl"
         file_b.write_text(
-            json.dumps({"type": "assistant", "message": {"content": "done\n\nMARKER"}}) + "\n"
+            json.dumps({"type": "assistant", "message": {"content": "initial"}}) + "\n"
         )
 
-        result = await _session_log_monitor(
-            tmp_path,
-            "MARKER",
-            stale_threshold=10.0,
-            spawn_time=time.time() - 2,
-            expected_session_id="nonexistent-session-id",
-        )
-        assert result.status == ChannelBStatus.COMPLETION
-        assert result.session_id == session_b
+        async def append_marker():
+            await anyio.sleep(0.2)
+            with file_b.open("a") as f:
+                f.write(
+                    json.dumps({"type": "assistant", "message": {"content": "done\n\nMARKER"}})
+                    + "\n"
+                )
+
+        result_box: list[SessionMonitorResult] = []
+
+        async def run_monitor():
+            result_box.append(
+                await _session_log_monitor(
+                    tmp_path,
+                    "MARKER",
+                    stale_threshold=10.0,
+                    spawn_time=time.time() - 2,
+                    expected_session_id="nonexistent-session-id",
+                    _phase1_poll=0.01,
+                    _phase2_poll=0.05,
+                )
+            )
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(run_monitor)
+            tg.start_soon(append_marker)
+
+        assert result_box[0].status == ChannelBStatus.COMPLETION
+        assert result_box[0].session_id == session_b
 
 
 class TestSessionLogMonitorDirMissing:

--- a/tests/execution/test_process_session_log_monitor.py
+++ b/tests/execution/test_process_session_log_monitor.py
@@ -544,6 +544,177 @@ class TestSessionLogMonitorDirMissing:
         assert result.session_id == ""
 
 
+class TestResumeBoundary:
+    """Phase 2 must not fire on completion markers that existed before monitoring began."""
+
+    @pytest.mark.anyio
+    async def test_monitor_skips_preexisting_completion_marker(self, tmp_path):
+        """Phase 2 must NOT fire on a completion marker that existed before monitoring began.
+
+        Reproduces the resume-boundary false-fire: on `claude --resume`, the JSONL
+        file already contains the completion marker from the prior session.
+        """
+        import json
+
+        log_dir = tmp_path / "session_logs"
+        log_dir.mkdir()
+        marker = "%%L3_DONE::abcd1234%%"
+        spawn_time = time.time() - 10
+
+        session_file = log_dir / "session-abc.jsonl"
+        # Pre-populate with a completion marker from the "prior session"
+        session_file.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": f"Done\n\n{marker}"}],
+                    },
+                }
+            )
+            + "\n"
+        )
+
+        poll_count = 0
+
+        def count_polls():
+            nonlocal poll_count
+            poll_count += 1
+
+        async def append_activity():
+            for i in range(3):
+                await anyio.sleep(0.1)
+                with session_file.open("a") as f:
+                    f.write(
+                        json.dumps(
+                            {
+                                "type": "assistant",
+                                "message": {"role": "assistant", "content": f"resumed msg {i}"},
+                            }
+                        )
+                        + "\n"
+                    )
+
+        result_box: list[SessionMonitorResult] = []
+
+        async def run_monitor():
+            result_box.append(
+                await _session_log_monitor(
+                    log_dir,
+                    marker,
+                    stale_threshold=1.0,
+                    spawn_time=spawn_time,
+                    _phase1_poll=0.01,
+                    _phase2_poll=0.05,
+                    _on_poll=count_polls,
+                )
+            )
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(run_monitor)
+            tg.start_soon(append_activity)
+
+        assert result_box[0].status == ChannelBStatus.STALE
+        assert poll_count > 2, "Monitor should have polled multiple times, not fired immediately"
+
+    @pytest.mark.anyio
+    async def test_monitor_fires_on_new_marker_after_preexisting_content(self, tmp_path):
+        """Phase 2 fires on a new marker written after monitoring starts,
+        even when the file has substantial pre-existing content."""
+        import json
+
+        log_dir = tmp_path / "session_logs"
+        log_dir.mkdir()
+        marker = "%%L3_DONE::efgh5678%%"
+        spawn_time = time.time() - 10
+
+        session_file = log_dir / "session-def.jsonl"
+        lines = []
+        for i in range(10):
+            lines.append(
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {"role": "assistant", "content": f"prior msg {i}"},
+                    }
+                )
+            )
+        session_file.write_text("\n".join(lines) + "\n")
+
+        async def append_new_marker():
+            await anyio.sleep(0.3)
+            with session_file.open("a") as f:
+                f.write(
+                    json.dumps(
+                        {
+                            "type": "assistant",
+                            "message": {
+                                "role": "assistant",
+                                "content": f"Completed\n\n{marker}",
+                            },
+                        }
+                    )
+                    + "\n"
+                )
+
+        result_box: list[SessionMonitorResult] = []
+
+        async def run_monitor():
+            result_box.append(
+                await _session_log_monitor(
+                    log_dir,
+                    marker,
+                    stale_threshold=30,
+                    spawn_time=spawn_time,
+                    _phase1_poll=0.01,
+                    _phase2_poll=0.05,
+                )
+            )
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(run_monitor)
+            tg.start_soon(append_new_marker)
+
+        assert result_box[0].status == ChannelBStatus.COMPLETION
+
+    @pytest.mark.anyio
+    async def test_phase2_no_spurious_read_on_preexisting_content(self, tmp_path):
+        """When file has pre-existing content and no new writes occur,
+        Phase 2 should go stale without ever triggering a content read."""
+        import json
+
+        log_dir = tmp_path / "session_logs"
+        log_dir.mkdir()
+        marker = "%%L3_DONE::ijkl9012%%"
+        spawn_time = time.time() - 10
+
+        session_file = log_dir / "session-ghi.jsonl"
+        session_file.write_text(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": f"Prior session done\n\n{marker}"}],
+                    },
+                }
+            )
+            + "\n"
+        )
+
+        result = await _session_log_monitor(
+            log_dir,
+            marker,
+            stale_threshold=0.2,
+            spawn_time=spawn_time,
+            _phase1_poll=0.01,
+            _phase2_poll=0.05,
+        )
+
+        assert result.status == ChannelBStatus.STALE
+
+
 @pytest.mark.anyio
 async def test_watch_session_log_passes_marker_dir_to_monitor_kwargs(
     tmp_path: anyio.Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/execution/test_process_session_log_monitor.py
+++ b/tests/execution/test_process_session_log_monitor.py
@@ -729,7 +729,7 @@ class TestResumeBoundary:
                 await _session_log_monitor(
                     log_dir,
                     marker,
-                    stale_threshold=30,
+                    stale_threshold=5,
                     spawn_time=spawn_time,
                     _phase1_poll=0.01,
                     _phase2_poll=0.05,


### PR DESCRIPTION
## Summary

Channel B's `_session_log_monitor` has no resume-boundary awareness. Phase 2 unconditionally initializes `scan_pos = 0` and `last_size = 0`, causing it to read the entire JSONL file — including content from the original session that already contains the completion marker. On resumed sessions (`claude --resume`), this produces a false `ChannelBStatus.COMPLETION` that kills the session in ~14 seconds with 0 tokens.

The architectural weakness is that `_session_log_monitor` treats every JSONL file as if it were freshly created, with no concept of a content boundary between prior and current session activity. The fix makes Phase 2's scan position a function of file state at discovery time, eliminating the entire class of stale-content false-fires.

Closes #3360

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-172850-168963/.autoskillit/temp/rectify/rectify_channel_b_resume_boundary_2026-05-30_172850_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 93 | 37.3k | 3.0M | 151.4k | 241 | 173.3k | 24m 29s |
| review_approach* | sonnet | 1 | 4.7k | 8.3k | 199.6k | 52.0k | 133 | 40.1k | 7m 52s |
| dry_walkthrough* | opus | 2 | 2.4k | 34.5k | 1.3M | 80.6k | 164 | 97.2k | 15m 39s |
| implement* | sonnet | 2 | 144 | 7.9k | 650.5k | 47.0k | 73 | 32.7k | 8m 16s |
| audit_impl* | sonnet | 2 | 1.0k | 13.2k | 3.8M | 72.4k | 142 | 247.5k | 15m 18s |
| prepare_pr* | sonnet | 1 | 94.2k | 3.3k | 193.0k | 27.6k | 22 | 40.5k | 1m 12s |
| compose_pr* | sonnet | 1 | 37.9k | 1.4k | 162.6k | 27.6k | 14 | 15.5k | 41s |
| review_pr* | sonnet | 3 | 506 | 125.8k | 4.0M | 119.0k | 207 | 329.1k | 29m 32s |
| resolve_review* | opus | 3 | 195 | 48.3k | 5.9M | 91.2k | 219 | 273.9k | 32m 48s |
| **Total** | | | 141.2k | 280.0k | 19.2M | 151.4k | | 1.2M | 2h 15m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 195 | 3335.9 | 167.8 | 40.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 47 | 124837.1 | 5827.4 | 1028.0 |
| **Total** | **242** | 79375.1 | 5164.7 | 1157.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 93 | 37.3k | 3.0M | 173.3k | 24m 29s |
| sonnet | 6 | 138.4k | 159.9k | 9.0M | 705.5k | 1h 2m |
| opus | 2 | 2.6k | 82.8k | 7.2M | 371.0k | 48m 27s |