### PR TITLE
Route scripts/*.py files through manifest in test filter

### DIFF
--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -1,8 +1,8 @@
 # Test Filter Manifest
 #
-# Maps non-Python file glob patterns (repo-relative) to test directories
+# Maps file glob patterns (repo-relative) to test directories
 # (relative to tests/). Used by _test_filter.py to select which tests
-# to run when non-Python files change.
+# to run when matched files change.
 #
 # Files already handled by Bucket A (pyproject.toml, uv.lock, conftest.py)
 # are intentionally absent — Bucket A triggers a full run before the
@@ -179,6 +179,29 @@ install.sh:
   - cli/
 
 scripts/verify-test-filter.sh:
+  - infra/
+
+# Python scripts under scripts/ — route to verified test consumers
+scripts/benchmark-testmon.py:
+  - infra/
+scripts/check_contract_freshness.py:
+  - infra/
+scripts/check_doc_counts.py:
+  - infra/
+scripts/check_sub_claude_md.py:
+  - docs/
+scripts/check_tool_annotations.py:
+  - arch/
+scripts/compare-coverage-ast.py:
+  - infra/
+scripts/compile_recipes.py:
+  - recipe/
+  - infra/
+scripts/recipe_contract_freshness.py:
+  - hooks/
+scripts/regen_contracts.py:
+  - infra/
+scripts/sync_versions.py:
   - infra/
 
 # Source non-Python files

--- a/src/autoskillit/_test_filter.py
+++ b/src/autoskillit/_test_filter.py
@@ -1,6 +1,6 @@
-"""Test filter manifest: glob-to-test-directory mapping for non-Python files.
+"""Test filter manifest: glob-to-test-directory mapping.
 
-Loads ``.autoskillit/test-filter-manifest.yaml`` and resolves changed non-Python
+Loads ``.autoskillit/test-filter-manifest.yaml`` and resolves changed
 file paths to the minimal set of test directories that must run.
 """
 
@@ -36,14 +36,14 @@ def apply_manifest(
     changed_files: list[str],
     manifest: dict[str, list[str]],
 ) -> set[str] | None:
-    """Resolve changed non-Python files to test directories via the manifest.
+    """Resolve changed files to test directories via the manifest.
 
     For each manifest entry, compiles the glob pattern using pathspec's
     gitwildmatch and checks whether any changed file matches. Collects the
     union of all matched test directories.
 
     Args:
-        changed_files: Repo-relative paths of changed non-Python files.
+        changed_files: Repo-relative paths of changed files.
         manifest: Output of ``load_manifest()``.
 
     Returns:

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -123,7 +123,7 @@ changed files. Controlled by env var + CLI flags:
 2. **Changed files**: `git merge-base HEAD base_ref` → SHA, then `git diff --name-only <sha>` (working tree vs merge-base: committed + staged + unstaged tracked) + `git ls-files --others --exclude-standard` (new untracked files). Union of all three — a strict superset of the old three-dot form. **Known limitation**: `git rm --cached` (stage-only deletions) are not captured — the file still exists on disk so the working-tree diff misses the deletion. This is acceptable given the fail-open design.
 3. **Bucket A**: If any "global impact" file changed (conftest.py, pyproject.toml, etc.) -> full run
 4. **Large changeset**: >30 files -> full run
-5. **Classification**: src Python -> layer cascade, test Python -> direct, non-Python -> manifest lookup
+5. **Classification**: src Python -> layer cascade, test Python -> direct, other Python -> manifest lookup, non-Python -> manifest lookup
 6. **Always-run**: `arch/` + `contracts/` always included (+ `infra/` + `docs/` in conservative mode)
 7. **Deselection**: `pytest_collection_modifyitems` deselects items outside scope paths
 

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -1341,7 +1341,10 @@ def build_test_scope(
             else:
                 return FullRunReason.UNMAPPED_FILE
         elif f.endswith(".py"):
-            return FullRunReason.UNMAPPED_FILE
+            manifest_dirs = apply_manifest({f}, manifest)
+            if manifest_dirs is None:
+                return FullRunReason.UNMAPPED_FILE
+            test_dirs.update(manifest_dirs)
         else:
             manifest_dirs = apply_manifest({f}, manifest)
             if manifest_dirs is None:

--- a/tests/infra/test_filter_activation.py
+++ b/tests/infra/test_filter_activation.py
@@ -109,3 +109,16 @@ def test_build_test_scope_returns_full_run_reason_for_unmapped():
     changed = {"scripts/random_script.py"}
     result = build_test_scope(changed_files=changed, mode=FilterMode.CONSERVATIVE)
     assert result is FullRunReason.UNMAPPED_FILE
+
+
+def test_build_test_scope_routes_known_script_via_manifest():
+    from tests._test_filter import FilterMode, FullRunReason, build_test_scope, load_manifest
+
+    manifest = load_manifest(REPO_ROOT)
+    changed = {"scripts/benchmark-testmon.py"}
+    result = build_test_scope(
+        changed_files=changed, mode=FilterMode.CONSERVATIVE, manifest=manifest
+    )
+    assert result is not FullRunReason.UNMAPPED_FILE
+    assert isinstance(result, set)
+    assert any(p.name == "infra" for p in result)

--- a/tests/infra/test_manifest_completeness.py
+++ b/tests/infra/test_manifest_completeness.py
@@ -4,7 +4,8 @@ Completeness test: every non-Python tracked file (outside Bucket A and the ignor
 list) must match at least one pattern in .autoskillit/test-filter-manifest.yaml.
 
 Orphan detection test: every manifest pattern must match at least one currently
-tracked non-Python file (no dead/stale patterns).
+tracked file eligible for manifest routing (non-Python files plus Python files
+outside src/ and tests/ — no dead/stale patterns).
 """
 
 from __future__ import annotations
@@ -82,6 +83,31 @@ def _tracked_non_python_files() -> tuple[str, ...]:
     return tuple(f for f in result.stdout.splitlines() if not f.endswith(".py"))
 
 
+@functools.cache
+def _tracked_files_for_orphan_check() -> tuple[str, ...]:
+    """Return tracked files eligible for manifest orphan detection.
+
+    Includes all non-Python files plus Python files outside src/ and tests/
+    (which are routed through the manifest rather than cascade logic).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--cached"],
+            capture_output=True,
+            text=True,
+            cwd=_REPO_ROOT,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        msg = f"git ls-files failed in {_REPO_ROOT}: {e.stderr.strip()}"
+        raise RuntimeError(msg) from e
+    return tuple(
+        f
+        for f in result.stdout.splitlines()
+        if not f.endswith(".py") or (not f.startswith("src/") and not f.startswith("tests/"))
+    )
+
+
 def _should_be_covered(file_path: str) -> bool:
     """Return True if file_path must be covered by a manifest pattern."""
     if file_path in _BUCKET_A_FILES:
@@ -132,14 +158,14 @@ def test_file_covered_by_manifest(file_path: str) -> None:
 
 @pytest.mark.parametrize("pattern", _MANIFEST_PATTERNS)
 def test_manifest_pattern_matches_real_file(pattern: str) -> None:
-    """Every manifest pattern must match at least one currently tracked non-Python file.
+    """Every manifest pattern must match at least one currently tracked file.
 
     Failure means the pattern is orphaned — either the files it matched were deleted,
     renamed, or the pattern was misspelled from the start.
     Fix: remove the stale pattern from .autoskillit/test-filter-manifest.yaml or
     correct its path.
     """
-    all_tracked = _tracked_non_python_files()
+    all_tracked = _tracked_files_for_orphan_check()
     matched_files = [f for f in all_tracked if _PER_PATTERN_SPECS[pattern].match_file(f)]
     assert matched_files, (
         f"Manifest pattern {pattern!r} matches no tracked files — it may be stale "

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -441,6 +441,66 @@ class TestBuildTestScope:
         assert result is not None
         assert result is not FullRunReason.UNMAPPED_FILE
 
+    def test_scope_script_py_manifest_match(self, tmp_path: Path) -> None:
+        """scripts/*.py files with a manifest entry route via manifest, not UNMAPPED_FILE."""
+        tests_root = tmp_path / "tests"
+        for d in ["infra", "docs", "arch"]:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+
+        manifest = {"scripts/check_sub_claude_md.py": ["docs"]}
+        result = build_test_scope(
+            changed_files={"scripts/check_sub_claude_md.py"},
+            mode=FilterMode.CONSERVATIVE,
+            manifest=manifest,
+            tests_root=tests_root,
+        )
+        assert isinstance(result, set)
+        assert {p.name for p in result} >= {"docs"}
+
+    def test_scope_script_py_no_manifest_match(self, tmp_path: Path) -> None:
+        """scripts/*.py without manifest entry still returns UNMAPPED_FILE."""
+        tests_root = tmp_path / "tests"
+        (tests_root / "infra").mkdir(parents=True, exist_ok=True)
+
+        manifest = {"scripts/other_script.py": ["infra"]}
+        result = build_test_scope(
+            changed_files={"scripts/unknown_script.py"},
+            mode=FilterMode.CONSERVATIVE,
+            manifest=manifest,
+            tests_root=tests_root,
+        )
+        assert result is FullRunReason.UNMAPPED_FILE
+
+    def test_scope_script_py_none_manifest(self, tmp_path: Path) -> None:
+        """scripts/*.py with manifest=None returns UNMAPPED_FILE (fail-open)."""
+        tests_root = tmp_path / "tests"
+        (tests_root / "infra").mkdir(parents=True, exist_ok=True)
+
+        result = build_test_scope(
+            changed_files={"scripts/benchmark-testmon.py"},
+            mode=FilterMode.CONSERVATIVE,
+            manifest=None,
+            tests_root=tests_root,
+        )
+        assert result is FullRunReason.UNMAPPED_FILE
+
+    def test_scope_mixed_script_and_src_py(self, tmp_path: Path) -> None:
+        """scripts/*.py via manifest + src/*.py via cascade both contribute test_dirs."""
+        tests_root = tmp_path / "tests"
+        for d in ["infra", "core"]:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+
+        manifest = {"scripts/sync_versions.py": ["infra"]}
+        result = build_test_scope(
+            changed_files={"scripts/sync_versions.py", "src/autoskillit/core/paths.py"},
+            mode=FilterMode.CONSERVATIVE,
+            manifest=manifest,
+            tests_root=tests_root,
+        )
+        assert isinstance(result, set)
+        names = {p.name for p in result}
+        assert "infra" in names
+
 
 # ---------------------------------------------------------------------------
 # Conservative vs Aggressive Tests (M1–M4)

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -441,66 +441,6 @@ class TestBuildTestScope:
         assert result is not None
         assert result is not FullRunReason.UNMAPPED_FILE
 
-    def test_scope_script_py_manifest_match(self, tmp_path: Path) -> None:
-        """scripts/*.py files with a manifest entry route via manifest, not UNMAPPED_FILE."""
-        tests_root = tmp_path / "tests"
-        for d in ["infra", "docs", "arch"]:
-            (tests_root / d).mkdir(parents=True, exist_ok=True)
-
-        manifest = {"scripts/check_sub_claude_md.py": ["docs"]}
-        result = build_test_scope(
-            changed_files={"scripts/check_sub_claude_md.py"},
-            mode=FilterMode.CONSERVATIVE,
-            manifest=manifest,
-            tests_root=tests_root,
-        )
-        assert isinstance(result, set)
-        assert {p.name for p in result} >= {"docs"}
-
-    def test_scope_script_py_no_manifest_match(self, tmp_path: Path) -> None:
-        """scripts/*.py without manifest entry still returns UNMAPPED_FILE."""
-        tests_root = tmp_path / "tests"
-        (tests_root / "infra").mkdir(parents=True, exist_ok=True)
-
-        manifest = {"scripts/other_script.py": ["infra"]}
-        result = build_test_scope(
-            changed_files={"scripts/unknown_script.py"},
-            mode=FilterMode.CONSERVATIVE,
-            manifest=manifest,
-            tests_root=tests_root,
-        )
-        assert result is FullRunReason.UNMAPPED_FILE
-
-    def test_scope_script_py_none_manifest(self, tmp_path: Path) -> None:
-        """scripts/*.py with manifest=None returns UNMAPPED_FILE (fail-open)."""
-        tests_root = tmp_path / "tests"
-        (tests_root / "infra").mkdir(parents=True, exist_ok=True)
-
-        result = build_test_scope(
-            changed_files={"scripts/benchmark-testmon.py"},
-            mode=FilterMode.CONSERVATIVE,
-            manifest=None,
-            tests_root=tests_root,
-        )
-        assert result is FullRunReason.UNMAPPED_FILE
-
-    def test_scope_mixed_script_and_src_py(self, tmp_path: Path) -> None:
-        """scripts/*.py via manifest + src/*.py via cascade both contribute test_dirs."""
-        tests_root = tmp_path / "tests"
-        for d in ["infra", "core"]:
-            (tests_root / d).mkdir(parents=True, exist_ok=True)
-
-        manifest = {"scripts/sync_versions.py": ["infra"]}
-        result = build_test_scope(
-            changed_files={"scripts/sync_versions.py", "src/autoskillit/core/paths.py"},
-            mode=FilterMode.CONSERVATIVE,
-            manifest=manifest,
-            tests_root=tests_root,
-        )
-        assert isinstance(result, set)
-        names = {p.name for p in result}
-        assert "infra" in names
-
 
 # ---------------------------------------------------------------------------
 # Conservative vs Aggressive Tests (M1–M4)

--- a/tests/test_test_filter_script_manifest.py
+++ b/tests/test_test_filter_script_manifest.py
@@ -1,0 +1,71 @@
+"""Tests for scripts/*.py manifest routing in build_test_scope."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests._test_filter import FilterMode, FullRunReason, build_test_scope
+
+
+def test_scope_script_py_manifest_match(tmp_path: Path) -> None:
+    """scripts/*.py files with a manifest entry route via manifest, not UNMAPPED_FILE."""
+    tests_root = tmp_path / "tests"
+    for d in ["infra", "docs", "arch"]:
+        (tests_root / d).mkdir(parents=True, exist_ok=True)
+
+    manifest = {"scripts/check_sub_claude_md.py": ["docs"]}
+    result = build_test_scope(
+        changed_files={"scripts/check_sub_claude_md.py"},
+        mode=FilterMode.CONSERVATIVE,
+        manifest=manifest,
+        tests_root=tests_root,
+    )
+    assert isinstance(result, set)
+    assert {p.name for p in result} >= {"docs"}
+
+
+def test_scope_script_py_no_manifest_match(tmp_path: Path) -> None:
+    """scripts/*.py without manifest entry still returns UNMAPPED_FILE."""
+    tests_root = tmp_path / "tests"
+    (tests_root / "infra").mkdir(parents=True, exist_ok=True)
+
+    manifest = {"scripts/other_script.py": ["infra"]}
+    result = build_test_scope(
+        changed_files={"scripts/unknown_script.py"},
+        mode=FilterMode.CONSERVATIVE,
+        manifest=manifest,
+        tests_root=tests_root,
+    )
+    assert result is FullRunReason.UNMAPPED_FILE
+
+
+def test_scope_script_py_none_manifest(tmp_path: Path) -> None:
+    """scripts/*.py with manifest=None returns UNMAPPED_FILE (fail-open)."""
+    tests_root = tmp_path / "tests"
+    (tests_root / "infra").mkdir(parents=True, exist_ok=True)
+
+    result = build_test_scope(
+        changed_files={"scripts/benchmark-testmon.py"},
+        mode=FilterMode.CONSERVATIVE,
+        manifest=None,
+        tests_root=tests_root,
+    )
+    assert result is FullRunReason.UNMAPPED_FILE
+
+
+def test_scope_mixed_script_and_src_py(tmp_path: Path) -> None:
+    """scripts/*.py via manifest + src/*.py via cascade both contribute test_dirs."""
+    tests_root = tmp_path / "tests"
+    for d in ["infra", "core"]:
+        (tests_root / d).mkdir(parents=True, exist_ok=True)
+
+    manifest = {"scripts/sync_versions.py": ["infra"]}
+    result = build_test_scope(
+        changed_files={"scripts/sync_versions.py", "src/autoskillit/core/paths.py"},
+        mode=FilterMode.CONSERVATIVE,
+        manifest=manifest,
+        tests_root=tests_root,
+    )
+    assert isinstance(result, set)
+    names = {p.name for p in result}
+    assert "infra" in names

--- a/tests/test_test_filter_script_manifest.py
+++ b/tests/test_test_filter_script_manifest.py
@@ -69,3 +69,4 @@ def test_scope_mixed_script_and_src_py(tmp_path: Path) -> None:
     assert isinstance(result, set)
     names = {p.name for p in result}
     assert "infra" in names
+    assert "core" in names


### PR DESCRIPTION
## Summary

Modify `build_test_scope()` in `tests/_test_filter.py` so that `.py` files outside `src/` and `tests/` consult the manifest before returning `UNMAPPED_FILE`. Add per-script manifest entries to `.autoskillit/test-filter-manifest.yaml` mapping each `scripts/*.py` to its verified test consumer directory. Update the manifest orphan detection test to handle Python-file patterns. Update docstrings and comments that incorrectly restrict the manifest to "non-Python" files.

## Motivation

The test filter currently routes `scripts/*.py` files to `UNMAPPED_FILE` (causing a full run) because they fall through the `.py` branch without a manifest lookup. Ten `scripts/*.py` files have verified test consumers in `tests/infra/`, `tests/docs/`, `tests/arch/`, and `tests/hooks/`, but the manifest only covered `.sh` files under `scripts/`. This change routes those Python scripts through the same manifest mechanism, reducing unnecessary full runs.

## Requirements

- **REQ-MANIFEST-001:** Modify `build_test_scope()` line 1330–1331 to attempt manifest lookup for non-src/non-test `.py` files before returning `UNMAPPED_FILE`
- **REQ-MANIFEST-002:** Add per-script manifest entries to `.autoskillit/test-filter-manifest.yaml` with correct test directory mappings
- **REQ-MANIFEST-003:** Add test assertion(s) verifying `scripts/*.py` manifest routing works
- **REQ-MANIFEST-004:** Verify existing `scripts/*.sh` and `scripts/recipe/*.sh` entries remain unaffected

## Changes

### New Files

- `tests/test_test_filter_script_manifest.py` — unit tests for `scripts/*.py` manifest routing

### Modified Files

- `.autoskillit/test-filter-manifest.yaml` — added 10 `scripts/*.py` entries with verified test directory mappings
- `src/autoskillit/_test_filter.py` — `build_test_scope()` now calls `apply_manifest()` for non-src/non-test `.py` files; updated docstrings to remove "non-Python" qualifier
- `tests/_test_filter.py` — added `TestBuildTestScope` cases for script manifest routing
- `tests/CLAUDE.md` — updated classification description to reflect that "other Python" also uses manifest lookup
- `tests/infra/test_filter_activation.py` — added integration test with real manifest
- `tests/infra/test_manifest_completeness.py` — added `_tracked_files_for_orphan_check()` to include `scripts/*.py` files in orphan detection; updated docstrings

## Test Plan

- [ ] Unit tests in `tests/test_test_filter_script_manifest.py` pass (4 cases: manifest match, no match, None manifest, mixed with src/*.py)
- [ ] Integration test `test_build_test_scope_routes_known_script_via_manifest` in `tests/infra/test_filter_activation.py` passes
- [ ] `test_manifest_pattern_matches_real_file` passes for all 10 new `scripts/*.py` patterns
- [ ] `test_file_covered_by_manifest` continues to parametrize over non-Python files only
- [ ] `task test-check` passes
- [ ] `pre-commit run --all-files` passes

## Closing Issue

Fixes #3369.

---

Plan: `.autoskillit/temp/make-plan/add_scripts_py_manifest_entry_plan_2026-05-30_210500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.4k | 17.9k | 2.1M | 84.7k | 173 | 124.0k | 11m 19s |
| verify* | opus | 1 | 40 | 14.0k | 659.1k | 71.1k | 127 | 71.3k | 9m 11s |
| implement* | opus | 1 | 813.4k | 8.9k | 889.7k | 61.9k | 113 | 76.4k | 5m 55s |
| audit_impl* | opus | 1 | 25 | 12.6k | 208.2k | 39.3k | 92 | 35.0k | 5m 20s |
| prepare_pr* | opus | 1 | 43.0k | 3.3k | 194.6k | 0 | 19 | 0 | 1m 16s |
| compose_pr* | opus | 1 | 44.4k | 2.4k | 323.5k | 19.3k | 28 | 0 | 1m 36s |
| review_pr* | opus | 2 | 90 | 46.8k | 1.3M | 71.0k | 76 | 126.7k | 11m 41s |
| resolve_review* | opus | 1 | 40 | 4.2k | 646.1k | 56.2k | 29 | 42.4k | 3m 8s |
| **Total** | | | 902.4k | 110.1k | 6.3M | 84.7k | | 475.7k | 49m 29s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 147 | 6052.6 | 519.5 | 60.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 1 | 646071.0 | 42352.0 | 4227.0 |
| **Total** | **148** | 42354.9 | 3214.2 | 743.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.4k | 17.9k | 2.1M | 124.0k | 11m 19s |
| opus | 7 | 901.0k | 92.2k | 4.2M | 351.7k | 38m 10s |