### PR TITLE
[FIX] CancelledError immunity — _cancellation_shield decorator + run_skill inner handler

### DIFF
--- a/src/autoskillit/core/types/_type_enums.py
+++ b/src/autoskillit/core/types/_type_enums.py
@@ -58,9 +58,7 @@ class RetryReason(StrEnum):
     THINKING_STALL = "thinking_stall"  # final turn: thinking blocks only, no text or tool output
     IDLE_STALL = "idle_stall"  # stdout idle watchdog kill — session may have partial progress
     RATE_LIMITED = "rate_limited"  # transient HTTP 429 or rate-limit pattern — wait-and-retry
-    CANCELLED = (
-        "cancelled"  # transport-induced asyncio.CancelledError — retry if orchestrator alive
-    )
+    CANCELLED = "cancelled"
 
 
 class InfraExitCategory(StrEnum):

--- a/src/autoskillit/core/types/_type_enums.py
+++ b/src/autoskillit/core/types/_type_enums.py
@@ -58,6 +58,9 @@ class RetryReason(StrEnum):
     THINKING_STALL = "thinking_stall"  # final turn: thinking blocks only, no text or tool output
     IDLE_STALL = "idle_stall"  # stdout idle watchdog kill — session may have partial progress
     RATE_LIMITED = "rate_limited"  # transient HTTP 429 or rate-limit pattern — wait-and-retry
+    CANCELLED = (
+        "cancelled"  # transport-induced asyncio.CancelledError — retry if orchestrator alive
+    )
 
 
 class InfraExitCategory(StrEnum):

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -368,6 +368,34 @@ class SkillResult:
             evidence=WriteEvidence.none_observed(),
         )
 
+    @classmethod
+    def cancelled(
+        cls,
+        skill_command: str = "",
+        session_id: str = "",
+        order_id: str = "",
+    ) -> SkillResult:
+        """Construct a SkillResult for transport-level CancelledError.
+
+        Produces a retriable result with needs_retry=True and
+        retry_reason=RetryReason.CANCELLED so the orchestrator can route
+        via on_failure (cancellation is not a context-limit event).
+        """
+        return cls(
+            success=False,
+            result=f"CancelledError: transport teardown | skill_command={skill_command!r}",
+            session_id=session_id,
+            subtype="cancelled",
+            is_error=True,
+            exit_code=-1,
+            needs_retry=True,
+            retry_reason=RetryReason.CANCELLED,
+            stderr="",
+            kill_reason=KillReason.EXCEPTION,
+            order_id=order_id,
+            evidence=WriteEvidence.none_observed(),
+        )
+
     @property
     def outcome(self) -> SessionOutcome:
         """Classify this result as SUCCEEDED, RETRIABLE, or FAILED.

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -461,5 +461,6 @@ _ABANDON_REASONS: frozenset[str] = frozenset(
         RetryReason.PATH_CONTAMINATION,
         RetryReason.CLONE_CONTAMINATION,
         RetryReason.IDLE_STALL,
+        RetryReason.CANCELLED,  # transport teardown — session was never started or was torn down
     }
 )

--- a/src/autoskillit/server/tools/CLAUDE.md
+++ b/src/autoskillit/server/tools/CLAUDE.md
@@ -8,6 +8,7 @@ MCP `@mcp.tool()` handlers registered on import (18 tool modules).
 |------|---------|
 | `__init__.py` | Docstring-only — tools register via `@mcp.tool()` on import |
 | `_auto_overrides.py` | Shared `_build_auto_overrides()` factory for server-authoritative ingredient injection |
+| `_cancellation_shield.py` | `_cancellation_shield` decorator — catches `asyncio.CancelledError` at MCP tool boundary, returns structured JSON |
 | `_types.py` | TypedDict definitions for server tool JSON responses (RunSkillResult, RunCmdResult, etc.) |
 | `tools_kitchen.py` | `open_kitchen`, `close_kitchen` (gate lifecycle), `recipe://` MCP resource |
 | `tools_config.py` | `configure_fleet`, `configure_order` (session config overlay) |

--- a/src/autoskillit/server/tools/_cancellation_shield.py
+++ b/src/autoskillit/server/tools/_cancellation_shield.py
@@ -26,18 +26,12 @@ F = TypeVar("F", bound=Callable[..., Any])
 def _cancellation_shield(
     result_type: Literal["fleet_error", "run_cmd", "run_python", "generic"] = "generic",
 ) -> Callable[[F], F]:
-    """Decorator that catches asyncio.CancelledError at the MCP tool boundary.
-
-    Apply BELOW @mcp.tool() and ABOVE @track_response_size() so FastMCP
-    invokes this wrapper as the outermost layer after @mcp.tool() registration.
-
-    Uses anyio.CancelScope(shield=True) for response construction to prevent
-    re-cancellation while building the structured return value.
+    """Apply BELOW @mcp.tool() and ABOVE @track_response_size().
 
     result_type controls the response schema:
     - "fleet_error": fleet_error() envelope (dispatch_food_truck, record_gate_dispatch)
     - "run_cmd": {"success": False, "exit_code": -1, "stdout": "", "stderr": ...}
-    - "run_python": same as run_cmd
+    - "run_python": {"success": False, "exit_code": -1, "stdout": "", "stderr": ...}
     - "generic" (default): {"success": False, "error": "cancelled", "subtype": "cancelled"}
     """
 
@@ -48,7 +42,10 @@ def _cancellation_shield(
                 return await fn(*args, **kwargs)
             except asyncio.CancelledError:
                 with anyio.CancelScope(shield=True):
-                    logger.warning("mcp_tool_cancelled", tool=fn.__name__)
+                    try:
+                        logger.warning("mcp_tool_cancelled", tool=fn.__name__)
+                    except Exception:
+                        pass
                     return _build_cancellation_response(result_type)
 
         return wrapper  # type: ignore[return-value]

--- a/src/autoskillit/server/tools/_cancellation_shield.py
+++ b/src/autoskillit/server/tools/_cancellation_shield.py
@@ -1,0 +1,68 @@
+"""Cancellation shield decorator for MCP tool handlers.
+
+Catches asyncio.CancelledError at the MCP tool boundary, converting
+transport teardown into a structured JSON response. Without this guard
+every tool handler that lacks an explicit except-BaseException clause
+silently drops the MCP session instead of returning a routable result.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, Literal, TypeVar
+
+import anyio
+
+from autoskillit.core import get_logger
+
+logger = get_logger(__name__)
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def _cancellation_shield(
+    result_type: Literal["fleet_error", "run_cmd", "run_python", "generic"] = "generic",
+) -> Callable[[F], F]:
+    """Decorator that catches asyncio.CancelledError at the MCP tool boundary.
+
+    Apply BELOW @mcp.tool() and ABOVE @track_response_size() so FastMCP
+    invokes this wrapper as the outermost layer after @mcp.tool() registration.
+
+    Uses anyio.CancelScope(shield=True) for response construction to prevent
+    re-cancellation while building the structured return value.
+
+    result_type controls the response schema:
+    - "fleet_error": fleet_error() envelope (dispatch_food_truck, record_gate_dispatch)
+    - "run_cmd": {"success": False, "exit_code": -1, "stdout": "", "stderr": ...}
+    - "run_python": same as run_cmd
+    - "generic" (default): {"success": False, "error": "cancelled", "subtype": "cancelled"}
+    """
+
+    def decorator(fn: F) -> F:
+        @wraps(fn)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return await fn(*args, **kwargs)
+            except asyncio.CancelledError:
+                with anyio.CancelScope(shield=True):
+                    logger.warning("mcp_tool_cancelled", tool=fn.__name__)
+                    return _build_cancellation_response(result_type)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def _build_cancellation_response(result_type: str) -> str:
+    """Build a structured JSON error response for transport-level CancelledError."""
+    msg = "CancelledError: transport teardown"
+    if result_type == "fleet_error":
+        from autoskillit.core import FleetErrorCode, fleet_error  # noqa: PLC0415
+
+        return fleet_error(FleetErrorCode.FLEET_L3_STARTUP_OR_CRASH, msg)
+    if result_type in ("run_cmd", "run_python"):
+        return json.dumps({"success": False, "exit_code": -1, "stdout": "", "stderr": msg})
+    return json.dumps({"success": False, "error": "cancelled", "subtype": "cancelled"})

--- a/src/autoskillit/server/tools/_cancellation_shield.py
+++ b/src/autoskillit/server/tools/_cancellation_shield.py
@@ -42,10 +42,7 @@ def _cancellation_shield(
                 return await fn(*args, **kwargs)
             except asyncio.CancelledError:
                 with anyio.CancelScope(shield=True):
-                    try:
-                        logger.warning("mcp_tool_cancelled", tool=fn.__name__)
-                    except Exception:
-                        pass
+                    logger.warning("mcp_tool_cancelled", tool=fn.__name__)
                     return _build_cancellation_response(result_type)
 
         return wrapper  # type: ignore[return-value]

--- a/src/autoskillit/server/tools/tools_agents.py
+++ b/src/autoskillit/server/tools/tools_agents.py
@@ -8,6 +8,7 @@ from fastmcp.exceptions import ResourceError
 
 from autoskillit.core import AGENT_PACK_REGISTRY, get_logger, pkg_root
 from autoskillit.server import mcp
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
 
@@ -37,6 +38,7 @@ def list_plan_review_agents() -> str:
     tags={"autoskillit", "kitchen", "kitchen-core", "headless"},
     annotations={"readOnlyHint": True},
 )
+@_cancellation_shield()
 async def unlock_agent_pack(pack_name: str, ctx: Context = CurrentContext()) -> str:
     """Unlock bundled agent definitions for this session.
 

--- a/src/autoskillit/server/tools/tools_ci.py
+++ b/src/autoskillit/server/tools/tools_ci.py
@@ -16,11 +16,13 @@ from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import fetch_repo_merge_state, resolve_repo_from_remote
 from autoskillit.server._notify import track_response_size
 from autoskillit.server._subprocess import _run_subprocess
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("set_commit_status")
 async def set_commit_status(
     sha: str,
@@ -112,6 +114,7 @@ async def set_commit_status(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "ci"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("check_repo_merge_state")
 async def check_repo_merge_state(
     branch: str,

--- a/src/autoskillit/server/tools/tools_ci_merge_queue.py
+++ b/src/autoskillit/server/tools/tools_ci_merge_queue.py
@@ -14,11 +14,13 @@ from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import resolve_repo_from_remote
 from autoskillit.server._notify import _notify, track_response_size
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "ci"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("toggle_auto_merge")
 async def toggle_auto_merge(
     pr_number: int,
@@ -88,6 +90,7 @@ async def toggle_auto_merge(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "ci"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("enqueue_pr")
 async def enqueue_pr(
     pr_number: int,
@@ -169,6 +172,7 @@ async def enqueue_pr(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "ci"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("wait_for_merge_queue")
 async def wait_for_merge_queue(
     pr_number: int,

--- a/src/autoskillit/server/tools/tools_ci_watch.py
+++ b/src/autoskillit/server/tools/tools_ci_watch.py
@@ -18,6 +18,7 @@ from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import resolve_repo_from_remote
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._subprocess import _run_subprocess
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
 
@@ -31,6 +32,7 @@ def _coerce_none_string(value: str | None, *, tool: str) -> str | None:
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "ci"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("wait_for_ci")
 async def wait_for_ci(
     branch: str,
@@ -232,6 +234,7 @@ async def wait_for_ci(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "ci"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("get_ci_status")
 async def get_ci_status(
     branch: str | None = None,

--- a/src/autoskillit/server/tools/tools_clone.py
+++ b/src/autoskillit/server/tools/tools_clone.py
@@ -22,11 +22,13 @@ from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import clone_registry
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._subprocess import _run_subprocess
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "clone"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("clone_repo")
 async def clone_repo(
     source_dir: str,
@@ -124,6 +126,7 @@ async def clone_repo(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "clone"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("remove_clone")
 async def remove_clone(
     clone_path: str,
@@ -177,6 +180,7 @@ async def remove_clone(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("push_to_remote")
 async def push_to_remote(
     clone_path: str,
@@ -286,6 +290,7 @@ async def push_to_remote(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "clone"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("register_clone_status")
 async def register_clone_status(
     clone_path: str,
@@ -373,6 +378,7 @@ async def register_clone_status(
 
 
 @mcp.tool(tags={"autoskillit", "clone", "fleet"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("batch_cleanup_clones")
 async def batch_cleanup_clones(
     registry_path: str = "",
@@ -486,6 +492,7 @@ def _require_clone_success(clone_result: CloneResult, source_dir: str) -> str | 
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "clone"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("bootstrap_clone")
 async def bootstrap_clone(
     source_dir: str,

--- a/src/autoskillit/server/tools/tools_config.py
+++ b/src/autoskillit/server/tools/tools_config.py
@@ -10,6 +10,7 @@ from autoskillit.server import mcp
 from autoskillit.server._guards import _require_orchestrator_exact
 from autoskillit.server._misc import _hook_config_overlay_path, _hook_config_path
 from autoskillit.server._notify import track_response_size
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
 
@@ -132,6 +133,7 @@ def _replace_fleet_semaphore(ctx, max_concurrent: int, acquire_timeout_sec: floa
 @mcp.tool(
     tags={"autoskillit"}, annotations={"readOnlyHint": True}, meta={"anthropic/alwaysLoad": True}
 )
+@_cancellation_shield()
 @track_response_size("configure_fleet")
 async def configure_fleet(
     max_concurrent_dispatches: int | None = None,
@@ -201,6 +203,7 @@ async def configure_fleet(
 @mcp.tool(
     tags={"autoskillit"}, annotations={"readOnlyHint": True}, meta={"anthropic/alwaysLoad": True}
 )
+@_cancellation_shield()
 @track_response_size("configure_order")
 async def configure_order(
     timeout: int | None = None,

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -37,6 +37,7 @@ from autoskillit.server._guards import (
 from autoskillit.server._misc import SCENARIO_STEP_NAME_ENV, _hook_config_overlay_path
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._subprocess import _run_subprocess
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
 
@@ -99,6 +100,7 @@ def _check_ingredient_locks(step_name: str, order_id: str) -> str | None:
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
+@_cancellation_shield(result_type="run_cmd")
 @track_response_size("run_cmd")
 async def run_cmd(
     cmd: str,
@@ -180,6 +182,7 @@ async def run_cmd(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
+@_cancellation_shield(result_type="run_python")
 @track_response_size("run_python")
 async def run_python(
     callable: str,
@@ -267,6 +270,7 @@ def _compute_write_prefixes(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("run_skill")
 async def run_skill(
     skill_command: str,
@@ -745,9 +749,14 @@ async def run_skill(
             skill_command=skill_command,
             order_id=order_id,
         ).to_json()
-    except BaseException:
+    except asyncio.CancelledError:
         logger.warning("run_skill cancelled", exc_info=True)
-        raise
+        _cmd = locals().get("resolved_command", skill_command)
+        _oid = locals().get("effective_order_id", order_id)
+        return SkillResult.cancelled(
+            skill_command=_cmd,  # type: ignore[arg-type]
+            order_id=_oid,  # type: ignore[arg-type]
+        ).to_json()
     finally:
         if _sn_token is not None:
             _current_step_name.reset(_sn_token)  # type: ignore[possibly-undefined]

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -9,6 +9,7 @@ import shutil
 import time
 from pathlib import Path
 
+import anyio
 import regex as re
 import structlog
 from fastmcp import Context
@@ -750,7 +751,8 @@ async def run_skill(
             order_id=order_id,
         ).to_json()
     except asyncio.CancelledError:
-        logger.warning("run_skill cancelled", exc_info=True)
+        with anyio.CancelScope(shield=True):
+            logger.warning("run_skill cancelled", exc_info=True)
         _cmd = locals().get("resolved_command", skill_command)
         _oid = locals().get("effective_order_id", order_id)
         return SkillResult.cancelled(

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -21,6 +21,7 @@ from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled, _require_fleet
 from autoskillit.server._misc import resolve_log_dir
 from autoskillit.server._notify import track_response_size
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
 
@@ -125,6 +126,7 @@ def _get_food_truck_prompt_builder() -> Callable[..., str]:
     tags={"autoskillit", "kitchen-core", "fleet"},
     annotations={"readOnlyHint": True},
 )
+@_cancellation_shield(result_type="fleet_error")
 @track_response_size("dispatch_food_truck")
 async def dispatch_food_truck(
     recipe: str,
@@ -388,6 +390,7 @@ async def dispatch_food_truck(
     tags={"autoskillit", "kitchen-core", "fleet"},
     annotations={"readOnlyHint": True},
 )
+@_cancellation_shield(result_type="fleet_error")
 @track_response_size("record_gate_dispatch")
 async def record_gate_dispatch(
     dispatch_name: str,

--- a/src/autoskillit/server/tools/tools_git.py
+++ b/src/autoskillit/server/tools/tools_git.py
@@ -17,6 +17,7 @@ from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._subprocess import _run_subprocess
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 _BRANCH_DATE_FORMAT = "%Y%m%d"
 
@@ -35,6 +36,7 @@ logger = get_logger(__name__)
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("merge_worktree")
 async def merge_worktree(
     worktree_path: str,
@@ -107,6 +109,7 @@ async def merge_worktree(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("classify_fix")
 async def classify_fix(
     worktree_path: str,
@@ -258,6 +261,7 @@ async def classify_fix(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("create_unique_branch")
 async def create_unique_branch(
     slug: str = "",
@@ -355,6 +359,7 @@ async def create_unique_branch(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("check_pr_mergeable")
 async def check_pr_mergeable(
     pr_number: int,
@@ -490,6 +495,7 @@ async def _resolve_and_create_branch(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("create_and_publish_branch")
 async def create_and_publish_branch(
     issue_slug: str,

--- a/src/autoskillit/server/tools/tools_github.py
+++ b/src/autoskillit/server/tools/tools_github.py
@@ -18,6 +18,7 @@ from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import _extract_block, resolve_log_dir
 from autoskillit.server._notify import _notify, track_response_size
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 if TYPE_CHECKING:
     from autoskillit.core import GitHubFetcher, HeadlessExecutor
@@ -33,6 +34,7 @@ _FINGERPRINT_END = "---/bug-fingerprint---"
 
 
 @mcp.tool(tags={"autoskillit", "github", "fleet-dispatch"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("fetch_github_issue")
 async def fetch_github_issue(
     issue_url: str,
@@ -109,6 +111,7 @@ async def fetch_github_issue(
 
 
 @mcp.tool(tags={"autoskillit", "github", "fleet-dispatch"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("get_issue_title")
 async def get_issue_title(issue_url: str) -> str:
     """Fetch only the title and slug for a GitHub issue — no body, no comments.
@@ -157,6 +160,7 @@ async def get_issue_title(issue_url: str) -> str:
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("report_bug")
 async def report_bug(
     error_context: str,

--- a/src/autoskillit/server/tools/tools_issue_composite.py
+++ b/src/autoskillit/server/tools/tools_issue_composite.py
@@ -17,6 +17,7 @@ from autoskillit.core import (
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._notify import track_response_size
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 from autoskillit.server.tools._claim_helpers import (
     _get_campaign_state_paths,
     _try_claim_with_liveness,
@@ -30,6 +31,7 @@ def _extract_label_names(raw_labels: list[Any]) -> list[str]:
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("claim_and_resolve_issue")
 async def claim_and_resolve_issue(
     issue_url: str,

--- a/src/autoskillit/server/tools/tools_issue_headless.py
+++ b/src/autoskillit/server/tools/tools_issue_headless.py
@@ -14,6 +14,7 @@ from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import _extract_block
 from autoskillit.server._notify import _notify, track_response_size
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 if TYPE_CHECKING:
     from autoskillit.core import SkillResult, WriteBehaviorSpec
@@ -148,6 +149,7 @@ def _parse_enrich_result(response_text: str) -> dict[str, Any]:
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("prepare_issue")
 async def prepare_issue(
     title: str,
@@ -255,6 +257,7 @@ async def prepare_issue(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("enrich_issues")
 async def enrich_issues(
     issue_number: int | None = None,

--- a/src/autoskillit/server/tools/tools_issue_labels.py
+++ b/src/autoskillit/server/tools/tools_issue_labels.py
@@ -16,6 +16,7 @@ from autoskillit.core import (
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._notify import track_response_size
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 from autoskillit.server.tools._claim_helpers import (
     _get_campaign_state_paths,
     _try_claim_with_liveness,
@@ -30,6 +31,7 @@ def _extract_label_names(raw_labels: list[Any]) -> list[str]:
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("claim_issue")
 async def claim_issue(
     issue_url: str,
@@ -177,6 +179,7 @@ async def claim_issue(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("release_issue")
 async def release_issue(
     issue_url: str,

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -791,6 +791,7 @@ def _apply_unlock_keys(current_pipeline_li: dict[str, str], unlock_keys: list[st
 @mcp.tool(
     tags={"autoskillit"}, annotations={"readOnlyHint": True}, meta={"anthropic/alwaysLoad": True}
 )
+@_cancellation_shield()
 @track_response_size("lock_ingredients")
 async def lock_ingredients(
     locked: dict[str, str] | None = None,

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -47,6 +47,7 @@ from autoskillit.server._misc import (
     resolve_provider,
 )
 from autoskillit.server._notify import track_response_size
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
 
@@ -330,6 +331,7 @@ def _build_tool_category_listing(
     annotations={"readOnlyHint": True},
     meta={"anthropic/maxResultSizeChars": 100_000, "anthropic/alwaysLoad": True},
 )
+@_cancellation_shield()
 @track_response_size("open_kitchen")
 async def open_kitchen(
     name: str | None = None,
@@ -632,6 +634,7 @@ async def open_kitchen(
 @mcp.tool(
     tags={"autoskillit"}, annotations={"readOnlyHint": True}, meta={"anthropic/alwaysLoad": True}
 )
+@_cancellation_shield()
 @track_response_size("close_kitchen")
 async def close_kitchen(ctx: Context = CurrentContext()) -> str:
     """Close the AutoSkillit kitchen.
@@ -652,6 +655,7 @@ async def close_kitchen(ctx: Context = CurrentContext()) -> str:
 @mcp.tool(
     tags={"autoskillit"}, annotations={"readOnlyHint": True}, meta={"anthropic/alwaysLoad": True}
 )
+@_cancellation_shield()
 @track_response_size("disable_quota_guard")
 async def disable_quota_guard() -> str:
     """Disable the quota guard for the remainder of this kitchen session.
@@ -916,6 +920,7 @@ def _reload_session_handler() -> dict[str, str]:
 @mcp.tool(
     tags={"autoskillit"}, annotations={"readOnlyHint": True}, meta={"anthropic/alwaysLoad": True}
 )
+@_cancellation_shield()
 @track_response_size("reload_session")
 async def reload_session() -> str:
     """Signal the parent autoskillit process to reload this session with the full

--- a/src/autoskillit/server/tools/tools_pr_ops.py
+++ b/src/autoskillit/server/tools/tools_pr_ops.py
@@ -16,6 +16,7 @@ from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._subprocess import _run_subprocess
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
 
@@ -101,6 +102,7 @@ async def _close_issues_sequentially(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("get_pr_reviews")
 async def get_pr_reviews(
     pr_number: int,
@@ -172,6 +174,7 @@ async def get_pr_reviews(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("bulk_close_issues")
 async def bulk_close_issues(
     issue_numbers: list[int],

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -17,6 +17,7 @@ from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import _apply_triage_gate, resolve_log_dir
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._state import _get_ctx_or_none
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
 
@@ -25,6 +26,7 @@ logger = get_logger(__name__)
     tags={"autoskillit", "kitchen-core", "fleet-dispatch"},
     annotations={"readOnlyHint": True},
 )
+@_cancellation_shield()
 @track_response_size("list_recipes")
 async def list_recipes() -> str:
     """List available recipes from .autoskillit/recipes/.
@@ -65,6 +67,7 @@ async def list_recipes() -> str:
     annotations={"readOnlyHint": True},
     meta={"anthropic/maxResultSizeChars": 100_000},
 )
+@_cancellation_shield()
 @track_response_size("load_recipe")
 async def load_recipe(
     name: str, overrides: dict[str, str] | None = None, ingredients_only: bool = False
@@ -228,6 +231,7 @@ async def load_recipe(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("validate_recipe")
 async def validate_recipe(script_path: str) -> str:
     """Validate a recipe YAML file against the recipe schema.
@@ -271,6 +275,7 @@ async def validate_recipe(script_path: str) -> str:
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("migrate_recipe")
 async def migrate_recipe(name: str, ctx: Context = CurrentContext()) -> str:
     """Apply pending migration notes to a recipe file.

--- a/src/autoskillit/server/tools/tools_status.py
+++ b/src/autoskillit/server/tools/tools_status.py
@@ -17,6 +17,7 @@ from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled, _require_fleet
 from autoskillit.server._misc import resolve_log_dir, write_telemetry_clear_marker
 from autoskillit.server._notify import _notify, track_response_size
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
 
@@ -29,6 +30,7 @@ def _get_log_root() -> Path:
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("kitchen_status")
 async def kitchen_status() -> str:
     """Return version health and configuration status for the running server.
@@ -79,6 +81,7 @@ async def kitchen_status() -> str:
     tags={"autoskillit", "kitchen-core", "fleet"},
     annotations={"readOnlyHint": True},
 )
+@_cancellation_shield()
 @track_response_size("get_pipeline_report")
 async def get_pipeline_report(clear: bool = False) -> str:
     """Return accumulated run_skill failures since last clear.
@@ -158,6 +161,7 @@ def _merge_wall_clock_seconds(steps: list[dict], timing_report: list[dict]) -> l
     tags={"autoskillit", "kitchen-core", "telemetry", "fleet"},
     annotations={"readOnlyHint": True},
 )
+@_cancellation_shield()
 @track_response_size("get_token_summary")
 async def get_token_summary(clear: bool = False, format: str = "json", order_id: str = "") -> str:
     """Return accumulated run_skill token usage grouped by step name.
@@ -227,6 +231,7 @@ async def get_token_summary(clear: bool = False, format: str = "json", order_id:
     tags={"autoskillit", "kitchen-core", "telemetry", "fleet"},
     annotations={"readOnlyHint": True},
 )
+@_cancellation_shield()
 @track_response_size("get_timing_summary")
 async def get_timing_summary(clear: bool = False, format: str = "json", order_id: str = "") -> str:
     """Return accumulated wall-clock timing grouped by step name.
@@ -273,6 +278,7 @@ async def get_timing_summary(clear: bool = False, format: str = "json", order_id
     tags={"autoskillit", "kitchen", "kitchen-core", "telemetry"},
     annotations={"readOnlyHint": True},
 )
+@_cancellation_shield()
 @track_response_size("analyze_tool_sequences")
 async def analyze_tool_sequences(
     recipe: str = "",
@@ -383,6 +389,7 @@ def _read_quota_events(log_root: Path, n: int) -> tuple[list[dict], int]:
     tags={"autoskillit", "kitchen-core", "telemetry", "fleet"},
     annotations={"readOnlyHint": True},
 )
+@_cancellation_shield()
 @track_response_size("get_quota_events")
 async def get_quota_events(n: int = 50) -> str:
     """Return the most recent quota guard events from the diagnostic log.
@@ -427,6 +434,7 @@ async def get_quota_events(n: int = 50) -> str:
     tags={"autoskillit", "kitchen", "kitchen-core", "telemetry"},
     annotations={"readOnlyHint": True},
 )
+@_cancellation_shield()
 @track_response_size("write_telemetry_files")
 async def write_telemetry_files(
     output_dir: str,
@@ -511,6 +519,7 @@ async def write_telemetry_files(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("read_db")
 async def read_db(
     db_path: str,

--- a/src/autoskillit/server/tools/tools_workspace.py
+++ b/src/autoskillit/server/tools/tools_workspace.py
@@ -17,6 +17,7 @@ from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import condense_test_output
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._subprocess import _run_subprocess
+from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
 
@@ -24,6 +25,7 @@ logger = get_logger(__name__)
 @mcp.tool(
     tags={"autoskillit", "kitchen", "kitchen-core", "headless"}, annotations={"readOnlyHint": True}
 )
+@_cancellation_shield()
 # No _require_enabled() — headless skill sessions need test_check without opening kitchen.
 # The kitchen tag governs visibility only; the headless tag provides access in SKILL sessions.
 @track_response_size("test_check")
@@ -127,6 +129,7 @@ async def test_check(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("reset_test_dir")
 async def reset_test_dir(
     test_dir: str,
@@ -212,6 +215,7 @@ async def reset_test_dir(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
+@_cancellation_shield()
 @track_response_size("reset_workspace")
 async def reset_workspace(test_dir: str, ctx: Context = CurrentContext()) -> str:
     """Runs a configured reset command then deletes directory contents,

--- a/tests/arch/_helpers.py
+++ b/tests/arch/_helpers.py
@@ -343,6 +343,20 @@ def _is_mcp_tool_decorator(node: ast.expr) -> bool:
     return False
 
 
+def _has_cancellation_shield(func_node: ast.AsyncFunctionDef | ast.FunctionDef) -> bool:
+    """Return True if the function has @_cancellation_shield in its decorator list."""
+    for dec in func_node.decorator_list:
+        if isinstance(dec, ast.Name) and dec.id == "_cancellation_shield":
+            return True
+        if (
+            isinstance(dec, ast.Call)
+            and isinstance(dec.func, ast.Name)
+            and dec.func.id == "_cancellation_shield"
+        ):
+            return True
+    return False
+
+
 def _has_toplevel_except_exception(func_node: ast.AsyncFunctionDef | ast.FunctionDef) -> bool:
     """Return True if the function has a top-level try/except Exception.
 

--- a/tests/arch/test_never_raises_contracts.py
+++ b/tests/arch/test_never_raises_contracts.py
@@ -15,7 +15,12 @@ import ast
 import re
 from pathlib import Path
 
-from tests.arch._helpers import SRC_ROOT, _has_toplevel_except_exception, _is_mcp_tool_decorator
+from tests.arch._helpers import (
+    SRC_ROOT,
+    _has_cancellation_shield,
+    _has_toplevel_except_exception,
+    _is_mcp_tool_decorator,
+)
 
 _NEVER_RAISES_RE = re.compile(r"never raises", re.IGNORECASE)
 
@@ -78,6 +83,34 @@ def test_all_mcp_tool_handlers_claim_never_raises() -> None:
     assert not missing, (
         "@mcp.tool() handlers should claim 'Never raises' in their docstring.\n"
         "Missing:\n" + "\n".join(f"  {v}" for v in missing)
+    )
+
+
+def test_all_mcp_tool_handlers_have_cancellation_shield() -> None:
+    """Every @mcp.tool() decorated function in server/ must have @_cancellation_shield.
+
+    Prevents asyncio.CancelledError (a BaseException) from escaping the MCP tool
+    boundary and dropping the transport session without a structured result.
+    Scope matches test_all_mcp_tool_handlers_have_except_exception.
+    """
+    server_dir = SRC_ROOT / "server"
+    violations: list[str] = []
+
+    for path in sorted(server_dir.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                continue
+            if not any(_is_mcp_tool_decorator(d) for d in node.decorator_list):
+                continue
+            if not _has_cancellation_shield(node):
+                rel = path.relative_to(SRC_ROOT.parent.parent)
+                violations.append(f"{rel}:{node.lineno} — {node.name}()")
+
+    assert not violations, (
+        "@mcp.tool() handlers must have @_cancellation_shield to prevent asyncio.CancelledError "
+        "from escaping the tool boundary without a structured result.\n"
+        "Violations:\n" + "\n".join(f"  {v}" for v in violations)
     )
 
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -857,7 +857,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "pipeline": 12,
         "fleet": 21,  # REQ-CNST-003-E9: _dispatch_reaper.py; +_sidecar_synthesis.py
         "recipe/rules": 35,
-        "server/tools": 22,  # _auto_overrides.py added for shared _build_auto_overrides() factory
+        "server/tools": 23,  # _auto_overrides.py + _cancellation_shield.py
         "hooks/guards": 24,  # +1: ingredient_lock_guard.py for session-scoped ingredient locking
     }
     violations: list[str] = []

--- a/tests/cli/test_routing_completeness.py
+++ b/tests/cli/test_routing_completeness.py
@@ -16,9 +16,12 @@ pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 # Reasons excluded from orchestrator-prompt routing check:
 # - NONE: not a retry scenario, no routing needed
 # - BUDGET_EXHAUSTED: caps other reasons; orchestrator never sees it directly
+# - CANCELLED: transport-level event; tool handler converts to structured result at the boundary,
+#   orchestrator sees success=False + subtype="cancelled" and routes via on_failure
 _ROUTING_EXCLUDED = {
     RetryReason.NONE,
     RetryReason.BUDGET_EXHAUSTED,
+    RetryReason.CANCELLED,
 }
 
 # Routing contract: RetryReason → (expected_route_keyword, evidence_condition_keyword_or_None)

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -66,11 +66,6 @@ def test_retry_reason_values():
     assert RetryReason.NONE.value == "none"
 
 
-def test_retry_reason_has_cancelled_variant():
-    """RetryReason.CANCELLED exists with the correct string value."""
-    assert RetryReason.CANCELLED == "cancelled"
-
-
 def test_skill_result_cancelled_factory():
     """SkillResult.cancelled() produces a correctly shaped retriable result."""
     from autoskillit.core.types import KillReason

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -61,8 +61,30 @@ def test_retry_reason_values():
         RetryReason.THINKING_STALL,
         RetryReason.IDLE_STALL,
         RetryReason.RATE_LIMITED,
+        RetryReason.CANCELLED,
     }
     assert RetryReason.NONE.value == "none"
+
+
+def test_retry_reason_has_cancelled_variant():
+    """RetryReason.CANCELLED exists with the correct string value."""
+    assert RetryReason.CANCELLED == "cancelled"
+
+
+def test_skill_result_cancelled_factory():
+    """SkillResult.cancelled() produces a correctly shaped retriable result."""
+    from autoskillit.core.types import KillReason
+
+    result = SkillResult.cancelled(skill_command="/test-skill", order_id="oid-123")
+    assert result.success is False
+    assert result.subtype == "cancelled"
+    assert result.needs_retry is True
+    assert result.retry_reason == RetryReason.CANCELLED
+    assert result.kill_reason == KillReason.EXCEPTION
+    assert result.is_error is True
+    assert result.exit_code == -1
+    assert result.order_id == "oid-123"
+    assert "/test-skill" in result.result
 
 
 def test_merge_failed_step_values():

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -267,9 +267,9 @@ def test_bundled_recipe_count_is_15() -> None:
     assert recipes == expected, f"Recipes drifted: {recipes}"
 
 
-def test_retry_reason_value_count_is_15() -> None:
+def test_retry_reason_value_count_is_16() -> None:
     values = _retry_reason_values()
-    assert len(values) == 15, f"RetryReason has {len(values)} values: {values}"
+    assert len(values) == 16, f"RetryReason has {len(values)} values: {values}"
 
 
 def test_semantic_rule_family_count_is_51() -> None:

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -117,14 +117,14 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 64),
     # tools_kitchen.py — hook config dict, quota guard overlay, ingredient locks overlay
-    ("src/autoskillit/server/tools/tools_kitchen.py", 127),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 146),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 691),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 751),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 128),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 147),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 695),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 755),
     # tools_status.py — mcp_data dict
-    ("src/autoskillit/server/tools/tools_status.py", 499),
+    ("src/autoskillit/server/tools/tools_status.py", 507),
     # tools_github.py — bug report dict
-    ("src/autoskillit/server/tools/tools_github.py", 303),
+    ("src/autoskillit/server/tools/tools_github.py", 307),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 24),
     # _init_helpers.py — ~/.claude.json (co-owned)
@@ -138,7 +138,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _marketplace.py — hooks.json (co-owned)
     ("src/autoskillit/cli/_marketplace.py", 188),
     # tools_config.py — hook config overlay dict (session-scoped, not schema-versioned)
-    ("src/autoskillit/server/tools/tools_config.py", 47),
+    ("src/autoskillit/server/tools/tools_config.py", 48),
     # _update_checks.py — dismissal state file
     ("src/autoskillit/cli/update/_update_checks.py", 77),
     # _update_checks_fetch.py — fetch cache (extracted from _update_checks.py)

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -297,3 +297,32 @@ class TestDispatchFoodTruckExecution:
         )
 
         assert tool_ctx.config.quota_guard.cache_path in invalidate_calls
+
+    @pytest.mark.anyio
+    async def test_dispatch_food_truck_returns_structured_result_on_cancelled_error(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ) -> None:
+        """dispatch_food_truck returns a fleet error envelope on asyncio.CancelledError.
+
+        This is the secondary gap test: CancelledError escaping execute_dispatch must be
+        caught at the MCP tool boundary and returned as a structured JSON response rather
+        than propagating to the MCP transport and dropping the session.
+        """
+        import autoskillit.fleet as _fleet_mod
+        from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
+
+        # Bypass fleet-session gate — test focuses on the CancelledError path, not the gate
+        monkeypatch.setattr(
+            "autoskillit.server.tools.tools_fleet_dispatch._require_fleet",
+            lambda _name: None,
+        )
+        # execute_dispatch is dynamically imported inside the function; patch the module attr
+        monkeypatch.setattr(
+            _fleet_mod,
+            "execute_dispatch",
+            AsyncMock(side_effect=asyncio.CancelledError()),
+        )
+
+        result_json = await dispatch_food_truck(recipe="test-recipe", task="test task")
+        data = json.loads(result_json)
+        assert data["success"] is False

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -326,3 +326,4 @@ class TestDispatchFoodTruckExecution:
         result_json = await dispatch_food_truck(recipe="test-recipe", task="test task")
         data = json.loads(result_json)
         assert data["success"] is False
+        assert "cancelled" in data["user_visible_message"].lower()

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -326,4 +326,5 @@ class TestDispatchFoodTruckExecution:
         result_json = await dispatch_food_truck(recipe="test-recipe", task="test task")
         data = json.loads(result_json)
         assert data["success"] is False
+        assert data["error"] == "fleet_l3_startup_or_crash"
         assert "cancelled" in data["user_visible_message"].lower()

--- a/tests/server/test_tools_execution_results.py
+++ b/tests/server/test_tools_execution_results.py
@@ -761,6 +761,7 @@ async def test_run_skill_returns_structured_result_on_cancelled_error(
     assert data["subtype"] == "cancelled"
     assert data["needs_retry"] is True
     assert data["retry_reason"] == "cancelled"
+    assert "cancelled" in data["result"].lower()
 
 
 class TestCwdExistenceValidation:

--- a/tests/server/test_tools_execution_results.py
+++ b/tests/server/test_tools_execution_results.py
@@ -732,6 +732,37 @@ async def test_run_skill_returns_structured_error_when_executor_raises(
     assert "unexpected executor failure" in data["result"]
 
 
+@pytest.mark.anyio
+async def test_run_skill_returns_structured_result_on_cancelled_error(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+) -> None:
+    """run_skill returns SkillResult JSON with subtype=cancelled on asyncio.CancelledError.
+
+    This is the primary gap test: CancelledError from executor.run() must produce a
+    structured SkillResult (needs_retry=True, subtype=cancelled) rather than escaping
+    the tool handler and dropping the MCP transport session.
+    """
+    import asyncio
+
+    from autoskillit.core import SkillResult
+
+    class CancellingExecutor:
+        async def run(self, *args, **kwargs) -> SkillResult:
+            raise asyncio.CancelledError()
+
+    tool_ctx_kitchen_open.executor = CancellingExecutor()
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    from autoskillit.server.tools.tools_execution import run_skill
+
+    result_json = await run_skill("/test-skill arg", str(tmp_path))
+    data = json.loads(result_json)
+    assert data["success"] is False
+    assert data["subtype"] == "cancelled"
+    assert data["needs_retry"] is True
+    assert data["retry_reason"] == "cancelled"
+
+
 class TestCwdExistenceValidation:
     """run_skill and run_cmd reject non-existent cwd before reaching executor/subprocess."""
 


### PR DESCRIPTION
## Summary

`asyncio.CancelledError` from MCP transport teardown (SIGTERM/SIGINT/SIGHUP) propagates through MCP tool handlers (`run_skill`, `dispatch_food_truck`, `record_gate_dispatch`) without producing a structured SkillResult. The retry FSM is never consulted, no SkillResult is returned, and pipeline orchestrators proceed with stale artifacts. Part A adds: a `SkillResult.cancelled()` factory, the `CANCELLED` retry reason enum variant, a `_cancellation_shield` decorator for all MCP tool handlers, an explicit inner `except asyncio.CancelledError` handler in `run_skill`, and tests that prove the gap and verify the fix. Part B (separate) covers recipe schema routing.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-193133-478133/.autoskillit/temp/rectify/rectify_cancelled_error_skill_result_gap_2026-05-30_193500.md`

Closes #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 90 | 29.2k | 2.8M | 128.7k | 235 | 112.4k | 25m 14s |
| review_approach* | sonnet | 1 | 3.5k | 7.5k | 235.7k | 51.5k | 80 | 39.1k | 5m 9s |
| dry_walkthrough* | opus | 2 | 86 | 16.3k | 988.4k | 62.4k | 216 | 106.0k | 10m 24s |
| implement* | sonnet | 2 | 1.1k | 69.0k | 16.5M | 176.1k | 375 | 276.5k | 21m 59s |
| audit_impl* | sonnet | 2 | 864 | 28.6k | 637.6k | 76.8k | 132 | 126.5k | 11m 28s |
| make_plan* | sonnet | 1 | 95 | 6.1k | 352.9k | 42.4k | 34 | 44.7k | 2m 38s |
| prepare_pr* | sonnet | 1 | 120.6k | 4.8k | 226.2k | 33.0k | 24 | 55.3k | 1m 30s |
| compose_pr* | sonnet | 1 | 108.5k | 1.4k | 246.5k | 27.8k | 20 | 16.5k | 46s |
| review_pr* | sonnet | 2 | 324 | 60.8k | 2.0M | 95.9k | 164 | 150.4k | 15m 35s |
| resolve_review* | opus | 2 | 135 | 38.8k | 6.9M | 100.4k | 174 | 224.6k | 32m 55s |
| resolve_pre_review_conflicts* | opus | 1 | 37 | 6.2k | 1.2M | 85.5k | 42 | 69.0k | 2m 31s |
| **Total** | | | 235.3k | 268.7k | 32.1M | 176.1k | | 1.2M | 2h 10m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 242 | 68208.6 | 1142.5 | 285.3 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 26 | 265776.8 | 8636.6 | 1492.2 |
| resolve_pre_review_conflicts | 2345 | 502.7 | 29.4 | 2.6 |
| **Total** | **2613** | 12266.6 | 467.2 | 102.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 90 | 29.2k | 2.8M | 112.4k | 25m 14s |
| sonnet | 7 | 235.0k | 178.3k | 20.2M | 709.0k | 59m 8s |
| opus | 3 | 258 | 61.3k | 9.1M | 399.5k | 45m 51s |