### PR TITLE
Add test_campaign_dispatch_capture_value_type_checked

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -115,7 +115,7 @@ async def execute_dispatch(
     quota_checker: Callable[..., Any],
     quota_refresher: Callable[..., Any],
     cache_invalidator: Callable[[str], None] | None = None,
-    capture: dict[str, str] | None = None,
+    capture: dict[str, str | dict[str, str]] | None = None,
     resume_session_id: str | None = None,
     resume_checkpoint: SessionCheckpoint | None = None,
     idle_output_timeout: int | None = None,

--- a/src/autoskillit/fleet/_capture.py
+++ b/src/autoskillit/fleet/_capture.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from autoskillit.core import (
+    CAPTURE_VALID_VALUE_TYPES,
     CaptureEntrySpec,
     CaptureValueTypeError,
     get_logger,
@@ -76,6 +77,8 @@ def _validate_capture_value(key: str, value: str, declared_type: str) -> None:
                 declared_type=declared_type,
                 reason=f"url value must start with http://, https://, or file://: {value!r}",
             )
+    elif declared_type == "optional_string":
+        return
 
 
 def _extract_captures(
@@ -127,19 +130,27 @@ def _extract_captures(
 
 
 def _normalize_capture_spec(
-    capture: Mapping[str, str | CaptureEntrySpec] | None,
+    capture: Mapping[str, str | dict[str, str] | CaptureEntrySpec] | None,
 ) -> dict[str, CaptureEntrySpec] | None:
-    """Convert YAML-format ``dict[str, str]`` capture spec to ``dict[str, CaptureEntrySpec]``.
+    """Convert YAML-format capture spec to ``dict[str, CaptureEntrySpec]``.
 
-    The recipe YAML uses shorthand capture entries: ``{key: "${{ result.field }}"}``.
-    This converts them to the typed ``CaptureEntrySpec`` format used internally.
-    Already-typed ``CaptureEntrySpec`` values are passed through unchanged.
+    Accepts three value forms:
+    - ``CaptureEntrySpec`` — passed through unchanged.
+    - ``dict`` with ``from`` and optional ``type`` — long-form with explicit value_type.
+    - ``str`` — shorthand; defaults to ``value_type="string"``.
     """
     if capture is None:
         return None
-    return {
-        key: val
-        if isinstance(val, CaptureEntrySpec)
-        else CaptureEntrySpec(from_=val, value_type="string")
-        for key, val in capture.items()
-    }
+    result: dict[str, CaptureEntrySpec] = {}
+    for key, val in capture.items():
+        if isinstance(val, CaptureEntrySpec):
+            result[key] = val
+        elif isinstance(val, dict):
+            from_ = val.get("from", "")
+            type_ = val.get("type", "string")
+            if type_ not in CAPTURE_VALID_VALUE_TYPES:
+                type_ = "string"
+            result[key] = CaptureEntrySpec(from_=from_, value_type=type_)  # type: ignore[arg-type]
+        else:
+            result[key] = CaptureEntrySpec(from_=str(val), value_type="string")
+    return result

--- a/src/autoskillit/fleet/_capture.py
+++ b/src/autoskillit/fleet/_capture.py
@@ -146,9 +146,18 @@ def _normalize_capture_spec(
         if isinstance(val, CaptureEntrySpec):
             result[key] = val
         elif isinstance(val, dict):
-            from_ = val.get("from", "")
+            from_ = val.get("from")
+            if not isinstance(from_, str) or not from_:
+                logger.warning("capture_spec_malformed_longform", capture_name=key, raw=val)
+                continue
             type_ = val.get("type", "string")
             if type_ not in CAPTURE_VALID_VALUE_TYPES:
+                logger.warning(
+                    "capture_spec_unknown_type",
+                    capture_name=key,
+                    type_value=type_,
+                    fallback="string",
+                )
                 type_ = "string"
             result[key] = CaptureEntrySpec(from_=from_, value_type=type_)  # type: ignore[arg-type]
         else:

--- a/src/autoskillit/recipe/_rule_helpers.py
+++ b/src/autoskillit/recipe/_rule_helpers.py
@@ -14,6 +14,7 @@ from autoskillit.core import get_logger
 from autoskillit.recipe._analysis import ValidationContext
 
 if TYPE_CHECKING:
+    from autoskillit.recipe._contracts_types import SkillContract
     from autoskillit.recipe.schema import CampaignDispatch, Recipe, RecipeStep
 
 logger = get_logger(__name__)
@@ -214,3 +215,22 @@ def push_reachable(
         for succ in graph.get(name, set()):
             queue.append((succ, hops + 1))
     return False, None
+
+
+def _identify_optional_output_fields(contract: SkillContract) -> set[str]:
+    """Return output field names whose contract patterns allow an empty value.
+
+    Cross-references ``contract.outputs`` names with ``expected_output_patterns``:
+    a field is considered optional when its pattern contains a fully-optional capture
+    group ``(...)? `` at the end (same check as ``_has_optional_capture_group``).
+    Patterns that don't start with a recognized output name are skipped.
+    """
+    output_names = {o.name for o in contract.outputs}
+    optional: set[str] = set()
+    for pattern in contract.expected_output_patterns:
+        if not re.search(r"\((?!\?:)[^)]+\)\?$", pattern):
+            continue
+        m = re.match(r"^([\w-]+)", pattern)
+        if m and m.group(1) in output_names:
+            optional.add(m.group(1))
+    return optional

--- a/src/autoskillit/recipe/rules/campaign/rules_campaign_capture.py
+++ b/src/autoskillit/recipe/rules/campaign/rules_campaign_capture.py
@@ -12,6 +12,7 @@ from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe._contracts_types import RESULT_CAPTURE_RE
 from autoskillit.recipe._rule_helpers import (
     _extract_sentinel_fields,
+    _identify_optional_output_fields,
     _is_failure_sentinel_value,
     _load_dispatch_target,
     extract_sentinel_json_blocks,
@@ -23,7 +24,6 @@ from autoskillit.recipe.contracts import (
 )
 from autoskillit.recipe.io import find_recipe_by_name, load_recipe
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
-from autoskillit.recipe.rules.rules_optional_capture import _identify_optional_output_fields
 from autoskillit.recipe.schema import RecipeKind
 
 if TYPE_CHECKING:

--- a/src/autoskillit/recipe/rules/campaign/rules_campaign_capture.py
+++ b/src/autoskillit/recipe/rules/campaign/rules_campaign_capture.py
@@ -7,15 +7,23 @@ from typing import TYPE_CHECKING
 
 import regex as re
 
-from autoskillit.core import Severity, get_logger
+from autoskillit.core import Severity, get_logger, pkg_root
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._contracts_types import RESULT_CAPTURE_RE
 from autoskillit.recipe._rule_helpers import (
     _extract_sentinel_fields,
     _is_failure_sentinel_value,
     _load_dispatch_target,
     extract_sentinel_json_blocks,
 )
+from autoskillit.recipe.contracts import (
+    get_skill_contract,
+    load_bundled_manifest,
+    resolve_skill_name,
+)
+from autoskillit.recipe.io import find_recipe_by_name, load_recipe
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
+from autoskillit.recipe.rules.rules_optional_capture import _identify_optional_output_fields
 from autoskillit.recipe.schema import RecipeKind
 
 if TYPE_CHECKING:
@@ -206,4 +214,91 @@ def _check_dispatch_capture_field_in_all_sentinels(
                         ),
                     )
                 )
+    return findings
+
+
+@semantic_rule(
+    name="dispatch-capture-type-matches-contract-optionality",
+    description=(
+        "Flag campaign dispatches whose capture value_type='string' but the target "
+        "recipe's skill contract allows an empty value for that field."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_dispatch_capture_type_matches_contract_optionality(
+    ctx: ValidationContext,
+) -> list[RuleFinding]:
+    """Detect string captures on fields that target-recipe skill contracts allow to be empty."""
+    if ctx.recipe.kind != RecipeKind.CAMPAIGN:
+        return []
+    findings: list[RuleFinding] = []
+    manifest = load_bundled_manifest()
+
+    for d in ctx.recipe.dispatches:
+        if not d.capture:
+            continue
+
+        target = _load_dispatch_target(d, ctx.project_dir)
+        if target is None:
+            info = find_recipe_by_name(d.recipe, pkg_root())
+            if info is not None:
+                try:
+                    target = load_recipe(info.path)
+                except Exception:
+                    logger.debug(
+                        "dispatch_target_load_failed_fallback", recipe=d.recipe, exc_info=True
+                    )
+            if target is None:
+                findings.append(
+                    RuleFinding(
+                        rule="dispatch-capture-type-matches-contract-optionality",
+                        severity=Severity.WARNING,
+                        step_name="(top-level)",
+                        message=(
+                            f"Cannot verify capture type compatibility for dispatch "
+                            f"{d.name!r} — target recipe {d.recipe!r} could not be loaded."
+                        ),
+                    )
+                )
+                continue
+
+        # Collect all skill contracts from run_skill steps in the target recipe
+        contracts = []
+        for step in target.steps.values():
+            if step.tool != "run_skill":
+                continue
+            skill_cmd = step.with_args.get("skill_command", "")
+            name = resolve_skill_name(skill_cmd)
+            if not name:
+                continue
+            contract = get_skill_contract(name, manifest)
+            if contract is not None:
+                contracts.append(contract)
+
+        if not contracts:
+            continue
+
+        for cap_key, cap_entry in d.capture.items():
+            m = RESULT_CAPTURE_RE.match(cap_entry.from_.strip())
+            if not m:
+                continue
+            field_name = m.group(1)
+            for contract in contracts:
+                optional_fields = _identify_optional_output_fields(contract)
+                if field_name in optional_fields and cap_entry.value_type == "string":
+                    findings.append(
+                        RuleFinding(
+                            rule="dispatch-capture-type-matches-contract-optionality",
+                            severity=Severity.ERROR,
+                            step_name="(top-level)",
+                            message=(
+                                f"Dispatch {d.name!r} capture key {cap_key!r} captures "
+                                f"field '{field_name}' with value_type='string' but target "
+                                f"recipe {d.recipe!r} skill contract allows empty values "
+                                f"for this field. Use 'type: optional_string'."
+                            ),
+                        )
+                    )
+                    break  # one finding per cap_key is enough
+
     return findings

--- a/src/autoskillit/recipe/rules/rules_optional_capture.py
+++ b/src/autoskillit/recipe/rules/rules_optional_capture.py
@@ -6,7 +6,10 @@ import regex as re
 
 from autoskillit.core import Severity
 from autoskillit.recipe._analysis import ValidationContext
-from autoskillit.recipe._contracts_types import RESULT_CAPTURE_RE, SkillContract
+from autoskillit.recipe._contracts_types import RESULT_CAPTURE_RE
+from autoskillit.recipe._rule_helpers import (
+    _identify_optional_output_fields as _identify_optional_output_fields,
+)
 from autoskillit.recipe.contracts import (
     get_skill_contract,
     load_bundled_manifest,
@@ -88,25 +91,6 @@ def _has_guard_for_key(
             to_visit.append(step.on_success)
 
     return False
-
-
-def _identify_optional_output_fields(contract: SkillContract) -> set[str]:
-    """Return output field names whose contract patterns allow an empty value.
-
-    Cross-references ``contract.outputs`` names with ``expected_output_patterns``:
-    a field is considered optional when its pattern contains a fully-optional capture
-    group ``(...)? `` at the end (same check as ``_has_optional_capture_group``).
-    Patterns that don't start with a recognized output name are skipped.
-    """
-    output_names = {o.name for o in contract.outputs}
-    optional: set[str] = set()
-    for pattern in contract.expected_output_patterns:
-        if not re.search(r"\((?!\?:)[^)]+\)\?$", pattern):
-            continue
-        m = re.match(r"^([\w-]+)", pattern)
-        if m and m.group(1) in output_names:
-            optional.add(m.group(1))
-    return optional
 
 
 @semantic_rule(

--- a/src/autoskillit/recipe/rules/rules_optional_capture.py
+++ b/src/autoskillit/recipe/rules/rules_optional_capture.py
@@ -6,6 +6,7 @@ import regex as re
 
 from autoskillit.core import Severity
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._contracts_types import RESULT_CAPTURE_RE, SkillContract
 from autoskillit.recipe.contracts import (
     get_skill_contract,
     load_bundled_manifest,
@@ -87,6 +88,74 @@ def _has_guard_for_key(
             to_visit.append(step.on_success)
 
     return False
+
+
+def _identify_optional_output_fields(contract: SkillContract) -> set[str]:
+    """Return output field names whose contract patterns allow an empty value.
+
+    Cross-references ``contract.outputs`` names with ``expected_output_patterns``:
+    a field is considered optional when its pattern contains a fully-optional capture
+    group ``(...)? `` at the end (same check as ``_has_optional_capture_group``).
+    Patterns that don't start with a recognized output name are skipped.
+    """
+    output_names = {o.name for o in contract.outputs}
+    optional: set[str] = set()
+    for pattern in contract.expected_output_patterns:
+        if not re.search(r"\((?!\?:)[^)]+\)\?$", pattern):
+            continue
+        m = re.match(r"^([\w-]+)", pattern)
+        if m and m.group(1) in output_names:
+            optional.add(m.group(1))
+    return optional
+
+
+@semantic_rule(
+    name="capture-type-matches-contract-optionality",
+    description=(
+        "Flag run_skill steps whose capture value_type='string' but the skill contract "
+        "allows an empty value for that field (optional capture group in pattern)."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_capture_type_matches_contract_optionality(ctx: ValidationContext) -> list[RuleFinding]:
+    """Detect shorthand string captures on fields that skill contracts allow to be empty."""
+    findings: list[RuleFinding] = []
+    manifest = load_bundled_manifest()
+
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        skill_cmd = step.with_args.get("skill_command", "")
+        name = resolve_skill_name(skill_cmd)
+        if not name:
+            continue
+        contract = get_skill_contract(name, manifest)
+        if not contract:
+            continue
+        optional_fields = _identify_optional_output_fields(contract)
+        if not optional_fields or not step.capture:
+            continue
+        for cap_key, cap_entry in step.capture.items():
+            m = RESULT_CAPTURE_RE.match(cap_entry.from_.strip())
+            if not m:
+                continue
+            field_name = m.group(1)
+            if field_name in optional_fields and cap_entry.value_type == "string":
+                findings.append(
+                    RuleFinding(
+                        rule="capture-type-matches-contract-optionality",
+                        severity=Severity.ERROR,
+                        step_name=step_name,
+                        message=(
+                            f"Step '{step_name}' capture key '{cap_key}' captures field "
+                            f"'{field_name}' with value_type='string' but skill '{name}' "
+                            f"contract allows empty values for this field. "
+                            f"Use 'type: optional_string'."
+                        ),
+                    )
+                )
+
+    return findings
 
 
 @semantic_rule(

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2237,6 +2237,7 @@ skills:
     - name: pr_body_path
       type: file_path
     expected_output_patterns:
+    - "pr_url[ \\t]*=[ \\t]*(\\S+)?"
     - "verdict[ \\t]*=[ \\t]*(created|dry_run|preflight_failed)"
     pattern_examples:
     - "pr_url = https://github.com/org/repo/pull/42\nverdict = created\ncategory_summary = 14 fixes, 3 features\n%%ORDER_UP%%"

--- a/src/autoskillit/recipes/campaigns/promote-to-main.json
+++ b/src/autoskillit/recipes/campaigns/promote-to-main.json
@@ -119,7 +119,10 @@
         "source_dir": "${{ inputs.source_dir }}"
       },
       "capture": {
-        "pr_url": "${{ result.pr_url }}",
+        "pr_url": {
+          "from": "${{ result.pr_url }}",
+          "type": "optional_string"
+        },
         "verdict": "${{ result.verdict }}"
       },
       "depends_on": [

--- a/src/autoskillit/recipes/campaigns/promote-to-main.yaml
+++ b/src/autoskillit/recipes/campaigns/promote-to-main.yaml
@@ -101,7 +101,9 @@ dispatches:
       base_branch: "${{ inputs.base_branch }}"
       source_dir: "${{ inputs.source_dir }}"
     capture:
-      pr_url: "${{ result.pr_url }}"
+      pr_url:
+        from: "${{ result.pr_url }}"
+        type: optional_string
       verdict: "${{ result.verdict }}"
     depends_on:
       - implement-findings

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -864,7 +864,10 @@
         "issue_number": "${{ context.issue_number }}"
       },
       "capture": {
-        "pr_url": "${{ result.pr_url }}"
+        "pr_url": {
+          "from": "${{ result.pr_url }}",
+          "type": "optional_string"
+        }
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -788,7 +788,9 @@ steps:
       step_name: "compose_pr"
       issue_number: "${{ context.issue_number }}"
     capture:
-      pr_url: "${{ result.pr_url }}"
+      pr_url:
+        from: "${{ result.pr_url }}"
+        type: optional_string
     on_result:
     - when: "${{ result.pr_url }}"
       route: guard_pr_url

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -921,7 +921,10 @@
         "step_name": "compose_pr"
       },
       "capture": {
-        "pr_url": "${{ result.pr_url }}"
+        "pr_url": {
+          "from": "${{ result.pr_url }}",
+          "type": "optional_string"
+        }
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -854,7 +854,9 @@ steps:
       output_dir: '.'
       step_name: compose_pr
     capture:
-      pr_url: ${{ result.pr_url }}
+      pr_url:
+        from: ${{ result.pr_url }}
+        type: optional_string
     on_result:
     - when: ${{ result.pr_url }}
       route: guard_pr_url

--- a/src/autoskillit/recipes/promote-to-main-wrapper.json
+++ b/src/autoskillit/recipes/promote-to-main-wrapper.json
@@ -38,9 +38,15 @@
         "output_dir": "{{AUTOSKILLIT_TEMP}}/promote-to-main"
       },
       "capture": {
-        "pr_url": "${{ result.pr_url }}",
+        "pr_url": {
+          "from": "${{ result.pr_url }}",
+          "type": "optional_string"
+        },
         "verdict": "${{ result.verdict }}",
-        "category_summary": "${{ result.category_summary }}"
+        "category_summary": {
+          "from": "${{ result.category_summary }}",
+          "type": "optional_string"
+        }
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/promote-to-main-wrapper.yaml
@@ -38,9 +38,13 @@ steps:
       step_name: "promote"
       output_dir: "{{AUTOSKILLIT_TEMP}}/promote-to-main"
     capture:
-      pr_url: "${{ result.pr_url }}"
+      pr_url:
+        from: "${{ result.pr_url }}"
+        type: optional_string
       verdict: "${{ result.verdict }}"
-      category_summary: "${{ result.category_summary }}"
+      category_summary:
+        from: "${{ result.category_summary }}"
+        type: optional_string
     on_result:
     - when: "${{ result.verdict }} == 'preflight_failed'"
       route: escalate_stop

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -1054,7 +1054,10 @@
         "step_name": "compose_pr"
       },
       "capture": {
-        "pr_url": "${{ result.pr_url }}"
+        "pr_url": {
+          "from": "${{ result.pr_url }}",
+          "type": "optional_string"
+        }
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -958,7 +958,9 @@ steps:
       output_dir: '.'
       step_name: compose_pr
     capture:
-      pr_url: ${{ result.pr_url }}
+      pr_url:
+        from: ${{ result.pr_url }}
+        type: optional_string
     on_result:
     - when: ${{ result.pr_url }}
       route: guard_pr_url

--- a/src/autoskillit/recipes/research-review.json
+++ b/src/autoskillit/recipes/research-review.json
@@ -177,7 +177,10 @@
         "output_dir": "."
       },
       "capture": {
-        "pr_url": "${{ result.pr_url }}"
+        "pr_url": {
+          "from": "${{ result.pr_url }}",
+          "type": "optional_string"
+        }
       },
       "on_success": "guard_pr_url",
       "on_failure": "escalate_stop"

--- a/src/autoskillit/recipes/research-review.yaml
+++ b/src/autoskillit/recipes/research-review.yaml
@@ -170,7 +170,9 @@ steps:
       step_name: compose_research_pr
       output_dir: '.'
     capture:
-      pr_url: "${{ result.pr_url }}"
+      pr_url:
+        from: "${{ result.pr_url }}"
+        type: optional_string
     on_success: guard_pr_url
     on_failure: escalate_stop
 

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -909,7 +909,10 @@
         "output_dir": "."
       },
       "capture": {
-        "pr_url": "${{ result.pr_url }}"
+        "pr_url": {
+          "from": "${{ result.pr_url }}",
+          "type": "optional_string"
+        }
       },
       "on_success": "guard_pr_url",
       "on_failure": "escalate_stop"

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -871,7 +871,9 @@ steps:
       step_name: compose_research_pr
       output_dir: '.'
     capture:
-      pr_url: "${{ result.pr_url }}"
+      pr_url:
+        from: "${{ result.pr_url }}"
+        type: optional_string
     on_success: guard_pr_url
     on_failure: escalate_stop
 

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -134,7 +134,7 @@ async def dispatch_food_truck(
     ingredients: dict[str, str] | None = None,
     dispatch_name: str | None = None,
     timeout_sec: int | None = None,
-    capture: dict[str, str] | None = None,
+    capture: dict[str, str | dict[str, str]] | None = None,
     resume_session_id: str | None = None,
     resume_checkpoint: dict[str, object] | None = None,
     idle_output_timeout: int | None = None,

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -877,3 +877,52 @@ def test_captures_from_prior_session_invisible_with_different_campaign_id(tmp_pa
 
     result = read_all_campaign_captures(dispatches_dir, "kitchen-uuid-B")
     assert result == {}  # orphaned — this is the bug we're preventing
+
+
+# ---------------------------------------------------------------------------
+# String value_type, normalization, and optional_string tests (1a, 1b, 1c, 1f)
+# ---------------------------------------------------------------------------
+
+
+def test_string_type_rejects_empty_value():
+    """_validate_capture_value with value_type='string' must reject empty string."""
+    from autoskillit.core import CaptureValueTypeError
+    from autoskillit.fleet._capture import _validate_capture_value
+
+    with pytest.raises(CaptureValueTypeError) as exc_info:
+        _validate_capture_value("pr_url", "", "string")
+    assert exc_info.value.declared_type == "string"
+    assert exc_info.value.key == "pr_url"
+    assert "non-empty" in str(exc_info.value)
+
+
+def test_normalize_capture_spec_shorthand_defaults_to_string():
+    """Shorthand string values in _normalize_capture_spec produce value_type='string'."""
+    from autoskillit.fleet._capture import _normalize_capture_spec
+
+    result = _normalize_capture_spec({"pr_url": "${{ result.pr_url }}"})
+    assert result is not None
+    assert result["pr_url"].from_ == "${{ result.pr_url }}"
+    assert result["pr_url"].value_type == "string"
+
+
+def test_shorthand_capture_with_empty_value_from_optional_contract_raises():
+    """End-to-end: shorthand capture normalized to string raises on empty payload value."""
+    from autoskillit.core import CaptureValueTypeError
+    from autoskillit.fleet._capture import _extract_captures, _normalize_capture_spec
+
+    normalized = _normalize_capture_spec({"pr_url": "${{ result.pr_url }}"})
+    assert normalized is not None
+
+    with pytest.raises(CaptureValueTypeError) as exc_info:
+        _extract_captures(normalized, {"pr_url": ""})
+    assert exc_info.value.declared_type == "string"
+    assert exc_info.value.key == "pr_url"
+
+
+def test_optional_string_explicitly_accepted():
+    """_validate_capture_value with value_type='optional_string' must accept empty string."""
+    from autoskillit.fleet._capture import _validate_capture_value
+
+    # Must not raise — optional_string permits empty values
+    _validate_capture_value("pr_url", "", "optional_string")

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -947,7 +947,13 @@ def _dispatchable_recipe_names() -> list[str]:
 
 
 def test_recipe_step_shorthand_capture_parses_to_capture_entry_spec() -> None:
-    """Shorthand capture values must load as CaptureEntrySpec with value_type='string'."""
+    """Shorthand captures default to value_type='string' and are valid for mandatory fields.
+
+    Shorthand syntax (``key: "${{ result.field }}"``) is still permitted for fields
+    whose skill contract output patterns do NOT have an optional group. For optional
+    fields, the ``capture-type-matches-contract-optionality`` semantic rule blocks
+    recipe loading at validation time, enforcing 'type: optional_string'.
+    """
     from autoskillit.core import CaptureEntrySpec
 
     recipe = load_recipe(builtin_recipes_dir() / "remediation.yaml")
@@ -957,6 +963,57 @@ def test_recipe_step_shorthand_capture_parses_to_capture_entry_spec() -> None:
     assert isinstance(value, CaptureEntrySpec)
     assert value.value_type == "string"
     assert "${{ result." in value.from_
+
+
+def test_optional_output_with_string_capture_type_flagged() -> None:
+    """No bundled recipe may capture an optional-output field with value_type='string'.
+
+    For each capture entry whose skill contract output pattern has an optional group,
+    value_type must not be 'string'. Shorthand captures default to 'string' and will
+    be caught by the capture-type-matches-contract-optionality semantic rule at load time.
+    """
+    from autoskillit.recipe._contracts_types import RESULT_CAPTURE_RE
+    from autoskillit.recipe.rules.rules_optional_capture import _identify_optional_output_fields
+
+    manifest = load_bundled_manifest()
+    violations: list[str] = []
+
+    for recipe_file in builtin_recipes_dir().glob("*.yaml"):
+        recipe = load_recipe(recipe_file)
+        for step_name, step in recipe.steps.items():
+            if step.tool != "run_skill" or not step.capture:
+                continue
+            skill_cmd = step.with_args.get("skill_command", "")
+            name = resolve_skill_name(skill_cmd)
+            if not name:
+                continue
+            contract = manifest.get("skills", {}).get(name)
+            if contract is None:
+                continue
+            from autoskillit.recipe.contracts import get_skill_contract
+
+            c = get_skill_contract(name, manifest)
+            if c is None:
+                continue
+            optional_fields = _identify_optional_output_fields(c)
+            if not optional_fields:
+                continue
+            for cap_key, cap_entry in step.capture.items():
+                m = RESULT_CAPTURE_RE.match(cap_entry.from_.strip())
+                if not m:
+                    continue
+                field_name = m.group(1)
+                if field_name in optional_fields and cap_entry.value_type == "string":
+                    violations.append(
+                        f"{recipe_file.name}::{step_name}::{cap_key} captures optional "
+                        f"field '{field_name}' with value_type='string'"
+                    )
+
+    assert not violations, (
+        "Bundled recipes have shorthand captures on optional-output fields. "
+        "Use 'type: optional_string' in the capture spec:\n"
+        + "\n".join(f"  - {v}" for v in violations)
+    )
 
 
 @pytest.mark.parametrize("recipe_name", _dispatchable_recipe_names())

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -529,6 +529,7 @@ def test_research_campaign_run_review_capture():
     assert d.name == "run-review"
     assert set(d.capture.keys()) == {"pr_url", "report_path_after_finalize"}
     assert d.capture["pr_url"].from_ == "${{ result.pr_url }}"
+    assert d.capture["pr_url"].value_type == "optional_string"
     assert (
         d.capture["report_path_after_finalize"].from_ == "${{ result.report_path_after_finalize }}"
     )

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from autoskillit.core import DispatchGateType, Severity, pkg_root
+from autoskillit.core import CaptureEntrySpec, DispatchGateType, Severity, pkg_root
 from autoskillit.recipe._analysis import make_validation_context
 from autoskillit.recipe.io import (
     _parse_recipe,
@@ -306,6 +306,64 @@ def test_promote_to_main_campaign_in_list_campaign_recipes(tmp_path: Path):
     assert result.errors == []
     names = [r.name for r in result.items]
     assert "promote-to-main" in names
+
+
+def test_campaign_dispatch_capture_value_type_checked() -> None:
+    """dispatch-capture-type-matches-contract-optionality: string on optional field → ERROR."""
+    import dataclasses
+
+    path = pkg_root() / "recipes" / "campaigns" / "promote-to-main.yaml"
+    recipe = load_recipe(path)
+    project_dir = pkg_root() / "recipes"
+    available_recipes = frozenset(p.stem for p in project_dir.glob("*.yaml"))
+
+    # Build a modified recipe where pr_url uses value_type="string" (wrong type).
+    # The rule must emit an ERROR for this.
+    modified_dispatches = []
+    for d in recipe.dispatches:
+        if d.capture and "pr_url" in d.capture:
+            new_capture = dict(d.capture)
+            new_capture["pr_url"] = CaptureEntrySpec(
+                from_=d.capture["pr_url"].from_,
+                value_type="string",
+            )
+            modified_dispatches.append(dataclasses.replace(d, capture=new_capture))
+        else:
+            modified_dispatches.append(d)
+
+    wrong_recipe = dataclasses.replace(recipe, dispatches=modified_dispatches)
+    wrong_ctx = make_validation_context(
+        wrong_recipe,
+        available_recipes=available_recipes,
+        project_dir=project_dir,
+    )
+    wrong_findings = [
+        f
+        for f in run_semantic_rules(wrong_ctx)
+        if f.rule == "dispatch-capture-type-matches-contract-optionality"
+        and f.severity == Severity.ERROR
+    ]
+    assert wrong_findings, (
+        "Expected dispatch-capture-type-matches-contract-optionality ERROR "
+        "when pr_url uses value_type='string'"
+    )
+
+    # Original recipe (fixed with optional_string) must produce no ERROR.
+    fixed_ctx = make_validation_context(
+        recipe,
+        available_recipes=available_recipes,
+        project_dir=project_dir,
+    )
+    fixed_findings = [
+        f
+        for f in run_semantic_rules(fixed_ctx)
+        if f.rule == "dispatch-capture-type-matches-contract-optionality"
+        and f.severity == Severity.ERROR
+    ]
+    assert not fixed_findings, (
+        "promote-to-main.yaml must not trigger dispatch-capture-type-matches-contract-optionality "
+        "after the optional_string fix: " + "; ".join(f.message for f in fixed_findings)
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/recipe/test_optional_capture_guard_rule.py
+++ b/tests/recipe/test_optional_capture_guard_rule.py
@@ -172,3 +172,33 @@ def test_implementation_yaml_no_diagnostic_after_guard_added() -> None:
         "expected 0 optional-capture-requires-guard findings on implementation.yaml, got "
         + "; ".join(f"[{f.step_name}]: {f.message}" for f in guard_findings)
     )
+
+
+def test_identify_optional_output_fields_extracts_from_contract() -> None:
+    """_identify_optional_output_fields returns field names whose patterns allow empty values."""
+    from autoskillit.recipe._contracts_types import SkillContract, SkillOutput
+    from autoskillit.recipe.rules.rules_optional_capture import _identify_optional_output_fields
+
+    # Pattern with optional group matching a known output name — field is optional
+    contract = SkillContract(
+        inputs=[],
+        outputs=[SkillOutput(name="pr_url", type="string")],
+        expected_output_patterns=[r"pr_url[ \t]*=[ \t]*(https://github\.com/.*/pull/\d+)?"],
+    )
+    assert _identify_optional_output_fields(contract) == {"pr_url"}
+
+    # Pattern without optional group — field is mandatory, not returned
+    contract_mandatory = SkillContract(
+        inputs=[],
+        outputs=[SkillOutput(name="pr_url", type="string")],
+        expected_output_patterns=[r"pr_url[ \t]*=[ \t]*https://github\.com/.+"],
+    )
+    assert _identify_optional_output_fields(contract_mandatory) == set()
+
+    # Pattern whose leading identifier does not match any output name — skipped
+    contract_no_match = SkillContract(
+        inputs=[],
+        outputs=[SkillOutput(name="category_summary", type="string")],
+        expected_output_patterns=[r"pr_url[ \t]*=[ \t]*(https://github\.com/.*/pull/\d+)?"],
+    )
+    assert _identify_optional_output_fields(contract_no_match) == set()


### PR DESCRIPTION
## Summary

Add the missing test function `test_campaign_dispatch_capture_value_type_checked` to `tests/recipe/test_campaign_loader.py`. This test exercises the `dispatch-capture-type-matches-contract-optionality` semantic rule with two assertions:
1. A campaign dispatch with `value_type="string"` on an optional output field → ERROR finding.
2. The fixed `promote-to-main.yaml` (which uses `optional_string`) → no ERROR finding.

Closes #3334

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-204907-415625/.autoskillit/temp/make-plan/remediation_capture_value_type_test_plan_2026-05-30_214500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 95 | 32.2k | 2.3M | 134.6k | 314 | 123.6k | 24m 34s |
| review_approach* | sonnet | 1 | 8.1k | 8.3k | 194.4k | 67.2k | 173 | 43.0k | 6m 41s |
| dry_walkthrough* | opus | 2 | 107 | 32.4k | 3.1M | 133.4k | 354 | 164.4k | 17m 23s |
| implement* | sonnet | 2 | 4.0k | 51.1k | 8.3M | 129.8k | 277 | 265.0k | 19m 44s |
| audit_impl* | sonnet | 2 | 2.8k | 19.6k | 596.4k | 60.2k | 129 | 94.4k | 11m 4s |
| make_plan* | sonnet | 1 | 183 | 16.4k | 1.4M | 84.4k | 56 | 69.2k | 4m 45s |
| prepare_pr* | sonnet | 1 | 142.8k | 5.0k | 358.4k | 27.8k | 27 | 15.8k | 1m 44s |
| compose_pr* | sonnet | 1 | 51.7k | 1.4k | 191.7k | 27.8k | 17 | 15.5k | 46s |
| review_pr* | sonnet | 1 | 110 | 31.5k | 596.0k | 82.5k | 77 | 70.8k | 9m 25s |
| resolve_review* | opus | 1 | 75 | 16.2k | 3.0M | 97.8k | 111 | 82.0k | 11m 58s |
| **Total** | | | 210.0k | 214.0k | 20.0M | 134.6k | | 943.9k | 1h 48m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 474 | 17490.4 | 559.1 | 107.9 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 57 | 52770.7 | 1438.3 | 283.8 |
| **Total** | **531** | 37750.4 | 1777.6 | 403.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 95 | 32.2k | 2.3M | 123.6k | 24m 34s |
| sonnet | 7 | 209.7k | 133.2k | 11.6M | 573.9k | 54m 11s |
| opus | 2 | 182 | 48.6k | 6.1M | 246.4k | 29m 22s |