### PR TITLE
Codex Backend Architectural Immunity — Capability Consumption, Symmetric Env, and NotImplementedError Arch Tests

### DIFF
--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -468,6 +468,8 @@ classified `REJECT` with `category: "arch_violation"`.
 | Boot step symmetry | `test_boot_step_symmetry.py` | Both boot functions must call all required boot steps in the right order |
 | BackendCapabilities consumed | `test_capability_consumption.py` | Every `BackendCapabilities` field must have a production consumer — unused capability fields are prohibited |
 | BackendCapabilities documented | `test_capability_docstrings.py` | `BackendCapabilities` class and every field must have docstrings |
+| Env var symmetry | `test_env_symmetry.py` | `build_skill_session_cmd` and `build_food_truck_cmd` must both set required base env vars; `AGENT_BACKEND_ENV_VAR` must appear in food_truck |
+| No NotImplementedError in backends | `test_no_not_implemented.py` | Registered backend classes must not raise `NotImplementedError` — `CodingAgentBackend` is a Protocol, not an ABC |
 | Channel B timeout floor | `test_channel_b_timeout_guard.py` | Channel B calls with `timeout` below `TimeoutTier.CHANNEL_B` minimum |
 | Clone network timeouts | `test_clone_timeouts.py` | `subprocess.run()` with git network subcommands (clone/fetch/pull/push/ls-remote) in `clone.py` without `timeout=` |
 | Dispatch timeout resolver | `test_dispatch_timeout_guard.py` | `_run_dispatch` using hardcoded timeout instead of `resolve_dispatch_timeout()` |

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -23,6 +23,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_backend_protocol_completeness.py` | Protocol completeness tests for CodingAgentBackend command builders |
 | `test_audit_feature_gates_skill.py` | Structural integrity tests for the audit-feature-gates skill |
 | `test_eval_agent_skill.py` | Structural integrity tests for the eval-agent skill |
+| `test_env_symmetry.py` | Architectural invariant: skill and food-truck builders must set the same required base env vars |
 | `test_boot_step_symmetry.py` | AST guard: both boot functions (_fleet_auto_gate_boot, _food_truck_auto_gate_boot) must call sweep_stale_dispatch_labels |
 | `test_bundled_recipes_split.py` | Enforcement: test_bundled_recipes.py split structure guard |
 | `test_cascade_map_guard.py` | REQ-GUARD-001..003, 005: CI guard validating cascade maps against AST-derived reverse import graph |
@@ -54,6 +55,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_no_error_dict_return.py` | AST guard: load_and_validate must not return dicts with 'error' key — errors flow via exceptions |
 | `test_flush_no_rid_guard.py` | AST guard: no requestId truthiness guard in flush_session_log turn extraction loop |
 | `test_no_inline_jsonl_request_id_dedup.py` | AST guard: no inline requestId dedup in session_log.py or tool_sequence_analysis.py |
+| `test_no_not_implemented.py` | Architectural invariant: no registered backend may raise NotImplementedError |
 | `test_resolve_turn_id_guard.py` | AST guard: no direct .get("requestId") calls outside _resolve_turn_id() in tool_sequence_analysis.py |
 | `test_protocol_names.py` | T5-T6: Protocol naming and DefaultSkillResolver export smoke tests |
 | `test_provider_profile_contract.py` | Tier 3 contract: _resolve_provider_profile must never return step_name as profile |

--- a/tests/arch/test_env_symmetry.py
+++ b/tests/arch/test_env_symmetry.py
@@ -45,7 +45,7 @@ def test_skill_and_food_truck_share_required_env_vars() -> None:
 
 
 @pytest.mark.xfail(
-    reason="AGENT_BACKEND_ENV_VAR not yet added to build_food_truck_cmd",
+    reason="#3385: AUTOSKILLIT_AGENT_BACKEND not yet added to build_food_truck_cmd",
     strict=True,
 )
 def test_agent_backend_env_var_in_food_truck(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/arch/test_env_symmetry.py
+++ b/tests/arch/test_env_symmetry.py
@@ -26,6 +26,7 @@ def test_skill_and_food_truck_share_required_env_vars() -> None:
     from autoskillit.core.types._type_plugin_source import DirectInstall
     from autoskillit.execution.backends import BACKEND_REGISTRY
 
+    assert BACKEND_REGISTRY, "BACKEND_REGISTRY is empty — test provides no coverage"
     for name, cls in BACKEND_REGISTRY.items():
         backend = cls()
         skill_spec = backend.build_skill_session_cmd(
@@ -56,6 +57,7 @@ def test_agent_backend_env_var_in_food_truck(monkeypatch: pytest.MonkeyPatch) ->
     # Ensure clean environment - remove any residual AGENT_BACKEND_ENV_VAR from host
     monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
 
+    assert BACKEND_REGISTRY, "BACKEND_REGISTRY is empty — test provides no coverage"
     for name, cls in BACKEND_REGISTRY.items():
         backend = cls()
         food_truck_spec = backend.build_food_truck_cmd(

--- a/tests/arch/test_env_symmetry.py
+++ b/tests/arch/test_env_symmetry.py
@@ -19,6 +19,7 @@ _REQUIRED_IN_BOTH: frozenset[str] = frozenset(
 def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_ID", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_KITCHEN_SESSION_ID", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
 
 
 def test_skill_and_food_truck_share_required_env_vars() -> None:

--- a/tests/arch/test_env_symmetry.py
+++ b/tests/arch/test_env_symmetry.py
@@ -1,0 +1,69 @@
+"""Architectural invariant: skill and food-truck builders must set the same required base env vars."""  # noqa: E501
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+_REQUIRED_IN_BOTH: frozenset[str] = frozenset(
+    {
+        "AUTOSKILLIT_HEADLESS",
+        "AUTOSKILLIT_SESSION_TYPE",
+        "MAX_MCP_OUTPUT_TOKENS",
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_ID", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_KITCHEN_SESSION_ID", raising=False)
+
+
+def test_skill_and_food_truck_share_required_env_vars() -> None:
+    """build_skill_session_cmd and build_food_truck_cmd must both set the required base env vars."""  # noqa: E501
+    from autoskillit.core.types._type_plugin_source import DirectInstall
+    from autoskillit.execution.backends import BACKEND_REGISTRY
+
+    for name, cls in BACKEND_REGISTRY.items():
+        backend = cls()
+        skill_spec = backend.build_skill_session_cmd(
+            "/autoskillit:investigate", "/repo", completion_marker="DONE"
+        )
+        food_truck_spec = backend.build_food_truck_cmd(
+            orchestrator_prompt="test prompt",
+            plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
+            cwd="/repo",
+            completion_marker="DONE",
+        )
+        for var in _REQUIRED_IN_BOTH:
+            assert var in skill_spec.env, f"{name}: {var} missing from build_skill_session_cmd env"
+            assert var in food_truck_spec.env, (
+                f"{name}: {var} missing from build_food_truck_cmd env"
+            )
+
+
+@pytest.mark.xfail(
+    reason="AGENT_BACKEND_ENV_VAR not yet added to build_food_truck_cmd",
+    strict=True,
+)
+def test_agent_backend_env_var_in_food_truck(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AUTOSKILLIT_AGENT_BACKEND must appear in build_food_truck_cmd env for every backend."""
+    from autoskillit.core.types._type_plugin_source import DirectInstall
+    from autoskillit.execution.backends import BACKEND_REGISTRY
+
+    # Ensure clean environment - remove any residual AGENT_BACKEND_ENV_VAR from host
+    monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
+
+    for name, cls in BACKEND_REGISTRY.items():
+        backend = cls()
+        food_truck_spec = backend.build_food_truck_cmd(
+            orchestrator_prompt="test prompt",
+            plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
+            cwd="/repo",
+            completion_marker="DONE",
+        )
+        assert "AUTOSKILLIT_AGENT_BACKEND" in food_truck_spec.env, (
+            f"{name}: AUTOSKILLIT_AGENT_BACKEND missing from build_food_truck_cmd env"
+        )

--- a/tests/arch/test_env_symmetry.py
+++ b/tests/arch/test_env_symmetry.py
@@ -46,10 +46,6 @@ def test_skill_and_food_truck_share_required_env_vars() -> None:
             )
 
 
-@pytest.mark.xfail(
-    reason="#3385: AUTOSKILLIT_AGENT_BACKEND not yet added to build_food_truck_cmd",
-    strict=True,
-)
 def test_agent_backend_env_var_in_food_truck(monkeypatch: pytest.MonkeyPatch) -> None:
     """AUTOSKILLIT_AGENT_BACKEND must appear in build_food_truck_cmd env for every backend."""
     from autoskillit.core.types._type_plugin_source import DirectInstall

--- a/tests/arch/test_no_not_implemented.py
+++ b/tests/arch/test_no_not_implemented.py
@@ -32,7 +32,7 @@ def test_no_not_implemented_error_in_registered_backends() -> None:
                 isinstance(exc, ast.Call)
                 and isinstance(exc.func, ast.Name)
                 and exc.func.id == "NotImplementedError"
-            ):
+            ) or (isinstance(exc, ast.Name) and exc.id == "NotImplementedError"):
                 violations.append(f"{name}:{node.lineno}")
 
     assert not violations, (

--- a/tests/arch/test_no_not_implemented.py
+++ b/tests/arch/test_no_not_implemented.py
@@ -1,0 +1,41 @@
+"""Architectural invariant: no registered backend may raise NotImplementedError."""
+
+import ast
+import inspect
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+@pytest.mark.xfail(
+    reason="#3383: CodexBackend.validate_skill_content and .list_plugins not yet implemented",
+    strict=True,
+)
+def test_no_not_implemented_error_in_registered_backends() -> None:
+    """No method on any BACKEND_REGISTRY class should raise NotImplementedError.
+
+    CodingAgentBackend is a typing.Protocol, not an ABC — there are no legitimate
+    abstract stubs. Any raise NotImplementedError in a registered backend is a bug.
+    """
+    from autoskillit.execution.backends import BACKEND_REGISTRY
+
+    violations: list[str] = []
+    for name, cls in BACKEND_REGISTRY.items():
+        source = inspect.getsource(cls)
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Raise):
+                continue
+            exc = node.exc
+            if (
+                isinstance(exc, ast.Call)
+                and isinstance(exc.func, ast.Name)
+                and exc.func.id == "NotImplementedError"
+            ):
+                violations.append(f"{name}:{node.lineno}")
+
+    assert not violations, (
+        f"Registered backends must not raise NotImplementedError "
+        f"(CodingAgentBackend is a Protocol, not an ABC): {violations}"
+    )

--- a/tests/arch/test_no_not_implemented.py
+++ b/tests/arch/test_no_not_implemented.py
@@ -8,10 +8,6 @@ import pytest
 pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 
 
-@pytest.mark.xfail(
-    reason="#3383: CodexBackend.validate_skill_content and .list_plugins not yet implemented",
-    strict=True,
-)
 def test_no_not_implemented_error_in_registered_backends() -> None:
     """No method on any BACKEND_REGISTRY class should raise NotImplementedError.
 

--- a/tests/server/test_server_init_gate.py
+++ b/tests/server/test_server_init_gate.py
@@ -66,6 +66,24 @@ class TestKitchenVisibility:
 
         mock_ctx.disable_components.assert_called_once_with(tags={"kitchen-core"})
 
+    @pytest.mark.anyio
+    async def test_tool_list_changes_after_enable_within_session(self):
+        """Tool list visible to a client changes when kitchen tags are enabled mid-session."""  # noqa: E501
+        from fastmcp.client import Client
+
+        from autoskillit.pipeline.gate import GATED_TOOLS
+        from autoskillit.server import mcp
+
+        async with Client(mcp) as client:
+            tools_before = {t.name for t in await client.list_tools()}
+            assert not (tools_before & GATED_TOOLS), "Kitchen tools should be hidden before enable"
+
+            mcp.enable(tags={"kitchen"})
+
+            tools_after = {t.name for t in await client.list_tools()}
+            new_tools = tools_after - tools_before
+            assert new_tools, "Enabling kitchen tags should make new tools visible"
+
 
 class TestGatedToolAccess:
     """Prompt-gated tool access: tools disabled by default, user-only activation."""

--- a/tests/server/test_server_init_gate.py
+++ b/tests/server/test_server_init_gate.py
@@ -67,7 +67,7 @@ class TestKitchenVisibility:
         mock_ctx.disable_components.assert_called_once_with(tags={"kitchen-core"})
 
     @pytest.mark.anyio
-    async def test_tool_list_changes_after_enable_within_session(self):
+    async def test_tool_list_changes_after_enable_within_session(self) -> None:
         """Tool list visible to a client changes when kitchen tags are enabled mid-session."""  # noqa: E501
         from fastmcp.client import Client
 
@@ -82,7 +82,9 @@ class TestKitchenVisibility:
 
             tools_after = {t.name for t in await client.list_tools()}
             new_tools = tools_after - tools_before
-            assert new_tools, "Enabling kitchen tags should make new tools visible"
+            assert new_tools & GATED_TOOLS, (
+                "Enabling kitchen tags should make kitchen-gated tools visible"
+            )
 
 
 class TestGatedToolAccess:


### PR DESCRIPTION
## Summary

Add 3 new arch/server tests (plus verify 1 existing) to enforce structural invariants that prevent recurring Codex backend bugs. The tests cover: (1) verifying existing `BackendCapabilities` consumption test coverage, (2) symmetric env var contract between `build_skill_session_cmd` and `build_food_truck_cmd`, (3) no `raise NotImplementedError` in registered backend classes, and (4) tool-list visibility delta after kitchen enable within a live client session. Also update `tests/arch/CLAUDE.md` to register the new test files.

## Requirements

### 1. BackendCapabilities Consumption Contract
- **Purpose:** Every field on `BackendCapabilities` must be consumed by at least one production read site in `src/`, OR registered in `_FORWARD_DECLARED` with a linked issue number
- **Location:** `tests/arch/test_capability_consumption.py` — already exists. Verify coverage includes any new fields added by #3382 (`supports_tool_list_changed`). Currently has 4 entries in `_FORWARD_DECLARED`.
- **Note:** The `_FORWARD_DECLARED` dict requires a real `#NNNN` issue reference per field — enforced by `test_forward_declared_has_linked_issues()`.

### 2. Symmetric Command Builder Env Vars
- **Purpose:** `build_skill_session_cmd` and `build_food_truck_cmd` on every backend must set the same required base env vars
- **Location:** `tests/arch/` (new test file or extend `test_backend_coherence.py`)
- **Rationale:** G5 was caused by the two methods being written independently. `build_skill_session_cmd` sets `AGENT_BACKEND_ENV_VAR`, `AUTOSKILLIT_HEADLESS_AUTO_GATE`, `AUTOSKILLIT_APPLICABLE_GUARDS` — all missing from `build_food_truck_cmd`.
- **Implementation:** Call both methods on each backend in `BACKEND_REGISTRY`. The `food_truck_cmd` requires `plugin_source` arg — use `DirectInstall(plugin_dir=Path("/plugins"))` per existing pattern.
- **Important:** Some env vars are intentionally asymmetric. `AUTOSKILLIT_SKILL_NAME` is IL-1-only (should NOT be in food truck). The test must define a precise "required-in-both" subset: `AUTOSKILLIT_HEADLESS`, `AUTOSKILLIT_SESSION_TYPE`, `MAX_MCP_OUTPUT_TOKENS`, `AGENT_BACKEND_ENV_VAR`.

### 3. No NotImplementedError in Production Backends
- **Purpose:** No method on any backend class registered in `BACKEND_REGISTRY` should raise `NotImplementedError`
- **Location:** `tests/arch/` (new test file)
- **Rationale:** `CodingAgentBackend` is a `typing.Protocol` (with `@runtime_checkable`), NOT an ABC — so there are no legitimate abstract stubs. Any `raise NotImplementedError` in a registered backend class is a bug.
- **Implementation:** AST-scan for `raise NotImplementedError` in classes from `BACKEND_REGISTRY.values()`.
- **Note:** This test is expected to fail until #3383 lands (which implements the actual fixes for `validate_skill_content` and `list_plugins`).

### 4. Notification-Support Integration Test
- **Purpose:** Verify that after `open_kitchen` is called, the tool list visible to the client actually changes
- **Location:** `tests/server/` (extend `test_server_init_gate.py`)
- **Rationale:** G1 was completely invisible to the existing test suite.
- **Implementation:** Use `from fastmcp.client import Client; async with Client(mcp) as client: tools = await client.list_tools()` pattern.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260530-215854-975848/.autoskillit/temp/make-plan/codex_backend_arch_immunity_plan_2026-05-30_220600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 71 | 24.9k | 1.3M | 116.4k | 207 | 122.0k | 16m 29s |
| review_approach* | sonnet | 1 | 15.1k | 8.3k | 197.9k | 56.4k | 177 | 44.6k | 6m 55s |
| verify* | sonnet | 1 | 919 | 8.6k | 295.7k | 49.2k | 73 | 32.9k | 3m 29s |
| implement* | sonnet | 1 | 4.2M | 30.4k | 2.1M | 33.1k | 206 | 120.2k | 39m 4s |
| audit_impl* | sonnet | 1 | 116 | 15.1k | 455.1k | 51.6k | 50 | 36.7k | 5m 15s |
| prepare_pr* | sonnet | 1 | 71.6k | 3.6k | 224.8k | 33.2k | 22 | 25.3k | 1m 31s |
| compose_pr* | sonnet | 1 | 42.1k | 2.2k | 163.8k | 27.8k | 14 | 15.5k | 44s |
| review_pr* | sonnet | 3 | 462 | 132.4k | 3.2M | 109.6k | 185 | 305.0k | 27m 42s |
| resolve_review* | sonnet | 3 | 727 | 43.1k | 5.2M | 85.1k | 217 | 188.3k | 24m 51s |
| diagnose_ci* | sonnet | 3 | 672.4k | 9.3k | 1.4M | 28.0k | 109 | 95.9k | 5m 1s |
| resolve_ci* | sonnet | 3 | 6.5k | 12.4k | 1.3M | 52.0k | 94 | 119.2k | 18m 10s |
| post_run_diagnostics* | sonnet | 1 | 70 | 16.5k | 200.8k | 91.8k | 428 | 85.0k | 11m 17s |
| ci_conflict_fix* | sonnet | 1 | 116 | 3.6k | 486.2k | 41.7k | 37 | 27.6k | 1m 34s |
| **Total** | | | 5.0M | 310.3k | 16.5M | 116.4k | | 1.2M | 2h 42m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 132 | 15617.6 | 910.8 | 230.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 13 | 396567.3 | 14482.0 | 3313.8 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 8 | 163205.8 | 14896.4 | 1553.6 |
| post_run_diagnostics | 0 | — | — | — |
| ci_conflict_fix | 4008 | 121.3 | 6.9 | 0.9 |
| **Total** | **4161** | 3959.6 | 292.8 | 74.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 71 | 24.9k | 1.3M | 122.0k | 16m 29s |
| sonnet | 12 | 5.0M | 285.4k | 15.2M | 1.1M | 2h 25m |