### PR TITLE
[FIX] Rectify: Cross-Campaign Reaper Kills Actively Executing Dispatches

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -23,6 +23,7 @@ from autoskillit.core import (
     get_logger,
     truncate_text,
 )
+from autoskillit.core.io import atomic_write
 from autoskillit.fleet._capture import _extract_captures, _normalize_capture_spec
 from autoskillit.fleet._expressions import _CAMPAIGN_REF_RE, _interpolate_campaign_refs
 from autoskillit.fleet._outcome import _checkpoint_to_dict, classify_dispatch_outcome
@@ -59,7 +60,7 @@ async def _dispatch_heartbeat(
     hb_path = dispatches_dir / f"dispatch-{dispatch_id}.heartbeat"
     try:
         hb_path.parent.mkdir(parents=True, exist_ok=True)
-        hb_path.write_text("{}")
+        atomic_write(hb_path, "{}")
     except OSError:
         logger.warning("dispatch_heartbeat_write_failed", heartbeat=str(hb_path), exc_info=True)
         yield None

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -18,12 +18,12 @@ from autoskillit.core import (
     ProcessStaleError,
     SessionCheckpoint,  # noqa: F401, TC001
     SkillResult,
+    atomic_write,
     claude_code_log_path,
     claude_code_project_dir,
     get_logger,
     truncate_text,
 )
-from autoskillit.core.io import atomic_write
 from autoskillit.fleet._capture import _extract_captures, _normalize_capture_spec
 from autoskillit.fleet._expressions import _CAMPAIGN_REF_RE, _interpolate_campaign_refs
 from autoskillit.fleet._outcome import _checkpoint_to_dict, classify_dispatch_outcome

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import Callable
+from collections.abc import AsyncGenerator, Callable
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -41,6 +42,58 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 ENVELOPE_STDERR_MAX = 2000
+
+
+@asynccontextmanager
+async def _dispatch_heartbeat(
+    dispatches_dir: Path,
+    dispatch_id: str,
+    heartbeat_interval: float = 30.0,
+) -> AsyncGenerator[Path | None]:
+    """Write, heartbeat, and clean up a dispatch heartbeat file.
+
+    Co-locates the heartbeat file with the dispatch state file in ``dispatches_dir``
+    so the cross-campaign reaper can discover it without any path threading.
+    Yields the heartbeat ``Path`` on success, or ``None`` if the initial write fails.
+    """
+    hb_path = dispatches_dir / f"dispatch-{dispatch_id}.heartbeat"
+    try:
+        hb_path.parent.mkdir(parents=True, exist_ok=True)
+        hb_path.write_text("{}")
+    except OSError:
+        logger.warning("dispatch_heartbeat_write_failed", heartbeat=str(hb_path), exc_info=True)
+        yield None
+        return
+
+    async def _touch_heartbeat() -> None:
+        while True:
+            await asyncio.sleep(heartbeat_interval)
+            try:
+                hb_path.touch()
+            except OSError:
+                logger.warning(
+                    "dispatch_heartbeat_touch_failed", heartbeat=str(hb_path), exc_info=True
+                )
+
+    hb_task: asyncio.Task[None] | None = None
+    try:
+        hb_task = asyncio.get_running_loop().create_task(_touch_heartbeat())
+        yield hb_path
+    finally:
+        if hb_task is not None:
+            hb_task.cancel()
+            try:
+                await hb_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.warning("dispatch_heartbeat_task_failed", exc_info=True)
+        try:
+            hb_path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning(
+                "dispatch_heartbeat_unlink_failed", heartbeat=str(hb_path), exc_info=True
+            )
 
 
 def resolve_dispatch_timeout(
@@ -599,36 +652,37 @@ async def _run_dispatch(
             caller_session_id,
             "dispatch",
         ):
-            skill_result = await tool_ctx.executor.dispatch_food_truck(
-                orchestrator_prompt=prompt,
-                cwd=str(tool_ctx.project_dir),
-                completion_marker=completion_marker,
-                prior_completion_markers=prior_completion_markers,
-                resume_session_id=resume_session_id,
-                resume_checkpoint=resume_checkpoint,
-                kitchen_id=tool_ctx.kitchen_id,
-                order_id=dispatch_id,
-                campaign_id=campaign_id,
-                dispatch_id=dispatch_id,
-                caller_session_id=caller_session_id,
-                project_dir=str(tool_ctx.project_dir),
-                marker_dir=marker_dir,
-                session_id=caller_session_id,
-                timeout=resolved_timeout,
-                idle_output_timeout=float(idle_output_timeout)
-                if idle_output_timeout is not None
-                else None,
-                env_extras={
-                    "AUTOSKILLIT_PROJECT_DIR": str(tool_ctx.project_dir),
-                    "AUTOSKILLIT_CAMPAIGN_ID": campaign_id,
-                    "AUTOSKILLIT_DISPATCH_ID": dispatch_id,
-                    "AUTOSKILLIT_SESSION_DEADLINE": str(started_at + resolved_timeout),
-                },
-                requires_packs=list(full_recipe.requires_packs) or ["kitchen-core"],
-                on_spawn=_on_spawn,
-                sentinel_contract=sentinel_contract,
-                resume_message=resume_message,
-            )
+            async with _dispatch_heartbeat(dispatches_dir, dispatch_id):
+                skill_result = await tool_ctx.executor.dispatch_food_truck(
+                    orchestrator_prompt=prompt,
+                    cwd=str(tool_ctx.project_dir),
+                    completion_marker=completion_marker,
+                    prior_completion_markers=prior_completion_markers,
+                    resume_session_id=resume_session_id,
+                    resume_checkpoint=resume_checkpoint,
+                    kitchen_id=tool_ctx.kitchen_id,
+                    order_id=dispatch_id,
+                    campaign_id=campaign_id,
+                    dispatch_id=dispatch_id,
+                    caller_session_id=caller_session_id,
+                    project_dir=str(tool_ctx.project_dir),
+                    marker_dir=marker_dir,
+                    session_id=caller_session_id,
+                    timeout=resolved_timeout,
+                    idle_output_timeout=float(idle_output_timeout)
+                    if idle_output_timeout is not None
+                    else None,
+                    env_extras={
+                        "AUTOSKILLIT_PROJECT_DIR": str(tool_ctx.project_dir),
+                        "AUTOSKILLIT_CAMPAIGN_ID": campaign_id,
+                        "AUTOSKILLIT_DISPATCH_ID": dispatch_id,
+                        "AUTOSKILLIT_SESSION_DEADLINE": str(started_at + resolved_timeout),
+                    },
+                    requires_packs=list(full_recipe.requires_packs) or ["kitchen-core"],
+                    on_spawn=_on_spawn,
+                    sentinel_contract=sentinel_contract,
+                    resume_message=resume_message,
+                )
 
         ended_at = time.time()
         _dispatch_completed_normally = True

--- a/src/autoskillit/fleet/_dispatch_reaper.py
+++ b/src/autoskillit/fleet/_dispatch_reaper.py
@@ -92,6 +92,24 @@ def _mark_dead_pid(
         logger.info("reap: [MARKED]      %s  pid=%d  (process dead)", name, pid)
 
 
+def _is_dispatch_heartbeating(
+    dispatches_dir: Path,
+    dispatch_id: str,
+    grace_seconds: float = 90.0,
+) -> bool:
+    """Return True if the dispatch has a fresh heartbeat file.
+
+    A fresh heartbeat means the file exists and its mtime is within ``grace_seconds``
+    of the current time, indicating the dispatch is actively executing.
+    """
+    hb_path = dispatches_dir / f"dispatch-{dispatch_id}.heartbeat"
+    try:
+        mtime = hb_path.stat().st_mtime
+        return time.time() - mtime <= grace_seconds
+    except OSError:
+        return False
+
+
 def reap_stale_dispatches(
     state_path: Path,
     *,
@@ -100,6 +118,7 @@ def reap_stale_dispatches(
     own_campaign_id: str | None = None,
     min_reap_age_seconds: float = 60.0,
     reaper_dispatch_id: str = "",
+    heartbeat_grace_seconds: float = 90.0,
 ) -> None:
     """Reap stale RUNNING dispatches with PID-recycling-safe identity checks.
 
@@ -223,6 +242,15 @@ def reap_stale_dispatches(
                 identity_confirmed = False
 
             if identity_confirmed:
+                if _is_dispatch_heartbeating(
+                    state_path.parent, dispatch.dispatch_id, heartbeat_grace_seconds
+                ):
+                    logger.info(
+                        "reap: [SKIPPED]     %s  dispatch_id=%s  (dispatch heartbeat active)",
+                        name,
+                        dispatch.dispatch_id,
+                    )
+                    continue
                 if dry_run:
                     logger.info(
                         "reap: [WOULD KILL]  %s  pid=%d  (orphan, identity match)", name, pid
@@ -257,6 +285,7 @@ async def reap_stale_dispatches_async(
     own_campaign_id: str | None = None,
     min_reap_age_seconds: float = 60.0,
     reaper_dispatch_id: str = "",
+    heartbeat_grace_seconds: float = 90.0,
 ) -> None:
     import functools  # noqa: PLC0415
 
@@ -271,5 +300,6 @@ async def reap_stale_dispatches_async(
                 own_campaign_id=own_campaign_id,
                 min_reap_age_seconds=min_reap_age_seconds,
                 reaper_dispatch_id=reaper_dispatch_id,
+                heartbeat_grace_seconds=heartbeat_grace_seconds,
             ),
         )

--- a/src/autoskillit/fleet/_dispatch_reaper.py
+++ b/src/autoskillit/fleet/_dispatch_reaper.py
@@ -95,17 +95,18 @@ def _mark_dead_pid(
 def _is_dispatch_heartbeating(
     dispatches_dir: Path,
     dispatch_id: str,
-    grace_seconds: float = 90.0,
+    heartbeat_grace_seconds: float = 90.0,
 ) -> bool:
     """Return True if the dispatch has a fresh heartbeat file.
 
-    A fresh heartbeat means the file exists and its mtime is within ``grace_seconds``
-    of the current time, indicating the dispatch is actively executing.
+    A fresh heartbeat means the file exists and its mtime is within
+    ``heartbeat_grace_seconds`` of the current time, indicating the dispatch
+    is actively executing.
     """
     hb_path = dispatches_dir / f"dispatch-{dispatch_id}.heartbeat"
     try:
         mtime = hb_path.stat().st_mtime
-        return time.time() - mtime <= grace_seconds
+        return time.time() - mtime <= heartbeat_grace_seconds
     except OSError:
         return False
 

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -254,6 +254,7 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
                 own_campaign_id=ctx.kitchen_id,
                 min_reap_age_seconds=60.0,
                 reaper_dispatch_id=os.environ.get("AUTOSKILLIT_DISPATCH_ID", ""),
+                heartbeat_grace_seconds=90.0,
             )
         except Exception:
             logger.warning("fleet_auto_gate_boot_reap_failed", exc_info=True)
@@ -384,6 +385,7 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
                 own_campaign_id=_own_campaign_id,
                 min_reap_age_seconds=60.0,
                 reaper_dispatch_id=os.environ.get("AUTOSKILLIT_DISPATCH_ID", ""),
+                heartbeat_grace_seconds=90.0,
             )
         except Exception:
             logger.warning("food_truck_auto_gate_boot_reap_failed", exc_info=True)

--- a/tests/fleet/test_api_dispatch_marker.py
+++ b/tests/fleet/test_api_dispatch_marker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from pathlib import Path
 
 import anyio
@@ -153,3 +154,91 @@ async def test_marker_not_written_when_cwd_unavailable(
 
     assert len(tool_ctx.executor.dispatch_calls) == 1
     assert list(tmp_path.rglob("*.marker")) == []
+
+
+@pytest.mark.anyio
+async def test_run_dispatch_writes_heartbeat_file(tool_ctx, monkeypatch) -> None:
+    _setup_dispatch(tool_ctx, monkeypatch)
+    dispatches_dir = tool_ctx.temp_dir / "dispatches"
+
+    await _run_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="test-recipe",
+        task="t",
+        ingredients=None,
+        dispatch_name=None,
+        timeout_sec=None,
+        prompt_builder=lambda **kw: "prompt",
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+
+    remaining = list(dispatches_dir.glob("dispatch-*.heartbeat"))
+    assert remaining == [], (
+        f"Heartbeat file should be deleted after normal completion: {remaining}"
+    )
+
+
+@pytest.mark.anyio
+async def test_run_dispatch_heartbeat_exists_during_execution(tool_ctx, monkeypatch) -> None:
+    _setup_dispatch(tool_ctx, monkeypatch)
+    dispatches_dir = tool_ctx.temp_dir / "dispatches"
+    heartbeat_files_during: list[list[Path]] = []
+
+    async def _asserting_dispatch(**_kw):
+        found = list(dispatches_dir.glob("dispatch-*.heartbeat"))
+        heartbeat_files_during.append(found)
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(tool_ctx.executor, "dispatch_food_truck", _asserting_dispatch)
+
+    with pytest.raises(asyncio.CancelledError):
+        await _run_dispatch(
+            tool_ctx=tool_ctx,
+            recipe="test-recipe",
+            task="t",
+            ingredients=None,
+            dispatch_name=None,
+            timeout_sec=None,
+            prompt_builder=lambda **kw: "prompt",
+            quota_checker=_no_sleep_quota_checker,
+            quota_refresher=_noop_quota_refresher,
+        )
+
+    assert len(heartbeat_files_during) == 1
+    assert len(heartbeat_files_during[0]) == 1, (
+        f"Expected 1 heartbeat file during dispatch, found {heartbeat_files_during[0]}"
+    )
+
+    remaining = list(dispatches_dir.glob("dispatch-*.heartbeat"))
+    assert remaining == [], f"Heartbeat file should be deleted after CancelledError: {remaining}"
+
+
+@pytest.mark.anyio
+async def test_run_dispatch_heartbeat_mtime_is_fresh(tool_ctx, monkeypatch) -> None:
+    _setup_dispatch(tool_ctx, monkeypatch)
+    dispatches_dir = tool_ctx.temp_dir / "dispatches"
+    recorded_mtime: list[float] = []
+
+    async def _record_mtime_dispatch(**_kw):
+        found = list(dispatches_dir.glob("dispatch-*.heartbeat"))
+        if found:
+            recorded_mtime.append(found[0].stat().st_mtime)
+
+    monkeypatch.setattr(tool_ctx.executor, "dispatch_food_truck", _record_mtime_dispatch)
+
+    before = time.time()
+    await _run_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="test-recipe",
+        task="t",
+        ingredients=None,
+        dispatch_name=None,
+        timeout_sec=None,
+        prompt_builder=lambda **kw: "prompt",
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+
+    assert len(recorded_mtime) == 1
+    assert recorded_mtime[0] >= before - 1.0, "Heartbeat mtime should be recent at dispatch start"

--- a/tests/fleet/test_api_dispatch_marker.py
+++ b/tests/fleet/test_api_dispatch_marker.py
@@ -9,7 +9,9 @@ from pathlib import Path
 import anyio
 import pytest
 
+from autoskillit.core import SkillResult
 from autoskillit.core._execution_marker import _touch_marker
+from autoskillit.core.types._type_enums import RetryReason
 from autoskillit.fleet._api import _run_dispatch
 from tests.fleet._helpers import _no_sleep_quota_checker, _noop_quota_refresher, _setup_dispatch
 
@@ -224,6 +226,17 @@ async def test_run_dispatch_heartbeat_mtime_is_fresh(tool_ctx, monkeypatch) -> N
         found = list(dispatches_dir.glob("dispatch-*.heartbeat"))
         if found:
             recorded_mtime.append(found[0].stat().st_mtime)
+        return SkillResult(
+            success=True,
+            result="ok",
+            session_id="",
+            subtype="success",
+            is_error=False,
+            exit_code=0,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+            stderr="",
+        )
 
     monkeypatch.setattr(tool_ctx.executor, "dispatch_food_truck", _record_mtime_dispatch)
 

--- a/tests/fleet/test_dispatch_reaper.py
+++ b/tests/fleet/test_dispatch_reaper.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -419,6 +420,7 @@ class TestReap:
             own_campaign_id=None,
             min_reap_age_seconds=60.0,
             reaper_dispatch_id="",
+            heartbeat_grace_seconds=90.0,
         )
 
     def test_reap_writes_tombstone_to_victim_session_log_dir(self, tmp_path: Path) -> None:
@@ -714,3 +716,134 @@ class TestReap:
         assert 11111 not in killed_pids, "dispatch-a should be skipped (own campaign sp1)"
         assert 22222 not in killed_pids, "dispatch-b should be skipped (own campaign sp2)"
         assert 33333 in killed_pids, "dispatch-c from campaign-2 should be reaped"
+
+    def test_reap_skips_cross_campaign_dispatch_with_fresh_heartbeat(self, tmp_path: Path) -> None:
+        sp = _make_running_state(
+            tmp_path,
+            dispatch_id="dispatch-c",
+            dispatched_pid=12345,
+            dispatched_starttime_ticks=1000,
+            dispatched_boot_id=BOOT_ID,
+        )
+        hb_path = tmp_path / "dispatch-dispatch-c.heartbeat"
+        hb_path.write_text("{}")
+
+        with (
+            patch("autoskillit.fleet._dispatch_reaper.psutil.pid_exists", return_value=True),
+            patch("autoskillit.fleet._dispatch_reaper.read_starttime_ticks", return_value=1000),
+            patch("autoskillit.fleet._dispatch_reaper.read_boot_id", return_value=BOOT_ID),
+            patch("autoskillit.fleet._dispatch_reaper.kill_process_tree") as mock_kill,
+        ):
+            from autoskillit.fleet import reap_stale_dispatches
+
+            reap_stale_dispatches(sp, own_campaign_id="campaign-1", heartbeat_grace_seconds=90.0)
+
+        mock_kill.assert_not_called()
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].status == DispatchStatus.RUNNING
+
+    def test_reap_kills_cross_campaign_dispatch_with_stale_heartbeat(self, tmp_path: Path) -> None:
+        sp = _make_running_state(
+            tmp_path,
+            dispatch_id="dispatch-c",
+            dispatched_pid=12345,
+            dispatched_starttime_ticks=1000,
+            dispatched_boot_id=BOOT_ID,
+        )
+        hb_path = tmp_path / "dispatch-dispatch-c.heartbeat"
+        hb_path.write_text("{}")
+        stale_mtime = time.time() - 200.0
+        import os
+
+        os.utime(hb_path, (stale_mtime, stale_mtime))
+
+        with (
+            patch("autoskillit.fleet._dispatch_reaper.psutil.pid_exists", return_value=True),
+            patch("autoskillit.fleet._dispatch_reaper.read_starttime_ticks", return_value=1000),
+            patch("autoskillit.fleet._dispatch_reaper.read_boot_id", return_value=BOOT_ID),
+            patch("autoskillit.fleet._dispatch_reaper.kill_process_tree") as mock_kill,
+        ):
+            from autoskillit.fleet import reap_stale_dispatches
+
+            reap_stale_dispatches(sp, own_campaign_id="campaign-1", heartbeat_grace_seconds=90.0)
+
+        mock_kill.assert_called_once_with(12345)
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].reason == "reaped_orphan"
+
+    def test_reap_kills_cross_campaign_dispatch_with_no_heartbeat(self, tmp_path: Path) -> None:
+        sp = _make_running_state(
+            tmp_path,
+            dispatch_id="dispatch-c",
+            dispatched_pid=12345,
+            dispatched_starttime_ticks=1000,
+            dispatched_boot_id=BOOT_ID,
+        )
+
+        with (
+            patch("autoskillit.fleet._dispatch_reaper.psutil.pid_exists", return_value=True),
+            patch("autoskillit.fleet._dispatch_reaper.read_starttime_ticks", return_value=1000),
+            patch("autoskillit.fleet._dispatch_reaper.read_boot_id", return_value=BOOT_ID),
+            patch("autoskillit.fleet._dispatch_reaper.kill_process_tree") as mock_kill,
+        ):
+            from autoskillit.fleet import reap_stale_dispatches
+
+            reap_stale_dispatches(sp, own_campaign_id="campaign-1", heartbeat_grace_seconds=90.0)
+
+        mock_kill.assert_called_once_with(12345)
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].reason == "reaped_orphan"
+
+    def test_reap_skips_heartbeat_with_configurable_grace_period(self, tmp_path: Path) -> None:
+        sp = _make_running_state(
+            tmp_path,
+            dispatch_id="dispatch-c",
+            dispatched_pid=12345,
+            dispatched_starttime_ticks=1000,
+            dispatched_boot_id=BOOT_ID,
+        )
+        hb_path = tmp_path / "dispatch-dispatch-c.heartbeat"
+        hb_path.write_text("{}")
+        import os
+
+        mtime_200s_ago = time.time() - 200.0
+        os.utime(hb_path, (mtime_200s_ago, mtime_200s_ago))
+
+        with (
+            patch("autoskillit.fleet._dispatch_reaper.psutil.pid_exists", return_value=True),
+            patch("autoskillit.fleet._dispatch_reaper.read_starttime_ticks", return_value=1000),
+            patch("autoskillit.fleet._dispatch_reaper.read_boot_id", return_value=BOOT_ID),
+            patch("autoskillit.fleet._dispatch_reaper.kill_process_tree") as mock_kill,
+        ):
+            from autoskillit.fleet import reap_stale_dispatches
+
+            reap_stale_dispatches(sp, own_campaign_id="campaign-1", heartbeat_grace_seconds=300.0)
+
+        mock_kill.assert_not_called()
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].status == DispatchStatus.RUNNING
+
+        sp2 = _make_running_state(
+            tmp_path / "sub",
+            dispatch_id="dispatch-d",
+            dispatched_pid=99999,
+            dispatched_starttime_ticks=2000,
+            dispatched_boot_id=BOOT_ID,
+        )
+        hb_path2 = (tmp_path / "sub") / "dispatch-dispatch-d.heartbeat"
+        hb_path2.write_text("{}")
+        os.utime(hb_path2, (mtime_200s_ago, mtime_200s_ago))
+
+        with (
+            patch("autoskillit.fleet._dispatch_reaper.psutil.pid_exists", return_value=True),
+            patch("autoskillit.fleet._dispatch_reaper.read_starttime_ticks", return_value=2000),
+            patch("autoskillit.fleet._dispatch_reaper.read_boot_id", return_value=BOOT_ID),
+            patch("autoskillit.fleet._dispatch_reaper.kill_process_tree") as mock_kill2,
+        ):
+            reap_stale_dispatches(sp2, own_campaign_id="campaign-1", heartbeat_grace_seconds=120.0)
+
+        mock_kill2.assert_called_once_with(99999)

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -1065,6 +1065,7 @@ class TestFoodTruckAutoGateBoot:
             own_campaign_id="my-campaign-1",
             min_reap_age_seconds=60.0,
             reaper_dispatch_id="my-ft-dispatch",
+            heartbeat_grace_seconds=90.0,
         )
 
     @pytest.mark.anyio
@@ -1116,6 +1117,7 @@ class TestFoodTruckAutoGateBoot:
             own_campaign_id="my-campaign-2",
             min_reap_age_seconds=60.0,
             reaper_dispatch_id="",
+            heartbeat_grace_seconds=90.0,
         )
 
 


### PR DESCRIPTION
## Summary

The dispatch reaper (`_dispatch_reaper.py`) kills actively-executing dispatches from other campaigns because it has zero awareness of execution activity. Its only guards do not distinguish "orphaned process from a crashed campaign" from "actively-executing process doing real work."

The architectural solution is a dispatch-level heartbeat sidecar (`.heartbeat` file co-located with dispatch state files) combined with a reaper activity gate that checks the heartbeat mtime before killing. The heartbeat file is written by `_run_dispatch()` via a new `_dispatch_heartbeat` async context manager, is touch()ed every 30s, and is deleted on normal completion.

Closes #3355

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-231830-883536/.autoskillit/temp/rectify/rectify_cross_campaign_reaper_immunity_2026-05-30_233000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 7.7k | 20.3k | 2.0M | 116.5k | 266 | 106.6k | 19m 47s |
| review_approach* | sonnet | 1 | 52 | 8.5k | 208.7k | 53.7k | 105 | 42.5k | 7m 21s |
| dry_walkthrough* | opus | 1 | 636 | 10.5k | 1.6M | 89.5k | 101 | 128.7k | 4m 41s |
| implement* | sonnet | 1 | 2.1k | 18.2k | 2.3M | 90.9k | 102 | 75.5k | 5m 52s |
| audit_impl* | sonnet | 1 | 78 | 9.7k | 276.6k | 41.8k | 44 | 36.7k | 5m 48s |
| prepare_pr* | sonnet | 1 | 80.5k | 3.6k | 166.8k | 27.8k | 21 | 40.8k | 1m 18s |
| compose_pr* | sonnet | 1 | 57.2k | 1.5k | 163.9k | 27.8k | 15 | 15.5k | 43s |
| review_pr* | sonnet | 1 | 1.8k | 34.9k | 1.2M | 87.5k | 88 | 72.3k | 9m 39s |
| resolve_review* | opus | 1 | 54 | 8.1k | 838.8k | 53.8k | 43 | 63.8k | 5m 25s |
| **Total** | | | 150.3k | 115.5k | 8.8M | 116.5k | | 582.3k | 1h 0m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 372 | 6169.6 | 203.0 | 48.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 9 | 93197.2 | 7084.1 | 905.1 |
| **Total** | **381** | 23110.2 | 1528.4 | 303.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 7.7k | 20.3k | 2.0M | 106.6k | 19m 47s |
| sonnet | 6 | 141.9k | 76.5k | 4.3M | 283.3k | 30m 43s |
| opus | 2 | 690 | 18.6k | 2.5M | 192.4k | 10m 6s |