### PR TITLE
[FIX] Session-scoped git write detection and FS sentinel disambiguation

### DIFF
--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -42,7 +42,7 @@ from autoskillit.execution.headless._headless_execute import (
 from autoskillit.execution.headless._headless_git import (
     _capture_git_head_sha,  # noqa: F401
     _compute_loc_changed,  # noqa: F401
-    _detect_branch_divergence,  # noqa: F401
+    _detect_session_git_writes,  # noqa: F401
 )
 from autoskillit.execution.headless._headless_helpers import (
     PostSessionMetrics,

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -49,7 +49,7 @@ from autoskillit.execution.headless._headless_evidence import (
 )
 from autoskillit.execution.headless._headless_git import (
     _capture_git_head_sha,
-    _detect_branch_divergence,
+    _detect_session_git_writes,
 )
 from autoskillit.execution.headless._headless_helpers import (
     _compute_post_session_metrics,
@@ -223,6 +223,10 @@ async def _execute_claude_headless(
             except OSError:
                 logger.warning("watch_dir_pre_scan_failed", watch_dir=str(_wd), exc_info=True)
                 _temp_snapshots_pre[_wd] = None
+        else:
+            # {} sentinel: dir missing at pre-scan. Distinct from None (OSError): {} allows
+            # post-scan comparison so session-created files are detected as writes.
+            _temp_snapshots_pre[_wd] = {}
 
     _pre_session_sha = _capture_git_head_sha(cwd)
     _result: SubprocessResult | None = None
@@ -389,7 +393,7 @@ async def _execute_claude_headless(
 
         _git_writes_detected = False
         if is_in_git_repo(Path(cwd)):
-            _git_writes_detected = _detect_branch_divergence(cwd)
+            _git_writes_detected = _detect_session_git_writes(cwd, _pre_session_sha)
 
         audit_count_before = len(ctx.audit.get_report())
         _supports_fmt = _step_backend.capabilities.supports_claude_format_stdout

--- a/src/autoskillit/execution/headless/_headless_git.py
+++ b/src/autoskillit/execution/headless/_headless_git.py
@@ -67,6 +67,21 @@ def _compute_loc_changed(cwd: str, pre_sha: str) -> tuple[int, int]:
         return 0, 0
 
 
+def _detect_session_git_writes(cwd: str, pre_session_sha: str) -> bool:
+    """Return True iff the session committed new changes to the repo.
+
+    Compares pre-session HEAD SHA to post-session HEAD SHA; if they differ
+    the session made commits. Returns False when pre_session_sha is empty
+    (non-git dir or capture error at session start — safe default).
+    """
+    if not pre_session_sha:
+        return False
+    post_sha = _capture_git_head_sha(cwd)
+    if not post_sha:
+        return False
+    return post_sha != pre_session_sha
+
+
 def _detect_branch_divergence(cwd: str) -> bool:
     """Check if current branch has commits ahead of the remote default branch.
 

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -18,7 +18,7 @@ NEW_HEADLESS_MODULES = [
 HEADLESS_SIZE_BUDGETS = {
     "headless/__init__.py": 465,
     "headless/_headless_helpers.py": 220,
-    "headless/_headless_execute.py": 595,
+    "headless/_headless_execute.py": 600,
     "headless/_headless_recovery.py": 366,
     "headless/_headless_path_tokens.py": 175,
     "headless/_headless_result.py": 865,

--- a/tests/execution/test_write_evidence.py
+++ b/tests/execution/test_write_evidence.py
@@ -431,3 +431,129 @@ class TestPlannerSkillEndToEnd:
             write_behavior=WriteBehaviorSpec(mode="always"),
         )
         assert sr.evidence.fs_writes_detected is True
+
+
+class TestLateCreatedDirectoryDetection:
+    """write_watch_dirs detects writes in directories created during the session (T-WE-FS-FN)."""
+
+    @pytest.mark.anyio
+    async def test_late_created_dir_write_detected(self, tmp_path: Path, minimal_ctx) -> None:
+        """Directory that didn't exist at session start but is created with files must be detected.
+
+        T-WE-FS-FN: fails under old code (missing key → None → skip comparison);
+        passes under new code (missing dir → {} → comparison fires).
+        """
+        from autoskillit.execution.headless import run_headless_core
+        from tests.execution.conftest import _success_session_json
+
+        watch_dir = tmp_path / "output"
+        # watch_dir does NOT exist at session start
+
+        async def mock_runner(cmd, **kwargs):
+            if cmd[0] == "git":
+                return _make_result(returncode=1, stdout="")
+            watch_dir.mkdir(parents=True)
+            (watch_dir / "result.json").write_text('{"done": true}')
+            return _make_result(returncode=0, stdout=_success_session_json("done"))
+
+        minimal_ctx.runner = mock_runner
+        minimal_ctx.backend = _mock_backend()
+        proj = tmp_path / "proj"
+        proj.mkdir()
+
+        result = await run_headless_core(
+            "/autoskillit:test-skill",
+            str(proj),
+            minimal_ctx,
+            write_watch_dirs=[watch_dir],
+        )
+        assert result.evidence.fs_writes_detected is True, (
+            "fs_writes_detected must be True when session creates a nonexistent watch directory"
+        )
+
+
+class TestSentinelDisambiguation:
+    """Sentinel disambiguation: None (OSError) vs {} (missing dir) (T-WE-FS-SENTINEL)."""
+
+    @pytest.mark.anyio
+    async def test_oserror_pre_scan_skips_comparison(self, tmp_path: Path, minimal_ctx) -> None:
+        """OSError pre-scan → None sentinel → comparison skipped → fs_writes_detected=False."""
+        from unittest.mock import patch
+
+        from autoskillit.execution.headless import run_headless_core
+        from autoskillit.execution.headless._headless_helpers import (
+            _stat_snapshot as _real_snap,
+        )
+        from tests.execution.conftest import _success_session_json
+
+        watch_dir = tmp_path / "output"
+        watch_dir.mkdir()
+
+        call_count: list[int] = [0]
+
+        def _mock_snap(d):
+            call_count[0] += 1
+            if call_count[0] == 1 and d == watch_dir:
+                raise OSError("simulated scan failure")
+            return _real_snap(d)
+
+        async def mock_runner(cmd, **kwargs):
+            if cmd[0] == "git":
+                return _make_result(returncode=1, stdout="")
+            (watch_dir / "new_file.json").write_text("{}")
+            return _make_result(returncode=0, stdout=_success_session_json("done"))
+
+        minimal_ctx.runner = mock_runner
+        minimal_ctx.backend = _mock_backend()
+        proj = tmp_path / "proj"
+        proj.mkdir()
+
+        with patch("autoskillit.execution.headless._headless_execute._stat_snapshot", _mock_snap):
+            result = await run_headless_core(
+                "/autoskillit:test-skill",
+                str(proj),
+                minimal_ctx,
+                write_watch_dirs=[watch_dir],
+            )
+
+        assert result.evidence.fs_writes_detected is False, (
+            "OSError in pre-scan must not produce a false positive — comparison must be skipped"
+        )
+
+    @pytest.mark.anyio
+    async def test_missing_dir_pre_scan_empty_dict_sentinel_detects_new_files(
+        self, tmp_path: Path, minimal_ctx
+    ) -> None:
+        """Missing dir at pre-scan → {} sentinel → comparison fires → fs_writes_detected=True.
+
+        Contrast with OSError (None sentinel) which skips comparison.
+        T-WE-FS-SENTINEL: fails under old code (missing key → None → skip);
+        passes under new code ({} → comparison fires).
+        """
+        from autoskillit.execution.headless import run_headless_core
+        from tests.execution.conftest import _success_session_json
+
+        watch_dir = tmp_path / "output"
+        # watch_dir does NOT exist at session start
+
+        async def mock_runner(cmd, **kwargs):
+            if cmd[0] == "git":
+                return _make_result(returncode=1, stdout="")
+            watch_dir.mkdir(parents=True)
+            (watch_dir / "result.json").write_text('{"done": true}')
+            return _make_result(returncode=0, stdout=_success_session_json("done"))
+
+        minimal_ctx.runner = mock_runner
+        minimal_ctx.backend = _mock_backend()
+        proj = tmp_path / "proj"
+        proj.mkdir()
+
+        result = await run_headless_core(
+            "/autoskillit:test-skill",
+            str(proj),
+            minimal_ctx,
+            write_watch_dirs=[watch_dir],
+        )
+        assert result.evidence.fs_writes_detected is True, (
+            "Missing dir at pre-scan must detect new files created by the session"
+        )

--- a/tests/execution/test_write_evidence.py
+++ b/tests/execution/test_write_evidence.py
@@ -489,11 +489,12 @@ class TestSentinelDisambiguation:
         watch_dir = tmp_path / "output"
         watch_dir.mkdir()
 
-        call_count: list[int] = [0]
+        raised = False
 
         def _mock_snap(d):
-            call_count[0] += 1
-            if call_count[0] == 1 and d == watch_dir:
+            nonlocal raised
+            if not raised and d == watch_dir:
+                raised = True
                 raise OSError("simulated scan failure")
             return _real_snap(d)
 

--- a/tests/execution/test_zero_write_detection.py
+++ b/tests/execution/test_zero_write_detection.py
@@ -742,7 +742,7 @@ class TestTempDirSnapshot:
 
 
 class TestGitWritesClonePath:
-    """Integration tests: clone-path git write detection reaches _detect_branch_divergence."""
+    """Unit tests: `_detect_branch_divergence` standalone (not the production call path)."""
 
     def test_git_writes_detected_on_clone_path(self, tmp_path: Path) -> None:
         """Clone path (main checkout) with commits ahead of origin returns True."""
@@ -935,6 +935,58 @@ class TestGitWritesDetection:
             "write_behavior is conditional and pattern matches"
         )
         assert sr.subtype != "zero_writes"
+
+
+class TestSessionScopedGitDetection:
+    """Integration tests: session-scoped git write detection (T-ZW-GIT-FP)."""
+
+    @pytest.mark.anyio
+    async def test_git_writes_false_positive_on_predivergd_branch(
+        self, tmp_path: Path, minimal_ctx
+    ) -> None:
+        """Pre-diverged branch + zero-commit session must NOT set git_writes_detected=True.
+
+        T-ZW-GIT-FP: fails under _detect_branch_divergence (global state);
+        passes under _detect_session_git_writes (session-scoped delta).
+        """
+        import subprocess
+
+        from autoskillit.execution.headless import run_headless_core
+        from tests.execution.conftest import _mock_backend, _success_session_json
+
+        repo = tmp_path / "repo"
+        bare = tmp_path / "bare.git"
+
+        subprocess.run(["git", "init", str(bare), "--bare"], check=True, capture_output=True)
+        subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+        for cmd in [
+            ["git", "-C", str(repo), "config", "user.email", "test@test.com"],
+            ["git", "-C", str(repo), "config", "user.name", "Test"],
+            ["git", "-C", str(repo), "remote", "add", "origin", str(bare)],
+            ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "init"],
+            ["git", "-C", str(repo), "push", "origin", "HEAD:main"],
+            ["git", "-C", str(repo), "branch", "--set-upstream-to=origin/main"],
+            # Pre-existing divergence: 1 commit ahead of origin BEFORE the session starts
+            ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "pre-session-commit"],
+        ]:
+            subprocess.run(cmd, check=True, capture_output=True)
+
+        async def mock_runner(cmd, **kwargs):
+            if cmd[0] == "git":
+                return _make_result(returncode=1, stdout="")
+            return _make_result(returncode=0, stdout=_success_session_json("done"))
+
+        minimal_ctx.runner = mock_runner
+        minimal_ctx.backend = _mock_backend()
+
+        result = await run_headless_core(
+            "/autoskillit:test-skill",
+            str(repo),
+            minimal_ctx,
+        )
+        assert result.evidence.git_writes_detected is False, (
+            "git_writes_detected must be False when the branch divergence pre-dates the session"
+        )
 
 
 class TestWriteExpectedWhenPatternSync:

--- a/tests/execution/test_zero_write_detection.py
+++ b/tests/execution/test_zero_write_detection.py
@@ -989,6 +989,81 @@ class TestSessionScopedGitDetection:
         )
 
 
+class TestDetectSessionGitWritesUnit:
+    """Unit tests for _detect_session_git_writes (T-ZW-GIT-SESSION-*)."""
+
+    def test_empty_pre_sha_returns_false(self, tmp_path: Path) -> None:
+        """T-ZW-GIT-SESSION-1: empty baseline is safe default (non-git dir or capture error)."""
+        from autoskillit.execution.headless._headless_git import _detect_session_git_writes
+
+        result = _detect_session_git_writes(str(tmp_path), "")
+        assert result is False
+
+    def test_same_sha_returns_false(self, tmp_path: Path) -> None:
+        """T-ZW-GIT-SESSION-2: pre and post SHA identical → no session commits → False."""
+        import subprocess
+
+        from autoskillit.execution.headless._headless_git import (
+            _capture_git_head_sha,
+            _detect_session_git_writes,
+        )
+
+        repo = tmp_path / "repo"
+        subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+        for cmd in [
+            ["git", "-C", str(repo), "config", "user.email", "test@test.com"],
+            ["git", "-C", str(repo), "config", "user.name", "Test"],
+            ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "init"],
+        ]:
+            subprocess.run(cmd, check=True, capture_output=True)
+
+        pre_sha = _capture_git_head_sha(str(repo))
+        assert pre_sha, "should have captured a valid SHA"
+
+        result = _detect_session_git_writes(str(repo), pre_sha)
+        assert result is False
+
+    def test_different_sha_returns_true(self, tmp_path: Path) -> None:
+        """T-ZW-GIT-SESSION-3: SHA moved after a new commit → True."""
+        import subprocess
+
+        from autoskillit.execution.headless._headless_git import (
+            _capture_git_head_sha,
+            _detect_session_git_writes,
+        )
+
+        repo = tmp_path / "repo"
+        subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+        for cmd in [
+            ["git", "-C", str(repo), "config", "user.email", "test@test.com"],
+            ["git", "-C", str(repo), "config", "user.name", "Test"],
+            ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "init"],
+        ]:
+            subprocess.run(cmd, check=True, capture_output=True)
+
+        pre_sha = _capture_git_head_sha(str(repo))
+        assert pre_sha, "should have captured a valid SHA"
+
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "session-commit"],
+            check=True,
+            capture_output=True,
+        )
+
+        result = _detect_session_git_writes(str(repo), pre_sha)
+        assert result is True
+
+    def test_post_capture_error_returns_false(self, tmp_path: Path) -> None:
+        """T-ZW-GIT-SESSION-4: valid pre_sha but post-capture fails (non-git cwd) → False."""
+        from autoskillit.execution.headless._headless_git import _detect_session_git_writes
+
+        non_git = tmp_path / "not_a_git_repo"
+        non_git.mkdir()
+
+        result = _detect_session_git_writes(str(non_git), "abc123def456deadbeef")
+        assert result is False
+
+
 class TestWriteExpectedWhenPatternSync:
     """write_expected_when patterns in tests must match skill_contracts.yaml."""
 


### PR DESCRIPTION
## Summary

Two complementary false-signal bugs in the write-evidence detection subsystem share a root cause pattern: pre/post comparisons without proper baseline handling. Bug 1 (`git_writes_detected` false positive) uses a global git state check instead of a session-scoped delta. Bug 2 (`fs_writes_detected` false negative) silently skips directories created mid-session because the pre-scan omits them and the post-scan conflates "missing key" with "scan error" via a shared `None` sentinel.

This is the 5th+ fix to this subsystem. The architectural solution introduces session-scoped baselines and sentinel disambiguation, following the `CloneSnapshot`/`detect_contamination` pattern already proven in `clone_guard.py`.

Part B will cover broader regression test hardening and the discriminated union for `DirSnapshot` — implement as a separate task.

## Requirements

Two complementary false-signal bugs in the write-evidence detection subsystem:

1. **`git_writes_detected` false positive**: `_detect_branch_divergence()` reports `True` for every session on any branch already ahead of `origin/HEAD`, regardless of whether the session committed anything. On a branch 977 commits ahead, every session gets `git_writes_detected=true` unconditionally.

2. **`fs_writes_detected` false negative**: When a skill creates its output directory mid-session (e.g., `mkdir -p .autoskillit/temp/review-approach/`), the pre-session `_stat_snapshot` scan skips it (directory doesn't exist yet), and the post-session comparison short-circuits on the missing key. `fs_writes_detected` remains `false` despite confirmed file writes.

Both bugs share a root cause pattern: the pre/post comparison model lacks proper baseline handling for pre-existing state.

Closes #3372

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-232504-860060/.autoskillit/temp/rectify/rectify_write_evidence_false_signals_2026-05-30_233500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 70 | 22.4k | 1.8M | 98.6k | 221 | 88.2k | 17m 49s |
| review_approach* | sonnet | 1 | 9.8k | 7.4k | 154.5k | 61.6k | 99 | 67.4k | 5m 7s |
| dry_walkthrough* | opus | 1 | 57 | 9.9k | 1.4M | 83.9k | 170 | 67.4k | 6m 45s |
| implement* | sonnet | 1 | 358 | 40.1k | 3.2M | 100.1k | 125 | 84.6k | 12m 31s |
| audit_impl* | sonnet | 1 | 78 | 10.4k | 270.5k | 38.9k | 71 | 34.3k | 5m 45s |
| prepare_pr* | sonnet | 1 | 76.4k | 3.8k | 224.9k | 33.2k | 23 | 27.1k | 1m 28s |
| compose_pr* | sonnet | 1 | 70.4k | 1.8k | 191.7k | 27.8k | 16 | 15.5k | 48s |
| review_pr* | sonnet | 1 | 150 | 59.7k | 1.1M | 102.7k | 59 | 87.6k | 13m 43s |
| resolve_review* | opus | 1 | 41 | 7.7k | 1.4M | 73.2k | 45 | 57.2k | 8m 10s |
| **Total** | | | 157.4k | 163.2k | 9.8M | 102.7k | | 529.2k | 1h 12m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 280 | 11470.9 | 302.1 | 143.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 7 | 196844.4 | 8176.4 | 1099.0 |
| **Total** | **287** | 34016.5 | 1844.0 | 568.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 70 | 22.4k | 1.8M | 88.2k | 17m 49s |
| sonnet | 6 | 157.2k | 123.3k | 5.2M | 316.5k | 39m 23s |
| opus | 2 | 98 | 17.5k | 2.8M | 124.6k | 14m 56s |