### PR TITLE
[FIX] Rectify: run_python CWD Path Resolution Mismatch — PART A ONLY

### DIFF
--- a/src/autoskillit/recipe/rules/dataflow/rules_dataflow_callable.py
+++ b/src/autoskillit/recipe/rules/dataflow/rules_dataflow_callable.py
@@ -18,7 +18,7 @@ from autoskillit.recipe.registry import RuleFinding, semantic_rule
 def _get_provided_args(with_args: dict) -> set[str]:
     _nested = with_args.get("args")
     nested_args: set[str] = set(_nested.keys()) if isinstance(_nested, dict) else set()
-    top_level_args = set(with_args.keys()) - {"callable", "timeout", "args"}
+    top_level_args = set(with_args.keys()) - {"callable", "timeout", "args", "work_dir"}
     return nested_args | top_level_args
 
 
@@ -28,7 +28,7 @@ def _get_args_values(with_args: dict) -> dict[str, object]:
     if isinstance(_nested, dict):
         result.update(_nested)
     for key, val in with_args.items():
-        if key not in {"callable", "timeout", "args"}:
+        if key not in {"callable", "timeout", "args", "work_dir"}:
             result[key] = val
     return result
 

--- a/src/autoskillit/recipe/rules/dataflow/rules_dataflow_callable.py
+++ b/src/autoskillit/recipe/rules/dataflow/rules_dataflow_callable.py
@@ -13,12 +13,13 @@ from autoskillit.recipe.contracts import (
     load_bundled_manifest,
 )
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
+from autoskillit.recipe.rules.rules_tools import _TOOL_PARAMS
 
 
 def _get_provided_args(with_args: dict) -> set[str]:
     _nested = with_args.get("args")
     nested_args: set[str] = set(_nested.keys()) if isinstance(_nested, dict) else set()
-    top_level_args = set(with_args.keys()) - {"callable", "timeout", "args", "work_dir"}
+    top_level_args = set(with_args.keys()) - {"callable", "timeout", "args"}
     return nested_args | top_level_args
 
 
@@ -28,7 +29,7 @@ def _get_args_values(with_args: dict) -> dict[str, object]:
     if isinstance(_nested, dict):
         result.update(_nested)
     for key, val in with_args.items():
-        if key not in {"callable", "timeout", "args", "work_dir"}:
+        if key not in {"callable", "timeout", "args"}:
             result[key] = val
     return result
 
@@ -91,7 +92,12 @@ def _check_callable_signature_mismatch(ctx: ValidationContext) -> list[RuleFindi
         if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
             continue
         valid_params = set(sig.parameters.keys())
-        provided_args = _get_provided_args(step.with_args)
+        tool_level_params = _TOOL_PARAMS.get(step.tool, frozenset()) - {
+            "callable",
+            "args",
+            "timeout",
+        }
+        provided_args = _get_provided_args(step.with_args) - tool_level_params
         invalid = provided_args - valid_params
         for arg_name in sorted(invalid):
             findings.append(

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -45,7 +45,7 @@ _TOOL_PARAMS: dict[str, frozenset[str]] = {
         }
     ),
     "run_cmd": frozenset({"cmd", "cwd", "timeout", "step_name"}),
-    "run_python": frozenset({"callable", "args", "timeout"}),
+    "run_python": frozenset({"callable", "args", "timeout", "work_dir"}),
     # --- Workspace tools ---
     "test_check": frozenset({"worktree_path", "step_name"}),
     "merge_worktree": frozenset({"worktree_path", "base_branch", "step_name"}),

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2371,6 +2371,8 @@ callable_contracts:
       type: file_path
     - name: review_mode
       type: str
+    - name: head_sha
+      type: str
   autoskillit.smoke_utils.compute_domain_partitions:
     inputs:
     - name: batch_branch

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -931,7 +931,8 @@
         "hunk_ranges_path": "${{ result.hunk_ranges_path }}",
         "valid_lines_path": "${{ result.valid_lines_path }}",
         "diff_metrics_path": "${{ result.diff_metrics_path }}",
-        "review_mode": "${{ result.review_mode }}"
+        "review_mode": "${{ result.review_mode }}",
+        "pr_head_sha": "${{ result.head_sha }}"
       },
       "on_success": "review_pr",
       "on_failure": "review_pr",
@@ -946,7 +947,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} valid_lines_path=${{ context.valid_lines_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }}",
+        "skill_command": "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} valid_lines_path=${{ context.valid_lines_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }} pr_head_sha=${{ context.pr_head_sha }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "review_pr",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr"

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -325,7 +325,8 @@
         "callable": "autoskillit.smoke_utils.diagnose_merge_gate",
         "test_stdout": "${{ context.merge_test_stdout }}",
         "test_stderr": "${{ context.merge_test_stderr }}",
-        "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate",
+        "work_dir": "${{ context.work_dir }}"
       },
       "capture": {
         "merge_gate_diagnosis_path": "${{ result.diagnosis_path }}",
@@ -922,7 +923,8 @@
         "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr",
         "base_branch": "${{ inputs.base_branch }}",
         "local_review_rounds": "${{ inputs.local_review_rounds }}",
-        "current_iteration": "${{ context.review_loop_count }}"
+        "current_iteration": "${{ context.review_loop_count }}",
+        "work_dir": "${{ context.work_dir }}"
       },
       "capture": {
         "annotated_diff_path": "${{ result.annotated_diff_path }}",
@@ -1027,8 +1029,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.review_path_rebase",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {
@@ -1427,8 +1431,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.review_path_rebase",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {
@@ -1745,8 +1751,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.queue_ejected_fix",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {
@@ -1992,8 +2000,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.direct_merge_conflict_fix",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {
@@ -2101,8 +2111,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.immediate_merge_conflict_fix",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -847,6 +847,7 @@ steps:
       valid_lines_path: "${{ result.valid_lines_path }}"
       diff_metrics_path: "${{ result.diff_metrics_path }}"
       review_mode: "${{ result.review_mode }}"
+      pr_head_sha: "${{ result.head_sha }}"
     on_success: review_pr
     on_failure: review_pr
     optional: true
@@ -861,7 +862,7 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} valid_lines_path=${{ context.valid_lines_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }}"
+      skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} valid_lines_path=${{ context.valid_lines_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }} pr_head_sha=${{ context.pr_head_sha }}"
       cwd: "${{ context.work_dir }}"
       step_name: "review_pr"
       output_dir: "{{AUTOSKILLIT_TEMP}}/review-pr"

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -314,6 +314,7 @@ steps:
       test_stdout: "${{ context.merge_test_stdout }}"
       test_stderr: "${{ context.merge_test_stderr }}"
       output_dir: "{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate"
+      work_dir: "${{ context.work_dir }}"
     capture:
       merge_gate_diagnosis_path: "${{ result.diagnosis_path }}"
       merge_gate_ci_conclusion: "${{ result.ci_conclusion }}"
@@ -839,6 +840,7 @@ steps:
       base_branch: "${{ inputs.base_branch }}"
       local_review_rounds: "${{ inputs.local_review_rounds }}"
       current_iteration: "${{ context.review_loop_count }}"
+      work_dir: "${{ context.work_dir }}"
     capture:
       annotated_diff_path: "${{ result.annotated_diff_path }}"
       hunk_ranges_path: "${{ result.hunk_ranges_path }}"

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -933,8 +933,9 @@ steps:
     tool: run_python
     with:
       callable: autoskillit.recipe._cmd_rpc.review_path_rebase
-      work_dir: ${{ context.work_dir }}
-      base_branch: ${{ inputs.base_branch }}
+      args:
+        work_dir: ${{ context.work_dir }}
+        base_branch: ${{ inputs.base_branch }}
     on_result:
     - when: ${{ result.status }} == clean
       route: re_push_review
@@ -1302,8 +1303,9 @@ steps:
     tool: run_python
     with:
       callable: autoskillit.recipe._cmd_rpc.review_path_rebase
-      work_dir: ${{ context.work_dir }}
-      base_branch: ${{ inputs.base_branch }}
+      args:
+        work_dir: ${{ context.work_dir }}
+        base_branch: ${{ inputs.base_branch }}
     on_result:
     - when: ${{ result.status }} == clean
       route: check_ci_rebase_loop
@@ -1572,8 +1574,9 @@ steps:
     tool: run_python
     with:
       callable: "autoskillit.recipe._cmd_rpc.queue_ejected_fix"
-      work_dir: "${{ context.work_dir }}"
-      base_branch: "${{ inputs.base_branch }}"
+      args:
+        work_dir: "${{ context.work_dir }}"
+        base_branch: "${{ inputs.base_branch }}"
     on_result:
     - when: "${{ result.status }} == clean"
       route: re_push_queue_fix
@@ -1779,8 +1782,9 @@ steps:
     tool: run_python
     with:
       callable: "autoskillit.recipe._cmd_rpc.direct_merge_conflict_fix"
-      work_dir: "${{ context.work_dir }}"
-      base_branch: "${{ inputs.base_branch }}"
+      args:
+        work_dir: "${{ context.work_dir }}"
+        base_branch: "${{ inputs.base_branch }}"
     on_result:
     - when: "${{ result.status }} == clean"
       route: re_push_direct_fix
@@ -1884,8 +1888,9 @@ steps:
     tool: run_python
     with:
       callable: "autoskillit.recipe._cmd_rpc.immediate_merge_conflict_fix"
-      work_dir: "${{ context.work_dir }}"
-      base_branch: "${{ inputs.base_branch }}"
+      args:
+        work_dir: "${{ context.work_dir }}"
+        base_branch: "${{ inputs.base_branch }}"
     on_result:
     - when: "${{ result.status }} == clean"
       route: re_push_immediate_fix

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -387,7 +387,8 @@
         "callable": "autoskillit.smoke_utils.diagnose_merge_gate",
         "test_stdout": "${{ context.merge_test_stdout }}",
         "test_stderr": "${{ context.merge_test_stderr }}",
-        "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate",
+        "work_dir": "${{ context.work_dir }}"
       },
       "capture": {
         "merge_gate_diagnosis_path": "${{ result.diagnosis_path }}",
@@ -979,7 +980,8 @@
         "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr",
         "base_branch": "${{ inputs.base_branch }}",
         "local_review_rounds": "${{ inputs.local_review_rounds }}",
-        "current_iteration": "${{ context.review_loop_count }}"
+        "current_iteration": "${{ context.review_loop_count }}",
+        "work_dir": "${{ context.work_dir }}"
       },
       "capture": {
         "annotated_diff_path": "${{ result.annotated_diff_path }}",
@@ -1097,8 +1099,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.review_path_rebase",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {
@@ -1687,8 +1691,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.queue_ejected_fix",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {
@@ -1934,8 +1940,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.direct_merge_conflict_fix",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {
@@ -2043,8 +2051,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.immediate_merge_conflict_fix",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {
@@ -2178,8 +2188,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.review_path_rebase",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -988,7 +988,8 @@
         "hunk_ranges_path": "${{ result.hunk_ranges_path }}",
         "valid_lines_path": "${{ result.valid_lines_path }}",
         "diff_metrics_path": "${{ result.diff_metrics_path }}",
-        "review_mode": "${{ result.review_mode }}"
+        "review_mode": "${{ result.review_mode }}",
+        "pr_head_sha": "${{ result.head_sha }}"
       },
       "on_success": "review_pr",
       "on_failure": "review_pr",
@@ -1003,7 +1004,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} valid_lines_path=${{ context.valid_lines_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }}",
+        "skill_command": "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} valid_lines_path=${{ context.valid_lines_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }} pr_head_sha=${{ context.pr_head_sha }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "review_pr",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr"

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -387,6 +387,7 @@ steps:
       test_stdout: ${{ context.merge_test_stdout }}
       test_stderr: ${{ context.merge_test_stderr }}
       output_dir: '{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate'
+      work_dir: ${{ context.work_dir }}
     capture:
       merge_gate_diagnosis_path: ${{ result.diagnosis_path }}
       merge_gate_ci_conclusion: ${{ result.ci_conclusion }}
@@ -906,6 +907,7 @@ steps:
       base_branch: ${{ inputs.base_branch }}
       local_review_rounds: ${{ inputs.local_review_rounds }}
       current_iteration: ${{ context.review_loop_count }}
+      work_dir: ${{ context.work_dir }}
     capture:
       annotated_diff_path: ${{ result.annotated_diff_path }}
       hunk_ranges_path: ${{ result.hunk_ranges_path }}

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1020,8 +1020,9 @@ steps:
     tool: run_python
     with:
       callable: autoskillit.recipe._cmd_rpc.review_path_rebase
-      work_dir: ${{ context.work_dir }}
-      base_branch: ${{ inputs.base_branch }}
+      args:
+        work_dir: ${{ context.work_dir }}
+        base_branch: ${{ inputs.base_branch }}
     on_result:
     - when: ${{ result.status }} == clean
       route: re_push_review
@@ -1548,8 +1549,9 @@ steps:
     tool: run_python
     with:
       callable: autoskillit.recipe._cmd_rpc.queue_ejected_fix
-      work_dir: ${{ context.work_dir }}
-      base_branch: ${{ inputs.base_branch }}
+      args:
+        work_dir: ${{ context.work_dir }}
+        base_branch: ${{ inputs.base_branch }}
     on_result:
     - when: ${{ result.status }} == clean
       route: re_push_queue_fix
@@ -1751,8 +1753,9 @@ steps:
     tool: run_python
     with:
       callable: autoskillit.recipe._cmd_rpc.direct_merge_conflict_fix
-      work_dir: ${{ context.work_dir }}
-      base_branch: ${{ inputs.base_branch }}
+      args:
+        work_dir: ${{ context.work_dir }}
+        base_branch: ${{ inputs.base_branch }}
     on_result:
     - when: ${{ result.status }} == clean
       route: re_push_direct_fix
@@ -1855,8 +1858,9 @@ steps:
     tool: run_python
     with:
       callable: autoskillit.recipe._cmd_rpc.immediate_merge_conflict_fix
-      work_dir: ${{ context.work_dir }}
-      base_branch: ${{ inputs.base_branch }}
+      args:
+        work_dir: ${{ context.work_dir }}
+        base_branch: ${{ inputs.base_branch }}
     on_result:
     - when: ${{ result.status }} == clean
       route: re_push_immediate_fix
@@ -1981,8 +1985,9 @@ steps:
     tool: run_python
     with:
       callable: autoskillit.recipe._cmd_rpc.review_path_rebase
-      work_dir: ${{ context.work_dir }}
-      base_branch: ${{ inputs.base_branch }}
+      args:
+        work_dir: ${{ context.work_dir }}
+        base_branch: ${{ inputs.base_branch }}
     on_result:
     - when: ${{ result.status }} == clean
       route: check_ci_rebase_loop

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -914,6 +914,7 @@ steps:
       valid_lines_path: ${{ result.valid_lines_path }}
       diff_metrics_path: ${{ result.diff_metrics_path }}
       review_mode: ${{ result.review_mode }}
+      pr_head_sha: ${{ result.head_sha }}
     on_success: review_pr
     on_failure: review_pr
     optional: true
@@ -932,7 +933,7 @@ steps:
         }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{
         context.hunk_ranges_path }} valid_lines_path=${{ context.valid_lines_path }}
         diff_metrics_path=${{ context.diff_metrics_path
-        }} mode=${{ context.review_mode }}
+        }} mode=${{ context.review_mode }} pr_head_sha=${{ context.pr_head_sha }}
       cwd: ${{ context.work_dir }}
       step_name: review_pr
       output_dir: '{{AUTOSKILLIT_TEMP}}/review-pr'

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -1445,7 +1445,8 @@
         "annotated_diff_path": "${{ result.annotated_diff_path }}",
         "hunk_ranges_path": "${{ result.hunk_ranges_path }}",
         "valid_lines_path": "${{ result.valid_lines_path }}",
-        "diff_metrics_path": "${{ result.diff_metrics_path }}"
+        "diff_metrics_path": "${{ result.diff_metrics_path }}",
+        "pr_head_sha": "${{ result.head_sha }}"
       },
       "on_success": "review_pr_integration",
       "on_failure": "review_pr_integration",
@@ -1455,7 +1456,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:review-pr ${{ context.batch_branch }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} valid_lines_path=${{ context.valid_lines_path }} diff_metrics_path=${{ context.diff_metrics_path }}",
+        "skill_command": "/autoskillit:review-pr ${{ context.batch_branch }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} valid_lines_path=${{ context.valid_lines_path }} diff_metrics_path=${{ context.diff_metrics_path }} pr_head_sha=${{ context.pr_head_sha }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "review_pr_integration",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr"

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -156,7 +156,8 @@
         "callable": "autoskillit.smoke_utils.fetch_merge_queue_data",
         "base_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "{{AUTOSKILLIT_TEMP}}/merge-prs"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/merge-prs",
+        "work_dir": "${{ context.work_dir }}"
       },
       "capture": {
         "merge_queue_data_path": "${{ result.merge_queue_data_path }}"
@@ -1307,7 +1308,8 @@
         "batch_branch": "${{ context.batch_branch }}",
         "base_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "output_dir": "{{AUTOSKILLIT_TEMP}}/open-integration-pr"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/open-integration-pr",
+        "work_dir": "${{ context.work_dir }}"
       },
       "capture": {
         "domain_partitions_path": "${{ result.domain_partitions_path }}"
@@ -1436,7 +1438,8 @@
         "pr_number": "${{ context.review_pr_number }}",
         "cwd": "${{ context.work_dir }}",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr",
-        "local_review_rounds": "0"
+        "local_review_rounds": "0",
+        "work_dir": "${{ context.work_dir }}"
       },
       "capture": {
         "annotated_diff_path": "${{ result.annotated_diff_path }}",
@@ -1525,8 +1528,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.review_path_rebase",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -1506,8 +1506,9 @@ steps:
     tool: run_python
     with:
       callable: autoskillit.recipe._cmd_rpc.review_path_rebase
-      work_dir: ${{ context.work_dir }}
-      base_branch: ${{ inputs.base_branch }}
+      args:
+        work_dir: ${{ context.work_dir }}
+        base_branch: ${{ inputs.base_branch }}
     on_result:
     - when: ${{ result.status }} == clean
       route: re_push_review_integration

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -1427,6 +1427,7 @@ steps:
       hunk_ranges_path: ${{ result.hunk_ranges_path }}
       valid_lines_path: ${{ result.valid_lines_path }}
       diff_metrics_path: ${{ result.diff_metrics_path }}
+      pr_head_sha: ${{ result.head_sha }}
     on_success: review_pr_integration
     on_failure: review_pr_integration
     note: 'Pre-computes annotated diff and hunk ranges for review-pr server-side (where
@@ -1443,7 +1444,7 @@ steps:
         }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{
         context.hunk_ranges_path }} valid_lines_path=${{ context.valid_lines_path }}
         diff_metrics_path=${{ context.diff_metrics_path
-        }}
+        }} pr_head_sha=${{ context.pr_head_sha }}
       cwd: ${{ context.work_dir }}
       step_name: review_pr_integration
       output_dir: '{{AUTOSKILLIT_TEMP}}/review-pr'

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -211,6 +211,7 @@ steps:
       base_branch: ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
       output_dir: '{{AUTOSKILLIT_TEMP}}/merge-prs'
+      work_dir: ${{ context.work_dir }}
     capture:
       merge_queue_data_path: ${{ result.merge_queue_data_path }}
     on_success: analyze_prs
@@ -1289,6 +1290,7 @@ steps:
       base_branch: ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
       output_dir: '{{AUTOSKILLIT_TEMP}}/open-integration-pr'
+      work_dir: ${{ context.work_dir }}
     capture:
       domain_partitions_path: ${{ result.domain_partitions_path }}
     on_success: open_integration_pr
@@ -1419,6 +1421,7 @@ steps:
       cwd: ${{ context.work_dir }}
       output_dir: '{{AUTOSKILLIT_TEMP}}/review-pr'
       local_review_rounds: '0'
+      work_dir: ${{ context.work_dir }}
     capture:
       annotated_diff_path: ${{ result.annotated_diff_path }}
       hunk_ranges_path: ${{ result.hunk_ranges_path }}

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -1121,7 +1121,8 @@
         "hunk_ranges_path": "${{ result.hunk_ranges_path }}",
         "valid_lines_path": "${{ result.valid_lines_path }}",
         "diff_metrics_path": "${{ result.diff_metrics_path }}",
-        "review_mode": "${{ result.review_mode }}"
+        "review_mode": "${{ result.review_mode }}",
+        "pr_head_sha": "${{ result.head_sha }}"
       },
       "on_success": "review_pr",
       "on_failure": "review_pr",
@@ -1136,7 +1137,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} valid_lines_path=${{ context.valid_lines_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }}",
+        "skill_command": "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} valid_lines_path=${{ context.valid_lines_path }} diff_metrics_path=${{ context.diff_metrics_path }} mode=${{ context.review_mode }} pr_head_sha=${{ context.pr_head_sha }}",
         "cwd": "${{ context.work_dir }}",
         "step_name": "review_pr",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr"

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -428,7 +428,8 @@
         "callable": "autoskillit.smoke_utils.diagnose_merge_gate",
         "test_stdout": "${{ context.merge_test_stdout }}",
         "test_stderr": "${{ context.merge_test_stderr }}",
-        "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate",
+        "work_dir": "${{ context.work_dir }}"
       },
       "capture": {
         "merge_gate_diagnosis_path": "${{ result.diagnosis_path }}",
@@ -1112,7 +1113,8 @@
         "output_dir": "{{AUTOSKILLIT_TEMP}}/review-pr",
         "base_branch": "${{ inputs.base_branch }}",
         "local_review_rounds": "${{ inputs.local_review_rounds }}",
-        "current_iteration": "${{ context.review_loop_count }}"
+        "current_iteration": "${{ context.review_loop_count }}",
+        "work_dir": "${{ context.work_dir }}"
       },
       "capture": {
         "annotated_diff_path": "${{ result.annotated_diff_path }}",
@@ -1217,8 +1219,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.review_path_rebase",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {
@@ -1807,8 +1811,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.queue_ejected_fix",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {
@@ -2054,8 +2060,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.direct_merge_conflict_fix",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {
@@ -2163,8 +2171,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.immediate_merge_conflict_fix",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {
@@ -2298,8 +2308,10 @@
       "tool": "run_python",
       "with": {
         "callable": "autoskillit.recipe._cmd_rpc.review_path_rebase",
-        "work_dir": "${{ context.work_dir }}",
-        "base_branch": "${{ inputs.base_branch }}"
+        "args": {
+          "work_dir": "${{ context.work_dir }}",
+          "base_branch": "${{ inputs.base_branch }}"
+        }
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1016,6 +1016,7 @@ steps:
       valid_lines_path: ${{ result.valid_lines_path }}
       diff_metrics_path: ${{ result.diff_metrics_path }}
       review_mode: ${{ result.review_mode }}
+      pr_head_sha: ${{ result.head_sha }}
     on_success: review_pr
     on_failure: review_pr
     optional: true
@@ -1034,7 +1035,7 @@ steps:
         }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{
         context.hunk_ranges_path }} valid_lines_path=${{ context.valid_lines_path }}
         diff_metrics_path=${{ context.diff_metrics_path
-        }} mode=${{ context.review_mode }}
+        }} mode=${{ context.review_mode }} pr_head_sha=${{ context.pr_head_sha }}
       cwd: ${{ context.work_dir }}
       step_name: review_pr
       output_dir: '{{AUTOSKILLIT_TEMP}}/review-pr'

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -424,6 +424,7 @@ steps:
       test_stdout: ${{ context.merge_test_stdout }}
       test_stderr: ${{ context.merge_test_stderr }}
       output_dir: '{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate'
+      work_dir: ${{ context.work_dir }}
     capture:
       merge_gate_diagnosis_path: ${{ result.diagnosis_path }}
       merge_gate_ci_conclusion: ${{ result.ci_conclusion }}
@@ -1008,6 +1009,7 @@ steps:
       base_branch: ${{ inputs.base_branch }}
       local_review_rounds: ${{ inputs.local_review_rounds }}
       current_iteration: ${{ context.review_loop_count }}
+      work_dir: ${{ context.work_dir }}
     capture:
       annotated_diff_path: ${{ result.annotated_diff_path }}
       hunk_ranges_path: ${{ result.hunk_ranges_path }}

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1107,8 +1107,9 @@ steps:
     tool: run_python
     with:
       callable: autoskillit.recipe._cmd_rpc.review_path_rebase
-      work_dir: ${{ context.work_dir }}
-      base_branch: ${{ inputs.base_branch }}
+      args:
+        work_dir: ${{ context.work_dir }}
+        base_branch: ${{ inputs.base_branch }}
     on_result:
     - when: ${{ result.status }} == clean
       route: re_push_review
@@ -1636,8 +1637,9 @@ steps:
     tool: run_python
     with:
       callable: autoskillit.recipe._cmd_rpc.queue_ejected_fix
-      work_dir: ${{ context.work_dir }}
-      base_branch: ${{ inputs.base_branch }}
+      args:
+        work_dir: ${{ context.work_dir }}
+        base_branch: ${{ inputs.base_branch }}
     on_result:
     - when: ${{ result.status }} == clean
       route: re_push_queue_fix
@@ -1839,8 +1841,9 @@ steps:
     tool: run_python
     with:
       callable: autoskillit.recipe._cmd_rpc.direct_merge_conflict_fix
-      work_dir: ${{ context.work_dir }}
-      base_branch: ${{ inputs.base_branch }}
+      args:
+        work_dir: ${{ context.work_dir }}
+        base_branch: ${{ inputs.base_branch }}
     on_result:
     - when: ${{ result.status }} == clean
       route: re_push_direct_fix
@@ -1943,8 +1946,9 @@ steps:
     tool: run_python
     with:
       callable: autoskillit.recipe._cmd_rpc.immediate_merge_conflict_fix
-      work_dir: ${{ context.work_dir }}
-      base_branch: ${{ inputs.base_branch }}
+      args:
+        work_dir: ${{ context.work_dir }}
+        base_branch: ${{ inputs.base_branch }}
     on_result:
     - when: ${{ result.status }} == clean
       route: re_push_immediate_fix
@@ -2069,8 +2073,9 @@ steps:
     tool: run_python
     with:
       callable: autoskillit.recipe._cmd_rpc.review_path_rebase
-      work_dir: ${{ context.work_dir }}
-      base_branch: ${{ inputs.base_branch }}
+      args:
+        work_dir: ${{ context.work_dir }}
+        base_branch: ${{ inputs.base_branch }}
     on_result:
     - when: ${{ result.status }} == clean
       route: check_ci_rebase_loop

--- a/src/autoskillit/server/tools/_execution_helpers.py
+++ b/src/autoskillit/server/tools/_execution_helpers.py
@@ -6,13 +6,26 @@ import asyncio
 import json
 import types
 import typing
+from pathlib import Path
 
 from autoskillit.core import get_logger
 
 logger = get_logger(__name__)
 
 
-_RUN_PYTHON_SENTINEL_KEYS: frozenset[str] = frozenset({"callable", "timeout"})
+_RUN_PYTHON_SENTINEL_KEYS: frozenset[str] = frozenset({"callable", "timeout", "work_dir"})
+
+_PATH_LIKE_ARGS: frozenset[str] = frozenset({"output_dir"})
+
+
+def resolve_relative_path_args(args: dict[str, object], work_dir: str) -> dict[str, object]:
+    """Anchor relative path arguments to work_dir."""
+    resolved = dict(args)
+    for key in _PATH_LIKE_ARGS:
+        val = resolved.get(key)
+        if isinstance(val, str) and val and not Path(val).is_absolute():
+            resolved[key] = str(Path(work_dir) / val)
+    return resolved
 
 
 def _coerce_scalar(val: object, annotation: object) -> object:

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -189,6 +189,7 @@ async def run_python(
     callable: str,
     args: dict[str, object] | None = None,
     timeout: int = 30,
+    work_dir: str = "",
     ctx: Context = CurrentContext(),
 ) -> str:
     """Call a Python function directly by dotted module path.
@@ -205,6 +206,8 @@ async def run_python(
         callable: Dotted path to the function (e.g. "mypackage.module.function").
         args: Keyword arguments to pass to the function.
         timeout: Max seconds before aborting the call (default 30).
+        work_dir: When set, relative path-like args (output_dir, etc.) are
+            anchored to this directory before the callable is invoked.
 
     Never raises.
     """
@@ -224,9 +227,13 @@ async def run_python(
             )
             from autoskillit.server.tools._execution_helpers import (
                 _import_and_call,  # noqa: PLC0415
+                resolve_relative_path_args,  # noqa: PLC0415
             )
 
-            result = await _import_and_call(callable, args=args, timeout=float(timeout))
+            resolved_args = args
+            if work_dir:
+                resolved_args = resolve_relative_path_args(args or {}, work_dir)
+            result = await _import_and_call(callable, args=resolved_args, timeout=float(timeout))
             if not result.get("success"):
                 await _notify(
                     ctx,

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -461,6 +461,7 @@ classified `REJECT` with `category: "arch_violation"`.
 | Capability-based dispatch | `test_no_backend_name_bypass.py` | `if backend.name == "..."` — must use capability fields |
 | step_name in run_cmd | `test_anti_pattern_guards.py` | Missing `step_name` in `run_cmd` `with:` blocks in recipe YAML |
 | No hardcoded temp paths | `test_python_no_hardcoded_temp.py` | Literal `{{AUTOSKILLIT_TEMP}}` path string in Python outside whitelist |
+| run_python path resolution | `test_run_python_path_resolution.py` | smoke_utils callable with relative-path fallback or path-like param not in `_PATH_LIKE_ARGS` |
 | SkillResult kill_reason | `test_skill_result_construction_guard.py` | `SkillResult()` without `kill_reason=` kwarg |
 | Never-raises contracts | `test_never_raises_contracts.py` | `mcp.tool()` handlers without top-level `try/except` and "Never raises" docstring |
 | ClaudeFlags isolation | `test_backend_flag_isolation.py` | `ClaudeFlags` referenced in `_session_launch.py` — backend flags belong in backend layer only |

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -194,28 +194,40 @@ Save the diff to `{{AUTOSKILLIT_TEMP}}/review-pr/diff_{pr_number}.txt`. (relativ
 
 ### Step 2.7: Deterministic Diff Annotation
 
-Read pre-computed annotated diff and hunk ranges from disk when available:
+Read pre-computed annotated diff and hunk ranges from disk when available, but only if the
+cached metadata is fresh (i.e., the embedded `_head_sha` matches the PR's current HEAD commit).
+Stale metadata from a previous loop iteration is discarded to prevent posting inline comments
+with wrong line numbers after a force-push.
 
 ```bash
 ANNOTATED_DIFF=""
 VALID_LINE_RANGES="{}"
 VALID_DIFF_LINES=""
-if [ -n "${annotated_diff_path:-}" ] && [ -f "$annotated_diff_path" ]; then
-    ANNOTATED_DIFF="$(cat "$annotated_diff_path")"
-fi
-if [ -n "${hunk_ranges_path:-}" ] && [ -f "$hunk_ranges_path" ]; then
-    VALID_LINE_RANGES="$(cat "$hunk_ranges_path")"
-fi
-if [ -n "${valid_lines_path:-}" ] && [ -f "$valid_lines_path" ]; then
-    VALID_DIFF_LINES="$(cat "$valid_lines_path")"
+if [ -n "${diff_metrics_path:-}" ] && [ -f "$diff_metrics_path" ]; then
+    cached_sha=$(python3 -c "import json; d=json.load(open('$diff_metrics_path')); print(d.get('_head_sha',''))" 2>/dev/null || echo "")
+    live_sha=$(gh pr view "${pr_number}" --json headRefOid -q .headRefOid 2>/dev/null || echo "")
+
+    if [ -n "$cached_sha" ] && [ -n "$live_sha" ] && [ "$cached_sha" = "$live_sha" ]; then
+        if [ -n "${annotated_diff_path:-}" ] && [ -f "$annotated_diff_path" ]; then
+            ANNOTATED_DIFF="$(tail -n +2 "$annotated_diff_path")"
+        fi
+        if [ -n "${hunk_ranges_path:-}" ] && [ -f "$hunk_ranges_path" ]; then
+            VALID_LINE_RANGES="$(cat "$hunk_ranges_path")"
+        fi
+        if [ -n "${valid_lines_path:-}" ] && [ -f "$valid_lines_path" ]; then
+            VALID_DIFF_LINES="$(cat "$valid_lines_path")"
+        fi
+    else
+        unset annotated_diff_path hunk_ranges_path valid_lines_path diff_metrics_path
+    fi
 fi
 ```
 
 `VALID_DIFF_LINES` is a JSON mapping `{filepath: [line_numbers]}` containing the exact set of
 new-file line numbers present in the diff. When available, Step 4 uses set-membership for
 validation instead of hunk-span interval checking. `VALID_LINE_RANGES` is a JSON mapping file
-paths to valid hunk line ranges used as fallback. If all paths are absent, leave variables
-empty (no filtering).
+paths to valid hunk line ranges used as fallback. If all paths are absent or the SHA check
+fails, leave variables empty (no filtering).
 
 ### Step 2.5: Deletion Context Pre-Computation
 

--- a/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
+++ b/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
@@ -44,10 +44,9 @@ def diagnose_merge_gate(
     subtype = _classify_subtype(test_stdout, test_stderr)
     failed_tests = _extract_failed_tests(test_stdout, test_stderr)
 
-    if output_dir:
-        out_path = Path(output_dir) / "diagnosis.md"
-    else:
-        out_path = Path(".autoskillit") / "temp" / "diagnose-merge-gate" / "diagnosis.md"
+    if not output_dir:
+        raise ValueError("output_dir is required — pass via run_python work_dir anchoring")
+    out_path = Path(output_dir) / "diagnosis.md"
 
     failed_section = "\n".join(f"- {t}" for t in failed_tests) if failed_tests else "- none"
     log_excerpt = test_stdout.strip() or test_stderr.strip() or "(no output captured)"

--- a/src/autoskillit/smoke_utils/_review.py
+++ b/src/autoskillit/smoke_utils/_review.py
@@ -71,12 +71,29 @@ def annotate_pr_diff(
             timeout=60,
         )
     diff = result.stdout
+    if review_mode == "github":
+        head_sha_result = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", "headRefOid", "-q", ".headRefOid"],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=30,
+        )
+    else:
+        head_sha_result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=10,
+        )
+    head_sha = head_sha_result.stdout.strip() if head_sha_result.returncode == 0 else ""
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
     annotated_path = out / f"annotated_diff_{pr_number}.txt"
     ranges_path = out / f"ranges_{pr_number}.json"
     valid_lines_path = out / f"valid_lines_{pr_number}.json"
-    atomic_write(annotated_path, annotate_diff(diff))
+    atomic_write(annotated_path, f"# sha: {head_sha}\n{annotate_diff(diff)}")
     atomic_write(ranges_path, json.dumps(parse_hunk_ranges(diff)))
     atomic_write(valid_lines_path, json.dumps(extract_valid_lines(diff)))
     metrics = compute_diff_metrics(diff)
@@ -88,6 +105,7 @@ def annotate_pr_diff(
         file_threshold=file_thresh,
     )
     metrics_data = {
+        "_head_sha": head_sha,
         "added_lines": metrics.added_lines,
         "removed_lines": metrics.removed_lines,
         "changed_files": metrics.changed_files,
@@ -97,6 +115,7 @@ def annotate_pr_diff(
     metrics_path = out / f"metrics_{pr_number}.json"
     atomic_write(metrics_path, json.dumps(metrics_data))
     return {
+        "head_sha": head_sha,
         "review_mode": review_mode,
         "annotated_diff_path": str(annotated_path),
         "hunk_ranges_path": str(ranges_path),

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -64,6 +64,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_regex_import.py` | Structural guard: src/ must use `import regex as re`, not bare `import re` (hooks/ exempt) |
 | `test_registry.py` | Symbolic rule registry tests (RuleDescriptor, RULES, Violation) |
 | `test_registry_key_casing.py` | Architectural invariant tests for registry key casing |
+| `test_run_python_path_resolution.py` | Architectural invariants for run_python path resolution: no smoke_utils fallback paths, _PATH_LIKE_ARGS registry completeness |
 | `test_size_markers.py` | Enforce pytestmark size markers on in-scope test files |
 | `test_startup_budget.py` | Startup budget enforcement (REQ-STARTUP-001): serve() critical path must not contain subprocess calls |
 | `test_subpackage_isolation.py` | IL-1/IL-2/IL-3 sub-package isolation, __all__ completeness, size/file-count constraints |

--- a/tests/arch/test_run_python_path_resolution.py
+++ b/tests/arch/test_run_python_path_resolution.py
@@ -1,0 +1,107 @@
+"""Architectural invariants for run_python path resolution.
+
+Verifies that:
+1. No smoke_utils callable falls back to a relative path when output_dir is absent.
+2. Every smoke_utils callable parameter matching *_dir, *_path, or *_file is in
+   _PATH_LIKE_ARGS (the set that run_python resolves against work_dir) or is
+   explicitly excluded with justification.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+_SMOKE_UTILS_DIR = Path(__file__).resolve().parent.parent.parent / "src/autoskillit/smoke_utils"
+
+_PATH_LIKE_SUFFIXES = ("_dir", "_path", "_file")
+
+_EXPLICITLY_EXCLUDED: dict[str, str] = {
+    "counter_file": (
+        "constructed as absolute via ${{ context.work_dir }}/... in recipe YAML; "
+        "is_absolute() guard in resolve_relative_path_args skips it safely"
+    ),
+}
+
+
+def test_smoke_utils_output_dir_never_resolves_against_implicit_cwd() -> None:
+    """No smoke_utils callable may fall back to a relative path when output_dir is falsy."""
+    violations: list[str] = []
+
+    for py_file in sorted(_SMOKE_UTILS_DIR.glob("*.py")):
+        source = py_file.read_text()
+        tree = ast.parse(source, filename=str(py_file))
+
+        for func_node in ast.walk(tree):
+            if not isinstance(func_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            param_names = {arg.arg for arg in func_node.args.args}
+            if "output_dir" not in param_names:
+                continue
+
+            for stmt in ast.walk(func_node):
+                if not isinstance(stmt, ast.If):
+                    continue
+                for else_stmt in stmt.orelse:
+                    for call_node in ast.walk(else_stmt):
+                        if not isinstance(call_node, ast.Call):
+                            continue
+                        func = call_node.func
+                        if not (isinstance(func, ast.Name) and func.id == "Path"):
+                            continue
+                        if not call_node.args:
+                            continue
+                        first_arg = call_node.args[0]
+                        if not isinstance(first_arg, ast.Constant):
+                            continue
+                        val = first_arg.value
+                        if isinstance(val, str) and not val.startswith("/"):
+                            violations.append(
+                                f"{py_file.name}:{call_node.lineno}: "
+                                f"'{func_node.name}' falls back to relative Path({val!r}) "
+                                f"— raise ValueError instead"
+                            )
+
+    assert not violations, (
+        "smoke_utils callables must not fall back to relative paths; "
+        "run_python work_dir anchoring ensures output_dir always arrives absolute:\n"
+        + "\n".join(violations)
+    )
+
+
+def test_path_like_args_registry_complete() -> None:
+    """Every smoke_utils callable param named *_dir, *_path, or *_file must be in _PATH_LIKE_ARGS
+    or explicitly excluded."""
+    from autoskillit.server.tools._execution_helpers import _PATH_LIKE_ARGS
+
+    unregistered: list[str] = []
+
+    for py_file in sorted(_SMOKE_UTILS_DIR.glob("*.py")):
+        source = py_file.read_text()
+        tree = ast.parse(source, filename=str(py_file))
+
+        for func_node in ast.walk(tree):
+            if not isinstance(func_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for arg in func_node.args.args:
+                name = arg.arg
+                if not any(name.endswith(suffix) for suffix in _PATH_LIKE_SUFFIXES):
+                    continue
+                if name in _PATH_LIKE_ARGS:
+                    continue
+                if name in _EXPLICITLY_EXCLUDED:
+                    continue
+                unregistered.append(
+                    f"{py_file.name}:{func_node.name}: param '{name}' not in "
+                    f"_PATH_LIKE_ARGS and not explicitly excluded"
+                )
+
+    assert not unregistered, (
+        "smoke_utils callable params with path-like names must be registered in "
+        "_PATH_LIKE_ARGS or listed in _EXPLICITLY_EXCLUDED with justification:\n"
+        + "\n".join(unregistered)
+    )

--- a/tests/arch/test_run_python_path_resolution.py
+++ b/tests/arch/test_run_python_path_resolution.py
@@ -25,6 +25,23 @@ _EXPLICITLY_EXCLUDED: dict[str, str] = {
         "constructed as absolute via ${{ context.work_dir }}/... in recipe YAML; "
         "is_absolute() guard in resolve_relative_path_args skips it safely"
     ),
+    "eval_run_dir": (
+        "always passed as an absolute path from context (eval_run_dir is set by "
+        "the recipe executor as an absolute directory); never a relative path at the "
+        "run_python call site"
+    ),
+    "worktree_path": (
+        "always absolute; git worktree paths are inherently absolute by design "
+        "and are never passed as relative paths to run_python steps"
+    ),
+    "work_dir": (
+        "enrich_diff_context receives work_dir as the anchor/base directory itself "
+        "for constructing temp_dir; resolving it against itself would be circular"
+    ),
+    "log_dir": (
+        "patch_pr_token_summary receives log_dir as an absolute path from the "
+        "caller context; never passed as a relative string to run_python steps"
+    ),
 }
 
 

--- a/tests/contracts/test_review_pr_diff_annotation.py
+++ b/tests/contracts/test_review_pr_diff_annotation.py
@@ -132,3 +132,23 @@ def test_annotate_pr_diff_callable_contract_has_valid_lines_path() -> None:
     assert "valid_lines_path" in names, (
         "annotate_pr_diff contract must have a valid_lines_path output entry"
     )
+
+
+def test_review_pr_skill_validates_sha_freshness() -> None:
+    """SKILL.md Step 2.7 must compare embedded SHA against live headRefOid."""
+    skill_md = _SKILL_MD.read_text()
+    assert "headRefOid" in skill_md or "_head_sha" in skill_md, (
+        "Step 2.7 must validate SHA freshness, not just file existence"
+    )
+
+
+def test_annotate_pr_diff_callable_contract_has_head_sha() -> None:
+    """annotate_pr_diff contract must declare head_sha as an output."""
+    raw = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    outputs = (
+        raw.get("callable_contracts", {})
+        .get("autoskillit.smoke_utils.annotate_pr_diff", {})
+        .get("outputs", [])
+    )
+    names = [o["name"] for o in outputs]
+    assert "head_sha" in names, "annotate_pr_diff contract must declare head_sha output"

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -144,10 +144,10 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _update_checks_fetch.py — fetch cache (extracted from _update_checks.py)
     ("src/autoskillit/cli/update/_update_checks_fetch.py", 58),
     # smoke_utils/_review.py — ranges, valid lines, diff metrics, enriched handoff
-    ("src/autoskillit/smoke_utils/_review.py", 80),
-    ("src/autoskillit/smoke_utils/_review.py", 81),
+    ("src/autoskillit/smoke_utils/_review.py", 97),
     ("src/autoskillit/smoke_utils/_review.py", 98),
-    ("src/autoskillit/smoke_utils/_review.py", 279),
+    ("src/autoskillit/smoke_utils/_review.py", 116),
+    ("src/autoskillit/smoke_utils/_review.py", 298),
     # smoke_utils/_git.py — partitions, merge queue data
     # Line 102 is a list-payload write site (dual membership: also in list_sites
     # in test_allowlist_includes_list_payloads_as_documented). The AST scanner catches

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -229,7 +229,7 @@ class TestSchemaVersionConvention:
         """List-payload sites are included since the AST scanner can't distinguish return types."""
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
-            ("src/autoskillit/smoke_utils/_review.py", 80),
+            ("src/autoskillit/smoke_utils/_review.py", 97),
             ("src/autoskillit/smoke_utils/_git.py", 102),
         ]
         for site in list_sites:

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -1043,8 +1043,13 @@ def test_run_python_steps_with_relative_output_dir_have_work_dir(recipe_yaml: Pa
         output_dir = step.with_args.get("output_dir", "")
         if not output_dir or not isinstance(output_dir, str):
             continue
-        # {{AUTOSKILLIT_TEMP}} expands to a relative string; treat it as relative
-        is_relative = not output_dir.startswith("/") or "{{AUTOSKILLIT_TEMP}}" in output_dir
+        # Only flag explicit template placeholders and literal relative paths.
+        # Context variable refs (${{ context.* }}) resolve at runtime and may be
+        # absolute — do not flag them.
+        is_context_ref = output_dir.startswith("${{")
+        is_relative = not is_context_ref and (
+            not output_dir.startswith("/") or "{{AUTOSKILLIT_TEMP}}" in output_dir
+        )
         if is_relative:
             assert "work_dir" in step.with_args, (
                 f"{recipe_yaml.name} step '{step_name}': run_python step has relative "

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -1027,3 +1027,26 @@ def test_recipe_all_stop_steps_have_sentinel_instructions(recipe_name: str) -> N
                 f"{recipe_name}.yaml step '{step_name}' must instruct "
                 f"L3 sentinel emission in its message"
             )
+
+
+@pytest.mark.parametrize(
+    "recipe_yaml",
+    sorted(builtin_recipes_dir().glob("*.yaml")),
+    ids=lambda p: p.stem,
+)
+def test_run_python_steps_with_relative_output_dir_have_work_dir(recipe_yaml: Path) -> None:
+    """Every run_python step that passes a relative output_dir must also pass work_dir."""
+    recipe = load_recipe(recipe_yaml)
+    for step_name, step in recipe.steps.items():
+        if step.tool != "run_python":
+            continue
+        output_dir = step.with_args.get("output_dir", "")
+        if not output_dir or not isinstance(output_dir, str):
+            continue
+        # {{AUTOSKILLIT_TEMP}} expands to a relative string; treat it as relative
+        is_relative = not output_dir.startswith("/") or "{{AUTOSKILLIT_TEMP}}" in output_dir
+        if is_relative:
+            assert "work_dir" in step.with_args, (
+                f"{recipe_yaml.name} step '{step_name}': run_python step has relative "
+                f"output_dir={output_dir!r} but no work_dir"
+            )

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -476,6 +476,30 @@ def test_annotate_pr_diff_captures_both_paths(recipe_name: str) -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "recipe_name",
+    ["implementation", "remediation", "implementation-groups", "merge-prs"],
+)
+def test_annotate_pr_diff_captures_head_sha(recipe_name: str) -> None:
+    """The annotate_pr_diff step must capture head_sha for freshness tracking."""
+    recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+    annotate_steps = [
+        (name, step)
+        for name, step in recipe.steps.items()
+        if step.tool == "run_python"
+        and step.with_args.get("callable", "") == "autoskillit.smoke_utils.annotate_pr_diff"
+    ]
+    assert annotate_steps, f"No annotate_pr_diff step found in {recipe_name}.yaml"
+    for step_name, step in annotate_steps:
+        assert step.capture is not None, (
+            f"{recipe_name}.yaml: annotate_pr_diff step '{step_name}' has no capture block"
+        )
+        assert "pr_head_sha" in step.capture or "head_sha" in step.capture, (
+            f"{recipe_name}.yaml: annotate_pr_diff step '{step_name}' must capture "
+            f"pr_head_sha (or head_sha) for SHA-freshness validation"
+        )
+
+
 class TestRunModeIngredient:
     """REQ-INGREDIENT-001 through REQ-INGREDIENT-005: run_mode ingredient in multi-issue recipes."""  # noqa: E501
 

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -104,6 +104,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_tools_run_cmd.py` | Tests for run_cmd and run_python MCP tool handlers |
 | `test_tools_run_cmd_unit.py` | Unit tests for run_cmd: observability, timing, and headless gate enforcement |
 | `test_tools_run_python.py` | Unit tests for run_python: observability and headless gate enforcement |
+| `test_tools_run_python_cwd.py` | Tests for run_python work_dir path resolution: anchors relative output_dir to work_dir |
 | `test_clone_result_exhaustiveness.py` | Structural test enforcing exhaustive CloneResult gate handling in _require_clone_success |
 | `test_subprocess_validation.py` | Tests for _run_subprocess cwd validation (empty, relative, nonexistent paths) |
 | `test_tools_bootstrap.py` | Tests for bootstrap composite MCP tools (bootstrap_clone, claim_and_resolve_issue, create_and_publish_branch) |

--- a/tests/server/test_tools_run_python_cwd.py
+++ b/tests/server/test_tools_run_python_cwd.py
@@ -1,0 +1,91 @@
+"""Tests for run_python work_dir path resolution."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autoskillit.server.tools.tools_execution import run_python
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.mark.anyio
+async def test_run_python_resolves_relative_output_dir_against_work_dir(
+    tool_ctx_kitchen_open, tmp_path
+):
+    """run_python must anchor relative output_dir to work_dir, not server process CWD."""
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    output_rel = ".autoskillit/temp/diagnose-test"
+
+    result_json = await run_python(
+        callable="autoskillit.smoke_utils.diagnose_merge_gate",
+        args={"test_stdout": "FAILED test_foo", "test_stderr": "", "output_dir": output_rel},
+        work_dir=str(work_dir),
+    )
+    result = json.loads(result_json)
+    assert result["success"] is True, f"Expected success, got: {result}"
+    expected = work_dir / output_rel / "diagnosis.md"
+    assert expected.exists(), f"File should be at {expected}, not under server CWD"
+
+
+@pytest.mark.anyio
+async def test_run_python_output_readable_from_run_skill_cwd(tool_ctx_kitchen_open, tmp_path):
+    """File path returned by run_python must be accessible from the recipe's work_dir."""
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    output_rel = ".autoskillit/temp/diagnose-test"
+
+    result_json = await run_python(
+        callable="autoskillit.smoke_utils.diagnose_merge_gate",
+        args={"test_stdout": "FAILED test_foo", "test_stderr": "", "output_dir": output_rel},
+        work_dir=str(work_dir),
+    )
+    result = json.loads(result_json)
+    assert result["success"] is True
+    diagnosis_path = result["result"]["diagnosis_path"]
+    assert Path(diagnosis_path).exists(), "run_skill must be able to read this file"
+    assert Path(diagnosis_path).is_absolute(), "Returned path must be absolute"
+
+
+@pytest.mark.anyio
+async def test_run_python_callable_cwd_arg_not_hijacked(tool_ctx_kitchen_open, tmp_path):
+    """Callable's own args remain intact when work_dir is passed as a tool-level param."""
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    output_dir = str(tmp_path / "output")
+
+    result_json = await run_python(
+        callable="autoskillit.smoke_utils.diagnose_merge_gate",
+        args={
+            "test_stdout": "FAILED test_bar",
+            "test_stderr": "",
+            "output_dir": output_dir,
+        },
+        work_dir=str(work_dir),
+    )
+    result = json.loads(result_json)
+    assert result["success"] is True
+
+
+@pytest.mark.anyio
+async def test_run_python_absolute_output_dir_unchanged_by_work_dir(
+    tool_ctx_kitchen_open, tmp_path
+):
+    """Absolute output_dir values must not be modified by work_dir resolution."""
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    abs_output = str(tmp_path / "absolute-output")
+
+    result_json = await run_python(
+        callable="autoskillit.smoke_utils.diagnose_merge_gate",
+        args={"test_stdout": "FAILED test_baz", "test_stderr": "", "output_dir": abs_output},
+        work_dir=str(work_dir),
+    )
+    result = json.loads(result_json)
+    assert result["success"] is True
+    expected_file = Path(abs_output) / "diagnosis.md"
+    assert expected_file.exists(), "Absolute output_dir must be used unchanged"

--- a/tests/server/test_tools_run_python_cwd.py
+++ b/tests/server/test_tools_run_python_cwd.py
@@ -7,6 +7,10 @@ from pathlib import Path
 
 import pytest
 
+from autoskillit.server.tools._execution_helpers import (
+    _PATH_LIKE_ARGS,
+    resolve_relative_path_args,
+)
 from autoskillit.server.tools.tools_execution import run_python
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
@@ -51,24 +55,24 @@ async def test_run_python_output_readable_from_run_skill_cwd(tool_ctx_kitchen_op
     assert Path(diagnosis_path).is_absolute(), "Returned path must be absolute"
 
 
-@pytest.mark.anyio
-async def test_run_python_callable_cwd_arg_not_hijacked(tool_ctx_kitchen_open, tmp_path):
-    """Callable's own args remain intact when work_dir is passed as a tool-level param."""
+def test_run_python_callable_cwd_arg_not_hijacked(tmp_path):
+    """Tool-level work_dir must not consume or overwrite a callable's own cwd arg in args."""
     work_dir = tmp_path / "work"
     work_dir.mkdir()
-    output_dir = str(tmp_path / "output")
+    callable_cwd = str(tmp_path / "callable_cwd")
 
-    result_json = await run_python(
-        callable="autoskillit.smoke_utils.diagnose_merge_gate",
-        args={
-            "test_stdout": "FAILED test_bar",
-            "test_stderr": "",
-            "output_dir": output_dir,
-        },
-        work_dir=str(work_dir),
+    args: dict[str, object] = {"cwd": callable_cwd, "output_dir": ".autoskillit/temp/test"}
+    resolved = resolve_relative_path_args(args, str(work_dir))
+
+    assert "cwd" not in _PATH_LIKE_ARGS, (
+        "cwd must not be in _PATH_LIKE_ARGS — it is a callable-level arg, not path-anchored"
     )
-    result = json.loads(result_json)
-    assert result["success"] is True
+    assert resolved["cwd"] == callable_cwd, (
+        f"Callable's cwd arg was mutated: {resolved['cwd']!r} != {callable_cwd!r}"
+    )
+    assert resolved["output_dir"] == str(work_dir / ".autoskillit/temp/test"), (
+        "Relative output_dir must be anchored to work_dir"
+    )
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_run_python_cwd.py
+++ b/tests/server/test_tools_run_python_cwd.py
@@ -34,22 +34,6 @@ async def test_run_python_resolves_relative_output_dir_against_work_dir(
     assert result["success"] is True, f"Expected success, got: {result}"
     expected = work_dir / output_rel / "diagnosis.md"
     assert expected.exists(), f"File should be at {expected}, not under server CWD"
-
-
-@pytest.mark.anyio
-async def test_run_python_output_readable_from_run_skill_cwd(tool_ctx_kitchen_open, tmp_path):
-    """File path returned by run_python must be accessible from the recipe's work_dir."""
-    work_dir = tmp_path / "work"
-    work_dir.mkdir()
-    output_rel = ".autoskillit/temp/diagnose-test"
-
-    result_json = await run_python(
-        callable="autoskillit.smoke_utils.diagnose_merge_gate",
-        args={"test_stdout": "FAILED test_foo", "test_stderr": "", "output_dir": output_rel},
-        work_dir=str(work_dir),
-    )
-    result = json.loads(result_json)
-    assert result["success"] is True
     diagnosis_path = result["result"]["diagnosis_path"]
     assert Path(diagnosis_path).exists(), "run_skill must be able to read this file"
     assert Path(diagnosis_path).is_absolute(), "Returned path must be absolute"

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -1068,7 +1068,7 @@ def test_annotate_pr_diff_local_mode_empty_base_branch_falls_back_to_github(
         base_branch="",
     )
     assert result["review_mode"] == "github"
-    args = mock_run.call_args[0][0]
+    args = mock_run.call_args_list[0][0][0]
     assert args[:3] == ["gh", "pr", "diff"]
 
 

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -2085,6 +2085,16 @@ def test_diagnose_merge_gate_returns_ci_conclusion_failure(tmp_path: object) -> 
     assert Path(result["diagnosis_path"]).exists()
 
 
+def test_diagnose_merge_gate_rejects_empty_output_dir() -> None:
+    """diagnose_merge_gate must raise ValueError when output_dir is empty."""
+    import pytest
+
+    from autoskillit.smoke_utils._merge_gate_diagnosis import diagnose_merge_gate
+
+    with pytest.raises(ValueError, match="output_dir is required"):
+        diagnose_merge_gate(test_stdout="FAILED test_foo", test_stderr="")
+
+
 # ---------------------------------------------------------------------------
 # T_FACADE_1–T_FACADE_2: smoke_utils package facade verification
 # ---------------------------------------------------------------------------

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -1002,9 +1002,9 @@ def test_annotate_pr_diff_local_mode_uses_git_diff(mock_run, tmp_path: Path) -> 
         current_iteration="0",
         base_branch="main",
     )
-    args = mock_run.call_args[0][0]
+    args = mock_run.call_args_list[0][0][0]
     assert args[:3] == ["git", "diff", "main...HEAD"]
-    mock_run.assert_called_once()
+    assert mock_run.call_count == 2
 
 
 @patch("subprocess.run")
@@ -1019,8 +1019,8 @@ def test_annotate_pr_diff_github_mode_uses_gh_pr_diff(mock_run, tmp_path: Path) 
         current_iteration="2",
         base_branch="",
     )
-    mock_run.assert_called_once()
-    args = mock_run.call_args[0][0]
+    assert mock_run.call_count == 2
+    args = mock_run.call_args_list[0][0][0]
     assert args[:3] == ["gh", "pr", "diff"]
 
 
@@ -1131,6 +1131,63 @@ def test_annotate_pr_diff_produces_valid_lines_artifact(mock_run, tmp_path: Path
     content = json.loads(vl_path.read_text())
     expected = extract_valid_lines(_DIFF_OUTPUT)
     assert content == expected
+
+
+# ─── SHA embedding tests (T_SHA_1–T_SHA_4) ──────────────────────────────────
+
+_SHA = "abc1234567890"
+
+
+@patch("subprocess.run")
+def test_annotate_pr_diff_embeds_head_sha_in_metrics(mock_run, tmp_path: Path) -> None:
+    """T_SHA_1: metrics_{pr}.json must include _head_sha field."""
+    mock_run.side_effect = [
+        subprocess.CompletedProcess([], 0, _DIFF_OUTPUT, ""),
+        subprocess.CompletedProcess([], 0, _SHA, ""),
+    ]
+    annotate_pr_diff(pr_number="999", cwd=str(tmp_path), output_dir=str(tmp_path))
+    metrics = json.loads((tmp_path / "metrics_999.json").read_text())
+    assert "_head_sha" in metrics
+    assert len(metrics["_head_sha"]) >= 7
+
+
+@patch("subprocess.run")
+def test_annotate_pr_diff_embeds_sha_header_in_diff_text(mock_run, tmp_path: Path) -> None:
+    """T_SHA_2: annotated_diff_{pr}.txt first line must be # sha: {sha}."""
+    mock_run.side_effect = [
+        subprocess.CompletedProcess([], 0, _DIFF_OUTPUT, ""),
+        subprocess.CompletedProcess([], 0, _SHA, ""),
+    ]
+    annotate_pr_diff(pr_number="999", cwd=str(tmp_path), output_dir=str(tmp_path))
+    first_line = (tmp_path / "annotated_diff_999.txt").read_text().split("\n")[0]
+    assert first_line.startswith("# sha:")
+
+
+@patch("subprocess.run")
+def test_annotate_pr_diff_returns_head_sha(mock_run, tmp_path: Path) -> None:
+    """T_SHA_3: Return dict must include head_sha for downstream capture."""
+    mock_run.side_effect = [
+        subprocess.CompletedProcess([], 0, _DIFF_OUTPUT, ""),
+        subprocess.CompletedProcess([], 0, _SHA, ""),
+    ]
+    result = annotate_pr_diff(pr_number="999", cwd=str(tmp_path), output_dir=str(tmp_path))
+    assert "head_sha" in result
+    assert len(result["head_sha"]) >= 7
+
+
+@patch("subprocess.run")
+def test_annotate_pr_diff_valid_lines_flat_schema(mock_run, tmp_path: Path) -> None:
+    """T_SHA_4: valid_lines_{pr}.json must be a flat {filepath: [lines]} dict, not wrapped."""
+    mock_run.side_effect = [
+        subprocess.CompletedProcess([], 0, _DIFF_OUTPUT, ""),
+        subprocess.CompletedProcess([], 0, _SHA, ""),
+    ]
+    annotate_pr_diff(pr_number="999", cwd=str(tmp_path), output_dir=str(tmp_path))
+    data = json.loads((tmp_path / "valid_lines_999.json").read_text())
+    assert "_head_sha" not in data, (
+        "valid_lines must not contain _head_sha — breaks SKILL.md Step 4"
+    )
+    assert all(isinstance(v, list) for v in data.values()), "values must be lists of line numbers"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -2144,8 +2144,6 @@ def test_diagnose_merge_gate_returns_ci_conclusion_failure(tmp_path: object) -> 
 
 def test_diagnose_merge_gate_rejects_empty_output_dir() -> None:
     """diagnose_merge_gate must raise ValueError when output_dir is empty."""
-    import pytest
-
     from autoskillit.smoke_utils._merge_gate_diagnosis import diagnose_merge_gate
 
     with pytest.raises(ValueError, match="output_dir is required"):


### PR DESCRIPTION
## Summary

The root cause: `run_python` executes callables in-process without changing the working directory. When callables receive relative paths via `{{AUTOSKILLIT_TEMP}}` substitution (e.g., `.autoskillit/temp/review-pr`), `Path(output_dir)` resolves against the MCP server's process CWD instead of the recipe's `work_dir`. Files written by `run_python` are invisible to subsequent `run_skill` steps that read from the recipe's `work_dir`.

The fix: Add a `work_dir` parameter to the `run_python` MCP tool (named to avoid collision with callable-level `cwd` args) that anchors relative path arguments before dispatch. Update all recipe YAML `run_python` steps to pass `work_dir: ${{ context.work_dir }}`. Fix `diagnose_merge_gate` to raise `ValueError` on empty `output_dir` instead of silently falling back to wrong directory. Update registry constants (`_TOOL_PARAMS`, `_RUN_PYTHON_SENTINEL_KEYS`, `_get_provided_args` exclusion set).

Affected callables: `annotate_pr_diff`, `compute_domain_partitions`, `fetch_merge_queue_data`, `diagnose_merge_gate`. All four are broken with the same pattern.

Part B (temporal staleness immunity: SHA-embedding in output files) is deferred.

## Requirements

(None — closing issue contains investigation/analysis rather than a requirements section)

## Conflict Resolution Decisions

(None provided)

Closes #3374

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-233021-502998/.autoskillit/temp/rectify/rectify_run_python_cwd_path_resolution_2026-05-30_233021.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 9.1k | 33.7k | 2.9M | 125.4k | 312 | 185.6k | 27m 2s |
| review_approach* | sonnet | 1 | 54 | 7.7k | 199.5k | 51.2k | 146 | 37.1k | 7m 29s |
| dry_walkthrough* | opus | 3 | 139 | 26.0k | 1.3M | 89.1k | 309 | 127.2k | 14m 43s |
| implement* | sonnet | 3 | 1.3k | 112.7k | 14.8M | 175.5k | 454 | 398.8k | 36m 46s |
| audit_impl* | sonnet | 3 | 2.2k | 40.9k | 890.0k | 73.3k | 258 | 146.3k | 20m 23s |
| make_plan* | sonnet | 1 | 87 | 6.3k | 374.2k | 51.0k | 25 | 37.5k | 2m 27s |
| prepare_pr* | sonnet | 1 | 89.6k | 5.5k | 167.9k | 28.0k | 21 | 41.0k | 1m 40s |
| compose_pr* | sonnet | 1 | 38.9k | 1.5k | 165.0k | 28.0k | 14 | 15.6k | 46s |
| review_pr* | sonnet | 1 | 134 | 36.3k | 1.1M | 118.3k | 49 | 103.5k | 9m 14s |
| resolve_review* | opus | 1 | 2.1k | 13.0k | 1.5M | 76.4k | 78 | 60.8k | 9m 10s |
| **Total** | | | 143.8k | 283.7k | 23.4M | 175.5k | | 1.2M | 2h 9m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 623 | 23813.9 | 640.2 | 181.0 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 18 | 80632.8 | 3380.5 | 723.7 |
| **Total** | **641** | 36524.3 | 1799.3 | 442.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 9.1k | 33.7k | 2.9M | 185.6k | 27m 2s |
| sonnet | 7 | 132.4k | 210.9k | 17.7M | 779.7k | 1h 18m |
| opus | 2 | 2.3k | 39.0k | 2.8M | 188.1k | 23m 54s |