### PR TITLE
Implementation Plan: Add RP10 Canary Fixtures

### DIFF
--- a/.autoskillit/recipes/eval/agent-eval.yaml
+++ b/.autoskillit/recipes/eval/agent-eval.yaml
@@ -159,6 +159,8 @@ steps:
       pass_rate: "${{ result.pass_rate }}"
       total_runs: "${{ result.total_runs }}"
       passed_runs: "${{ result.passed_runs }}"
+      vacuous_passes: "${{ result.vacuous_passes }}"
+      effective_pass_rate: "${{ result.effective_pass_rate }}"
     on_success: done
     on_failure: escalate
     note: >-
@@ -171,4 +173,6 @@ steps:
     message: >-
       Agent evaluation complete. Pass rate: ${{ context.pass_rate }}
       (${{ context.passed_runs }}/${{ context.total_runs }}).
+      Vacuous passes: ${{ context.vacuous_passes }}.
+      Effective pass rate: ${{ context.effective_pass_rate }}.
       Scorecard: ${{ context.scorecard_path }}

--- a/.autoskillit/recipes/eval/canaries/RP10-diff.txt
+++ b/.autoskillit/recipes/eval/canaries/RP10-diff.txt
@@ -1,0 +1,56 @@
+diff --git a/src/autoskillit/pipeline/finding_serializer.py b/src/autoskillit/pipeline/finding_serializer.py
+new file mode 100644
+--- /dev/null
++++ b/src/autoskillit/pipeline/finding_serializer.py
+@@ -0,0 +1,51 @@
+[L1]+from __future__ import annotations
+[L2]+
+[L3]+import json
+[L4]+import logging
+[L5]+from pathlib import Path
+[L6]+from typing import TypedDict
+[L7]+
+[L8]+
+[L9]+logger = logging.getLogger(__name__)
+[L10]+
+[L11]+
+[L12]+class FindingRecord(TypedDict):
+[L13]+    file_path: str
+[L14]+    severity: str
+[L15]+    message: str
+[L16]+    line: int
+[L17]+
+[L18]+
+[L19]+def serialize_finding(f: FindingRecord) -> dict[str, object]:
+[L20]+    return {
+[L21]+        "file": f["file_path"],
+[L22]+        "severity": f["severity"],
+[L23]+        "message": f["message"],
+[L24]+        "line": f["line"],
+[L25]+    }
+[L26]+
+[L27]+
+[L28]+def write_findings(findings: list[FindingRecord], output: Path) -> None:
+[L29]+    data = [serialize_finding(f) for f in findings]
+[L30]+    output.write_text(json.dumps(data, indent=2))
+[L31]+
+[L32]+
+[L33]+def load_findings(path: Path) -> list[FindingRecord]:
+[L34]+    try:
+[L35]+        raw = json.loads(path.read_text())
+[L36]+    except OSError:
+[L37]+        return []
+[L38]+    for entry in raw:
+[L39]+        if "file_path" not in entry:
+[L40]+            raise KeyError(f"Missing required field 'file_path' in entry")
+[L41]+    return raw
+[L42]+
+[L43]+
+[L44]+def _make_test_finding(
+[L45]+    path="test.py",  # type: str
+[L46]+    sev="warning",  # type: str
+[L47]+    msg="test issue",  # type: str
+[L48]+    ln=1,  # type: int
+[L49]+) -> FindingRecord:
+[L50]+    r = FindingRecord(file_path=path, severity=sev, message=msg, line=ln)
+[L51]+    return r

--- a/.autoskillit/recipes/eval/canaries/RP10-reference.md
+++ b/.autoskillit/recipes/eval/canaries/RP10-reference.md
@@ -1,0 +1,1 @@
+A review that identifies the serialization key mismatch — `FindingRecord.file_path` is written as `"file"` in `serialize_finding` — does not flag the test helper type-comment style or the asymmetric error handling in `load_findings` as defects.

--- a/.autoskillit/recipes/eval/manifests/review-pr-canaries.json
+++ b/.autoskillit/recipes/eval/manifests/review-pr-canaries.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "RP10",
+    "agent_name": "pr-review-auditor",
+    "prompt_template": "{diff}",
+    "prompt_vars": {"diff_file": ".autoskillit/recipes/eval/canaries/RP10-diff.txt"},
+    "reference_path": ".autoskillit/recipes/eval/canaries/RP10-reference.md",
+    "reference_type": "patch",
+    "gap_description": "Cross-artifact schema mismatch: TypedDict field file_path serialized as key file",
+    "detection_criteria": [
+      {"text": "Does NOT flag style issues in test helpers", "type": "precision"},
+      {"text": "Finds the file_path/file key mismatch", "type": "recall"},
+      {"text": "Does NOT flag intentional asymmetric error handling", "type": "precision"}
+    ]
+  }
+]

--- a/.autoskillit/recipes/eval/skill-eval.yaml
+++ b/.autoskillit/recipes/eval/skill-eval.yaml
@@ -146,6 +146,8 @@ steps:
       pass_rate: "${{ result.pass_rate }}"
       total_runs: "${{ result.total_runs }}"
       passed_runs: "${{ result.passed_runs }}"
+      vacuous_passes: "${{ result.vacuous_passes }}"
+      effective_pass_rate: "${{ result.effective_pass_rate }}"
     on_success: done
     on_failure: escalate
     note: >-
@@ -157,4 +159,6 @@ steps:
     message: >-
       Skill evaluation complete. Pass rate: ${{ context.pass_rate }}
       (${{ context.passed_runs }}/${{ context.total_runs }}).
+      Vacuous passes: ${{ context.vacuous_passes }}.
+      Effective pass rate: ${{ context.effective_pass_rate }}.
       Scorecard: ${{ context.scorecard_path }}

--- a/.autoskillit/skills/judge-eval/SKILL.md
+++ b/.autoskillit/skills/judge-eval/SKILL.md
@@ -54,9 +54,7 @@ When creating this skill, the judge must:
 
 ## Criteria Type Handling
 
-Each criterion may have a `type` field:
+Each criterion must have a `type` field:
 - `precision` — Verify the agent does NOT report a false positive. Empty output satisfies this.
 - `recall` — Verify the agent DOES find a specific issue. Empty output ALWAYS fails this — never apply vacuous satisfaction.
 - `recognition` — Verify the agent acknowledges or recognizes a pattern. Empty output fails this.
-
-If a criterion has no `type` field, treat it as precision (backward compatible default).

--- a/.autoskillit/skills/judge-eval/SKILL.md
+++ b/.autoskillit/skills/judge-eval/SKILL.md
@@ -51,3 +51,12 @@ When creating this skill, the judge must:
   "cross_variant_notes": "..."
 }
 ```
+
+## Criteria Type Handling
+
+Each criterion may have a `type` field:
+- `precision` — Verify the agent does NOT report a false positive. Empty output satisfies this.
+- `recall` — Verify the agent DOES find a specific issue. Empty output ALWAYS fails this — never apply vacuous satisfaction.
+- `recognition` — Verify the agent acknowledges or recognizes a pattern. Empty output fails this.
+
+If a criterion has no `type` field, treat it as precision (backward compatible default).

--- a/src/autoskillit/agents/CLAUDE.md
+++ b/src/autoskillit/agents/CLAUDE.md
@@ -13,6 +13,10 @@ Bundled agent definition markdown files that serve as both **plugin agents**
 | `plan-registry-tracer.md` | Adversarial agent: registry/artifact auditor — LSP + tree-sitter + grep symbol tracing |
 | `wp-elaborator.md` | Pipeline agent: work-package elaboration — codebase analysis and structured JSON output |
 | `pipeline-health-scanner.md` | Pipeline agent: session log scanner — reads session data, investigates anomalies, reports with adversarial validation |
+| `pr-review-auditor-baseline.md` | PR review agent: baseline control variant for agent-eval |
+| `pr-review-auditor-v1-precision.md` | PR review agent: precision-focused with 5-step verification checklist |
+| `pr-review-auditor-v2-contrastive.md` | PR review agent: junior/senior contrastive framing |
+| `pr-review-auditor-v3-simulation.md` | PR review agent: simulation-first with inconclusive fallback |
 
 ## Layout
 
@@ -64,4 +68,6 @@ agent definitions are readable via `ReadMcpResourceTool` at `agent://{pack}/{nam
 `subagent_type: "autoskillit:{name}"` and does NOT need MCP resource access via
 `unlock_agent_pack`, only step 1 is required. Steps 2–5 exist for the
 `agent://{pack}/{name}` resource path and can be skipped for packless agents.
-Current packless agents: `wp-elaborator`, `pipeline-health-scanner`, `audit-impl-slice-auditor`.
+Current packless agents: `wp-elaborator`, `pipeline-health-scanner`, `audit-impl-slice-auditor`,
+`pr-review-auditor-baseline`, `pr-review-auditor-v1-precision`, `pr-review-auditor-v2-contrastive`,
+`pr-review-auditor-v3-simulation`.

--- a/src/autoskillit/agents/pr-review-auditor-baseline.md
+++ b/src/autoskillit/agents/pr-review-auditor-baseline.md
@@ -1,0 +1,47 @@
+---
+name: pr-review-auditor-baseline
+description: Baseline extraction of review-pr dimension audit subagent prompt — control variant for agent-eval
+tools: [Read, Grep, Glob, Bash]
+model: sonnet
+maxTurns: 30
+---
+
+You are reviewing a GitHub PR diff for [{dimension}] issues only.
+Scope: examine only the diff content provided. Do not fetch or read files outside the diff.
+Return a JSON array of findings. Each finding must have:
+  file, line, severity (critical/warning/info), dimension, message,
+  requires_decision (boolean).
+
+Set requires_decision=true ONLY for findings where the correct path forward is
+genuinely ambiguous and cannot be determined without the human's intent or
+preference — for example: design trade-offs, approach choices with valid
+alternatives, unclear intent after a merge conflict, plan/implementation
+divergences where both directions are valid.
+
+Set requires_decision=false for ALL bugs, style issues, or anything with a
+clear fix, regardless of severity. When in doubt, set requires_decision=false.
+
+Each line in the diff is prefixed with `[LNNN]` where NNN is the new-file line number.
+When reporting findings, use the `[LNNN]` number as the `line` value in your finding.
+Do not compute line numbers yourself — use the marker.
+If the finding cannot be anchored to a specific `[LNNN]` marker, use the nearest
+`+` or context line's marker in the same hunk.
+
+If no issues found, return an empty array [].
+
+### Verdict
+
+```json
+[
+  {
+    "file": "path/to/file.py",
+    "line": 42,
+    "severity": "critical",
+    "dimension": "bugs",
+    "message": "Description of the finding",
+    "requires_decision": false
+  }
+]
+```
+
+Return `[]` (empty array) when no issues are found in the diff.

--- a/src/autoskillit/agents/pr-review-auditor-v1-precision.md
+++ b/src/autoskillit/agents/pr-review-auditor-v1-precision.md
@@ -1,0 +1,59 @@
+---
+name: pr-review-auditor-v1-precision
+description: Precision-focused reviewer with false-positive suppression via contrastive pre-check
+tools: [Read, Grep, Glob, Bash]
+model: sonnet
+maxTurns: 30
+---
+
+You are a senior code reviewer examining a GitHub PR diff for [{dimension}] issues only.
+
+## Scope
+
+Examine only the diff content provided. Do not fetch or read files outside the diff.
+
+## Before Reporting ANY Finding
+
+For each potential finding, apply this verification sequence before including it:
+
+1. **Scope check**: Is the code I'm about to flag actually a `+` (added) line, or is it a context line from a different function/scope? Context lines before `+` blocks belong to the PRECEDING code, not the added code.
+
+2. **Multi-hunk check**: Does a later hunk in this same diff already fix the issue? Read ALL hunks for the file before flagging anything.
+
+3. **Documented intent check**: Does the code or a nearby comment explicitly state WHY it does what it does? If the rationale is documented, the pattern is intentional — do not flag it.
+
+4. **Type contract check**: Does the called function's signature or docstring guarantee a return type? If a function documents "Returns str, never None" or "Raises ValueError on invalid input", do not flag callers for missing None guards.
+
+5. **Assertion direction check**: For test assertions, read the FULL assertion: `assert X not in Y` is an absence check (passes when X is absent), not a presence check. `assert X in Y` is a presence check.
+
+## Output Format
+
+Return a JSON array of findings. Each finding must have:
+  file, line, severity (critical/warning/info), dimension, message,
+  requires_decision (boolean).
+
+Set requires_decision=true ONLY for findings where the correct path forward is genuinely ambiguous and cannot be determined without the human's intent or preference.
+
+Set requires_decision=false for ALL bugs, style issues, or anything with a clear fix. When in doubt, set requires_decision=false.
+
+Each line in the diff is prefixed with `[LNNN]` where NNN is the new-file line number.
+Use the `[LNNN]` number as the `line` value. Do not compute line numbers yourself.
+
+If no issues found, return an empty array [].
+
+### Verdict
+
+```json
+[
+  {
+    "file": "path/to/file.py",
+    "line": 42,
+    "severity": "critical",
+    "dimension": "bugs",
+    "message": "Description of the finding",
+    "requires_decision": false
+  }
+]
+```
+
+Return `[]` (empty array) when no issues are found in the diff.

--- a/src/autoskillit/agents/pr-review-auditor-v2-contrastive.md
+++ b/src/autoskillit/agents/pr-review-auditor-v2-contrastive.md
@@ -1,0 +1,52 @@
+---
+name: pr-review-auditor-v2-contrastive
+description: Contrastive-framing reviewer that uses junior/senior split to distinguish real bugs from false alarms
+tools: [Read, Grep, Glob, Bash]
+model: sonnet
+maxTurns: 30
+---
+
+You are a senior code reviewer examining a GitHub PR diff for [{dimension}] issues only.
+
+## Your Review Process
+
+**Phase 1 — Junior scan**: Read the diff and note every potential issue a junior reviewer might flag. List them internally.
+
+**Phase 2 — Senior filter**: For each junior finding, ask:
+
+- "Would I still flag this if I knew the codebase conventions?" — Patterns used consistently across 10+ files are established conventions, not bugs.
+- "Am I reading the right scope?" — Diff context lines (no `+`/`-` prefix) belong to the SURROUNDING code, not to the added block. A docstring on a context line belongs to the preceding function.
+- "Does a later hunk already fix this?" — Multi-commit PRs often show a bug introduced then fixed. Check ALL hunks before flagging.
+- "Am I understanding the assertion correctly?" — `assert X not in Y` PASSES when X is absent. `assert X in Y` PASSES when X is present. Read the direction.
+- "Does the type contract make this safe?" — If a function documents "returns str, never None" or its implementation clearly never returns None, callers do not need None guards.
+- "Is the asymmetry intentional?" — Different error handling for setup vs teardown, or for happy-path vs finally-block, is a common and correct design pattern.
+
+Only findings that survive Phase 2 should be reported.
+
+## Output Format
+
+Return a JSON array of findings. Each finding must have:
+  file, line, severity (critical/warning/info), dimension, message,
+  requires_decision (boolean).
+
+Set requires_decision=true ONLY for genuinely ambiguous design decisions.
+Set requires_decision=false for bugs, style issues, or anything with a clear fix.
+
+Use `[LNNN]` markers for line numbers. If no issues found, return [].
+
+### Verdict
+
+```json
+[
+  {
+    "file": "path/to/file.py",
+    "line": 42,
+    "severity": "critical",
+    "dimension": "bugs",
+    "message": "Description of the finding",
+    "requires_decision": false
+  }
+]
+```
+
+Return `[]` (empty array) when no issues are found in the diff.

--- a/src/autoskillit/agents/pr-review-auditor-v3-simulation.md
+++ b/src/autoskillit/agents/pr-review-auditor-v3-simulation.md
@@ -1,0 +1,58 @@
+---
+name: pr-review-auditor-v3-simulation
+description: Simulation-first reviewer that traces actual values through code paths before flagging
+tools: [Read, Grep, Glob, Bash]
+model: sonnet
+maxTurns: 30
+---
+
+You are reviewing a GitHub PR diff for [{dimension}] issues only.
+Scope: examine only the diff content provided. Do not fetch or read files outside the diff.
+
+## Methodology: Simulate Before You Flag
+
+For every potential finding, you MUST mentally execute the code path with concrete values before reporting it.
+
+**Trace the value**: If you think a variable could be None, trace its assignment chain backward. What function produced it? What does that function's return statement actually return? If it returns `text.strip()` where text is a str, the return type is str — not Optional[str].
+
+**Trace the assertion**: If you think a test assertion is wrong, substitute actual values. For `assert "eval(" not in sanitized`: if sanitized = "result = run_step(ctx)", then "eval(" is NOT in sanitized, so the assertion PASSES. That's the intended behavior of an absence check.
+
+**Trace the scope**: Diff hunks show context lines (no prefix), removed lines (`-`), and added lines (`+`). A context line showing `return cls(config)` at the top of a hunk is the END of the preceding function, not the beginning of the next function.
+
+**Trace across hunks**: A diff may have multiple hunks for the same file. If hunk 1 introduces `x = foo` and hunk 2 changes it to `x = bar`, the final state is `x = bar`. Do not flag the intermediate state.
+
+## When Simulation Is Inconclusive
+
+If you cannot trace the value chain to a definitive conclusion (external dependencies,
+config-driven values, opaque function calls):
+- Report the finding with severity "info" and prefix the message with "[INCONCLUSIVE TRACE]"
+- Explain what you traced and where the trace became inconclusive
+- Do NOT silently drop findings you cannot fully simulate
+
+## Output Format
+
+Return a JSON array of findings. Each finding must have:
+  file, line, severity (critical/warning/info), dimension, message,
+  requires_decision (boolean).
+
+Set requires_decision=true ONLY for genuinely ambiguous design decisions.
+Set requires_decision=false for bugs, style issues, or anything with a clear fix.
+
+Use `[LNNN]` markers for line numbers. If no issues found, return [].
+
+### Verdict
+
+```json
+[
+  {
+    "file": "path/to/file.py",
+    "line": 42,
+    "severity": "critical",
+    "dimension": "bugs",
+    "message": "Description of the finding",
+    "requires_decision": false
+  }
+]
+```
+
+Return `[]` (empty array) when no issues are found in the diff.

--- a/src/autoskillit/smoke_utils/_eval.py
+++ b/src/autoskillit/smoke_utils/_eval.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import regex as re
+
 from autoskillit.smoke_utils._helpers import _load_json, try_load_json
 
 
@@ -377,8 +379,9 @@ def build_agent_eval_context(
     )
 
 
-VACUOUS_SIGNALS = frozenset(
-    {"empty", "no findings", "vacuously", "no output", "trivially satisfied"}
+_VACUOUS_SIGNAL_RE = re.compile(
+    r"\b(?:empty|no\s+findings|vacuously|no\s+output|trivially\s+satisfied)\b",
+    re.IGNORECASE,
 )
 
 
@@ -387,8 +390,8 @@ def _is_vacuous_pass(verdict_entry: dict) -> bool:
         return False
     for c in verdict_entry.get("criteria", []):
         if c.get("result") == "PASS":
-            evidence = (c.get("evidence") or "").lower()
-            if any(signal in evidence for signal in VACUOUS_SIGNALS):
+            evidence = c.get("evidence") or ""
+            if _VACUOUS_SIGNAL_RE.search(evidence):
                 return True
     return False
 

--- a/src/autoskillit/smoke_utils/_eval.py
+++ b/src/autoskillit/smoke_utils/_eval.py
@@ -142,6 +142,34 @@ def parse_agent_eval_manifests(
         if "prompt_template" not in canary:
             return {"success": "false", "error": f"Canary {canary_id} missing prompt_template"}
 
+        criteria = canary.get("detection_criteria", [])
+        if not criteria:
+            return {"success": "false", "error": f"Canary {canary_id} has no detection_criteria"}
+
+        for i, c in enumerate(criteria):
+            if not isinstance(c, dict) or "type" not in c or "text" not in c:
+                return {
+                    "success": "false",
+                    "error": (
+                        f"Canary {canary_id} criterion {i} must have 'text' and 'type' fields"
+                    ),
+                }
+            if c["type"] not in ("precision", "recall", "recognition"):
+                return {
+                    "success": "false",
+                    "error": (f"Canary {canary_id} criterion {i} has invalid type '{c['type']}'"),
+                }
+
+        types_present = {c["type"] for c in criteria}
+        if "recall" not in types_present:
+            return {
+                "success": "false",
+                "error": (
+                    f"Canary {canary_id} has no recall criterion — "
+                    "add at least one type: 'recall' criterion"
+                ),
+            }
+
         canary_dir = eval_run_dir / canary_id
         canary_dir.mkdir(parents=True, exist_ok=True)
 
@@ -349,6 +377,22 @@ def build_agent_eval_context(
     )
 
 
+VACUOUS_SIGNALS = frozenset(
+    {"empty", "no findings", "vacuously", "no output", "trivially satisfied"}
+)
+
+
+def _is_vacuous_pass(verdict_entry: dict) -> bool:
+    if verdict_entry.get("overall") != "PASS":
+        return False
+    for c in verdict_entry.get("criteria", []):
+        if c.get("result") == "PASS":
+            evidence = (c.get("evidence") or "").lower()
+            if any(signal in evidence for signal in VACUOUS_SIGNALS):
+                return True
+    return False
+
+
 def compile_eval_scorecard(
     eval_run_dir: str,
     canary_manifest: str,
@@ -379,6 +423,7 @@ def compile_eval_scorecard(
         return {"success": "false", "error": "Empty canary or variant manifest"}
     total_runs = len(canary_ids) * len(variant_ids)
     passed_runs = 0
+    vacuous_passes = 0
 
     canary_results: dict[str, dict[str, str]] = {}
     variant_summary: dict[str, dict[str, int]] = {
@@ -398,22 +443,29 @@ def compile_eval_scorecard(
         for variant in variants:
             vid = variant["id"]
             if verdict_data and verdict_data.get("verdicts", {}).get(vid) is not None:
-                overall = verdict_data["verdicts"][vid].get("overall", "FAIL")
+                verdict_entry = verdict_data["verdicts"][vid]
+                overall = verdict_entry.get("overall", "FAIL")
             else:
+                verdict_entry = {}
                 overall = "FAIL"
             canary_results[cid][vid] = overall
             if overall == "PASS":
                 passed_runs += 1
                 variant_summary[vid]["pass"] += 1
+                if _is_vacuous_pass(verdict_entry):
+                    vacuous_passes += 1
             else:
                 variant_summary[vid]["fail"] += 1
 
     pass_rate = passed_runs / total_runs if total_runs > 0 else 0.0
+    effective_pass_rate = (passed_runs - vacuous_passes) / total_runs if total_runs > 0 else 0.0
 
     scorecard = {
         "pass_rate": pass_rate,
         "total_runs": total_runs,
         "passed_runs": passed_runs,
+        "vacuous_passes": vacuous_passes,
+        "effective_pass_rate": effective_pass_rate,
         "canary_results": canary_results,
         "variant_summary": {
             vid: {"pass": s["pass"], "fail": s["fail"]} for vid, s in variant_summary.items()
@@ -461,4 +513,6 @@ def compile_eval_scorecard(
         "pass_rate": str(pass_rate),
         "total_runs": str(total_runs),
         "passed_runs": str(passed_runs),
+        "vacuous_passes": str(vacuous_passes),
+        "effective_pass_rate": str(effective_pass_rate),
     }

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -24,6 +24,8 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_audit_feature_gates_skill.py` | Structural integrity tests for the audit-feature-gates skill |
 | `test_eval_agent_skill.py` | Structural integrity tests for the eval-agent skill |
 | `test_env_symmetry.py` | Architectural invariant: skill and food-truck builders must set the same required base env vars |
+| `test_judge_eval_skill.py` | Structural integrity tests for the judge-eval skill |
+| `test_agent_prompt_structure.py` | Structural validation: agent definition MUST-gate fallback and empty-array documentation |
 | `test_boot_step_symmetry.py` | AST guard: both boot functions (_fleet_auto_gate_boot, _food_truck_auto_gate_boot) must call sweep_stale_dispatch_labels |
 | `test_bundled_recipes_split.py` | Enforcement: test_bundled_recipes.py split structure guard |
 | `test_cascade_map_guard.py` | REQ-GUARD-001..003, 005: CI guard validating cascade maps against AST-derived reverse import graph |

--- a/tests/arch/test_agent_prompt_structure.py
+++ b/tests/arch/test_agent_prompt_structure.py
@@ -1,0 +1,55 @@
+"""Structural validation: agent definition MUST-gate fallback and empty-array documentation."""
+
+import re
+
+from autoskillit.core import pkg_root
+
+_AGENTS_DIR = pkg_root() / "agents"
+
+_MUST_PROCESS_VERBS = re.compile(
+    r"\bMUST\b.{0,60}\b(simulate|execute|trace|verify|validate)\b",
+    re.IGNORECASE,
+)
+_INCONCLUSIVE_PATTERNS = re.compile(
+    r"\b(inconclusive|uncertain|unable|cannot|can't|may not be able)\b",
+    re.IGNORECASE,
+)
+_JSON_ARRAY_OUTPUT = re.compile(r"```json\s*\[", re.DOTALL)
+_EMPTY_ARRAY_DOC = re.compile(
+    r"\[\s*\]|\bempty\b.*\barray\b|\barray\b.*\bempty\b|\bno findings\b|\bzero findings\b",
+    re.IGNORECASE,
+)
+
+
+def test_agent_definitions_with_must_gate_have_fallback() -> None:
+    """Agent definitions with MUST+process-verb gates must document inconclusive outcomes."""
+    failures: list[str] = []
+    for md_file in sorted(_AGENTS_DIR.glob("*.md")):
+        if md_file.name == "CLAUDE.md":
+            continue
+        content = md_file.read_text()
+        parts = content.split("---", 2)
+        body = parts[2] if len(parts) >= 3 else content
+        if _MUST_PROCESS_VERBS.search(body):
+            if not _INCONCLUSIVE_PATTERNS.search(body):
+                failures.append(
+                    f"{md_file.name}: MUST+process-verb gate with no inconclusive fallback"
+                )
+    assert not failures, "\n".join(failures)
+
+
+def test_agent_definitions_output_format_mentions_empty_array() -> None:
+    """Every agent definition that specifies JSON array output must document what [] means."""
+    failures: list[str] = []
+    for md_file in sorted(_AGENTS_DIR.glob("*.md")):
+        if md_file.name == "CLAUDE.md":
+            continue
+        content = md_file.read_text()
+        parts = content.split("---", 2)
+        body = parts[2] if len(parts) >= 3 else content
+        if _JSON_ARRAY_OUTPUT.search(body):
+            if not _EMPTY_ARRAY_DOC.search(body):
+                failures.append(
+                    f"{md_file.name}: JSON array output but does not document what [] means"
+                )
+    assert not failures, "\n".join(failures)

--- a/tests/arch/test_judge_eval_skill.py
+++ b/tests/arch/test_judge_eval_skill.py
@@ -1,0 +1,43 @@
+"""Structural integrity tests for the judge-eval skill."""
+
+from pathlib import Path
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_SKILL_DIR = _PROJECT_ROOT / ".autoskillit" / "skills" / "judge-eval"
+_SKILL_FILE = _SKILL_DIR / "SKILL.md"
+
+
+def test_judge_eval_skill_exists() -> None:
+    """judge-eval SKILL.md exists at .autoskillit/skills/judge-eval/SKILL.md."""
+    assert _SKILL_FILE.is_file(), ".autoskillit/skills/judge-eval/SKILL.md must exist"
+
+
+def test_judge_eval_frontmatter_name() -> None:
+    """Frontmatter name field matches directory name."""
+    source = _SKILL_FILE.read_text()
+    parts = source.split("---", 2)
+    assert len(parts) >= 3, "SKILL.md must have YAML frontmatter"
+    fm = yaml.safe_load(parts[1])
+    assert isinstance(fm, dict), "frontmatter must parse to dict"
+    assert fm.get("name") == "judge-eval"
+
+
+def test_judge_eval_categories_include_eval() -> None:
+    """Frontmatter categories includes eval."""
+    source = _SKILL_FILE.read_text()
+    parts = source.split("---", 2)
+    fm = yaml.safe_load(parts[1])
+    assert "eval" in fm.get("categories", [])
+
+
+def test_judge_eval_skill_handles_criteria_types() -> None:
+    """judge-eval SKILL.md must contain instructions for handling criteria with a type field.
+
+    Specifically, type: 'recall' criteria must fail on empty output.
+    """
+    source = _SKILL_FILE.read_text()
+    assert "type" in source, "SKILL.md must reference the 'type' field on criteria"
+    assert "recall" in source, "SKILL.md must mention 'recall' criterion type"
+    assert "empty" in source.lower(), "SKILL.md must address empty output behavior"

--- a/tests/arch/test_judge_eval_skill.py
+++ b/tests/arch/test_judge_eval_skill.py
@@ -28,6 +28,7 @@ def test_judge_eval_categories_include_eval() -> None:
     """Frontmatter categories includes eval."""
     source = _SKILL_FILE.read_text()
     parts = source.split("---", 2)
+    assert len(parts) >= 3, "SKILL.md must have YAML frontmatter"
     fm = yaml.safe_load(parts[1])
     assert "eval" in fm.get("categories", [])
 

--- a/tests/arch/test_judge_eval_skill.py
+++ b/tests/arch/test_judge_eval_skill.py
@@ -39,6 +39,7 @@ def test_judge_eval_skill_handles_criteria_types() -> None:
     Specifically, type: 'recall' criteria must fail on empty output.
     """
     source = _SKILL_FILE.read_text()
-    assert "type" in source, "SKILL.md must reference the 'type' field on criteria"
-    assert "recall" in source, "SKILL.md must mention 'recall' criterion type"
-    assert "empty" in source.lower(), "SKILL.md must address empty output behavior"
+    assert "`type` field" in source, "SKILL.md must reference the 'type' field on criteria"
+    assert "`recall`" in source, "SKILL.md must mention 'recall' criterion type"
+    assert "`precision`" in source, "SKILL.md must mention 'precision' criterion type"
+    assert "empty output" in source.lower(), "SKILL.md must address empty output behavior"

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -157,12 +157,12 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils/_git.py", 50),
     ("src/autoskillit/smoke_utils/_git.py", 102),
     # smoke_utils/_eval.py — eval resolved/manifest/scorecard/eval_context, agent-eval
-    ("src/autoskillit/smoke_utils/_eval.py", 77),
-    ("src/autoskillit/smoke_utils/_eval.py", 88),
-    ("src/autoskillit/smoke_utils/_eval.py", 223),
-    ("src/autoskillit/smoke_utils/_eval.py", 234),
-    ("src/autoskillit/smoke_utils/_eval.py", 312),
-    ("src/autoskillit/smoke_utils/_eval.py", 476),
+    ("src/autoskillit/smoke_utils/_eval.py", 79),
+    ("src/autoskillit/smoke_utils/_eval.py", 90),
+    ("src/autoskillit/smoke_utils/_eval.py", 225),
+    ("src/autoskillit/smoke_utils/_eval.py", 236),
+    ("src/autoskillit/smoke_utils/_eval.py", 314),
+    ("src/autoskillit/smoke_utils/_eval.py", 479),
     # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)
     ("src/autoskillit/planner/consolidation.py", 333),
     # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -159,10 +159,10 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # smoke_utils/_eval.py — eval resolved/manifest/scorecard/eval_context, agent-eval
     ("src/autoskillit/smoke_utils/_eval.py", 77),
     ("src/autoskillit/smoke_utils/_eval.py", 88),
-    ("src/autoskillit/smoke_utils/_eval.py", 195),
-    ("src/autoskillit/smoke_utils/_eval.py", 206),
-    ("src/autoskillit/smoke_utils/_eval.py", 284),
-    ("src/autoskillit/smoke_utils/_eval.py", 424),
+    ("src/autoskillit/smoke_utils/_eval.py", 223),
+    ("src/autoskillit/smoke_utils/_eval.py", 234),
+    ("src/autoskillit/smoke_utils/_eval.py", 312),
+    ("src/autoskillit/smoke_utils/_eval.py", 476),
     # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)
     ("src/autoskillit/planner/consolidation.py", 333),
     # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)

--- a/tests/recipe/test_io_discovery.py
+++ b/tests/recipe/test_io_discovery.py
@@ -490,6 +490,8 @@ def test_eval_fixture_inventory() -> None:
         "C7-task.md",
         "C7-reference.md",
         "impl_commit_b7fa51e2.patch",
+        "RP10-diff.txt",
+        "RP10-reference.md",
     ]
     expected_overlays = [
         "baseline.md",
@@ -502,6 +504,7 @@ def test_eval_fixture_inventory() -> None:
     expected_manifests = [
         "make-plan-canaries.json",
         "make-plan-variants.json",
+        "review-pr-canaries.json",
     ]
 
     missing = []
@@ -551,4 +554,17 @@ def test_eval_manifest_paths_point_to_recipes_eval() -> None:
             assert "temp/" not in entry["overlay_file"], (
                 f"Variant {entry['id']} overlay_file still points to temp/: "
                 f"{entry['overlay_file']!r}"
+            )
+
+    review_canary_manifest = json.loads((manifests_dir / "review-pr-canaries.json").read_text())
+    for entry in review_canary_manifest:
+        for key, val in entry.get("prompt_vars", {}).items():
+            if isinstance(val, str):
+                assert "temp/" not in val, (
+                    f"Canary {entry['id']} prompt_vars.{key} still points to temp/: {val!r}"
+                )
+        if entry.get("reference_path"):
+            assert "temp/" not in entry["reference_path"], (
+                f"Canary {entry['id']} reference_path still points to temp/: "
+                f"{entry['reference_path']!r}"
             )

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -1590,6 +1590,108 @@ def test_compile_eval_scorecard_empty_run_dir(tmp_path: Path) -> None:
     assert result["total_runs"] == "4"
 
 
+# T_CES5
+def test_compile_eval_scorecard_flags_vacuous_pass(tmp_path: Path) -> None:
+    """A PASS verdict with vacuous evidence signals is flagged with vacuous_passes > 0."""
+    eval_run_dir = tmp_path / "eval_run"
+    eval_run_dir.mkdir()
+    canary_dir = eval_run_dir / "c1"
+    canary_dir.mkdir(parents=True)
+    (canary_dir / "verdict.json").write_text(
+        json.dumps(
+            {
+                "verdicts": {
+                    "v1": {
+                        "overall": "PASS",
+                        "criteria": [
+                            {
+                                "criterion": "Finds the bug",
+                                "result": "PASS",
+                                "evidence": "no findings — agent returned empty output",
+                                "quote": None,
+                            }
+                        ],
+                    }
+                }
+            }
+        )
+    )
+    canary_manifest_file = tmp_path / "canary_manifest.json"
+    variant_manifest_file = tmp_path / "variant_manifest.json"
+    canary_manifest_file.write_text(json.dumps([{"id": "c1"}]))
+    variant_manifest_file.write_text(json.dumps([{"id": "v1"}]))
+    result = compile_eval_scorecard(
+        str(eval_run_dir), str(canary_manifest_file), str(variant_manifest_file)
+    )
+    assert result["success"] == "true"
+    assert result["passed_runs"] == "1"
+    assert result["vacuous_passes"] == "1"
+    scorecard = json.loads(Path(result["scorecard_path"]).read_text())
+    assert scorecard["vacuous_passes"] == 1
+
+
+# T_CES6
+def test_compile_eval_scorecard_vacuous_lowers_pass_rate(tmp_path: Path) -> None:
+    """effective_pass_rate < pass_rate when vacuous passes exist."""
+    eval_run_dir = tmp_path / "eval_run"
+    eval_run_dir.mkdir()
+    # c1/v1: vacuous PASS (empty output satisfies precision-only criteria)
+    c1 = eval_run_dir / "c1"
+    c1.mkdir(parents=True)
+    (c1 / "verdict.json").write_text(
+        json.dumps(
+            {
+                "verdicts": {
+                    "v1": {
+                        "overall": "PASS",
+                        "criteria": [
+                            {
+                                "result": "PASS",
+                                "evidence": "vacuously satisfied — agent output was empty",
+                                "quote": None,
+                            }
+                        ],
+                    }
+                }
+            }
+        )
+    )
+    # c2/v1: genuine PASS
+    c2 = eval_run_dir / "c2"
+    c2.mkdir(parents=True)
+    (c2 / "verdict.json").write_text(
+        json.dumps(
+            {
+                "verdicts": {
+                    "v1": {
+                        "overall": "PASS",
+                        "criteria": [
+                            {
+                                "result": "PASS",
+                                "evidence": "null dereference correctly identified on line 42",
+                                "quote": "line 42 raises AttributeError",
+                            }
+                        ],
+                    }
+                }
+            }
+        )
+    )
+    canary_manifest_file = tmp_path / "canary_manifest.json"
+    variant_manifest_file = tmp_path / "variant_manifest.json"
+    canary_manifest_file.write_text(json.dumps([{"id": "c1"}, {"id": "c2"}]))
+    variant_manifest_file.write_text(json.dumps([{"id": "v1"}]))
+    result = compile_eval_scorecard(
+        str(eval_run_dir), str(canary_manifest_file), str(variant_manifest_file)
+    )
+    assert result["success"] == "true"
+    assert result["passed_runs"] == "2"
+    assert result["vacuous_passes"] == "1"
+    pass_rate = float(result["pass_rate"])
+    effective_pass_rate = float(result["effective_pass_rate"])
+    assert effective_pass_rate < pass_rate
+
+
 # ---------------------------------------------------------------------------
 # T_PAEM1–T_PAEM9: parse_agent_eval_manifests tests
 # ---------------------------------------------------------------------------
@@ -1608,7 +1710,7 @@ def test_parse_agent_eval_manifests_creates_directory_tree(tmp_path: Path) -> No
             "reference_path": str(prompt_file),
             "reference_type": "patch",
             "gap_description": "False positive on style",
-            "detection_criteria": ["Does not flag style issues"],
+            "detection_criteria": [{"text": "Does not flag style issues", "type": "recall"}],
         }
     ]
     variant_manifest = [
@@ -1636,7 +1738,7 @@ def test_parse_agent_eval_manifests_resolves_file_vars(tmp_path: Path) -> None:
             "prompt_vars": {"diff_content_file": str(diff_file), "dimension": "bugs"},
             "reference_path": str(diff_file),
             "reference_type": "patch",
-            "detection_criteria": ["Finds the bug"],
+            "detection_criteria": [{"text": "Finds the bug", "type": "recall"}],
         }
     ]
     variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
@@ -1662,7 +1764,7 @@ def test_parse_agent_eval_manifests_writes_manifest_index(tmp_path: Path) -> Non
             "prompt_vars": {},
             "reference_path": "/ref",
             "reference_type": "patch",
-            "detection_criteria": ["test"],
+            "detection_criteria": [{"text": "test", "type": "recall"}],
         }
     ]
     variant_manifest = [
@@ -1689,7 +1791,7 @@ def test_parse_agent_eval_manifests_unreadable_file_var(tmp_path: Path) -> None:
             "prompt_vars": {"content_file": "/nonexistent/file.txt"},
             "reference_path": "/ref",
             "reference_type": "patch",
-            "detection_criteria": ["test"],
+            "detection_criteria": [{"text": "test", "type": "recall"}],
         }
     ]
     variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
@@ -1709,7 +1811,7 @@ def test_parse_agent_eval_manifests_missing_prompt_template(tmp_path: Path) -> N
             "prompt_vars": {},
             "reference_path": "/ref",
             "reference_type": "patch",
-            "detection_criteria": ["test"],
+            "detection_criteria": [{"text": "test", "type": "recall"}],
         }
     ]
     variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
@@ -1729,7 +1831,7 @@ def test_parse_agent_eval_manifests_resolved_has_variant_agent_files(tmp_path: P
             "prompt_vars": {},
             "reference_path": "/ref",
             "reference_type": "patch",
-            "detection_criteria": ["test"],
+            "detection_criteria": [{"text": "test", "type": "recall"}],
         }
     ]
     variant_manifest = [
@@ -1756,7 +1858,7 @@ def test_parse_agent_eval_manifests_missing_agent_name(tmp_path: Path) -> None:
             "prompt_vars": {},
             "reference_path": "/ref",
             "reference_type": "patch",
-            "detection_criteria": ["test"],
+            "detection_criteria": [{"text": "test", "type": "recall"}],
         }
     ]
     variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
@@ -1777,7 +1879,7 @@ def test_parse_agent_eval_manifests_template_var_not_resolved(tmp_path: Path) ->
             "prompt_vars": {"other": "value"},
             "reference_path": "/ref",
             "reference_type": "patch",
-            "detection_criteria": ["test"],
+            "detection_criteria": [{"text": "test", "type": "recall"}],
         }
     ]
     variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
@@ -1800,7 +1902,7 @@ def test_parse_agent_eval_manifests_file_var_collision(tmp_path: Path) -> None:
             "prompt_vars": {"content": "direct", "content_file": str(diff_file)},
             "reference_path": "/ref",
             "reference_type": "patch",
-            "detection_criteria": ["test"],
+            "detection_criteria": [{"text": "test", "type": "recall"}],
         }
     ]
     variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
@@ -1809,6 +1911,102 @@ def test_parse_agent_eval_manifests_file_var_collision(tmp_path: Path) -> None:
     )
     assert result["success"] == "false"
     assert "collision" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Criteria taxonomy tests: parse_agent_eval_manifests schema enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_parse_agent_eval_manifests_rejects_untyped_criteria(tmp_path: Path) -> None:
+    canary_manifest = [
+        {
+            "id": "RA1",
+            "agent_name": "test-agent",
+            "prompt_template": "test",
+            "prompt_vars": {},
+            "reference_path": "/ref",
+            "reference_type": "patch",
+            "detection_criteria": ["plain string without type"],
+        }
+    ]
+    variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
+    result = parse_agent_eval_manifests(
+        json.dumps(canary_manifest), json.dumps(variant_manifest), str(tmp_path)
+    )
+    assert result["success"] == "false"
+    assert (
+        "criterion_type" in result["error"]
+        or "text" in result["error"]
+        or "type" in result["error"]
+    )
+
+
+def test_parse_agent_eval_manifests_rejects_precision_only_canary(tmp_path: Path) -> None:
+    canary_manifest = [
+        {
+            "id": "RA1",
+            "agent_name": "test-agent",
+            "prompt_template": "test",
+            "prompt_vars": {},
+            "reference_path": "/ref",
+            "reference_type": "patch",
+            "detection_criteria": [
+                {"text": "Does not flag style issues", "type": "precision"},
+                {"text": "Does not flag whitespace", "type": "precision"},
+            ],
+        }
+    ]
+    variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
+    result = parse_agent_eval_manifests(
+        json.dumps(canary_manifest), json.dumps(variant_manifest), str(tmp_path)
+    )
+    assert result["success"] == "false"
+    assert "recall" in result["error"].lower()
+
+
+def test_parse_agent_eval_manifests_accepts_balanced_criteria(tmp_path: Path) -> None:
+    canary_manifest = [
+        {
+            "id": "RA1",
+            "agent_name": "test-agent",
+            "prompt_template": "test",
+            "prompt_vars": {},
+            "reference_path": "/ref",
+            "reference_type": "patch",
+            "detection_criteria": [
+                {"text": "Finds the bug", "type": "recall"},
+                {"text": "Does not flag style issues", "type": "precision"},
+            ],
+        }
+    ]
+    variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
+    result = parse_agent_eval_manifests(
+        json.dumps(canary_manifest), json.dumps(variant_manifest), str(tmp_path)
+    )
+    assert result["success"] == "true"
+
+
+def test_parse_agent_eval_manifests_accepts_recall_only(tmp_path: Path) -> None:
+    canary_manifest = [
+        {
+            "id": "RA1",
+            "agent_name": "test-agent",
+            "prompt_template": "test",
+            "prompt_vars": {},
+            "reference_path": "/ref",
+            "reference_type": "patch",
+            "detection_criteria": [
+                {"text": "Finds the bug", "type": "recall"},
+                {"text": "Identifies the affected module", "type": "recall"},
+            ],
+        }
+    ]
+    variant_manifest = [{"id": "v1", "label": "V1", "agent_file": "/v1.md"}]
+    result = parse_agent_eval_manifests(
+        json.dumps(canary_manifest), json.dumps(variant_manifest), str(tmp_path)
+    )
+    assert result["success"] == "true"
 
 
 # ---------------------------------------------------------------------------
@@ -1828,7 +2026,7 @@ def test_build_agent_eval_context_writes_eval_context(tmp_path: Path) -> None:
                 "id": "RA1",
                 "agent_name": "pr-review-auditor",
                 "gap_description": "False positive on style",
-                "detection_criteria": ["Does not flag style"],
+                "detection_criteria": [{"text": "Does not flag style", "type": "recall"}],
                 "reference_path": "/path/to/diff.patch",
                 "reference_type": "patch",
                 "variants": {"baseline": {"label": "Baseline", "agent_file": "/baseline.md"}},
@@ -1864,7 +2062,7 @@ def test_build_agent_eval_context_handles_null_output(tmp_path: Path) -> None:
                 "id": "RA1",
                 "agent_name": "test-agent",
                 "gap_description": "test",
-                "detection_criteria": ["test"],
+                "detection_criteria": [{"text": "test", "type": "recall"}],
                 "reference_path": "/ref",
                 "reference_type": "patch",
                 "variants": {"v1": {"label": "V1", "agent_file": "/v1.md"}},
@@ -1894,7 +2092,7 @@ def test_build_agent_eval_context_uses_agent_name_as_subject(tmp_path: Path) -> 
                 "id": "RA1",
                 "agent_name": "review-intent-validator",
                 "gap_description": "test",
-                "detection_criteria": ["test"],
+                "detection_criteria": [{"text": "test", "type": "recall"}],
                 "reference_path": "/ref",
                 "reference_type": "patch",
                 "variants": {},
@@ -1935,7 +2133,7 @@ def test_build_agent_eval_context_missing_reference_path(tmp_path: Path) -> None
                 "id": "RA1",
                 "agent_name": "test-agent",
                 "gap_description": "test",
-                "detection_criteria": ["test"],
+                "detection_criteria": [{"text": "test", "type": "recall"}],
                 "variants": {},
             }
         )
@@ -1961,7 +2159,7 @@ def test_build_agent_eval_context_default_reference_type_is_patch(tmp_path: Path
                 "id": "RA1",
                 "agent_name": "test-agent",
                 "gap_description": "test",
-                "detection_criteria": ["test"],
+                "detection_criteria": [{"text": "test", "type": "recall"}],
                 "reference_path": "/ref",
                 "variants": {},
             }

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -1935,11 +1935,7 @@ def test_parse_agent_eval_manifests_rejects_untyped_criteria(tmp_path: Path) -> 
         json.dumps(canary_manifest), json.dumps(variant_manifest), str(tmp_path)
     )
     assert result["success"] == "false"
-    assert (
-        "criterion_type" in result["error"]
-        or "text" in result["error"]
-        or "type" in result["error"]
-    )
+    assert "'text' and 'type'" in result["error"]
 
 
 def test_parse_agent_eval_manifests_rejects_precision_only_canary(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

The bundled `review-pr-canaries.json` manifest (committed in `a37f3427`) declares canary
RP10 for "cross-artifact schema mismatch: TypedDict field `file_path` serialized as key
`file`" but references two fixture files that do not exist:
- `.autoskillit/recipes/eval/canaries/RP10-diff.txt` — annotated unified diff fed to
  pr-review-auditor agents via the `diff_file` indirection in `parse_agent_eval_manifests`
- `.autoskillit/recipes/eval/canaries/RP10-reference.md` — reference document used by the
  judge to score verdicts against the three detection criteria

Additionally:
- `test_eval_fixture_inventory` does not yet guard RP10-diff.txt, RP10-reference.md, or
  `review-pr-canaries.json` against accidental deletion
- `test_eval_manifest_paths_point_to_recipes_eval` does not validate that
  `review-pr-canaries.json`'s fixture paths are free of `"temp/"` references

This plan creates both fixture files and extends both regression guard tests.

Closes #3364

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260530-231905-271404/.autoskillit/temp/make-plan/rp10_canary_fixtures_plan_2026-05-31_001900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 99 | 25.8k | 3.5M | 137.0k | 316 | 108.9k | 23m 48s |
| review_approach* | sonnet | 1 | 52 | 6.3k | 189.2k | 43.5k | 52 | 30.8k | 3m 33s |
| dry_walkthrough* | opus | 4 | 5.7k | 27.5k | 2.5M | 88.7k | 303 | 183.1k | 15m 34s |
| implement* | sonnet | 4 | 2.7k | 59.0k | 8.2M | 127.5k | 324 | 194.5k | 24m 53s |
| audit_impl* | sonnet | 6 | 4.4k | 72.6k | 2.0M | 71.6k | 314 | 274.6k | 38m 28s |
| make_plan* | sonnet | 3 | 2.5k | 52.1k | 2.3M | 92.5k | 432 | 200.3k | 35m 53s |
| post_run_diagnostics* | sonnet | 2 | 108 | 24.1k | 367.4k | 115.1k | 555 | 96.9k | 24m 23s |
| prepare_pr* | sonnet | 1 | 133.8k | 5.9k | 279.8k | 28.0k | 31 | 41.1k | 1m 52s |
| compose_pr* | sonnet | 1 | 38.2k | 1.2k | 165.0k | 28.0k | 14 | 15.5k | 39s |
| review_pr* | sonnet | 1 | 228 | 47.0k | 2.0M | 110.8k | 66 | 97.1k | 12m 3s |
| resolve_review* | opus | 1 | 51 | 9.7k | 2.1M | 82.7k | 65 | 98.2k | 9m 5s |
| ci_conflict_fix* | opus | 1 | 37 | 4.3k | 779.0k | 51.2k | 37 | 34.9k | 1m 52s |
| diagnose_ci* | sonnet | 1 | 179.0k | 2.5k | 277.0k | 28.0k | 23 | 15.4k | 1m 8s |
| resolve_ci* | opus | 1 | 60 | 10.5k | 1.8M | 70.7k | 60 | 54.5k | 11m 7s |
| **Total** | | | 366.9k | 348.5k | 26.6M | 137.0k | | 1.4M | 3h 24m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 886 | 9269.8 | 219.6 | 66.6 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| post_run_diagnostics | 4759 | 77.2 | 20.4 | 5.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 31 | 69338.6 | 3167.5 | 313.1 |
| ci_conflict_fix | 4759 | 163.7 | 7.3 | 0.9 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 12 | 148833.0 | 4542.4 | 873.5 |
| **Total** | **10447** | 2541.4 | 138.4 | 33.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 99 | 25.8k | 3.5M | 108.9k | 23m 48s |
| sonnet | 9 | 360.9k | 270.6k | 15.8M | 966.1k | 2h 22m |
| opus | 4 | 5.9k | 52.0k | 7.2M | 370.7k | 37m 40s |