### PR TITLE
feat: support relative paths in interpreter write guard

### DIFF
--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -28,9 +28,15 @@ _SUBPROCESS_APIS_RE = re.compile(
     r"|os\.(?:system|popen|exec[lv]p?e?)\s*\("
 )
 
-_LITERAL_OPEN_PATH_RE = re.compile(r"""open\s*\(\s*(['"])(/[^'"]+)\1\s*,\s*['"][wWaAxX]""")
+_LITERAL_OPEN_PATH_RE = re.compile(r"""open\s*\(\s*(['"])([^'"]+)\1\s*,\s*['"][wWaAxX]""")
 _LITERAL_PATH_CONSTRUCTOR_RE = re.compile(
-    r"""Path\s*\(\s*(['"])(/[^'"]+)\1\s*\)\s*\.(?:write_text|write_bytes)\s*\("""
+    r"""Path\s*\(\s*(['"])([^'"]+)\1\s*\)\s*\.(?:write_text|write_bytes)\s*\("""
+)
+
+_WRITE_CALL_SITE_RE = re.compile(
+    r"open\s*\([^)]*['\"][wWaAxX]\+?[bB]?['\"]"
+    r"|Path\s*\([^)]*\)\s*\.(?:write_text|write_bytes)\s*\("
+    r"|shutil\.(?:copy|move|copyfile|copytree)\s*\("
 )
 
 _SHELL_OPS: frozenset[str] = frozenset({"&&", "||", ";", "!", "|", "("})
@@ -154,30 +160,32 @@ def has_interpreter_write(command: str) -> bool:
     return bool(_WRITE_APIS_RE.search(command))
 
 
-def extract_interpreter_write_path(command: str) -> str | None:
-    """Extract the literal file path from an interpreter write command.
+def extract_interpreter_write_paths(command: str) -> list[str] | None:
+    """Extract literal file paths from an interpreter write command.
 
-    Returns the path string when a static literal is found.
-    Returns None when:
-    - The command is not an interpreter write (no interpreter prefix or no write API)
-    - The path is constructed dynamically (variable, f-string, concatenation)
-    - The write API is shutil.copy/move (two paths — ambiguous which is the target)
-
-    shutil.* calls intentionally return None (fall through to has_interpreter_write's
-    unconditional deny) because they have two path arguments and extracting the correct
-    target requires deeper parsing than regex can reliably provide.
+    Returns:
+        None    — command is not an interpreter write (no prefix or no write API).
+        []      — interpreter write detected but not all paths are static literals
+                  (dynamic variable, f-string, shutil two-arg, or mixed).
+        [paths] — all write target paths are static literals (may be relative).
     """
     if not _INTERPRETER_RE.search(command):
         return None
     if not _WRITE_APIS_RE.search(command):
         return None
-    m = _LITERAL_OPEN_PATH_RE.search(command)
-    if m:
-        return m.group(2)
-    m = _LITERAL_PATH_CONSTRUCTOR_RE.search(command)
-    if m:
-        return m.group(2)
-    return None
+
+    call_site_count = len(_WRITE_CALL_SITE_RE.findall(command))
+
+    paths: list[str] = []
+    for m in _LITERAL_OPEN_PATH_RE.finditer(command):
+        paths.append(m.group(2))
+    for m in _LITERAL_PATH_CONSTRUCTOR_RE.finditer(command):
+        paths.append(m.group(2))
+
+    if len(paths) < call_site_count:
+        return []
+
+    return paths if paths else []
 
 
 def has_interpreter_wrapped_command(command: str, *, target_commands: Sequence[str]) -> bool:

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -15,9 +15,8 @@ if _HOOKS_DIR not in sys.path:
 
 from _command_classification import (  # type: ignore[import-not-found]  # noqa: E402
     command_verb,
-    extract_interpreter_write_path,
+    extract_interpreter_write_paths,
     extract_redirect_targets,
-    has_interpreter_write,
     is_gh_command,
     tokenize_command_segments,
 )
@@ -250,20 +249,39 @@ def main() -> None:
     if tool_name == "Bash" or "run_cmd" in tool_name:
         command = tool_input.get("command", "") or tool_input.get("cmd", "")
 
-        interp_path = extract_interpreter_write_path(command)
-        if interp_path is not None:
-            if not _within_any_prefix(interp_path):
+        interp_paths = extract_interpreter_write_paths(command)
+        if interp_paths is not None:
+            if not interp_paths:
                 _deny(
                     f"Write/Edit/apply_patch blocked: {WRITE_GUARD_DENY_TRIGGER}. "
-                    f"Only writes to {display_prefix} are permitted."
+                    f"Interpreter-mediated file writes are not permitted."
                 )
                 return
-        elif has_interpreter_write(command):
-            _deny(
-                f"Write/Edit/apply_patch blocked: {WRITE_GUARD_DENY_TRIGGER}. "
-                f"Interpreter-mediated file writes are not permitted."
-            )
-            return
+
+            cwd = os.environ.get("AUTOSKILLIT_CWD", "")
+            if cwd and not os.path.isabs(cwd):
+                cwd = ""
+
+            resolved: list[str] = []
+            for p in interp_paths:
+                if os.path.isabs(p):
+                    resolved.append(p)
+                elif cwd:
+                    resolved.append(os.path.join(cwd, p))
+                else:
+                    _deny(
+                        f"Write/Edit/apply_patch blocked: {WRITE_GUARD_DENY_TRIGGER}. "
+                        f"Interpreter-mediated file writes are not permitted."
+                    )
+                    return
+
+            for rp in resolved:
+                if not _within_any_prefix(rp):
+                    _deny(
+                        f"Write/Edit/apply_patch blocked: {WRITE_GUARD_DENY_TRIGGER}. "
+                        f"Only writes to {display_prefix} are permitted."
+                    )
+                    return
 
         targets = _extract_bash_write_targets(command)
         if targets is None:

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -215,6 +215,8 @@ class TestExtractInterpreterWritePathsMulti:
         result = extract_interpreter_write_paths(cmd)
         assert result is not None
         assert len(result) == 2
+        assert "/clone/a.txt" in result
+        assert "/clone/b.txt" in result
 
     def test_partial_dynamic_denies_all(self):
         cmd = "python3 -c \"open('/clone/a.txt', 'w').write('x'); open(var, 'w').write('y')\""

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -6,7 +6,7 @@ import pytest
 
 from autoskillit.hooks._command_classification import (
     command_verb,
-    extract_interpreter_write_path,
+    extract_interpreter_write_paths,
     extract_redirect_targets,
     has_interpreter_wrapped_command,
     has_interpreter_write,
@@ -145,34 +145,88 @@ class TestIsGhCommand:
         assert gh_segments[0][0] == "gh"
 
 
-class TestExtractInterpreterWritePath:
+class TestExtractInterpreterWritePaths:
     def test_open_literal_path(self):
         cmd = "python3 -c \"open('/clone/.autoskillit/temp/out.json', 'w').write('x')\""
-        assert extract_interpreter_write_path(cmd) == "/clone/.autoskillit/temp/out.json"
+        assert extract_interpreter_write_paths(cmd) == ["/clone/.autoskillit/temp/out.json"]
 
     def test_path_write_text(self):
         cmd = "python3 -c \"Path('/clone/temp/out.json').write_text('x')\""
-        assert extract_interpreter_write_path(cmd) == "/clone/temp/out.json"
+        assert extract_interpreter_write_paths(cmd) == ["/clone/temp/out.json"]
 
     def test_path_write_bytes(self):
         cmd = "python3 -c \"Path('/clone/temp/out.bin').write_bytes(b'x')\""
-        assert extract_interpreter_write_path(cmd) == "/clone/temp/out.bin"
+        assert extract_interpreter_write_paths(cmd) == ["/clone/temp/out.bin"]
 
-    def test_dynamic_path_returns_none(self):
+    def test_dynamic_path_returns_empty_list(self):
         cmd = "python3 -c \"open(sys.argv[1], 'w').write('x')\""
-        assert extract_interpreter_write_path(cmd) is None
+        assert extract_interpreter_write_paths(cmd) == []
 
     def test_no_interpreter_returns_none(self):
         cmd = "open('/tmp/x', 'w')"
-        assert extract_interpreter_write_path(cmd) is None
+        assert extract_interpreter_write_paths(cmd) is None
 
-    def test_shutil_returns_none(self):
+    def test_shutil_returns_empty_list(self):
         cmd = "python3 -c \"import shutil; shutil.copy('/tmp/a', '/clone/src/f.py')\""
-        assert extract_interpreter_write_path(cmd) is None
+        assert extract_interpreter_write_paths(cmd) == []
 
-    def test_dynamic_path_with_non_literal_var_returns_none(self):
+    def test_dynamic_path_with_non_literal_var_returns_empty_list(self):
         cmd = "python3 -c \"open(some_var, 'w').write('x')\""
-        assert extract_interpreter_write_path(cmd) is None
+        assert extract_interpreter_write_paths(cmd) == []
+
+
+class TestExtractInterpreterWritePathsRelative:
+    def test_relative_open_path(self):
+        cmd = "python3 -c \"open('.autoskillit/temp/foo.txt', 'w').write('x')\""
+        assert extract_interpreter_write_paths(cmd) == [".autoskillit/temp/foo.txt"]
+
+    def test_relative_path_constructor(self):
+        cmd = "python3 -c \"Path('temp/out.json').write_text('x')\""
+        assert extract_interpreter_write_paths(cmd) == ["temp/out.json"]
+
+    def test_dotslash_relative_path(self):
+        cmd = "python3 -c \"open('./output.txt', 'w').write('x')\""
+        assert extract_interpreter_write_paths(cmd) == ["./output.txt"]
+
+
+class TestExtractInterpreterWritePathsMulti:
+    def test_multiple_open_calls(self):
+        cmd = (
+            'python3 -c "'
+            "open('/clone/.autoskillit/temp/a.txt', 'w').write('x'); "
+            "open('/clone/.autoskillit/temp/b.txt', 'w').write('y'); "
+            "open('/clone/.autoskillit/temp/c.txt', 'w').write('z')"
+            '"'
+        )
+        result = extract_interpreter_write_paths(cmd)
+        assert result is not None
+        assert len(result) == 3
+        assert "/clone/.autoskillit/temp/a.txt" in result
+        assert "/clone/.autoskillit/temp/b.txt" in result
+        assert "/clone/.autoskillit/temp/c.txt" in result
+
+    def test_mixed_open_and_path_constructor(self):
+        cmd = (
+            'python3 -c "'
+            "open('/clone/a.txt', 'w').write('x'); "
+            "Path('/clone/b.txt').write_text('y')"
+            '"'
+        )
+        result = extract_interpreter_write_paths(cmd)
+        assert result is not None
+        assert len(result) == 2
+
+    def test_partial_dynamic_denies_all(self):
+        cmd = "python3 -c \"open('/clone/a.txt', 'w').write('x'); open(var, 'w').write('y')\""
+        assert extract_interpreter_write_paths(cmd) == []
+
+    def test_chained_write_text_on_open_not_double_counted(self):
+        cmd = "python3 -c \"open('/clone/temp/out.txt', 'w').write_text('data')\""
+        assert extract_interpreter_write_paths(cmd) == ["/clone/temp/out.txt"]
+
+    def test_chained_write_bytes_on_open_not_double_counted(self):
+        cmd = "python3 -c \"open('/clone/temp/out.bin', 'wb').write_bytes(b'data')\""
+        assert extract_interpreter_write_paths(cmd) == ["/clone/temp/out.bin"]
 
 
 class TestExtractRedirectTargets:

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -671,6 +671,80 @@ class TestRelativePathResolution:
         assert result == []
 
 
+class TestInterpreterRelativePathResolution:
+    """Tests for interpreter write relative path resolution via AUTOSKILLIT_CWD."""
+
+    def test_relative_open_resolved_against_cwd(self, monkeypatch: pytest.MonkeyPatch):
+        """Relative open() path should be resolved and allowed when within prefix."""
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/workspace/.autoskillit/temp")
+        monkeypatch.setenv("AUTOSKILLIT_CWD", "/workspace")
+        event = _build_bash_event(
+            "python3 -c \"open('.autoskillit/temp/out.txt', 'w').write('x')\""
+        )
+        out = _run_hook(event)
+        assert "blocked" not in out.lower()
+
+    def test_relative_open_outside_prefix_denied(self, monkeypatch: pytest.MonkeyPatch):
+        """Relative open() path outside prefix should be denied after resolution."""
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/workspace/.autoskillit/temp")
+        monkeypatch.setenv("AUTOSKILLIT_CWD", "/workspace")
+        event = _build_bash_event("python3 -c \"open('src/main.py', 'w').write('x')\"")
+        out = _run_hook(event)
+        assert "blocked" in out.lower()
+
+    def test_no_cwd_denies_relative_interpreter_write(self, monkeypatch: pytest.MonkeyPatch):
+        """Without AUTOSKILLIT_CWD, relative interpreter writes are denied."""
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/workspace/.autoskillit/temp")
+        monkeypatch.delenv("AUTOSKILLIT_CWD", raising=False)
+        event = _build_bash_event(
+            "python3 -c \"open('.autoskillit/temp/out.txt', 'w').write('x')\""
+        )
+        out = _run_hook(event)
+        assert "blocked" in out.lower()
+
+    def test_non_absolute_cwd_denies_relative_interpreter_write(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Non-absolute AUTOSKILLIT_CWD denies relative interpreter writes."""
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/workspace/.autoskillit/temp")
+        monkeypatch.setenv("AUTOSKILLIT_CWD", "relative/cwd")
+        event = _build_bash_event(
+            "python3 -c \"open('.autoskillit/temp/out.txt', 'w').write('x')\""
+        )
+        out = _run_hook(event)
+        assert "blocked" in out.lower()
+
+    def test_multi_path_all_within_prefix_allowed(self, monkeypatch: pytest.MonkeyPatch):
+        """Multiple open() calls all within prefix should be allowed."""
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/workspace/.autoskillit/temp")
+        monkeypatch.setenv("AUTOSKILLIT_CWD", "/workspace")
+        event = _build_bash_event(
+            'python3 -c "'
+            "open('.autoskillit/temp/a.txt', 'w').write('x'); "
+            "open('.autoskillit/temp/b.txt', 'w').write('y')\""
+        )
+        out = _run_hook(event)
+        assert "blocked" not in out.lower()
+
+    def test_multi_path_one_outside_prefix_denied(self, monkeypatch: pytest.MonkeyPatch):
+        """If any of multiple open() paths is outside prefix, deny the command."""
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/workspace/.autoskillit/temp")
+        monkeypatch.setenv("AUTOSKILLIT_CWD", "/workspace")
+        event = _build_bash_event(
+            'python3 -c "'
+            "open('.autoskillit/temp/a.txt', 'w').write('x'); "
+            "open('src/main.py', 'w').write('y')\""
+        )
+        out = _run_hook(event)
+        assert "blocked" in out.lower()
+
+
 class TestWriteGuardMultiPrefix:
     """Tests for multi-prefix (AUTOSKILLIT_ALLOWED_WRITE_PREFIXES) support."""
 


### PR DESCRIPTION
## Summary

Extend the write guard's interpreter-write path extraction to handle relative paths and multi-path commands. Currently, `_LITERAL_OPEN_PATH_RE` and `_LITERAL_PATH_CONSTRUCTOR_RE` in `_command_classification.py` only match absolute paths. When an interpreter command uses relative paths (e.g., `open('.autoskillit/temp/foo.txt', 'w')`), the path cannot be extracted, and the guard unconditionally denies the command — wasting a session turn.

The fix:
1. Remove the leading `/` requirement from both regex patterns so relative literal paths are extractable
2. Change `extract_interpreter_write_path` → `extract_interpreter_write_paths` (plural) returning `list[str] | None` to support multi-path commands
3. Add a dedicated `_WRITE_CALL_SITE_RE` regex for counting distinct write call sites (avoids double-counting `.write_text()`/`.write_bytes()` chained on `open()` return values)
4. Add CWD-resolution logic in `write_guard.py` (mirroring the existing `_extract_bash_write_targets` pattern) to resolve relative paths against `AUTOSKILLIT_CWD` before prefix checking

## Requirements

**REQ-WG-001:** `extract_interpreter_write_path()` must extract relative literal paths from inline python scripts (e.g., `open('.autoskillit/temp/foo.txt', 'w')`)

**REQ-WG-002:** Extracted relative paths must be resolved to absolute paths using `AUTOSKILLIT_CWD` before prefix checking; if `AUTOSKILLIT_CWD` is unset or non-absolute, return `None` (preserves deny behavior)

**REQ-WG-003:** Non-literal, dynamic, or computed paths (f-strings, variables, concatenation) must still be denied — only bare string literals are extractable

**REQ-WG-004:** Test coverage must include relative path extraction, CWD resolution, and the multi-path edge case

**REQ-WG-005:** Existing absolute-path extraction behavior must not regress

**REQ-WG-006:** Commands with multiple `open()` write calls must have ALL paths verified against the allowed prefix (not just the first)

## Changed Files

- `src/autoskillit/hooks/_command_classification.py` — updated `_LITERAL_OPEN_PATH_RE` and `_LITERAL_PATH_CONSTRUCTOR_RE` regexes to accept relative paths; renamed `extract_interpreter_write_path` → `extract_interpreter_write_paths`
- `src/autoskillit/hooks/guards/write_guard.py` — added CWD-resolution logic for interpreter write paths; updated guard to verify all extracted paths
- `tests/hooks/test_command_classification.py` — added tests for relative path extraction and multi-path commands
- `tests/hooks/test_write_guard.py` — added tests for relative path CWD resolution in interpreter write guard

Closes #3407

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260531-080030-330899/.autoskillit/temp/make-plan/write_guard_relative_interpreter_paths_plan_2026-05-31_080500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.5k | 33.6k | 731.6k | 94.6k | 99 | 92.6k | 15m 2s |
| review_approach* | opus[1m] | 1 | 1.4k | 5.1k | 252.2k | 51.9k | 35 | 40.4k | 3m 1s |
| verify* | opus[1m] | 1 | 41 | 11.9k | 847.1k | 84.7k | 81 | 70.3k | 6m 1s |
| implement* | opus[1m] | 1 | 73.0k | 7.7k | 1.1M | 18.7k | 59 | 0 | 2m 16s |
| audit_impl* | opus[1m] | 1 | 320 | 11.8k | 224.4k | 36.6k | 65 | 68.2k | 5m 40s |
| prepare_pr* | opus[1m] | 1 | 47.0k | 3.7k | 157.9k | 0 | 16 | 0 | 57s |
| compose_pr* | opus[1m] | 1 | 37.4k | 1.9k | 220.8k | 0 | 20 | 0 | 26s |
| review_pr* | opus[1m] | 1 | 39 | 20.0k | 572.8k | 73.9k | 92 | 74.6k | 10m 53s |
| resolve_review* | opus[1m] | 1 | 55 | 10.5k | 1.0M | 64.8k | 55 | 49.0k | 6m 17s |
| diagnose_ci* | opus[1m] | 1 | 58.2k | 3.2k | 505.8k | 0 | 30 | 0 | 1m 12s |
| resolve_ci* | opus[1m] | 1 | 34 | 3.8k | 235.3k | 44.0k | 17 | 27.6k | 3m 4s |
| **Total** | | | 219.0k | 113.2k | 5.9M | 94.6k | | 422.7k | 54m 51s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 242 | 4490.0 | 0.0 | 32.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 520684.0 | 24491.5 | 5228.0 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 0 | — | — | — |
| **Total** | **244** | 24080.9 | 1732.4 | 464.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 11 | 219.0k | 113.2k | 5.9M | 422.7k | 54m 51s |