### PR TITLE
[FIX] Rectify: Recipe Cache Aliasing Immunity

### DIFF
--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -10,7 +10,7 @@ import json
 import time
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from autoskillit.core import (
     ProcessStaleError,
@@ -29,6 +29,7 @@ from autoskillit.recipe._analysis import make_validation_context
 from autoskillit.recipe._api_cache import (  # noqa: F401
     _LOAD_CACHE,
     _STALENESS_CACHES_CLEARED,
+    LoadCache,
     _check_process_staleness,
     _clear_stale_caches,
     _compute_registry_hash,
@@ -246,8 +247,7 @@ def load_and_validate(
         _user_method_traditions_hash,
     )
 
-    with _api_cache._LOAD_CACHE_LOCK:
-        cached = _api_cache._LOAD_CACHE.get(cache_key)
+    cached = _api_cache._LOAD_CACHE.get(cache_key)
 
     from autoskillit.recipe import registry as _registry  # noqa: PLC0415
 
@@ -270,7 +270,7 @@ def load_and_validate(
             and rs == cached.recipe_size
         ):
             logger.debug("load_recipe_cache_hit", recipe=name)
-            return cached.result
+            return cast(LoadRecipeResult, _api_cache._LOAD_CACHE.copy_result(cached.result))
 
     t0 = time.perf_counter()
 
@@ -546,7 +546,6 @@ def load_and_validate(
             rule_registry_hash=_rule_hash,
             result=result,
         )
-        with _api_cache._LOAD_CACHE_LOCK:
-            _api_cache._LOAD_CACHE[cache_key] = entry
+        _api_cache._LOAD_CACHE.put(cache_key, entry)
 
     return result

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -548,4 +548,4 @@ def load_and_validate(
         )
         _api_cache._LOAD_CACHE.put(cache_key, entry)
 
-    return result
+    return cast(LoadRecipeResult, _api_cache._LOAD_CACHE.copy_result(result))

--- a/src/autoskillit/recipe/_api_cache.py
+++ b/src/autoskillit/recipe/_api_cache.py
@@ -49,7 +49,7 @@ class LoadCache:
         with self._lock:
             return self._store.get(key)
 
-    def copy_result(self, result: dict[str, Any]) -> dict[str, Any]:
+    def copy_result(self, result: Any) -> dict[str, Any]:
         """Return a shallow copy of result with list fields independently copied."""
         r = dict(result)
         for list_key in (

--- a/src/autoskillit/recipe/_api_cache.py
+++ b/src/autoskillit/recipe/_api_cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import threading
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass as _dc
 from pathlib import Path
 from typing import Any
@@ -51,6 +52,9 @@ class LoadCache:
 
     def copy_result(self, result: Any) -> dict[str, Any]:
         """Return a shallow copy of result with list fields independently copied."""
+        if not isinstance(result, Mapping):
+            msg = f"copy_result expected a Mapping, got {type(result).__name__}"
+            raise TypeError(msg)
         r = dict(result)
         for list_key in (
             "suggestions",
@@ -70,19 +74,6 @@ class LoadCache:
     def clear(self) -> None:
         with self._lock:
             self._store.clear()
-
-    def keys(self):
-        with self._lock:
-            return list(self._store.keys())
-
-    def __bool__(self) -> bool:
-        return bool(self._store)
-
-    def __iter__(self):
-        return iter(list(self._store.keys()))
-
-    def __len__(self) -> int:
-        return len(self._store)
 
 
 _LOAD_CACHE = LoadCache()

--- a/src/autoskillit/recipe/_api_cache.py
+++ b/src/autoskillit/recipe/_api_cache.py
@@ -22,7 +22,7 @@ _STALENESS_SCAN_DIRS: tuple[str, ...] = ("recipe/rules",)
 _DEEP_MTIME_BASELINE: int | None = None
 
 
-@_dc
+@_dc(frozen=True, slots=True)
 class _LoadCacheEntry:
     recipe_path: Path
     recipe_mtime: int
@@ -34,8 +34,58 @@ class _LoadCacheEntry:
     result: Any  # LoadRecipeResult but avoiding circular import
 
 
-_LOAD_CACHE: dict[tuple, _LoadCacheEntry] = {}
-_LOAD_CACHE_LOCK = threading.Lock()
+class LoadCache:
+    """Thread-safe recipe cache with copy-on-read guarantee.
+
+    Encapsulates the lock internally so callers cannot bypass it.
+    Provides copy_result() for aliasing-safe access to cached dicts.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[tuple, _LoadCacheEntry] = {}
+        self._lock = threading.Lock()
+
+    def get(self, key: tuple) -> _LoadCacheEntry | None:
+        with self._lock:
+            return self._store.get(key)
+
+    def copy_result(self, result: dict[str, Any]) -> dict[str, Any]:
+        """Return a shallow copy of result with list fields independently copied."""
+        r = dict(result)
+        for list_key in (
+            "suggestions",
+            "kitchen_rules",
+            "requires_packs",
+            "requires_features",
+            "deferred_guards",
+        ):
+            if list_key in r:
+                r[list_key] = list(r[list_key])
+        return r
+
+    def put(self, key: tuple, entry: _LoadCacheEntry) -> None:
+        with self._lock:
+            self._store[key] = entry
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()
+
+    def keys(self):
+        with self._lock:
+            return list(self._store.keys())
+
+    def __bool__(self) -> bool:
+        return bool(self._store)
+
+    def __iter__(self):
+        return iter(list(self._store.keys()))
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+
+_LOAD_CACHE = LoadCache()
 
 
 def _path_mtime_ns(path: Path) -> int:
@@ -136,6 +186,5 @@ def _clear_stale_caches() -> None:
     _block_budgets.cache_clear()
     load_bundled_manifest.cache_clear()
     load_ml_sub_area_folding.cache_clear()
-    with _LOAD_CACHE_LOCK:
-        _LOAD_CACHE.clear()
+    _LOAD_CACHE.clear()
     _STALENESS_CACHES_CLEARED = True

--- a/src/autoskillit/server/_misc.py
+++ b/src/autoskillit/server/_misc.py
@@ -209,6 +209,14 @@ async def _apply_triage_gate(
     )
 
 
+_INGREDIENTS_ONLY_EXCLUDE = frozenset({"content", "orchestration_rules", "stop_step_semantics"})
+
+
+def strip_ingredients_only_keys(result: Any) -> dict[str, Any]:
+    """Return a copy of result with content/orchestration keys excluded."""
+    return {k: v for k, v in result.items() if k not in _INGREDIENTS_ONLY_EXCLUDE}
+
+
 async def resolve_repo_from_remote(cwd: str, hint: str | None = None) -> str:
     """Return 'owner/repo' from git remote URL, or '' on failure.
 

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -46,6 +46,7 @@ from autoskillit.server._misc import (
     _quota_refresh_loop,
     resolve_log_dir,
     resolve_provider,
+    strip_ingredients_only_keys,
 )
 from autoskillit.server._notify import track_response_size
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
@@ -55,7 +56,6 @@ logger = get_logger(__name__)
 _PR_CREATE_RECIPES: frozenset[str] = frozenset(
     {"merge-prs", "implementation", "implementation-groups", "remediation"}
 )
-_INGREDIENTS_ONLY_EXCLUDE = frozenset({"content", "orchestration_rules", "stop_step_semantics"})
 
 
 def _kitchen_failure_envelope(
@@ -579,7 +579,7 @@ async def open_kitchen(
             result["version"] = __version__
 
             if ingredients_only:
-                result = {k: v for k, v in result.items() if k not in _INGREDIENTS_ONLY_EXCLUDE}
+                result = strip_ingredients_only_keys(result)
 
             if "ingredients_table" not in result or not result["ingredients_table"]:
                 result["ingredients_table"] = None

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -55,6 +55,7 @@ logger = get_logger(__name__)
 _PR_CREATE_RECIPES: frozenset[str] = frozenset(
     {"merge-prs", "implementation", "implementation-groups", "remediation"}
 )
+_INGREDIENTS_ONLY_EXCLUDE = frozenset({"content", "orchestration_rules", "stop_step_semantics"})
 
 
 def _kitchen_failure_envelope(
@@ -578,9 +579,7 @@ async def open_kitchen(
             result["version"] = __version__
 
             if ingredients_only:
-                result.pop("content", None)
-                result.pop("orchestration_rules", None)
-                result.pop("stop_step_semantics", None)
+                result = {k: v for k, v in result.items() if k not in _INGREDIENTS_ONLY_EXCLUDE}
 
             if "ingredients_table" not in result or not result["ingredients_table"]:
                 result["ingredients_table"] = None

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -21,6 +21,8 @@ from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
 
+_INGREDIENTS_ONLY_EXCLUDE = frozenset({"content", "orchestration_rules", "stop_step_semantics"})
+
 
 @mcp.tool(
     tags={"autoskillit", "kitchen-core", "fleet-dispatch"},
@@ -221,9 +223,7 @@ async def load_recipe(
             recipe_info = tool_ctx.recipes.find(name, tool_ctx.project_dir)
             result = await _apply_triage_gate(result, name, recipe_info=recipe_info)
             if ingredients_only:
-                result.pop("content", None)
-                result.pop("orchestration_rules", None)
-                result.pop("stop_step_semantics", None)
+                result = {k: v for k, v in result.items() if k not in _INGREDIENTS_ONLY_EXCLUDE}
             return json.dumps(result)
     except Exception as exc:
         logger.error("load_recipe unhandled exception", exc_info=True)

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -14,14 +14,16 @@ from autoskillit.core import get_logger, temp_dir_display_str
 from autoskillit.pipeline import GATED_TOOLS, UNGATED_TOOLS  # noqa: F401
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
-from autoskillit.server._misc import _apply_triage_gate, resolve_log_dir
+from autoskillit.server._misc import (
+    _apply_triage_gate,
+    resolve_log_dir,
+    strip_ingredients_only_keys,
+)
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._state import _get_ctx_or_none
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
-
-_INGREDIENTS_ONLY_EXCLUDE = frozenset({"content", "orchestration_rules", "stop_step_semantics"})
 
 
 @mcp.tool(
@@ -223,7 +225,7 @@ async def load_recipe(
             recipe_info = tool_ctx.recipes.find(name, tool_ctx.project_dir)
             result = await _apply_triage_gate(result, name, recipe_info=recipe_info)
             if ingredients_only:
-                result = {k: v for k, v in result.items() if k not in _INGREDIENTS_ONLY_EXCLUDE}
+                result = strip_ingredients_only_keys(result)
             return json.dumps(result)
     except Exception as exc:
         logger.error("load_recipe unhandled exception", exc_info=True)

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -635,6 +635,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "server/test_mcp_overrides.py",
             "server/test_smoke_pipeline.py",
             "server/test_tools_kitchen_envelope.py",
+            "server/test_tools_kitchen_cache_poison.py",
             "server/test_service_wrappers.py",
             "server/test_tools_list_recipes.py",
             "server/test_tools_bootstrap.py",

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -91,6 +91,7 @@ SINGLETON_ALLOWED_MODULES: frozenset[str] = frozenset(
         # _REMOVE_LABELS = sorted(...) — stable label list derived from LABEL_LIFECYCLE_REGISTRY
         "_label_cleanup",  # fleet/_label_cleanup.py: _REMOVE_LABELS constant (see comment above)
         "_step_context",  # core/_step_context.py: current_step_name, current_order_id ContextVars
+        "_api_cache",  # recipe/_api_cache.py: _LOAD_CACHE = LoadCache()
     }
 )
 _SINGLETON_SAFE_CALL_NAMES: frozenset[str] = frozenset(

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -230,7 +230,7 @@ def test_show_cook_preview_uses_resolved_base_branch_for_smoke_test(monkeypatch,
     from autoskillit.recipe.io import find_recipe_by_name, load_recipe
 
     project_dir = pkg_root().parent.parent
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
     monkeypatch.setattr(
         "autoskillit.config.resolve_ingredient_defaults",
         lambda _: {"base_branch": "develop"},

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -117,10 +117,10 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 64),
     # tools_kitchen.py — hook config dict, quota guard overlay, ingredient locks overlay
-    ("src/autoskillit/server/tools/tools_kitchen.py", 129),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 148),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 714),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 774),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 130),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 149),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 713),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 773),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 164),
     # tools_status.py — mcp_data dict

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -11,6 +11,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_analysis_public_api.py` | Tests for the recipe analysis public API surface |
 | `test_anti_pattern_guards.py` | Guards for anti-patterns in recipe definitions |
 | `test_api.py` | Tests for recipe/_api.py orchestration API |
+| `test_api_cache_isolation.py` | Cache isolation tests: copy-on-read contract for LoadCache — prevents aliasing bugs where callers mutate returned results and corrupt cached entries |
 | `test_api_split.py` | Structural guard for recipe API split |
 | `test_audit_trail_artifacts.py` | Tests for audit/ directory creation and artifact copy in create_worktree.sh |
 | `test_audit_trail_format_doc.py` | Tests for audit-trail-format.md documentation |

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -289,8 +289,8 @@ def test_load_and_validate_cache_key_includes_all_result_affecting_params(tmp_pa
 
     api_mod.load_and_validate("myrecipe", tmp_path)
 
-    assert cache_snap, "cache was never populated"
-    cache_key = next(iter(cache_snap.keys()))
+    assert cache_snap._store, "cache was never populated"
+    cache_key = next(iter(cache_snap._store.keys()))
 
     # Verify each result-affecting param has a corresponding position in the cache key
     param_to_key_index: dict[str, int] = {

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -151,7 +151,7 @@ def test_load_and_validate_returns_cached_result_on_second_call(tmp_path, monkey
     import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
 
     recipes_dir = tmp_path / ".autoskillit" / "recipes"
     recipes_dir.mkdir(parents=True)
@@ -178,7 +178,7 @@ def test_load_and_validate_cache_invalidated_on_recipe_mtime_change(tmp_path, mo
     import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
 
     recipes_dir = tmp_path / ".autoskillit" / "recipes"
     recipes_dir.mkdir(parents=True)
@@ -206,7 +206,7 @@ def test_load_and_validate_cache_invalidated_on_pkg_version_change(tmp_path, mon
     import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
 
     recipes_dir = tmp_path / ".autoskillit" / "recipes"
     recipes_dir.mkdir(parents=True)
@@ -233,7 +233,7 @@ def test_load_and_validate_cache_invalidated_on_dir_mtime_change(tmp_path, monke
     import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
 
     recipes_dir = tmp_path / ".autoskillit" / "recipes"
     recipes_dir.mkdir(parents=True)
@@ -280,7 +280,7 @@ def test_load_and_validate_cache_key_includes_all_result_affecting_params(tmp_pa
     # Find all params NOT in the metadata-only allowlist
     result_affecting_params = all_params - RESULT_METADATA_ONLY_PARAMS
 
-    cache_snap: dict = {}
+    cache_snap = cache_mod.LoadCache()
     monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_snap)
 
     recipes_dir = tmp_path / ".autoskillit" / "recipes"
@@ -346,7 +346,7 @@ def test_load_and_validate_logs_stage_timing_at_debug(tmp_path, monkeypatch):
     import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
 
     recipes_dir = tmp_path / ".autoskillit" / "recipes"
     recipes_dir.mkdir(parents=True)
@@ -884,7 +884,7 @@ def test_load_and_validate_reuses_content_hash_from_recipe_info(tmp_path, monkey
     import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
 
     recipes_dir = tmp_path / ".autoskillit" / "recipes"
     recipes_dir.mkdir(parents=True)
@@ -914,7 +914,7 @@ def test_load_and_validate_calls_list_recipes_once(tmp_path, monkeypatch):
     import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
 
     recipes_dir = tmp_path / ".autoskillit" / "recipes"
     recipes_dir.mkdir(parents=True)
@@ -940,7 +940,7 @@ def test_load_and_validate_skips_list_recipes_when_recipe_list_provided(tmp_path
     import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
 
     recipes_dir = tmp_path / ".autoskillit" / "recipes"
     recipes_dir.mkdir(parents=True)
@@ -975,7 +975,7 @@ def test_load_and_validate_cache_invalidated_on_rule_registry_change(tmp_path, m
     import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
     monkeypatch.setattr(cache_mod, "_STALENESS_IS_STALE", False)
     monkeypatch.setattr(cache_mod, "_STALENESS_CACHES_CLEARED", False)
     monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
@@ -1009,7 +1009,7 @@ def test_load_and_validate_detects_stale_process(tmp_path, monkeypatch):
     import autoskillit.recipe._api_cache as cache_mod
     from autoskillit.core import ProcessStaleError
 
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
     monkeypatch.setattr(cache_mod, "_PROCESS_START_PKG_MTIME", 1000)
     monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
     monkeypatch.setattr(cache_mod, "_STALENESS_IS_STALE", False)
@@ -1040,7 +1040,7 @@ def test_load_and_validate_raises_on_not_found(tmp_path, monkeypatch):
     import autoskillit.recipe._api_cache as cache_mod
     from autoskillit.core import RecipeNotFoundError
 
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
     monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
     monkeypatch.setattr(cache_mod, "_STALENESS_IS_STALE", False)
 
@@ -1057,7 +1057,7 @@ def test_lru_cache_helpers_cleared_on_process_staleness(tmp_path, monkeypatch):
     from autoskillit.recipe.methodology_venue_appendix import load_ml_sub_area_folding
     from autoskillit.recipe.rules.rules_blocks import _block_budgets
 
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
 
     _block_budgets()
     load_bundled_manifest()

--- a/tests/recipe/test_api_cache_isolation.py
+++ b/tests/recipe/test_api_cache_isolation.py
@@ -1,0 +1,120 @@
+"""Cache isolation tests for recipe/_api_cache.py: LoadCache copy-on-read contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+_CACHE_TEST_RECIPE = """\
+name: cache-test
+description: minimal recipe for cache isolation tests
+autoskillit_version: "0.3.0"
+kitchen_rules:
+  - "No native tools"
+ingredients:
+  task:
+    description: The task
+    required: true
+steps:
+  stop:
+    action: stop
+    message: "done"
+"""
+
+
+def _setup_cache_recipe(tmp_path: Path) -> Path:
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    recipe_path = recipes_dir / "cache-test.yaml"
+    recipe_path.write_text(_CACHE_TEST_RECIPE)
+    return tmp_path
+
+
+def test_load_cache_content_survives_consumer_pop(tmp_path, monkeypatch):
+    """Mutating a returned result must not corrupt the cache entry."""
+    from autoskillit.recipe import _api_cache
+    from autoskillit.recipe._api import load_and_validate
+    from autoskillit.recipe._api_cache import LoadCache
+
+    monkeypatch.setattr(_api_cache, "_LOAD_CACHE", LoadCache())
+    _setup_cache_recipe(tmp_path)
+
+    result1 = load_and_validate("cache-test", project_dir=tmp_path)
+    assert "content" in result1
+    original_content = result1["content"]
+
+    # Simulate what tools_recipe.py used to do (mutate the returned dict)
+    result1.pop("content", None)
+    result1.pop("orchestration_rules", None)
+
+    # Second call must return unmutated content
+    result2 = load_and_validate("cache-test", project_dir=tmp_path)
+    assert "content" in result2
+    assert result2["content"] == original_content
+
+
+def test_load_cache_suggestions_not_aliased(tmp_path, monkeypatch):
+    """Appending to returned suggestions must not affect cached entry."""
+    from autoskillit.recipe import _api_cache
+    from autoskillit.recipe._api import load_and_validate
+    from autoskillit.recipe._api_cache import LoadCache
+
+    monkeypatch.setattr(_api_cache, "_LOAD_CACHE", LoadCache())
+    _setup_cache_recipe(tmp_path)
+
+    result1 = load_and_validate("cache-test", project_dir=tmp_path)
+    original_len = len(result1.get("suggestions", []))
+
+    result1.setdefault("suggestions", []).append({"injected": True})
+
+    result2 = load_and_validate("cache-test", project_dir=tmp_path)
+    assert len(result2.get("suggestions", [])) == original_len
+
+
+def test_load_cache_returns_distinct_objects(tmp_path, monkeypatch):
+    """Each cache hit must return a new dict object, not the cached reference."""
+    from autoskillit.recipe import _api_cache
+    from autoskillit.recipe._api import load_and_validate
+    from autoskillit.recipe._api_cache import LoadCache
+
+    monkeypatch.setattr(_api_cache, "_LOAD_CACHE", LoadCache())
+    _setup_cache_recipe(tmp_path)
+
+    result1 = load_and_validate("cache-test", project_dir=tmp_path)
+    result2 = load_and_validate("cache-test", project_dir=tmp_path)
+    assert result1 is not result2
+    if "suggestions" in result1 and "suggestions" in result2:
+        assert result1["suggestions"] is not result2["suggestions"]
+
+
+def test_copy_result_produces_independent_copy():
+    """copy_result must return a dict that shares no mutable references with the input."""
+    from autoskillit.recipe._api_cache import LoadCache
+
+    cache = LoadCache()
+    original = {
+        "content": "hello",
+        "suggestions": [{"rule": "stale-contract"}],
+        "kitchen_rules": ["rule1"],
+        "requires_packs": ["pack1"],
+        "requires_features": ["feat1"],
+        "deferred_guards": [{"step": "s1", "ingredient": "i1", "default": None}],
+    }
+    copy = cache.copy_result(original)
+
+    assert copy == original
+    assert copy is not original
+    assert copy["suggestions"] is not original["suggestions"]
+    assert copy["kitchen_rules"] is not original["kitchen_rules"]
+    assert copy["requires_packs"] is not original["requires_packs"]
+    assert copy["requires_features"] is not original["requires_features"]
+    assert copy["deferred_guards"] is not original["deferred_guards"]
+
+    # Mutating the copy must not affect the original
+    copy["suggestions"].append({"injected": True})
+    copy.pop("content", None)
+    assert "content" in original
+    assert len(original["suggestions"]) == 1

--- a/tests/recipe/test_deep_staleness.py
+++ b/tests/recipe/test_deep_staleness.py
@@ -12,7 +12,7 @@ def test_deep_staleness_detects_rule_file_changes(tmp_path, monkeypatch):
     import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
     monkeypatch.setattr(cache_mod, "_PROCESS_START_PKG_MTIME", 1000)
     monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
     monkeypatch.setattr(cache_mod, "_STALENESS_IS_STALE", False)

--- a/tests/recipe/test_recipe_temp_substitution.py
+++ b/tests/recipe/test_recipe_temp_substitution.py
@@ -137,7 +137,7 @@ def test_load_and_validate_different_temp_dir_relpath_produces_different_content
     import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
     _setup_project_recipe_with_placeholder(tmp_path, "temp-placeholder-test")
 
     result1 = api_mod.load_and_validate(

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -83,6 +83,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_tools_integrations_release.py` | Tests for release_issue staged lifecycle behaviour |
 | `test_claim_liveness.py` | Tests for liveness-aware claiming — dead dispatch recovery, alive dispatch blocking, shared helper parity |
 | `test_tools_issue_lifecycle.py` | Tests for server/tools/tools_issue_headless.py and server/tools/tools_issue_labels.py |
+| `test_tools_kitchen_cache_poison.py` | Cross-tool cache-poison regression: open_kitchen(ingredients_only=True) must not corrupt subsequent load_recipe calls for the same recipe |
 | `test_tools_kitchen_envelope.py` | Tests for tools_kitchen.py: hook drift warnings and failure envelopes |
 | `test_tools_kitchen_gate.py` | Tests for tools_kitchen.py: gate toggle, review gate cleanup, kitchen_id, misc |
 | `test_tools_kitchen_gate_features.py` | Tests for tools_kitchen.py: recipe packs, quota refresh, ingredients_only, project_dir |

--- a/tests/server/test_tools_kitchen_cache_poison.py
+++ b/tests/server/test_tools_kitchen_cache_poison.py
@@ -1,0 +1,54 @@
+"""Cross-tool cache-poison regression: open_kitchen(ingredients_only=True) must not corrupt
+subsequent load_recipe calls for the same recipe.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.anyio]
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_ingredients_only_does_not_poison_load_recipe(
+    tool_ctx_kitchen_open,
+    monkeypatch,
+):
+    """open_kitchen(ingredients_only=True) must not corrupt subsequent load_recipe."""
+    from autoskillit.recipe import _api_cache
+    from autoskillit.recipe._api_cache import LoadCache
+    from autoskillit.server.tools.tools_kitchen import open_kitchen
+    from autoskillit.server.tools.tools_recipe import load_recipe
+
+    monkeypatch.setattr(_api_cache, "_LOAD_CACHE", LoadCache())
+
+    with patch("autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()):
+        with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+            with patch("autoskillit.server.tools.tools_kitchen.create_background_task"):
+                with patch(
+                    "autoskillit.server.tools.tools_kitchen.resolve_kitchen_id",
+                    return_value="test-kitchen",
+                ):
+                    ok_result = json.loads(
+                        await open_kitchen(
+                            name="implementation",
+                            ingredients_only=True,
+                            ctx=tool_ctx_kitchen_open,
+                        )
+                    )
+
+    assert "content" not in ok_result, (
+        f"open_kitchen(ingredients_only=True) must not include 'content' in response, "
+        f"got keys: {list(ok_result.keys())}"
+    )
+
+    lr_result = json.loads(await load_recipe(name="implementation"))
+    assert "content" in lr_result, (
+        "load_recipe must return 'content' after open_kitchen(ingredients_only=True); "
+        "cache was poisoned by the ingredients_only pop"
+    )
+    assert isinstance(lr_result["content"], str)
+    assert len(lr_result["content"]) > 0

--- a/tests/server/test_tools_kitchen_cache_poison.py
+++ b/tests/server/test_tools_kitchen_cache_poison.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-pytestmark = [pytest.mark.layer("server"), pytest.mark.anyio]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.anyio, pytest.mark.medium]
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_kitchen_cache_poison.py
+++ b/tests/server/test_tools_kitchen_cache_poison.py
@@ -12,7 +12,6 @@ import pytest
 pytestmark = [pytest.mark.layer("server"), pytest.mark.anyio, pytest.mark.medium]
 
 
-@pytest.mark.anyio
 async def test_open_kitchen_ingredients_only_does_not_poison_load_recipe(
     tool_ctx_kitchen_open,
     monkeypatch,

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -364,7 +364,7 @@ async def test_open_kitchen_smoke_test_renders_resolved_base_branch(monkeypatch)
 
     project_dir = pkg_root().parent.parent
     monkeypatch.chdir(project_dir)
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
     monkeypatch.setattr(
         "autoskillit.server.tools.tools_kitchen.resolve_ingredient_defaults",
         lambda _: {"base_branch": "develop"},
@@ -460,7 +460,7 @@ async def test_open_kitchen_with_config_authority_ingredient(monkeypatch):
 
     project_dir = pkg_root().parent.parent
     monkeypatch.chdir(project_dir)
-    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
     monkeypatch.setattr(
         "autoskillit.server.tools.tools_kitchen.resolve_ingredient_defaults",
         lambda _: {


### PR DESCRIPTION
## Summary

The recipe `_LOAD_CACHE` returns stored dicts by reference. Tool handlers mutate these references via `.pop()`, `setdefault().append()`, and key-assignment — permanently corrupting cached entries. The architectural weakness is a missing copy-on-read boundary at the cache egress point, combined with a mutable `dict` result type that provides no runtime mutation protection.

The immunity plan introduces a `LoadCache` class that encapsulates thread-safe access with a `copy_result()` method that produces shallow copies with independently-copied list fields. Tool handlers switch from in-place `.pop()` mutation to non-mutating dict-comprehension exclusion. The refactor eliminates the entire class of cache-aliasing bugs by making it structurally impossible to mutate cached state through returned references.

## Requirements

### REQ-CACHE-1: Defensive Copy on Cache Return

`_api.py:273` must return a copy of the cached result dict, not the original reference. A shallow `dict()` copy protects against key-level mutations (`.pop()`, key assignment). For full protection against `list.append()` mutations on nested lists like `suggestions`, the `suggestions` key specifically should also be copied.

### REQ-CACHE-2: Copy Before Mutation in Tool Handlers

`tools_recipe.py:223-226` and `tools_kitchen.py:581-583` must create a new dict excluding the stripped keys instead of mutating in-place.

### REQ-CACHE-3: Copy Before Any Mutation in `open_kitchen`

`tools_kitchen.py` must copy the result dict before ANY mutation (before line 552), not just before the `ingredients_only` strip.

### REQ-CACHE-4: Regression Test

Add a test that verifies cache content survives consumer mutation and suggestions list is not aliased.

Closes #3405

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260531-073732-441605/.autoskillit/temp/rectify/rectify_cache_aliasing_immunity_2026-05-31_074500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 53 | 18.9k | 897.1k | 102.3k | 192 | 88.8k | 16m 16s |
| review_approach* | sonnet | 1 | 52 | 6.3k | 194.0k | 47.6k | 49 | 36.8k | 4m 17s |
| dry_walkthrough* | opus | 1 | 35 | 10.7k | 898.9k | 72.5k | 119 | 72.6k | 5m 12s |
| implement* | sonnet | 1 | 536 | 27.3k | 6.7M | 139.0k | 176 | 125.2k | 15m 19s |
| audit_impl* | sonnet | 1 | 740 | 11.9k | 260.0k | 44.7k | 56 | 61.4k | 5m 33s |
| prepare_pr* | sonnet | 1 | 214.7k | 5.8k | 335.7k | 28.0k | 30 | 41.0k | 1m 57s |
| compose_pr* | sonnet | 1 | 74.9k | 2.4k | 248.9k | 28.0k | 21 | 15.6k | 57s |
| review_pr* | sonnet | 1 | 238 | 44.6k | 1.6M | 115.5k | 74 | 100.4k | 11m 38s |
| resolve_review* | opus | 1 | 47 | 9.0k | 1.9M | 80.3k | 60 | 64.2k | 11m 45s |
| **Total** | | | 291.4k | 136.9k | 13.1M | 139.0k | | 605.9k | 1h 12m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 293 | 22856.7 | 427.4 | 93.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 22 | 87419.6 | 2916.9 | 407.7 |
| **Total** | **315** | 41542.1 | 1923.6 | 434.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 53 | 18.9k | 897.1k | 88.8k | 16m 16s |
| sonnet | 6 | 291.2k | 98.3k | 9.4M | 380.4k | 39m 42s |
| opus | 2 | 82 | 19.7k | 2.8M | 136.8k | 16m 58s |