### PR TITLE
[FIX] Rectify False Success from Infrastructure-Only Writes and Weak Contracts

### DIFF
--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -262,6 +262,10 @@ class WriteEvidence:
             or self.file_changes_count >= 1
         )
 
+    @property
+    def has_implementation_evidence(self) -> bool:
+        return self.write_call_count >= 1 or self.file_changes_count >= 1
+
 
 @dataclass
 class SkillResult:

--- a/src/autoskillit/execution/headless/_headless_evidence.py
+++ b/src/autoskillit/execution/headless/_headless_evidence.py
@@ -177,8 +177,10 @@ def _stdout_mentions_write_tools(stdout: str) -> bool:
         except json.JSONDecodeError:
             # Truncated line: check if it looks like an assistant record with a write tool name.
             if (
-                line.startswith('{"type":"assistant"') or line.startswith('{"type": "assistant"')
-            ) and ('"Write"' in line or '"Edit"' in line):
+                (line.startswith('{"type":"assistant"') or line.startswith('{"type": "assistant"'))
+                and '"tool_use"' in line
+                and ('"Write"' in line or '"Edit"' in line)
+            ):
                 return True
             continue
         if obj.get("type") != "assistant":

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -204,7 +204,7 @@ def _build_skill_result(
                 logger.warning(
                     "Session went stale but stdout contained a valid result; recovering"
                 )
-                return _make_terminated_result(
+                _stale_success_sr = _make_terminated_result(
                     result=result,
                     session=stale_session,
                     success=True,
@@ -216,6 +216,20 @@ def _build_skill_result(
                     provider_used=provider_used,
                     api_retry=stale_api_retry,
                 )
+                if (
+                    _stale_success_sr.success
+                    and write_behavior is not None
+                    and write_behavior.mode in ("always", "conditional")
+                    and not stale_evidence.has_implementation_evidence
+                ):
+                    _stale_success_sr = dataclasses.replace(
+                        _stale_success_sr,
+                        success=False,
+                        subtype="zero_writes",
+                        needs_retry=True,
+                        retry_reason=RetryReason.ZERO_WRITES,
+                    )
+                return _stale_success_sr
         # No valid result in stdout — fall through to original stale response
         _stale_is_rate_limited = has_rate_limit_signal(stale_session, result)
         _stale_is_api_error = stale_session.api_retry_exhausted or (
@@ -285,7 +299,7 @@ def _build_skill_result(
                 logger.warning(
                     "Session idle-stalled but stdout contained a valid result; recovering"
                 )
-                return _make_terminated_result(
+                _idle_success_sr = _make_terminated_result(
                     result=result,
                     session=idle_session,
                     success=True,
@@ -297,6 +311,20 @@ def _build_skill_result(
                     provider_used=provider_used,
                     api_retry=idle_api_retry,
                 )
+                if (
+                    _idle_success_sr.success
+                    and write_behavior is not None
+                    and write_behavior.mode in ("always", "conditional")
+                    and not idle_evidence.has_implementation_evidence
+                ):
+                    _idle_success_sr = dataclasses.replace(
+                        _idle_success_sr,
+                        success=False,
+                        subtype="zero_writes",
+                        needs_retry=True,
+                        retry_reason=RetryReason.ZERO_WRITES,
+                    )
+                return _idle_success_sr
         _idle_is_rate_limited = has_rate_limit_signal(idle_session, result)
         _idle_is_api_error = idle_session.api_retry_exhausted or (
             idle_session.api_error_status is not None and idle_session.api_error_status >= 400
@@ -558,6 +586,18 @@ def _build_skill_result(
         needs_retry = False
         retry_reason = RetryReason.NONE
 
+    if (
+        success
+        and write_behavior is not None
+        and write_behavior.mode in ("always", "conditional")
+        and not evidence.has_implementation_evidence
+    ):
+        normalized_subtype = "zero_writes"
+        outcome = SessionOutcome.RETRIABLE
+        success = False
+        needs_retry = True
+        retry_reason = RetryReason.ZERO_WRITES
+
     # Invariant: TIMED_OUT sessions must produce subtype='timeout'.
     if (
         result.termination == TerminationReason.TIMED_OUT
@@ -686,7 +726,7 @@ def _build_skill_result(
     # Zero-write gate: demote success to retriable failure when a write-expected
     # skill produced zero Edit/Write calls (silent degradation detection).
     # Write expectation is resolved from skill_contracts.yaml via WriteBehaviorSpec.
-    if sr.success and not _has_write_evidence and write_behavior is not None:
+    if sr.success and not evidence.has_implementation_evidence and write_behavior is not None:
         write_expected = False
         if write_behavior.mode == "always":
             write_expected = True

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -219,16 +219,23 @@ def _build_skill_result(
                 if (
                     _stale_success_sr.success
                     and write_behavior is not None
-                    and write_behavior.mode in ("always", "conditional")
                     and not stale_evidence.has_implementation_evidence
                 ):
-                    _stale_success_sr = dataclasses.replace(
-                        _stale_success_sr,
-                        success=False,
-                        subtype="zero_writes",
-                        needs_retry=True,
-                        retry_reason=RetryReason.ZERO_WRITES,
+                    _stale_write_expected = write_behavior.mode == "always" or (
+                        write_behavior.mode == "conditional"
+                        and write_behavior.expected_when
+                        and _check_expected_patterns(
+                            _stale_success_sr.result, write_behavior.expected_when
+                        )
                     )
+                    if _stale_write_expected:
+                        _stale_success_sr = dataclasses.replace(
+                            _stale_success_sr,
+                            success=False,
+                            subtype="zero_writes",
+                            needs_retry=True,
+                            retry_reason=RetryReason.ZERO_WRITES,
+                        )
                 return _stale_success_sr
         # No valid result in stdout — fall through to original stale response
         _stale_is_rate_limited = has_rate_limit_signal(stale_session, result)
@@ -314,16 +321,23 @@ def _build_skill_result(
                 if (
                     _idle_success_sr.success
                     and write_behavior is not None
-                    and write_behavior.mode in ("always", "conditional")
                     and not idle_evidence.has_implementation_evidence
                 ):
-                    _idle_success_sr = dataclasses.replace(
-                        _idle_success_sr,
-                        success=False,
-                        subtype="zero_writes",
-                        needs_retry=True,
-                        retry_reason=RetryReason.ZERO_WRITES,
+                    _idle_write_expected = write_behavior.mode == "always" or (
+                        write_behavior.mode == "conditional"
+                        and write_behavior.expected_when
+                        and _check_expected_patterns(
+                            _idle_success_sr.result, write_behavior.expected_when
+                        )
                     )
+                    if _idle_write_expected:
+                        _idle_success_sr = dataclasses.replace(
+                            _idle_success_sr,
+                            success=False,
+                            subtype="zero_writes",
+                            needs_retry=True,
+                            retry_reason=RetryReason.ZERO_WRITES,
+                        )
                 return _idle_success_sr
         _idle_is_rate_limited = has_rate_limit_signal(idle_session, result)
         _idle_is_api_error = idle_session.api_retry_exhausted or (
@@ -589,7 +603,7 @@ def _build_skill_result(
     if (
         success
         and write_behavior is not None
-        and write_behavior.mode in ("always", "conditional")
+        and write_behavior.mode == "always"
         and not evidence.has_implementation_evidence
     ):
         normalized_subtype = "zero_writes"

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -50,12 +50,12 @@ skills:
     - name: is_fixable
       type: string
     expected_output_patterns:
-    - "diagnosis_path[ \\t]*=[ \\t]*(?:/.+)?"
+    - "diagnosis_path[ \\t]*=[ \\t]*/.+"
     - "failure_subtype[ \\t]*=[ \\t]*(flaky|timing_race|deterministic|fixture|import|env|unknown)"
     pattern_examples:
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = deterministic\nis_fixable = true\n%%ORDER_UP%%"
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = flaky\nis_fixable = false\n%%ORDER_UP%%"
-    - "diagnosis_path = \nfailure_type = test\nfailure_subtype = unknown\nis_fixable = false\n%%ORDER_UP%%"
+    - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = unknown\nis_fixable = false\n%%ORDER_UP%%"
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = timing_race\nis_fixable = true\n%%ORDER_UP%%"
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = fixture\nis_fixable = true\n%%ORDER_UP%%"
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = import\nis_fixable = true\n%%ORDER_UP%%"
@@ -1534,10 +1534,10 @@ skills:
     - name: pr_url
       type: string
     expected_output_patterns:
-    - "pr_url[ \\t]*=[ \\t]*(https://github\\.com/.*/pull/\\d+)?"
+    - "pr_url[ \\t]*=[ \\t]*https://github\\.com/.*/pull/\\d+"
     pattern_examples:
     - "pr_url = https://github.com/owner/repo/pull/42\n%%ORDER_UP%%"
-    - "pr_url = \n%%ORDER_UP%%"
+    - "pr_url = https://github.com/owner/repo/pull/99\n%%ORDER_UP%%"
     write_behavior: always
 
   review-design:

--- a/tests/contracts/test_skill_contracts.py
+++ b/tests/contracts/test_skill_contracts.py
@@ -211,7 +211,7 @@ def test_skill_contracts_yaml_includes_prepare_research_pr(skills):
 def test_skill_contracts_yaml_includes_compose_research_pr(skills):
     """compose-research-pr must be registered with pr_url output pattern."""
     _assert_skill_has_patterns(
-        skills, "compose-research-pr", r"pr_url[ \t]*=[ \t]*(https://github\.com/.*/pull/\d+)?"
+        skills, "compose-research-pr", r"pr_url[ \t]*=[ \t]*https://github\.com/.*/pull/\d+"
     )
 
 

--- a/tests/core/types/test_type_results.py
+++ b/tests/core/types/test_type_results.py
@@ -54,3 +54,31 @@ class TestWriteEvidence:
     def test_file_changes_count_default_is_zero(self) -> None:
         we = WriteEvidence(write_call_count=0, fs_writes_detected=False, git_writes_detected=False)
         assert we.file_changes_count == 0
+
+    def test_has_implementation_evidence_excludes_infra_only(self) -> None:
+        ev = WriteEvidence(
+            write_call_count=0,
+            fs_writes_detected=True,
+            git_writes_detected=True,
+            file_changes_count=0,
+        )
+        assert ev.has_implementation_evidence is False
+        assert ev.has_evidence is True
+
+    def test_has_implementation_evidence_true_with_write_calls(self) -> None:
+        ev = WriteEvidence(
+            write_call_count=1,
+            fs_writes_detected=False,
+            git_writes_detected=False,
+            file_changes_count=0,
+        )
+        assert ev.has_implementation_evidence is True
+
+    def test_has_implementation_evidence_true_with_file_changes(self) -> None:
+        ev = WriteEvidence(
+            write_call_count=0,
+            fs_writes_detected=False,
+            git_writes_detected=False,
+            file_changes_count=1,
+        )
+        assert ev.has_implementation_evidence is True

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -1514,7 +1514,9 @@ class TestFalseSuccessInfraWritesBypass:
     def test_stale_recovery_with_zero_impl_writes_fails(self) -> None:
         """Stale recovery + fs_writes_detected but zero impl writes → zero_writes."""
         stdout = (
-            _tool_use_ndjson("Read", file_path="/a/b.py") + "\n" + _success_result_json("done")
+            _tool_use_ndjson("Read", file_path="/a/b.py")
+            + "\n"
+            + _success_result_json("Implementation complete.\n%%ORDER_UP%%")
         )
         result = SubprocessResult(
             returncode=-1,
@@ -1527,7 +1529,7 @@ class TestFalseSuccessInfraWritesBypass:
         )
         sr = _build_skill_result(
             result,
-            completion_marker="done",
+            completion_marker="%%ORDER_UP%%",
             write_behavior=WriteBehaviorSpec(mode="always"),
             fs_writes_detected=True,
             backend=ClaudeCodeBackend(),
@@ -1538,7 +1540,9 @@ class TestFalseSuccessInfraWritesBypass:
     def test_idle_stall_recovery_with_zero_impl_writes_fails(self) -> None:
         """Idle-stall recovery + fs_writes_detected but zero impl writes → zero_writes."""
         stdout = (
-            _tool_use_ndjson("Read", file_path="/a/b.py") + "\n" + _success_result_json("done")
+            _tool_use_ndjson("Read", file_path="/a/b.py")
+            + "\n"
+            + _success_result_json("Implementation complete.\n%%ORDER_UP%%")
         )
         result = SubprocessResult(
             returncode=-1,
@@ -1551,7 +1555,7 @@ class TestFalseSuccessInfraWritesBypass:
         )
         sr = _build_skill_result(
             result,
-            completion_marker="done",
+            completion_marker="%%ORDER_UP%%",
             write_behavior=WriteBehaviorSpec(mode="always"),
             fs_writes_detected=True,
             backend=ClaudeCodeBackend(),

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -815,6 +815,19 @@ def _system_init_ndjson(tools: list[str] | None = None) -> str:
             True,
             id="truncated_assistant_edit",
         ),
+        # truncated instructional text mentioning "Edit" without tool_use context → False
+        pytest.param(
+            '{"type":"assistant","message":{"content":[{"type":"text",'
+            '"text":"Use the \\"Edit\\" tool to',
+            False,
+            id="truncated_instructional_text_mentioning_edit",
+        ),
+        # truncated tool_use with Edit — has "tool_use" in the line → True
+        pytest.param(
+            '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","id":"toolu_',
+            True,
+            id="truncated_tool_use_with_edit",
+        ),
     ],
 )
 def test_stdout_mentions_write_tools_unit(stdout: str, expected: bool) -> None:
@@ -1438,3 +1451,137 @@ def test_build_skill_result_signal_death_returncode_yields_resume() -> None:
     assert skill_result.success is False
     assert skill_result.retry_reason == RetryReason.RESUME
     assert skill_result.infra.exit_category == "process_killed"
+
+
+class TestFalseSuccessInfraWritesBypass:
+    """Tests for false success when infrastructure-only writes satisfy write evidence checks."""
+
+    def test_marker_absent_contract_met_with_zero_impl_writes_fails(self) -> None:
+        """marker_absent_contract_met + fs_writes_detected but zero impl writes → zero_writes."""
+        stdout = (
+            _tool_use_ndjson("Read", file_path="/a/b.py")
+            + "\n"
+            + _success_result_json("worktree_path = /tmp/wt\nsome output")
+        )
+        result = SubprocessResult(
+            returncode=1,
+            stdout=stdout,
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+            session_id="sess-mcm-1",
+            channel_b_session_id="",
+        )
+        sr = _build_skill_result(
+            result,
+            completion_marker="%%ORDER_UP%%",
+            expected_output_patterns=(r"worktree_path[ \t]*=[ \t]*/.+",),
+            write_behavior=WriteBehaviorSpec(mode="always"),
+            fs_writes_detected=True,
+            backend=ClaudeCodeBackend(),
+        )
+        assert sr.success is False
+        assert sr.subtype == "zero_writes"
+        assert sr.needs_retry is True
+
+    def test_normalized_subtype_upgrade_respects_write_gate(self) -> None:
+        """missing_completion_marker upgrade with zero impl writes → zero_writes."""
+        stdout = (
+            _tool_use_ndjson("Read", file_path="/a/b.py")
+            + "\n"
+            + _success_result_json("worktree_path = /tmp/wt\nsome output")
+        )
+        result = SubprocessResult(
+            returncode=1,
+            stdout=stdout,
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+            session_id="sess-upgrade-1",
+            channel_b_session_id="",
+        )
+        sr = _build_skill_result(
+            result,
+            completion_marker="%%ORDER_UP%%",
+            expected_output_patterns=(r"worktree_path[ \t]*=[ \t]*/.+",),
+            write_behavior=WriteBehaviorSpec(mode="always"),
+            fs_writes_detected=True,
+            backend=ClaudeCodeBackend(),
+        )
+        assert sr.success is False
+        assert sr.subtype == "zero_writes"
+
+    def test_stale_recovery_with_zero_impl_writes_fails(self) -> None:
+        """Stale recovery + fs_writes_detected but zero impl writes → zero_writes."""
+        stdout = (
+            _tool_use_ndjson("Read", file_path="/a/b.py") + "\n" + _success_result_json("done")
+        )
+        result = SubprocessResult(
+            returncode=-1,
+            stdout=stdout,
+            stderr="",
+            termination=TerminationReason.STALE,
+            pid=12345,
+            session_id="sess-stale-impl-1",
+            channel_b_session_id="",
+        )
+        sr = _build_skill_result(
+            result,
+            completion_marker="done",
+            write_behavior=WriteBehaviorSpec(mode="always"),
+            fs_writes_detected=True,
+            backend=ClaudeCodeBackend(),
+        )
+        assert sr.success is False
+        assert sr.subtype == "zero_writes"
+
+    def test_idle_stall_recovery_with_zero_impl_writes_fails(self) -> None:
+        """Idle-stall recovery + fs_writes_detected but zero impl writes → zero_writes."""
+        stdout = (
+            _tool_use_ndjson("Read", file_path="/a/b.py") + "\n" + _success_result_json("done")
+        )
+        result = SubprocessResult(
+            returncode=-1,
+            stdout=stdout,
+            stderr="",
+            termination=TerminationReason.IDLE_STALL,
+            pid=12345,
+            session_id="sess-idle-impl-1",
+            channel_b_session_id="",
+        )
+        sr = _build_skill_result(
+            result,
+            completion_marker="done",
+            write_behavior=WriteBehaviorSpec(mode="always"),
+            fs_writes_detected=True,
+            backend=ClaudeCodeBackend(),
+        )
+        assert sr.success is False
+        assert sr.subtype == "zero_writes"
+
+    def test_conditional_mode_upgrade_path_with_zero_impl_writes_fails(self) -> None:
+        """Conditional mode upgrade with zero impl writes → zero_writes."""
+        stdout = (
+            _tool_use_ndjson("Read", file_path="/a/b.py")
+            + "\n"
+            + _success_result_json("worktree_path = /tmp/wt\nsome output")
+        )
+        result = SubprocessResult(
+            returncode=1,
+            stdout=stdout,
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+            session_id="sess-cond-1",
+            channel_b_session_id="",
+        )
+        sr = _build_skill_result(
+            result,
+            completion_marker="%%ORDER_UP%%",
+            expected_output_patterns=(r"worktree_path[ \t]*=[ \t]*/.+",),
+            write_behavior=WriteBehaviorSpec(mode="conditional", expected_when=("committed",)),
+            fs_writes_detected=True,
+            backend=ClaudeCodeBackend(),
+        )
+        assert sr.success is False
+        assert sr.subtype == "zero_writes"

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -1564,7 +1564,11 @@ class TestFalseSuccessInfraWritesBypass:
         assert sr.subtype == "zero_writes"
 
     def test_conditional_mode_upgrade_path_with_zero_impl_writes_fails(self) -> None:
-        """Conditional mode upgrade with zero impl writes → zero_writes."""
+        """Conditional mode upgrade with zero impl writes → zero_writes.
+
+        The expected_when pattern matches the result, so writes ARE expected.
+        With zero implementation evidence, the gate fires.
+        """
         stdout = (
             _tool_use_ndjson("Read", file_path="/a/b.py")
             + "\n"
@@ -1583,7 +1587,10 @@ class TestFalseSuccessInfraWritesBypass:
             result,
             completion_marker="%%ORDER_UP%%",
             expected_output_patterns=(r"worktree_path[ \t]*=[ \t]*/.+",),
-            write_behavior=WriteBehaviorSpec(mode="conditional", expected_when=("committed",)),
+            write_behavior=WriteBehaviorSpec(
+                mode="conditional",
+                expected_when=(r"worktree_path[ \t]*=[ \t]*/.+",),
+            ),
             fs_writes_detected=True,
             backend=ClaudeCodeBackend(),
         )

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -1484,32 +1484,36 @@ class TestFalseSuccessInfraWritesBypass:
         assert sr.subtype == "zero_writes"
         assert sr.needs_retry is True
 
-    def test_normalized_subtype_upgrade_respects_write_gate(self) -> None:
-        """missing_completion_marker upgrade with zero impl writes → zero_writes."""
+    def test_conditional_mode_with_matching_expected_when_fails(self) -> None:
+        """conditional mode + expected_when matches result + zero impl writes → zero_writes."""
         stdout = (
             _tool_use_ndjson("Read", file_path="/a/b.py")
             + "\n"
-            + _success_result_json("worktree_path = /tmp/wt\nsome output")
+            + _success_result_json("worktree_path = /tmp/wt\nsome output\n%%ORDER_UP%%")
         )
         result = SubprocessResult(
-            returncode=1,
+            returncode=0,
             stdout=stdout,
             stderr="",
             termination=TerminationReason.NATURAL_EXIT,
             pid=12345,
-            session_id="sess-upgrade-1",
+            session_id="sess-cond-1",
             channel_b_session_id="",
         )
         sr = _build_skill_result(
             result,
             completion_marker="%%ORDER_UP%%",
             expected_output_patterns=(r"worktree_path[ \t]*=[ \t]*/.+",),
-            write_behavior=WriteBehaviorSpec(mode="always"),
+            write_behavior=WriteBehaviorSpec(
+                mode="conditional",
+                expected_when=(r"worktree_path[ \t]*=[ \t]*/.+",),
+            ),
             fs_writes_detected=True,
             backend=ClaudeCodeBackend(),
         )
         assert sr.success is False
         assert sr.subtype == "zero_writes"
+        assert sr.needs_retry is True
 
     def test_stale_recovery_with_zero_impl_writes_fails(self) -> None:
         """Stale recovery + fs_writes_detected but zero impl writes → zero_writes."""

--- a/tests/execution/test_zero_write_detection.py
+++ b/tests/execution/test_zero_write_detection.py
@@ -639,9 +639,10 @@ class TestFilesystemWriteDetection:
         )
         assert sr.evidence.write_call_count == 0
 
-    def test_fs_writes_detected_suppresses_zero_writes_gate(self) -> None:
-        """When fs_writes_detected=True, zero_writes gate must NOT fire
-        even when write_call_count == 0."""
+    def test_fs_writes_detected_without_impl_evidence_demoted(self) -> None:
+        """When fs_writes_detected=True but write_call_count==0 and
+        file_changes_count==0, the zero_writes gate fires —
+        infrastructure-only writes do not satisfy implementation evidence."""
         stdout = _ndjson_with_tool_uses(["Bash"])
         sr = _build_skill_result(
             _make_result(returncode=0, stdout=stdout),
@@ -650,8 +651,8 @@ class TestFilesystemWriteDetection:
             fs_writes_detected=True,
             backend=ClaudeCodeBackend(),
         )
-        assert sr.success is True
-        assert sr.subtype != "zero_writes"
+        assert sr.success is False
+        assert sr.subtype == "zero_writes"
         assert sr.evidence.fs_writes_detected is True
 
     def test_fs_writes_detected_enables_contract_recovery(self) -> None:
@@ -888,9 +889,10 @@ class TestGitWritesStateMatrix:
 class TestGitWritesDetection:
     """Git-level write detection suppresses zero_writes false positives."""
 
-    def test_git_writes_detected_suppresses_zero_writes_gate(self) -> None:
-        """When git_writes_detected=True, zero_writes gate must NOT fire
-        even when write_call_count == 0."""
+    def test_git_writes_detected_without_impl_evidence_demoted(self) -> None:
+        """When git_writes_detected=True but write_call_count==0 and
+        file_changes_count==0, the zero_writes gate fires —
+        infrastructure-only writes do not satisfy implementation evidence."""
         stdout = _ndjson_with_tool_uses(["Read", "Grep"])
         sr = _build_skill_result(
             _make_result(returncode=0, stdout=stdout),
@@ -899,8 +901,8 @@ class TestGitWritesDetection:
             git_writes_detected=True,
             backend=ClaudeCodeBackend(),
         )
-        assert sr.success is True
-        assert sr.subtype != "zero_writes"
+        assert sr.success is False
+        assert sr.subtype == "zero_writes"
         assert sr.evidence.git_writes_detected is True
 
     def test_git_writes_detected_false_still_allows_gate(self) -> None:
@@ -917,8 +919,9 @@ class TestGitWritesDetection:
         assert sr.success is False
         assert sr.subtype == "zero_writes"
 
-    def test_git_writes_detected_suppresses_conditional_zero_writes(self) -> None:
-        """Conditional skill, zero writes, git_writes_detected=True → success preserved."""
+    def test_git_writes_detected_conditional_no_pattern_match_not_demoted(self) -> None:
+        """Conditional skill, zero writes, git_writes_detected=True, pattern NOT in
+        output → writes not expected → success preserved regardless of git_writes."""
         stdout = _ndjson_with_tool_uses(["Read", "Grep"])
         sr = _build_skill_result(
             _make_result(returncode=0, stdout=stdout),
@@ -931,8 +934,7 @@ class TestGitWritesDetection:
             backend=ClaudeCodeBackend(),
         )
         assert sr.success is True, (
-            "git_writes_detected=True must suppress zero_writes gate even when "
-            "write_behavior is conditional and pattern matches"
+            "Conditional mode with no pattern match → writes not expected → success preserved"
         )
         assert sr.subtype != "zero_writes"
 


### PR DESCRIPTION
## Summary

The implement step's success determination has two independent bypass paths that allow a session with zero implementation changes to report `success=true`, preventing the retry mechanism from firing. Both bypasses were triggered by session `31ca8509` (kitchen `ec8a019f`) where the model created a worktree but stopped after 5 turns without implementing anything (414 output tokens, `write_call_count: 0`, `file_changes_count: 0`). The step should have returned `success=false` with `needs_retry=true`, but instead passed through both gates.

The architectural immunity is achieved by: (1) splitting write evidence into infrastructure vs. implementation tiers via a new `has_implementation_evidence` property; (2) adding a mandatory write-evidence gate after ALL success-granting paths; (3) tightening the `_stdout_mentions_write_tools` heuristic to require `"tool_use"` context; and (4) strengthening contract patterns to require non-empty values.

### Root Cause 1: `marker_absent_contract_met` in `_check_session_content`

**File:** `src/autoskillit/execution/session/_session_content.py:147-155`

When `%%ORDER_UP%%` is absent from stdout but `expected_output_patterns` all match, the function logs `pattern_gated_success` / `reason="marker_absent_contract_met"` and does NOT return False. The session's contract in `skill_contracts.yaml:210-211` only requires:

```
worktree_path[ \t]*=[ \t]*/.+
```

This pattern is emitted by Step 1 (worktree creation) — the very first step of a 6-step workflow. Any session that creates a worktree and emits the path token satisfies the contract, even if Steps 2–6 are never executed.

### Root Cause 2: Infrastructure writes masking zero implementation writes in the zero-write gate

**File:** `src/autoskillit/execution/headless/_headless_result.py:689`

The zero-write gate checks: `if sr.success and not _has_write_evidence and write_behavior is not None`. For `implement-worktree-no-merge`, `write_behavior: always` is set. However, `WriteEvidence.has_evidence` is a pure OR that includes `fs_writes_detected` and `git_writes_detected`, which can be satisfied by infrastructure activity (worktree sidecar files, git divergence) independently of whether the agent wrote any code.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260531-080855-847653/.autoskillit/temp/rectify/rectify_false_success_infra_writes_2026-05-31_090000.md`

## Changed Files

### Modified (●):
- `src/autoskillit/core/types/_type_results.py`
- `src/autoskillit/execution/headless/_headless_evidence.py`
- `src/autoskillit/execution/headless/_headless_result.py`
- `src/autoskillit/recipe/skill_contracts.yaml`
- `tests/contracts/test_skill_contracts.py`
- `tests/core/types/test_type_results.py`
- `tests/execution/test_headless_result.py`
- `tests/execution/test_zero_write_detection.py`

Closes #3410

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 8.4k | 16.6k | 947.3k | 131.4k | 295 | 158.1k | 32m 4s |
| review_approach* | opus[1m] | 1 | 6.7k | 4.8k | 188.4k | 45.5k | 45 | 31.7k | 3m 24s |
| dry_walkthrough* | opus | 1 | 55 | 10.1k | 1.0M | 66.6k | 139 | 50.1k | 8m 57s |
| implement* | opus[1m] | 1 | 80 | 15.1k | 2.8M | 112.6k | 100 | 96.3k | 6m 44s |
| audit_impl* | opus[1m] | 1 | 46 | 12.4k | 369.2k | 53.2k | 61 | 39.1k | 6m 6s |
| prepare_pr* | opus[1m] | 1 | 47.7k | 3.6k | 157.8k | 0 | 18 | 0 | 43s |
| compose_pr* | opus[1m] | 1 | 51.1k | 1.8k | 218.8k | 0 | 18 | 0 | 53s |
| review_pr* | opus[1m] | 1 | 42 | 24.2k | 778.7k | 79.7k | 36 | 66.9k | 6m 42s |
| resolve_review* | opus[1m] | 1 | 60 | 8.2k | 1.5M | 74.4k | 49 | 58.3k | 7m 52s |
| **Total** | | | 114.2k | 96.8k | 8.0M | 131.4k | | 500.5k | 1h 13m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 241 | 11652.8 | 399.6 | 62.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 16 | 95760.1 | 3642.1 | 514.3 |
| **Total** | **257** | 31160.5 | 1947.5 | 376.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 8 | 114.2k | 86.8k | 7.0M | 450.4k | 1h 4m |
| opus | 1 | 55 | 10.1k | 1.0M | 50.1k | 8m 57s |