### PR TITLE
[FIX] Resolve-Review SKILL.md Inline Python Blocks Cause /tmp Scratch Writes

### DIFF
--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -40,7 +40,7 @@ branch already checked out.
 **NEVER:**
 - Fabricate, invent, or embellish information not supported by the available evidence or code.
 
-- Create files outside `{{AUTOSKILLIT_TEMP}}/resolve-review/`
+- Create files outside `{{AUTOSKILLIT_TEMP}}/resolve-review/` — never write to `/tmp`, `/var/tmp`, or any system scratch directory. All intermediate and scratch files belong in `{{AUTOSKILLIT_TEMP}}/resolve-review/`
 - Merge, push, or call `merge_worktree`
 - Fix issues beyond the explicit scope of the reviewer's comments
 - Exceed 3 fix-and-retest iterations
@@ -529,45 +529,33 @@ persistent local file for later posting when mode switches to `github`.
 Read the `iteration` field from `{{AUTOSKILLIT_TEMP}}/review-pr/local_findings_{pr_number}.json`
 to get the round number. If that file is absent, use `iteration = 0`.
 
-```python
-import json, pathlib
+Read `{{AUTOSKILLIT_TEMP}}/resolve-review/deferred_observations_${PR_NUMBER}.json` if it
+exists. If absent, start with an empty array.
 
-deferred_file = pathlib.Path("{{AUTOSKILLIT_TEMP}}/resolve-review/deferred_observations_${PR_NUMBER}.json")
+For each entry in `classification_map` with `verdict == "DISCUSS"` and `severity != "info"`,
+build an entry object:
 
-# Load existing entries if file exists
-existing = []
-if deferred_file.exists():
-    existing = json.loads(deferred_file.read_text())
-
-# Build new entries from classification_map (DISCUSS only, info-severity excluded)
-discuss_entries = []
-for c in classification_map.values():
-    if c.get("verdict") != "DISCUSS":
-        continue
-    if c.get("severity") == "info":
-        continue
-    entry = {
-        "round": iteration_number,
-        "path": c.get("path"),
-        "line": c.get("line"),
-        "body": c.get("body"),
-        "evidence": c.get("evidence", ""),
-        "severity": c["severity"],
-        "dimension": c.get("dimension", "unknown"),
-        "verdict": "DISCUSS",
-        "category": c.get("category", "design_decision"),
-    }
-    discuss_entries.append(entry)
-
-# Deduplicate: skip if (path, line, body) already in existing
-seen = {(e["path"], e["line"], e["body"]) for e in existing}
-new_entries = [e for e in discuss_entries if (e["path"], e["line"], e["body"]) not in seen]
-
-# Write atomically
-all_entries = existing + new_entries
-deferred_file.write_text(json.dumps(all_entries, indent=2))
-print(f"Accumulated {len(new_entries)} new DISCUSS findings ({len(all_entries)} total)")
+```json
+{
+  "round": "<iteration_number from local_findings>",
+  "path": "<path from classification_map entry>",
+  "line": "<line from classification_map entry>",
+  "body": "<body from classification_map entry>",
+  "evidence": "<evidence from classification_map entry, default empty string>",
+  "severity": "<severity from classification_map entry>",
+  "dimension": "<dimension from classification_map entry, default 'unknown'>",
+  "verdict": "DISCUSS",
+  "category": "<category from classification_map entry, default 'design_decision'>"
+}
 ```
+
+Deduplicate: skip any entry where `(path, line, body)` already exists in the loaded array.
+
+Append new entries to the loaded array and use the **Write tool** to save the result to
+`{{AUTOSKILLIT_TEMP}}/resolve-review/deferred_observations_${PR_NUMBER}.json` as
+pretty-printed JSON (indent 2).
+
+Log: `"Accumulated N new DISCUSS findings (M total)"`.
 
 Info-severity findings are acknowledged in the current round via Step 6.5's INFO reply template and are not carried forward to deferred observations. Only genuine DISCUSS verdicts from Step 3.5 sub-agent validation — representing findings that require a human design decision — are accumulated.
 
@@ -739,76 +727,62 @@ Track:
 After Step 6.5, save all REJECT-classified comments to a **stable, accumulating** JSON file
 (without timestamp — the same file is reused across local rounds):
 
-```python
-import json, pathlib
+Read `{{AUTOSKILLIT_TEMP}}/resolve-review/reject_patterns_${PR_NUMBER}.json` if it exists.
+If absent, start with an empty array.
 
-reject_file = pathlib.Path("{{AUTOSKILLIT_TEMP}}/resolve-review/reject_patterns_${PR_NUMBER}.json")
+For each entry in `classification_map` with `verdict == "REJECT"`, build an entry object.
+Use the entry's `comment_id` if present; otherwise use `"local_unknown_{index}"` as a
+synthetic identifier:
 
-# Load existing entries if file exists
-existing = []
-if reject_file.exists():
-    existing = json.loads(reject_file.read_text())
-
-# Build new entries — use synthetic comment_id for local-mode findings
-# Format: "local_{iteration}_{index}" derived from iteration in local_findings + index
-reject_entries = []
-for idx, c in enumerate(classification_map.values()):
-    if c.get("verdict") != "REJECT":
-        continue
-    # Build synthetic comment_id from local finding source
-    comment_id = c.get("comment_id", f"local_unknown_{idx}")
-    entry = {
-        "comment_id": comment_id,
-        "path": c.get("path"),
-        "line": c.get("line"),
-        "body": c.get("body"),
-        "evidence": c.get("evidence", ""),
-        "category": c.get("category", "other"),
-        "pr_number": ${PR_NUMBER},
-        "feature_branch": "${feature_branch}",
-    }
-    reject_entries.append(entry)
-
-# Deduplicate: skip if (path, line, body) already in existing
-seen = {(e["path"], e["line"], e["body"]) for e in existing}
-new_entries = [e for e in reject_entries if (e["path"], e["line"], e["body"]) not in seen]
-
-# Write atomically
-all_entries = existing + new_entries
-reject_file.write_text(json.dumps(all_entries, indent=2))
-print(f"Accumulated {len(new_entries)} new REJECT patterns ({len(all_entries)} total)")
+```json
+{
+  "comment_id": "<comment_id or synthetic 'local_unknown_{index}'>",
+  "path": "<path from classification_map entry>",
+  "line": "<line from classification_map entry>",
+  "body": "<body from classification_map entry>",
+  "evidence": "<evidence from classification_map entry, default empty string>",
+  "category": "<category from classification_map entry, default 'other'>",
+  "pr_number": "<PR_NUMBER>",
+  "feature_branch": "<feature_branch>"
+}
 ```
+
+Deduplicate: skip any entry where `(path, line, body)` already exists in the loaded array.
+
+Append new entries to the loaded array and use the **Write tool** to save the result to
+`{{AUTOSKILLIT_TEMP}}/resolve-review/reject_patterns_${PR_NUMBER}.json` as pretty-printed
+JSON (indent 2).
+
+Log: `"Accumulated N new REJECT patterns (M total)"`.
 
 **Note:** In local mode, `comment_id` may not be a GitHub database ID. Use whatever ID
 is in the classification_map entry. If the finding came from `local_findings_{pr_number}.json`
 and has no native ID, use `"local_{iteration}_{index}"` as a synthetic identifier.
 
-**When `mode=github`:** Execute the following current behavior (timestamped, one-shot write).
+**When `mode=github`:** Save REJECT-classified comments with a timestamped filename
+(one-shot write, not accumulating).
 
-```bash
-ts=$(date +%Y%m%d-%H%M%S)
-python3 -c "
-import json, pathlib
-reject_entries = [
-    {
-        'comment_id': c['comment_id'],
-        'path': c['path'],
-        'line': c['line'],
-        'body': c['body'],
-        'evidence': c['evidence'],
-        'category': c['category'],
-        'pr_number': ${PR_NUMBER},
-        'feature_branch': '${feature_branch}',
-    }
-    for c in classification_map.values()
-    if c['verdict'] == 'REJECT'
-]
-pathlib.Path('{{AUTOSKILLIT_TEMP}}/resolve-review/reject_patterns_${PR_NUMBER}_${ts}.json').write_text(
-    json.dumps(reject_entries, indent=2)
-)
-print(f'Saved {len(reject_entries)} reject patterns')
-"
+For each entry in `classification_map` with `verdict == "REJECT"`, build an entry object:
+
+```json
+{
+  "comment_id": "<comment_id from classification_map entry>",
+  "path": "<path from classification_map entry>",
+  "line": "<line from classification_map entry>",
+  "body": "<body from classification_map entry>",
+  "evidence": "<evidence from classification_map entry>",
+  "category": "<category from classification_map entry>",
+  "pr_number": "<PR_NUMBER>",
+  "feature_branch": "<feature_branch>"
+}
 ```
+
+Use the **Write tool** to save the array to
+`{{AUTOSKILLIT_TEMP}}/resolve-review/reject_patterns_${PR_NUMBER}_${YYYYMMDD-HHMMSS}.json`
+as pretty-printed JSON (indent 2). Generate the timestamp suffix using
+`date +%Y%m%d-%H%M%S` in a Bash call before writing.
+
+Log: `"Saved N reject patterns"`.
 
 ### Step 7: Report
 

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -532,6 +532,9 @@ to get the round number. If that file is absent, use `iteration = 0`.
 Read `{{AUTOSKILLIT_TEMP}}/resolve-review/deferred_observations_${PR_NUMBER}.json` if it
 exists. If absent, start with an empty array.
 
+**CRITICAL:** Do NOT output any prose status text between iterations. Collect all entries,
+deduplicate, then use a single Write tool call to persist the result.
+
 For each entry in `classification_map` with `verdict == "DISCUSS"` and `severity != "info"`,
 build an entry object:
 
@@ -730,6 +733,9 @@ After Step 6.5, save all REJECT-classified comments to a **stable, accumulating*
 Read `{{AUTOSKILLIT_TEMP}}/resolve-review/reject_patterns_${PR_NUMBER}.json` if it exists.
 If absent, start with an empty array.
 
+**CRITICAL:** Do NOT output any prose status text between iterations. Collect all entries,
+deduplicate, then use a single Write tool call to persist the result.
+
 For each entry in `classification_map` with `verdict == "REJECT"`, build an entry object.
 Use the entry's `comment_id` if present; otherwise use `"local_unknown_{index}"` as a
 synthetic identifier:
@@ -761,6 +767,9 @@ and has no native ID, use `"local_{iteration}_{index}"` as a synthetic identifie
 
 **When `mode=github`:** Save REJECT-classified comments with a timestamped filename
 (one-shot write, not accumulating).
+
+**CRITICAL:** Do NOT output any prose status text. Collect all entries and use a single
+Write tool call to persist the result.
 
 For each entry in `classification_map` with `verdict == "REJECT"`, build an entry object:
 

--- a/tests/contracts/CLAUDE.md
+++ b/tests/contracts/CLAUDE.md
@@ -83,6 +83,7 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `test_zero_change_circuit_breaker_contracts.py` | Contract tests: zero-change circuit breaker in implementation/remediation recipes |
 | `test_fetch_issue_mock_contracts.py` | Contract test: all fetch_issue mock return values must include a 'state' field |
 | `test_review_pr_severity_calibration.py` | Contract test: review-pr SKILL.md must contain severity calibration examples and grouping rule |
+| `test_resolve_review_no_inline_python.py` | Contract: resolve-review SKILL.md must not contain python3 -c invocations or ```python blocks with .write_text() |
 | `test_dry_walkthrough_transformation_extent.py` | Contract test: dry-walkthrough SKILL.md Step 2 must check transformation extent/scope |
 | `test_download_data_contracts.py` | Contract tests for download-data SKILL.md — external dataset acquisition step |
 

--- a/tests/contracts/test_resolve_review_no_inline_python.py
+++ b/tests/contracts/test_resolve_review_no_inline_python.py
@@ -4,43 +4,43 @@ from __future__ import annotations
 
 import re
 
+import pytest
+
 from tests.contracts.conftest import _all_skill_mds
 
-_RESOLVE_REVIEW_CONTENT: str | None = None
-for _name, _content in _all_skill_mds():
-    if _name == "resolve-review":
-        _RESOLVE_REVIEW_CONTENT = _content
-        break
+
+@pytest.fixture()
+def resolve_review_content() -> str:
+    for name, content in _all_skill_mds():
+        if name == "resolve-review":
+            return content
+    pytest.fail("resolve-review SKILL.md not found")
 
 
 class TestResolveReviewNoInlinePython:
-    def test_no_python3_c_invocations(self) -> None:
+    def test_no_python3_c_invocations(self, resolve_review_content: str) -> None:
         """resolve-review SKILL.md must not use python3 -c (causes /tmp scratch writes)."""
-        assert _RESOLVE_REVIEW_CONTENT is not None, "resolve-review SKILL.md not found"
-        matches = re.findall(r"python3\s+-c\b", _RESOLVE_REVIEW_CONTENT)
+        matches = re.findall(r"python3\s+-c\b", resolve_review_content)
         assert matches == [], (
             f"Found {len(matches)} python3 -c invocation(s) in resolve-review SKILL.md. "
             "These cause agents to materialize scratch scripts in /tmp. "
             "Use declarative Write-tool instructions instead."
         )
 
-    def test_python_blocks_no_write_text(self) -> None:
+    def test_python_blocks_no_write_text(self, resolve_review_content: str) -> None:
         """```python blocks must not contain .write_text() (agents try to execute them)."""
-        assert _RESOLVE_REVIEW_CONTENT is not None, "resolve-review SKILL.md not found"
-        # Extract content inside ```python ... ``` fences
-        python_blocks = re.findall(r"```python\s*\n(.*?)```", _RESOLVE_REVIEW_CONTENT, re.DOTALL)
+        python_blocks = re.findall(r"```python\s*\n(.*?)```", resolve_review_content, re.DOTALL)
         for i, block in enumerate(python_blocks):
             assert ".write_text(" not in block, (
                 f"```python block #{i + 1} contains .write_text() — agents may try to "
                 "execute this as a script. Use declarative Write-tool instructions instead."
             )
 
-    def test_never_constraint_mentions_tmp(self) -> None:
+    def test_never_constraint_mentions_tmp(self, resolve_review_content: str) -> None:
         """NEVER constraint must explicitly prohibit /tmp scratch files."""
-        assert _RESOLVE_REVIEW_CONTENT is not None, "resolve-review SKILL.md not found"
         never_section = re.search(
-            r"\*\*NEVER:\*\*\s*\n(.*?)(?:\n\*\*ALWAYS:\*\*|\n##)",
-            _RESOLVE_REVIEW_CONTENT,
+            r"\*\*NEVER:\*\*\s*\n(.*?)(?:\n\*\*ALWAYS:\*\*|\n##|\Z)",
+            resolve_review_content,
             re.DOTALL,
         )
         assert never_section is not None, "NEVER section not found in SKILL.md"

--- a/tests/contracts/test_resolve_review_no_inline_python.py
+++ b/tests/contracts/test_resolve_review_no_inline_python.py
@@ -1,0 +1,50 @@
+"""Contract: resolve-review SKILL.md must not contain python3 -c invocations."""
+
+from __future__ import annotations
+
+import re
+
+from tests.contracts.conftest import _all_skill_mds
+
+_RESOLVE_REVIEW_CONTENT: str | None = None
+for _name, _content in _all_skill_mds():
+    if _name == "resolve-review":
+        _RESOLVE_REVIEW_CONTENT = _content
+        break
+
+
+class TestResolveReviewNoInlinePython:
+    def test_no_python3_c_invocations(self) -> None:
+        """resolve-review SKILL.md must not use python3 -c (causes /tmp scratch writes)."""
+        assert _RESOLVE_REVIEW_CONTENT is not None, "resolve-review SKILL.md not found"
+        matches = re.findall(r"python3\s+-c\b", _RESOLVE_REVIEW_CONTENT)
+        assert matches == [], (
+            f"Found {len(matches)} python3 -c invocation(s) in resolve-review SKILL.md. "
+            "These cause agents to materialize scratch scripts in /tmp. "
+            "Use declarative Write-tool instructions instead."
+        )
+
+    def test_python_blocks_no_write_text(self) -> None:
+        """```python blocks must not contain .write_text() (agents try to execute them)."""
+        assert _RESOLVE_REVIEW_CONTENT is not None, "resolve-review SKILL.md not found"
+        # Extract content inside ```python ... ``` fences
+        python_blocks = re.findall(r"```python\s*\n(.*?)```", _RESOLVE_REVIEW_CONTENT, re.DOTALL)
+        for i, block in enumerate(python_blocks):
+            assert ".write_text(" not in block, (
+                f"```python block #{i + 1} contains .write_text() — agents may try to "
+                "execute this as a script. Use declarative Write-tool instructions instead."
+            )
+
+    def test_never_constraint_mentions_tmp(self) -> None:
+        """NEVER constraint must explicitly prohibit /tmp scratch files."""
+        assert _RESOLVE_REVIEW_CONTENT is not None, "resolve-review SKILL.md not found"
+        never_section = re.search(
+            r"\*\*NEVER:\*\*\s*\n(.*?)(?:\n\*\*ALWAYS:\*\*|\n##)",
+            _RESOLVE_REVIEW_CONTENT,
+            re.DOTALL,
+        )
+        assert never_section is not None, "NEVER section not found in SKILL.md"
+        never_text = never_section.group(1)
+        assert "/tmp" in never_text, (
+            "NEVER constraint must explicitly mention /tmp to prevent scratch-file writes"
+        )


### PR DESCRIPTION
## Summary

The resolve-review SKILL.md presents executable-looking Python code blocks that agents attempt to materialize as scratch scripts in `/tmp`, which is outside the permitted session write prefix. Three blocks are affected:

1. **Step 6.6 `mode=github`** (lines 788–811): A `python3 -c` bash block referencing `classification_map.values()` — an in-memory agent variable that doesn't exist in a subprocess. Semantically broken AND triggers `/tmp` scratch writes.
2. **Step 3.6** (lines 532–570): A ` ```python ` block for DISCUSS finding accumulation that agents may treat as executable code and write to `/tmp` as a scratch file.
3. **Step 6.6 `mode=local`** (lines 742–780): A ` ```python ` block for REJECT pattern accumulation with the same risk.

All three blocks will be refactored to use declarative Write-tool instructions with JSON schema templates — the established pattern used by other skills (analyze-pipeline-health, prepare-pr, select-directions, review-pr). The NEVER constraint will be strengthened to explicitly prohibit `/tmp` and scratch-file creation.

## Requirements

(No separate requirements section in closing issue — closing issue is a self-contained plan.)

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260531-092335-621201/.autoskillit/temp/make-plan/resolve_review_skillmd_inline_python_blocks_plan_2026-05-31_093700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 5.2k | 11.8k | 1.2M | 118.5k | 118 | 123.1k | 10m 38s |
| review_approach* | opus | 1 | 1.4k | 3.8k | 173.3k | 36.8k | 38 | 22.2k | 4m 15s |
| verify* | opus | 1 | 69 | 6.3k | 583.8k | 62.4k | 93 | 45.7k | 3m 54s |
| implement* | opus | 1 | 1.8M | 11.8k | 1.3M | 33.8k | 130 | 94.5k | 15m 40s |
| audit_impl* | opus | 1 | 401 | 8.4k | 210.7k | 38.9k | 45 | 32.1k | 4m 41s |
| prepare_pr* | opus | 1 | 88.1k | 3.3k | 197.2k | 28.2k | 23 | 42.0k | 1m 23s |
| compose_pr* | opus | 1 | 39.9k | 1.7k | 182.9k | 0 | 16 | 0 | 27s |
| review_pr* | opus | 2 | 87 | 37.2k | 1.6M | 72.5k | 82 | 110.2k | 10m 14s |
| resolve_review* | opus | 1 | 42 | 5.7k | 744.1k | 55.8k | 33 | 39.7k | 6m 35s |
| resolve_pre_review_conflicts* | opus | 1 | 31 | 2.9k | 448.9k | 40.0k | 26 | 23.3k | 1m 11s |
| **Total** | | | 1.9M | 92.8k | 6.6M | 118.5k | | 532.7k | 59m 3s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 230 | 5530.6 | 410.9 | 51.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 32 | 23254.2 | 1239.4 | 177.9 |
| resolve_pre_review_conflicts | 1352 | 332.0 | 17.2 | 2.1 |
| **Total** | **1614** | 4088.0 | 330.1 | 57.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 5.2k | 11.8k | 1.2M | 123.1k | 10m 38s |
| opus | 9 | 1.9M | 81.1k | 5.4M | 409.7k | 48m 24s |