### PR TITLE
Narrow hooks/ Cascade — Remove fleet/infra, Narrow cli/server to File-Level

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -717,10 +717,11 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
     "hooks": frozenset(
         {
             "hooks",
-            "infra",
-            "cli",
-            "fleet",
-            "server",
+            "cli/test_cli_hooks.py",
+            "cli/test_install.py",
+            "server/test_kitchen_lifecycle.py",
+            "server/test_tools_kitchen_gate.py",
+            "server/test_tools_kitchen_gate_hook_config.py",
             "execution/test_quota_sleep.py",
         }
     ),


### PR DESCRIPTION
## Summary

Replace over-broad directory entries in `LAYER_CASCADE_CONSERVATIVE["hooks"]` with precise file-level entries. Remove `fleet` (zero hooks imports), remove `infra` (redundant with tiered-always-run), and replace `cli` and `server` directory entries with the specific test files that actually import from `autoskillit.hooks`. Saves ~3,800 tests per hooks/ change.

## Requirements

## Problem

Current entry at `tests/_test_filter.py:717-726`:
```python
"hooks": frozenset({
    "hooks",
    "infra",
    "cli",
    "fleet",
    "server",
    "execution/test_quota_sleep.py",
})
```

| Entry | Tests | Justified? | Evidence |
|-------|-------|-----------|----------|
| `hooks` | 446 | YES | Direct tests |
| `infra` | 666 | NO — redundant | The tiered-always-run logic (lines 1485-1491) adds `infra/` when any `src/autoskillit/hooks/` file appears in changed_files — the same condition that triggers this cascade entry. So infra/ is already covered. |
| `cli` | 1,102 | Mostly NO | Only 2 cli test files import from `autoskillit.hooks`: `test_cli_hooks.py` and `test_install.py` |
| `fleet` | 725 | NO | Zero fleet test files import `autoskillit.hooks` (grep verified) |
| `server` | 1,487 | Mostly NO | Only 3 server test files import from `autoskillit.hooks`: `test_kitchen_lifecycle.py`, `test_tools_kitchen_gate.py`, `test_tools_kitchen_gate_hook_config.py` |
| `execution/test_quota_sleep.py` | ~5 | YES | File-level, already correct |

## Proposed Fix

```python
"hooks": frozenset({
    "hooks",
    # infra/ REMOVED — already added by tiered-always-run when hooks/ changes
    # fleet/ REMOVED — zero fleet tests import hooks
    "cli/test_cli_hooks.py",
    "cli/test_install.py",
    "server/test_kitchen_lifecycle.py",
    "server/test_tools_kitchen_gate.py",
    "server/test_tools_kitchen_gate_hook_config.py",
    "execution/test_quota_sleep.py",
})
```

## Acceptance Criteria

- [ ] `fleet` removed from hooks cascade
- [ ] `infra` removed (verified redundant with tiered-always-run)
- [ ] `cli` replaced with 2 file-level entries
- [ ] `server` replaced with 3 file-level entries
- [ ] `TestFileLevelCascadeDriftGuard` passes
- [ ] All existing tests pass

Closes #3433

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260531-104747-137576/.autoskillit/temp/make-plan/narrow_hooks_cascade_plan_2026-05-31_110500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 64 | 6.3k | 403.8k | 47.2k | 40 | 32.8k | 3m 23s |
| verify* | sonnet | 1 | 131 | 5.7k | 220.2k | 40.0k | 48 | 23.6k | 3m 9s |
| implement* | sonnet | 1 | 96.0k | 2.4k | 278.7k | 28.2k | 23 | 16.4k | 1m 10s |
| audit_impl* | sonnet | 1 | 76 | 5.2k | 279.8k | 37.3k | 24 | 23.7k | 1m 54s |
| prepare_pr* | sonnet | 1 | 107.7k | 4.0k | 335.0k | 28.2k | 25 | 16.0k | 1m 31s |
| compose_pr* | sonnet | 1 | 39.1k | 1.8k | 166.1k | 28.2k | 13 | 15.5k | 39s |
| review_pr* | sonnet | 3 | 386 | 50.1k | 2.0M | 73.2k | 182 | 121.4k | 15m 2s |
| **Total** | | | 243.4k | 75.5k | 3.6M | 73.2k | | 249.4k | 26m 51s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 9 | 30962.1 | 1818.2 | 263.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **9** | 405536.9 | 27710.4 | 8389.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 64 | 6.3k | 403.8k | 32.8k | 3m 23s |
| sonnet | 6 | 243.4k | 69.2k | 3.2M | 216.5k | 23m 27s |