### PR TITLE
Narrow workspace/ Cascade — Remove fleet, Narrow server to File-Level

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -612,8 +612,12 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
         {
             "workspace",
             "recipe",
-            "fleet",
-            "server",
+            # Server file-level entries (5 of ~52 import autoskillit.workspace):
+            "server/test_factory.py",
+            "server/test_tools_clone.py",
+            "server/test_tools_execution_routing.py",
+            "server/test_run_skill_add_dirs.py",
+            "server/test_tools_workspace.py",
             "cli",
             "skills",
             "_llm_triage",

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -612,7 +612,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
         {
             "workspace",
             "recipe",
-            # Server file-level entries (5 of ~52 import autoskillit.workspace):
+            # Server file-level entries:
             "server/test_factory.py",
             "server/test_tools_clone.py",
             "server/test_tools_execution_routing.py",


### PR DESCRIPTION
## Summary

Narrow `LAYER_CASCADE_CONSERVATIVE["workspace"]` by removing the unjustified `fleet` directory entry, replacing the over-broad `server` directory entry with 5 file-level entries, and keeping `cli` as a directory entry. This removes ~2,025 unnecessary tests from workspace-scoped filter runs.

**Verified facts:**
- **fleet**: Zero fleet test files import `autoskillit.workspace` (source or test side). Removal is unconditionally safe.
- **server**: Exactly 5 of ~52 server test files import `autoskillit.workspace`: `test_factory.py`, `test_run_skill_add_dirs.py`, `test_tools_execution_routing.py`, `test_tools_clone.py`, `test_tools_workspace.py`.
- **cli**: 3 files have AST-level imports (`test_workspace.py`, `test_reload_loop.py`, `test_cook_interactive.py`). 4 additional files reference workspace via string-based `patch()` / `monkeypatch.setattr()` calls. Only the 3 AST-importing files can be file-level entries per REQ-GUARD-006; the guard constraints make file-level narrowing impossible for cli without modifying the guard.

**Final plan:**
- Remove `fleet` (saves 725 tests)
- Replace `server` with 5 file-level entries (saves ~1,300 tests)
- Keep `cli` as directory entry (guard constraints)
- **Total savings: ~2,025 tests**

Closes #3434

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260531-104749-028958/.autoskillit/temp/make-plan/narrow_workspace_cascade_plan_2026-05-31_110200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 2.0k | 9.1k | 924.5k | 60.6k | 78 | 47.2k | 5m 13s |
| verify* | sonnet | 1 | 76 | 7.0k | 300.2k | 41.2k | 35 | 24.7k | 2m 23s |
| implement* | sonnet | 1 | 107.1k | 1.9k | 278.6k | 28.2k | 20 | 16.5k | 1m 6s |
| audit_impl* | sonnet | 1 | 60 | 6.6k | 210.7k | 37.2k | 28 | 22.7k | 3m 5s |
| prepare_pr* | sonnet | 1 | 122.2k | 3.6k | 335.0k | 28.2k | 24 | 15.9k | 1m 32s |
| compose_pr* | sonnet | 1 | 59.3k | 1.9k | 194.2k | 28.2k | 18 | 15.6k | 48s |
| review_pr* | sonnet | 3 | 1.1k | 66.2k | 2.7M | 68.3k | 170 | 139.8k | 16m 52s |
| resolve_review* | sonnet | 1 | 245 | 8.6k | 1.3M | 54.0k | 64 | 38.0k | 4m 18s |
| resolve_pre_review_conflicts* | sonnet | 1 | 100 | 2.8k | 386.9k | 37.2k | 34 | 20.9k | 1m 7s |
| **Total** | | | 292.1k | 107.7k | 6.6M | 68.3k | | 341.4k | 36m 26s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 8 | 34830.1 | 2058.5 | 235.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 663944.0 | 18992.5 | 4294.0 |
| resolve_pre_review_conflicts | 15 | 25792.2 | 1393.3 | 189.3 |
| **Total** | **25** | 264587.0 | 13654.0 | 4306.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.0k | 9.1k | 924.5k | 47.2k | 5m 13s |
| sonnet | 8 | 290.1k | 98.6k | 5.7M | 294.2k | 31m 13s |