### PR TITLE
Add MODULE_CASCADE_CONFIG for Per-Module Config Test Filtering

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -182,6 +182,7 @@ tests/
 ├── test_smoke_utils.py
 ├── test_test_filter.py
 ├── test_test_filter_cascade.py
+├── test_test_filter_config_cascade.py
 ├── test_test_filter_content_aware.py
 ├── test_test_filter_core_cascade.py
 ├── test_test_filter_coverage_map.py

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -370,6 +370,11 @@ SUBPKG_CASCADE_EXECUTION: dict[str, frozenset[str]] = {
     "backends": frozenset({"execution", "integration"}),
 }
 
+MODULE_CASCADE_CONFIG: dict[str, frozenset[str]] = {
+    "_config_loader": frozenset({"config", "cli"}),
+    "ingredient_defaults": frozenset({"config", "recipe"}),
+}
+
 MODULE_CASCADE_RECIPE: dict[str, frozenset[str]] = {
     # --- Narrowest: recipe/ only (no out-of-recipe importers) ---
     "rules_actions": frozenset({"recipe"}),
@@ -1368,6 +1373,14 @@ def build_test_scope(
                     test_dirs.update(MODULE_CASCADE_RECIPE[stem])
                 else:
                     test_dirs.update(cascade_map["recipe"])  # fail-open
+            elif pkg == "config" and mode == FilterMode.CONSERVATIVE:
+                stem = Path(f).stem
+                if stem in MODULE_CASCADE_CONFIG:
+                    test_dirs.update(MODULE_CASCADE_CONFIG[stem])
+                else:
+                    test_dirs.update(
+                        cascade_map["config"]
+                    )  # fail-open: __init__, settings, _config_dataclasses, etc.
             elif pkg and pkg in cascade_map:
                 test_dirs.update(cascade_map[pkg])
             else:
@@ -1485,6 +1498,27 @@ def build_test_scope(
                             test_dirs.update(MODULE_CASCADE_RECIPE[stem])
                         else:
                             test_dirs.update(cascade_map["recipe"])  # fail-open
+                    elif pkg == "config" and mode == FilterMode.CONSERVATIVE:
+                        stem = Path(f).stem
+                        if stem == "__init__":
+                            config_cause_stems = {
+                                Path(c).stem
+                                for c in changed_src_py
+                                if _file_to_package(c) == "config" and Path(c).stem != "__init__"
+                            }
+                            if config_cause_stems and all(
+                                s in MODULE_CASCADE_CONFIG for s in config_cause_stems
+                            ):
+                                for s in config_cause_stems:
+                                    test_dirs.update(MODULE_CASCADE_CONFIG[s])
+                            else:
+                                if not config_cause_stems:
+                                    logging.getLogger(__name__).debug(  # noqa: TID251
+                                        "config/__init__ backtrace: no non-init config cause stems"
+                                        " — failing open to full config cascade (expected behavior"
+                                        " when only config/__init__.py changed)"
+                                    )
+                                test_dirs.update(cascade_map["config"])  # fail-open
                     elif pkg and pkg in cascade_map:
                         test_dirs.update(cascade_map[pkg])
         except Exception:

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -1519,6 +1519,12 @@ def build_test_scope(
                                         " when only config/__init__.py changed)"
                                     )
                                 test_dirs.update(cascade_map["config"])  # fail-open
+                        elif stem in MODULE_CASCADE_CONFIG:
+                            test_dirs.update(MODULE_CASCADE_CONFIG[stem])
+                        else:
+                            test_dirs.update(
+                                cascade_map["config"]
+                            )  # fail-open: non-__init__ unmapped config stems
                     elif pkg and pkg in cascade_map:
                         test_dirs.update(cascade_map[pkg])
         except Exception:

--- a/tests/arch/test_cascade_map_guard.py
+++ b/tests/arch/test_cascade_map_guard.py
@@ -16,6 +16,7 @@ import pytest
 from tests._test_filter import (
     LAYER_CASCADE_AGGRESSIVE,
     LAYER_CASCADE_CONSERVATIVE,
+    MODULE_CASCADE_CONFIG,
     MODULE_CASCADE_CORE,
     MODULE_CASCADE_EXECUTION,
     MODULE_CASCADE_RECIPE,
@@ -242,6 +243,11 @@ def _build_recipe_module_reverse_graph() -> dict[str, set[str]]:
     return graph
 
 
+def _build_config_module_reverse_graph() -> dict[str, set[str]]:
+    """REQ-GUARD-001 (module level, config). Returns {stem: set[consuming_pkg]}."""
+    return _build_pkg_module_reverse_graph("config", _build_reexport_map("config"))
+
+
 class TestModuleCascadeCoreGuard:
     """REQ-GUARD-002: MODULE_CASCADE_CORE declared sets must be supersets of actual consumers."""
 
@@ -355,6 +361,43 @@ class TestModuleCascadeRecipeGuard:
         )
 
 
+class TestModuleCascadeConfigGuard:
+    """REQ-CONFIG-001: Validate MODULE_CASCADE_CONFIG against actual AST imports."""
+
+    def test_module_cascade_config_is_superset_of_ast_consumers(self) -> None:
+        graph = _build_config_module_reverse_graph()
+        violations: dict[str, dict[str, list[str]]] = {}
+        for stem, declared in MODULE_CASCADE_CONFIG.items():
+            actual = graph.get(stem, set())
+            declared_dirs = {d for d in declared if "/" not in d}
+            file_prefixes = {d.split("/", 1)[0] for d in declared if "/" in d}
+            covered = declared_dirs | file_prefixes
+            missing = actual - covered
+            if missing:
+                violations[stem] = {
+                    "declared": sorted(declared),
+                    "actual": sorted(actual),
+                    "missing": sorted(missing),
+                }
+        assert not violations, (
+            "MODULE_CASCADE_CONFIG entries are too narrow — update tests/_test_filter.py:\n"
+            + "\n".join(
+                f"  {stem}: add {v['missing']} (declared={v['declared']}, actual={v['actual']})"
+                for stem, v in sorted(violations.items())
+            )
+        )
+
+    def test_module_cascade_config_has_no_phantom_stems(self) -> None:
+        graph = _build_config_module_reverse_graph()
+        phantoms = [stem for stem in MODULE_CASCADE_CONFIG if not graph.get(stem)]
+        assert not phantoms, (
+            "MODULE_CASCADE_CONFIG contains stems with zero AST consumers — "
+            "the source file may have been renamed or deleted:\n"
+            f"  {sorted(phantoms)}\n"
+            "Remove the stale entry or rename it to match the current module."
+        )
+
+
 _TESTS_ROOT = Path(__file__).parent.parent
 
 
@@ -439,6 +482,89 @@ class TestModuleCascadeRecipeNarrowing:
         layer_dirs = {
             entry
             for entry in LAYER_CASCADE_CONSERVATIVE["recipe"]
+            if "/" not in entry and (_TESTS_ROOT / entry).is_dir()
+        }
+        for entry in layer_dirs:
+            assert any(entry in s for s in scope_strs), (
+                f"Mixed stems should fail-open; missing '{entry}'"
+            )
+
+
+class TestModuleCascadeConfigNarrowing:
+    """Validate that MODULE_CASCADE_CONFIG actually narrows scope in build_test_scope."""
+
+    def test_narrow_config_module_narrows_scope(self) -> None:
+        from tests._test_filter import FilterMode, build_test_scope
+
+        scope = build_test_scope(
+            changed_files={"src/autoskillit/config/_config_loader.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=_TESTS_ROOT,
+        )
+        assert not isinstance(scope, str)
+        assert any("config" in str(p) for p in scope)
+        layer_only = {"execution", "fleet", "pipeline", "workspace"}
+        dir_scope_names = {p.name for p in scope if p.is_dir()}
+        assert not (layer_only & dir_scope_names), (
+            f"_config_loader.py should narrow but got dirs: {dir_scope_names}"
+        )
+
+    def test_config_init_change_fails_open_to_layer_cascade(self) -> None:
+        from tests._test_filter import FilterMode, build_test_scope
+
+        scope = build_test_scope(
+            changed_files={"src/autoskillit/config/__init__.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=_TESTS_ROOT,
+        )
+        assert not isinstance(scope, str)
+        dir_scope_names = {p.name for p in scope if p.is_dir()}
+        assert "config" in dir_scope_names
+
+    def test_unmapped_config_stem_fails_open_to_layer_cascade(self) -> None:
+        from tests._test_filter import (
+            LAYER_CASCADE_CONSERVATIVE,
+            FilterMode,
+            build_test_scope,
+        )
+
+        scope = build_test_scope(
+            changed_files={"src/autoskillit/config/settings.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=_TESTS_ROOT,
+        )
+        assert not isinstance(scope, str)
+        scope_strs = {str(p) for p in scope}
+        layer_dirs = {
+            entry
+            for entry in LAYER_CASCADE_CONSERVATIVE["config"]
+            if "/" not in entry and (_TESTS_ROOT / entry).is_dir()
+        }
+        for entry in layer_dirs:
+            assert any(entry in s for s in scope_strs), (
+                f"Fail-open should include '{entry}' from LAYER_CASCADE"
+            )
+
+    def test_mixed_mapped_and_unmapped_config_stems_fail_open(self) -> None:
+        from tests._test_filter import (
+            LAYER_CASCADE_CONSERVATIVE,
+            FilterMode,
+            build_test_scope,
+        )
+
+        scope = build_test_scope(
+            changed_files={
+                "src/autoskillit/config/_config_loader.py",
+                "src/autoskillit/config/settings.py",
+            },
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=_TESTS_ROOT,
+        )
+        assert not isinstance(scope, str)
+        scope_strs = {str(p) for p in scope}
+        layer_dirs = {
+            entry
+            for entry in LAYER_CASCADE_CONSERVATIVE["config"]
             if "/" not in entry and (_TESTS_ROOT / entry).is_dir()
         }
         for entry in layer_dirs:

--- a/tests/test_test_filter_config_cascade.py
+++ b/tests/test_test_filter_config_cascade.py
@@ -1,0 +1,214 @@
+"""REQ-CONFIG-001..003: module-level cascade map for config/ submodules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests._test_filter import (
+    MODULE_CASCADE_CONFIG,
+    FilterMode,
+    build_test_scope,
+)
+
+_ALL_DIRS = [
+    "core",
+    "config",
+    "execution",
+    "pipeline",
+    "workspace",
+    "recipe",
+    "migration",
+    "fleet",
+    "server",
+    "cli",
+    "hooks",
+    "skills",
+    "arch",
+    "contracts",
+    "infra",
+    "docs",
+]
+
+
+def test_all_entries_present() -> None:
+    expected = {"_config_loader", "ingredient_defaults"}
+    assert expected <= set(MODULE_CASCADE_CONFIG.keys())
+
+
+class TestModuleCascadeConfig:
+    def test_all_values_are_frozensets(self) -> None:
+        for stem, consumers in MODULE_CASCADE_CONFIG.items():
+            assert isinstance(consumers, frozenset), f"{stem} value must be frozenset"
+
+    def test_all_consumers_include_config(self) -> None:
+        for stem, consumers in MODULE_CASCADE_CONFIG.items():
+            assert "config" in consumers, f"{stem} cascade must include 'config'"
+
+
+class TestBuildTestScopeConfigCascade:
+    ALL_DIRS = _ALL_DIRS
+
+    def _make_tests_root(self, tmp_path: Path, dirs: list[str]) -> Path:
+        tests_root = tmp_path / "tests"
+        for d in dirs:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+        return tests_root
+
+    def test_narrow_config_module_uses_narrow_scope(self, tmp_path: Path) -> None:
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/config/_config_loader.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "config" in dir_names
+        for excluded in ["execution", "fleet", "pipeline", "workspace"]:
+            assert excluded not in dir_names, (
+                f"narrow cascade for _config_loader should not include {excluded}"
+            )
+        assert "arch" in dir_names
+        assert "contracts" in dir_names
+
+    def test_ingredient_defaults_uses_narrow_scope(self, tmp_path: Path) -> None:
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/config/ingredient_defaults.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "config" in dir_names
+        for excluded in ["execution", "fleet", "pipeline", "workspace"]:
+            assert excluded not in dir_names, (
+                f"narrow cascade for ingredient_defaults should not include {excluded}"
+            )
+
+    def test_settings_falls_through_to_full_cascade(self, tmp_path: Path) -> None:
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/config/settings.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["config", "execution", "server", "cli"]:
+            assert pkg in dir_names, f"fail-open cascade for settings.py should include {pkg}"
+
+    def test_config_dataclasses_falls_through_to_full_cascade(self, tmp_path: Path) -> None:
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/config/_config_dataclasses.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["config", "execution", "server", "cli"]:
+            assert pkg in dir_names
+
+    def test_config_init_triggers_full_cascade(self, tmp_path: Path) -> None:
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/config/__init__.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["config", "execution", "server", "cli"]:
+            assert pkg in dir_names
+
+    def test_aggressive_mode_skips_config_cascade_branch(self, tmp_path: Path) -> None:
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/config/_config_loader.py"},
+            mode=FilterMode.AGGRESSIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "config" in dir_names
+        for excluded in ["execution", "fleet", "pipeline", "workspace", "server", "cli"]:
+            assert excluded not in dir_names
+
+
+class TestClosureConfigNarrowCascade:
+    ALL_DIRS = _ALL_DIRS
+
+    def _make_config_layout(self, tmp_path: Path, modules: dict[str, str]) -> Path:
+        config_dir = tmp_path / "src" / "autoskillit" / "config"
+        config_dir.mkdir(parents=True)
+        for name, content in modules.items():
+            (config_dir / name).write_text(content)
+        tests_root = tmp_path / "tests"
+        for d in self.ALL_DIRS:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+        return tests_root
+
+    def test_init_closure_narrow_single_cause(self, tmp_path: Path) -> None:
+        tests_root = self._make_config_layout(
+            tmp_path,
+            {
+                "__init__.py": "from ._config_loader import load_config\n",
+                "_config_loader.py": "def load_config(): ...\n",
+            },
+        )
+        result = build_test_scope(
+            changed_files={"src/autoskillit/config/_config_loader.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+            cwd=tmp_path,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "config" in dir_names
+        for excluded in ["execution", "fleet", "pipeline", "workspace"]:
+            assert excluded not in dir_names
+
+    def test_init_closure_mixed_causes_fail_open(self, tmp_path: Path) -> None:
+        tests_root = self._make_config_layout(
+            tmp_path,
+            {
+                "__init__.py": (
+                    "from ._config_loader import load_config\n"
+                    "from .settings import AutomationConfig\n"
+                ),
+                "_config_loader.py": "def load_config(): ...\n",
+                "settings.py": "class AutomationConfig: ...\n",
+            },
+        )
+        result = build_test_scope(
+            changed_files={
+                "src/autoskillit/config/_config_loader.py",
+                "src/autoskillit/config/settings.py",
+            },
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+            cwd=tmp_path,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "config" in dir_names
+        assert "execution" in dir_names or "server" in dir_names
+
+    def test_init_closure_only_init_fails_open(self, tmp_path: Path) -> None:
+        tests_root = self._make_config_layout(
+            tmp_path,
+            {
+                "__init__.py": "from .settings import AutomationConfig\n",
+                "settings.py": "class AutomationConfig: ...\n",
+            },
+        )
+        result = build_test_scope(
+            changed_files={"src/autoskillit/config/__init__.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+            cwd=tmp_path,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "config" in dir_names

--- a/tests/test_test_filter_config_cascade.py
+++ b/tests/test_test_filter_config_cascade.py
@@ -195,7 +195,8 @@ class TestClosureConfigNarrowCascade:
         assert result is not None
         dir_names = {p.name for p in result}
         assert "config" in dir_names
-        assert "execution" in dir_names or "server" in dir_names
+        for pkg in ["execution", "fleet", "pipeline", "workspace", "server", "cli"]:
+            assert pkg in dir_names, f"fail-open cascade should include {pkg}"
 
     def test_init_closure_only_init_fails_open(self, tmp_path: Path) -> None:
         tests_root = self._make_config_layout(

--- a/tests/test_test_filter_config_cascade.py
+++ b/tests/test_test_filter_config_cascade.py
@@ -85,6 +85,8 @@ class TestBuildTestScopeConfigCascade:
             assert excluded not in dir_names, (
                 f"narrow cascade for ingredient_defaults should not include {excluded}"
             )
+        assert "arch" in dir_names
+        assert "contracts" in dir_names
 
     def test_settings_falls_through_to_full_cascade(self, tmp_path: Path) -> None:
         tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)


### PR DESCRIPTION
## Summary

Add a `MODULE_CASCADE_CONFIG` mapping to `tests/_test_filter.py` so that changes to narrowable config modules (`_config_loader`, `ingredient_defaults`) trigger only their actual downstream test directories instead of the full 7-directory `LAYER_CASCADE_CONSERVATIVE["config"]` cascade. Modules with broad import surfaces (`settings.py`, `_config_dataclasses.py`) fall through to the full cascade. This follows the established patterns of `MODULE_CASCADE_CORE` and `MODULE_CASCADE_EXECUTION`.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260531-102925-323825/.autoskillit/temp/make-plan/add_module_cascade_config_plan_2026-05-31_103500.md`

## Changed Files

### New (★):
- tests/test_test_filter_config_cascade.py
- tests/CLAUDE.md

### Modified (●):
- tests/_test_filter.py
- tests/arch/test_cascade_map_guard.py

Closes #3429

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillIt
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 18.0k | 4.3k | 7.2M | 131.3k | 174 | 935.1k | 14m 50s |
| verify* | sonnet | 1 | 2.2k | 11.9k | 337.9k | 61.2k | 70 | 44.7k | 4m 32s |
| implement* | sonnet | 1 | 1.0M | 10.9k | 926.7k | 50.6k | 108 | 111.3k | 8m 14s |
| audit_impl* | sonnet | 1 | 92 | 10.4k | 370.0k | 43.4k | 52 | 35.7k | 4m 50s |
| prepare_pr* | sonnet | 1 | 56.4k | 2.8k | 137.9k | 28.2k | 16 | 16.0k | 1m 3s |
| compose_pr* | sonnet | 1 | 59.8k | 1.4k | 166.0k | 28.2k | 14 | 15.5k | 38s |
| review_pr* | sonnet | 2 | 268 | 88.9k | 1.9M | 94.8k | 99 | 155.0k | 19m 13s |
| resolve_review* | sonnet | 1 | 261 | 21.7k | 2.1M | 83.9k | 96 | 68.2k | 8m 40s |
| resolve_pre_review_conflicts* | sonnet | 1 | 108 | 2.6k | 461.6k | 44.8k | 28 | 28.6k | 1m 1s |
| **Total** | | | 1.2M | 155.0k | 13.6M | 131.3k | | 1.4M | 1h 3m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 375 | 2471.1 | 296.8 | 29.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 11 | 189042.3 | 6202.5 | 1973.7 |
| resolve_pre_review_conflicts | 432 | 1068.4 | 66.2 | 6.0 |
| **Total** | **818** | 16581.4 | 1723.8 | 189.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 18.0k | 4.3k | 7.2M | 935.1k | 14m 50s |
| sonnet | 8 | 1.1M | 150.7k | 6.4M | 475.0k | 48m 15s |