### PR TITLE
[FIX] Narrow Execution Session Indirect Deps

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -299,16 +299,6 @@ MODULE_CASCADE_EXECUTION: dict[str, frozenset[str]] = {
             "workspace/test_clone_ci_contract.py",
         }
     ),
-    "session": frozenset(
-        {
-            "cli",
-            "execution",
-            "fleet",
-            "server",
-            "migration/test_engine.py",
-            "test_llm_triage.py",
-        }
-    ),
     "quota": frozenset({"execution", "server", "cli/test_doctor.py"}),
     "session_log": frozenset(
         {
@@ -368,6 +358,34 @@ SUBPKG_CASCADE_EXECUTION: dict[str, frozenset[str]] = {
         }
     ),
     "backends": frozenset({"execution", "integration"}),
+    "session": frozenset(
+        {
+            "execution",
+            "server",
+            "migration/test_engine.py",
+            "test_llm_triage.py",
+            "cli/test_session_launch.py",
+            "cli/test_order_resume.py",
+            "cli/test_cook_ide_isolation.py",
+            "cli/test_cook_env_scrub.py",
+            "cli/test_terminal.py",
+            "cli/test_fleet_session.py",
+            "cli/test_reload_loop.py",
+            "fleet/test_result_parser.py",
+            "fleet/test_dispatch_outcome_classifier.py",
+            "fleet/test_dispatch_outcome_classifier_timeout.py",
+            "fleet/test_dispatch_lifespan.py",
+            "fleet/test_dispatch_state_handle.py",
+            "fleet/test_research_campaign_dispatch.py",
+            "fleet/test_campaign_capture.py",
+            "fleet/test_dispatch_failure_semantics.py",
+            "fleet/test_dispatch_stderr_forwarding.py",
+            "fleet/test_dispatch_envelope_fields.py",
+            "fleet/test_dispatch_labels_cleaned.py",
+            "fleet/test_resume_preflight.py",
+            "fleet/test_helpers_exports.py",
+        }
+    ),
 }
 
 MODULE_CASCADE_RECIPE: dict[str, frozenset[str]] = {

--- a/tests/test_test_filter_execution_cascade.py
+++ b/tests/test_test_filter_execution_cascade.py
@@ -272,10 +272,10 @@ class TestBuildTestScopeExecutionCascade:
         )
         assert result is not None
         dir_names = {p.name for p in result}
-        assert "cli" not in dir_names
-        assert "fleet" not in dir_names
-        assert "test_session_launch.py" in dir_names
-        assert "test_result_parser.py" in dir_names
+        assert "cli" not in dir_names  # full cli/ dir must not be a scope item
+        assert "fleet" not in dir_names  # full fleet/ dir must not be a scope item
+        assert (tests_root / "cli" / "test_session_launch.py") in result
+        assert (tests_root / "fleet" / "test_result_parser.py") in result
         assert "execution" in dir_names
         assert "server" in dir_names
 

--- a/tests/test_test_filter_execution_cascade.py
+++ b/tests/test_test_filter_execution_cascade.py
@@ -44,7 +44,6 @@ def test_all_entries_present() -> None:
         "recording",
         "github",
         "remote_resolver",
-        "session",
         "quota",
         "session_log",
         "linux_tracing",
@@ -255,6 +254,45 @@ class TestBuildTestScopeExecutionCascade:
         assert "test_pretty_output_hook_infra.py" in path_names, (
             "execution layer fallthrough must include infra/test_pretty_output_hook_infra.py"
         )
+
+    def test_session_subpkg_uses_narrowed_cli_fleet(self, tmp_path: Path) -> None:
+        """execution/session/ change → specific cli/fleet test files, NOT full dirs."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        for f in [
+            "cli/test_session_launch.py",
+            "cli/test_order_resume.py",
+            "fleet/test_result_parser.py",
+            "fleet/test_dispatch_outcome_classifier.py",
+        ]:
+            (tests_root / f).touch()
+        result = build_test_scope(
+            changed_files={"src/autoskillit/execution/session/_session_state.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "cli" not in dir_names
+        assert "fleet" not in dir_names
+        assert "test_session_launch.py" in dir_names
+        assert "test_result_parser.py" in dir_names
+        assert "execution" in dir_names
+        assert "server" in dir_names
+
+    def test_session_subpkg_excludes_unrelated_cli_fleet(self, tmp_path: Path) -> None:
+        """execution/session/ change must NOT include unrelated cli/fleet tests."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        (tests_root / "cli" / "test_doctor.py").touch()
+        (tests_root / "fleet" / "test_api.py").touch()
+        result = build_test_scope(
+            changed_files={"src/autoskillit/execution/session/_session_state.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        result_names = {p.name for p in result}
+        assert "test_doctor.py" not in result_names
+        assert "test_api.py" not in result_names
 
 
 class TestClosureExecutionNarrowCascade:
@@ -476,3 +514,8 @@ def test_headless_and_process_in_subpkg_cascade() -> None:
     """
     assert "headless" in SUBPKG_CASCADE_EXECUTION, "headless must have explicit cascade entry"
     assert "process" in SUBPKG_CASCADE_EXECUTION, "process must have explicit cascade entry"
+
+
+def test_session_in_subpkg_cascade() -> None:
+    """session must be in SUBPKG_CASCADE_EXECUTION (subpackage, not bare module)."""
+    assert "session" in SUBPKG_CASCADE_EXECUTION


### PR DESCRIPTION
## Summary

Move the `"session"` entry from `MODULE_CASCADE_EXECUTION` to `SUBPKG_CASCADE_EXECUTION` and replace the blanket `"cli"` and `"fleet"` directory entries with specific test file paths. This achieves two things: (1) makes the session cascade actually reachable (it is currently dead code), and (2) narrows the cascade from ~123 test files to ~20 specific files.

**Critical finding:** `MODULE_CASCADE_EXECUTION["session"]` is currently **unreachable** for `execution/session/` file changes. The routing at `_test_filter.py:1327` calls `_file_to_execution_subpkg()` first, which returns `"session"` for any file inside `execution/session/`. Since `"session"` is absent from `SUBPKG_CASCADE_EXECUTION`, the code falls through to `MODULE_CASCADE_EXECUTION[stem]` where `stem` is the individual file stem (e.g., `"_session_state"`), not `"session"`. No file stem matches, so every `execution/session/` change falls through to the full `cascade_map["execution"]` — the widest possible scope. The `MODULE_CASCADE_EXECUTION["session"]` entry has no effect.

Closes #3435

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260531-104736-797608/.autoskillit/temp/make-plan/narrow_execution_session_cascade_plan_2026-05-31_110300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.7k | 25.3k | 2.8M | 102.4k | 171 | 86.1k | 16m 57s |
| verify* | sonnet | 1 | 60 | 6.6k | 237.2k | 45.1k | 84 | 28.6k | 3m 6s |
| implement* | sonnet | 1 | 255.8k | 4.0k | 419.4k | 28.1k | 41 | 16.3k | 1m 36s |
| audit_impl* | sonnet | 1 | 323 | 7.7k | 245.4k | 37.7k | 30 | 26.3k | 3m 19s |
| prepare_pr* | sonnet | 1 | 83.8k | 3.4k | 197.1k | 28.2k | 21 | 41.2k | 1m 13s |
| compose_pr* | sonnet | 1 | 56.7k | 1.7k | 222.3k | 28.2k | 17 | 15.6k | 44s |
| review_pr* | sonnet | 1 | 116 | 26.9k | 568.8k | 65.9k | 36 | 55.0k | 5m 45s |
| resolve_review* | sonnet | 1 | 173 | 16.8k | 1.2M | 72.5k | 59 | 56.8k | 7m 4s |
| resolve_pre_review_conflicts* | sonnet | 1 | 108 | 2.8k | 431.3k | 38.7k | 26 | 22.3k | 1m 6s |
| **Total** | | | 398.7k | 95.1k | 6.3M | 102.4k | | 348.2k | 40m 55s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 83 | 5052.5 | 196.8 | 47.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 149255.9 | 7102.4 | 2105.5 |
| resolve_pre_review_conflicts | 15 | 28751.5 | 1483.9 | 186.5 |
| **Total** | **106** | 59150.2 | 3284.8 | 897.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.7k | 25.3k | 2.8M | 86.1k | 16m 57s |
| sonnet | 8 | 397.1k | 69.8k | 3.5M | 262.0k | 23m 57s |