### PR TITLE
Narrow recipe/ cascade inclusions in workspace, planner, and skills_extended

### DIFF
--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -68,7 +68,18 @@ src/autoskillit/skills/*/SKILL.md:
 src/autoskillit/skills_extended/*/SKILL.md:
   - skills/
   - contracts/
-  - recipe/
+  - recipe/test_skill_worktree_patterns.py
+  - recipe/test_plan_visualization_step.py
+  - recipe/test_diagnose_ci_subtype_output.py
+  - recipe/test_contracts.py
+  - recipe/test_silent_type_flows.py
+  - recipe/test_skill_emit_consistency.py
+  - recipe/test_diagnostic_steps.py
+  - recipe/test_bundled_recipes_general.py
+  - recipe/test_rules_skill_content.py
+  - recipe/test_rules_contracts.py
+  - recipe/test_rules_skills.py
+  - recipe/test_rules_dedup.py
   - skills_extended/
   - workspace/
   - planner/

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -660,7 +660,40 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
     "workspace": frozenset(
         {
             "workspace",
-            "recipe",
+            # recipe direct-import entries (import autoskillit.workspace at AST level):
+            "recipe/test_contracts.py",
+            "recipe/test_rules_skill_content.py",
+            # recipe transitive entries (exercise workspace via deferred imports in
+            # recipe/_api.py, _api_listing.py, _skill_helpers.py, _contracts_staleness.py,
+            # rules/rules_skills.py, rules/rules_skill_content.py):
+            "recipe/test_api.py",
+            "recipe/test_api_cache_isolation.py",
+            "recipe/test_bem_wrapper_structure.py",
+            "recipe/test_bundled_recipes_dispatch_ready.py",
+            "recipe/test_bundled_recipes_general.py",
+            "recipe/test_callable_contracts.py",
+            "recipe/test_contracts_block_fingerprint.py",
+            "recipe/test_contract_verdict_output_required.py",
+            "recipe/test_deep_staleness.py",
+            "recipe/test_diagnose_ci_subtype_output.py",
+            "recipe/test_hidden_ingredients.py",
+            "recipe/test_io_discovery.py",
+            "recipe/test_issue_url_pipeline.py",
+            "recipe/test_planner_contracts.py",
+            "recipe/test_recipe_temp_substitution.py",
+            "recipe/test_repository.py",
+            "recipe/test_research_campaign.py",
+            "recipe/test_rules_contracts.py",
+            "recipe/test_rules_dataflow_handoff.py",
+            "recipe/test_rules_skill_routing.py",
+            "recipe/test_rules_skills.py",
+            "recipe/test_rules_tools.py",
+            "recipe/test_skill_contract_completeness.py",
+            "recipe/test_skill_emit_consistency.py",
+            "recipe/test_skip_guard_deferral.py",
+            "recipe/test_staleness_cache.py",
+            "recipe/test_sub_recipe_loading.py",
+            "recipe/test_sub_recipe_validation.py",
             # Server file-level entries:
             "server/test_factory.py",
             "server/test_tools_clone.py",
@@ -790,11 +823,70 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
     # Standalone modules (not subpackage directories)
     # L1
     "report": frozenset({"report", "skills_extended"}),
-    "planner": frozenset({"planner", "recipe"}),
+    "planner": frozenset(
+        {
+            "planner",
+            # recipe file-level entries — exercise planner via _check_result_field_drift
+            # in rules/rules_contracts.py (deferred import of PHASE_REQUIRED_KEYS):
+            "recipe/test_rules_contracts.py",
+            "recipe/test_contracts.py",
+            "recipe/test_planner_recipe.py",
+        }
+    ),
     "_llm_triage": frozenset({"test_llm_triage.py", "server"}),
     "_test_filter": frozenset({"arch", "infra", "contracts"}),
     "smoke_utils": frozenset({"test_smoke_utils.py", "recipe", "smoke_utils"}),
     "version": frozenset({"test_version.py", "server", "cli"}),
+}
+
+# ---------------------------------------------------------------------------
+# Transitive override registry for REQ-GUARD-006
+# ---------------------------------------------------------------------------
+# Entries in LAYER_CASCADE_CONSERVATIVE whose test files do NOT import the
+# cascade package directly at AST level — they are transitively reachable via
+# deferred imports in recipe source modules (e.g. recipe/_api.py ->
+# autoskillit.workspace.DefaultSkillResolver).  These are exempt from the
+# direct-import check in test_file_level_entries_import_their_cascade_package.
+_IMPORT_GUARD_TRANSITIVE_OVERRIDES: dict[str, frozenset[str]] = {
+    "workspace": frozenset(
+        {
+            "recipe/test_api.py",
+            "recipe/test_api_cache_isolation.py",
+            "recipe/test_bem_wrapper_structure.py",
+            "recipe/test_bundled_recipes_dispatch_ready.py",
+            "recipe/test_bundled_recipes_general.py",
+            "recipe/test_callable_contracts.py",
+            "recipe/test_contracts_block_fingerprint.py",
+            "recipe/test_contract_verdict_output_required.py",
+            "recipe/test_deep_staleness.py",
+            "recipe/test_diagnose_ci_subtype_output.py",
+            "recipe/test_hidden_ingredients.py",
+            "recipe/test_io_discovery.py",
+            "recipe/test_issue_url_pipeline.py",
+            "recipe/test_planner_contracts.py",
+            "recipe/test_recipe_temp_substitution.py",
+            "recipe/test_repository.py",
+            "recipe/test_research_campaign.py",
+            "recipe/test_rules_contracts.py",
+            "recipe/test_rules_dataflow_handoff.py",
+            "recipe/test_rules_skill_routing.py",
+            "recipe/test_rules_skills.py",
+            "recipe/test_rules_tools.py",
+            "recipe/test_skill_contract_completeness.py",
+            "recipe/test_skill_emit_consistency.py",
+            "recipe/test_skip_guard_deferral.py",
+            "recipe/test_staleness_cache.py",
+            "recipe/test_sub_recipe_loading.py",
+            "recipe/test_sub_recipe_validation.py",
+        }
+    ),
+    "planner": frozenset(
+        {
+            "recipe/test_rules_contracts.py",
+            "recipe/test_contracts.py",
+            "recipe/test_planner_recipe.py",
+        }
+    ),
 }
 
 LAYER_CASCADE_AGGRESSIVE: dict[str, frozenset[str]] = {

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -847,6 +847,16 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
 # deferred imports in recipe source modules (e.g. recipe/_api.py ->
 # autoskillit.workspace.DefaultSkillResolver).  These are exempt from the
 # direct-import check in test_file_level_entries_import_their_cascade_package.
+#
+# COUPLING: each set here is a strict subset of the corresponding
+# LAYER_CASCADE_CONSERVATIVE entry — only the recipe/* transitive entries.
+# Excluded from "workspace": the two direct-import entries
+# ("recipe/test_contracts.py", "recipe/test_rules_skill_content.py") and all
+# non-recipe entries ("workspace", "fleet", "server", "cli", "skills",
+# "_llm_triage").  When adding a new transitive recipe/* entry to
+# LAYER_CASCADE_CONSERVATIVE["workspace"] or ["planner"], add it here too —
+# otherwise test_file_level_entries_import_their_cascade_package will
+# incorrectly require a direct AST import from those test files.
 _IMPORT_GUARD_TRANSITIVE_OVERRIDES: dict[str, frozenset[str]] = {
     "workspace": frozenset(
         {

--- a/tests/arch/test_cascade_map_guard.py
+++ b/tests/arch/test_cascade_map_guard.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 
 from tests._test_filter import (
+    _IMPORT_GUARD_TRANSITIVE_OVERRIDES,
     LAYER_CASCADE_AGGRESSIVE,
     LAYER_CASCADE_CONSERVATIVE,
     MODULE_CASCADE_CONFIG,
@@ -693,15 +694,20 @@ class TestFileLevelCascadeImportGuard:
     """REQ-GUARD-006: File-level entries must actually import their cascade package."""
 
     def test_file_level_entries_import_their_cascade_package(self) -> None:
-        """Every dir/file.py entry in a cascade frozenset must import autoskillit.{pkg}."""
+        """Every dir/file.py entry in a cascade frozenset must import autoskillit.{pkg},
+        unless listed in _IMPORT_GUARD_TRANSITIVE_OVERRIDES (transitive dependencies
+        through deferred imports in recipe source modules)."""
         tests_dir = Path(__file__).parent.parent
         violations: list[str] = []
 
         for pkg, entries in LAYER_CASCADE_CONSERVATIVE.items():
+            transitive_exempt = _IMPORT_GUARD_TRANSITIVE_OVERRIDES.get(pkg, frozenset())
             for entry in entries:
                 if "/" not in entry:
                     continue
                 if entry in _FIXTURE_MEDIATED_ENTRIES.get(pkg, frozenset()):
+                    continue
+                if entry in transitive_exempt:
                     continue
                 test_file = tests_dir / entry
                 if not test_file.exists():
@@ -729,6 +735,22 @@ class TestFileLevelCascadeImportGuard:
         assert not violations, (
             "File-level cascade entries that do not import their package:\n"
             + "\n".join(f"  {v}" for v in sorted(violations))
+        )
+
+    def test_transitive_overrides_are_valid(self) -> None:
+        """Every _IMPORT_GUARD_TRANSITIVE_OVERRIDES entry must exist and be in its cascade."""
+        tests_root = Path(__file__).parent.parent
+        violations: list[str] = []
+        for pkg, overrides in _IMPORT_GUARD_TRANSITIVE_OVERRIDES.items():
+            cascade_set = LAYER_CASCADE_CONSERVATIVE.get(pkg, frozenset())
+            for entry in sorted(overrides):
+                if entry not in cascade_set:
+                    violations.append(f"{pkg}: {entry} in overrides but not in cascade")
+                if not (tests_root / entry).is_file():
+                    violations.append(f"{pkg}: {entry} does not exist on disk")
+        assert not violations, (
+            "_IMPORT_GUARD_TRANSITIVE_OVERRIDES entries must exist and be in their cascade:\n"
+            + "\n".join(f"  {v}" for v in violations)
         )
 
 

--- a/tests/infra/test_manifest_directory_completeness.py
+++ b/tests/infra/test_manifest_directory_completeness.py
@@ -38,6 +38,11 @@ _SOURCE_DEPENDENCIES: dict[str, frozenset[str]] = {
             "src/autoskillit/agents/**",
         }
     ),
+    "recipe": frozenset(
+        {
+            "src/autoskillit/skills_extended/*/SKILL.md",
+        }
+    ),
     "contracts": frozenset(
         {
             "src/autoskillit/assets/**/*",

--- a/tests/test_test_filter_cascade.py
+++ b/tests/test_test_filter_cascade.py
@@ -283,44 +283,17 @@ class TestRecipeCascadeNarrowing:
         assert "hooks" not in path_names, "recipe layer must not include the entire hooks/ dir"
 
 
-_WORKSPACE_RECIPE_FILE_ENTRIES = [
-    "test_contracts.py",
-    "test_rules_skill_content.py",
-    "test_api.py",
-    "test_api_cache_isolation.py",
-    "test_bem_wrapper_structure.py",
-    "test_bundled_recipes_dispatch_ready.py",
-    "test_bundled_recipes_general.py",
-    "test_callable_contracts.py",
-    "test_contracts_block_fingerprint.py",
-    "test_contract_verdict_output_required.py",
-    "test_deep_staleness.py",
-    "test_diagnose_ci_subtype_output.py",
-    "test_hidden_ingredients.py",
-    "test_io_discovery.py",
-    "test_issue_url_pipeline.py",
-    "test_planner_contracts.py",
-    "test_recipe_temp_substitution.py",
-    "test_repository.py",
-    "test_research_campaign.py",
-    "test_rules_contracts.py",
-    "test_rules_dataflow_handoff.py",
-    "test_rules_skill_routing.py",
-    "test_rules_skills.py",
-    "test_rules_tools.py",
-    "test_skill_contract_completeness.py",
-    "test_skill_emit_consistency.py",
-    "test_skip_guard_deferral.py",
-    "test_staleness_cache.py",
-    "test_sub_recipe_loading.py",
-    "test_sub_recipe_validation.py",
-]
+_WORKSPACE_RECIPE_FILE_ENTRIES = sorted(
+    e.removeprefix("recipe/")
+    for e in LAYER_CASCADE_CONSERVATIVE["workspace"]
+    if e.startswith("recipe/")
+)
 
-_PLANNER_RECIPE_FILE_ENTRIES = [
-    "test_rules_contracts.py",
-    "test_contracts.py",
-    "test_planner_recipe.py",
-]
+_PLANNER_RECIPE_FILE_ENTRIES = sorted(
+    e.removeprefix("recipe/")
+    for e in LAYER_CASCADE_CONSERVATIVE["planner"]
+    if e.startswith("recipe/")
+)
 
 
 class TestWorkspacePlannerCascadeNarrowing:

--- a/tests/test_test_filter_cascade.py
+++ b/tests/test_test_filter_cascade.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 import pytest
 
-from tests._test_filter import LAYER_CASCADE_CONSERVATIVE, FilterMode, build_test_scope
+from tests._test_filter import (
+    LAYER_CASCADE_CONSERVATIVE,
+    FilterMode,
+    build_test_scope,
+    load_manifest,
+)
 
 
 class TestCascadeNewEntries:
@@ -375,6 +380,25 @@ class TestWorkspacePlannerCascadeNarrowing:
         assert not any(
             "/recipe/" in str(p) and p.name != "test_planner_recipe.py" for p in result
         ), f"planner cascade must not include the full recipe/ directory; got {result}"
+
+    def test_skills_extended_skill_md_recipe_file_level(self, tmp_path: Path) -> None:
+        tests_root = tmp_path / "tests"
+        recipe_dir = tests_root / "recipe"
+        recipe_dir.mkdir(parents=True, exist_ok=True)
+        (recipe_dir / "test_rules_skill_content.py").touch()
+        (recipe_dir / "test_unrelated.py").touch()
+
+        manifest = load_manifest(Path(__file__).parent.parent)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/skills_extended/make-plan/SKILL.md"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+            manifest=manifest,
+        )
+        assert result is not None
+        result_names = {p.name for p in result}
+        assert "test_rules_skill_content.py" in result_names
+        assert "test_unrelated.py" not in result_names
 
 
 def test_session_log_cascade_targets_hooks_quota_check() -> None:

--- a/tests/test_test_filter_cascade.py
+++ b/tests/test_test_filter_cascade.py
@@ -15,12 +15,22 @@ class TestCascadeNewEntries:
     @pytest.mark.parametrize(
         "filepath,mode,items_to_create,expected_in_result",
         [
-            # Conservative: planner only touches its own tests
+            # Conservative: planner only touches its own tests + specific recipe files
             (
                 "src/autoskillit/planner/__init__.py",
                 FilterMode.CONSERVATIVE,
-                ["planner"],
-                ["planner"],
+                [
+                    "planner",
+                    "recipe/test_rules_contracts.py",
+                    "recipe/test_contracts.py",
+                    "recipe/test_planner_recipe.py",
+                ],
+                [
+                    "planner",
+                    "test_rules_contracts.py",
+                    "test_contracts.py",
+                    "test_planner_recipe.py",
+                ],
             ),
             # Conservative: _llm_triage cascades into server + direct test file
             (
@@ -92,7 +102,10 @@ class TestCascadeNewEntries:
         tests_root = tmp_path / "tests"
         tests_root.mkdir(parents=True, exist_ok=True)
         for item in items_to_create:
-            if item.endswith(".py"):
+            if "/" in item:
+                (tests_root / item).parent.mkdir(parents=True, exist_ok=True)
+                (tests_root / item).touch()
+            elif item.endswith(".py"):
                 (tests_root / item).touch()
             else:
                 (tests_root / item).mkdir(parents=True, exist_ok=True)
@@ -263,6 +276,105 @@ class TestRecipeCascadeNarrowing:
             "recipe layer must include hooks/test_recipe_contract_freshness.py"
         )
         assert "hooks" not in path_names, "recipe layer must not include the entire hooks/ dir"
+
+
+_WORKSPACE_RECIPE_FILE_ENTRIES = [
+    "test_contracts.py",
+    "test_rules_skill_content.py",
+    "test_api.py",
+    "test_api_cache_isolation.py",
+    "test_bem_wrapper_structure.py",
+    "test_bundled_recipes_dispatch_ready.py",
+    "test_bundled_recipes_general.py",
+    "test_callable_contracts.py",
+    "test_contracts_block_fingerprint.py",
+    "test_contract_verdict_output_required.py",
+    "test_deep_staleness.py",
+    "test_diagnose_ci_subtype_output.py",
+    "test_hidden_ingredients.py",
+    "test_io_discovery.py",
+    "test_issue_url_pipeline.py",
+    "test_planner_contracts.py",
+    "test_recipe_temp_substitution.py",
+    "test_repository.py",
+    "test_research_campaign.py",
+    "test_rules_contracts.py",
+    "test_rules_dataflow_handoff.py",
+    "test_rules_skill_routing.py",
+    "test_rules_skills.py",
+    "test_rules_tools.py",
+    "test_skill_contract_completeness.py",
+    "test_skill_emit_consistency.py",
+    "test_skip_guard_deferral.py",
+    "test_staleness_cache.py",
+    "test_sub_recipe_loading.py",
+    "test_sub_recipe_validation.py",
+]
+
+_PLANNER_RECIPE_FILE_ENTRIES = [
+    "test_rules_contracts.py",
+    "test_contracts.py",
+    "test_planner_recipe.py",
+]
+
+
+class TestWorkspacePlannerCascadeNarrowing:
+    """REQ-FILT-003: workspace/planner cascade uses file-level recipe entries, not directory."""
+
+    def test_workspace_cascade_recipe_file_level_only(self, tmp_path: Path) -> None:
+        tests_root = tmp_path / "tests"
+        recipe_dir = tests_root / "recipe"
+        recipe_dir.mkdir(parents=True, exist_ok=True)
+        for fname in _WORKSPACE_RECIPE_FILE_ENTRIES:
+            (recipe_dir / fname).touch()
+        (recipe_dir / "test_unrelated.py").touch()
+
+        result = build_test_scope(
+            changed_files={"src/autoskillit/workspace/skills.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        result_names = {p.name for p in result}
+        for fname in _WORKSPACE_RECIPE_FILE_ENTRIES:
+            assert fname in result_names, f"{fname!r} missing from workspace cascade result"
+        assert "test_unrelated.py" not in result_names
+
+    def test_planner_cascade_recipe_file_level_only(self, tmp_path: Path) -> None:
+        tests_root = tmp_path / "tests"
+        recipe_dir = tests_root / "recipe"
+        recipe_dir.mkdir(parents=True, exist_ok=True)
+        for fname in _PLANNER_RECIPE_FILE_ENTRIES:
+            (recipe_dir / fname).touch()
+        (recipe_dir / "test_unrelated.py").touch()
+
+        result = build_test_scope(
+            changed_files={"src/autoskillit/planner/validator.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        result_names = {p.name for p in result}
+        for fname in _PLANNER_RECIPE_FILE_ENTRIES:
+            assert fname in result_names, f"{fname!r} missing from planner cascade result"
+        assert "test_unrelated.py" not in result_names
+
+    def test_planner_cascade_no_full_recipe_directory(self, tmp_path: Path) -> None:
+        """planner change must NOT include the full recipe/ directory."""
+        tests_root = tmp_path / "tests"
+        recipe_dir = tests_root / "recipe"
+        recipe_dir.mkdir(parents=True, exist_ok=True)
+        (recipe_dir / "test_planner_recipe.py").touch()
+
+        result = build_test_scope(
+            changed_files={"src/autoskillit/planner/validator.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        assert not any(
+            "/recipe/" in str(p) and p.name != "test_planner_recipe.py" for p in result
+        ), f"planner cascade must not include the full recipe/ directory; got {result}"
 
 
 def test_session_log_cascade_targets_hooks_quota_check() -> None:


### PR DESCRIPTION
## Summary

Replace the blanket "recipe" directory inclusion in LAYER_CASCADE_CONSERVATIVE["workspace"] (line 614), LAYER_CASCADE_CONSERVATIVE["planner"] (line 739), and the skills_extended/*/SKILL.md manifest entry (line 71) with specific file-level entries identified via transitive import analysis. This requires a guard override mechanism because most affected recipe tests reach workspace/planner code through deferred imports in recipe source modules — not through direct AST-level imports that TestFileLevelCascadeImportGuard (REQ-GUARD-006) checks.

Key architectural constraint: REQ-GUARD-006 verifies that every file-level cascade entry directly imports autoskillit.{pkg} at the AST level. Only 2 recipe test files import autoskillit.workspace directly; zero import autoskillit.planner. The remaining entries are transitively dependent through deferred imports in recipe source modules. An _IMPORT_GUARD_TRANSITIVE_OVERRIDES mechanism exempts documented transitive entries from the direct-import check.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260531-102914-645620/.autoskillit/temp/make-plan/narrow_recipe_cascade_inclusions_plan_2026-05-31_103600.md`

Closes #3430

## Changed Files

### Modified (●):
- `.autoskillit/test-filter-manifest.yaml`
- `tests/_test_filter.py`
- `tests/arch/test_cascade_map_guard.py`
- `tests/infra/test_manifest_directory_completeness.py`
- `tests/test_test_filter_cascade.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 3.5k | 41.0k | 3.1M | 118.8k | 379 | 220.4k | 28m 34s |
| verify* | sonnet | 2 | 964 | 23.0k | 698.2k | 54.3k | 102 | 71.8k | 8m 31s |
| implement* | sonnet | 2 | 2.4M | 30.4k | 2.6M | 61.4k | 194 | 71.4k | 18m 54s |
| audit_impl* | sonnet | 2 | 1.2k | 26.0k | 555.7k | 56.5k | 95 | 100.2k | 12m 8s |
| prepare_pr* | sonnet | 1 | 90.0k | 3.3k | 201.9k | 33.0k | 22 | 54.0k | 1m 13s |
| compose_pr* | sonnet | 1 | 49.1k | 1.9k | 194.2k | 28.2k | 19 | 15.6k | 46s |
| review_pr* | sonnet | 1 | 158 | 33.1k | 782.0k | 76.7k | 45 | 64.8k | 7m 53s |
| resolve_review* | sonnet | 1 | 263 | 17.5k | 1.9M | 74.2k | 76 | 57.7k | 6m 26s |
| resolve_pre_review_conflicts* | sonnet | 1 | 198 | 5.8k | 1.3M | 73.9k | 53 | 57.8k | 2m 15s |
| ci_conflict_fix* | sonnet | 1 | 180 | 7.2k | 964.5k | 58.0k | 59 | 41.8k | 2m 26s |
| **Total** | | | 2.5M | 189.2k | 12.2M | 118.8k | | 755.6k | 1h 29m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 279 | 9189.0 | 255.9 | 108.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 64 | 29212.6 | 902.1 | 273.5 |
| resolve_pre_review_conflicts | 430 | 2941.0 | 134.3 | 13.4 |
| ci_conflict_fix | 481 | 2005.3 | 86.9 | 15.0 |
| **Total** | **1254** | 9756.5 | 602.5 | 150.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 3.5k | 41.0k | 3.1M | 220.4k | 28m 34s |
| sonnet | 9 | 2.5M | 148.2k | 9.1M | 535.2k | 1h 0m |