### PR TITLE
[FIX] Rectify: Merge Queue Unbounded Re-Enqueue Loop

### DIFF
--- a/src/autoskillit/core/types/_type_protocols_github.py
+++ b/src/autoskillit/core/types/_type_protocols_github.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import Any, Protocol, runtime_checkable
 
 from ._type_results_execution import CIRunScope
@@ -148,6 +149,9 @@ class MergeQueueWatcher(Protocol):
         not_in_queue_confirmation_cycles: int = 2,
         max_inconclusive_retries: int = 5,
         auto_merge_available: bool = True,
+        max_merge_group_drops: int = 0,
+        merge_group_drop_backoff: float = 60.0,
+        progress_callback: Callable[[str], Awaitable[None]] | None = None,
     ) -> dict[str, Any]: ...
 
     async def toggle(

--- a/src/autoskillit/execution/merge_queue/__init__.py
+++ b/src/autoskillit/execution/merge_queue/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import random  # noqa: F401 — re-exported for test monkeypatching (_mq.random.uniform)
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, assert_never, cast
 
@@ -114,6 +114,9 @@ class DefaultMergeQueueWatcher:
         not_in_queue_confirmation_cycles: int = 2,
         max_inconclusive_retries: int = 5,
         auto_merge_available: bool = True,
+        max_merge_group_drops: int = 0,
+        merge_group_drop_backoff: float = 60.0,
+        progress_callback: Callable[[str], Awaitable[None]] | None = None,
     ) -> dict[str, Any]:
         """Poll until PR is merged, ejected, stalled, dropped, or timeout expires.
 
@@ -137,6 +140,8 @@ class DefaultMergeQueueWatcher:
         merge_group_ci_cache: str | None = None
         pending_ejection: PRState | None = None
         pending_reason: str = ""
+        drop_count: int = 0
+        last_progress_time: float = time.monotonic()
 
         def _make_result(
             success: bool, pr_state: PRState, reason: str, ejection_cause: str = ""
@@ -152,6 +157,13 @@ class DefaultMergeQueueWatcher:
             return result
 
         while time.monotonic() < deadline:
+            if progress_callback and (time.monotonic() - last_progress_time) >= 60:
+                await progress_callback(
+                    f"Polling merge queue for PR #{pr_number} "
+                    f"({int(deadline - time.monotonic())}s remaining)"
+                )
+                last_progress_time = time.monotonic()
+
             try:
                 state = await self._fetch_pr_and_queue_state(
                     pr_number, owner, repo_name, target_branch
@@ -287,7 +299,31 @@ class DefaultMergeQueueWatcher:
                 return _make_result(False, PRState.DROPPED_HEALTHY, classification.reason)
 
             elif classification.terminal == PRState.DROPPED_MERGE_GROUP_CI:
-                return _make_result(False, PRState.DROPPED_MERGE_GROUP_CI, classification.reason)
+                if drop_count < max_merge_group_drops:
+                    drop_count += 1
+                    logger.info(
+                        "merge_group_drop_internal_reenqueue",
+                        pr_number=pr_number,
+                        drop_count=drop_count,
+                        max_merge_group_drops=max_merge_group_drops,
+                    )
+                    await asyncio.sleep(merge_group_drop_backoff)
+                    await self.enqueue(
+                        pr_number,
+                        target_branch,
+                        repo,
+                        cwd,
+                        auto_merge_available=auto_merge_available,
+                    )
+                    deadline = time.monotonic() + timeout_seconds
+                    not_in_queue_cycles = 0
+                    ever_enrolled = True
+                    was_in_queue = False
+                    merge_group_ci_cache = None
+                    continue
+                result = _make_result(False, PRState.DROPPED_MERGE_GROUP_CI, classification.reason)
+                result["drop_count"] = drop_count
+                return result
 
             elif classification.terminal == PRState.NOT_ENROLLED:
                 return _make_result(False, PRState.NOT_ENROLLED, classification.reason)

--- a/src/autoskillit/execution/merge_queue/__init__.py
+++ b/src/autoskillit/execution/merge_queue/__init__.py
@@ -308,13 +308,21 @@ class DefaultMergeQueueWatcher:
                         max_merge_group_drops=max_merge_group_drops,
                     )
                     await asyncio.sleep(merge_group_drop_backoff)
-                    await self.enqueue(
+                    enqueue_result = await self.enqueue(
                         pr_number,
                         target_branch,
                         repo,
                         cwd,
                         auto_merge_available=auto_merge_available,
                     )
+                    if not enqueue_result.get("success", False):
+                        result = _make_result(
+                            False,
+                            PRState.DROPPED_MERGE_GROUP_CI,
+                            f"re-enqueue failed: {enqueue_result.get('error', 'unknown')}",
+                        )
+                        result["drop_count"] = drop_count
+                        return result
                     deadline = time.monotonic() + timeout_seconds
                     not_in_queue_cycles = 0
                     ever_enrolled = True

--- a/src/autoskillit/execution/merge_queue/__init__.py
+++ b/src/autoskillit/execution/merge_queue/__init__.py
@@ -160,7 +160,7 @@ class DefaultMergeQueueWatcher:
             if progress_callback and (time.monotonic() - last_progress_time) >= 60:
                 await progress_callback(
                     f"Polling merge queue for PR #{pr_number} "
-                    f"({int(deadline - time.monotonic())}s remaining)"
+                    f"({max(0, int(deadline - time.monotonic()))}s remaining)"
                 )
                 last_progress_time = time.monotonic()
 

--- a/src/autoskillit/recipe/rules/ci/rules_ci_merge_queue.py
+++ b/src/autoskillit/recipe/rules/ci/rules_ci_merge_queue.py
@@ -168,6 +168,9 @@ def _check_dropped_merge_group_ci_reenqueue_guard(
             continue
         if step.on_result is None or not step.on_result.conditions:
             continue
+        max_drops = int(step.with_args.get("max_merge_group_drops", 0)) if step.with_args else 0
+        if max_drops >= 1:
+            continue
         dmgci_target: str | None = None
         for cond in step.on_result.conditions:
             if cond.when and "dropped_merge_group_ci" in cond.when:

--- a/src/autoskillit/recipe/rules/ci/rules_ci_merge_queue.py
+++ b/src/autoskillit/recipe/rules/ci/rules_ci_merge_queue.py
@@ -141,3 +141,88 @@ def _check_wait_for_merge_queue_routing_conforms_to_expected_targets(
                 )
             )
     return findings
+
+
+# ---------------------------------------------------------------------------
+# dropped_merge_group_ci unguarded re-enqueue loop (I9)
+# ---------------------------------------------------------------------------
+
+
+@semantic_rule(
+    name="dropped-merge-group-ci-unguarded-reenqueue-loop",
+    description=(
+        "dropped_merge_group_ci routing must pass through a loop guard "
+        "before re-entering wait_for_merge_queue"
+    ),
+    severity=Severity.ERROR,
+)
+def _check_dropped_merge_group_ci_reenqueue_guard(
+    ctx: ValidationContext,
+) -> list[RuleFinding]:
+    if not _recipe_has_mq_routing_step(ctx):
+        return []
+    findings: list[RuleFinding] = []
+    mq_steps_set = {n for n, s in ctx.recipe.steps.items() if s.tool == "wait_for_merge_queue"}
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "wait_for_merge_queue":
+            continue
+        if step.on_result is None or not step.on_result.conditions:
+            continue
+        dmgci_target: str | None = None
+        for cond in step.on_result.conditions:
+            if cond.when and "dropped_merge_group_ci" in cond.when:
+                dmgci_target = cond.route
+                break
+        if dmgci_target is None:
+            continue
+        target_step = ctx.recipe.steps.get(dmgci_target)
+        if target_step is not None and target_step.tool == "run_python":
+            if target_step.on_result is not None:
+                guard_exits: set[str] = set()
+                for c in target_step.on_result.conditions or []:
+                    guard_exits.add(c.route)
+                if guard_exits - mq_steps_set:
+                    continue
+        visited_bfs: set[str] = set()
+        frontier: set[str] = {dmgci_target}
+        mq_reachable = False
+        while frontier:
+            frontier -= visited_bfs
+            if not frontier:
+                break
+            if frontier & mq_steps_set:
+                mq_reachable = True
+                break
+            visited_bfs |= frontier
+            next_frontier: set[str] = set()
+            for n in frontier:
+                ns = ctx.recipe.steps.get(n)
+                if ns is None:
+                    continue
+                if ns.on_success:
+                    next_frontier.add(ns.on_success)
+                if ns.on_failure:
+                    next_frontier.add(ns.on_failure)
+                if ns.on_result:
+                    for c in ns.on_result.conditions or []:
+                        next_frontier.add(c.route)
+                    for v in (ns.on_result.routes or {}).values():
+                        next_frontier.add(v)
+            frontier = next_frontier
+        if mq_reachable:
+            findings.append(
+                RuleFinding(
+                    rule="dropped-merge-group-ci-unguarded-reenqueue-loop",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"Step {step_name!r} routes dropped_merge_group_ci → "
+                        f"{dmgci_target!r} without a direct loop guard. The path "
+                        f"reaches wait_for_merge_queue, creating an unbounded "
+                        f"re-enqueue loop. Add a run_python guard step (e.g. "
+                        f"check_dropped_merge_group_ci_loop) between the "
+                        f"wait_for_merge_queue and diagnose_ci steps."
+                    ),
+                )
+            )
+    return findings

--- a/src/autoskillit/recipe/rules/graph/rules_graph.py
+++ b/src/autoskillit/recipe/rules/graph/rules_graph.py
@@ -6,7 +6,7 @@ from autoskillit.core import SKILL_TOOLS, Severity
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
-_STRUCTURAL_ON_RESULT_TOOLS = {"run_python", "wait_for_ci"}
+_STRUCTURAL_ON_RESULT_TOOLS = {"run_python", "wait_for_ci", "wait_for_merge_queue"}
 
 
 @semantic_rule(
@@ -44,26 +44,71 @@ def _check_unbounded_cycles(ctx: ValidationContext) -> list[RuleFinding]:
                 reported_cycles.add(cycle_key)
                 cycle_set = set(cycle_steps)
 
-                has_on_result_exit = False
-                for s in cycle_steps:
-                    if s not in recipe.steps:
-                        continue
-                    step = recipe.steps[s]
-                    if step.tool not in _STRUCTURAL_ON_RESULT_TOOLS or step.on_result is None:
-                        continue
-                    targets: set[str] = set()
-                    if step.on_result.conditions:
-                        targets = {c.route for c in step.on_result.conditions}
-                    elif step.on_result.routes:
-                        targets = set(step.on_result.routes.values())
-                    routes_out = targets - cycle_set
-                    if routes_out:
-                        has_on_result_exit = True
-                        break
+                structural_steps = [
+                    s
+                    for s in cycle_steps
+                    if s in recipe.steps
+                    and recipe.steps[s].tool in _STRUCTURAL_ON_RESULT_TOOLS
+                    and recipe.steps[s].on_result is not None
+                ]
+                if structural_steps:
+                    unguarded_branches: list[str] = []
+                    all_bounded = True
+                    for s in structural_steps:
+                        step = recipe.steps[s]
+                        on_result = step.on_result
+                        assert on_result is not None  # guaranteed by list comprehension filter
+                        conditions = on_result.conditions or []
+                        routes_map = on_result.routes or {}
+                        branch_items: list[tuple[str | None, str]] = []
+                        if conditions:
+                            branch_items = [(c.when, c.route) for c in conditions]
+                        elif routes_map:
+                            branch_items = [(k, v) for k, v in routes_map.items()]
+                        for label, target in branch_items:
+                            if target not in cycle_set:
+                                continue
+                            target_step = recipe.steps.get(target)
+                            if (
+                                target_step is not None
+                                and target_step.tool in _STRUCTURAL_ON_RESULT_TOOLS
+                                and target_step.on_result is not None
+                            ):
+                                guard_targets: set[str] = set()
+                                if target_step.on_result.conditions:
+                                    guard_targets = {
+                                        c.route for c in target_step.on_result.conditions
+                                    }
+                                elif target_step.on_result.routes:
+                                    guard_targets = set(target_step.on_result.routes.values())
+                                if guard_targets - cycle_set:
+                                    continue
+                            branch_desc = label if label else "(default)"
+                            unguarded_branches.append(f"{s}[{branch_desc}]→{target}")
+                            all_bounded = False
 
-                if has_on_result_exit:
-                    rec_stack.discard(node)
-                    return
+                    if all_bounded:
+                        rec_stack.discard(node)
+                        return
+
+                    if unguarded_branches:
+                        findings.append(
+                            RuleFinding(
+                                rule="unbounded-cycle",
+                                severity=Severity.ERROR,
+                                step_name=node,
+                                message=(
+                                    f"Routing cycle detected: {' → '.join(cycle_steps)} → "
+                                    f"{neighbor}. Unguarded re-entering branch(es): "
+                                    f"{', '.join(unguarded_branches)}. Each re-entering "
+                                    f"on_result branch must route through a direct guard "
+                                    f"step (run_python/wait_for_ci with an on_result exit "
+                                    f"outside the cycle) before re-entering the cycle."
+                                ),
+                            )
+                        )
+                        rec_stack.discard(node)
+                        return
 
                 has_retry_exit = any(
                     recipe.steps[s].retries > 0

--- a/src/autoskillit/recipe/rules/graph/rules_graph.py
+++ b/src/autoskillit/recipe/rules/graph/rules_graph.py
@@ -6,7 +6,7 @@ from autoskillit.core import SKILL_TOOLS, Severity
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
-_STRUCTURAL_ON_RESULT_TOOLS = {"run_python", "wait_for_ci", "wait_for_merge_queue"}
+_STRUCTURAL_ON_RESULT_TOOLS = {"run_python", "wait_for_ci"}
 
 
 @semantic_rule(
@@ -44,76 +44,26 @@ def _check_unbounded_cycles(ctx: ValidationContext) -> list[RuleFinding]:
                 reported_cycles.add(cycle_key)
                 cycle_set = set(cycle_steps)
 
-                structural_steps = [
-                    s
-                    for s in cycle_steps
-                    if s in recipe.steps
-                    and recipe.steps[s].tool in _STRUCTURAL_ON_RESULT_TOOLS
-                    and recipe.steps[s].on_result is not None
-                ]
-                _BRANCH_AWARE_TOOLS = {"wait_for_ci", "wait_for_merge_queue"}
+                has_on_result_exit = False
+                for s in cycle_steps:
+                    if s not in recipe.steps:
+                        continue
+                    step = recipe.steps[s]
+                    if step.tool not in _STRUCTURAL_ON_RESULT_TOOLS or step.on_result is None:
+                        continue
+                    targets: set[str] = set()
+                    if step.on_result.conditions:
+                        targets = {c.route for c in step.on_result.conditions}
+                    elif step.on_result.routes:
+                        targets = set(step.on_result.routes.values())
+                    routes_out = targets - cycle_set
+                    if routes_out:
+                        has_on_result_exit = True
+                        break
 
-                if structural_steps:
-                    unguarded_branches: list[str] = []
-                    all_bounded = True
-                    for s in structural_steps:
-                        step = recipe.steps[s]
-                        on_result = step.on_result
-                        assert on_result is not None  # guaranteed by list comprehension filter
-                        conditions = on_result.conditions or []
-                        routes_map = on_result.routes or {}
-                        branch_items: list[tuple[str | None, str]] = []
-                        if conditions:
-                            branch_items = [(c.when, c.route) for c in conditions]
-                        elif routes_map:
-                            branch_items = [(k, v) for k, v in routes_map.items()]
-                        has_own_exit = any(t not in cycle_set for _, t in branch_items)
-                        if has_own_exit and step.tool not in _BRANCH_AWARE_TOOLS:
-                            continue
-                        for label, target in branch_items:
-                            if target not in cycle_set:
-                                continue
-                            target_step = recipe.steps.get(target)
-                            if (
-                                target_step is not None
-                                and target_step.tool in _STRUCTURAL_ON_RESULT_TOOLS
-                                and target_step.on_result is not None
-                            ):
-                                guard_targets: set[str] = set()
-                                if target_step.on_result.conditions:
-                                    guard_targets = {
-                                        c.route for c in target_step.on_result.conditions
-                                    }
-                                elif target_step.on_result.routes:
-                                    guard_targets = set(target_step.on_result.routes.values())
-                                if guard_targets - cycle_set:
-                                    continue
-                            branch_desc = label if label else "(default)"
-                            unguarded_branches.append(f"{s}[{branch_desc}]→{target}")
-                            all_bounded = False
-
-                    if all_bounded:
-                        rec_stack.discard(node)
-                        return
-
-                    if unguarded_branches:
-                        findings.append(
-                            RuleFinding(
-                                rule="unbounded-cycle",
-                                severity=Severity.ERROR,
-                                step_name=node,
-                                message=(
-                                    f"Routing cycle detected: {' → '.join(cycle_steps)} → "
-                                    f"{neighbor}. Unguarded re-entering branch(es): "
-                                    f"{', '.join(unguarded_branches)}. Each re-entering "
-                                    f"on_result branch must route through a direct guard "
-                                    f"step (run_python/wait_for_ci with an on_result exit "
-                                    f"outside the cycle) before re-entering the cycle."
-                                ),
-                            )
-                        )
-                        rec_stack.discard(node)
-                        return
+                if has_on_result_exit:
+                    rec_stack.discard(node)
+                    return
 
                 has_retry_exit = any(
                     recipe.steps[s].retries > 0
@@ -123,9 +73,6 @@ def _check_unbounded_cycles(ctx: ValidationContext) -> list[RuleFinding]:
                     if s in recipe.steps
                 )
                 if has_retry_exit:
-                    # Check whether the success path of the retrying step stays inside
-                    # the cycle. If it does, the retry exit only bounds individual visits
-                    # but the outer loop can still iterate unboundedly.
                     retrying_steps = [
                         s
                         for s in cycle_steps
@@ -134,10 +81,6 @@ def _check_unbounded_cycles(ctx: ValidationContext) -> list[RuleFinding]:
                         and recipe.steps[s].tool in SKILL_TOOLS
                         and recipe.steps[s].on_exhausted not in cycle_set
                     ]
-                    # Check whether any non-failure successor of the retrying step
-                    # stays within the cycle. Uses the step graph (which includes
-                    # on_result routes) rather than on_success alone, so steps that
-                    # route via on_result without an explicit on_success are handled.
                     success_stays_in_cycle = False
                     for _s in retrying_steps:
                         _step = recipe.steps[_s]
@@ -158,9 +101,6 @@ def _check_unbounded_cycles(ctx: ValidationContext) -> list[RuleFinding]:
                             success_stays_in_cycle = True
                             break
                     if not success_stays_in_cycle:
-                        # Success path exits the cycle — but does it loop back?
-                        # BFS from exit targets to check if they can reach any
-                        # cycle member through the step graph.
                         exit_targets: set[str] = set()
                         for _rs in retrying_steps:
                             _step_r = recipe.steps[_rs]
@@ -195,12 +135,9 @@ def _check_unbounded_cycles(ctx: ValidationContext) -> list[RuleFinding]:
                                 nxt |= set(graph.get(f, set())) - visited_exit
                             frontier = nxt
                         if not loops_back:
-                            # Truly exits — cycle is bounded
                             rec_stack.discard(node)
                             return
 
-                    # Success path re-enters the cycle — retry exit only bounds
-                    # individual step visits, not the outer loop. Emit ERROR.
                     findings.append(
                         RuleFinding(
                             rule="unbounded-cycle",
@@ -257,5 +194,78 @@ def _check_unbounded_cycles(ctx: ValidationContext) -> list[RuleFinding]:
     for step_name in recipe.steps:
         if step_name not in visited:
             dfs(step_name, [step_name])
+
+    # --- Per-branch analysis for wait_for_merge_queue steps ---
+    # The DFS above uses aggregate suppression: if ANY step in a cycle has
+    # an on_result exit, the whole cycle is suppressed. This misses the case
+    # where one branch (e.g. dropped_merge_group_ci) has no guard while
+    # sibling branches (ejected, dropped_healthy) do. Analyze each branch
+    # independently using BFS reachability.
+    mq_steps = {
+        name: step
+        for name, step in recipe.steps.items()
+        if step.tool == "wait_for_merge_queue"
+        and step.on_result is not None
+        and step.on_result.conditions
+    }
+    enqueue_tools = {"enqueue_pr", "wait_for_merge_queue"}
+    for step_name, step in mq_steps.items():
+        assert step.on_result is not None
+        max_drops = int(step.with_args.get("max_merge_group_drops", 0)) if step.with_args else 0
+        if max_drops >= 1:
+            continue
+        for cond in step.on_result.conditions:
+            if cond.when is None:
+                continue
+            if "dropped_merge_group_ci" not in cond.when:
+                continue
+            target = cond.route
+            if target not in recipe.steps:
+                continue
+            target_step = recipe.steps[target]
+            if target_step.tool == "run_python" and target_step.on_result is not None:
+                continue
+            if target_step.tool in enqueue_tools:
+                continue
+            bfs_visited: set[str] = set()
+            bfs_frontier: set[str] = {target}
+            reaches_mq = False
+            while bfs_frontier:
+                bfs_frontier -= bfs_visited
+                if not bfs_frontier:
+                    break
+                for n in bfs_frontier:
+                    if n in mq_steps and n != step_name:
+                        reaches_mq = True
+                    elif n == step_name:
+                        reaches_mq = True
+                if reaches_mq:
+                    break
+                bfs_visited |= bfs_frontier
+                next_bfs: set[str] = set()
+                for n in bfs_frontier:
+                    next_bfs |= graph.get(n, set())
+                bfs_frontier = next_bfs
+            if reaches_mq:
+                branch_label = (
+                    cond.when.split("==")[-1].strip().strip("'\"")
+                    if "==" in cond.when
+                    else cond.when
+                )
+                findings.append(
+                    RuleFinding(
+                        rule="unbounded-cycle",
+                        severity=Severity.ERROR,
+                        step_name=step_name,
+                        message=(
+                            f"Per-branch cycle: {step_name}[{branch_label}] → "
+                            f"{target} reaches wait_for_merge_queue without a "
+                            f"direct guard step. The {branch_label} branch has no "
+                            f"run_python guard at its immediate route target, so "
+                            f"the re-enqueue loop is unbounded. Add a "
+                            f"check_dropped_merge_group_ci_loop guard step."
+                        ),
+                    )
+                )
 
     return findings

--- a/src/autoskillit/recipe/rules/graph/rules_graph.py
+++ b/src/autoskillit/recipe/rules/graph/rules_graph.py
@@ -51,6 +51,8 @@ def _check_unbounded_cycles(ctx: ValidationContext) -> list[RuleFinding]:
                     and recipe.steps[s].tool in _STRUCTURAL_ON_RESULT_TOOLS
                     and recipe.steps[s].on_result is not None
                 ]
+                _BRANCH_AWARE_TOOLS = {"wait_for_ci", "wait_for_merge_queue"}
+
                 if structural_steps:
                     unguarded_branches: list[str] = []
                     all_bounded = True
@@ -65,6 +67,9 @@ def _check_unbounded_cycles(ctx: ValidationContext) -> list[RuleFinding]:
                             branch_items = [(c.when, c.route) for c in conditions]
                         elif routes_map:
                             branch_items = [(k, v) for k, v in routes_map.items()]
+                        has_own_exit = any(t not in cycle_set for _, t in branch_items)
+                        if has_own_exit and step.tool not in _BRANCH_AWARE_TOOLS:
+                            continue
                         for label, target in branch_items:
                             if target not in cycle_set:
                                 continue

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -125,6 +125,8 @@ _TOOL_PARAMS: dict[str, frozenset[str]] = {
             "not_in_queue_confirmation_cycles",
             "max_inconclusive_retries",
             "auto_merge_available",
+            "max_merge_group_drops",
+            "merge_group_drop_backoff",
             "step_name",
         }
     ),

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -43,15 +43,15 @@ skills:
       type: file_path
     - name: failure_type
       type: string
-      allowed_values: [test, lint, build, type_check, env, unknown]
+      allowed_values: [test, lint, build, type_check, env, unknown, no_failure]
     - name: failure_subtype
       type: string
-      allowed_values: [flaky, timing_race, deterministic, fixture, import, env, unknown]
+      allowed_values: [flaky, timing_race, deterministic, fixture, import, env, unknown, no_failure]
     - name: is_fixable
       type: string
     expected_output_patterns:
-    - "diagnosis_path[ \\t]*=[ \\t]*/.+"
-    - "failure_subtype[ \\t]*=[ \\t]*(flaky|timing_race|deterministic|fixture|import|env|unknown)"
+    - "diagnosis_path[ \\t]*=[ \\t]*(?:/.+)?"
+    - "failure_subtype[ \\t]*=[ \\t]*(flaky|timing_race|deterministic|fixture|import|env|unknown|no_failure)"
     pattern_examples:
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = deterministic\nis_fixable = true\n%%ORDER_UP%%"
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = flaky\nis_fixable = false\n%%ORDER_UP%%"
@@ -64,6 +64,7 @@ skills:
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = type_check\nfailure_subtype = unknown\nis_fixable = true\n%%ORDER_UP%%"
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = env\nfailure_subtype = env\nis_fixable = false\n%%ORDER_UP%%"
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = unknown\nfailure_subtype = unknown\nis_fixable = false\n%%ORDER_UP%%"
+    - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = no_failure\nfailure_subtype = no_failure\nis_fixable = false\n%%ORDER_UP%%"
     write_behavior: always
   resolve-design-review:
     inputs:

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -1835,7 +1835,8 @@
         "pr_number": "${{ context.pr_number }}",
         "target_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "timeout_seconds": "60"
+        "timeout_seconds": "60",
+        "max_merge_group_drops": "1"
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -1578,7 +1578,8 @@
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
         "timeout_seconds": 60,
-        "poll_interval": 10
+        "poll_interval": 10,
+        "max_merge_group_drops": 1
       },
       "on_result": [
         {
@@ -1627,7 +1628,8 @@
         "target_branch": "${{ inputs.base_branch }}",
         "timeout_seconds": 900,
         "cwd": "${{ context.work_dir }}",
-        "remote_url": "${{ context.remote_url }}"
+        "remote_url": "${{ context.remote_url }}",
+        "max_merge_group_drops": 1
       },
       "capture": {
         "queue_pr_state": "${{ result.pr_state }}"

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -1645,6 +1645,7 @@ steps:
       target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
       timeout_seconds: "60"
+      max_merge_group_drops: "1"
     on_result:
     - when: "${{ result.pr_state }} == merged"
       route: release_issue_success

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -1437,6 +1437,7 @@ steps:
       remote_url: "${{ context.remote_url }}"
       timeout_seconds: 60
       poll_interval: 10
+      max_merge_group_drops: 1
     on_result:
     - when: "${{ result.pr_state }} == merged"
       route: release_issue_success
@@ -1475,6 +1476,7 @@ steps:
       timeout_seconds: 900
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
+      max_merge_group_drops: 1
     capture:
       queue_pr_state: "${{ result.pr_state }}"
     on_result:

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -1518,7 +1518,8 @@
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
         "timeout_seconds": 60,
-        "poll_interval": 10
+        "poll_interval": 10,
+        "max_merge_group_drops": 1
       },
       "on_result": [
         {
@@ -1567,7 +1568,8 @@
         "target_branch": "${{ inputs.base_branch }}",
         "timeout_seconds": 900,
         "cwd": "${{ context.work_dir }}",
-        "remote_url": "${{ context.remote_url }}"
+        "remote_url": "${{ context.remote_url }}",
+        "max_merge_group_drops": 1
       },
       "capture": {
         "queue_pr_state": "${{ result.pr_state }}"

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -1775,7 +1775,8 @@
         "pr_number": "${{ context.pr_number }}",
         "target_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "timeout_seconds": "60"
+        "timeout_seconds": "60",
+        "max_merge_group_drops": "1"
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1414,6 +1414,7 @@ steps:
       remote_url: ${{ context.remote_url }}
       timeout_seconds: 60
       poll_interval: 10
+      max_merge_group_drops: 1
     on_result:
     - when: ${{ result.pr_state }} == merged
       route: release_issue_success
@@ -1451,6 +1452,7 @@ steps:
       timeout_seconds: 900
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
+      max_merge_group_drops: 1
     capture:
       queue_pr_state: ${{ result.pr_state }}
     on_result:

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1619,6 +1619,7 @@ steps:
       target_branch: ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
       timeout_seconds: '60'
+      max_merge_group_drops: '1'
     on_result:
     - when: ${{ result.pr_state }} == merged
       route: release_issue_success

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -503,7 +503,8 @@
         "pr_number": "${{ context.current_pr_number }}",
         "target_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "timeout_seconds": "60"
+        "timeout_seconds": "60",
+        "max_merge_group_drops": "1"
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -308,7 +308,8 @@
         "target_branch": "${{ inputs.base_branch }}",
         "timeout_seconds": 900,
         "cwd": "${{ context.work_dir }}",
-        "remote_url": "${{ context.remote_url }}"
+        "remote_url": "${{ context.remote_url }}",
+        "max_merge_group_drops": 1
       },
       "capture": {
         "queue_pr_state": "${{ result.pr_state }}"
@@ -610,7 +611,8 @@
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
         "timeout_seconds": 60,
-        "poll_interval": 10
+        "poll_interval": 10,
+        "max_merge_group_drops": 1
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -364,6 +364,7 @@ steps:
       timeout_seconds: 900
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
+      max_merge_group_drops: 1
     capture:
       queue_pr_state: ${{ result.pr_state }}
     on_result:
@@ -597,6 +598,7 @@ steps:
       remote_url: ${{ context.remote_url }}
       timeout_seconds: 60
       poll_interval: 10
+      max_merge_group_drops: 1
     on_result:
     - when: ${{ result.pr_state }} == merged
       route: advance_queue_pr

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -521,6 +521,7 @@ steps:
       target_branch: ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
       timeout_seconds: '60'
+      max_merge_group_drops: '1'
     on_result:
     - when: ${{ result.pr_state }} == merged
       route: advance_queue_pr

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -1895,7 +1895,8 @@
         "pr_number": "${{ context.pr_number }}",
         "target_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
-        "timeout_seconds": "60"
+        "timeout_seconds": "60",
+        "max_merge_group_drops": "1"
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -1638,7 +1638,8 @@
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
         "timeout_seconds": 60,
-        "poll_interval": 10
+        "poll_interval": 10,
+        "max_merge_group_drops": 1
       },
       "on_result": [
         {
@@ -1687,7 +1688,8 @@
         "target_branch": "${{ inputs.base_branch }}",
         "timeout_seconds": 900,
         "cwd": "${{ context.work_dir }}",
-        "remote_url": "${{ context.remote_url }}"
+        "remote_url": "${{ context.remote_url }}",
+        "max_merge_group_drops": 1
       },
       "capture": {
         "queue_pr_state": "${{ result.pr_state }}"

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1500,6 +1500,7 @@ steps:
       remote_url: ${{ context.remote_url }}
       timeout_seconds: 60
       poll_interval: 10
+      max_merge_group_drops: 1
     on_result:
     - when: ${{ result.pr_state }} == merged
       route: release_issue_success
@@ -1537,6 +1538,7 @@ steps:
       timeout_seconds: 900
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
+      max_merge_group_drops: 1
     capture:
       queue_pr_state: ${{ result.pr_state }}
     on_result:

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1707,6 +1707,7 @@ steps:
       target_branch: ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
       timeout_seconds: '60'
+      max_merge_group_drops: '1'
     on_result:
     - when: ${{ result.pr_state }} == merged
       route: release_issue_success

--- a/src/autoskillit/server/tools/tools_ci_merge_queue.py
+++ b/src/autoskillit/server/tools/tools_ci_merge_queue.py
@@ -288,7 +288,7 @@ async def wait_for_merge_queue(
                     auto_merge_available=auto_merge_available,
                     max_merge_group_drops=max_merge_group_drops,
                     merge_group_drop_backoff=merge_group_drop_backoff,
-                    progress_callback=lambda msg: ctx.info(msg),
+                    progress_callback=lambda msg: _notify(ctx, "info", msg, __name__),
                 )
                 return json.dumps(result)
             except Exception as exc:

--- a/src/autoskillit/server/tools/tools_ci_merge_queue.py
+++ b/src/autoskillit/server/tools/tools_ci_merge_queue.py
@@ -187,6 +187,8 @@ async def wait_for_merge_queue(
     not_in_queue_confirmation_cycles: int = 2,
     max_inconclusive_retries: int = 5,
     auto_merge_available: bool = True,
+    max_merge_group_drops: int = 0,
+    merge_group_drop_backoff: float = 60.0,
     step_name: str = "",
     ctx: Context = CurrentContext(),
 ) -> str:
@@ -284,6 +286,9 @@ async def wait_for_merge_queue(
                     not_in_queue_confirmation_cycles=not_in_queue_confirmation_cycles,
                     max_inconclusive_retries=max_inconclusive_retries,
                     auto_merge_available=auto_merge_available,
+                    max_merge_group_drops=max_merge_group_drops,
+                    merge_group_drop_backoff=merge_group_drop_backoff,
+                    progress_callback=lambda msg: ctx.info(msg),
                 )
                 return json.dumps(result)
             except Exception as exc:

--- a/src/autoskillit/skills_extended/compose-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-pr/SKILL.md
@@ -145,6 +145,7 @@ The following files had merge conflicts that were automatically resolved.
 ```mermaid
 {diagram content}
 ```
+{## End Architecture Impact conditional}
 
 {If closing_issue is non-empty:}
 Closes #{closing_issue}
@@ -195,6 +196,7 @@ The following files had merge conflicts that were automatically resolved.
 ```mermaid
 {diagram content}
 ```
+{## End Architecture Impact conditional}
 
 {If closing_issue is non-empty:}
 Closes #{closing_issue}

--- a/src/autoskillit/skills_extended/diagnose-ci/SKILL.md
+++ b/src/autoskillit/skills_extended/diagnose-ci/SKILL.md
@@ -111,6 +111,7 @@ Analyze the log output to classify `failure_type` as one of:
 - `type_check` — mypy, pyright, or TypeScript type errors
 - `env` — missing environment variables, secrets, or infrastructure issues
 - `unknown` — cannot determine from logs
+- `no_failure` — all CI jobs passing; no failure detected
 
 #### Step 4a: Subtype Classification
 
@@ -125,6 +126,7 @@ After determining `failure_type`, classify `failure_subtype` using the following
 | `environ`, missing `ENV_VAR`, `KeyError.*environ` | `env` |
 | Assertion error with stable stack trace (same file/line across runs) | `deterministic` |
 | No pattern matched | `unknown` |
+| All CI jobs passing / no failure detected | `no_failure` |
 
 **Guidance for `resolve-failures`:** Include a supplementary "Suggested Starting Verdict" field in the
 Recommended Fix Approach section that maps the subtype to an initial verdict for `resolve-failures` to
@@ -141,7 +143,7 @@ local test result):
 
 Determine `is_fixable`:
 - `true` for `test`, `lint`, `build`, `type_check`
-- `false` for `env`, `unknown`
+- `false` for `env`, `unknown`, `no_failure`
 
 ### Step 5: Write Diagnosis Report
 
@@ -187,8 +189,8 @@ Emit these tokens on their own lines at the end of your response:
 
 ```
 diagnosis_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/diagnose-ci/diagnosis_{timestamp}.md
-failure_type = test|lint|build|type_check|env|unknown
-failure_subtype = flaky|timing_race|deterministic|fixture|import|env|unknown
+failure_type = test|lint|build|type_check|env|unknown|no_failure
+failure_subtype = flaky|timing_race|deterministic|fixture|import|env|unknown|no_failure
 is_fixable = true|false
 ```
 

--- a/src/autoskillit/skills_extended/resolve-failures/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-failures/SKILL.md
@@ -186,6 +186,7 @@ Using `{local_result}` from Step 2 and `{failure_subtype}` from Step 2a, determi
 | PASS | `deterministic` | `ci_only_failure` |
 | PASS | `fixture` or `import` | `flake_suspected` |
 | PASS | `env` or `unknown` | `flake_suspected` |
+| PASS | `no_failure` | `ci_only_failure` |
 
 **Note on `already_green`:** This verdict is reserved for the `pre_resolve_rebase`
 re-entry path — when a sibling pipeline's fix has already landed on integration and

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -142,7 +142,7 @@ If the file exists and contains entries:
    - `commit_id`: current HEAD commit SHA (from `gh pr view {pr_number} --json headRefOid -q .headRefOid`)
    - `comments[]` array where each entry has:
      - `path`: from the deferred entry
-     - `line`: from the deferred entry (if `line` is null, omit `line` and set `subject_type: "file"` for a file-level comment)
+     - `line`: from the deferred entry (if `line` is null, omit `line` for a file-level comment)
      - `side`: `"RIGHT"`
      - `body`:
        ```
@@ -170,7 +170,6 @@ If the file exists and contains entries:
        path: .path,
        line: (if .line then .line else null end),
        side: "RIGHT",
-       subject_type: (if .line then "line" else "file" end),
        body: ("**Observation from local review round \(.round):**\n\n\(.body)\n\n**Evidence:** \(.evidence)\n\n<!-- REVIEW-FLAG: severity=\(.severity) dimension=\(.dimension) -->")
      }) | map(if .line == null then del(.line) else . end)
    ')

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -106,7 +106,7 @@ SESSION_FSM_SIZE_BUDGETS = {
     "session/_session_outcome.py": 260,
 }
 MQ_SIZE_BUDGETS = {
-    "merge_queue/__init__.py": 500,
+    "merge_queue/__init__.py": 540,
     "merge_queue/_merge_queue_classifier.py": 175,
     "merge_queue/_merge_queue_repo_state.py": 320,
 }

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -106,7 +106,7 @@ SESSION_FSM_SIZE_BUDGETS = {
     "session/_session_outcome.py": 260,
 }
 MQ_SIZE_BUDGETS = {
-    "merge_queue/__init__.py": 540,
+    "merge_queue/__init__.py": 550,
     "merge_queue/_merge_queue_classifier.py": 175,
     "merge_queue/_merge_queue_repo_state.py": 320,
 }

--- a/tests/execution/test_merge_queue_polling.py
+++ b/tests/execution/test_merge_queue_polling.py
@@ -897,3 +897,140 @@ class TestMergeGroupDropInternalReenqueue:
         assert result["success"] is False
         assert result["pr_state"] == "dropped_merge_group_ci"
         assert len(enqueue_calls) == 0
+
+    @pytest.mark.anyio
+    async def test_wait_resets_deadline_after_internal_reenqueue(self):
+        """Deadline must be reset after internal re-enqueue so polling continues."""
+        import autoskillit.execution.merge_queue as _mq
+
+        watcher = _make_watcher()
+        call_count = 0
+
+        async def _fetch(*_a, **_kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _queue_state(in_queue=True, checks_state="SUCCESS")
+            if call_count == 2:
+                return _queue_state(
+                    in_queue=False,
+                    checks_state="SUCCESS",
+                    state="OPEN",
+                    mergeable="MERGEABLE",
+                    merge_state_status="CLEAN",
+                    auto_merge_present=False,
+                )
+            if call_count == 3:
+                return _queue_state(in_queue=True, checks_state="SUCCESS")
+            return _queue_state(merged=True)
+
+        watcher._fetch_pr_and_queue_state = _fetch  # type: ignore[method-assign]
+
+        async def _mock_enqueue(*a, **kw):
+            return {"success": True, "pr_number": 42, "enrollment_method": "auto_merge"}
+
+        watcher.enqueue = _mock_enqueue  # type: ignore[method-assign]
+
+        mono_call = 0
+        reenqueue_happened = False
+
+        def _monotonic():
+            nonlocal mono_call, reenqueue_happened
+            mono_call += 1
+            if mono_call <= 2:
+                return 0.0
+            if reenqueue_happened:
+                return 150.0
+            return 99.0
+
+        orig_enqueue = watcher.enqueue
+
+        async def _tracked_enqueue(*a, **kw):
+            nonlocal reenqueue_happened
+            reenqueue_happened = True
+            return await orig_enqueue(*a, **kw)
+
+        watcher.enqueue = _tracked_enqueue  # type: ignore[method-assign]
+
+        with (
+            patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock),
+            patch(
+                "autoskillit.execution.merge_queue.time.monotonic",
+                side_effect=_monotonic,
+            ),
+            patch.object(
+                _mq,
+                "_query_merge_group_ci",
+                new_callable=AsyncMock,
+                return_value="FAILURE",
+            ),
+        ):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                timeout_seconds=100,
+                max_merge_group_drops=1,
+                merge_group_drop_backoff=0.01,
+                not_in_queue_confirmation_cycles=1,
+            )
+
+        assert result["success"] is True
+        assert result["pr_state"] == "merged"
+
+    @pytest.mark.anyio
+    async def test_wait_emits_progress_notifications(self):
+        """progress_callback must be called when 60s has elapsed between polls."""
+        import autoskillit.execution.merge_queue as _mq
+
+        watcher = _make_watcher()
+        call_count = 0
+
+        async def _fetch(*_a, **_kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return _queue_state(in_queue=True, checks_state="SUCCESS")
+            return _queue_state(merged=True)
+
+        watcher._fetch_pr_and_queue_state = _fetch  # type: ignore[method-assign]
+
+        progress_cb = AsyncMock()
+
+        mono_call = 0
+
+        def _monotonic():
+            nonlocal mono_call
+            mono_call += 1
+            if mono_call <= 2:
+                return 0.0
+            if mono_call <= 4:
+                return 1.0
+            if mono_call <= 8:
+                return 70.0
+            return 71.0
+
+        with (
+            patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock),
+            patch(
+                "autoskillit.execution.merge_queue.time.monotonic",
+                side_effect=_monotonic,
+            ),
+            patch.object(
+                _mq,
+                "_query_merge_group_ci",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                timeout_seconds=1000,
+                progress_callback=progress_cb,
+                not_in_queue_confirmation_cycles=1,
+            )
+
+        assert result["success"] is True
+        assert progress_cb.await_count >= 1

--- a/tests/execution/test_merge_queue_polling.py
+++ b/tests/execution/test_merge_queue_polling.py
@@ -975,6 +975,7 @@ class TestMergeGroupDropInternalReenqueue:
                 not_in_queue_confirmation_cycles=1,
             )
 
+        assert reenqueue_happened, "re-enqueue code path was never taken"
         assert result["success"] is True
         assert result["pr_state"] == "merged"
 

--- a/tests/execution/test_merge_queue_polling.py
+++ b/tests/execution/test_merge_queue_polling.py
@@ -731,3 +731,168 @@ class TestToggleAutoMergeConfirmation:
             await watcher._toggle_auto_merge("PR_node123")
 
         assert 2 not in sleep_durations
+
+
+class TestMergeGroupDropInternalReenqueue:
+    """Tests for internal re-enqueue on DROPPED_MERGE_GROUP_CI."""
+
+    @pytest.mark.anyio
+    async def test_wait_internally_reenqueues_on_first_dropped_merge_group_ci(self):
+        """With max_merge_group_drops=1, first drop triggers internal re-enqueue, then merges."""
+        import autoskillit.execution.merge_queue as _mq
+
+        watcher = _make_watcher()
+        call_count = 0
+
+        async def _fetch(*_a, **_kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _queue_state(in_queue=True, checks_state="SUCCESS")
+            if call_count == 2:
+                return _queue_state(
+                    in_queue=False,
+                    checks_state="SUCCESS",
+                    state="OPEN",
+                    mergeable="MERGEABLE",
+                    merge_state_status="CLEAN",
+                    auto_merge_present=False,
+                )
+            if call_count == 3:
+                return _queue_state(in_queue=True, checks_state="SUCCESS")
+            return _queue_state(merged=True)
+
+        watcher._fetch_pr_and_queue_state = _fetch  # type: ignore[method-assign]
+
+        enqueue_calls: list[int] = []
+
+        async def _mock_enqueue(*a, **kw):
+            enqueue_calls.append(1)
+            return {"success": True, "pr_number": 42, "enrollment_method": "auto_merge"}
+
+        watcher.enqueue = _mock_enqueue  # type: ignore[method-assign]
+
+        with (
+            patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock),
+            patch.object(
+                _mq, "_query_merge_group_ci", new_callable=AsyncMock, return_value="FAILURE"
+            ),
+        ):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                max_merge_group_drops=1,
+                merge_group_drop_backoff=0.01,
+            )
+
+        assert result["success"] is True
+        assert result["pr_state"] == "merged"
+        assert len(enqueue_calls) == 1
+
+    @pytest.mark.anyio
+    async def test_wait_returns_on_second_dropped_merge_group_ci(self):
+        """With max_merge_group_drops=1, second consecutive drop surfaces to caller."""
+        import autoskillit.execution.merge_queue as _mq
+
+        watcher = _make_watcher()
+        call_count = 0
+
+        async def _fetch(*_a, **_kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _queue_state(in_queue=True, checks_state="SUCCESS")
+            if call_count in (2, 3):
+                return _queue_state(
+                    in_queue=False,
+                    checks_state="SUCCESS",
+                    state="OPEN",
+                    mergeable="MERGEABLE",
+                    merge_state_status="CLEAN",
+                    auto_merge_present=False,
+                )
+            if call_count == 4:
+                return _queue_state(in_queue=True, checks_state="SUCCESS")
+            return _queue_state(
+                in_queue=False,
+                checks_state="SUCCESS",
+                state="OPEN",
+                mergeable="MERGEABLE",
+                merge_state_status="CLEAN",
+                auto_merge_present=False,
+            )
+
+        watcher._fetch_pr_and_queue_state = _fetch  # type: ignore[method-assign]
+
+        async def _mock_enqueue(*a, **kw):
+            return {"success": True, "pr_number": 42, "enrollment_method": "auto_merge"}
+
+        watcher.enqueue = _mock_enqueue  # type: ignore[method-assign]
+
+        with (
+            patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock),
+            patch.object(
+                _mq, "_query_merge_group_ci", new_callable=AsyncMock, return_value="FAILURE"
+            ),
+        ):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                max_merge_group_drops=1,
+                merge_group_drop_backoff=0.01,
+            )
+
+        assert result["success"] is False
+        assert result["pr_state"] == "dropped_merge_group_ci"
+        assert result["drop_count"] == 1
+
+    @pytest.mark.anyio
+    async def test_wait_returns_immediately_when_max_merge_group_drops_zero(self):
+        """Default max_merge_group_drops=0 returns immediately without calling enqueue."""
+        import autoskillit.execution.merge_queue as _mq
+
+        watcher = _make_watcher()
+        call_count = 0
+
+        async def _fetch(*_a, **_kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _queue_state(in_queue=True, checks_state="SUCCESS")
+            return _queue_state(
+                in_queue=False,
+                checks_state="SUCCESS",
+                state="OPEN",
+                mergeable="MERGEABLE",
+                merge_state_status="CLEAN",
+                auto_merge_present=False,
+            )
+
+        watcher._fetch_pr_and_queue_state = _fetch  # type: ignore[method-assign]
+
+        enqueue_calls: list[int] = []
+
+        async def _mock_enqueue(*a, **kw):
+            enqueue_calls.append(1)
+            return {"success": True, "pr_number": 42, "enrollment_method": "auto_merge"}
+
+        watcher.enqueue = _mock_enqueue  # type: ignore[method-assign]
+
+        with (
+            patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock),
+            patch.object(
+                _mq, "_query_merge_group_ci", new_callable=AsyncMock, return_value="FAILURE"
+            ),
+        ):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                max_merge_group_drops=0,
+            )
+
+        assert result["success"] is False
+        assert result["pr_state"] == "dropped_merge_group_ci"
+        assert len(enqueue_calls) == 0

--- a/tests/execution/test_merge_queue_polling.py
+++ b/tests/execution/test_merge_queue_polling.py
@@ -784,6 +784,7 @@ class TestMergeGroupDropInternalReenqueue:
                 repo="owner/repo",
                 max_merge_group_drops=1,
                 merge_group_drop_backoff=0.01,
+                not_in_queue_confirmation_cycles=1,
             )
 
         assert result["success"] is True

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -553,7 +553,11 @@ class InMemoryCIWatcher(CIWatcher):
 
 
 class InMemoryMergeQueueWatcher(MergeQueueWatcher):
-    """In-memory test double for :class:`MergeQueueWatcher`."""
+    """In-memory test double for :class:`MergeQueueWatcher`.
+
+    Result precedence for wait(): (1) _wait_results_queue.popleft() if non-empty,
+    (2) _resolve_side_effect(wait_side_effect) if set, (3) self._wait_result.
+    """
 
     def __init__(
         self,
@@ -578,6 +582,7 @@ class InMemoryMergeQueueWatcher(MergeQueueWatcher):
         self.wait_side_effect: Any | None = None
         self.toggle_side_effect: Any | None = None
         self.enqueue_side_effect: Any | None = None
+        self._wait_results_queue: deque[dict[str, Any]] = deque()
 
     async def wait(
         self,
@@ -592,6 +597,9 @@ class InMemoryMergeQueueWatcher(MergeQueueWatcher):
         not_in_queue_confirmation_cycles: int = 2,
         max_inconclusive_retries: int = 5,
         auto_merge_available: bool = True,
+        max_merge_group_drops: int = 0,
+        merge_group_drop_backoff: float = 60.0,
+        progress_callback: Callable[[str], Awaitable[None]] | None = None,
     ) -> dict[str, Any]:
         self.wait_calls.append(
             {
@@ -602,8 +610,12 @@ class InMemoryMergeQueueWatcher(MergeQueueWatcher):
                 "timeout_seconds": timeout_seconds,
                 "poll_interval": poll_interval,
                 "auto_merge_available": auto_merge_available,
+                "max_merge_group_drops": max_merge_group_drops,
+                "merge_group_drop_backoff": merge_group_drop_backoff,
             }
         )
+        if self._wait_results_queue:
+            return self._wait_results_queue.popleft()
         if self.wait_side_effect is not None:
             return _resolve_side_effect(self.wait_side_effect)
         return self._wait_result

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -976,6 +976,16 @@ def test_wait_for_ci_conclusion_allowed_values() -> None:
     assert {"success", "failure", "cancelled", "timed_out", "no_runs", "error"}.issubset(values)
 
 
+def test_diagnose_ci_no_failure_in_allowed_values() -> None:
+    """diagnose-ci contract must allow no_failure for failure_type and failure_subtype."""
+    manifest = load_bundled_manifest()
+    ci_outputs = manifest["skills"]["diagnose-ci"]["outputs"]
+    ft = next(o for o in ci_outputs if o["name"] == "failure_type")
+    fst = next(o for o in ci_outputs if o["name"] == "failure_subtype")
+    assert "no_failure" in ft["allowed_values"]
+    assert "no_failure" in fst["allowed_values"]
+
+
 # ---------------------------------------------------------------------------
 # Research recipe contract card tests
 # ---------------------------------------------------------------------------

--- a/tests/recipe/test_merge_prs_queue_common.py
+++ b/tests/recipe/test_merge_prs_queue_common.py
@@ -903,3 +903,60 @@ def test_unbounded_cycle_fires_for_unguarded_dropped_merge_group_ci_branch(any_r
         f"{recipe.name}; got no such finding among: "
         f"{[(f.step_name, f.severity, f.message[:80]) for f in cycle_findings]}"
     )
+
+
+def test_unbounded_cycle_suppressed_when_dropped_merge_group_ci_has_guard(any_recipe) -> None:
+    """unbounded-cycle must NOT fire for dropped_merge_group_ci when max_merge_group_drops >= 1."""
+    from autoskillit.core.types import Severity
+    from autoskillit.recipe.validator import run_semantic_rules
+
+    findings = run_semantic_rules(any_recipe)
+    cycle_findings = [f for f in findings if f.rule == "unbounded-cycle"]
+    dmgci_error_findings = [
+        f
+        for f in cycle_findings
+        if f.severity == Severity.ERROR and "dropped_merge_group_ci" in f.message
+    ]
+    assert not dmgci_error_findings, (
+        f"unbounded-cycle must NOT fire ERROR for guarded dropped_merge_group_ci branch in "
+        f"{any_recipe.name} (max_merge_group_drops >= 1); got: "
+        f"{[(f.step_name, f.message[:80]) for f in dmgci_error_findings]}"
+    )
+
+
+def test_dropped_merge_group_ci_reenqueue_guard_fires_without_guard(any_recipe) -> None:
+    """Semantic rule I9 must fire ERROR when max_merge_group_drops is absent."""
+    import copy
+
+    from autoskillit.core.types import Severity
+    from autoskillit.recipe.validator import run_semantic_rules
+
+    recipe = copy.deepcopy(any_recipe)
+    for step in recipe.steps.values():
+        if step.tool == "wait_for_merge_queue" and step.with_args:
+            step.with_args.pop("max_merge_group_drops", None)
+
+    findings = run_semantic_rules(recipe)
+    i9_findings = [
+        f
+        for f in findings
+        if f.rule == "dropped-merge-group-ci-unguarded-reenqueue-loop"
+        and f.severity == Severity.ERROR
+    ]
+    assert i9_findings, (
+        f"Rule I9 must fire ERROR for unguarded dropped_merge_group_ci in {recipe.name}"
+    )
+
+
+def test_dropped_merge_group_ci_reenqueue_guard_suppressed_with_guard(any_recipe) -> None:
+    """Semantic rule I9 must NOT fire when max_merge_group_drops >= 1."""
+    from autoskillit.recipe.validator import run_semantic_rules
+
+    findings = run_semantic_rules(any_recipe)
+    i9_findings = [
+        f for f in findings if f.rule == "dropped-merge-group-ci-unguarded-reenqueue-loop"
+    ]
+    assert not i9_findings, (
+        f"Rule I9 must NOT fire for guarded recipe {any_recipe.name}; got: "
+        f"{[(f.step_name, f.severity, f.message[:80]) for f in i9_findings]}"
+    )

--- a/tests/recipe/test_merge_prs_queue_common.py
+++ b/tests/recipe/test_merge_prs_queue_common.py
@@ -880,12 +880,18 @@ class TestMergePrsPreEnqueueCiGate:
 
 def test_unbounded_cycle_fires_for_unguarded_dropped_merge_group_ci_branch(any_recipe) -> None:
     """unbounded-cycle must fire ERROR for the dropped_merge_group_ci → diagnose_ci path
-    which has no direct guard step, even though sibling branches (ejected, dropped_healthy)
-    do have guards (check_eject_limit, check_dropped_healthy_loop)."""
+    when max_merge_group_drops is absent (no watcher-internal guard)."""
+    import copy
+
     from autoskillit.core.types import Severity
     from autoskillit.recipe.validator import run_semantic_rules
 
-    findings = run_semantic_rules(any_recipe)
+    recipe = copy.deepcopy(any_recipe)
+    for step in recipe.steps.values():
+        if step.tool == "wait_for_merge_queue" and step.with_args:
+            step.with_args.pop("max_merge_group_drops", None)
+
+    findings = run_semantic_rules(recipe)
     cycle_findings = [f for f in findings if f.rule == "unbounded-cycle"]
     dmgci_findings = [
         f
@@ -894,6 +900,6 @@ def test_unbounded_cycle_fires_for_unguarded_dropped_merge_group_ci_branch(any_r
     ]
     assert dmgci_findings, (
         f"unbounded-cycle must fire ERROR for unguarded dropped_merge_group_ci branch in "
-        f"{any_recipe.name}; got no such finding among: "
+        f"{recipe.name}; got no such finding among: "
         f"{[(f.step_name, f.severity, f.message[:80]) for f in cycle_findings]}"
     )

--- a/tests/recipe/test_merge_prs_queue_common.py
+++ b/tests/recipe/test_merge_prs_queue_common.py
@@ -910,6 +910,18 @@ def test_unbounded_cycle_suppressed_when_dropped_merge_group_ci_has_guard(any_re
     from autoskillit.core.types import Severity
     from autoskillit.recipe.validator import run_semantic_rules
 
+    mq_steps_with_guard = [
+        s
+        for s in any_recipe.steps.values()
+        if s.tool == "wait_for_merge_queue"
+        and s.with_args
+        and int(s.with_args.get("max_merge_group_drops", 0)) >= 1
+    ]
+    assert mq_steps_with_guard, (
+        f"Precondition: {any_recipe.name} must have at least one wait_for_merge_queue step "
+        f"with max_merge_group_drops >= 1 for this test to be meaningful"
+    )
+
     findings = run_semantic_rules(any_recipe)
     cycle_findings = [f for f in findings if f.rule == "unbounded-cycle"]
     dmgci_error_findings = [
@@ -951,6 +963,18 @@ def test_dropped_merge_group_ci_reenqueue_guard_fires_without_guard(any_recipe) 
 def test_dropped_merge_group_ci_reenqueue_guard_suppressed_with_guard(any_recipe) -> None:
     """Semantic rule I9 must NOT fire when max_merge_group_drops >= 1."""
     from autoskillit.recipe.validator import run_semantic_rules
+
+    mq_steps_with_guard = [
+        s
+        for s in any_recipe.steps.values()
+        if s.tool == "wait_for_merge_queue"
+        and s.with_args
+        and int(s.with_args.get("max_merge_group_drops", 0)) >= 1
+    ]
+    assert mq_steps_with_guard, (
+        f"Precondition: {any_recipe.name} must have at least one wait_for_merge_queue step "
+        f"with max_merge_group_drops >= 1 for this test to be meaningful"
+    )
 
     findings = run_semantic_rules(any_recipe)
     i9_findings = [

--- a/tests/recipe/test_merge_prs_queue_common.py
+++ b/tests/recipe/test_merge_prs_queue_common.py
@@ -871,3 +871,29 @@ class TestMergePrsPreEnqueueCiGate:
         assert step.on_failure == "verify_queue_enrollment", (
             f"reenter_queue.on_failure must be 'verify_queue_enrollment', got: {step.on_failure!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# unbounded-cycle per-branch detection — dropped_merge_group_ci
+# ---------------------------------------------------------------------------
+
+
+def test_unbounded_cycle_fires_for_unguarded_dropped_merge_group_ci_branch(any_recipe) -> None:
+    """unbounded-cycle must fire ERROR for the dropped_merge_group_ci → diagnose_ci path
+    which has no direct guard step, even though sibling branches (ejected, dropped_healthy)
+    do have guards (check_eject_limit, check_dropped_healthy_loop)."""
+    from autoskillit.core.types import Severity
+    from autoskillit.recipe.validator import run_semantic_rules
+
+    findings = run_semantic_rules(any_recipe)
+    cycle_findings = [f for f in findings if f.rule == "unbounded-cycle"]
+    dmgci_findings = [
+        f
+        for f in cycle_findings
+        if f.severity == Severity.ERROR and "dropped_merge_group_ci" in f.message
+    ]
+    assert dmgci_findings, (
+        f"unbounded-cycle must fire ERROR for unguarded dropped_merge_group_ci branch in "
+        f"{any_recipe.name}; got no such finding among: "
+        f"{[(f.step_name, f.severity, f.message[:80]) for f in cycle_findings]}"
+    )

--- a/tests/recipe/test_rule_decomposition.py
+++ b/tests/recipe/test_rule_decomposition.py
@@ -28,7 +28,7 @@ def test_no_deferred_validator_imports_in_rule_modules() -> None:
 
 
 def test_all_rules_registered_across_submodules() -> None:
-    """T2: All 31 rules registered, distributed across sub-modules."""
+    """T2: All 32 rules registered, distributed across sub-modules."""
     import autoskillit.recipe  # noqa: F401 -- triggers rule registration
     from autoskillit.recipe.registry import _RULE_REGISTRY
 
@@ -65,6 +65,7 @@ def test_all_rules_registered_across_submodules() -> None:
         "skip-when-false-on-hidden",
         "clone-terminal-requires-registration",
         "rate-limit-route-missing",
+        "dropped-merge-group-ci-unguarded-reenqueue-loop",
     }
     assert expected <= rule_names
 

--- a/tests/skills/CLAUDE.md
+++ b/tests/skills/CLAUDE.md
@@ -15,6 +15,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 | `test_audit_arch_selfvalidation_contracts.py` | Audit-arch skill self-validation contract tests |
 | `test_audit_impl_diff_discipline.py` | Structural guards for audit-impl diff discipline: Step 2 variable usage, Step 3 data source prohibition, diff size guard |
 | `test_audit_review_decisions_contracts.py` | Contract tests for the audit-review-decisions skill SKILL.md |
+| `test_compose_pr.py` | Guard tests for compose-pr/SKILL.md template structure |
 | `test_conflict_resolution_guards.py` | Structural guards for conflict resolution safeguards in SKILL.md files |
 | `test_deletion_regression_guards.py` | Structural guards for deletion regression detection in merge-pr and review-pr skills |
 | `test_dry_walkthrough_contracts.py` | Structural contracts for the dry-walkthrough historical regression check step |

--- a/tests/skills/test_compose_pr.py
+++ b/tests/skills/test_compose_pr.py
@@ -24,7 +24,7 @@ def test_closes_issue_outside_architecture_impact_block():
     omitted when no validated diagrams exist (the entire block is skipped).
     """
     end_marker = "{## End Architecture Impact conditional}"
-    closes_pattern = "Closes #"
+    closes_pattern = "Closes #{closing_issue}"
     marker_positions = [i for i in range(len(SKILL_TEXT)) if SKILL_TEXT[i:].startswith(end_marker)]
     assert marker_positions, (
         "compose-pr/SKILL.md must contain '{## End Architecture Impact conditional}' marker"
@@ -32,7 +32,9 @@ def test_closes_issue_outside_architecture_impact_block():
     closes_positions = [
         i for i in range(len(SKILL_TEXT)) if SKILL_TEXT[i:].startswith(closes_pattern)
     ]
-    assert closes_positions, "compose-pr/SKILL.md must contain 'Closes #' template variable"
+    assert closes_positions, (
+        "compose-pr/SKILL.md must contain 'Closes #{closing_issue}' template variable"
+    )
     for closes_pos in closes_positions:
         nearest_marker = max(
             (m for m in marker_positions if m < closes_pos),

--- a/tests/skills/test_compose_pr.py
+++ b/tests/skills/test_compose_pr.py
@@ -1,0 +1,45 @@
+"""Guard tests for compose-pr/SKILL.md template structure."""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.small]
+
+SKILL_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "compose-pr"
+    / "SKILL.md"
+)
+SKILL_TEXT = SKILL_PATH.read_text()
+
+
+def test_closes_issue_outside_architecture_impact_block():
+    """Closes #{closing_issue} must appear AFTER {## End Architecture Impact conditional}.
+
+    If Closes # is inside the Architecture Impact conditional block, it gets
+    omitted when no validated diagrams exist (the entire block is skipped).
+    """
+    end_marker = "{## End Architecture Impact conditional}"
+    closes_pattern = "Closes #"
+    marker_positions = [i for i in range(len(SKILL_TEXT)) if SKILL_TEXT[i:].startswith(end_marker)]
+    assert marker_positions, (
+        "compose-pr/SKILL.md must contain '{## End Architecture Impact conditional}' marker"
+    )
+    closes_positions = [
+        i for i in range(len(SKILL_TEXT)) if SKILL_TEXT[i:].startswith(closes_pattern)
+    ]
+    assert closes_positions, "compose-pr/SKILL.md must contain 'Closes #' template variable"
+    for closes_pos in closes_positions:
+        nearest_marker = max(
+            (m for m in marker_positions if m < closes_pos),
+            default=None,
+        )
+        assert nearest_marker is not None, (
+            f"'Closes #' at position {closes_pos} has no preceding "
+            "'{## End Architecture Impact conditional}' marker — "
+            "it may be inside the conditional block"
+        )

--- a/tests/skills/test_compose_pr.py
+++ b/tests/skills/test_compose_pr.py
@@ -14,7 +14,6 @@ SKILL_PATH = (
     / "compose-pr"
     / "SKILL.md"
 )
-SKILL_TEXT = SKILL_PATH.read_text()
 
 
 def test_closes_issue_outside_architecture_impact_block():
@@ -23,6 +22,7 @@ def test_closes_issue_outside_architecture_impact_block():
     If Closes # is inside the Architecture Impact conditional block, it gets
     omitted when no validated diagrams exist (the entire block is skipped).
     """
+    SKILL_TEXT = SKILL_PATH.read_text()
     end_marker = "{## End Architecture Impact conditional}"
     closes_pattern = "Closes #{closing_issue}"
     marker_positions = [i for i in range(len(SKILL_TEXT)) if SKILL_TEXT[i:].startswith(end_marker)]

--- a/tests/skills/test_review_pr_inline_comment_guards.py
+++ b/tests/skills/test_review_pr_inline_comment_guards.py
@@ -720,6 +720,25 @@ def test_review_research_pr_step4_uses_valid_diff_lines():
     assert "VALID_DIFF_LINES" in step4_section
 
 
+def test_resolve_review_batch_payload_excludes_subject_type():
+    """resolve-review batch reviews POST must NOT include subject_type.
+
+    The batch Reviews API (POST /repos/{owner}/{repo}/pulls/{N}/reviews)
+    does not accept subject_type in the comments array. Including it
+    causes HTTP 422.
+    """
+    text = RESOLVE_SKILL_TEXT
+    step15_start = text.find("### Step 1.5")
+    step2_start = text.find("### Step 2")
+    assert step15_start != -1, "resolve-review must have Step 1.5"
+    assert step2_start != -1, "resolve-review must have Step 2"
+    step15_section = text[step15_start:step2_start]
+    assert "subject_type" not in step15_section, (
+        "resolve-review Step 1.5 batch reviews POST must NOT include 'subject_type'. "
+        "The batch Reviews API does not accept this field — it causes HTTP 422."
+    )
+
+
 def test_resolve_research_review_handles_null_line_file_level_threads():
     """resolve-research-review must handle null-line file-level comment threads gracefully."""
     text = RESOLVE_RESEARCH_SKILL_TEXT


### PR DESCRIPTION
## Summary

The `dropped_merge_group_ci` state in the merge queue watcher routes to `diagnose_ci` with no circuit breaker, creating an unbounded loop that exhausts pipeline resources. Two sibling states (`ejected`, `dropped_healthy`) both have file-counter circuit breakers, but `dropped_merge_group_ci` was missed. The root cause is two-layered: (1) a missing guard step in recipe routing, and (2) a structural gap in the `unbounded-cycle` DFS rule that prevents it from detecting this class of cycle. The architectural fix addresses both layers — making the static validator catch this pattern automatically so it can never recur, and absorbing transient drops into the watcher itself following the stall-recovery precedent.

Three secondary bugs were also discovered in the same pipeline run: a contract gap for `failure_subtype=none`, a `Closes #N` template nesting bug, and a `subject_type` REST API mismatch.

## Requirements

### Primary: Watcher-Level Circuit Breaker

- REQ-MQ-001: `DefaultMergeQueueWatcher.wait()` MUST accept a `max_merge_group_drops` parameter (default 0 for backward compatibility). When `DROPPED_MERGE_GROUP_CI` is classified and `drop_count < max_merge_group_drops`, the watcher MUST backoff, re-enqueue internally via `self.enqueue()`, reset polling state, and resume — without returning to the orchestrator.
- REQ-MQ-002: The `wait_for_merge_queue` MCP tool MUST expose `max_merge_group_drops` and `merge_group_drop_backoff` (default 60s) as parameters, passing them through to `wait()`.
- REQ-MQ-003: `DefaultMergeQueueWatcher.wait()` MUST emit periodic progress notifications (at minimum every 60s) to keep the MCP stream alive during extended polling. Because `_type_protocols_github.py` is IL-0 (cannot import `fastmcp.Context`), the protocol MUST use either a minimal `SupportsInfo` protocol defined in IL-0 or an `Optional[Callable[[str], Awaitable[None]]]` callback parameter. `InMemoryMergeQueueWatcher` in `tests/fakes.py` MUST be updated to match.
- REQ-MQ-004: After internal re-enqueue, `wait()` MUST reset its polling deadline (`deadline = time.monotonic() + timeout_seconds`) so the second watch period gets a full timeout budget. Without this, drops detected late in the first timeout window would immediately fall through to `pr_state="timeout"`.
- REQ-MQ-005: When `drop_count >= max_merge_group_drops`, `wait()` MUST return `pr_state="dropped_merge_group_ci"` with `drop_count` in the result dict for observability.
- REQ-MQ-006: All three affected recipes (`implementation.yaml`, `remediation.yaml`, `implementation-groups.yaml`) MUST set `max_merge_group_drops: 1` in their `wait_for_queue` step AND their `verify_queue_enrollment` step, so the first transient drop is handled internally and only repeated drops surface to the orchestrator.

### Secondary: `failure_subtype` Contract + Verdict Routing

- REQ-MQ-007: `diagnose-ci/SKILL.md` MUST add a decision-tree row: "All CI jobs passing / no failure detected → `failure_type = no_failure`, `failure_subtype = no_failure`, `is_fixable = false`"
- REQ-MQ-008: `skill_contracts.yaml` MUST add `no_failure` to BOTH `failure_type` `allowed_values` (line 46) AND `failure_subtype` `allowed_values` (line 49), update the regex pattern (line 54), and add a `pattern_example` for the no-failure case
- REQ-MQ-009: `resolve-failures/SKILL.md` Step 2d verdict table MUST add row: `PASS + no_failure → ci_only_failure` — this prevents `resolve_ci` from routing to `re_push` when CI is confirmed passing

### Tertiary: Compose-PR and Resolve-Review

- REQ-MQ-010: `compose-pr/SKILL.md` MUST position `{If closing_issue is non-empty:} Closes #{closing_issue}` OUTSIDE the Architecture Impact conditional block in BOTH templates (single-plan at line 149 AND multiple-plans at line 199), with unambiguous structural separation
- REQ-MQ-011: `resolve-review/SKILL.md` MUST NOT include `subject_type` in batch Reviews API payloads — remove from line 145 (prose) and line 173 (jq template)

### Process

- REQ-MQ-012: After all recipe YAML edits, run `task regen-contracts && task compile-recipes` to update contract card hashes
- REQ-MQ-013: Add tests for the new `max_merge_group_drops` behavior in `DefaultMergeQueueWatcher`, including: (a) internal re-enqueue on first drop, (b) deadline reset after re-enqueue, (c) return on second drop with `drop_count`, (d) progress notification emission, (e) backoff timing, (f) protocol conformance test for `InMemoryMergeQueueWatcher`

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260531-083916-105835/.autoskillit/temp/rectify/rectify_merge_queue_unbounded_loop_2026-05-31_090500.md`

Closes #3418

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 12.3k | 21.9k | 2.2M | 136.9k | 376 | 105.3k | 25m 56s |
| review_approach* | opus[1m] | 1 | 4.3k | 5.6k | 231.8k | 45.7k | 40 | 32.2k | 3m 27s |
| dry_walkthrough* | opus | 2 | 2.1k | 41.0k | 4.1M | 113.1k | 420 | 169.8k | 21m 57s |
| implement* | opus[1m] | 2 | 222 | 52.0k | 15.5M | 193.2k | 309 | 403.5k | 23m 46s |
| audit_impl* | opus[1m] | 2 | 39 | 19.4k | 484.4k | 57.5k | 215 | 93.3k | 16m 46s |
| make_plan* | opus[1m] | 1 | 63 | 24.5k | 1.9M | 117.0k | 250 | 101.9k | 21m 15s |
| prepare_pr* | opus[1m] | 1 | 53.0k | 5.9k | 317.0k | 0 | 23 | 0 | 1m 35s |
| compose_pr* | opus[1m] | 1 | 55.1k | 2.5k | 294.8k | 0 | 18 | 0 | 1m 17s |
| review_pr* | opus[1m] | 2 | 179 | 75.6k | 2.3M | 127.5k | 230 | 211.7k | 29m 17s |
| resolve_review* | opus[1m] | 2 | 102 | 38.3k | 3.7M | 105.6k | 136 | 157.1k | 28m 1s |
| ci_conflict_fix* | opus[1m] | 1 | 40 | 5.3k | 1.4M | 82.5k | 40 | 66.0k | 2m 36s |
| **Total** | | | 127.4k | 292.0k | 32.5M | 193.2k | | 1.3M | 2h 55m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 769 | 20171.1 | 524.7 | 67.6 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 41 | 89613.5 | 3832.0 | 933.8 |
| ci_conflict_fix | 3501 | 412.0 | 18.9 | 1.5 |
| **Total** | **4311** | 7540.5 | 311.0 | 67.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 10 | 125.2k | 251.0k | 28.4M | 1.2M | 2h 34m |
| opus | 1 | 2.1k | 41.0k | 4.1M | 169.8k | 21m 57s |