### PR TITLE
Narrow hook_registry Cascade — Replace server/infra/docs with File-Level Entries

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -781,10 +781,20 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
     "hook_registry": frozenset(
         {
             "hooks",
-            "server",
-            "infra",
             "cli",
-            "docs",
+            # server/ narrowed to 2 files
+            "server/test_tools_kitchen_envelope.py",
+            "server/test_lifespan.py",
+            # infra/ narrowed to 7 files
+            "infra/test_adr_runtime_guard_coverage.py",
+            "infra/test_command_guard_completeness.py",
+            "infra/test_guard_coverage.py",
+            "infra/test_risky_gh_subcommand_coverage.py",
+            "infra/test_session_scope_enforcement.py",
+            "infra/test_session_type_exemption_enforcement.py",
+            "infra/test_skill_exemption_enforcement.py",
+            # docs/ narrowed to 1 file
+            "docs/test_doc_counts.py",
         }
     ),
     # Standalone modules (not subpackage directories)


### PR DESCRIPTION
## Summary

Replace over-broad directory entries (`server`, `infra`, `docs`) in `LAYER_CASCADE_CONSERVATIVE["hook_registry"]` with verified file-level entries. Keep `hooks` (direct consumer) and `cli` (10/38 files = 26%, borderline) as directory entries. Saves ~2,068 tests from running on every `hook_registry` change.

## Requirements

Replace over-broad directory entries in `LAYER_CASCADE_CONSERVATIVE["hook_registry"]` with verified file-level entries. Keep `hooks` (direct consumer) and `cli` (10/38 files = 26%, borderline) as directory entries. Saves ~2,068 tests from running on every `hook_registry` change.

- `server` replaced with 2 file-level entries
- `infra` replaced with 7 file-level entries (verified — `test_filter_activation.py` has string references only, not imports)
- `docs` replaced with 1 file-level entry
- CLI kept as directory (10/38 files = 26%, borderline)
- `TestFileLevelCascadeDriftGuard` passes
- All existing tests pass

## Changed Files

- **tests/_test_filter.py** — Modified (replaced 3 directory entries with 10 file-level entries)

Closes #3436

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260531-120112-510794/.autoskillit/temp/make-plan/narrow_hook_registry_cascade_plan_2026-05-31_120600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.3k | 6.1k | 623.9k | 55.1k | 50 | 41.0k | 3m 40s |
| verify* | sonnet | 1 | 76 | 6.5k | 292.2k | 39.6k | 28 | 23.2k | 2m 48s |
| implement* | sonnet | 1 | 91.9k | 1.7k | 253.4k | 28.2k | 21 | 41.6k | 1m 0s |
| audit_impl* | sonnet | 1 | 263 | 7.0k | 240.1k | 36.2k | 27 | 22.7k | 2m 59s |
| prepare_pr* | sonnet | 1 | 70.9k | 3.3k | 197.0k | 28.1k | 19 | 41.2k | 1m 13s |
| compose_pr* | sonnet | 1 | 53.6k | 1.6k | 194.1k | 28.1k | 16 | 15.5k | 42s |
| review_pr* | sonnet | 3 | 490 | 47.5k | 2.5M | 58.8k | 164 | 118.5k | 12m 2s |
| **Total** | | | 218.6k | 73.6k | 4.3M | 58.8k | | 303.7k | 24m 26s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 16 | 15834.9 | 2599.5 | 104.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **16** | 271593.2 | 18982.9 | 4601.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.3k | 6.1k | 623.9k | 41.0k | 3m 40s |
| sonnet | 6 | 217.3k | 67.5k | 3.7M | 262.7k | 20m 45s |