### PR TITLE
Rectify: Ingredient Lock Bypass via Empty step_name — Fail-Closed Enforcement

### DIFF
--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -51,6 +51,8 @@ _PURE_SLEEP_RE = re.compile(
     r"|sleep\s+(?P<sh_secs>\d+(?:\.\d+)?))$"
 )
 
+INGREDIENT_LOCK_DENY_PREFIX = "INGREDIENT LOCK ENFORCED"
+
 
 def _is_absolute_path(path: str) -> bool:
     """Return True if path is an absolute filesystem path."""
@@ -81,7 +83,7 @@ def _check_ingredient_locks(step_name: str, order_id: str) -> str | None:
                     "success": False,
                     "is_error": True,
                     "error": (
-                        f"INGREDIENT LOCK ENFORCED: Step '{step_name}' is locked out. "
+                        f"{INGREDIENT_LOCK_DENY_PREFIX}: Step '{step_name}' is locked out. "
                         f"Locked ingredients for pipeline '{effective_oid}': {ingredient_info}. "
                         f"Call lock_ingredients(unlock=[...]) to release."
                     ),
@@ -95,7 +97,7 @@ def _check_ingredient_locks(step_name: str, order_id: str) -> str | None:
                         "success": False,
                         "is_error": True,
                         "error": (
-                            f"INGREDIENT LOCK ENFORCED: Step '{step_name}' is locked out "
+                            f"{INGREDIENT_LOCK_DENY_PREFIX}: Step '{step_name}' is locked out "
                             f"by pipeline '{pid}'. Pass order_id to scope the check, "
                             f"or call lock_ingredients(unlock=[...]) to release."
                         ),
@@ -140,6 +142,51 @@ def _check_pipeline_deps(step_name: str, order_id: str) -> str | None:
             ),
         }
     )
+
+
+def _resolve_step_name_from_recipe(
+    skill_command: str,
+    active_recipe_steps: dict,
+) -> tuple[str, bool]:
+    """Resolve step_name from active_recipe_steps by matching skill_command prefix.
+
+    Returns (step_name, is_ambiguous):
+    - (name, False) when exactly one recipe step matches
+    - ("", True) when multiple steps match (ambiguous)
+    - ("", False) when no steps match
+    """
+    cmd_prefix = skill_command.split()[0] if skill_command.strip() else ""
+    if not cmd_prefix:
+        return ("", False)
+    matches: list[str] = []
+    for step_key, step_obj in active_recipe_steps.items():
+        step_sc = step_obj.with_args.get("skill_command", "")
+        if step_sc.split()[0] == cmd_prefix:
+            matches.append(step_key)
+    if len(matches) == 1:
+        return (matches[0], False)
+    return ("", len(matches) > 1)
+
+
+def _has_active_locks(order_id: str) -> bool:
+    """Return True if any ingredient locks are actively denying steps."""
+    from autoskillit.server import _get_ctx
+
+    ctx = _get_ctx()
+    overlay_path = _hook_config_overlay_path(ctx.project_dir)
+    if not overlay_path.exists():
+        return False
+    try:
+        overlay = json.loads(overlay_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return False
+    locked_steps = overlay.get("locked_steps", {})
+    if not locked_steps:
+        return False
+    effective_oid = order_id or os.environ.get(DISPATCH_ID_ENV_VAR, "")
+    if effective_oid:
+        return any(v is False for v in locked_steps.get(effective_oid, {}).values())
+    return any(v is False for steps in locked_steps.values() for v in steps.values())
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
@@ -431,6 +478,36 @@ async def run_skill(
 
         _cleanup_session_id: str | None = None
         tool_ctx = _get_ctx()
+
+        if not step_name and not resume_session_id and tool_ctx.active_recipe_steps:
+            _resolved, _ambiguous = _resolve_step_name_from_recipe(
+                skill_command, tool_ctx.active_recipe_steps
+            )
+            if _resolved:
+                step_name = _resolved
+                logger.warning(
+                    "step_name_resolved_from_recipe",
+                    step=step_name,
+                    command=skill_command[:80],
+                )
+                if (_lock_denial := _check_ingredient_locks(step_name, order_id)) is not None:
+                    return _lock_denial
+                if (_dep_denial := _check_pipeline_deps(step_name, order_id)) is not None:
+                    return _dep_denial
+            elif not _ambiguous and _has_active_locks(order_id):
+                return json.dumps(
+                    {
+                        "success": False,
+                        "is_error": True,
+                        "error": (
+                            f"{INGREDIENT_LOCK_DENY_PREFIX}: step_name is empty and could "
+                            "not be resolved from the recipe. Cannot verify lock "
+                            "status. Pass step_name explicitly or call "
+                            "lock_ingredients(unlock=[...]) to release all locks."
+                        ),
+                    }
+                )
+
         with structlog.contextvars.bound_contextvars(tool="run_skill", cwd=cwd):
             logger.info("run_skill", command=skill_command[:80], cwd=cwd)
             await _notify(

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -146,7 +146,7 @@ def _check_pipeline_deps(step_name: str, order_id: str) -> str | None:
 
 def _resolve_step_name_from_recipe(
     skill_command: str,
-    active_recipe_steps: dict,
+    active_recipe_steps: dict[str, object],
 ) -> tuple[str, bool]:
     """Resolve step_name from active_recipe_steps by matching skill_command prefix.
 
@@ -160,8 +160,11 @@ def _resolve_step_name_from_recipe(
         return ("", False)
     matches: list[str] = []
     for step_key, step_obj in active_recipe_steps.items():
-        step_sc = step_obj.with_args.get("skill_command", "")
-        if step_sc.split()[0] == cmd_prefix:
+        with_args = getattr(step_obj, "with_args", None)
+        if not isinstance(with_args, dict):
+            continue
+        step_sc = with_args.get("skill_command", "")
+        if step_sc and step_sc.split()[0] == cmd_prefix:
             matches.append(step_key)
     if len(matches) == 1:
         return (matches[0], False)

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -467,7 +467,12 @@ parallel run of the same step reports under the same canonical step name.
 
 ---
 
-## PARAMETER FORWARDING — output_dir, stale_threshold, idle_output_timeout, step_provider
+## PARAMETER FORWARDING — step_name, output_dir, stale_threshold, idle_output_timeout, step_provider
+
+When a recipe step's `with:` block contains `step_name`, you MUST pass it as the
+`step_name` parameter of `run_skill`. This enables ingredient lock enforcement,
+pipeline dependency checks, and all per-step parameter auto-fills. Omitting it
+degrades enforcement and may cause the call to be denied when locks are active.
 
 When a recipe step's `with:` block contains `output_dir`, you MUST pass it as the
 `output_dir` parameter of `run_skill`. This controls the write guard — omitting it

--- a/tests/contracts/test_sous_chef_parameter_forwarding.py
+++ b/tests/contracts/test_sous_chef_parameter_forwarding.py
@@ -29,3 +29,15 @@ def test_sous_chef_skill_md_mentions_step_provider():
         "The LLM must be instructed to forward step_provider from recipe "
         "step provider: fields to run_skill."
     )
+
+
+def test_sous_chef_skill_md_mentions_step_name():
+    """Sous-chef SKILL.md must instruct the LLM to forward step_name."""
+    skill_md = (
+        Path(__file__).parents[2] / "src/autoskillit/skills/sous-chef/SKILL.md"
+    ).read_text()
+    assert "step_name" in skill_md, (
+        "sous-chef SKILL.md does not mention step_name. "
+        "The LLM must be instructed to forward step_name from recipe "
+        "step with: blocks to run_skill for lock enforcement."
+    )

--- a/tests/hooks/test_hook_sync.py
+++ b/tests/hooks/test_hook_sync.py
@@ -84,3 +84,15 @@ def test_quota_post_budget_exceeded_trigger_sync():
         f"QUOTA_POST_BUDGET_EXCEEDED_TRIGGER mismatch: "
         f"core={QUOTA_POST_BUDGET_EXCEEDED_TRIGGER!r} vs quota_post_hook={_HOOK!r}"
     )
+
+
+def test_ingredient_lock_deny_trigger_sync():
+    """INGREDIENT_LOCK_DENY_TRIGGER must be identical in server and hook guard."""
+    from autoskillit.hooks.guards.ingredient_lock_guard import INGREDIENT_LOCK_DENY_TRIGGER
+    from autoskillit.server.tools.tools_execution import INGREDIENT_LOCK_DENY_PREFIX
+
+    assert INGREDIENT_LOCK_DENY_PREFIX == INGREDIENT_LOCK_DENY_TRIGGER, (
+        f"Ingredient lock deny trigger mismatch: "
+        f"server={INGREDIENT_LOCK_DENY_PREFIX!r} vs "
+        f"hook={INGREDIENT_LOCK_DENY_TRIGGER!r}"
+    )

--- a/tests/hooks/test_ingredient_lock_guard.py
+++ b/tests/hooks/test_ingredient_lock_guard.py
@@ -211,3 +211,62 @@ class TestIngredientLockGuardPipelineScoped:
         assert code == 0
         decision = json.loads(stdout)
         assert decision["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+class TestIngredientLockGuardEmptyStepName:
+    """Hook guard stays fail-open for empty step_name — defers to server-side resolution."""
+
+    def test_ingredient_lock_guard_allows_empty_step_name_when_locks_active(
+        self, tmp_path, monkeypatch
+    ):
+        temp_dir = tmp_path / ".autoskillit" / "temp"
+        temp_dir.mkdir(parents=True)
+
+        overlay = temp_dir / ".hook_config_overlay.json"
+        overlay.write_text(
+            json.dumps(
+                {
+                    "locked_steps": {"": {"investigate": False}},
+                    "locked_ingredients": {"": {"investigate": "false"}},
+                }
+            )
+        )
+
+        monkeypatch.chdir(tmp_path)
+
+        event = json.dumps(
+            {
+                "tool_input": {
+                    "step_name": "",
+                    "order_id": "",
+                }
+            }
+        )
+
+        code, stdout = _run(event)
+        assert code == 0
+        assert stdout.strip() == ""
+
+    def test_ingredient_lock_guard_allows_empty_step_name_when_no_locks(
+        self, tmp_path, monkeypatch
+    ):
+        temp_dir = tmp_path / ".autoskillit" / "temp"
+        temp_dir.mkdir(parents=True)
+
+        overlay = temp_dir / ".hook_config_overlay.json"
+        overlay.write_text(json.dumps({"locked_steps": {}}))
+
+        monkeypatch.chdir(tmp_path)
+
+        event = json.dumps(
+            {
+                "tool_input": {
+                    "step_name": "",
+                    "order_id": "",
+                }
+            }
+        )
+
+        code, stdout = _run(event)
+        assert code == 0
+        assert stdout.strip() == ""

--- a/tests/server/test_run_skill_locks.py
+++ b/tests/server/test_run_skill_locks.py
@@ -277,3 +277,173 @@ class TestRunSkillAllowsResumeOfLockedStep:
             )
         )
         assert "INGREDIENT LOCK" not in result.get("error", "")
+
+
+class TestRunSkillResolvesStepNameFromRecipe:
+    """Auto-resolution of step_name from recipe when LLM omits it."""
+
+    @pytest.mark.anyio
+    async def test_run_skill_resolves_step_name_from_recipe_and_denies_locked_step(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
+        temp_dir = tmp_path / ".autoskillit" / "temp"
+        temp_dir.mkdir(parents=True)
+        (temp_dir / ".hook_config.json").write_text("{}")
+
+        overlay = temp_dir / ".hook_config_overlay.json"
+        overlay.write_text(
+            json.dumps(
+                {
+                    "locked_steps": {"": {"investigate": False}},
+                    "locked_ingredients": {"": {"investigate": "false"}},
+                }
+            )
+        )
+
+        step = _make_step_mock("inputs.investigate")
+        step.with_args = {"skill_command": "/autoskillit:investigate ${{ inputs.target }}"}
+
+        tool_ctx_kitchen_open.project_dir = tmp_path
+        tool_ctx_kitchen_open.active_recipe_steps = {"investigate": step}
+
+        result = json.loads(
+            await run_skill(
+                "/autoskillit:investigate some-error",
+                str(tmp_path),
+                step_name="",
+                order_id="",
+            )
+        )
+
+        assert result["success"] is False
+        assert "INGREDIENT LOCK" in result["error"]
+
+    @pytest.mark.anyio
+    async def test_run_skill_allows_empty_step_name_when_ambiguous_match(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
+        temp_dir = tmp_path / ".autoskillit" / "temp"
+        temp_dir.mkdir(parents=True)
+        (temp_dir / ".hook_config.json").write_text("{}")
+
+        overlay = temp_dir / ".hook_config_overlay.json"
+        overlay.write_text(
+            json.dumps(
+                {
+                    "locked_steps": {"": {"assess": False}},
+                    "locked_ingredients": {"": {"assess": "false"}},
+                }
+            )
+        )
+
+        step_a = _make_step_mock("inputs.assess")
+        step_a.with_args = {"skill_command": "/autoskillit:resolve-failures ..."}
+        step_b = _make_step_mock(None)
+        step_b.with_args = {"skill_command": "/autoskillit:resolve-failures ..."}
+
+        tool_ctx_kitchen_open.project_dir = tmp_path
+        tool_ctx_kitchen_open.active_recipe_steps = {
+            "assess": step_a,
+            "merge_gate_assess": step_b,
+        }
+
+        result = json.loads(
+            await run_skill(
+                "/autoskillit:resolve-failures target",
+                str(tmp_path),
+                step_name="",
+                order_id="",
+            )
+        )
+        assert "INGREDIENT LOCK" not in result.get("error", "")
+
+    @pytest.mark.anyio
+    async def test_run_skill_denies_unresolvable_step_name_when_locks_active(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
+        temp_dir = tmp_path / ".autoskillit" / "temp"
+        temp_dir.mkdir(parents=True)
+        (temp_dir / ".hook_config.json").write_text("{}")
+
+        overlay = temp_dir / ".hook_config_overlay.json"
+        overlay.write_text(
+            json.dumps(
+                {
+                    "locked_steps": {"": {"investigate": False}},
+                    "locked_ingredients": {"": {"investigate": "false"}},
+                }
+            )
+        )
+
+        step = _make_step_mock("inputs.investigate")
+        step.with_args = {"skill_command": "/autoskillit:investigate ..."}
+
+        tool_ctx_kitchen_open.project_dir = tmp_path
+        tool_ctx_kitchen_open.active_recipe_steps = {"investigate": step}
+
+        result = json.loads(
+            await run_skill(
+                "/autoskillit:unknown-skill target",
+                str(tmp_path),
+                step_name="",
+                order_id="",
+            )
+        )
+
+        assert result["success"] is False
+        assert "step_name is empty and could not be resolved" in result["error"]
+
+    @pytest.mark.anyio
+    async def test_run_skill_allows_empty_step_name_when_no_recipe(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
+        temp_dir = tmp_path / ".autoskillit" / "temp"
+        temp_dir.mkdir(parents=True)
+        (temp_dir / ".hook_config.json").write_text("{}")
+
+        tool_ctx_kitchen_open.project_dir = tmp_path
+        tool_ctx_kitchen_open.active_recipe_steps = None
+
+        result = json.loads(
+            await run_skill(
+                "/autoskillit:investigate target",
+                str(tmp_path),
+                step_name="",
+                order_id="",
+            )
+        )
+        assert "INGREDIENT LOCK" not in result.get("error", "")
+
+    @pytest.mark.anyio
+    async def test_run_skill_allows_empty_step_name_when_no_active_denials(
+        self, tool_ctx_kitchen_open, tmp_path
+    ):
+        temp_dir = tmp_path / ".autoskillit" / "temp"
+        temp_dir.mkdir(parents=True)
+        (temp_dir / ".hook_config.json").write_text("{}")
+
+        overlay = temp_dir / ".hook_config_overlay.json"
+        overlay.write_text(
+            json.dumps(
+                {
+                    "locked_steps": {"": {"investigate": True}},
+                    "locked_ingredients": {},
+                }
+            )
+        )
+
+        step = _make_step_mock("inputs.investigate")
+        step.with_args = {"skill_command": "/autoskillit:other-skill ..."}
+
+        tool_ctx_kitchen_open.project_dir = tmp_path
+        tool_ctx_kitchen_open.active_recipe_steps = {"investigate": step}
+
+        result = json.loads(
+            await run_skill(
+                "/autoskillit:unknown-skill target",
+                str(tmp_path),
+                step_name="",
+                order_id="",
+            )
+        )
+        assert "INGREDIENT LOCK" not in result.get("error", "")


### PR DESCRIPTION
## Summary

The ingredient lock system fails open when `step_name` is empty — both the server-side gate (`tools_execution.py:416-421`) and the hook guard (`ingredient_lock_guard.py:35-37`) short-circuit on falsy `step_name`, allowing locked steps to execute unchecked. The fix auto-resolves `step_name` from recipe context when the LLM omits it, implements fail-closed enforcement when locks are active but resolution fails, and adds defense-in-depth tests and contract guards.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_ingredient_lock_bypass_2026-05-31_120600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 2.8k | 23.4k | 1.6M | 137.0k | 222 | 92.5k | 23m 38s |
| review_approach* | opus[1m] | 1 | 6.7k | 5.9k | 210.7k | 47.5k | 57 | 65.5k | 5m 23s |
| dry_walkthrough* | opus | 1 | 47 | 13.0k | 519.6k | 77.1k | 89 | 48.1k | 6m 40s |
| implement* | opus[1m] | 1 | 89 | 17.4k | 3.2M | 79.9k | 107 | 63.2k | 7m 4s |
| audit_impl* | opus[1m] | 1 | 1.0k | 10.6k | 219.1k | 43.4k | 76 | 39.9k | 5m 57s |
| prepare_pr* | opus[1m] | 1 | 105.4k | 3.2k | 197.3k | 28.2k | 21 | 43.2k | 1m 27s |
| compose_pr* | opus[1m] | 1 | 59.1k | 1.8k | 264.5k | 0 | 20 | 0 | 53s |
| review_pr* | opus[1m] | 3 | 122 | 81.4k | 2.9M | 93.3k | 181 | 208.5k | 21m 24s |
| resolve_review* | opus[1m] | 1 | 35 | 7.5k | 1.1M | 78.1k | 41 | 62.0k | 8m 8s |
| **Total** | | | 175.3k | 164.2k | 10.2M | 137.0k | | 622.9k | 1h 20m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 341 | 9347.4 | 185.4 | 51.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 9 | 122773.9 | 6886.6 | 836.9 |
| **Total** | **350** | 29265.9 | 1779.8 | 469.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 8 | 175.3k | 151.2k | 9.7M | 574.8k | 1h 13m |
| opus | 1 | 47 | 13.0k | 519.6k | 48.1k | 6m 40s |