### PR TITLE
feat(recipe): add @lru_cache(maxsize=1) to skill helper functions

### DIFF
--- a/src/autoskillit/recipe/_api_cache.py
+++ b/src/autoskillit/recipe/_api_cache.py
@@ -168,6 +168,10 @@ def _check_process_staleness() -> bool:
 def _clear_stale_caches() -> None:
     """Clear all lru_cache helpers and the load cache when staleness is detected."""
     global _STALENESS_CACHES_CLEARED  # noqa: PLW0603
+    from autoskillit.recipe._skill_helpers import (  # noqa: PLC0415
+        _get_bundled_skill_names,
+        _get_skill_category_map,
+    )
     from autoskillit.recipe.contracts import load_bundled_manifest  # noqa: PLC0415
     from autoskillit.recipe.methodology_venue_appendix import (  # noqa: PLC0415
         load_ml_sub_area_folding,
@@ -177,5 +181,7 @@ def _clear_stale_caches() -> None:
     _block_budgets.cache_clear()
     load_bundled_manifest.cache_clear()
     load_ml_sub_area_folding.cache_clear()
+    _get_bundled_skill_names.cache_clear()
+    _get_skill_category_map.cache_clear()
     _LOAD_CACHE.clear()
     _STALENESS_CACHES_CLEARED = True

--- a/src/autoskillit/recipe/_skill_helpers.py
+++ b/src/autoskillit/recipe/_skill_helpers.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 from autoskillit.core import SkillLister
 
 MULTIPART_SKILL_NAMES: frozenset[str] = frozenset({"make-plan", "rectify"})
 
 
+@lru_cache(maxsize=1)
 def _get_skill_category_map(lister: SkillLister | None = None) -> dict[str, frozenset[str]]:
     """Return {skill_name: categories} for all bundled skills."""
     if lister is None:
@@ -16,6 +19,7 @@ def _get_skill_category_map(lister: SkillLister | None = None) -> dict[str, froz
     return {s.name: s.categories for s in lister.list_all()}
 
 
+@lru_cache(maxsize=1)
 def _get_bundled_skill_names(lister: SkillLister | None = None) -> frozenset[str]:
     """Return the set of all bundled skill names."""
     if lister is None:

--- a/tests/recipe/test_rules_skills.py
+++ b/tests/recipe/test_rules_skills.py
@@ -12,6 +12,19 @@ from autoskillit.recipe.schema import Recipe, RecipeStep
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
+@pytest.fixture(autouse=True)
+def _clear_skill_helper_caches():
+    """Clear lru_cache on skill helpers between tests."""
+    from autoskillit.recipe._skill_helpers import (
+        _get_bundled_skill_names,
+        _get_skill_category_map,
+    )
+
+    yield
+    _get_bundled_skill_names.cache_clear()
+    _get_skill_category_map.cache_clear()
+
+
 def _make_recipe(skill_command: str) -> Recipe:
     """Minimal recipe factory for unknown-skill-command rule tests."""
     return Recipe(
@@ -81,16 +94,28 @@ def test_non_skill_step_not_checked() -> None:
     assert not unknown, "run_cmd steps must not trigger unknown-skill-command"
 
 
-def test_get_bundled_skill_names_is_not_lru_cached() -> None:
-    """_get_bundled_skill_names must not use @lru_cache (Composition Root fix)."""
-    import autoskillit.recipe.rules.rules_skills as mod
+def test_get_bundled_skill_names_is_lru_cached() -> None:
+    """_get_bundled_skill_names uses @lru_cache for call-site memoization."""
+    from autoskillit.recipe._skill_helpers import (
+        _get_bundled_skill_names,
+        _get_skill_category_map,
+    )
 
-    assert not hasattr(mod._get_bundled_skill_names, "cache_clear"), (
-        "_get_bundled_skill_names must not be lru_cache-decorated"
+    assert hasattr(_get_bundled_skill_names, "cache_clear"), (
+        "_get_bundled_skill_names must be lru_cache-decorated"
     )
-    assert not hasattr(mod._get_skill_category_map, "cache_clear"), (
-        "_get_skill_category_map must not be lru_cache-decorated"
+    assert hasattr(_get_skill_category_map, "cache_clear"), (
+        "_get_skill_category_map must be lru_cache-decorated"
     )
+
+
+def test_lru_cache_returns_same_object() -> None:
+    """Repeated calls without lister return the exact same cached object."""
+    from autoskillit.recipe._skill_helpers import _get_bundled_skill_names
+
+    result1 = _get_bundled_skill_names()
+    result2 = _get_bundled_skill_names()
+    assert result1 is result2
 
 
 def test_bundled_skill_names_not_computed_at_import_v2() -> None:

--- a/tests/recipe/test_rules_skills.py
+++ b/tests/recipe/test_rules_skills.py
@@ -20,6 +20,8 @@ def _clear_skill_helper_caches():
         _get_skill_category_map,
     )
 
+    _get_bundled_skill_names.cache_clear()
+    _get_skill_category_map.cache_clear()
     yield
     _get_bundled_skill_names.cache_clear()
     _get_skill_category_map.cache_clear()


### PR DESCRIPTION
## Summary

Add `@lru_cache(maxsize=1)` to `_get_skill_category_map()` and `_get_bundled_skill_names()` in `src/autoskillit/recipe/_skill_helpers.py`. This eliminates repeated `DefaultSkillResolver` construction and `list_all()` dispatch on the default (no-arg) call path, saving ~0.24s per test run. The fsync-on-tmpfs elimination from issue #3450 is dropped per the corrected analysis — the 18.4s figure was a cProfile instrumentation artifact; actual cost is 0.0014s for 7,770 calls.

An existing guard test (`test_get_bundled_skill_names_is_not_lru_cached`) explicitly prohibits `@lru_cache` on these functions. This test was added as a "Composition Root fix" to protect dependency injection via the `lister` parameter. The concern is valid for unbounded caches but does not apply to `maxsize=1`: in production, `lister` is always `None` (the only cache key), and in tests, callers inject via `ValidationContext.available_skills` / `ValidationContext.skill_category_map` — the helpers are never called directly with a test double. The guard test must be inverted to assert the cache IS present, and `cache_clear` isolation must be added.

## Requirements

### 1. fsync elimination on tmpfs (`core/io.py`)
`atomic_write()` calls `os.fsync()` 7,770 times when writing SKILL.md files to `/dev/shm`. On tmpfs, fsync is a no-op but still costs ~2.4 ms per syscall — 18.4 seconds total per test run.

**Fix**: Add `_is_tmpfs(path)` helper using `ctypes statfs(2)` to check `f_type == 0x01021994` (TMPFS_MAGIC). Skip both data and directory fsyncs on tmpfs. Cache result per parent directory. Only applies on Linux 64-bit; all other platforms retain fsync.

Note: Python's `os.statvfs()` does NOT expose `f_type` — ctypes is required. Verified on this system: `/dev/shm` returns `0x1021994`, `/home` returns `0xef53` (ext4).

### 2. `@lru_cache` on skill helpers (`recipe/_skill_helpers.py`)
`_get_skill_category_map()` and `_get_bundled_skill_names()` construct a `DefaultSkillResolver()` on each call (though they immediately hit the warm `_LIST_ALL_CACHE`). Adding `@lru_cache(maxsize=1)` eliminates the construction overhead. Saves 3-5s per test run.

## Files Changed
- `src/autoskillit/core/io.py` (~25 lines)
- `src/autoskillit/recipe/_skill_helpers.py` (2 lines)

## Evidence
- fsync design: `.autoskillit/temp/mem-opt-evidence/batch-3/agent-3D-fsync-cleanup.md`
- Caching design: `.autoskillit/temp/mem-opt-evidence/batch-3/agent-3C-caching-design.md`
- Correctness: `.autoskillit/temp/mem-opt-evidence/batch-4/agent-4B-correctness-risks.md`

---

### Corrections (validated 2026-05-31)

### fsync: OPTIMIZATION IS NOT WORTH IT
- **Actual fsync cost on /dev/shm: 0.0002 ms per call** (measured, 1000 iterations)
- **Total for 7,770 calls: 0.0014 seconds** — not 18.4 seconds
- The 18.4s figure was a **cProfile instrumentation artifact** — cProfile adds ~2.4 ms overhead per call to nanosecond-scale syscalls, inflating the apparent cost by ~8,000×
- The ctypes `_is_tmpfs()` detection adds more complexity than the savings justify
- **Recommendation: DROP the fsync elimination. Keep the LRU cache only.**

### LRU cache: savings overstated
- Actual savings from `@lru_cache`: ~0.24s (not 3-5s)
- The "3-5s" figure from agent-3C was for a session-scoped pytest fixture approach, not the `@lru_cache` approach
- Still worth doing as a 2-line zero-risk change, but impact is modest

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

None

Closes #3450

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/lru_cache_skill_helpers_plan_2026-05-31_124600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 58 | 9.9k | 672.2k | 68.2k | 54 | 54.5k | 5m 35s |
| verify* | opus | 1 | 51 | 8.4k | 765.6k | 66.3k | 89 | 49.6k | 4m 45s |
| implement* | opus | 1 | 218.4k | 3.5k | 422.3k | 28.2k | 41 | 62.6k | 2m 6s |
| audit_impl* | opus | 1 | 23 | 4.2k | 139.8k | 35.3k | 24 | 22.3k | 2m 38s |
| prepare_pr* | opus | 1 | 64.5k | 3.6k | 194.3k | 28.2k | 23 | 16.7k | 1m 43s |
| compose_pr* | opus | 1 | 64.0k | 2.0k | 194.3k | 28.2k | 17 | 16.4k | 1m 5s |
| review_pr* | opus | 1 | 28 | 14.7k | 411.8k | 53.2k | 27 | 39.6k | 4m 19s |
| resolve_review* | opus | 1 | 34 | 5.2k | 864.9k | 64.7k | 35 | 48.2k | 7m 30s |
| resolve_pre_review_conflicts* | opus | 1 | 28 | 2.5k | 322.9k | 38.1k | 23 | 21.4k | 1m 5s |
| **Total** | | | 347.1k | 54.0k | 4.0M | 68.2k | | 331.3k | 30m 50s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 49 | 8617.9 | 1277.7 | 71.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 432454.5 | 24109.5 | 2600.0 |
| resolve_pre_review_conflicts | 823 | 392.3 | 26.0 | 3.0 |
| **Total** | **874** | 4562.9 | 379.1 | 61.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 58 | 9.9k | 672.2k | 54.5k | 5m 35s |
| opus | 8 | 347.0k | 44.1k | 3.3M | 276.8k | 25m 15s |