### PR TITLE
Defer infra conftest registry build to eliminate 57 MB/worker server import

### DIFF
--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -65,7 +65,7 @@ CHANNEL_B_NO_STDOUT_SCRIPT = textwrap.dedent("""\
                 "content": "working..."}}
         f.write(json.dumps(init) + "\\n")
         f.flush()
-    time.sleep(0.15)
+    time.sleep(2.0)
     with open(jsonl_path, "a") as f:
         record = {"type": "assistant", "message": {"role": "assistant",
                   "content": "%%ORDER_UP%%"}}
@@ -197,16 +197,17 @@ class TestChannelBDrainWait:
         """Channel B fires; Channel A never fires; drain times out and process is killed.
 
         Sequence (fast poll params):
-          t=0.10s  script writes %%ORDER_UP%% to session JSONL
-          t=0.16s  Channel B fires → drain wait starts with 0.5s timeout
-          t=0.66s  drain times out (script never wrote to stdout)
-          t=0.66s  process killed with empty stdout
+          t=0.10s  script creates session JSONL with initial content
+          t=2.10s  script writes %%ORDER_UP%% to session JSONL
+          t~2.15s  Channel B fires → drain wait starts with 0.5s timeout
+          t~2.65s  drain times out (script never wrote to stdout)
+          t~2.65s  process killed with empty stdout
+
+        The 2.0s gap between file creation and marker write ensures Phase 1 discovers
+        the JSONL file before the marker arrives, preventing a race where Phase 2
+        initializes scan_pos past the marker under xdist -n 4 event loop saturation.
 
         timeout=300s: guards against the outer wall-clock expiring under xdist -n 4 load.
-        _watch_session_log waits up to _session_id_timeout (default 1.0s, tests pass 0.01s)
-        for stdout_session_id_ready before Phase 1 starts;
-        under CI load both the preamble and Phase 1 polls can overrun, so the outer
-        timeout must exceed _session_id_timeout + _phase1_timeout (30s default) + drain (0.5s) = 31.5s.
         _phase1_timeout=400: must exceed outer timeout (300s) so that Phase 1 never fires
         first with STALE when subprocess startup is slow under WSL2 + xdist load; the
         outer 300s guard cancels all tasks before Phase 1 can timeout independently.

--- a/tests/infra/conftest.py
+++ b/tests/infra/conftest.py
@@ -131,4 +131,11 @@ def _build_registry() -> dict[str, FormatterCoverageDef]:
     }
 
 
-_FORMATTER_COVERAGE_REGISTRY: dict[str, FormatterCoverageDef] = _build_registry()
+_FORMATTER_COVERAGE_REGISTRY: dict[str, FormatterCoverageDef] | None = None
+
+
+def _get_formatter_coverage_registry() -> dict[str, FormatterCoverageDef]:
+    global _FORMATTER_COVERAGE_REGISTRY  # noqa: PLW0603
+    if _FORMATTER_COVERAGE_REGISTRY is None:
+        _FORMATTER_COVERAGE_REGISTRY = _build_registry()
+    return _FORMATTER_COVERAGE_REGISTRY

--- a/tests/infra/test_pretty_output_hook_infra.py
+++ b/tests/infra/test_pretty_output_hook_infra.py
@@ -17,9 +17,20 @@ from tests.infra._pretty_output_helpers import (
     _wrap_plain_str_for_claude_code,
 )
 from tests.infra.conftest import (
-    _FORMATTER_COVERAGE_REGISTRY,
     FormatterCoverageDef,
+    _get_formatter_coverage_registry,
 )
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    if "tool_name" in metafunc.fixturenames and "entry" in metafunc.fixturenames:
+        registry = _get_formatter_coverage_registry()
+        metafunc.parametrize(
+            "tool_name,entry",
+            list(registry.items()),
+            ids=list(registry),
+        )
+
 
 pytestmark = [pytest.mark.layer("infra"), pytest.mark.medium]
 
@@ -100,7 +111,9 @@ def test_formatter_coverage_contract():
 def test_all_formatters_have_coverage_contracts():
     """Every dedicated formatter must have a registered field coverage contract."""
     from autoskillit.hooks.formatters.pretty_output_hook import _FORMATTERS
-    from tests.infra.conftest import _FORMATTER_COVERAGE_REGISTRY
+    from tests.infra.conftest import _get_formatter_coverage_registry
+
+    _FORMATTER_COVERAGE_REGISTRY = _get_formatter_coverage_registry()
 
     uncovered = set(_FORMATTERS.keys()) - set(_FORMATTER_COVERAGE_REGISTRY.keys())
     assert uncovered == set(), (
@@ -112,7 +125,9 @@ def test_all_formatters_have_coverage_contracts():
 
 def test_coverage_registry_entries_are_valid():
     """Every registry entry's frozensets must exactly cover its TypedDict annotations."""
-    from tests.infra.conftest import _FORMATTER_COVERAGE_REGISTRY
+    from tests.infra.conftest import _get_formatter_coverage_registry
+
+    _FORMATTER_COVERAGE_REGISTRY = _get_formatter_coverage_registry()
 
     for name, entry in _FORMATTER_COVERAGE_REGISTRY.items():
         import typing
@@ -257,11 +272,6 @@ def test_typeddict_covers_to_json_keys() -> None:
     )
 
 
-@pytest.mark.parametrize(
-    "tool_name,entry",
-    list(_FORMATTER_COVERAGE_REGISTRY.items()),
-    ids=list(_FORMATTER_COVERAGE_REGISTRY),
-)
 def test_typeddict_covers_json_producer_keys(tool_name: str, entry: FormatterCoverageDef) -> None:
     """Each formatter with a json_producer must have TypedDict keys covering all JSON keys.
 
@@ -279,4 +289,26 @@ def test_typeddict_covers_json_producer_keys(tool_name: str, entry: FormatterCov
     assert not missing, (
         f"{tool_name}: json_producer keys absent from TypedDict: {sorted(missing)}. "
         "Add them to the TypedDict in server/tools/_types.py."
+    )
+
+
+def test_conftest_import_does_not_load_server():
+    """Importing the infra conftest must not trigger the 57 MB server import chain."""
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import tests.infra.conftest; import sys; "
+            "assert 'autoskillit.server' not in sys.modules, "
+            "'server loaded at conftest import time'",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(__import__("pathlib").Path(__file__).resolve().parents[2]),
+    )
+    assert result.returncode == 0, (
+        f"Importing tests.infra.conftest triggered autoskillit.server import:\n{result.stderr}"
     )


### PR DESCRIPTION
## Summary

Replace the eager module-level `_FORMATTER_COVERAGE_REGISTRY = _build_registry()` call in `tests/infra/conftest.py` with a lazy sentinel + accessor function `_get_formatter_coverage_registry()`, and convert the `@pytest.mark.parametrize` on `test_typeddict_covers_json_producer_keys` to a `pytest_generate_tests` hook. This eliminates the 57 MB `autoskillit.server` import chain at test collection time, saving 228 MB per xdist run (4 workers).

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260531-124309-479437/.autoskillit/temp/make-plan/defer_infra_conftest_registry_plan_2026-05-31_124600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 345 | 6.7k | 496.9k | 57.8k | 57 | 41.5k | 4m 34s |
| verify* | opus | 1 | 46 | 16.6k | 461.0k | 68.9k | 64 | 52.2k | 7m 0s |
| implement* | opus | 1 | 102.5k | 4.3k | 979.5k | 0 | 49 | 0 | 2m 17s |
| merge_gate_fix* | opus | 1 | 128 | 16.1k | 1.6M | 82.5k | 51 | 131.4k | 14m 35s |
| audit_impl* | opus | 1 | 338 | 5.9k | 206.6k | 36.3k | 31 | 25.9k | 2m 46s |
| prepare_pr* | opus | 1 | 50.8k | 3.1k | 180.3k | 0 | 19 | 0 | 1m 0s |
| compose_pr* | opus | 1 | 39.9k | 1.9k | 317.2k | 0 | 26 | 0 | 32s |
| review_pr* | opus | 1 | 29 | 14.4k | 472.0k | 56.4k | 28 | 41.2k | 4m 1s |
| resolve_review* | opus | 1 | 36 | 6.4k | 388.9k | 50.4k | 26 | 34.2k | 6m 46s |
| resolve_pre_review_conflicts* | opus | 1 | 29 | 2.3k | 360.8k | 38.1k | 24 | 21.5k | 1m 15s |
| **Total** | | | 194.2k | 77.9k | 5.4M | 82.5k | | 348.0k | 44m 50s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 57 | 17183.7 | 0.0 | 75.9 |
| merge_gate_fix | 19 | 82768.8 | 6917.5 | 848.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| resolve_pre_review_conflicts | 1218 | 296.2 | 17.7 | 1.9 |
| **Total** | **1294** | 4200.7 | 268.9 | 60.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 345 | 6.7k | 496.9k | 41.5k | 4m 34s |
| opus | 9 | 193.8k | 71.2k | 4.9M | 306.4k | 40m 15s |