### PR TITLE
Migrate Test YAML Parsing to CSafeLoader + Enforce via Lint Rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,8 @@ select = ["E", "F", "I", "UP", "TID251"]
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "logging.getLogger" = {msg = "Use get_logger() from autoskillit._logging instead."}
 "signal.signal" = {msg = "Use anyio.open_signal_receiver instead of signal.signal — see _serve_with_signal_guard in cli/app.py."}
+"yaml.safe_load" = {msg = "Use load_yaml() from autoskillit.core.io instead — CSafeLoader is 9-11x faster."}
+"yaml.safe_dump" = {msg = "Use dump_yaml_str() from autoskillit.core.io instead — CDumper is faster."}
 
 [tool.importlinter]
 root_packages = ["autoskillit"]

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -1232,8 +1232,9 @@ def load_manifest(path: str | Path) -> dict[str, Any] | None:
     if not manifest_path.exists():
         return None
     try:
+        _Loader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
         with manifest_path.open() as f:
-            return yaml.safe_load(f)
+            return yaml.load(f, Loader=_Loader)
     except OSError as exc:
         warnings.warn(f"Cannot read manifest {manifest_path}: {exc}", stacklevel=2)
         return None

--- a/tests/arch/test_audit_feature_gates_skill.py
+++ b/tests/arch/test_audit_feature_gates_skill.py
@@ -3,7 +3,7 @@
 import re
 from pathlib import Path
 
-import yaml
+from autoskillit.core.io import load_yaml
 
 _PROJECT_ROOT = Path(__file__).parent.parent.parent
 _SKILLS_ROOT = _PROJECT_ROOT / "src" / "autoskillit" / "skills_extended"
@@ -26,7 +26,7 @@ def test_audit_feature_gates_skill_has_audit_category():
     source = _SKILL_FILE.read_text()
     parts = source.split("---", 2)
     assert len(parts) >= 3, "SKILL.md must have YAML frontmatter"
-    fm = yaml.safe_load(parts[1])
+    fm = load_yaml(parts[1])
     assert isinstance(fm, dict), "SKILL.md frontmatter must parse to a dict"
     assert "audit" in fm.get("categories", []), "audit-feature-gates must have categories: [audit]"
 

--- a/tests/arch/test_eval_agent_skill.py
+++ b/tests/arch/test_eval_agent_skill.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-import yaml
+from autoskillit.core.io import load_yaml
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _SKILL_DIR = _PROJECT_ROOT / ".autoskillit" / "skills" / "eval-agent"
@@ -20,7 +20,7 @@ def test_eval_agent_frontmatter_name():
     source = _SKILL_FILE.read_text()
     parts = source.split("---", 2)
     assert len(parts) >= 3, "SKILL.md must have YAML frontmatter"
-    fm = yaml.safe_load(parts[1])
+    fm = load_yaml(parts[1])
     assert isinstance(fm, dict), "frontmatter must parse to dict"
     assert fm.get("name") == "eval-agent"
 
@@ -29,7 +29,7 @@ def test_eval_agent_categories_include_eval():
     """Frontmatter categories includes eval."""
     source = _SKILL_FILE.read_text()
     parts = source.split("---", 2)
-    fm = yaml.safe_load(parts[1])
+    fm = load_yaml(parts[1])
     assert "eval" in fm.get("categories", [])
 
 

--- a/tests/arch/test_feature_markers.py
+++ b/tests/arch/test_feature_markers.py
@@ -15,6 +15,8 @@ from unittest.mock import patch
 
 import pytest
 
+from autoskillit.core.io import load_yaml
+
 _TESTS_ROOT = Path(__file__).parent.parent
 
 # Auto-discover all test files in the fleet directory — self-maintaining
@@ -248,13 +250,10 @@ def _has_module_level_skip(tree: ast.Module) -> bool:
 
 def test_ci_workflow_gates_experimental_for_stable_track() -> None:
     """CI workflow must set AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED in the test job."""
-    import yaml
-
     workflow_path = _TESTS_ROOT.parent / ".github" / "workflows" / "tests.yml"
     assert workflow_path.exists(), f"CI workflow not found at {workflow_path}"
 
-    with workflow_path.open() as f:
-        wf = yaml.safe_load(f)
+    wf = load_yaml(workflow_path)
 
     assert isinstance(wf, dict), f"CI workflow YAML is empty or invalid at {workflow_path}"
     jobs = wf.get("jobs", {})

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -130,6 +130,7 @@ def test_feature_skill_categories_match_real_skills():
     """Every FeatureDef.skill_categories entry must map to a frontmatter category tag."""
     import yaml
 
+    from autoskillit.core.io import load_yaml
     from autoskillit.core.paths import pkg_root
     from autoskillit.core.types._type_constants_features import FEATURE_REGISTRY
 
@@ -149,7 +150,7 @@ def test_feature_skill_categories_match_real_skills():
             if len(parts) < 3:
                 continue
             try:
-                data = yaml.safe_load(parts[1]) or {}
+                data = load_yaml(parts[1]) or {}
             except yaml.YAMLError:
                 continue
             cats = data.get("categories", [])
@@ -545,11 +546,11 @@ def test_build_config_schema_accepts_experimental_enabled():
 
 def test_defaults_yaml_omits_experimental_enabled():
     """Package defaults.yaml omits experimental_enabled; no per-feature entries."""
-    import yaml
 
+    from autoskillit.core.io import load_yaml
     from autoskillit.core.paths import pkg_root
 
-    defaults = yaml.safe_load((pkg_root() / "config" / "defaults.yaml").read_text())
+    defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
     features = defaults.get("features", {})
     assert "experimental_enabled" not in features
     assert "fleet" not in features, "fleet entry removed from defaults.yaml"

--- a/tests/arch/test_judge_eval_skill.py
+++ b/tests/arch/test_judge_eval_skill.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-import yaml
+from autoskillit.core.io import load_yaml
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _SKILL_DIR = _PROJECT_ROOT / ".autoskillit" / "skills" / "judge-eval"
@@ -19,7 +19,7 @@ def test_judge_eval_frontmatter_name() -> None:
     source = _SKILL_FILE.read_text()
     parts = source.split("---", 2)
     assert len(parts) >= 3, "SKILL.md must have YAML frontmatter"
-    fm = yaml.safe_load(parts[1])
+    fm = load_yaml(parts[1])
     assert isinstance(fm, dict), "frontmatter must parse to dict"
     assert fm.get("name") == "judge-eval"
 
@@ -29,7 +29,7 @@ def test_judge_eval_categories_include_eval() -> None:
     source = _SKILL_FILE.read_text()
     parts = source.split("---", 2)
     assert len(parts) >= 3, "SKILL.md must have YAML frontmatter"
-    fm = yaml.safe_load(parts[1])
+    fm = load_yaml(parts[1])
     assert "eval" in fm.get("categories", [])
 
 

--- a/tests/arch/test_skill_registries.py
+++ b/tests/arch/test_skill_registries.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import pathlib
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.execution.clone_guard import CLONE_COMMIT_SKILLS, WORKTREE_SKILLS
 from autoskillit.recipe.rules.rules_worktree import _WORKTREE_MODIFYING_SKILLS
 
@@ -25,8 +25,7 @@ def _load_skill_contracts() -> dict:
     import autoskillit.recipe
 
     contracts_path = pathlib.Path(autoskillit.recipe.__file__).parent / "skill_contracts.yaml"
-    with open(contracts_path) as f:
-        data = yaml.safe_load(f)
+    data = load_yaml(contracts_path)
     return data.get("skills", data)
 
 

--- a/tests/arch/test_write_restriction_coverage.py
+++ b/tests/arch/test_write_restriction_coverage.py
@@ -86,7 +86,7 @@ def _has_write_restriction_prose(skill_md: str) -> bool:
 
 
 def _load_contracts() -> dict:
-    return load_yaml(_CONTRACTS_PATH.read_text())
+    return load_yaml(_CONTRACTS_PATH)
 
 
 def _skill_is_read_only(skill_name: str, contracts: dict) -> bool:
@@ -105,7 +105,7 @@ def _load_parsed_recipes() -> list[dict]:
     """Parse all recipe YAML files once and return their data dicts."""
     results: list[dict] = []
     for recipe_path in sorted(_RECIPES_DIR.glob("*.yaml")):
-        data = load_yaml(recipe_path.read_text())
+        data = load_yaml(recipe_path)
         if isinstance(data, dict):
             results.append(data)
     return results
@@ -204,7 +204,7 @@ def test_planner_skills_always_have_output_dir() -> None:
     planner skill sessions — no planner skill runs without an allowed_write_prefix.
     """
     planner_yaml = _RECIPES_DIR / "planner.yaml"
-    data = load_yaml(planner_yaml.read_text())
+    data = load_yaml(planner_yaml)
     steps = data.get("steps", {})
 
     violations: list[str] = []

--- a/tests/arch/test_write_restriction_coverage.py
+++ b/tests/arch/test_write_restriction_coverage.py
@@ -15,7 +15,8 @@ import re
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 
@@ -85,7 +86,7 @@ def _has_write_restriction_prose(skill_md: str) -> bool:
 
 
 def _load_contracts() -> dict:
-    return yaml.safe_load(_CONTRACTS_PATH.read_text())
+    return load_yaml(_CONTRACTS_PATH.read_text())
 
 
 def _skill_is_read_only(skill_name: str, contracts: dict) -> bool:
@@ -104,7 +105,7 @@ def _load_parsed_recipes() -> list[dict]:
     """Parse all recipe YAML files once and return their data dicts."""
     results: list[dict] = []
     for recipe_path in sorted(_RECIPES_DIR.glob("*.yaml")):
-        data = yaml.safe_load(recipe_path.read_text())
+        data = load_yaml(recipe_path.read_text())
         if isinstance(data, dict):
             results.append(data)
     return results
@@ -203,7 +204,7 @@ def test_planner_skills_always_have_output_dir() -> None:
     planner skill sessions — no planner skill runs without an allowed_write_prefix.
     """
     planner_yaml = _RECIPES_DIR / "planner.yaml"
-    data = yaml.safe_load(planner_yaml.read_text())
+    data = load_yaml(planner_yaml.read_text())
     steps = data.get("steps", {})
 
     violations: list[str] = []

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -7,10 +7,10 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-import yaml
 
 from autoskillit import cli
 from autoskillit.cli import _generate_config_yaml
+from autoskillit.core.io import load_yaml
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
@@ -59,7 +59,7 @@ class TestCLIInit:
         cli.init(test_command="pytest -v")
         config_path = tmp_path / ".autoskillit" / "config.yaml"
         assert config_path.is_file()
-        data = yaml.safe_load(config_path.read_text())
+        data = load_yaml(config_path)
         assert data["test_check"]["command"] == ["pytest", "-v"]
         assert data["safety"]["reset_guard_marker"] == ".autoskillit-workspace"
 
@@ -72,7 +72,7 @@ class TestCLIInit:
         with patch("autoskillit.cli.app._prompt_test_command", return_value=["npm", "test"]):
             cli.init()
         config_path = tmp_path / ".autoskillit" / "config.yaml"
-        data = yaml.safe_load(config_path.read_text())
+        data = load_yaml(config_path)
         assert data["test_check"]["command"] == ["npm", "test"]
 
     # CL6
@@ -120,7 +120,7 @@ class TestCLIInit:
 
         cli.init(test_command="pytest -v", force=True)
 
-        data = yaml.safe_load(config_path.read_text())
+        data = load_yaml(config_path)
         assert data["test_check"]["command"] == ["pytest", "-v"]
 
     def test_generate_config_yaml_contains_test_command(self) -> None:
@@ -138,7 +138,7 @@ class TestCLIInit:
     def test_generate_config_yaml_uncommented_parts_are_valid(self) -> None:
         """The uncommented portion of generated YAML parses as valid config."""
         yaml_str = _generate_config_yaml(["task", "test-all"])
-        parsed = yaml.safe_load(yaml_str)
+        parsed = load_yaml(yaml_str)
         assert parsed["test_check"]["command"] == ["task", "test-all"]
         assert parsed["safety"]["reset_guard_marker"] == ".autoskillit-workspace"
 
@@ -147,7 +147,7 @@ class TestCLIInit:
         yaml_str = _generate_config_yaml(["task", "test-check"])
         # Strip comment lines, then parse with YAML to inspect keys and values only
         active_lines = [ln for ln in yaml_str.splitlines() if not ln.lstrip().startswith("#")]
-        parsed = yaml.safe_load("\n".join(active_lines)) or {}
+        parsed = load_yaml("\n".join(active_lines)) or {}
 
         def _collect_strings(obj: object) -> list[str]:
             if isinstance(obj, dict):
@@ -189,7 +189,7 @@ class TestCLIInit:
 
         cli.init(test_command="npm test", force=True)
 
-        data = yaml.safe_load((config_dir / "config.yaml").read_text())
+        data = load_yaml(config_dir / "config.yaml")
         assert data["test_check"]["command"] == ["npm", "test"]
 
     def test_init_idempotent_rerun(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -639,8 +639,6 @@ def test_init_proceeds_with_correct_phrase(
 # SS-INIT-5
 def test_init_bypass_logged_to_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """When bypass is accepted, .state.yaml records the bypass with a timestamp."""
-    import yaml as _yaml
-
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
@@ -648,7 +646,7 @@ def test_init_bypass_logged_to_config(tmp_path: Path, monkeypatch: pytest.Monkey
     with patch("builtins.input", side_effect=[phrase, "pytest -v", ""]) as mock_input:
         cli.init()
     assert mock_input.call_count == 3
-    state = _yaml.safe_load((tmp_path / ".autoskillit" / ".state.yaml").read_text())
+    state = load_yaml(tmp_path / ".autoskillit" / ".state.yaml")
     bypass_value = state.get("safety", {}).get("secret_scan_bypass_accepted")
     assert bypass_value is not None, "bypass_accepted timestamp must be persisted in .state.yaml"
 
@@ -684,8 +682,6 @@ def test_bypass_log_writes_to_state_file_not_config(
 
     config.yaml is schema-validated; .state.yaml holds internal operational state only.
     """
-    import yaml as _yaml
-
     from autoskillit.cli._init_helpers import _log_secret_scan_bypass
 
     _log_secret_scan_bypass(tmp_path)
@@ -694,12 +690,12 @@ def test_bypass_log_writes_to_state_file_not_config(
     config_path = tmp_path / ".autoskillit" / "config.yaml"
 
     assert state_path.is_file(), ".state.yaml must be created by _log_secret_scan_bypass"
-    state_data = _yaml.safe_load(state_path.read_text())
+    state_data = load_yaml(state_path)
     assert state_data.get("safety", {}).get("secret_scan_bypass_accepted") is not None
 
     # config.yaml must NOT have the bypass key (either no file or no key)
     if config_path.is_file():
-        config_data = _yaml.safe_load(config_path.read_text()) or {}
+        config_data = load_yaml(config_path) or {}
         assert "secret_scan_bypass_accepted" not in config_data.get("safety", {}), (
             "config.yaml must not contain secret_scan_bypass_accepted"
         )

--- a/tests/config/test_plan_config.py
+++ b/tests/config/test_plan_config.py
@@ -3,10 +3,10 @@
 from pathlib import Path
 
 import pytest
-import yaml
 
 import autoskillit.config
 from autoskillit.config import AutomationConfig, load_config
+from autoskillit.core.io import load_yaml
 
 pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
 
@@ -42,8 +42,7 @@ class TestPlanConfigDefaultsYaml:
         """T1.4: defaults.yaml plan.adversarial_review_level == 'auto'."""
         pkg_root = Path(autoskillit.config.__file__).parent
         defaults_file = pkg_root / "defaults.yaml"
-        with open(defaults_file) as f:
-            data = yaml.safe_load(f)
+        data = load_yaml(defaults_file)
         assert data["plan"]["adversarial_review_level"] == "auto"
 
 

--- a/tests/config/test_quota_guard_config.py
+++ b/tests/config/test_quota_guard_config.py
@@ -7,6 +7,7 @@ import yaml
 
 from autoskillit.config import AutomationConfig, load_config
 from autoskillit.config.settings import QuotaGuardConfig
+from autoskillit.core.io import load_yaml
 from autoskillit.core.paths import pkg_root
 
 pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
@@ -85,7 +86,7 @@ class TestQuotaGuardConfig:
 
     def test_defaults_yaml_has_cache_refresh_interval(self):
         """QG_C4: defaults.yaml defines quota_guard.cache_refresh_interval < cache_max_age."""
-        defaults = yaml.safe_load((pkg_root() / "config" / "defaults.yaml").read_text())
+        defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
         assert "quota_guard" in defaults, (
             f"Missing 'quota_guard' key in defaults.yaml: {list(defaults.keys())}"
         )
@@ -121,7 +122,7 @@ class TestQuotaGuardConfig:
 
     def test_defaults_yaml_has_per_window_enabled_keys(self):
         """QG_C7: defaults.yaml has both per-window enabled keys set to True."""
-        defaults = yaml.safe_load((pkg_root() / "config" / "defaults.yaml").read_text())
+        defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
         assert defaults["quota_guard"]["short_window_enabled"] is True
         assert defaults["quota_guard"]["long_window_enabled"] is True
 

--- a/tests/config/test_review_config.py
+++ b/tests/config/test_review_config.py
@@ -3,10 +3,10 @@
 from pathlib import Path
 
 import pytest
-import yaml
 
 import autoskillit.config
 from autoskillit.config import AutomationConfig, load_config
+from autoskillit.core.io import load_yaml
 
 pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
 
@@ -42,6 +42,5 @@ class TestReviewConfigDefaultsYaml:
         """T1.4: defaults.yaml review.local_review_rounds == 2."""
         pkg_root = Path(autoskillit.config.__file__).parent
         defaults_file = pkg_root / "defaults.yaml"
-        with open(defaults_file) as f:
-            data = yaml.safe_load(f)
+        data = load_yaml(defaults_file)
         assert data["review"]["local_review_rounds"] == 2

--- a/tests/config/test_workspace_temp_dir_config.py
+++ b/tests/config/test_workspace_temp_dir_config.py
@@ -60,12 +60,11 @@ def test_temp_dir_env_override_wins(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
 
 def test_default_yaml_contains_temp_dir_key() -> None:
-    import yaml
-
     from autoskillit.core import pkg_root
+    from autoskillit.core.io import load_yaml
 
     defaults_path = pkg_root() / "config" / "defaults.yaml"
-    data = yaml.safe_load(defaults_path.read_text())
+    data = load_yaml(defaults_path)
     assert data["workspace"]["temp_dir"] == ".autoskillit/temp"
 
 

--- a/tests/config/test_write_config_layer.py
+++ b/tests/config/test_write_config_layer.py
@@ -31,14 +31,14 @@ class TestWriteConfigLayer:
 
     def test_write_config_layer_writes_valid_content(self, tmp_path: Path) -> None:
         """write_config_layer writes valid schema content atomically."""
-        import yaml as _yaml
 
         from autoskillit.config.settings import write_config_layer
+        from autoskillit.core.io import load_yaml
 
         config_path = tmp_path / "config.yaml"
         write_config_layer(config_path, {"github": {"default_repo": "owner/repo"}})
         assert config_path.is_file()
-        data = _yaml.safe_load(config_path.read_text())
+        data = load_yaml(config_path)
         assert data["github"]["default_repo"] == "owner/repo"
 
     def test_write_config_layer_accepts_packs_enabled(self, tmp_path: Path) -> None:

--- a/tests/contracts/test_analyze_pipeline_health_contracts.py
+++ b/tests/contracts/test_analyze_pipeline_health_contracts.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.execution.session._session_content import _check_expected_patterns
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
@@ -17,7 +17,7 @@ def _load_contract() -> dict:
 
     contracts_path = pkg_root() / "recipe" / "skill_contracts.yaml"
     assert contracts_path.is_file(), f"skill_contracts.yaml not found at {contracts_path}"
-    raw = yaml.safe_load(contracts_path.read_text()) or {}
+    raw = load_yaml(contracts_path) or {}
     return raw.get("skills", {}).get("analyze-pipeline-health", {})
 
 

--- a/tests/contracts/test_execution_map_contracts.py
+++ b/tests/contracts/test_execution_map_contracts.py
@@ -7,7 +7,8 @@ import re
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 
 def _skill_md_text() -> str:
@@ -394,7 +395,7 @@ def test_bem_contract_pattern_example_includes_new_tokens() -> None:
         / "recipe"
         / "skill_contracts.yaml"
     )
-    raw = yaml.safe_load(contracts_yaml.read_text())
+    raw = load_yaml(contracts_yaml)
     skills = raw.get("skills", {})
     example = skills["build-execution-map"]["pattern_examples"][0]
     assert "has_deferred" in example

--- a/tests/contracts/test_figure_spec_contracts.py
+++ b/tests/contracts/test_figure_spec_contracts.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 
 from autoskillit.core import PRODUCER_SCHEMA_FIELDS, REQUIRED_CONSUMER_FIELDS, FigureSpec
+from autoskillit.core.io import load_yaml
 from autoskillit.core.paths import pkg_root
 
 _VIS_LENS_DIR = pkg_root() / "skills_extended"
@@ -39,7 +40,7 @@ def _figure_spec_blocks_in(skill_md: Path) -> list[tuple[str, str]]:
 def _field_names_from_yaml_block(block_text: str) -> frozenset[str]:
     """Parse field names from a figure-spec YAML block (top-level scalar keys only)."""
     try:
-        parsed = yaml.safe_load(block_text)
+        parsed = load_yaml(block_text)
     except yaml.YAMLError:
         return frozenset()
     if not isinstance(parsed, dict):

--- a/tests/contracts/test_generate_report_contracts.py
+++ b/tests/contracts/test_generate_report_contracts.py
@@ -122,7 +122,7 @@ def test_anti_fabrication_never_rule() -> None:
 
 def test_generate_report_group_manifest_input() -> None:
     """generate-report contract must declare group_manifest as an optional input."""
-    import yaml
+    from autoskillit.core.io import load_yaml
 
     contract_path = (
         Path(__file__).resolve().parent.parent.parent
@@ -132,7 +132,7 @@ def test_generate_report_group_manifest_input() -> None:
         / "contracts"
         / "research.yaml"
     )
-    manifest = yaml.safe_load(contract_path.read_text())
+    manifest = load_yaml(contract_path)
     assert isinstance(manifest, dict), f"research.yaml did not parse to a dict: {type(manifest)}"
     assert "skills" in manifest, "research.yaml missing top-level 'skills' key"
     assert "generate-report" in manifest["skills"], (

--- a/tests/contracts/test_make_campaign_skill_contracts.py
+++ b/tests/contracts/test_make_campaign_skill_contracts.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
-import yaml
-
 from autoskillit.core import pkg_root
+from autoskillit.core.io import load_yaml
 from autoskillit.workspace.skills import DefaultSkillResolver
 
 _SKILL_DIR = pkg_root() / "skills_extended" / "make-campaign"
@@ -22,7 +21,7 @@ def _parse_frontmatter(content: str) -> dict[str, Any]:
     """Extract YAML frontmatter between --- delimiters."""
     m = re.match(r"^---\n(.+?)\n---\n", content, re.DOTALL)
     assert m, "SKILL.md must have YAML frontmatter delimited by ---"
-    parsed = yaml.safe_load(m.group(1))
+    parsed = load_yaml(m.group(1))
     assert isinstance(parsed, dict), "SKILL.md frontmatter must be a YAML mapping"
     return parsed
 

--- a/tests/contracts/test_prepare_compose_pr_contracts.py
+++ b/tests/contracts/test_prepare_compose_pr_contracts.py
@@ -79,9 +79,9 @@ RECIPES_DIR = Path(__file__).parents[2] / "src" / "autoskillit" / "recipes"
 
 def test_compose_pr_skill_command_includes_issue_number() -> None:
     """compose_pr skill_command must structurally include context.issue_number."""
-    import yaml
+    from autoskillit.core.io import load_yaml
 
-    data = yaml.safe_load((RECIPES_DIR / "implementation.yaml").read_text())
+    data = load_yaml(RECIPES_DIR / "implementation.yaml")
     skill_command = data["steps"]["compose_pr"]["with"]["skill_command"]
     assert "${{ context.issue_number }}" in skill_command, (
         f"compose_pr skill_command must include"
@@ -92,9 +92,9 @@ def test_compose_pr_skill_command_includes_issue_number() -> None:
 
 def test_prepare_pr_skill_command_includes_issue_number() -> None:
     """prepare_pr skill_command must structurally include context.issue_number."""
-    import yaml
+    from autoskillit.core.io import load_yaml
 
-    data = yaml.safe_load((RECIPES_DIR / "implementation.yaml").read_text())
+    data = load_yaml(RECIPES_DIR / "implementation.yaml")
     skill_command = data["steps"]["prepare_pr"]["with"]["skill_command"]
     assert "${{ context.issue_number }}" in skill_command, (
         f"prepare_pr skill_command must include"

--- a/tests/contracts/test_prepare_issue_contracts.py
+++ b/tests/contracts/test_prepare_issue_contracts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-import yaml
+from autoskillit.core.io import load_yaml
 
 SKILL_MD = Path(__file__).parents[2] / "src/autoskillit/skills_extended/prepare-issue/SKILL.md"
 
@@ -126,7 +126,7 @@ def test_prepare_issue_trigger_phrases_in_description_frontmatter():
     raw = SKILL_MD.read_text()
     parts = raw.split("---", 2)
     assert len(parts) >= 3, "SKILL.md must have YAML frontmatter"
-    fm = yaml.safe_load(parts[1])
+    fm = load_yaml(parts[1])
     desc = fm.get("description", "").lower()
     trigger_phrases = [
         "open an issue",

--- a/tests/contracts/test_review_local_mode_contracts.py
+++ b/tests/contracts/test_review_local_mode_contracts.py
@@ -9,7 +9,7 @@ Verifies that:
 
 from pathlib import Path
 
-import yaml
+from autoskillit.core.io import load_yaml
 
 CONTRACTS_YAML = (
     Path(__file__).parent.parent.parent / "src" / "autoskillit" / "recipe" / "skill_contracts.yaml"
@@ -35,7 +35,7 @@ RESOLVE_REVIEW_SKILL_PATH = (
 
 
 def _contracts() -> dict:
-    return yaml.safe_load(CONTRACTS_YAML.read_text())
+    return load_yaml(CONTRACTS_YAML)
 
 
 def _review_pr_skill() -> str:

--- a/tests/contracts/test_review_pr_diff_annotation.py
+++ b/tests/contracts/test_review_pr_diff_annotation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import yaml
+from autoskillit.core.io import load_yaml
 
 _CONTRACTS_YAML = Path(__file__).parents[2] / "src/autoskillit/recipe/skill_contracts.yaml"
 _SKILL_MD = Path(__file__).parents[2] / "src/autoskillit/skills_extended/review-pr/SKILL.md"
@@ -12,7 +12,7 @@ _SKILL_MD = Path(__file__).parents[2] / "src/autoskillit/skills_extended/review-
 
 def test_review_pr_contract_has_annotated_diff_path() -> None:
     """C-RPR-1a: review-pr contract must declare annotated_diff_path input."""
-    raw = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    raw = load_yaml(_CONTRACTS_YAML)
     inputs = raw.get("skills", {}).get("review-pr", {}).get("inputs", [])
     names = [inp["name"] for inp in inputs]
     assert "annotated_diff_path" in names, (
@@ -22,7 +22,7 @@ def test_review_pr_contract_has_annotated_diff_path() -> None:
 
 def test_review_pr_contract_has_hunk_ranges_path() -> None:
     """C-RPR-1b: review-pr contract must declare hunk_ranges_path input."""
-    raw = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    raw = load_yaml(_CONTRACTS_YAML)
     inputs = raw.get("skills", {}).get("review-pr", {}).get("inputs", [])
     names = [inp["name"] for inp in inputs]
     assert "hunk_ranges_path" in names, (
@@ -74,7 +74,7 @@ def test_review_pr_skill_reads_hunk_ranges_from_file() -> None:
 
 def test_review_pr_contract_has_diff_metrics_path() -> None:
     """annotate_pr_diff callable contract must declare diff_metrics_path output."""
-    raw = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    raw = load_yaml(_CONTRACTS_YAML)
     outputs = (
         raw.get("callable_contracts", {})
         .get("autoskillit.smoke_utils.annotate_pr_diff", {})
@@ -96,7 +96,7 @@ def test_review_pr_skill_reads_diff_metrics_from_file() -> None:
 
 def test_review_research_pr_hunk_ranges_in_contract() -> None:
     """review-research-pr contract must declare hunk_ranges_path input."""
-    raw = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    raw = load_yaml(_CONTRACTS_YAML)
     inputs = raw.get("skills", {}).get("review-research-pr", {}).get("inputs", [])
     names = [inp["name"] for inp in inputs]
     assert "hunk_ranges_path" in names, (
@@ -106,7 +106,7 @@ def test_review_research_pr_hunk_ranges_in_contract() -> None:
 
 def test_review_skills_valid_lines_in_contract() -> None:
     """review-pr and review-research-pr contracts must declare valid_lines_path input."""
-    raw = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    raw = load_yaml(_CONTRACTS_YAML)
     for skill_name in ("review-pr", "review-research-pr"):
         inputs = raw.get("skills", {}).get(skill_name, {}).get("inputs", [])
         names = [inp["name"] for inp in inputs]
@@ -122,7 +122,7 @@ def test_review_skills_valid_lines_in_contract() -> None:
 
 def test_annotate_pr_diff_callable_contract_has_valid_lines_path() -> None:
     """annotate_pr_diff callable contract must declare valid_lines_path output."""
-    raw = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    raw = load_yaml(_CONTRACTS_YAML)
     outputs = (
         raw.get("callable_contracts", {})
         .get("autoskillit.smoke_utils.annotate_pr_diff", {})
@@ -144,7 +144,7 @@ def test_review_pr_skill_validates_sha_freshness() -> None:
 
 def test_annotate_pr_diff_callable_contract_has_head_sha() -> None:
     """annotate_pr_diff contract must declare head_sha as an output."""
-    raw = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    raw = load_yaml(_CONTRACTS_YAML)
     outputs = (
         raw.get("callable_contracts", {})
         .get("autoskillit.smoke_utils.annotate_pr_diff", {})

--- a/tests/contracts/test_run_experiment_contracts.py
+++ b/tests/contracts/test_run_experiment_contracts.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-import yaml
+from autoskillit.core.io import load_yaml
 
 SKILL_PATH = (
     Path(__file__).resolve().parent.parent.parent
@@ -21,7 +21,7 @@ _SKILL_CONTRACTS_PATH = (
     / "skill_contracts.yaml"
 )
 
-_SKILL_CONTRACTS_MANIFEST = yaml.safe_load(_SKILL_CONTRACTS_PATH.read_text())
+_SKILL_CONTRACTS_MANIFEST = load_yaml(_SKILL_CONTRACTS_PATH)
 
 
 def test_blocked_hypotheses_declared_in_contract() -> None:
@@ -74,7 +74,7 @@ def test_run_experiment_group_manifest_output() -> None:
         / "contracts"
         / "research.yaml"
     )
-    manifest = yaml.safe_load(contract_path.read_text())
+    manifest = load_yaml(contract_path)
     assert isinstance(manifest, dict), f"research.yaml did not parse to a dict: {type(manifest)}"
     assert "skills" in manifest, "research.yaml missing top-level 'skills' key"
     assert "run-experiment" in manifest["skills"], (

--- a/tests/contracts/test_skill_contracts.py
+++ b/tests/contracts/test_skill_contracts.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Any, Final
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.execution.session._session_content import _check_expected_patterns
 
 _CONTRACTS_YAML = Path(__file__).parents[2] / "src/autoskillit/recipe/skill_contracts.yaml"
@@ -16,7 +16,7 @@ _CONTRACTS_YAML = Path(__file__).parents[2] / "src/autoskillit/recipe/skill_cont
 
 @pytest.fixture(scope="module")
 def skills() -> dict:
-    raw = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    raw = load_yaml(_CONTRACTS_YAML)
     return raw.get("skills", {})
 
 
@@ -135,7 +135,7 @@ def test_review_design_experiment_type_output_has_allowed_values() -> None:
     Without this constraint, invalid values (e.g. 'controlled') can propagate
     silently through capture and downstream recipe steps.
     """
-    contracts = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    contracts = load_yaml(_CONTRACTS_YAML)
     review_design = contracts["skills"]["review-design"]
     outputs = {o["name"]: o for o in review_design["outputs"]}
     et_output = outputs.get("experiment_type")
@@ -171,9 +171,7 @@ def test_all_exp_lens_skills_have_contracts(skills):
 
 
 _EXP_LENS_SKILLS: Final[list[str]] = sorted(
-    name
-    for name in yaml.safe_load(_CONTRACTS_YAML.read_text()).get("skills", {})
-    if name.startswith("exp-lens-")
+    name for name in load_yaml(_CONTRACTS_YAML).get("skills", {}) if name.startswith("exp-lens-")
 )
 
 
@@ -244,7 +242,7 @@ def test_infrastructure_missing_verdict_present_in_contract() -> None:
     The no_test_infrastructure verdict is emitted when test_check detects that
     the worktree lacks test infrastructure (no Taskfile, command not in PATH).
     """
-    contracts = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    contracts = load_yaml(_CONTRACTS_YAML)
     rf = contracts["skills"]["resolve-failures"]
     outputs = {o["name"]: o for o in rf["outputs"]}
     verdict_output = outputs.get("verdict")
@@ -314,7 +312,7 @@ def test_skill_contracts_allowed_values_covers_recipe_routes() -> None:
         "implementation-groups.yaml",
         "merge-prs.yaml",
     ]
-    contracts = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    contracts = load_yaml(_CONTRACTS_YAML)
     verdict_output = next(
         (o for o in contracts["skills"]["review-pr"].get("outputs", []) if o["name"] == "verdict"),
         None,

--- a/tests/contracts/test_skill_yaml_validation.py
+++ b/tests/contracts/test_skill_yaml_validation.py
@@ -14,8 +14,7 @@ def _all_skill_roots() -> list[Path]:
 
 def test_skill_md_yaml_examples_are_valid_workflows() -> None:
     """YAML workflow examples embedded in SKILL.md files must pass validation."""
-    import yaml as _yaml
-
+    from autoskillit.core.io import load_yaml
     from autoskillit.recipe.io import (
         _parse_recipe as _parse_workflow,
     )
@@ -36,7 +35,7 @@ def test_skill_md_yaml_examples_are_valid_workflows() -> None:
                 # Skip format templates that use {placeholder} syntax
                 if "{script-name}" in block or "{mcp_tool_name}" in block:
                     continue
-                data = _yaml.safe_load(block)
+                data = load_yaml(block)
                 if not isinstance(data, dict) or "steps" not in data:
                     continue
                 wf = _parse_workflow(data)

--- a/tests/contracts/test_skillmd_output_structure.py
+++ b/tests/contracts/test_skillmd_output_structure.py
@@ -11,8 +11,8 @@ import re
 from pathlib import Path
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.workspace.skills import DefaultSkillResolver
 
 _CONTRACTS_YAML = Path(__file__).parents[2] / "src/autoskillit/recipe/skill_contracts.yaml"
@@ -32,7 +32,7 @@ _HIGH_RISK_SKILLS = [
 
 
 def _skills_with_output_patterns() -> list[str]:
-    raw = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    raw = load_yaml(_CONTRACTS_YAML)
     return sorted(
         name
         for name, contract in raw.get("skills", {}).items()

--- a/tests/contracts/test_synthesize_vis_plan_contracts.py
+++ b/tests/contracts/test_synthesize_vis_plan_contracts.py
@@ -6,7 +6,8 @@ import re
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 pytestmark = [pytest.mark.small]
 
@@ -34,7 +35,7 @@ def _frontmatter() -> dict[str, object]:
         None,
     )
     assert end is not None, "SKILL.md frontmatter missing closing ---"
-    return yaml.safe_load("\n".join(lines[1:end]))
+    return load_yaml("\n".join(lines[1:end]))
 
 
 def test_skill_md_exists() -> None:

--- a/tests/contracts/test_version_consistency.py
+++ b/tests/contracts/test_version_consistency.py
@@ -9,9 +9,8 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-import yaml
-
 import autoskillit
+from autoskillit.core.io import load_yaml
 
 
 class TestVersionConsistency:
@@ -58,7 +57,7 @@ class TestVersionConsistency:
         recipes_dir = Path(autoskillit.__file__).parent / "recipes"
         has_field = {}
         for recipe_path in sorted(recipes_dir.rglob("*.yaml")):
-            data = yaml.safe_load(recipe_path.read_text())
+            data = load_yaml(recipe_path)
             if not isinstance(data, dict):
                 continue
             if "autoskillit_version" in data:

--- a/tests/contracts/test_zero_change_circuit_breaker_contracts.py
+++ b/tests/contracts/test_zero_change_circuit_breaker_contracts.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
 
@@ -13,7 +14,7 @@ RECIPES_DIR = Path(__file__).parents[2] / "src" / "autoskillit" / "recipes"
 
 
 def _load(name: str) -> dict:
-    return yaml.safe_load((RECIPES_DIR / f"{name}.yaml").read_text())
+    return load_yaml(RECIPES_DIR / f"{name}.yaml")
 
 
 def test_implementation_recipe_has_change_check_after_implement() -> None:

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -11,7 +11,8 @@ import re
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC_DIR = REPO_ROOT / "src" / "autoskillit"
@@ -151,7 +152,7 @@ def _count_hooks_by_event() -> dict[str, int]:
 
 
 def _quota_thresholds_default() -> tuple[float, float]:
-    data = yaml.safe_load(_read(SRC_DIR / "config" / "defaults.yaml"))
+    data = load_yaml(SRC_DIR / "config" / "defaults.yaml")
     quota = data.get("quota_guard")
     assert quota is not None, "quota_guard key missing from config/defaults.yaml"
     short = quota.get("short_window_threshold")

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -859,11 +859,10 @@ async def test_multi_command_section_headers(tmp_path: Path) -> None:
 
 
 def test_defaults_yaml_has_commands_null() -> None:
-    import yaml
-
+    from autoskillit.core.io import load_yaml
     from autoskillit.core.paths import pkg_root
 
-    defaults = yaml.safe_load((pkg_root() / "config" / "defaults.yaml").read_text())
+    defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
     assert "commands" in defaults["test_check"]
     assert defaults["test_check"]["commands"] is None
 

--- a/tests/infra/test_ci_dev_config.py
+++ b/tests/infra/test_ci_dev_config.py
@@ -12,7 +12,8 @@ import tomllib
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 PRECOMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
@@ -27,7 +28,7 @@ class TestPreCommitConfig:
         Without this, developers can commit a stale uv.lock undetected.
         If this test fails, add a uv-lock-check hook to .pre-commit-config.yaml.
         """
-        config = yaml.safe_load(PRECOMMIT_CONFIG.read_text())
+        config = load_yaml(PRECOMMIT_CONFIG)
         entries = [
             hook.get("entry", "")
             for repo in config.get("repos", [])
@@ -57,7 +58,7 @@ class TestPreCommitConfig:
         Without this, agents can commit new .py files without updating the
         directory's CLAUDE.md file table, causing CI test failures.
         """
-        config = yaml.safe_load(PRECOMMIT_CONFIG.read_text())
+        config = load_yaml(PRECOMMIT_CONFIG)
         hooks = [hook for repo in config.get("repos", []) for hook in repo.get("hooks", [])]
         sub_claude_hooks = [h for h in hooks if "check_sub_claude_md" in h.get("entry", "")]
         assert sub_claude_hooks, (
@@ -76,7 +77,7 @@ class TestPreCommitConfig:
         Without this, recipe YAML edits that staleness-change contract cards
         go undetected until CI runs the staleness test.
         """
-        config = yaml.safe_load(PRECOMMIT_CONFIG.read_text())
+        config = load_yaml(PRECOMMIT_CONFIG)
         hooks = [hook for repo in config.get("repos", []) for hook in repo.get("hooks", [])]
         freshness_hooks = [h for h in hooks if "check_contract_freshness" in h.get("entry", "")]
         assert freshness_hooks, (
@@ -115,7 +116,7 @@ class TestCIWorkflow:
         This is the CI-level backstop that catches lockfile staleness even if
         pre-commit was bypassed (direct push, git commit --no-verify, etc.).
         """
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         run_commands = [
             step.get("run", "")
             for job in workflow.get("jobs", {}).values()
@@ -132,7 +133,7 @@ class TestCIWorkflow:
         A preflight job runs once on a cheap single runner and validates prerequisites
         before the matrix fans out. When it fails, only one runner fails instead of all.
         """
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         jobs = workflow.get("jobs", {})
         assert "preflight" in jobs, (
             "No 'preflight' job in CI workflow — "
@@ -145,7 +146,7 @@ class TestCIWorkflow:
         Without this, the test matrix spins up before the lockfile check completes,
         wasting runner time on a doomed run.
         """
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         jobs = workflow.get("jobs", {})
         test_job = jobs.get("test", {})
         needs = test_job.get("needs", [])
@@ -166,7 +167,7 @@ class TestCIWorkflow:
         If this test fails, change the Install dependencies step in tests.yml to:
             run: uv sync --locked --extra dev
         """
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         run_commands = [
             step.get("run", "")
             for job in workflow.get("jobs", {}).values()
@@ -193,7 +194,7 @@ class TestCIWorkflow:
         Note: the correct input parameter is 'version', not 'uv-version' — 'uv-version'
         is an output of the action and is silently ignored as an input.
         """
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         for job_name, job in workflow.get("jobs", {}).items():
             for step in job.get("steps", []):
                 uses = step.get("uses", "")
@@ -214,7 +215,7 @@ class TestCIWorkflow:
 
         If this test fails, add 'version: "X.Y.Z"' to all setup-task steps in tests.yml.
         """
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         for job_name, job in workflow.get("jobs", {}).items():
             for step in job.get("steps", []):
                 uses = step.get("uses", "")
@@ -229,7 +230,7 @@ class TestCIWorkflow:
     def test_ci_push_trigger_excludes_develop(self) -> None:
         """Push trigger must NOT include develop — PRs from develop already
         get CI via pull_request trigger, and including it in push causes duplicate checks."""
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         # PyYAML parses the YAML 'on:' key as Python True (boolean)
         triggers = workflow.get(True, workflow.get("on", {}))
         push_branches = triggers["push"]["branches"]
@@ -240,14 +241,14 @@ class TestCIWorkflow:
 
     def test_ci_pull_request_trigger_includes_develop(self) -> None:
         """PR trigger must include develop so PRs targeting it get CI."""
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         triggers = workflow.get(True, workflow.get("on", {}))
         pr_branches = triggers["pull_request"]["branches"]
         assert "develop" in pr_branches, "CI must trigger on PRs targeting develop branch"
 
     def test_ci_preflight_outputs_os_matrix(self) -> None:
         """preflight job must export an os-matrix output computed from base_ref."""
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         outputs = workflow["jobs"]["preflight"].get("outputs", {})
         assert "os-matrix" in outputs, (
             "preflight must export os-matrix so the test job can vary runners "
@@ -256,7 +257,7 @@ class TestCIWorkflow:
 
     def test_ci_test_matrix_uses_preflight_os_matrix(self) -> None:
         """test job matrix must consume the os-matrix from preflight, not a hardcoded list."""
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         matrix = workflow["jobs"]["test"]["strategy"]["matrix"]
         os_value = matrix["os"]
         assert "fromJSON" in os_value or "needs.preflight" in str(os_value), (
@@ -270,7 +271,7 @@ class TestCIWorkflow:
         Uses github.base_ref for pull_request events and github.ref for push events,
         since github.base_ref is empty on direct push events.
         """
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         steps = workflow["jobs"]["preflight"]["steps"]
         matrix_steps = [
             s
@@ -285,7 +286,7 @@ class TestCIWorkflow:
 
     def test_ci_stable_target_produces_dual_os_matrix(self) -> None:
         """The stable branch must produce a dual-element ubuntu+macos matrix."""
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         steps = workflow["jobs"]["preflight"]["steps"]
         for step in steps:
             run = step.get("run", "")
@@ -302,7 +303,7 @@ class TestCIWorkflow:
         automated tooling) must still run CI. Without this trigger, a push to stable
         skips all checks.
         """
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         triggers = workflow.get(True, workflow.get("on", {}))
         push_branches = triggers.get("push", {}).get("branches", [])
         assert "stable" in push_branches, (
@@ -315,7 +316,7 @@ class TestCIWorkflow:
         Without ruff in CI, lint violations that bypass pre-commit reach the repository
         unchallenged. If this test fails, add a 'uvx ruff check' step to the preflight job.
         """
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         preflight_steps = workflow["jobs"]["preflight"]["steps"]
         assert any("ruff check" in step.get("run", "") for step in preflight_steps), (
             "CI preflight job has no 'ruff check' step — "
@@ -333,7 +334,7 @@ class TestRecipeWorkflowField:
         they create capture inversions when the repo's actual trigger differs."""
         recipes_dir = REPO_ROOT / "src" / "autoskillit" / "recipes"
         for recipe_path in recipes_dir.glob("*.yaml"):
-            recipe = yaml.safe_load(recipe_path.read_text())
+            recipe = load_yaml(recipe_path)
             for step_name, step in recipe.get("steps", {}).items():
                 if step.get("tool") != "wait_for_ci":
                     continue
@@ -375,7 +376,7 @@ class TestCIWorkflowExpressions:
         in the merge queue for develop-targeting PRs, incorrectly disabling
         experimental features.
         """
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         jobs = workflow["jobs"]
         test_job = jobs["test"]
 
@@ -415,7 +416,7 @@ class TestCIEnvVarIsolation:
 
         This prevents Dynaconf env var leakage into tests.
         """
-        workflow = yaml.safe_load(CI_WORKFLOW.read_text())
+        workflow = load_yaml(CI_WORKFLOW)
         conftest_text = CONFTEST_PATH.read_text()
 
         # Collect all AUTOSKILLIT_* env vars from CI
@@ -463,7 +464,7 @@ class TestSetupUvVersionPin:
         workflows_dir = CI_WORKFLOW.parent
         violations = []
         for wf_path in sorted(workflows_dir.glob("*.yml")):
-            workflow = yaml.safe_load(wf_path.read_text())
+            workflow = load_yaml(wf_path)
             for job_name, job in workflow.get("jobs", {}).items():
                 for step in job.get("steps", []):
                     uses = step.get("uses", "")

--- a/tests/infra/test_ci_workflow.py
+++ b/tests/infra/test_ci_workflow.py
@@ -16,9 +16,9 @@ def test_ci_workflow_does_not_pre_regenerate_hooks_json() -> None:
     then the test compared on-disk vs generate_hooks_json() — always passing.
     The new test uses registry.sha256 (committed) which cannot be silenced by pre-regen.
     """
-    import yaml
+    from autoskillit.core.io import load_yaml
 
-    workflow = yaml.safe_load((_repo_root() / ".github" / "workflows" / "tests.yml").read_text())
+    workflow = load_yaml(_repo_root() / ".github" / "workflows" / "tests.yml")
     step_names = [s.get("name") for job in workflow["jobs"].values() for s in job.get("steps", [])]
     assert not any("Generate hooks.json" in (n or "") for n in step_names), (
         "CI must not pre-regenerate hooks.json — this defeats drift detection. "

--- a/tests/infra/test_release_workflows.py
+++ b/tests/infra/test_release_workflows.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import yaml
+from autoskillit.core.io import load_yaml
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 VERSION_BUMP_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "version-bump.yml"
@@ -19,7 +19,7 @@ RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
 
 
 def _load(path: Path) -> dict:
-    return yaml.safe_load(path.read_text())
+    return load_yaml(path)
 
 
 def _uv_version_pins(workflow: dict) -> list[str]:
@@ -114,7 +114,7 @@ class TestVersionBumpWorkflow:
 
     def test_uv_version_consistent_with_tests_yml(self):
         """uv version pin must match the pin used in tests.yml."""
-        tests_wf = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "tests.yml").read_text())
+        tests_wf = load_yaml(REPO_ROOT / ".github" / "workflows" / "tests.yml")
         bump_wf = _load(VERSION_BUMP_WORKFLOW)
         tests_pins = _uv_version_pins(tests_wf)
         bump_pins = _uv_version_pins(bump_wf)
@@ -295,7 +295,7 @@ class TestPatchBumpDevelopWorkflow:
         assert all(p for p in pins)
 
     def test_uv_version_consistent_with_tests_yml(self):
-        tests_wf = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "tests.yml").read_text())
+        tests_wf = load_yaml(REPO_ROOT / ".github" / "workflows" / "tests.yml")
         bump_wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         tests_pins = _uv_version_pins(tests_wf)
         bump_pins = _uv_version_pins(bump_wf)
@@ -432,7 +432,7 @@ class TestReleaseWorkflow:
         assert all(p for p in pins)
 
     def test_uv_version_consistent_with_tests_yml(self):
-        tests_wf = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "tests.yml").read_text())
+        tests_wf = load_yaml(REPO_ROOT / ".github" / "workflows" / "tests.yml")
         release_wf = _load(RELEASE_WORKFLOW)
         tests_pins = _uv_version_pins(tests_wf)
         release_pins = _uv_version_pins(release_wf)

--- a/tests/infra/test_taskfile.py
+++ b/tests/infra/test_taskfile.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-import yaml
+from autoskillit.core.io import load_yaml
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 TASKFILE = REPO_ROOT / "Taskfile.yml"
@@ -11,7 +11,7 @@ TASKFILE = REPO_ROOT / "Taskfile.yml"
 
 class TestTaskfile:
     def _load(self) -> dict:
-        return yaml.safe_load(TASKFILE.read_text())
+        return load_yaml(TASKFILE)
 
     def test_install_worktree_has_status_block(self):
         """T1 — install-worktree has a status: block with at least two entries."""

--- a/tests/migration/test_fleet_migration_note.py
+++ b/tests/migration/test_fleet_migration_note.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from autoskillit.core.io import load_yaml
+
 pytestmark = [pytest.mark.layer("migration"), pytest.mark.small]
 
 MIGRATIONS_DIR = Path(__file__).parents[2] / "src" / "autoskillit" / "migrations"
@@ -14,7 +16,7 @@ def test_fleet_rename_migration_note_exists():
     detect_keys = []
     for note_path in notes:
         try:
-            data = yaml.safe_load(note_path.read_text())
+            data = load_yaml(note_path.read_text())
         except yaml.YAMLError as exc:
             pytest.fail(f"Malformed YAML in {note_path.name}: {exc}")
         for change in data.get("changes", []):
@@ -32,7 +34,7 @@ def test_fleet_rename_migration_note_is_valid():
     notes = list(MIGRATIONS_DIR.glob("*.yaml"))
     for note_path in notes:
         try:
-            data = yaml.safe_load(note_path.read_text())
+            data = load_yaml(note_path.read_text())
         except yaml.YAMLError as exc:
             pytest.fail(f"Malformed YAML in {note_path.name}: {exc}")
         for change in data.get("changes", []):

--- a/tests/migration/test_fleet_migration_note.py
+++ b/tests/migration/test_fleet_migration_note.py
@@ -16,7 +16,7 @@ def test_fleet_rename_migration_note_exists():
     detect_keys = []
     for note_path in notes:
         try:
-            data = load_yaml(note_path.read_text())
+            data = load_yaml(note_path)
         except yaml.YAMLError as exc:
             pytest.fail(f"Malformed YAML in {note_path.name}: {exc}")
         for change in data.get("changes", []):
@@ -34,7 +34,7 @@ def test_fleet_rename_migration_note_is_valid():
     notes = list(MIGRATIONS_DIR.glob("*.yaml"))
     for note_path in notes:
         try:
-            data = load_yaml(note_path.read_text())
+            data = load_yaml(note_path)
         except yaml.YAMLError as exc:
             pytest.fail(f"Malformed YAML in {note_path.name}: {exc}")
         for change in data.get("changes", []):

--- a/tests/migration/test_vis_lens_rename_migration_note.py
+++ b/tests/migration/test_vis_lens_rename_migration_note.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from autoskillit.core.io import load_yaml
+
 pytestmark = [pytest.mark.layer("migration"), pytest.mark.small]
 
 MIGRATIONS_DIR = Path(__file__).parents[2] / "src" / "autoskillit" / "migrations"
@@ -14,7 +16,7 @@ def test_vis_lens_rename_migration_note_exists():
     matches = []
     for note_path in notes:
         try:
-            data = yaml.safe_load(note_path.read_text())
+            data = load_yaml(note_path.read_text())
         except yaml.YAMLError as exc:
             pytest.fail(f"Malformed YAML in {note_path.name}: {exc}")
         for change in data.get("changes", []):
@@ -33,7 +35,7 @@ def test_vis_lens_rename_migration_note_is_valid():
     notes = list(MIGRATIONS_DIR.glob("*.yaml"))
     for note_path in notes:
         try:
-            data = yaml.safe_load(note_path.read_text())
+            data = load_yaml(note_path.read_text())
         except yaml.YAMLError as exc:
             pytest.fail(f"Malformed YAML in {note_path.name}: {exc}")
         for change in data.get("changes", []):

--- a/tests/migration/test_vis_lens_rename_migration_note.py
+++ b/tests/migration/test_vis_lens_rename_migration_note.py
@@ -16,7 +16,7 @@ def test_vis_lens_rename_migration_note_exists():
     matches = []
     for note_path in notes:
         try:
-            data = load_yaml(note_path.read_text())
+            data = load_yaml(note_path)
         except yaml.YAMLError as exc:
             pytest.fail(f"Malformed YAML in {note_path.name}: {exc}")
         for change in data.get("changes", []):
@@ -35,7 +35,7 @@ def test_vis_lens_rename_migration_note_is_valid():
     notes = list(MIGRATIONS_DIR.glob("*.yaml"))
     for note_path in notes:
         try:
-            data = load_yaml(note_path.read_text())
+            data = load_yaml(note_path)
         except yaml.YAMLError as exc:
             pytest.fail(f"Malformed YAML in {note_path.name}: {exc}")
         for change in data.get("changes", []):

--- a/tests/planner/test_elaborate_assignments_contract.py
+++ b/tests/planner/test_elaborate_assignments_contract.py
@@ -3,7 +3,8 @@
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 pytestmark = [
     pytest.mark.layer("planner"),
@@ -22,7 +23,7 @@ SKILL_MD_PATH = (
 
 @pytest.fixture(scope="module")
 def contracts() -> dict:
-    return yaml.safe_load(CONTRACTS_PATH.read_text())
+    return load_yaml(CONTRACTS_PATH)
 
 
 @pytest.fixture(scope="module")

--- a/tests/planner/test_elaborate_wps_contract.py
+++ b/tests/planner/test_elaborate_wps_contract.py
@@ -5,7 +5,8 @@ Contract conformance tests for planner-elaborate-wps skill registration.
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 pytestmark = [
     pytest.mark.layer("planner"),
@@ -28,7 +29,7 @@ ASSIGN_SKILL_MD_PATH = (
 
 @pytest.fixture(scope="module")
 def contracts() -> dict:
-    return yaml.safe_load(CONTRACTS_PATH.read_text())
+    return load_yaml(CONTRACTS_PATH)
 
 
 @pytest.fixture(scope="module")

--- a/tests/planner/test_refine_assignments_contract.py
+++ b/tests/planner/test_refine_assignments_contract.py
@@ -5,7 +5,8 @@ Contract conformance tests for planner-refine-assignments skill registration.
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 pytestmark = [
     pytest.mark.layer("planner"),
@@ -24,7 +25,7 @@ SKILL_MD_PATH = (
 
 @pytest.fixture(scope="module")
 def contracts() -> dict:
-    return yaml.safe_load(CONTRACTS_PATH.read_text())
+    return load_yaml(CONTRACTS_PATH)
 
 
 @pytest.fixture(scope="module")

--- a/tests/planner/test_refine_phases_contract.py
+++ b/tests/planner/test_refine_phases_contract.py
@@ -5,7 +5,8 @@ Contract conformance tests for planner-refine-phases skill registration.
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 pytestmark = [
     pytest.mark.layer("planner"),
@@ -24,7 +25,7 @@ SKILL_MD_PATH = (
 
 @pytest.fixture(scope="module")
 def contracts() -> dict:
-    return yaml.safe_load(CONTRACTS_PATH.read_text())
+    return load_yaml(CONTRACTS_PATH)
 
 
 @pytest.fixture(scope="module")

--- a/tests/planner/test_refine_wps_contract.py
+++ b/tests/planner/test_refine_wps_contract.py
@@ -3,7 +3,8 @@
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 pytestmark = [
     pytest.mark.layer("planner"),
@@ -22,7 +23,7 @@ SKILL_MD_PATH = (
 
 @pytest.fixture(scope="module")
 def contracts() -> dict:
-    return yaml.safe_load(CONTRACTS_PATH.read_text())
+    return load_yaml(CONTRACTS_PATH)
 
 
 @pytest.fixture(scope="module")

--- a/tests/recipe/test_anti_pattern_guards.py
+++ b/tests/recipe/test_anti_pattern_guards.py
@@ -104,7 +104,7 @@ def test_merge_prs_no_run_cmd_push():
 
 def test_merge_prs_has_no_loop_push_kitchen_rule():
     """AP2: merge-prs.yaml push_to_remote must only appear in the designated push steps."""
-    raw = load_yaml((builtin_recipes_dir() / "merge-prs.yaml").read_text())
+    raw = load_yaml(builtin_recipes_dir() / "merge-prs.yaml")
     steps = raw.get("steps", {})
     push_steps = {name for name, step in steps.items() if step.get("tool") == "push_to_remote"}
     unexpected = push_steps - {

--- a/tests/recipe/test_anti_pattern_guards.py
+++ b/tests/recipe/test_anti_pattern_guards.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.rules.rules_blocks import _block_budgets  # re-use the cached loader
 
@@ -26,7 +26,7 @@ def test_all_run_cmd_steps_have_step_name(recipe_path):
     """AP5: Every run_cmd step in every bundled recipe must declare step_name in with:.
     Unnamed run_cmd calls are invisible to pipeline reports and timing instrumentation.
     """
-    raw = yaml.safe_load(recipe_path.read_text())
+    raw = load_yaml(recipe_path)
     steps = raw.get("steps", {})
     violations = []
     for step_name, step_data in steps.items():
@@ -104,7 +104,7 @@ def test_merge_prs_no_run_cmd_push():
 
 def test_merge_prs_has_no_loop_push_kitchen_rule():
     """AP2: merge-prs.yaml push_to_remote must only appear in the designated push steps."""
-    raw = yaml.safe_load((builtin_recipes_dir() / "merge-prs.yaml").read_text())
+    raw = load_yaml((builtin_recipes_dir() / "merge-prs.yaml").read_text())
     steps = raw.get("steps", {})
     push_steps = {name for name, step in steps.items() if step.get("tool") == "push_to_remote"}
     unexpected = push_steps - {

--- a/tests/recipe/test_audit_trail_recipe_contracts.py
+++ b/tests/recipe/test_audit_trail_recipe_contracts.py
@@ -3,7 +3,8 @@
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
@@ -12,7 +13,7 @@ RECIPE_PATH = Path("src/autoskillit/recipes/research.yaml")
 
 def test_plan_visualization_captures_disambiguation_fields():
     """plan_visualization step captures disambiguation_rule_applied and tier_c_lens."""
-    recipe = yaml.safe_load(RECIPE_PATH.read_text())
+    recipe = load_yaml(RECIPE_PATH)
     pv_step = recipe["steps"]["plan_visualization"]
     captures = pv_step.get("capture", {})
     assert "disambiguation_rule_applied" in captures
@@ -21,7 +22,7 @@ def test_plan_visualization_captures_disambiguation_fields():
 
 def test_review_design_captures_classification_timestamp():
     """review_design step captures classification_timestamp."""
-    recipe = yaml.safe_load(RECIPE_PATH.read_text())
+    recipe = load_yaml(RECIPE_PATH)
     rd_step = recipe["steps"]["review_design"]
     captures = rd_step.get("capture", {})
     assert "classification_timestamp" in captures
@@ -29,7 +30,7 @@ def test_review_design_captures_classification_timestamp():
 
 def test_generate_report_receives_audit_fields():
     """generate_report step receives disambiguation, verdict, and timestamp flags."""
-    recipe = yaml.safe_load(RECIPE_PATH.read_text())
+    recipe = load_yaml(RECIPE_PATH)
     gr_step = recipe["steps"]["generate_report"]
     skill_command = gr_step.get("with", {}).get("skill_command", "")
     for field in [

--- a/tests/recipe/test_bundled_recipes_dispatch_ready.py
+++ b/tests/recipe/test_bundled_recipes_dispatch_ready.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.core.types import Severity
 from autoskillit.recipe._api import load_and_validate
 from autoskillit.recipe.contracts import (
@@ -73,7 +73,7 @@ def test_bundled_recipe_dispatch_ready(recipe_name: str) -> None:
 @pytest.mark.parametrize("contract_name", _CONTRACT_STEMS)
 def test_contract_card_fresh(contract_name: str) -> None:
     contract_path = _CONTRACTS_DIR / f"{contract_name}.yaml"
-    contract = yaml.safe_load(contract_path.read_text())
+    contract = load_yaml(contract_path)
     assert isinstance(contract, dict), f"Malformed: expected dict, got {type(contract)}"
     stale = check_contract_staleness(contract)
     assert stale == [], f"Contract '{contract_name}' is stale: {stale}"
@@ -85,7 +85,7 @@ def test_contract_covers_all_recipe_steps(contract_name: str) -> None:
     if not recipe_path.exists():
         pytest.skip(f"No recipe YAML for contract '{contract_name}'")
     contract_path = _CONTRACTS_DIR / f"{contract_name}.yaml"
-    contract = yaml.safe_load(contract_path.read_text())
+    contract = load_yaml(contract_path)
     recipe = load_recipe(recipe_path)
 
     contract_steps = {entry["step"] for entry in contract.get("dataflow", [])}

--- a/tests/recipe/test_bundled_recipes_no_inversions.py
+++ b/tests/recipe/test_bundled_recipes_no_inversions.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 
@@ -31,7 +31,7 @@ def test_bundled_recipe_has_no_capture_inversions(recipe_path):
 def test_diagnose_ci_skill_command_uses_captured_ci_event(recipe_path):
     """No skill_command step may pass a hardcoded trigger event as a positional.
     All /autoskillit:diagnose-ci invocations must thread ${{ context.ci_event }}."""
-    recipe = yaml.safe_load(recipe_path.read_text())
+    recipe = load_yaml(recipe_path)
     for step_name, step in recipe.get("steps", {}).items():
         cmd = step.get("skill_command") or step.get("with", {}).get("skill_command", "")
         if "diagnose-ci" in cmd:

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.recipe.contracts import (
     check_contract_staleness,
     classify_step_arg_style,
@@ -238,7 +238,7 @@ def test_generate_recipe_card(tmp_path: Path) -> None:
 
     contract_path = recipes_dir / "contracts" / "test-pipeline.yaml"
     assert contract_path.exists()
-    contract = yaml.safe_load(contract_path.read_text())
+    contract = load_yaml(contract_path)
     assert "bundled_manifest_version" in contract
     assert "skill_hashes" in contract
     assert "skills" in contract
@@ -621,7 +621,7 @@ def test_pipeline_summary_contract_declared() -> None:
     from autoskillit.core.paths import pkg_root
 
     contracts_path = pkg_root() / "recipe" / "skill_contracts.yaml"
-    contracts = yaml.safe_load(contracts_path.read_text())
+    contracts = load_yaml(contracts_path)
     assert "pipeline-summary" in contracts["skills"]
     skill = contracts["skills"]["pipeline-summary"]
     required_inputs = [i["name"] for i in skill["inputs"] if i.get("required", False)]
@@ -1074,7 +1074,7 @@ def test_all_bundled_contract_cards_have_source_hash():
     recipes_dir = builtin_recipes_dir()
     missing_hash = []
     for card_path in sorted((recipes_dir / "contracts").glob("*.yaml")):
-        card = yaml.safe_load(card_path.read_text())
+        card = load_yaml(card_path)
         if "recipe_source_hash" not in card:
             missing_hash.append(card_path.stem)
     assert not missing_hash, f"Contract cards without recipe_source_hash: {missing_hash}"
@@ -1083,7 +1083,6 @@ def test_all_bundled_contract_cards_have_source_hash():
 @pytest.mark.medium
 def test_all_bundled_contract_cards_are_fresh():
     """Contract card content must match what generate_recipe_card would produce now."""
-    from autoskillit.core.io import load_yaml
     from autoskillit.recipe.staleness_cache import compute_recipe_hash
 
     recipes_dir = builtin_recipes_dir()
@@ -1112,7 +1111,6 @@ def test_all_bundled_contract_cards_are_fresh():
 
 def test_generate_recipe_card_embeds_source_hash(tmp_path: Path) -> None:
     """generate_recipe_card must embed a recipe_source_hash in the card."""
-    from autoskillit.core.io import load_yaml
     from autoskillit.recipe.staleness_cache import compute_recipe_hash
 
     recipes_dir = tmp_path / "recipes"

--- a/tests/recipe/test_full_audit_recipe.py
+++ b/tests/recipe/test_full_audit_recipe.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
@@ -96,7 +97,7 @@ def test_full_audit_done_step_has_message() -> None:
 def test_full_audit_done_step_message_embeds_issue_urls_in_sentinel() -> None:
     """done step message must instruct the model to include issue_urls in the sentinel JSON."""
 
-    data = yaml.safe_load(RECIPE_PATH.read_text())
+    data = load_yaml(RECIPE_PATH)
     message = data["steps"]["done"]["message"]
     assert "issue_urls" in message, "done message must reference issue_urls"
     msg_lower = message.lower()
@@ -147,21 +148,21 @@ def test_full_audit_semantic_rules_no_errors() -> None:
 def test_full_audit_description_mentions_review_decisions() -> None:
     """full-audit description must mention audit-review-decisions."""
 
-    data = yaml.safe_load(RECIPE_PATH.read_text())
+    data = load_yaml(RECIPE_PATH)
     assert "audit-review-decisions" in data["description"]
 
 
 def test_full_audit_summary_mentions_six() -> None:
     """full-audit summary must reference 6 parallel chains."""
 
-    data = yaml.safe_load(RECIPE_PATH.read_text())
+    data = load_yaml(RECIPE_PATH)
     assert "6" in data["summary"]
 
 
 def test_full_audit_run_audits_note_mentions_review_decisions() -> None:
     """run_audits note must include audit-review-decisions as the 6th skill."""
 
-    data = yaml.safe_load(RECIPE_PATH.read_text())
+    data = load_yaml(RECIPE_PATH)
     note = data["steps"]["run_audits"]["note"]
     assert "audit-review-decisions" in note
 
@@ -169,7 +170,7 @@ def test_full_audit_run_audits_note_mentions_review_decisions() -> None:
 def test_full_audit_validate_audits_note_mentions_review_decisions() -> None:
     """validate_audits note must include review_decisions validation."""
 
-    data = yaml.safe_load(RECIPE_PATH.read_text())
+    data = load_yaml(RECIPE_PATH)
     note = data["steps"]["validate_audits"]["note"]
     assert "review_decisions" in note
 
@@ -177,7 +178,7 @@ def test_full_audit_validate_audits_note_mentions_review_decisions() -> None:
 def test_full_audit_validate_audits_routes_tests_to_specialized_skill() -> None:
     """validate_audits step must route test audits to validate-test-audit."""
 
-    data = yaml.safe_load(RECIPE_PATH.read_text())
+    data = load_yaml(RECIPE_PATH)
     note = data["steps"]["validate_audits"]["note"]
     assert "validate-test-audit" in note
 
@@ -185,7 +186,7 @@ def test_full_audit_validate_audits_routes_tests_to_specialized_skill() -> None:
 def test_full_audit_validate_audits_routes_review_decisions_to_specialized_skill() -> None:
     """validate_audits step must route review-decisions to validate-review-decisions."""
 
-    data = yaml.safe_load(RECIPE_PATH.read_text())
+    data = load_yaml(RECIPE_PATH)
     note = data["steps"]["validate_audits"]["note"]
     assert "validate-review-decisions" in note
 
@@ -223,21 +224,21 @@ def test_full_audit_kitchen_rule_mentions_prefer_completion() -> None:
 
 def test_full_audit_run_audits_note_mentions_max_parallel() -> None:
 
-    data = yaml.safe_load(RECIPE_PATH.read_text())
+    data = load_yaml(RECIPE_PATH)
     note = data["steps"]["run_audits"]["note"].lower()
     assert "max_parallel" in note or "max parallel" in note
 
 
 def test_full_audit_validate_audits_no_wave_barrier() -> None:
 
-    data = yaml.safe_load(RECIPE_PATH.read_text())
+    data = load_yaml(RECIPE_PATH)
     note = data["steps"]["validate_audits"]["note"].lower()
     assert "as each" in note or "as soon as" in note or "slot" in note
 
 
 def test_full_audit_create_issues_uses_batched_graphql() -> None:
 
-    data = yaml.safe_load(RECIPE_PATH.read_text())
+    data = load_yaml(RECIPE_PATH)
     step = data["steps"]["create_issues"]
     assert step["tool"] == "run_skill"
     assert "file-audit-issues" in step["with"]["skill_command"]
@@ -246,9 +247,7 @@ def test_full_audit_create_issues_uses_batched_graphql() -> None:
 
 
 def test_full_audit_create_issues_captures_issue_urls() -> None:
-    import yaml
-
-    data = yaml.safe_load(RECIPE_PATH.read_text())
+    data = load_yaml(RECIPE_PATH)
     capture = data["steps"]["create_issues"]["capture"]
     assert "issue_urls" in capture
 
@@ -256,5 +255,5 @@ def test_full_audit_create_issues_captures_issue_urls() -> None:
 def test_full_audit_recipe_version_bumped() -> None:
     from packaging.version import Version
 
-    data = yaml.safe_load(RECIPE_PATH.read_text())
+    data = load_yaml(RECIPE_PATH)
     assert Version(data["recipe_version"]) > Version("1.0.0")

--- a/tests/recipe/test_io_json_precompile.py
+++ b/tests/recipe/test_io_json_precompile.py
@@ -10,6 +10,7 @@ import pytest
 import yaml
 
 from autoskillit.core import RecipeSource
+from autoskillit.core.io import load_yaml
 from autoskillit.recipe.io import (
     _collect_recipes,
     _load_recipe_dict,
@@ -33,7 +34,7 @@ def _write_yaml(path: Path, data: dict) -> None:
 
 def _compile_json(yaml_path: Path) -> None:
     """Inline compilation: YAML -> JSON sibling."""
-    data = yaml.safe_load(yaml_path.read_bytes())
+    data = load_yaml(yaml_path)
     json_path = yaml_path.with_suffix(".json")
     json_path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
@@ -201,7 +202,7 @@ def test_collect_recipes_identical_with_json(tmp_path):
 
 def test_compile_recipes_roundtrip():
     for yaml_path in sorted(builtin_recipes_dir().rglob("*.yaml")):
-        data = yaml.safe_load(yaml_path.read_bytes())
+        data = load_yaml(yaml_path)
         json_text = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
         roundtripped = json.loads(json_text)
         assert roundtripped == data, f"Roundtrip failed for {yaml_path.name}"
@@ -212,7 +213,7 @@ def test_bundled_json_files_are_fresh():
         json_path = yaml_path.with_suffix(".json")
         assert json_path.exists(), f"Missing JSON sibling for {yaml_path.name}"
 
-        yaml_data = yaml.safe_load(yaml_path.read_bytes())
+        yaml_data = load_yaml(yaml_path)
         json_data = json.loads(json_path.read_text(encoding="utf-8"))
         assert json_data == yaml_data, f"JSON is stale for {yaml_path.name}"
         assert json_path.stat().st_mtime_ns >= yaml_path.stat().st_mtime_ns, (

--- a/tests/recipe/test_issue_url_pipeline.py
+++ b/tests/recipe/test_issue_url_pipeline.py
@@ -3,8 +3,8 @@
 from pathlib import Path
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.core.types import Severity
 from autoskillit.recipe._api import load_and_validate, validate_from_path
 from autoskillit.recipe.io import load_recipe
@@ -29,7 +29,7 @@ class TestImplementationPipelineIssueUrl:
 
     def test_issue_url_ingredient_declared(self):
         """issue_url ingredient must be declared as optional with no default."""
-        data = yaml.safe_load(_recipe_path("implementation").read_text())
+        data = load_yaml(_recipe_path("implementation"))
         assert "issue_url" in data["ingredients"]
         ing = data["ingredients"]["issue_url"]
         assert ing.get("required", False) is False
@@ -37,12 +37,12 @@ class TestImplementationPipelineIssueUrl:
 
     def test_no_fetch_issue_step(self):
         """fetch_issue step must NOT exist — orchestrator no longer fetches issue content."""
-        data = yaml.safe_load(_recipe_path("implementation").read_text())
+        data = load_yaml(_recipe_path("implementation"))
         assert "fetch_issue" not in data["steps"]
 
     def test_get_issue_title_step_present(self):
         """claim_and_resolve step must exist with correct structure."""
-        data = yaml.safe_load(_recipe_path("implementation").read_text())
+        data = load_yaml(_recipe_path("implementation"))
         assert "claim_and_resolve" in data["steps"]
         assert "parse_issue_number" not in data["steps"]
         step = data["steps"]["claim_and_resolve"]
@@ -55,7 +55,7 @@ class TestImplementationPipelineIssueUrl:
 
     def test_get_issue_title_between_capture_base_sha_and_create_branch(self):
         """clone step must route to claim_and_resolve, which routes to create_and_publish."""
-        data = yaml.safe_load(_recipe_path("implementation").read_text())
+        data = load_yaml(_recipe_path("implementation"))
         assert data["steps"]["clone"]["on_success"] == "claim_and_resolve"
         on_result = data["steps"]["claim_and_resolve"].get("on_result", [])
         true_routes = [r["route"] for r in on_result if r.get("when", "").endswith("== true")]
@@ -63,20 +63,20 @@ class TestImplementationPipelineIssueUrl:
 
     def test_create_branch_uses_callable(self):
         """create_and_publish step must use create_and_publish_branch MCP tool."""
-        data = yaml.safe_load(_recipe_path("implementation").read_text())
+        data = load_yaml(_recipe_path("implementation"))
         step = data["steps"]["create_and_publish"]
         assert step["tool"] == "create_and_publish_branch"
 
     def test_issue_url_referenced_in_downstream_skill_step(self):
         """plan step must reference inputs.issue_url, not issue_content."""
-        data = yaml.safe_load(_recipe_path("implementation").read_text())
+        data = load_yaml(_recipe_path("implementation"))
         skill_step_with = data["steps"]["plan"].get("with", {})
         assert any("issue_url" in str(v) for v in skill_step_with.values())
         assert not any("issue_content" in str(v) for v in skill_step_with.values())
 
     def test_issue_number_referenced_in_prepare_pr_step(self):
         """prepare_pr must reference context.issue_number in with: for dataflow tracking."""
-        data = yaml.safe_load(_recipe_path("implementation").read_text())
+        data = load_yaml(_recipe_path("implementation"))
         prepare_pr_with = data["steps"]["prepare_pr"].get("with", {})
         assert any("issue_number" in str(v) for v in prepare_pr_with.values())
 
@@ -101,7 +101,7 @@ class TestImplementationPipelineIssueUrl:
             w for w in report.warnings if w.code == "DEAD_OUTPUT" and w.field == "issue_content"
         ]
         assert issue_content_dead == []
-        data = yaml.safe_load(_recipe_path("implementation").read_text())
+        data = load_yaml(_recipe_path("implementation"))
         for step_name, step in data["steps"].items():
             captures = step.get("capture", {})
             assert "issue_content" not in captures, (
@@ -116,7 +116,7 @@ class TestInvestigateFirstIssueUrl:
         assert errors == [], f"Unexpected errors: {errors}"
 
     def test_issue_url_ingredient_declared(self):
-        data = yaml.safe_load(_recipe_path("remediation").read_text())
+        data = load_yaml(_recipe_path("remediation"))
         assert "issue_url" in data["ingredients"]
         ing = data["ingredients"]["issue_url"]
         assert ing.get("required", False) is False
@@ -124,12 +124,12 @@ class TestInvestigateFirstIssueUrl:
 
     def test_no_fetch_issue_step(self):
         """fetch_issue step must NOT exist — orchestrator no longer fetches issue content."""
-        data = yaml.safe_load(_recipe_path("remediation").read_text())
+        data = load_yaml(_recipe_path("remediation"))
         assert "fetch_issue" not in data["steps"]
 
     def test_get_issue_title_step_present(self):
         """claim_and_resolve step must exist with correct structure."""
-        data = yaml.safe_load(_recipe_path("remediation").read_text())
+        data = load_yaml(_recipe_path("remediation"))
         assert "claim_and_resolve" in data["steps"]
         assert "parse_issue_number" not in data["steps"]
         step = data["steps"]["claim_and_resolve"]
@@ -143,7 +143,7 @@ class TestInvestigateFirstIssueUrl:
 
     def test_get_issue_title_between_set_merge_target_and_create_branch(self):
         """clone step must route to claim_and_resolve (set_merge_target is now part of clone)."""
-        data = yaml.safe_load(_recipe_path("remediation").read_text())
+        data = load_yaml(_recipe_path("remediation"))
         assert data["steps"]["clone"]["on_success"] == "claim_and_resolve"
         on_result = data["steps"]["claim_and_resolve"].get("on_result", [])
         true_routes = [r["route"] for r in on_result if r.get("when", "").endswith("== true")]
@@ -151,19 +151,19 @@ class TestInvestigateFirstIssueUrl:
 
     def test_create_branch_uses_callable(self):
         """create_and_publish step must use create_and_publish_branch MCP tool."""
-        data = yaml.safe_load(_recipe_path("remediation").read_text())
+        data = load_yaml(_recipe_path("remediation"))
         step = data["steps"]["create_and_publish"]
         assert step["tool"] == "create_and_publish_branch"
 
     def test_issue_url_referenced_in_downstream_skill_step(self):
         """investigate step must reference inputs.issue_url, not issue_content."""
-        data = yaml.safe_load(_recipe_path("remediation").read_text())
+        data = load_yaml(_recipe_path("remediation"))
         skill_step_with = data["steps"]["investigate"].get("with", {})
         assert any("issue_url" in str(v) for v in skill_step_with.values())
         assert not any("issue_content" in str(v) for v in skill_step_with.values())
 
     def test_issue_number_referenced_in_prepare_pr_step(self):
-        data = yaml.safe_load(_recipe_path("remediation").read_text())
+        data = load_yaml(_recipe_path("remediation"))
         prepare_pr_with = data["steps"]["prepare_pr"].get("with", {})
         assert any("issue_number" in str(v) for v in prepare_pr_with.values())
 
@@ -188,7 +188,7 @@ class TestInvestigateFirstIssueUrl:
             w for w in report.warnings if w.code == "DEAD_OUTPUT" and w.field == "issue_content"
         ]
         assert issue_content_dead == []
-        data = yaml.safe_load(_recipe_path("remediation").read_text())
+        data = load_yaml(_recipe_path("remediation"))
         for step_name, step in data["steps"].items():
             captures = step.get("capture", {})
             assert "issue_content" not in captures, (
@@ -203,31 +203,31 @@ class TestImplementationGroupsIssueTitle:
         assert errors == [], f"Unexpected errors: {errors}"
 
     def test_fetch_issue_step_replaced(self):
-        data = yaml.safe_load(_recipe_path("implementation-groups").read_text())
+        data = load_yaml(_recipe_path("implementation-groups"))
         assert "fetch_issue" not in data["steps"]
         assert "claim_and_resolve" in data["steps"]
 
     def test_get_issue_title_captures_three_fields(self):
-        data = yaml.safe_load(_recipe_path("implementation-groups").read_text())
+        data = load_yaml(_recipe_path("implementation-groups"))
         step = data["steps"]["claim_and_resolve"]
         assert "issue_number" in step["capture"]
         assert "issue_title" in step["capture"]
         assert "issue_slug" in step["capture"]
 
     def test_get_issue_title_skips_when_no_url(self):
-        data = yaml.safe_load(_recipe_path("implementation-groups").read_text())
+        data = load_yaml(_recipe_path("implementation-groups"))
         step = data["steps"]["claim_and_resolve"]
         assert step.get("skip_when_false") == "inputs.issue_url"
         assert step.get("optional") is True
 
     def test_create_branch_uses_callable(self):
-        data = yaml.safe_load(_recipe_path("implementation-groups").read_text())
+        data = load_yaml(_recipe_path("implementation-groups"))
         step = data["steps"]["create_and_publish"]
         assert step["tool"] == "create_and_publish_branch"
 
     def test_no_issue_content_capture(self):
         """issue_content must not be captured anywhere in the recipe."""
-        data = yaml.safe_load(_recipe_path("implementation-groups").read_text())
+        data = load_yaml(_recipe_path("implementation-groups"))
         all_captures = {
             k: v
             for step in data["steps"].values()
@@ -237,7 +237,7 @@ class TestImplementationGroupsIssueTitle:
         assert "issue_content" not in all_captures
 
     def test_prepare_pr_step_still_references_issue_number(self):
-        data = yaml.safe_load(_recipe_path("implementation-groups").read_text())
+        data = load_yaml(_recipe_path("implementation-groups"))
         step = data["steps"]["prepare_pr"]
         assert "context.issue_number" in str(step)
 
@@ -275,21 +275,21 @@ class TestClaimReleaseGates:
 
     def test_claim_issue_step_present(self):
         for name in self.RECIPES:
-            data = yaml.safe_load(_recipe_path(name).read_text())
+            data = load_yaml(_recipe_path(name))
             assert "claim_and_resolve" in data["steps"], (
                 f"{name}: missing claim_and_resolve step (claim_and_resolve_issue tool)"
             )
 
     def test_get_issue_title_routes_to_claim_issue(self):
         for name in self.RECIPES:
-            data = yaml.safe_load(_recipe_path(name).read_text())
+            data = load_yaml(_recipe_path(name))
             assert data["steps"]["clone"]["on_success"] == "claim_and_resolve", (
                 f"{name}: clone.on_success should be claim_and_resolve"
             )
 
     def test_claim_issue_routes_to_create_branch_on_true(self):
         for name in self.RECIPES:
-            data = yaml.safe_load(_recipe_path(name).read_text())
+            data = load_yaml(_recipe_path(name))
             step = data["steps"]["claim_and_resolve"]
             routes = step.get("on_result", [])
             true_routes = [r["route"] for r in routes if r.get("when", "").endswith("== true")]
@@ -298,7 +298,7 @@ class TestClaimReleaseGates:
             )
 
     def test_release_issue_steps_present(self):
-        cache = {name: yaml.safe_load(_recipe_path(name).read_text()) for name in self.RECIPES}
+        cache = {name: load_yaml(_recipe_path(name)) for name in self.RECIPES}
         for name in self.RECIPES:
             assert "release_issue_failure" in cache[name]["steps"], (
                 f"{name}: missing release_issue_failure"
@@ -314,7 +314,7 @@ class TestClaimReleaseGates:
 
     def test_release_issue_success_routes_to_register_clone_success(self):
         for name in self.RECIPES_WITH_RELEASE_SUCCESS_STEP:
-            data = yaml.safe_load(_recipe_path(name).read_text())
+            data = load_yaml(_recipe_path(name))
             step = data["steps"]["release_issue_success"]
             assert step["on_success"] == "patch_token_summary", (
                 f"{name}: release_issue_success.on_success should be patch_token_summary"
@@ -322,7 +322,7 @@ class TestClaimReleaseGates:
 
     def test_release_issue_failure_routes_to_register_clone_failure(self):
         for name in self.RECIPES:
-            data = yaml.safe_load(_recipe_path(name).read_text())
+            data = load_yaml(_recipe_path(name))
             step = data["steps"]["release_issue_failure"]
             assert step["on_success"] == "register_clone_failure", (
                 f"{name}: release_issue_failure.on_success should be register_clone_failure"
@@ -340,7 +340,7 @@ class TestClaimReleaseGates:
             "expected dict does not cover all RECIPES — update split lists"
         )
         for name, expected_route in expected.items():
-            data = yaml.safe_load(_recipe_path(name).read_text())
+            data = load_yaml(_recipe_path(name))
             ci_step = data["steps"]["ci_watch"]
             on_result = ci_step.get("on_result")
             if on_result:
@@ -391,7 +391,7 @@ class TestClaimReleaseGates:
     def test_claim_issue_step_passes_allow_reentry_from_upfront_claimed(self):
         """claim_and_resolve with: block includes allow_reentry from inputs.upfront_claimed."""
         for name in self.RECIPES:
-            data = yaml.safe_load(_recipe_path(name).read_text())
+            data = load_yaml(_recipe_path(name))
             claim_with = data["steps"]["claim_and_resolve"].get("with", {})
             assert "allow_reentry" in claim_with, (
                 f"{name}: claim_and_resolve.with missing allow_reentry"
@@ -403,7 +403,7 @@ class TestClaimReleaseGates:
     def test_upfront_claimed_ingredient_present_with_default_false(self):
         """Recipes expose upfront_claimed ingredient defaulting to 'false'."""
         for name in self.RECIPES:
-            data = yaml.safe_load(_recipe_path(name).read_text())
+            data = load_yaml(_recipe_path(name))
             ingredients = data.get("ingredients", {})
             assert "upfront_claimed" in ingredients, f"{name}: missing upfront_claimed ingredient"
             assert ingredients["upfront_claimed"].get("default") == "false", (
@@ -413,7 +413,7 @@ class TestClaimReleaseGates:
     def test_claim_issue_routes_register_clone_failure_when_not_claimed(self):
         """claim_and_resolve fallthrough routes through register_clone_failure."""
         for name in self.RECIPES:
-            data = yaml.safe_load(_recipe_path(name).read_text())
+            data = load_yaml(_recipe_path(name))
             on_result = data["steps"]["claim_and_resolve"].get("on_result", [])
             # The fallthrough route (no 'when' key) must route through register_clone_failure
             # so the clone is registered before escalation (clone-terminal-requires-registration)
@@ -451,7 +451,7 @@ class TestIssueUrlPruning:
             "remediation",
             ingredient_overrides={"issue_url": "https://github.com/org/repo/issues/42"},
         )
-        content = yaml.safe_load(result["content"])
+        content = load_yaml(result["content"])
         steps = content.get("steps", {})
         assert "claim_and_resolve" in steps, (
             "claim_and_resolve must be present when issue_url is a URL"
@@ -468,7 +468,7 @@ class TestIssueUrlPruning:
             ingredient_overrides={},
         )
         content_str = result["content"]
-        content = yaml.safe_load(content_str)
+        content = load_yaml(content_str)
         steps = content.get("steps", {})
         assert (
             "claim_and_resolve" not in steps

--- a/tests/recipe/test_planner_contracts.py
+++ b/tests/recipe/test_planner_contracts.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml
 
 from autoskillit.core import SKILL_TOOLS
+from autoskillit.core.io import load_yaml
 from autoskillit.recipe.contracts import load_bundled_manifest, resolve_skill_name
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
@@ -23,7 +23,7 @@ _RECIPE_DIR = Path(__file__).parent.parent.parent / "src" / "autoskillit" / "rec
 
 @pytest.fixture(scope="module")
 def planner_yaml() -> dict:
-    return yaml.safe_load((_RECIPE_DIR / "planner.yaml").read_text())
+    return load_yaml(_RECIPE_DIR / "planner.yaml")
 
 
 _ALL_BUNDLED_RECIPE_PATHS = sorted(builtin_recipes_dir().glob("*.yaml"))

--- a/tests/recipe/test_planner_recipe.py
+++ b/tests/recipe/test_planner_recipe.py
@@ -120,11 +120,10 @@ def test_planner_init_captures_planner_dir(planner_recipe):
 
 
 def test_planner_steps_use_context_planner_dir():
-    import yaml
-
+    from autoskillit.core.io import load_yaml
     from autoskillit.recipe.io import builtin_recipes_dir
 
-    raw = yaml.safe_load((builtin_recipes_dir() / "planner.yaml").read_text())
+    raw = load_yaml(builtin_recipes_dir() / "planner.yaml")
     raw_steps = raw.get("steps", {})
     for step_name, step_dict in raw_steps.items():
         step_str = str(step_dict)

--- a/tests/recipe/test_recipe_ci_applicable_routing.py
+++ b/tests/recipe/test_recipe_ci_applicable_routing.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 import re
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.recipe.io import builtin_recipes_dir
 
 from .conftest import (
@@ -30,8 +30,7 @@ RECIPE_FILES = sorted(builtin_recipes_dir().glob("*.yaml"))
 
 @pytest.fixture(params=RECIPE_FILES, ids=lambda p: p.stem)
 def recipe_data(request):
-    with open(request.param) as f:
-        return request.param.stem, yaml.safe_load(f)
+    return request.param.stem, load_yaml(request.param)
 
 
 def _find_ci_event_capture_steps(steps: dict) -> list[tuple[str, dict]]:
@@ -122,8 +121,7 @@ def test_merge_prs_routes_around_ci_wait_when_not_applicable(recipe_data) -> Non
 def test_impl_recipes_route_around_ci_wait_when_not_applicable(recipe_name) -> None:
     """implementation/implementation-groups/remediation must have ci_applicable routing."""
     recipe_path = builtin_recipes_dir() / f"{recipe_name}.yaml"
-    with open(recipe_path) as f:
-        data = yaml.safe_load(f)
+    data = load_yaml(recipe_path)
     steps = data.get("steps") or {}
     assert "route_ci_applicable" in steps, f"{recipe_name} must have route_ci_applicable step"
     route_step = steps["route_ci_applicable"]

--- a/tests/recipe/test_recipe_ci_contracts.py
+++ b/tests/recipe/test_recipe_ci_contracts.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 import re
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.recipe.io import builtin_recipes_dir
 
 from .conftest import (
@@ -47,8 +47,7 @@ RECIPE_FILES = sorted(builtin_recipes_dir().glob("*.yaml"))
 
 @pytest.fixture(params=RECIPE_FILES, ids=lambda p: p.stem)
 def recipe_data(request):
-    with open(request.param) as f:
-        return request.param.stem, yaml.safe_load(f)
+    return request.param.stem, load_yaml(request.param)
 
 
 def test_wait_for_ci_event_branch_coherence(recipe_data) -> None:

--- a/tests/recipe/test_recipe_ci_watch_event.py
+++ b/tests/recipe/test_recipe_ci_watch_event.py
@@ -3,6 +3,8 @@ ci_event derivation."""
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from autoskillit.core.io import load_yaml
@@ -19,7 +21,7 @@ RECIPE_FILES = [
 @pytest.mark.parametrize("recipe_path", RECIPE_FILES)
 def test_ci_watch_step_has_event_parameter(recipe_path: str) -> None:
     """Primary ci_watch steps must pass event: to prevent branch-event mismatch."""
-    recipe = load_yaml(recipe_path)
+    recipe = load_yaml(Path(recipe_path))
     steps = recipe["steps"]
     assert "ci_watch" in steps, f"{recipe_path}: no ci_watch step found"
     ci_watch = steps["ci_watch"]
@@ -33,7 +35,7 @@ def test_ci_watch_step_has_event_parameter(recipe_path: str) -> None:
 @pytest.mark.parametrize("recipe_path", RECIPE_FILES)
 def test_check_repo_ci_event_step_exists_before_ci_watch(recipe_path: str) -> None:
     """Each recipe must have a check_repo_ci_event step that routes to ci_watch."""
-    recipe = load_yaml(recipe_path)
+    recipe = load_yaml(Path(recipe_path))
     steps = recipe["steps"]
     assert "check_repo_ci_event" in steps, (
         f"{recipe_path}: missing check_repo_ci_event step. "

--- a/tests/recipe/test_recipe_ci_watch_event.py
+++ b/tests/recipe/test_recipe_ci_watch_event.py
@@ -4,7 +4,8 @@ ci_event derivation."""
 from __future__ import annotations
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
@@ -18,8 +19,7 @@ RECIPE_FILES = [
 @pytest.mark.parametrize("recipe_path", RECIPE_FILES)
 def test_ci_watch_step_has_event_parameter(recipe_path: str) -> None:
     """Primary ci_watch steps must pass event: to prevent branch-event mismatch."""
-    with open(recipe_path) as f:
-        recipe = yaml.safe_load(f)
+    recipe = load_yaml(recipe_path)
     steps = recipe["steps"]
     assert "ci_watch" in steps, f"{recipe_path}: no ci_watch step found"
     ci_watch = steps["ci_watch"]
@@ -33,8 +33,7 @@ def test_ci_watch_step_has_event_parameter(recipe_path: str) -> None:
 @pytest.mark.parametrize("recipe_path", RECIPE_FILES)
 def test_check_repo_ci_event_step_exists_before_ci_watch(recipe_path: str) -> None:
     """Each recipe must have a check_repo_ci_event step that routes to ci_watch."""
-    with open(recipe_path) as f:
-        recipe = yaml.safe_load(f)
+    recipe = load_yaml(recipe_path)
     steps = recipe["steps"]
     assert "check_repo_ci_event" in steps, (
         f"{recipe_path}: missing check_repo_ci_event step. "

--- a/tests/recipe/test_report_frontmatter_schema.py
+++ b/tests/recipe/test_report_frontmatter_schema.py
@@ -1,7 +1,8 @@
 """Verify report.md YAML frontmatter matches the audit-trail schema."""
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
@@ -59,6 +60,6 @@ def test_frontmatter_round_trips_through_yaml(sample_report_text: str):
     assert lines[0] == "---", "Report must start with YAML frontmatter delimiter"
     end_idx = lines.index("---", 1)
     yaml_block = "\n".join(lines[1:end_idx])
-    parsed = yaml.safe_load(yaml_block)
+    parsed = load_yaml(yaml_block)
     assert isinstance(parsed, dict)
     assert "experiment_type" in parsed

--- a/tests/recipe/test_research_campaign.py
+++ b/tests/recipe/test_research_campaign.py
@@ -1,8 +1,8 @@
 """Contract card assertions for the research-campaign recipe."""
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.recipe.contracts import check_contract_staleness, load_bundled_manifest
 from autoskillit.recipe.io import builtin_recipes_dir
 
@@ -21,7 +21,7 @@ def test_research_campaign_contract_exists():
 
 def test_research_campaign_contract_is_fresh():
     contract_path = builtin_recipes_dir() / "contracts" / "research-campaign.yaml"
-    contract = yaml.safe_load(contract_path.read_text())
+    contract = load_yaml(contract_path)
     assert isinstance(contract, dict), f"Malformed contract: expected dict, got {type(contract)}"
     stale = check_contract_staleness(contract)
     assert stale == [], f"Contract is stale: {stale}"
@@ -29,7 +29,7 @@ def test_research_campaign_contract_is_fresh():
 
 def test_research_campaign_contract_version_matches():
     contract_path = builtin_recipes_dir() / "contracts" / "research-campaign.yaml"
-    contract = yaml.safe_load(contract_path.read_text())
+    contract = load_yaml(contract_path)
     assert isinstance(contract, dict), f"Malformed contract: expected dict, got {type(contract)}"
     assert "bundled_manifest_version" in contract, (
         f"Contract missing 'bundled_manifest_version' key: {list(contract.keys())}"

--- a/tests/recipe/test_research_output_mode.py
+++ b/tests/recipe/test_research_output_mode.py
@@ -1,6 +1,7 @@
 # tests/recipe/test_research_output_mode.py
 import pytest
 
+from autoskillit.core.io import load_yaml
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
@@ -219,15 +220,13 @@ def test_research_bundles_documented_in_kitchen_rules(recipe):
 
 def test_research_output_mode_enum_rule_fires_for_invalid_value():
     """research-output-mode-enum rule must fire ERROR when output_mode.default is invalid."""
-    import yaml
-
     from autoskillit.core import Severity
     from autoskillit.recipe._analysis import make_validation_context
     from autoskillit.recipe.io import _parse_recipe
     from autoskillit.recipe.validator import run_semantic_rules
 
     src = RESEARCH_RECIPE_PATH.read_text()
-    data = yaml.safe_load(src)
+    data = load_yaml(src)
     data["ingredients"]["output_mode"] = {"default": "bogus", "required": False}
     bad_recipe = _parse_recipe(data)
     ctx = make_validation_context(bad_recipe)
@@ -243,15 +242,13 @@ def test_research_output_mode_enum_rule_fires_for_invalid_value():
 
 def test_research_output_mode_enum_rule_clean_for_valid_values():
     """research-output-mode-enum rule must NOT fire for 'local' or 'pr'."""
-    import yaml
-
     from autoskillit.recipe._analysis import make_validation_context
     from autoskillit.recipe.io import _parse_recipe
     from autoskillit.recipe.validator import run_semantic_rules
 
     for valid in ("local", "pr"):
         src = RESEARCH_RECIPE_PATH.read_text()
-        data = yaml.safe_load(src)
+        data = load_yaml(src)
         data["ingredients"]["output_mode"] = {"default": valid, "required": False}
         recipe = _parse_recipe(data)
         ctx = make_validation_context(recipe)

--- a/tests/recipe/test_rules_dataflow_capture.py
+++ b/tests/recipe/test_rules_dataflow_capture.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import textwrap
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.core.types import Severity
 from autoskillit.recipe.io import _parse_recipe
 from autoskillit.recipe.validator import run_semantic_rules
@@ -40,7 +40,7 @@ class TestCaptureOutputCoverageRule:
                 action: stop
                 message: Done
         """)
-        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        recipe = _parse_recipe(load_yaml(recipe_yaml))
         findings = run_semantic_rules(recipe)
         undeclared = [f for f in findings if f.rule == "undeclared-capture-key"]
         assert undeclared == []
@@ -64,7 +64,7 @@ class TestCaptureOutputCoverageRule:
                 action: stop
                 message: Done
         """)
-        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        recipe = _parse_recipe(load_yaml(recipe_yaml))
         findings = run_semantic_rules(recipe)
         undeclared = [f for f in findings if f.rule == "undeclared-capture-key"]
         assert len(undeclared) == 1
@@ -91,7 +91,7 @@ class TestCaptureOutputCoverageRule:
                 action: stop
                 message: Done
         """)
-        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        recipe = _parse_recipe(load_yaml(recipe_yaml))
         findings = run_semantic_rules(recipe)
         undeclared = [f for f in findings if f.rule == "undeclared-capture-key"]
         assert len(undeclared) == 1
@@ -117,7 +117,7 @@ class TestCaptureOutputCoverageRule:
                 action: stop
                 message: Done
         """)
-        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        recipe = _parse_recipe(load_yaml(recipe_yaml))
         findings = run_semantic_rules(recipe)
         undeclared = [f for f in findings if f.rule == "undeclared-capture-key"]
         assert len(undeclared) == 1
@@ -145,7 +145,7 @@ class TestCaptureOutputCoverageRule:
                 action: stop
                 message: Done
         """)
-        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        recipe = _parse_recipe(load_yaml(recipe_yaml))
         findings = run_semantic_rules(recipe)
         assert not compute_recipe_validity(
             errors=[],
@@ -434,7 +434,7 @@ class TestDownstreamContextCompletenessRule:
                 action: stop
                 message: Done
         """)
-        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        recipe = _parse_recipe(load_yaml(recipe_yaml))
         findings = run_semantic_rules(recipe)
         gap = [
             f for f in findings if f.rule == "downstream-context-gap" and f.step_name == "consume"

--- a/tests/recipe/test_rules_dataflow_handoff.py
+++ b/tests/recipe/test_rules_dataflow_handoff.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import textwrap
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.core.types import Severity
 from autoskillit.recipe.io import _parse_recipe
 from autoskillit.recipe.validator import run_semantic_rules
@@ -160,7 +160,7 @@ class TestPythonCaptureOutputCoverageRule:
                 action: stop
                 message: Done
         """)
-        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        recipe = _parse_recipe(load_yaml(recipe_yaml))
         findings = run_semantic_rules(recipe)
         undeclared = [f for f in findings if f.rule == "undeclared-python-capture-key"]
         assert undeclared == []
@@ -185,7 +185,7 @@ class TestPythonCaptureOutputCoverageRule:
                 action: stop
                 message: Done
         """)
-        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        recipe = _parse_recipe(load_yaml(recipe_yaml))
         findings = run_semantic_rules(recipe)
         undeclared = [f for f in findings if f.rule == "undeclared-python-capture-key"]
         assert len(undeclared) == 1
@@ -210,7 +210,7 @@ class TestPythonCaptureOutputCoverageRule:
                 action: stop
                 message: Done
         """)
-        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        recipe = _parse_recipe(load_yaml(recipe_yaml))
         findings = run_semantic_rules(recipe)
         undeclared = [f for f in findings if f.rule == "undeclared-python-capture-key"]
         assert len(undeclared) == 1
@@ -242,7 +242,7 @@ class TestPythonCaptureOutputCoverageRule:
                 action: stop
                 message: Done
         """)
-        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        recipe = _parse_recipe(load_yaml(recipe_yaml))
         findings = run_semantic_rules(recipe)
         undeclared = [f for f in findings if f.rule == "undeclared-python-capture-key"]
         assert len(undeclared) == 1
@@ -266,7 +266,7 @@ class TestPythonCaptureOutputCoverageRule:
                 action: stop
                 message: Done
         """)
-        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        recipe = _parse_recipe(load_yaml(recipe_yaml))
         findings = run_semantic_rules(recipe)
         undeclared = [f for f in findings if f.rule == "undeclared-python-capture-key"]
         assert undeclared == []

--- a/tests/recipe/test_validator_graph_and_actions.py
+++ b/tests/recipe/test_validator_graph_and_actions.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.recipe.io import _parse_recipe
 from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
 from autoskillit.recipe.validator import run_semantic_rules, validate_recipe_structure
@@ -224,7 +224,7 @@ def test_validate_recipe_catches_rectify_with_missing_investigation_path_capture
     return an error — confirming the enforcement layer works for the new context variable.
     """
     recipe = _parse_recipe(
-        yaml.safe_load(
+        load_yaml(
             """\
 name: test-missing-capture
 description: Recipe with investigate→rectify but no capture block

--- a/tests/server/test_tools_agents.py
+++ b/tests/server/test_tools_agents.py
@@ -227,9 +227,8 @@ def test_make_plan_no_activate_agents():
 # T12: Agent definition frontmatter has required fields
 def test_agent_definition_frontmatter_valid():
     """For each .md file in agents/, parse YAML frontmatter and assert required fields exist."""
-    import yaml
-
     from autoskillit.core import pkg_root
+    from autoskillit.core.io import load_yaml
 
     agents_dir = pkg_root() / "agents"
     for md_file in sorted(agents_dir.glob("*.md")):
@@ -240,7 +239,7 @@ def test_agent_definition_frontmatter_valid():
         if content.startswith("---"):
             parts = content.split("---", 2)
             assert len(parts) >= 3, f"{md_file.name}: missing YAML frontmatter"
-            frontmatter = yaml.safe_load(parts[1])
+            frontmatter = load_yaml(parts[1])
             for field in ("name", "description", "tools", "model", "maxTurns"):
                 assert field in frontmatter, f"{md_file.name}: missing frontmatter field '{field}'"
 
@@ -423,9 +422,8 @@ def test_wp_elaborator_is_packless():
 # DIAG_C6: pipeline-health-scanner agent exists
 def test_pipeline_health_scanner_agent_exists():
     """pipeline-health-scanner.md agent definition must exist with required frontmatter."""
-    import yaml
-
     from autoskillit.core import pkg_root
+    from autoskillit.core.io import load_yaml
 
     agent_path = pkg_root() / "agents" / "pipeline-health-scanner.md"
     assert agent_path.is_file(), f"pipeline-health-scanner.md not found at {agent_path}"
@@ -434,7 +432,7 @@ def test_pipeline_health_scanner_agent_exists():
 
     parts = content.split("---", 2)
     assert len(parts) >= 3, "pipeline-health-scanner.md must have YAML frontmatter"
-    frontmatter = yaml.safe_load(parts[1]) or {}
+    frontmatter = load_yaml(parts[1]) or {}
     max_turns = frontmatter.get("maxTurns")
     assert max_turns is not None and max_turns >= 80, (
         f"pipeline-health-scanner maxTurns must be >= 80 (got {max_turns}); "
@@ -455,9 +453,8 @@ def test_pipeline_health_scanner_agent_exists():
 # DIAG_C7: plan-registry-tracer maxTurns >= 80
 def test_plan_registry_tracer_max_turns_sufficient() -> None:
     """plan-registry-tracer.md maxTurns must be >= 80."""
-    import yaml
-
     from autoskillit.core import pkg_root
+    from autoskillit.core.io import load_yaml
 
     agent_path = pkg_root() / "agents" / "plan-registry-tracer.md"
     assert agent_path.is_file(), f"plan-registry-tracer.md not found at {agent_path}"
@@ -465,7 +462,7 @@ def test_plan_registry_tracer_max_turns_sufficient() -> None:
 
     parts = content.split("---", 2)
     assert len(parts) >= 3, "plan-registry-tracer.md must have YAML frontmatter"
-    frontmatter = yaml.safe_load(parts[1]) or {}
+    frontmatter = load_yaml(parts[1]) or {}
     max_turns = frontmatter.get("maxTurns")
     assert max_turns is not None and max_turns >= 80, (
         f"plan-registry-tracer maxTurns must be >= 80 (got {max_turns}); "
@@ -517,9 +514,8 @@ def test_agent_tool_list_covers_body_references():
     """Agent frontmatter tools must include all tools referenced in the body."""
     import re
 
-    import yaml
-
     from autoskillit.core import pkg_root
+    from autoskillit.core.io import load_yaml
 
     _SPAWN_SUBAGENT_RE = re.compile(r"spawn\s+\w+\s+subagent", re.IGNORECASE)
     _LSP_BODY_RE = re.compile(r"\bLSP\b")
@@ -533,7 +529,7 @@ def test_agent_tool_list_covers_body_references():
         parts = content.split("---", 2)
         if len(parts) < 3:
             continue
-        frontmatter = yaml.safe_load(parts[1]) or {}
+        frontmatter = load_yaml(parts[1]) or {}
         tools: list[str] = frontmatter.get("tools", [])
         body = parts[2]
         if _SPAWN_SUBAGENT_RE.search(body) and "Agent" not in tools:

--- a/tests/skills/test_analyze_prs_contracts.py
+++ b/tests/skills/test_analyze_prs_contracts.py
@@ -3,7 +3,8 @@
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 SKILL_MD = Path(__file__).parents[2] / "src/autoskillit/skills_extended/analyze-prs/SKILL.md"
 _CONTRACTS_YAML = Path(__file__).parents[2] / "src/autoskillit/recipe/skill_contracts.yaml"
@@ -55,7 +56,7 @@ def test_analyze_prs_json_example_uses_pr_batch_prefix(skill_text: str) -> None:
 
 def test_analyze_prs_contract_has_merge_queue_data_path() -> None:
     """C-APR-1: analyze-prs contract must declare merge_queue_data_path input."""
-    raw = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    raw = load_yaml(_CONTRACTS_YAML)
     inputs = raw.get("skills", {}).get("analyze-prs", {}).get("inputs", [])
     names = [inp["name"] for inp in inputs]
     assert "merge_queue_data_path" in names, (

--- a/tests/skills/test_conflict_resolution_guards.py
+++ b/tests/skills/test_conflict_resolution_guards.py
@@ -8,8 +8,8 @@ silent regression if sections are accidentally removed.
 import re
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.core.paths import pkg_root
 
 PROJECT_ROOT = pkg_root()
@@ -34,7 +34,7 @@ def impl_no_merge_skill_text():
 
 @pytest.fixture(scope="module")
 def recipe():
-    return yaml.safe_load(RECIPE_PATH.read_text())
+    return load_yaml(RECIPE_PATH)
 
 
 # --- merge-pr SKILL.md guards ---
@@ -177,7 +177,6 @@ def test_merge_prs_routes_escalation_to_stop(recipe):
 
 @pytest.fixture(scope="function")
 def skill_contracts_yaml():
-    from autoskillit.core.io import load_yaml
 
     contracts_path = pkg_root() / "recipe" / "skill_contracts.yaml"
     return load_yaml(contracts_path)
@@ -185,7 +184,6 @@ def skill_contracts_yaml():
 
 @pytest.fixture(scope="function")
 def merge_prs_recipe():
-    from autoskillit.core.io import load_yaml
 
     return load_yaml(RECIPE_PATH)
 
@@ -242,7 +240,7 @@ def test_resolve_merge_conflicts_never_runs_full_test_suite():
 
 def test_resolve_merge_conflicts_in_skill_contracts():
     contracts_path = pkg_root() / "recipe" / "skill_contracts.yaml"
-    contracts = yaml.safe_load(contracts_path.read_text())
+    contracts = load_yaml(contracts_path)
     assert "resolve-merge-conflicts" in contracts.get("skills", {}), (
         "skill_contracts.yaml must declare resolve-merge-conflicts as a key under 'skills'"
     )

--- a/tests/skills/test_make_campaign_compliance.py
+++ b/tests/skills/test_make_campaign_compliance.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 
 import re
 
-import yaml
-
 from autoskillit.core import pkg_root
+from autoskillit.core.io import load_yaml
 from autoskillit.recipe._skill_placeholder_parser import (
     extract_bash_blocks,
     extract_bash_placeholders,
@@ -49,7 +48,7 @@ def test_make_campaign_no_undefined_placeholders() -> None:
 
 def test_make_campaign_skill_contract_registered() -> None:
     """make-campaign has a skill_contracts.yaml entry with campaign_path file_path output."""
-    raw = yaml.safe_load(_CONTRACTS_PATH.read_text())
+    raw = load_yaml(_CONTRACTS_PATH)
     skills = raw.get("skills", {}) if isinstance(raw, dict) else {}
 
     assert "make-campaign" in skills, "make-campaign must be registered in skill_contracts.yaml"

--- a/tests/skills/test_open_integration_pr_domain_analysis.py
+++ b/tests/skills/test_open_integration_pr_domain_analysis.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 SKILL_MD = (
     Path(__file__).parents[2] / "src/autoskillit/skills_extended/open-integration-pr/SKILL.md"
@@ -86,7 +87,7 @@ def test_skill_skips_empty_domains(skill_text: str) -> None:
 
 def test_open_integration_pr_contract_has_domain_partitions_path() -> None:
     """C-OIP-1: open-integration-pr contract must declare domain_partitions_path input."""
-    raw = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    raw = load_yaml(_CONTRACTS_YAML)
     inputs = raw.get("skills", {}).get("open-integration-pr", {}).get("inputs", [])
     names = [inp["name"] for inp in inputs]
     assert "domain_partitions_path" in names, (

--- a/tests/skills/test_phase2_skills.py
+++ b/tests/skills/test_phase2_skills.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import re
 
-import yaml
-
+from autoskillit.core.io import load_yaml
 from autoskillit.core.paths import pkg_root
 from autoskillit.workspace.skills import DefaultSkillResolver
 
@@ -16,7 +15,7 @@ def test_open_kitchen_skill_has_disable_model_invocation() -> None:
     content = skill_md.read_text()
     fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
     assert fm_match, "SKILL.md must have YAML frontmatter"
-    fm = yaml.safe_load(fm_match.group(1))
+    fm = load_yaml(fm_match.group(1))
     assert fm.get("disable-model-invocation") is True
     assert fm.get("name") == "open-kitchen"
 
@@ -27,7 +26,7 @@ def test_close_kitchen_skill_has_disable_model_invocation() -> None:
     content = skill_md.read_text()
     fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
     assert fm_match
-    fm = yaml.safe_load(fm_match.group(1))
+    fm = load_yaml(fm_match.group(1))
     assert fm.get("disable-model-invocation") is True
     assert fm.get("name") == "close-kitchen"
 

--- a/tests/skills/test_plan_experiment_schema_contracts.py
+++ b/tests/skills/test_plan_experiment_schema_contracts.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+from autoskillit.core.io import load_yaml
+
 
 def _repo_root() -> Path:
     return Path(__file__).parent.parent.parent
@@ -85,10 +87,8 @@ def test_research_recipe_passes_revision_guidance_to_plan_experiment():
 
 def test_skill_contracts_plan_experiment_has_revision_guidance_input():
     """skill_contracts.yaml must register revision_guidance as optional (required: false) input."""
-    import yaml
-
     contracts_path = _repo_root() / "src/autoskillit/recipe/skill_contracts.yaml"
-    raw = yaml.safe_load(contracts_path.read_text())
+    raw = load_yaml(contracts_path)
     pe = raw.get("skills", {}).get("plan-experiment", {})
     inputs = {inp["name"]: inp for inp in pe.get("inputs", [])}
     assert "revision_guidance" in inputs, (

--- a/tests/skills/test_planner_skill_contracts.py
+++ b/tests/skills/test_planner_skill_contracts.py
@@ -1,6 +1,6 @@
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.core.paths import pkg_root
 from autoskillit.recipe.io import load_recipe
 
@@ -46,7 +46,7 @@ def test_skill_has_planner_category(skill_name: str) -> None:
     assert content.startswith("---"), f"{skill_name}: must start with YAML frontmatter"
     parts = content.split("---", 2)
     assert len(parts) >= 3
-    data = yaml.safe_load(parts[1]) or {}
+    data = load_yaml(parts[1]) or {}
     assert "planner" in (data.get("categories") or []), (
         f"{skill_name}: must declare 'categories: [planner]'"
     )
@@ -120,7 +120,7 @@ def test_refine_sizing_excluded_from_issues_fixed() -> None:
 
 @pytest.mark.parametrize("skill_name", PLANNER_FINALIZATION_SKILLS)
 def test_skill_in_defaults_yaml_tier2(skill_name: str) -> None:
-    defaults = yaml.safe_load((pkg_root() / "config" / "defaults.yaml").read_text())
+    defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
     tier2 = defaults["skills"]["tier2"]
     assert skill_name in tier2, f"{skill_name} must appear in defaults.yaml skills.tier2"
 
@@ -136,7 +136,7 @@ def test_all_planner_recipe_skills_registered_in_contract_card() -> None:
 
     card_path = RECIPES_ROOT / "contracts" / "planner.yaml"
     assert card_path.is_file(), "planner contract card not found — run generate_recipe_card"
-    card = yaml.safe_load(card_path.read_text())
+    card = load_yaml(card_path)
     registered = set(card.get("skills", {}).keys())
 
     missing = recipe_skills - registered
@@ -149,7 +149,7 @@ def test_planner_contract_card_records_positional_args_for_generate_phases() -> 
     """T1b: the generate_phases dataflow entry must record positional_args > 0."""
     card_path = RECIPES_ROOT / "contracts" / "planner.yaml"
     assert card_path.is_file(), "planner contract card not found — run generate_recipe_card"
-    card = yaml.safe_load(card_path.read_text())
+    card = load_yaml(card_path)
 
     generate_phases_entry = next(
         (e for e in card.get("dataflow", []) if e.get("step") == "generate_phases"),
@@ -327,7 +327,7 @@ def test_validate_task_alignment_skill_exists():
     assert skill_md.is_file(), "SKILL.md must exist"
     content = skill_md.read_text()
     parts = content.split("---", 2)
-    data = yaml.safe_load(parts[1])
+    data = load_yaml(parts[1])
     assert "planner" in (data.get("categories") or [])
     assert "warning" in content.lower(), "Must emit warning-severity findings"
 

--- a/tests/skills/test_project_local_audit_skill_content.py
+++ b/tests/skills/test_project_local_audit_skill_content.py
@@ -9,7 +9,8 @@ import re
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILLS_DIR = REPO_ROOT / ".claude" / "skills"
@@ -29,7 +30,7 @@ def _parse_frontmatter(content: str) -> dict:
     except ValueError as exc:
         raise ValueError("Unclosed frontmatter delimiter in SKILL.md content") from exc
     fm_text = content[3:end].strip()
-    return yaml.safe_load(fm_text) or {}
+    return load_yaml(fm_text) or {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/skills/test_review_pr_verdict_guards.py
+++ b/tests/skills/test_review_pr_verdict_guards.py
@@ -105,7 +105,7 @@ def test_review_pr_own_pr_comment_retry():
 def test_contract_yamls_include_approved_with_comments() -> None:
     """All 3 contract YAML files must include approved_with_comments in
     expected_output_patterns and pattern_examples for the review-pr contract."""
-    import yaml
+    from autoskillit.core.io import load_yaml
 
     contracts_dir = (
         Path(__file__).parent.parent.parent / "src" / "autoskillit" / "recipes" / "contracts"
@@ -116,7 +116,7 @@ def test_contract_yamls_include_approved_with_comments() -> None:
         contracts_dir / "implementation-groups.yaml",
     ]
     for contract_path in contract_files:
-        data = yaml.safe_load(contract_path.read_text())
+        data = load_yaml(contract_path)
         review_pr = data.get("skills", {}).get("review-pr", {})
         patterns = review_pr.get("expected_output_patterns", [])
         examples = review_pr.get("pattern_examples", [])

--- a/tests/skills/test_skill_output_compliance.py
+++ b/tests/skills/test_skill_output_compliance.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 import re
 
 import pytest
-import yaml
 
 from autoskillit.core import pkg_root
+from autoskillit.core.io import load_yaml
 from autoskillit.workspace.skills import DefaultSkillResolver
 
 # Skills whose output files are intentionally fixed-name (no timestamp needed).
@@ -364,7 +364,7 @@ def _extract_critical_constraints_section(skill_md: str) -> str:
 
 def _get_contracted_path_capture_skills() -> dict[str, list[str]]:
     """Return {skill_name: [token_names]} for skills with path-capture contracts."""
-    raw = yaml.safe_load(SKILL_CONTRACTS_PATH.read_text())
+    raw = load_yaml(SKILL_CONTRACTS_PATH)
     skills_data = raw.get("skills", {}) if isinstance(raw, dict) else {}
     result: dict[str, list[str]] = {}
     for skill_name, contract in skills_data.items():
@@ -435,7 +435,7 @@ def test_every_contracted_skill_has_emit_instruction() -> None:
 
 def test_contracted_path_capture_skills_includes_backslash_s_patterns() -> None:
     """_get_contracted_path_capture_skills must return all skills with \\S+-terminated patterns."""
-    raw = yaml.safe_load(SKILL_CONTRACTS_PATH.read_text())
+    raw = load_yaml(SKILL_CONTRACTS_PATH)
     skills_data = raw.get("skills", {}) if isinstance(raw, dict) else {}
 
     # Dynamically find skills whose contracts include \S+-terminated path-capture patterns.

--- a/tests/skills/test_troubleshoot_experiment_contracts.py
+++ b/tests/skills/test_troubleshoot_experiment_contracts.py
@@ -1,5 +1,4 @@
-import yaml
-
+from autoskillit.core.io import load_yaml
 from autoskillit.core.paths import pkg_root
 from autoskillit.workspace.skills import DefaultSkillResolver
 
@@ -57,7 +56,7 @@ def test_troubleshoot_experiment_emits_retry_delay_token():
 def test_troubleshoot_experiment_contract_includes_retry_delay():
     """skill_contracts.yaml must declare retry_delay as a troubleshoot-experiment output."""
     contracts_path = pkg_root() / "recipe" / "skill_contracts.yaml"
-    data = yaml.safe_load(contracts_path.read_text())
+    data = load_yaml(contracts_path)
     skill = data["skills"]["troubleshoot-experiment"]
     output_names = [o["name"] for o in skill["outputs"]]
     assert "retry_delay" in output_names

--- a/tests/skills/test_vis_lens_structural.py
+++ b/tests/skills/test_vis_lens_structural.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml
+
+from autoskillit.core.io import load_yaml
 
 SKILLS_DIR = Path(__file__).parents[2] / "src/autoskillit/skills_extended"
 
@@ -39,7 +40,7 @@ def _frontmatter(text: str) -> dict:
     if lines[0].strip() != "---":
         return {}
     end = next(i for i, ln in enumerate(lines[1:], 1) if ln.strip() == "---")
-    return yaml.safe_load("\n".join(lines[1:end]))
+    return load_yaml("\n".join(lines[1:end]))
 
 
 @pytest.mark.parametrize("slug", VIS_LENS_SLUGS)

--- a/tests/workspace/test_session_skills_provider.py
+++ b/tests/workspace/test_session_skills_provider.py
@@ -9,8 +9,8 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.workspace.session_skills import (
     _SKILLS_SUBDIR,
     CODEX_SKILLS_SUBDIR,
@@ -60,7 +60,7 @@ def test_provider_injects_disable_model_invocation_for_tier2() -> None:
     content = provider.get_skill_content("open-kitchen", gated=True)
     fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
     assert fm_match, "Content must have YAML frontmatter"
-    fm = yaml.safe_load(fm_match.group(1))
+    fm = load_yaml(fm_match.group(1))
     assert fm.get("disable-model-invocation") is True
 
 
@@ -73,7 +73,7 @@ def test_provider_does_not_inject_for_cook_session() -> None:
     content = provider.get_skill_content("mermaid", gated=False)
     fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
     assert fm_match, "Content must have YAML frontmatter"
-    fm = yaml.safe_load(fm_match.group(1))
+    fm = load_yaml(fm_match.group(1))
     assert fm.get("disable-model-invocation") is not True
 
 
@@ -203,7 +203,7 @@ def test_activate_skill_deps_removes_flag(tmp_path: Path) -> None:
     content = mermaid_md.read_text()
     fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
     assert fm_match
-    fm = yaml.safe_load(fm_match.group(1))
+    fm = load_yaml(fm_match.group(1))
     assert "disable-model-invocation" not in fm or fm.get("disable-model-invocation") is not True
 
 
@@ -232,7 +232,7 @@ def test_activate_with_deps_materialises_absent_skill(
     content = mermaid_md.read_text()
     fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
     assert fm_match
-    fm = yaml.safe_load(fm_match.group(1))
+    fm = load_yaml(fm_match.group(1))
     assert "disable-model-invocation" not in fm or fm.get("disable-model-invocation") is not True
 
 
@@ -268,7 +268,7 @@ def test_activate_with_deps_already_present_removes_flag(
     updated = mermaid_md.read_text()
     fm_match = re.match(r"^---\n(.*?)\n---", updated, re.DOTALL)
     assert fm_match
-    fm = yaml.safe_load(fm_match.group(1))
+    fm = load_yaml(fm_match.group(1))
     assert "disable-model-invocation" not in fm or fm.get("disable-model-invocation") is not True
 
 

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -7,9 +7,9 @@ import re
 from pathlib import Path
 
 import pytest
-import yaml
 
 import autoskillit.workspace.skills as _skills_mod
+from autoskillit.core.io import load_yaml
 from autoskillit.core.types import SkillSource
 from autoskillit.workspace.skills import (
     DefaultSkillResolver,
@@ -287,7 +287,7 @@ class TestSkillResolver:
                 if fm_match is None:
                     failures.append(f"  {skill_name}: no YAML frontmatter found")
                     continue
-                data = yaml.safe_load(fm_match.group(1))
+                data = load_yaml(fm_match.group(1))
                 if not isinstance(data, dict) or "name" not in data:
                     failures.append(f"  {skill_name}: frontmatter missing 'name' field")
                     continue


### PR DESCRIPTION
## Summary

Migrate 79 test files from `yaml.safe_load()` (pure Python SafeLoader) to `load_yaml()` (C-backed CSafeLoader via `autoskillit.core.io`). Measured speedup: 9-11× on YAML parsing, saving ~50s of CPU per full test run. Also adds ruff TID251 bans on `yaml.safe_load` and `yaml.safe_dump` to prevent regression.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260531-142606-943241/.autoskillit/temp/make-plan/migrate_test_yaml_to_csafeloader_plan_2026-05-31_143500.md`

## Changes

### pyproject.toml
Add ruff TID251 bans on `yaml.safe_load` and `yaml.safe_dump` to prevent regression.

### tests/_test_filter.py
Migrate `load_manifest()` to use `yaml.CSafeLoader` with SafeLoader fallback (no autoskillit imports — standalone file).

### 78 test files across 8 directories
Mechanical migration: `yaml.safe_load(path.read_text())` → `load_yaml(path)`, `yaml.safe_load(string)` → `load_yaml(string)`, and file-handle patterns → path-passed `load_yaml()`. Import cleanup where `yaml.*` usage is fully replaced.

### Architecture Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    subgraph QualityGates ["QUALITY GATES (pre-commit)"]
        direction TB
        RUFF_FMT["ruff format<br/>━━━━━━━━━━<br/>Auto-fix formatting"]
        RUFF_CHECK["● ruff check<br/>━━━━━━━━━━<br/>Lint + TID251 bans"]
        MYPY["mypy<br/>━━━━━━━━━━<br/>Type checking"]
    end

    subgraph BannedAPI ["★ TID251 BANNED-API (new entries)"]
        direction LR
        BAN_LOAD["yaml.safe_load<br/>━━━━━━━━━━<br/>→ load_yaml()"]
        BAN_DUMP["yaml.safe_dump<br/>━━━━━━━━━━<br/>→ dump_yaml_str()"]
    end

    subgraph CoreIO ["core/io.py (wrapper — per-file-ignored)"]
        direction LR
        LOAD_YAML["load_yaml()<br/>━━━━━━━━━━<br/>CSafeLoader<br/>PathLike | str"]
        DUMP_YAML["dump_yaml_str()<br/>━━━━━━━━━━<br/>CDumper"]
    end

    subgraph TestFiles ["TEST FILES (~69 files via load_yaml)"]
        direction TB
        PATTERN_A["● Pattern A: path.read_text()<br/>━━━━━━━━━━<br/>→ load_yaml(path)"]
        PATTERN_B["● Pattern B: string variable<br/>━━━━━━━━━━<br/>→ load_yaml(string)"]
        PATTERN_C["● Pattern C: file handle<br/>━━━━━━━━━━<br/>→ load_yaml(path)"]
        PATTERN_D["● Pattern D: read_bytes()<br/>━━━━━━━━━━<br/>→ load_yaml(path)"]
    end

    subgraph Standalone ["★ _test_filter.py (standalone — no pkg imports)"]
        FILTER["● load_manifest()<br/>━━━━━━━━━━<br/>yaml.load(f, Loader=CSafeLoader)<br/>preserves OSError + YAMLError"]
    end

    RUFF_FMT --> RUFF_CHECK
    RUFF_CHECK --> MYPY
    RUFF_CHECK --> BannedAPI
    BAN_LOAD --> LOAD_YAML
    BAN_DUMP --> DUMP_YAML
    PATTERN_A --> LOAD_YAML
    PATTERN_B --> LOAD_YAML
    PATTERN_C --> LOAD_YAML
    PATTERN_D --> LOAD_YAML

    class RUFF_FMT,RUFF_CHECK,MYPY detector;
    class BAN_LOAD,BAN_DUMP,FILTER newComponent;
    class LOAD_YAML,DUMP_YAML handler;
    class PATTERN_A,PATTERN_B,PATTERN_C,PATTERN_D phase;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Red | Quality Gate | Pre-commit linting and checking tools |
| Green | New Component | New TID251 banned-api entries + standalone migration |
| Orange | Handler | Core IO wrapper functions (existing) |
| Purple | Phase | Migration patterns in test files |

Closes #3447

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 5.3k | 6.7k | 12.1M | 111.1k | 255 | 941.0k | 20m 13s |
| verify* | opus | 1 | 45 | 21.7k | 370.9k | 69.8k | 152 | 88.0k | 9m 27s |
| implement* | opus | 1 | 5.5M | 36.1k | 2.5M | 80.7k | 751 | 535.2k | 23m 55s |
| fix* | opus | 2 | 85 | 8.8k | 1.3M | 88.7k | 119 | 68.2k | 21m 9s |
| audit_impl* | opus | 1 | 454 | 11.7k | 448.1k | 102.1k | 140 | 163.6k | 6m 36s |
| prepare_pr* | opus | 1 | 46.7k | 5.0k | 375.0k | 0 | 27 | 0 | 52s |
| compose_pr* | opus | 1 | 46.3k | 3.4k | 418.2k | 0 | 29 | 0 | 57s |
| dispatch:66f8a175-4185-4d29-bda6-5edcbcddfb0a* | sonnet | 1 | 452 | 104 | 3.9M | 86.5k | 56 | 378.1k | 1h 54m |
| review_pr* | opus | 1 | 53 | 18.6k | 2.2M | 126.9k | 49 | 111.1k | 13m 38s |
| resolve_review* | opus | 1 | 44 | 9.7k | 952.4k | 71.8k | 40 | 56.0k | 9m 38s |
| resolve_pre_review_conflicts* | opus | 1 | 29 | 2.6k | 354.6k | 41.1k | 24 | 47.5k | 1m 17s |
| **Total** | | | 5.6M | 124.6k | 24.9M | 126.9k | | 2.4M | 3h 41m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 635 | 3876.7 | 842.9 | 56.9 |
| fix | 6 | 223017.8 | 11371.3 | 1471.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| dispatch:66f8a175-4185-4d29-bda6-5edcbcddfb0a | 1128 | 3474.3 | 335.2 | 0.1 |
| review_pr | 0 | — | — | — |
| resolve_review | 16 | 59523.4 | 3500.4 | 603.9 |
| resolve_pre_review_conflicts | 8847 | 40.1 | 5.4 | 0.3 |
| **Total** | **10632** | 2344.2 | 224.7 | 11.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 5.3k | 6.7k | 12.1M | 941.0k | 20m 13s |
| opus | 9 | 5.6M | 117.8k | 8.9M | 1.1M | 1h 27m |
| sonnet | 1 | 452 | 104 | 3.9M | 378.1k | 1h 54m |