### PR TITLE
Optimize Test Infra Config — Retention Policy, Worksteal, Stale Cleanup

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,7 +38,7 @@ tasks:
 
         set -o pipefail
         set +e
-        $PYTEST_CMD ${PYTEST_TEST_PATHS:-tests/} -q --tb=short -n 4 -m "not smoke and not canary" ${PYTEST_IGNORE_PATHS:-} --disable-warnings -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
+        $PYTEST_CMD ${PYTEST_TEST_PATHS:-tests/} -q --tb=short -n 4 --dist worksteal -m "not smoke and not canary" ${PYTEST_IGNORE_PATHS:-} --disable-warnings -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
         PYTEST_EXIT=$?
         set +o pipefail
         set -e
@@ -67,7 +67,7 @@ tasks:
 
         set -o pipefail
         set +e
-        $PYTEST_CMD ${PYTEST_TEST_PATHS:-tests/} -q --tb=short -n 4 -m "not smoke and not canary" ${PYTEST_IGNORE_PATHS:-} --disable-warnings -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
+        $PYTEST_CMD ${PYTEST_TEST_PATHS:-tests/} -q --tb=short -n 4 --dist worksteal -m "not smoke and not canary" ${PYTEST_IGNORE_PATHS:-} --disable-warnings -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
         PYTEST_EXIT=$?
         set +o pipefail
         set -e
@@ -114,7 +114,7 @@ tasks:
 
         set +e
         $PYTEST_CMD tests/ -q --tb=short \
-          -n 4 \
+          -n 4 --dist worksteal \
           -m "not smoke and not canary" \
           --disable-warnings \
           -o "addopts=" \
@@ -434,3 +434,41 @@ tasks:
         $PYTHON scripts/benchmark-testmon.py \
           --mode="${TESTMON_BENCH_MODE:-compare}" \
           ${TESTMON_CHANGED_FILES:+--changed-files="$TESTMON_CHANGED_FILES"}
+
+  cleanup-shm:
+    desc: "Clean stale /dev/shm pytest and headless session dirs (age-gated, safe for concurrent worktrees)"
+    preconditions:
+      - sh: '[ "$(uname -s)" = "Linux" ]'
+        msg: "cleanup-shm requires Linux (/dev/shm)"
+    cmds:
+      - |
+        echo "Cleaning stale /dev/shm directories..."
+
+        # pytest-tmp dirs older than 2 hours
+        PYTEST_COUNT=$(find /dev/shm -maxdepth 1 -name 'pytest-tmp-*' -mmin +120 -type d 2>/dev/null | wc -l)
+        if [ "$PYTEST_COUNT" -gt 0 ]; then
+          find /dev/shm -maxdepth 1 -name 'pytest-tmp-*' -mmin +120 -type d -exec rm -rf {} +
+          echo "  Removed $PYTEST_COUNT stale pytest-tmp dirs (>2h old)"
+        else
+          echo "  No stale pytest-tmp dirs found"
+        fi
+
+        # pytest-cache dirs older than 2 hours
+        CACHE_COUNT=$(find /dev/shm -maxdepth 1 -name 'pytest-cache-*' -mmin +120 -type d 2>/dev/null | wc -l)
+        if [ "$CACHE_COUNT" -gt 0 ]; then
+          find /dev/shm -maxdepth 1 -name 'pytest-cache-*' -mmin +120 -type d -exec rm -rf {} +
+          echo "  Removed $CACHE_COUNT stale pytest-cache dirs (>2h old)"
+        else
+          echo "  No stale pytest-cache dirs found"
+        fi
+
+        # headless session dirs older than 4 hours
+        HEADLESS_COUNT=$(find /dev/shm/autoskillit-sessions -maxdepth 1 -name 'headless-*' -mmin +240 -type d 2>/dev/null | wc -l)
+        if [ "$HEADLESS_COUNT" -gt 0 ]; then
+          find /dev/shm/autoskillit-sessions -maxdepth 1 -name 'headless-*' -mmin +240 -type d -exec rm -rf {} +
+          echo "  Removed $HEADLESS_COUNT stale headless session dirs (>4h old)"
+        else
+          echo "  No stale headless session dirs found"
+        fi
+
+        echo "Done."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ empty_parameter_set_mark = "fail_at_collect"
 addopts = []
 timeout = 60
 timeout_method = "signal"
+tmp_path_retention_policy = "failed"
 markers = [
     "smoke: end-to-end smoke tests requiring Claude API access (deselect with: -m 'not smoke')",
     "integration: integration tests that spawn real subprocesses (deselect with: -m 'not integration')",


### PR DESCRIPTION
## Summary

Three config-only changes to reduce `/dev/shm` pressure and improve xdist scheduling: add `tmp_path_retention_policy = "failed"` to pytest config so passing tests clean temp dirs immediately; change `-n 4` to `-n 4 --dist worksteal` in Taskfile.yml to eliminate idle-worker tail latency; and add a standalone `cleanup-shm` task that age-gates stale tmpdir and headless session cleanup.

No source code changes. Two files modified: `pyproject.toml` (1 line), `Taskfile.yml` (~15 lines).

Closes #3445

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260531-161647-462490/.autoskillit/temp/make-plan/optimize-test-infra-config_plan_2026-05-31_162600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 50 | 5.9k | 571.5k | 48.8k | 24 | 35.5k | 2m 42s |
| verify* | opus | 1 | 48 | 7.2k | 503.9k | 53.5k | 25 | 36.8k | 4m 52s |
| implement* | opus | 1 | 80.6k | 3.7k | 596.2k | 0 | 34 | 0 | 1m 49s |
| audit_impl* | opus | 1 | 357 | 7.3k | 213.9k | 38.5k | 19 | 27.0k | 3m 27s |
| prepare_pr* | opus | 1 | 49.6k | 2.0k | 140.9k | 28.2k | 18 | 42.0k | 1m 5s |
| compose_pr* | opus | 1 | 55.8k | 1.2k | 222.5k | 28.2k | 18 | 16.3k | 44s |
| review_pr* | opus | 1 | 39 | 18.2k | 498.0k | 58.8k | 33 | 44.6k | 4m 50s |
| resolve_review* | opus | 1 | 38 | 6.3k | 484.6k | 48.9k | 28 | 32.7k | 6m 11s |
| resolve_pre_review_conflicts* | opus | 1 | 25 | 1.8k | 215.7k | 37.0k | 18 | 20.4k | 56s |
| **Total** | | | 186.5k | 53.5k | 3.4M | 58.8k | | 255.3k | 26m 39s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 45 | 13248.2 | 0.0 | 82.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| resolve_pre_review_conflicts | 525 | 410.9 | 38.8 | 3.3 |
| **Total** | **570** | 6047.6 | 447.9 | 93.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 50 | 5.9k | 571.5k | 35.5k | 2m 42s |
| opus | 8 | 186.5k | 47.6k | 2.9M | 219.9k | 23m 56s |