### PR TITLE
Rectify: run_python Relative Path Anchoring — Structural Immunity

### DIFF
--- a/.autoskillit/recipes/eval/agent-eval.yaml
+++ b/.autoskillit/recipes/eval/agent-eval.yaml
@@ -76,6 +76,7 @@ steps:
       canary_manifest: "${{ inputs.canary_manifest }}"
       variant_manifest: "${{ inputs.variant_manifest }}"
       output_dir: "${{ inputs.output_dir }}"
+      work_dir: "${{ context.work_dir }}"
     capture:
       eval_run_dir: "${{ result.eval_run_dir }}"
       canary_count: "${{ result.canary_count }}"

--- a/.autoskillit/recipes/eval/skill-eval.yaml
+++ b/.autoskillit/recipes/eval/skill-eval.yaml
@@ -63,6 +63,7 @@ steps:
       canary_manifest: "${{ inputs.canary_manifest }}"
       variant_manifest: "${{ inputs.variant_manifest }}"
       output_dir: "${{ inputs.output_dir }}"
+      work_dir: "${{ context.work_dir }}"
     capture:
       eval_run_dir: "${{ result.eval_run_dir }}"
       canary_count: "${{ result.canary_count }}"

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -587,4 +587,23 @@ def _check_run_python_requires_work_dir(ctx: ValidationContext) -> list[RuleFind
                     ),
                 )
             )
+        work_dir_val = with_args.get("work_dir")
+        if (
+            isinstance(work_dir_val, str)
+            and work_dir_val
+            and "${{" not in work_dir_val
+            and not PurePosixPath(work_dir_val).is_absolute()
+        ):
+            findings.append(
+                RuleFinding(
+                    rule="run-python-requires-work-dir",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"step '{step_name}' has work_dir='{work_dir_val}' "
+                        "which is not absolute and not a template — "
+                        "use an absolute path or template expression"
+                    ),
+                )
+            )
     return findings

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import deque
+from pathlib import PurePosixPath
 
 from autoskillit.core import (
     GATED_TOOLS,
@@ -25,6 +26,10 @@ from autoskillit.recipe.registry import RuleFinding, semantic_rule
 logger = get_logger(__name__)
 
 _ALL_TOOLS: frozenset[str] = GATED_TOOLS | UNGATED_TOOLS | HEADLESS_TOOLS
+
+_RUN_PYTHON_PATH_LIKE_ARGS: frozenset[str] = frozenset(
+    {"output_dir", "workspace", "diagnostics_log_dir"}
+)
 
 # Known parameter signatures for MCP tools that accept `with:` args in recipes.
 # Intentionally hardcoded — recipe validation runs without a live MCP server.
@@ -547,4 +552,39 @@ def _check_push_after_edit_requires_force(ctx: ValidationContext) -> list[RuleFi
                 )
             )
 
+    return findings
+
+
+@semantic_rule(
+    name="run-python-requires-work-dir",
+    description="run_python steps with relative path-like args must include work_dir",
+    severity=Severity.ERROR,
+)
+def _check_run_python_requires_work_dir(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        is_run_python = step.tool == "run_python" or step.python is not None
+        if not is_run_python:
+            continue
+        with_args = step.with_args or {}
+        has_relative_path_like = any(
+            k in _RUN_PYTHON_PATH_LIKE_ARGS
+            and isinstance(v, str)
+            and v
+            and "${{" not in v
+            and not PurePosixPath(v).is_absolute()
+            for k, v in with_args.items()
+        )
+        if has_relative_path_like and "work_dir" not in with_args:
+            findings.append(
+                RuleFinding(
+                    rule="run-python-requires-work-dir",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"step '{step_name}' has relative path-like args "
+                        "but no work_dir — add work_dir to anchor paths"
+                    ),
+                )
+            )
     return findings

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -1049,7 +1049,7 @@
       "with": {
         "callable": "autoskillit.smoke_utils.enrich_diff_context",
         "pr_number": "${{ context.pr_number }}",
-        "work_dir": "${{ context.work_dir }}"
+        "project_dir": "${{ context.work_dir }}"
       },
       "on_success": "resolve_review",
       "on_failure": "resolve_review",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -972,7 +972,7 @@ steps:
     with:
       callable: autoskillit.smoke_utils.enrich_diff_context
       pr_number: ${{ context.pr_number }}
-      work_dir: ${{ context.work_dir }}
+      project_dir: ${{ context.work_dir }}
     on_success: resolve_review
     on_failure: resolve_review
     optional: true

--- a/src/autoskillit/server/tools/_execution_helpers.py
+++ b/src/autoskillit/server/tools/_execution_helpers.py
@@ -15,7 +15,21 @@ logger = get_logger(__name__)
 
 _RUN_PYTHON_SENTINEL_KEYS: frozenset[str] = frozenset({"callable", "timeout", "work_dir"})
 
-_PATH_LIKE_ARGS: frozenset[str] = frozenset({"output_dir"})
+_PATH_LIKE_ARGS: frozenset[str] = frozenset({"output_dir", "workspace", "diagnostics_log_dir"})
+
+
+def validate_path_arg_anchoring(args: dict[str, object] | None, work_dir: str) -> str | None:
+    """Return error message if args contain relative path-like values without work_dir."""
+    if not args:
+        return None
+    for key in _PATH_LIKE_ARGS:
+        val = args.get(key)
+        if isinstance(val, str) and val and not Path(val).is_absolute() and not work_dir:
+            return (
+                f"run_python: arg '{key}' is a relative path ({val!r}) "
+                f"but work_dir was not provided — pass work_dir to anchor it"
+            )
+    return None
 
 
 def resolve_relative_path_args(args: dict[str, object], work_dir: str) -> dict[str, object]:

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -320,8 +320,19 @@ async def run_python(
             from autoskillit.server.tools._execution_helpers import (
                 _import_and_call,  # noqa: PLC0415
                 resolve_relative_path_args,  # noqa: PLC0415
+                validate_path_arg_anchoring,  # noqa: PLC0415
             )
 
+            if work_dir and not Path(work_dir).is_absolute():
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": f"run_python: work_dir must be absolute, got {work_dir!r}",
+                    }
+                )
+            anchor_err = validate_path_arg_anchoring(args, work_dir)
+            if anchor_err:
+                return json.dumps({"success": False, "error": anchor_err})
             resolved_args = args
             if work_dir:
                 resolved_args = resolve_relative_path_args(args or {}, work_dir)

--- a/src/autoskillit/server/tools/tools_status.py
+++ b/src/autoskillit/server/tools/tools_status.py
@@ -480,6 +480,9 @@ async def write_telemetry_files(
 
             tool_ctx = _get_ctx()
             out = Path(output_dir)
+            if not out.is_absolute():
+                msg = f"output_dir must be absolute, got {output_dir!r}"
+                return json.dumps({"success": False, "error": msg})
             out.mkdir(parents=True, exist_ok=True)
 
             token_steps = _merge_wall_clock_seconds(

--- a/src/autoskillit/smoke_utils/_eval.py
+++ b/src/autoskillit/smoke_utils/_eval.py
@@ -25,6 +25,8 @@ def parse_eval_manifests(
 
     from autoskillit.core import atomic_write  # noqa: PLC0415
 
+    if not Path(output_dir).is_absolute():
+        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     eval_run_dir = Path(output_dir) / "runs" / timestamp
     eval_run_dir.mkdir(parents=True, exist_ok=True)
@@ -108,6 +110,8 @@ def parse_agent_eval_manifests(
 
     from autoskillit.core import atomic_write  # noqa: PLC0415
 
+    if not Path(output_dir).is_absolute():
+        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     eval_run_dir = Path(output_dir) / "runs" / timestamp
     eval_run_dir.mkdir(parents=True, exist_ok=True)

--- a/src/autoskillit/smoke_utils/_git.py
+++ b/src/autoskillit/smoke_utils/_git.py
@@ -12,6 +12,8 @@ def check_bug_report_non_empty(workspace: str) -> dict[str, str]:
     Called by run_python from the check_summary step in smoke-test.yaml.
     The workspace argument is the root directory initialised by the setup step.
     """
+    if not Path(workspace).is_absolute():
+        raise ValueError(f"workspace must be absolute, got {workspace!r}")
     report = Path(workspace) / "bug_report.json"
     if not report.exists():
         return {"non_empty": "false"}
@@ -46,6 +48,8 @@ def compute_domain_partitions(
     )
     files = [f for f in result.stdout.strip().split("\n") if f]
     partitions = partition_files_by_domain(files)
+    if not Path(output_dir).is_absolute():
+        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
     out_path = Path(output_dir) / "domain_partitions.json"
     atomic_write(out_path, json.dumps(partitions))
     return {"domain_partitions_path": str(out_path)}
@@ -98,6 +102,8 @@ def fetch_merge_queue_data(base_branch: str, cwd: str, output_dir: str) -> dict[
         else:
             entries = parse_merge_queue_response(data)
 
+    if not Path(output_dir).is_absolute():
+        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
     out_path = Path(output_dir) / "merge_queue_data.json"
     atomic_write(out_path, json.dumps(entries))
     return {"merge_queue_data_path": str(out_path)}

--- a/src/autoskillit/smoke_utils/_git.py
+++ b/src/autoskillit/smoke_utils/_git.py
@@ -38,6 +38,9 @@ def compute_domain_partitions(
     from autoskillit.core import atomic_write  # noqa: PLC0415
     from autoskillit.execution import partition_files_by_domain  # noqa: PLC0415
 
+    if not Path(output_dir).is_absolute():
+        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
+
     result = subprocess.run(
         ["git", "diff", "--name-only", f"{base_branch}..{batch_branch}"],
         capture_output=True,
@@ -48,8 +51,6 @@ def compute_domain_partitions(
     )
     files = [f for f in result.stdout.strip().split("\n") if f]
     partitions = partition_files_by_domain(files)
-    if not Path(output_dir).is_absolute():
-        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
     out_path = Path(output_dir) / "domain_partitions.json"
     atomic_write(out_path, json.dumps(partitions))
     return {"domain_partitions_path": str(out_path)}
@@ -66,6 +67,9 @@ def fetch_merge_queue_data(base_branch: str, cwd: str, output_dir: str) -> dict[
 
     from autoskillit.core import atomic_write  # noqa: PLC0415
     from autoskillit.execution import parse_merge_queue_response  # noqa: PLC0415
+
+    if not Path(output_dir).is_absolute():
+        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
 
     repo_info = subprocess.run(
         ["gh", "repo", "view", "--json", "owner,name"],
@@ -102,8 +106,6 @@ def fetch_merge_queue_data(base_branch: str, cwd: str, output_dir: str) -> dict[
         else:
             entries = parse_merge_queue_response(data)
 
-    if not Path(output_dir).is_absolute():
-        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
     out_path = Path(output_dir) / "merge_queue_data.json"
     atomic_write(out_path, json.dumps(entries))
     return {"merge_queue_data_path": str(out_path)}

--- a/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
+++ b/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
@@ -44,8 +44,8 @@ def diagnose_merge_gate(
     subtype = _classify_subtype(test_stdout, test_stderr)
     failed_tests = _extract_failed_tests(test_stdout, test_stderr)
 
-    if not output_dir:
-        raise ValueError("output_dir is required — pass via run_python work_dir anchoring")
+    if not output_dir or not Path(output_dir).is_absolute():
+        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
     out_path = Path(output_dir) / "diagnosis.md"
 
     failed_section = "\n".join(f"- {t}" for t in failed_tests) if failed_tests else "- none"

--- a/src/autoskillit/smoke_utils/_review.py
+++ b/src/autoskillit/smoke_utils/_review.py
@@ -37,6 +37,10 @@ def annotate_pr_diff(
         select_review_agents,
     )  # noqa: PLC0415
 
+    out = Path(output_dir)
+    if not out.is_absolute():
+        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
+
     try:
         local_rounds = int(local_review_rounds.strip()) if local_review_rounds.strip() else 0
     except ValueError:
@@ -88,9 +92,6 @@ def annotate_pr_diff(
             timeout=10,
         )
     head_sha = head_sha_result.stdout.strip() if head_sha_result.returncode == 0 else ""
-    out = Path(output_dir)
-    if not out.is_absolute():
-        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
     out.mkdir(parents=True, exist_ok=True)
     annotated_path = out / f"annotated_diff_{pr_number}.txt"
     ranges_path = out / f"ranges_{pr_number}.json"

--- a/src/autoskillit/smoke_utils/_review.py
+++ b/src/autoskillit/smoke_utils/_review.py
@@ -89,6 +89,8 @@ def annotate_pr_diff(
         )
     head_sha = head_sha_result.stdout.strip() if head_sha_result.returncode == 0 else ""
     out = Path(output_dir)
+    if not out.is_absolute():
+        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
     out.mkdir(parents=True, exist_ok=True)
     annotated_path = out / f"annotated_diff_{pr_number}.txt"
     ranges_path = out / f"ranges_{pr_number}.json"
@@ -253,7 +255,7 @@ def check_loop_with_progress(
 
 def enrich_diff_context(
     pr_number: str,
-    work_dir: str,
+    project_dir: str,
     context_lines: str = "50",
 ) -> dict[str, str]:
     """Fill empty code_region fields in the review-pr diff_context handoff.
@@ -266,8 +268,10 @@ def enrich_diff_context(
     from autoskillit.core import atomic_write  # noqa: PLC0415
     from autoskillit.execution import extract_code_region  # noqa: PLC0415
 
+    if not Path(project_dir).is_absolute():
+        raise ValueError(f"project_dir must be absolute, got {project_dir!r}")
     ctx_lines = int(context_lines) if context_lines else 50
-    temp_dir = Path(work_dir) / ".autoskillit" / "temp"
+    temp_dir = Path(project_dir) / ".autoskillit" / "temp"
     handoff_path = temp_dir / "review-pr" / f"diff_context_{pr_number}.json"
 
     if not handoff_path.exists():

--- a/src/autoskillit/smoke_utils/_telemetry.py
+++ b/src/autoskillit/smoke_utils/_telemetry.py
@@ -118,6 +118,8 @@ def consolidate_health_reports(*, diagnostics_log_dir: str, kitchen_id: str) -> 
     Writes a JSON report file to {diagnostics_log_dir}/health-reports/ when running
     inside a food truck dispatch, persisting the report outside the clone filesystem.
     """
+    if not Path(diagnostics_log_dir).is_absolute():
+        raise ValueError(f"diagnostics_log_dir must be absolute, got {diagnostics_log_dir!r}")
     reports_dir = Path(diagnostics_log_dir) / "health-reports"
     if not reports_dir.is_dir():
         return {"summary": "No health reports directory found. No diagnostics to consolidate."}

--- a/tests/arch/test_run_python_path_resolution.py
+++ b/tests/arch/test_run_python_path_resolution.py
@@ -34,8 +34,8 @@ _EXPLICITLY_EXCLUDED: dict[str, str] = {
         "always absolute; git worktree paths are inherently absolute by design "
         "and are never passed as relative paths to run_python steps"
     ),
-    "work_dir": (
-        "enrich_diff_context receives work_dir as the anchor/base directory itself "
+    "project_dir": (
+        "enrich_diff_context receives project_dir as the anchor/base directory itself "
         "for constructing temp_dir; resolving it against itself would be circular"
     ),
     "log_dir": (

--- a/tests/arch/test_run_python_path_resolution.py
+++ b/tests/arch/test_run_python_path_resolution.py
@@ -45,47 +45,45 @@ _EXPLICITLY_EXCLUDED: dict[str, str] = {
 }
 
 
-def test_smoke_utils_output_dir_never_resolves_against_implicit_cwd() -> None:
-    """No smoke_utils callable may fall back to a relative path when output_dir is falsy."""
-    violations: list[str] = []
+def _find_absoluteness_guard(
+    func_node: ast.FunctionDef | ast.AsyncFunctionDef, _param_names: set[str]
+) -> bool:
+    """Check whether *func_node* guards *param_names* with is_absolute() or raise."""
+    for node in ast.walk(func_node):
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "is_absolute":
+                return True
+        if isinstance(node, ast.Raise) and node.exc is not None:
+            for child in ast.walk(node.exc):
+                if (
+                    isinstance(child, ast.Constant)
+                    and isinstance(child.value, str)
+                    and "absolute" in child.value.lower()
+                ):
+                    return True
+    return False
 
+
+_GUARDED_PARAMS = {"output_dir", "workspace", "diagnostics_log_dir", "project_dir"}
+
+
+def test_smoke_utils_path_params_always_guarded_absolute() -> None:
+    """Every Path(path_param) in smoke_utils must be preceded by an is_absolute() guard."""
+    violations = []
     for py_file in sorted(_SMOKE_UTILS_DIR.glob("*.py")):
-        source = py_file.read_text()
-        tree = ast.parse(source, filename=str(py_file))
-
+        tree = ast.parse(py_file.read_text(), filename=str(py_file))
         for func_node in ast.walk(tree):
             if not isinstance(func_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
-            param_names = {arg.arg for arg in func_node.args.args}
-            if "output_dir" not in param_names:
+            func_params = {a.arg for a in func_node.args.args}
+            guarded_in_func = func_params & _GUARDED_PARAMS
+            if not guarded_in_func:
                 continue
-
-            for stmt in ast.walk(func_node):
-                if not isinstance(stmt, ast.If):
-                    continue
-                for else_stmt in stmt.orelse:
-                    for call_node in ast.walk(else_stmt):
-                        if not isinstance(call_node, ast.Call):
-                            continue
-                        func = call_node.func
-                        if not (isinstance(func, ast.Name) and func.id == "Path"):
-                            continue
-                        if not call_node.args:
-                            continue
-                        first_arg = call_node.args[0]
-                        if not isinstance(first_arg, ast.Constant):
-                            continue
-                        val = first_arg.value
-                        if isinstance(val, str) and not val.startswith("/"):
-                            violations.append(
-                                f"{py_file.name}:{call_node.lineno}: "
-                                f"'{func_node.name}' falls back to relative Path({val!r}) "
-                                f"— raise ValueError instead"
-                            )
-
+            has_guard = _find_absoluteness_guard(func_node, guarded_in_func)
+            if not has_guard:
+                violations.append(f"{py_file.name}:{func_node.name}: missing absoluteness guard")
     assert not violations, (
-        "smoke_utils callables must not fall back to relative paths; "
-        "run_python work_dir anchoring ensures output_dir always arrives absolute:\n"
+        "smoke_utils callables with path params must check is_absolute():\n"
         + "\n".join(violations)
     )
 
@@ -121,4 +119,15 @@ def test_path_like_args_registry_complete() -> None:
         "smoke_utils callable params with path-like names must be registered in "
         "_PATH_LIKE_ARGS or listed in _EXPLICITLY_EXCLUDED with justification:\n"
         + "\n".join(unregistered)
+    )
+
+
+def test_path_like_args_synchronized_across_layers() -> None:
+    """_PATH_LIKE_ARGS and _RUN_PYTHON_PATH_LIKE_ARGS must stay in sync."""
+    from autoskillit.recipe.rules.rules_tools import _RUN_PYTHON_PATH_LIKE_ARGS
+    from autoskillit.server.tools._execution_helpers import _PATH_LIKE_ARGS
+
+    assert _PATH_LIKE_ARGS == _RUN_PYTHON_PATH_LIKE_ARGS, (
+        f"Path-like args registries out of sync: "
+        f"server={_PATH_LIKE_ARGS}, recipe={_RUN_PYTHON_PATH_LIKE_ARGS}"
     )

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -157,12 +157,12 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils/_git.py", 55),
     ("src/autoskillit/smoke_utils/_git.py", 110),
     # smoke_utils/_eval.py — eval resolved/manifest/scorecard/eval_context, agent-eval
-    ("src/autoskillit/smoke_utils/_eval.py", 79),
-    ("src/autoskillit/smoke_utils/_eval.py", 90),
-    ("src/autoskillit/smoke_utils/_eval.py", 225),
-    ("src/autoskillit/smoke_utils/_eval.py", 236),
-    ("src/autoskillit/smoke_utils/_eval.py", 314),
-    ("src/autoskillit/smoke_utils/_eval.py", 479),
+    ("src/autoskillit/smoke_utils/_eval.py", 81),
+    ("src/autoskillit/smoke_utils/_eval.py", 92),
+    ("src/autoskillit/smoke_utils/_eval.py", 229),
+    ("src/autoskillit/smoke_utils/_eval.py", 240),
+    ("src/autoskillit/smoke_utils/_eval.py", 318),
+    ("src/autoskillit/smoke_utils/_eval.py", 483),
     # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)
     ("src/autoskillit/planner/consolidation.py", 333),
     # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -124,7 +124,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 164),
     # tools_status.py — mcp_data dict
-    ("src/autoskillit/server/tools/tools_status.py", 510),
+    ("src/autoskillit/server/tools/tools_status.py", 513),
     # tools_github.py — bug report dict
     ("src/autoskillit/server/tools/tools_github.py", 307),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
@@ -146,16 +146,16 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _update_checks_fetch.py — fetch cache (extracted from _update_checks.py)
     ("src/autoskillit/cli/update/_update_checks_fetch.py", 58),
     # smoke_utils/_review.py — ranges, valid lines, diff metrics, enriched handoff
-    ("src/autoskillit/smoke_utils/_review.py", 97),
-    ("src/autoskillit/smoke_utils/_review.py", 98),
-    ("src/autoskillit/smoke_utils/_review.py", 116),
-    ("src/autoskillit/smoke_utils/_review.py", 298),
+    ("src/autoskillit/smoke_utils/_review.py", 100),
+    ("src/autoskillit/smoke_utils/_review.py", 101),
+    ("src/autoskillit/smoke_utils/_review.py", 119),
+    ("src/autoskillit/smoke_utils/_review.py", 303),
     # smoke_utils/_git.py — partitions, merge queue data
-    # Line 102 is a list-payload write site (dual membership: also in list_sites
+    # Line 110 is a list-payload write site (dual membership: also in list_sites
     # in test_allowlist_includes_list_payloads_as_documented). The AST scanner catches
     # it because it cannot distinguish list vs dict return types — intentional.
-    ("src/autoskillit/smoke_utils/_git.py", 50),
-    ("src/autoskillit/smoke_utils/_git.py", 102),
+    ("src/autoskillit/smoke_utils/_git.py", 55),
+    ("src/autoskillit/smoke_utils/_git.py", 110),
     # smoke_utils/_eval.py — eval resolved/manifest/scorecard/eval_context, agent-eval
     ("src/autoskillit/smoke_utils/_eval.py", 79),
     ("src/autoskillit/smoke_utils/_eval.py", 90),
@@ -231,8 +231,8 @@ class TestSchemaVersionConvention:
         """List-payload sites are included since the AST scanner can't distinguish return types."""
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
-            ("src/autoskillit/smoke_utils/_review.py", 97),
-            ("src/autoskillit/smoke_utils/_git.py", 102),
+            ("src/autoskillit/smoke_utils/_review.py", 100),
+            ("src/autoskillit/smoke_utils/_git.py", 110),
         ]
         for site in list_sites:
             assert site in _LEGACY_JSON_WRITES, (

--- a/tests/recipe/test_rules_tools.py
+++ b/tests/recipe/test_rules_tools.py
@@ -602,6 +602,79 @@ def test_push_after_readonly_skill_without_force_passes() -> None:
     assert not hits, "push-after-edit-requires-force must not fire for read_only skills"
 
 
+# ---------------------------------------------------------------------------
+# run-python-requires-work-dir rule tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_python_requires_work_dir_when_output_dir_relative() -> None:
+    """run_python step with relative output_dir and no work_dir triggers error."""
+    recipe = _make_recipe_with_args(
+        "run_python",
+        {"callable": "mod.fn", "output_dir": "{{AUTOSKILLIT_TEMP}}/y"},
+    )
+    findings = run_semantic_rules(recipe)
+    matched = [f for f in findings if f.rule == "run-python-requires-work-dir"]
+    assert matched, "Expected run-python-requires-work-dir finding"
+    assert all(f.severity == Severity.ERROR for f in matched)
+
+
+def test_run_python_no_violation_when_work_dir_present() -> None:
+    """run_python step with relative output_dir but work_dir present passes."""
+    recipe = _make_recipe_with_args(
+        "run_python",
+        {
+            "callable": "mod.fn",
+            "output_dir": "{{AUTOSKILLIT_TEMP}}/y",
+            "work_dir": "${{ context.work_dir }}",
+        },
+    )
+    findings = run_semantic_rules(recipe)
+    matched = [f for f in findings if f.rule == "run-python-requires-work-dir"]
+    assert not matched
+
+
+def test_run_python_no_violation_when_output_dir_absolute() -> None:
+    """run_python step with absolute output_dir needs no work_dir."""
+    recipe = _make_recipe_with_args(
+        "run_python",
+        {"callable": "mod.fn", "output_dir": "/absolute/path"},
+    )
+    findings = run_semantic_rules(recipe)
+    matched = [f for f in findings if f.rule == "run-python-requires-work-dir"]
+    assert not matched
+
+
+def test_python_shorthand_requires_work_dir_when_output_dir_relative() -> None:
+    """python: shorthand step with relative output_dir and no work_dir triggers error."""
+    recipe = Recipe(
+        name="test-recipe",
+        description="Test recipe.",
+        version="0.2.0",
+        kitchen_rules="Use run_skill only.",
+        steps={
+            "parse": RecipeStep(
+                python="autoskillit.smoke_utils.parse_eval_manifests",
+                with_args={"output_dir": "{{AUTOSKILLIT_TEMP}}/eval"},
+            )
+        },
+    )
+    findings = run_semantic_rules(recipe)
+    matched = [f for f in findings if f.rule == "run-python-requires-work-dir"]
+    assert matched, "python: shorthand must also be caught"
+
+
+def test_run_python_no_violation_when_recipe_expression() -> None:
+    """${{ }} recipe expressions are skipped — resolved to absolute paths at runtime."""
+    recipe = _make_recipe_with_args(
+        "run_python",
+        {"callable": "mod.fn", "output_dir": "${{ context.planner_dir }}"},
+    )
+    findings = run_semantic_rules(recipe)
+    matched = [f for f in findings if f.rule == "run-python-requires-work-dir"]
+    assert not matched
+
+
 def test_all_bundled_recipes_pass_push_after_edit_rule() -> None:
     """All bundled recipes must have zero push-after-edit-requires-force findings."""
     from autoskillit.core import pkg_root

--- a/tests/server/test_tools_run_python_cwd.py
+++ b/tests/server/test_tools_run_python_cwd.py
@@ -77,3 +77,49 @@ async def test_run_python_absolute_output_dir_unchanged_by_work_dir(
     assert result["success"] is True
     expected_file = Path(abs_output) / "diagnosis.md"
     assert expected_file.exists(), "Absolute output_dir must be used unchanged"
+
+
+@pytest.mark.anyio
+async def test_run_python_rejects_relative_work_dir(tool_ctx_kitchen_open):
+    result_json = await run_python(
+        callable="autoskillit.smoke_utils.diagnose_merge_gate",
+        args={"test_stdout": "x", "test_stderr": "", "output_dir": "out"},
+        work_dir="relative/work",
+    )
+    result = json.loads(result_json)
+    assert result["success"] is False
+    assert "absolute" in result["error"]
+
+
+@pytest.mark.anyio
+async def test_run_python_rejects_relative_output_dir_without_work_dir(tool_ctx_kitchen_open):
+    result_json = await run_python(
+        callable="autoskillit.smoke_utils.diagnose_merge_gate",
+        args={"test_stdout": "x", "test_stderr": "", "output_dir": ".autoskillit/temp/test"},
+        work_dir="",
+    )
+    result = json.loads(result_json)
+    assert result["success"] is False
+    assert "work_dir" in result["error"]
+
+
+@pytest.mark.anyio
+async def test_run_python_annotate_pr_diff_relative_output_dir(tool_ctx_kitchen_open, tmp_path):
+    """run_python anchors annotate_pr_diff's relative output_dir to work_dir."""
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    (work_dir / ".git").mkdir()
+
+    result_json = await run_python(
+        callable="autoskillit.smoke_utils.diagnose_merge_gate",
+        args={
+            "test_stdout": "FAILED test_foo",
+            "test_stderr": "",
+            "output_dir": ".autoskillit/temp/review-pr",
+        },
+        work_dir=str(work_dir),
+    )
+    result = json.loads(result_json)
+    assert result["success"] is True
+    expected = work_dir / ".autoskillit/temp/review-pr"
+    assert expected.exists()

--- a/tests/server/test_tools_status_quota_and_db.py
+++ b/tests/server/test_tools_status_quota_and_db.py
@@ -175,6 +175,12 @@ class TestWriteTelemetryFiles:
         assert result["success"] is False
         assert result["subtype"] == "gate_error"
 
+    @pytest.mark.anyio
+    async def test_rejects_relative_output_dir(self, tool_ctx_kitchen_open):
+        result = json.loads(await write_telemetry_files(".autoskillit/temp/telemetry"))
+        assert result["success"] is False
+        assert "absolute" in result["error"]
+
 
 # ---------------------------------------------------------------------------
 # TestReadDb — moved from test_tools_workspace.py (tools_status owns read_db)

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -2340,7 +2340,7 @@ def test_diagnose_merge_gate_rejects_empty_output_dir() -> None:
     """diagnose_merge_gate must raise ValueError when output_dir is empty."""
     from autoskillit.smoke_utils._merge_gate_diagnosis import diagnose_merge_gate
 
-    with pytest.raises(ValueError, match="output_dir is required"):
+    with pytest.raises(ValueError, match="output_dir must be absolute"):
         diagnose_merge_gate(test_stdout="FAILED test_foo", test_stderr="")
 
 

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -912,7 +912,7 @@ def test_enrich_diff_context_fills_empty_code_regions(tmp_path: Path) -> None:
             {"path": "src/app.py", "line": 42, "severity": "critical", "code_region": ""},
         ],
     )
-    result = enrich_diff_context(pr_number="123", work_dir=str(tmp_path))
+    result = enrich_diff_context(pr_number="123", project_dir=str(tmp_path))
     assert result["enriched"] == "true"
     assert result["enriched_count"] == "1"
 
@@ -936,7 +936,7 @@ def test_enrich_diff_context_preserves_existing_code_regions(tmp_path: Path) -> 
             {"path": "src/app.py", "line": 40, "severity": "warning", "code_region": ""},
         ],
     )
-    result = enrich_diff_context(pr_number="123", work_dir=str(tmp_path))
+    result = enrich_diff_context(pr_number="123", project_dir=str(tmp_path))
     assert result["enriched"] == "true"
     assert result["enriched_count"] == "1"
 
@@ -949,7 +949,7 @@ def test_enrich_diff_context_preserves_existing_code_regions(tmp_path: Path) -> 
 # T_EDC3
 def test_enrich_diff_context_missing_handoff_file(tmp_path: Path) -> None:
     """enrich_diff_context returns gracefully when handoff file does not exist."""
-    result = enrich_diff_context(pr_number="999", work_dir=str(tmp_path))
+    result = enrich_diff_context(pr_number="999", project_dir=str(tmp_path))
     assert result["enriched"] == "false"
     assert result["reason"] == "handoff_not_found"
 
@@ -2411,3 +2411,42 @@ def test_smoke_utils_callable_resolvable_via_importlib(name: str) -> None:
     mod = importlib.import_module("autoskillit.smoke_utils")
     attr = getattr(mod, name)
     assert callable(attr)
+
+
+# ---------------------------------------------------------------------------
+# Callable-level absoluteness guards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "callable_name,minimal_args",
+    [
+        ("annotate_pr_diff", {"pr_number": "1", "cwd": "/tmp/repo"}),
+        ("parse_eval_manifests", {"canary_manifest": "{}", "variant_manifest": "{}"}),
+        ("parse_agent_eval_manifests", {"canary_manifest": "{}", "variant_manifest": "{}"}),
+        ("compute_domain_partitions", {"batch_branch": "b", "base_branch": "main", "cwd": "/tmp"}),
+        ("fetch_merge_queue_data", {"base_branch": "main", "cwd": "/tmp"}),
+        ("diagnose_merge_gate", {"test_stdout": "FAILED x", "test_stderr": ""}),
+    ],
+)
+def test_callable_rejects_relative_output_dir(callable_name: str, minimal_args: dict) -> None:
+    from autoskillit import smoke_utils
+
+    func = getattr(smoke_utils, callable_name)
+    with pytest.raises(ValueError, match="absolute"):
+        func(**minimal_args, output_dir=".autoskillit/temp/test")
+
+
+def test_enrich_diff_context_rejects_relative_project_dir() -> None:
+    with pytest.raises(ValueError, match="absolute"):
+        enrich_diff_context(pr_number="1", project_dir="relative/path")
+
+
+def test_check_bug_report_non_empty_rejects_relative_workspace() -> None:
+    with pytest.raises(ValueError, match="absolute"):
+        check_bug_report_non_empty(workspace="relative/path")
+
+
+def test_consolidate_health_reports_rejects_relative_log_dir() -> None:
+    with pytest.raises(ValueError, match="absolute"):
+        consolidate_health_reports(diagnostics_log_dir="relative/path", kitchen_id="test")


### PR DESCRIPTION
## Summary

Smoke-utils callables invoked via `run_python` use `Path(output_dir)` to resolve output paths. When `output_dir` is a relative string (e.g., `.autoskillit/temp/review-pr` from `{{AUTOSKILLIT_TEMP}}` substitution), it resolves against the MCP server's process CWD — not the run's working directory. The existing `resolve_relative_path_args` mechanism correctly anchors relative `output_dir` to `work_dir`, but only fires when `work_dir` is provided. No structural guarantee forces `work_dir` to be present, validates it is absolute, or ensures callables refuse unanchored relative paths.

This PR (Part A) establishes runtime immunity: callable-level absoluteness assertions, tool-boundary `work_dir` validation, a sentinel-collision fix for `enrich_diff_context`, and path-like argument extension for `workspace`/`diagnostics_log_dir`.

## Problem

`annotate_pr_diff` in `src/autoskillit/smoke_utils/_review.py` resolves the `output_dir` argument against the MCP server's process CWD instead of the run's working directory. All four output files are written to the wrong location, causing downstream `review_pr` sessions to fall back to the full 6-reviewer path (losing pre-computation optimization).

### Root Cause

**Bug 1:** `_review.py` line 91 — relative path resolved against wrong CWD

When `output_dir` is a relative path (`.autoskillit/temp/review-pr`), `Path()` resolves it against the MCP server process's CWD (`/home/talon/projects/generic_automation_mcp`), not the `cwd` argument already passed to the function. The `cwd` parameter is used for `gh pr diff` commands but never applied to output path resolution.

**Bug 2:** Recipe-side `work_dir` addition is a no-op

The current `remediation.yaml` added `work_dir: ${{ context.work_dir }}` to the `annotate_pr_diff` step. However, the Python function's signature does not accept a `work_dir` parameter — it is silently ignored. The `run_python` tool only calls `resolve_relative_path_args` when `work_dir` is truthy.

**Bug 3:** Returned paths are relative

The function returns relative paths (`annotated_diff_path: .autoskillit/temp/review-pr/annotated_diff_3394.txt`). The orchestrator passes these verbatim to `review_pr` via `skill_command`. The `review_pr` skill resolves them against its own CWD (the run directory), where the files don't exist.

### Impact

- Two `review_pr` sessions lost pre-computed optimization (adaptive agent selection via `dispatch_agents`, exact line-range validation via `valid_lines`)
- Both sessions fell back to full 6-reviewer path — higher latency, no exact-line validation
- `annotate_pr_diff` compute was entirely wasted (ran twice, produced correct output, but to the wrong directory)

### Proposed Fix

1. Add callable-level absoluteness assertions to 9 smoke_utils callables
2. Add tool-boundary `work_dir` absoluteness validation
3. Add `validate_path_arg_anchoring` requiring `work_dir` when relative path-like args present
4. Rename `enrich_diff_context`'s `work_dir` param to `project_dir` to fix sentinel collision
5. Fix `write_telemetry_files` in `tools_status.py`
6. Extend `_PATH_LIKE_ARGS` to include `workspace` and `diagnostics_log_dir`
7. Add comprehensive failing tests for all affected callables

## Changed Files

### Modified (●):

- `.autoskillit/recipes/eval/agent-eval.yaml`
- `.autoskillit/recipes/eval/skill-eval.yaml`
- `src/autoskillit/recipe/rules/rules_tools.py`
- `src/autoskillit/recipes/implementation.json`
- `src/autoskillit/recipes/implementation.yaml`
- `src/autoskillit/server/tools/_execution_helpers.py`
- `src/autoskillit/server/tools/tools_execution.py`
- `src/autoskillit/server/tools/tools_status.py`
- `src/autoskillit/smoke_utils/_eval.py`
- `src/autoskillit/smoke_utils/_git.py`
- `src/autoskillit/smoke_utils/_merge_gate_diagnosis.py`
- `src/autoskillit/smoke_utils/_review.py`
- `src/autoskillit/smoke_utils/_telemetry.py`
- `tests/arch/test_run_python_path_resolution.py`
- `tests/infra/test_schema_version_convention.py`
- `tests/recipe/test_rules_tools.py`
- `tests/server/test_tools_run_python_cwd.py`
- `tests/server/test_tools_status_quota_and_db.py`
- `tests/test_smoke_utils.py`

Closes #3419

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_run_python_path_anchoring_part_a_2026-05-31_153851.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 3.1k | 26.0k | 2.2M | 122.5k | 70 | 105.8k | 21m 45s |
| review_approach* | opus[1m] | 1 | 24 | 4.5k | 190.0k | 42.2k | 12 | 28.1k | 3m 2s |
| dry_walkthrough* | opus | 2 | 109 | 28.9k | 2.5M | 74.5k | 88 | 140.3k | 14m 1s |
| implement* | opus[1m] | 2 | 178 | 26.2k | 5.8M | 120.3k | 148 | 159.7k | 12m 1s |
| audit_impl* | opus[1m] | 2 | 66 | 21.3k | 380.7k | 59.1k | 35 | 102.1k | 15m 14s |
| prepare_pr* | opus[1m] | 1 | 49.2k | 4.6k | 209.0k | 0 | 19 | 0 | 1m 5s |
| compose_pr* | opus[1m] | 1 | 58.6k | 3.0k | 338.1k | 0 | 28 | 0 | 1m 18s |
| review_pr* | opus[1m] | 1 | 34 | 21.9k | 870.4k | 96.9k | 38 | 82.6k | 5m 56s |
| resolve_review* | opus[1m] | 1 | 43 | 8.3k | 800.4k | 59.5k | 33 | 44.4k | 8m 35s |
| resolve_pre_review_conflicts* | opus[1m] | 1 | 27 | 2.3k | 305.7k | 42.0k | 21 | 25.3k | 1m 0s |
| **Total** | | | 111.4k | 147.3k | 13.5M | 122.5k | | 688.2k | 1h 24m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 277 | 20874.7 | 576.4 | 94.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 19 | 42128.1 | 2337.5 | 439.5 |
| resolve_pre_review_conflicts | 7397 | 41.3 | 3.4 | 0.3 |
| **Total** | **7693** | 1760.1 | 89.5 | 19.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 9 | 111.3k | 118.3k | 11.1M | 547.9k | 1h 9m |
| opus | 1 | 109 | 28.9k | 2.5M | 140.3k | 14m 1s |