### PR TITLE
CPU/Memory Quick Fixes — Lazy NetworkX, Precompile Regex, Session-Scope Structlog Flush

### DIFF
--- a/src/autoskillit/planner/_dag_ops.py
+++ b/src/autoskillit/planner/_dag_ops.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from collections import deque
 from typing import Any
 
-import networkx as nx
-
 
 def topological_sort(wp_results: dict[str, dict[str, Any]]) -> list[str]:
     """Return topologically sorted WP IDs. Raises RuntimeError on cycle."""
@@ -36,6 +34,8 @@ def topological_sort(wp_results: dict[str, dict[str, Any]]) -> list[str]:
 
 def find_sccs(adjacency: dict[str, list[str]]) -> list[set[str]]:
     """Return all SCCs with size >= 2 using Tarjan's algorithm via NetworkX."""
+    import networkx as nx
+
     graph: nx.DiGraph = nx.DiGraph()
     for node, neighbors in adjacency.items():
         graph.add_node(node)

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -672,6 +672,9 @@ _REVIEWS_POST_RE: re.Pattern[str] = re.compile(
 )
 
 
+_LINE_CONTINUATION_RE: re.Pattern[str] = re.compile(r"\\\n\s*")
+
+
 @semantic_rule(
     name="reviews-post-requires-input-flag",
     severity=Severity.ERROR,
@@ -701,7 +704,7 @@ def _check_reviews_post_requires_input_flag(ctx: ValidationContext) -> list[Rule
         except OSError:
             continue
         for subsection in _extract_subsections(content):
-            collapsed = re.sub(r"\\\n\s*", " ", subsection)
+            collapsed = _LINE_CONTINUATION_RE.sub(" ", subsection)
             if _REVIEWS_POST_RE.search(collapsed) and "--input -" not in collapsed:
                 findings.append(
                     RuleFinding(

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -20,6 +20,23 @@ def strip_markdown_code_regions(text: str) -> str:
     return text
 
 
+def _collect_structlog_proxies() -> list[object]:
+    """Return all BoundLoggerLazyProxy instances from autoskillit modules."""
+    import structlog._config as _sc
+
+    proxies: list[object] = []
+    for mod_name in list(sys.modules):
+        if not mod_name.startswith("autoskillit"):
+            continue
+        mod = sys.modules.get(mod_name)
+        if mod is None:
+            continue
+        for val in vars(mod).values():
+            if isinstance(val, _sc.BoundLoggerLazyProxy):
+                proxies.append(val)
+    return proxies
+
+
 def _flush_structlog_proxy_caches() -> None:
     """Reconnect autoskillit module-level loggers to the current structlog config.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from autoskillit.core.types import (
     SubprocessResult,
     TerminationReason,
 )
-from tests._helpers import _flush_structlog_proxy_caches
+from tests._helpers import _collect_structlog_proxies, _flush_structlog_proxy_caches
 
 _LAYER_DIRS: frozenset[str] = frozenset(
     {
@@ -72,46 +72,43 @@ class TimeoutTier:
     CHANNEL_B = 60  # Full session_log_dir + Channel B path
 
 
+_structlog_proxies: list[object] = []
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _structlog_session_init():
-    """One-time structlog proxy cache flush per worker session.
+    """One-time structlog proxy cache flush and proxy inventory per worker session.
 
-    Repairs module-level loggers cached at import time (before any fixture ran).
-    After this, cache_logger_on_first_use=False prevents new proxy caches from
-    forming, so the expensive _flush_structlog_proxy_caches() scan is not needed
-    per-test.
+    Repairs module-level loggers cached at import time (before any fixture ran)
+    and collects all BoundLoggerLazyProxy instances for cheap per-test clearing.
     """
     import structlog
 
     structlog.configure(cache_logger_on_first_use=False)
     _flush_structlog_proxy_caches()
+    _structlog_proxies.clear()
+    _structlog_proxies.extend(_collect_structlog_proxies())
 
 
 @pytest.fixture(autouse=True)
 def _structlog_to_null():
     """Suppress structlog output in every test.
 
-    Lightweight per-test fixture. The expensive proxy cache flush runs once
-    per session via _structlog_session_init. Here we only re-configure (cheap)
-    and wrap the test in capture_logs().
-
-    The session fixture sets cache_logger_on_first_use=False, preventing new
-    proxy caches. reset_defaults() in teardown restores structlog defaults
-    (including cache_logger_on_first_use=True), but no log calls occur between
-    teardown and the next test's setup, so no proxies cache in that window.
-
-    Three test classes manage their own structlog state alongside this fixture:
-    TestConfigureLogging (tests/core/test_logging.py) overrides _structlog_to_null
-    with a no-op and manages state via its own _reset_structlog fixture.
-    TestParseSessionResult (tests/execution/test_session_parsing.py) and
-    TestReadTempOutputLogging (tests/execution/test_process_run.py) add separate
-    autouse _reset_structlog/_reset_structlog_config fixtures that run alongside
-    the conftest _structlog_to_null.
+    Resets wrapper_class to BoundLogger (allowing all log levels through to
+    LogCapture — core/logging.py sets BoundLoggerFilteringAtInfo which silently
+    drops DEBUG events before processors see them). Clears cached ``bind``
+    methods on known proxies so tests that call configure_logging() don't
+    leak cached production loggers into subsequent tests.
     """
     import structlog
     import structlog.testing
 
-    structlog.configure(cache_logger_on_first_use=False)
+    structlog.configure(
+        cache_logger_on_first_use=False,
+        wrapper_class=structlog.BoundLogger,
+    )
+    for proxy in _structlog_proxies:
+        proxy.__dict__.pop("bind", None)
     structlog.contextvars.clear_contextvars()
     with structlog.testing.capture_logs():
         yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,12 +100,14 @@ def _structlog_to_null():
     methods on known proxies so tests that call configure_logging() don't
     leak cached production loggers into subsequent tests.
     """
+    import logging as _logging
+
     import structlog
     import structlog.testing
 
     structlog.configure(
         cache_logger_on_first_use=False,
-        wrapper_class=structlog.BoundLogger,
+        wrapper_class=structlog.make_filtering_bound_logger(_logging.DEBUG),
     )
     for proxy in _structlog_proxies:
         proxy.__dict__.pop("bind", None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,38 +72,46 @@ class TimeoutTier:
     CHANNEL_B = 60  # Full session_log_dir + Channel B path
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _structlog_session_init():
+    """One-time structlog proxy cache flush per worker session.
+
+    Repairs module-level loggers cached at import time (before any fixture ran).
+    After this, cache_logger_on_first_use=False prevents new proxy caches from
+    forming, so the expensive _flush_structlog_proxy_caches() scan is not needed
+    per-test.
+    """
+    import structlog
+
+    structlog.configure(cache_logger_on_first_use=False)
+    _flush_structlog_proxy_caches()
+
+
 @pytest.fixture(autouse=True)
 def _structlog_to_null():
-    """Prevent structlog from writing to stdout in any test.
+    """Suppress structlog output in every test.
 
-    In the default state (before configure_logging() is called), structlog's
-    PrintLoggerFactory routes all log output to sys.stdout. Tests that use
-    capsys to inspect stdout are silently corrupted when a mock bypass causes
-    a real production function to log.
+    Lightweight per-test fixture. The expensive proxy cache flush runs once
+    per session via _structlog_session_init. Here we only re-configure (cheap)
+    and wrap the test in capture_logs().
 
-    Two-layer isolation strategy:
+    The session fixture sets cache_logger_on_first_use=False, preventing new
+    proxy caches. reset_defaults() in teardown restores structlog defaults
+    (including cache_logger_on_first_use=True), but no log calls occur between
+    teardown and the next test's setup, so no proxies cache in that window.
 
-    1. Primary: ``structlog.configure(cache_logger_on_first_use=False)`` — the
-       official structlog recommendation for test environments. Prevents proxy
-       caches from being populated during tests, so ``reset_defaults()`` is
-       sufficient after each test without manual cache surgery.
-
-    2. Secondary: ``_flush_structlog_proxy_caches()`` — repairs loggers that
-       were cached before this fixture ran (e.g., module-level loggers cached
-       at import time before the fixture had a chance to set
-       cache_logger_on_first_use=False).
-
-    Then wraps the test in ``capture_logs()`` to drop all log output.
-
-    Note: TestConfigureLogging in test_logging.py has its own class-scoped
-    ``_structlog_to_null`` no-op override and ``_reset_structlog`` fixture that
-    owns structlog state management for those tests.
+    Three test classes manage their own structlog state alongside this fixture:
+    TestConfigureLogging (tests/core/test_logging.py) overrides _structlog_to_null
+    with a no-op and manages state via its own _reset_structlog fixture.
+    TestParseSessionResult (tests/execution/test_session_parsing.py) and
+    TestReadTempOutputLogging (tests/execution/test_process_run.py) add separate
+    autouse _reset_structlog/_reset_structlog_config fixtures that run alongside
+    the conftest _structlog_to_null.
     """
     import structlog
     import structlog.testing
 
     structlog.configure(cache_logger_on_first_use=False)
-    _flush_structlog_proxy_caches()
     structlog.contextvars.clear_contextvars()
     with structlog.testing.capture_logs():
         yield

--- a/tests/contracts/test_skill_format_compliance.py
+++ b/tests/contracts/test_skill_format_compliance.py
@@ -25,7 +25,7 @@ class TestSkillFormatCompliance:
     def test_skill_mds_collection_nonempty(self) -> None:
         assert _SKILL_MDS, "No bundled SKILL.md files found — check package installation"
 
-    @pytest.mark.parametrize("skill_name,content", _SKILL_MDS)
+    @pytest.mark.parametrize("skill_name,content", _SKILL_MDS, ids=[n for n, _ in _SKILL_MDS])
     def test_skill_md_has_valid_frontmatter(self, skill_name: str, content: str) -> None:
         fm = parse_frontmatter_content(content)
         errors = validate_skill_frontmatter(fm, skill_name)

--- a/tests/planner/CLAUDE.md
+++ b/tests/planner/CLAUDE.md
@@ -14,6 +14,7 @@ Planner manifest, validation, compilation, and merge tests.
 | `test_consolidation_writeback.py` | Consolidation write-back, pipeline integration, lifecycle registry |
 | `test_consolidation_cycles.py` | Consolidation cycle-breaking via greedy FAS |
 | `test_dag_ops.py` | Tests for _dag_ops: topological_sort, find_sccs, break_cycles_greedy_fas, filter_self_references |
+| `test_dag_ops_lazy_import.py` | Regression guard: verifies networkx is not eagerly imported at module level in _dag_ops |
 | `test_elaborate_assignments_contract.py` | Contract conformance tests for planner-elaborate-assignments skill |
 | `test_elaborate_wps_contract.py` | Contract conformance tests for planner-elaborate-wps skill |
 | `test_manifests_builders.py` | build_phase_assignment_manifest and build_phase_wp_manifest |

--- a/tests/planner/test_dag_ops_lazy_import.py
+++ b/tests/planner/test_dag_ops_lazy_import.py
@@ -1,0 +1,30 @@
+"""Regression guard: _dag_ops must not eagerly import networkx at module level."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import autoskillit.planner._dag_ops as _dag_ops_mod
+
+pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
+
+
+def test_dag_ops_no_toplevel_networkx_import():
+    """Top-level 'import networkx' in _dag_ops.py would add 17 MB per xdist worker."""
+    src_file = Path(_dag_ops_mod.__file__)
+    tree = ast.parse(src_file.read_text())
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name != "networkx", (
+                    f"Top-level 'import networkx' found at line {node.lineno}; "
+                    "must be a function-level import inside find_sccs()"
+                )
+        if isinstance(node, ast.ImportFrom) and (node.module or "").split(".")[0] == "networkx":
+            assert False, (
+                f"Top-level 'from {node.module} import ...' found at line {node.lineno}; "
+                "networkx must only be imported inside find_sccs()"
+            )


### PR DESCRIPTION
## Summary

Four independent micro-optimizations targeting CPU waste and memory overhead identified in profiling:

1. **Lazy `import networkx`** in `planner/_dag_ops.py` — defer 17 MB import to first `find_sccs()` call
2. **Pre-compile regex** in `recipe/rules/rules_skill_content.py:704` — eliminate per-iteration recompilation in hot loop
3. **Session-scope structlog flush** in `tests/conftest.py` — reduce per-test fixture overhead from ~0.9 ms to near-zero for most tests
4. **Add `ids=`** to parametrize in `tests/contracts/test_skill_format_compliance.py` — eliminate 1.6 MB of SKILL.md content in pytest node IDs

## Requirements

Four micro-optimizations with measurable impact on CPU and memory:

1. **Lazy networkx import** — Move `import networkx as nx` from module level to inside `find_sccs()` function in `planner/_dag_ops.py`. Saves ~17 MB per xdist worker at collection time (68 MB per test run, 340 MB at 20 concurrent worktrees). NetworkX is only used inside `find_sccs()` (lines 39, 45), and `break_cycles_greedy_fas()` calls `find_sccs()` but never references `nx` directly.

2. **Pre-compile regex** — The `re.sub(r"\\\n\s*", " ", subsection)` call at `recipe/rules/rules_skill_content.py:704` uses an inline string literal inside a hot loop — the regex module recompiles this pattern on every call. Move to a module-level `_LINE_CONTINUATION_RE = re.compile(r"\\\n\s*")`. Saves ~7s per full test run.

3. **Session-scope structlog flush** — Currently an autouse function-scope fixture doing 0.9 ms of work before EVERY test (~13.4s total per run). Only needs to run once per worker session plus after the 7 `structlog.reset_defaults()` calls in 3 specific test files. Fix: session-scoped init + lightweight per-test suppressor.

4. **Parametrize ids=** — Currently `pytest.mark.parametrize` embeds 1.6 MB of full SKILL.md content as pytest node IDs, bloating collection and slowing tracebacks. Fix: `ids=[n for n, _ in _SKILL_MDS]`.

## Changed Files

**New:**
- `tests/planner/test_dag_ops_lazy_import.py`

**Modified:**
- `src/autoskillit/planner/_dag_ops.py`
- `src/autoskillit/recipe/rules/rules_skill_content.py`
- `tests/_helpers.py`
- `tests/conftest.py`
- `tests/contracts/test_skill_format_compliance.py`
- `tests/planner/CLAUDE.md`

Closes #3446

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260531-124318-020173/.autoskillit/temp/make-plan/cpu_memory_quick_fixes_plan_2026-05-31_124500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 642 | 23.7k | 1.1M | 98.6k | 121 | 86.3k | 13m 57s |
| verify* | opus | 1 | 47 | 9.2k | 440.1k | 54.1k | 120 | 37.4k | 6m 17s |
| implement* | opus | 1 | 505.5k | 6.3k | 671.7k | 46.1k | 90 | 56.9k | 4m 33s |
| fix* | opus | 2 | 122 | 46.2k | 4.9M | 108.6k | 127 | 152.7k | 35m 52s |
| audit_impl* | opus | 1 | 465 | 11.7k | 215.3k | 41.0k | 55 | 32.8k | 5m 6s |
| prepare_pr* | opus | 2 | 196.2k | 8.4k | 422.7k | 28.2k | 49 | 83.9k | 3m 4s |
| post_run_diagnostics* | opus | 1 | 41 | 18.9k | 751.4k | 106.9k | 504 | 74.9k | 12m 28s |
| dispatch:dbd3b971-dd43-41e5-a20d-9f7e70f13592* | sonnet | 1 | 226 | 12.0k | 2.0M | 87.6k | 59 | 119.9k | 1h 45m |
| compose_pr* | opus | 1 | 46.7k | 1.9k | 174.4k | 0 | 15 | 0 | 46s |
| review_pr* | opus | 3 | 107 | 80.5k | 2.4M | 86.2k | 126 | 186.3k | 21m 17s |
| **Total** | | | 750.0k | 218.7k | 13.1M | 108.6k | | 831.1k | 3h 29m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 98 | 6853.9 | 580.5 | 64.7 |
| fix | 62 | 79578.0 | 2463.0 | 744.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| post_run_diagnostics | 0 | — | — | — |
| dispatch:dbd3b971-dd43-41e5-a20d-9f7e70f13592 | 1167 | 1704.5 | 102.8 | 10.3 |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **1327** | 9841.5 | 626.3 | 164.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 642 | 23.7k | 1.1M | 86.3k | 13m 57s |
| opus | 8 | 749.2k | 183.0k | 10.0M | 624.9k | 1h 29m |
| sonnet | 1 | 226 | 12.0k | 2.0M | 119.9k | 1h 45m |