### PR TITLE
Rectify: Model Drift Profile Suppression Guard Over-Correction

### DIFF
--- a/src/autoskillit/execution/anomaly_detection.py
+++ b/src/autoskillit/execution/anomaly_detection.py
@@ -433,11 +433,7 @@ def detect_model_drift(
     anomalies: list[dict[str, object]] = []
     if not configured_model or not observed_model:
         return anomalies
-    if (
-        profile_name
-        and _is_non_anthropic(normalize_model_id(observed_model))
-        and _is_non_anthropic(normalize_model_id(configured_model))
-    ):
+    if profile_name and _is_non_anthropic(normalize_model_id(observed_model)):
         return anomalies
     norm_cfg = normalize_model_id(configured_model)
     norm_obs = normalize_model_id(observed_model)

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -478,7 +478,7 @@ classified `REJECT` with `category: "arch_violation"`.
 | CLI prompts via timed_prompt | `test_input_tty_contracts.py` | `input()` calls in `src/autoskillit/cli/` not routed through `timed_prompt()` |
 | Interactive ordering gate | `test_interactive_ordering_gate.py` | Interactive launch sites that skip `assert_interactive_ordering()` before `_session_launch` |
 | Kitchen guard scoping | `test_kitchen_guard_scoping.py` | `any_kitchen_open()` call sites not passing `project_path` — must use scoped check |
-| Model identity contract | `test_model_identity_contract.py` | `detect_model_drift()` using raw string comparison instead of `normalize_model_id()` and `_models_match()`, or missing `profile_name` suppression guard with `normalize_model_id` normalization |
+| Model identity contract | `test_model_identity_contract.py` | `detect_model_drift()` using raw string comparison instead of `normalize_model_id()` and `_models_match()`, missing `profile_name` suppression guard with `normalize_model_id` normalization, or `profile_name` guard calling `_is_non_anthropic` more than once or on `configured_model` instead of `observed_model` (over-restriction that kills the guard for the standard Anthropic-configured + non-Anthropic-observed production path) |
 | No error-dict returns | `test_no_error_dict_return.py` | `load_and_validate()` returning `{"error": ...}` dict — errors must propagate via exceptions |
 | No inline requestId dedup | `test_no_inline_jsonl_request_id_dedup.py` | `seen_request_ids` variable in `session_log.py` or `tool_sequence_analysis.py` |
 | No Path.cwd() in server tools | `test_no_path_cwd_in_tools.py` | `Path.cwd()` in server tool handlers — use injected project path instead |

--- a/tests/arch/test_model_identity_contract.py
+++ b/tests/arch/test_model_identity_contract.py
@@ -1,9 +1,6 @@
 """AST guard: detect_model_drift must use normalize_model_id and _models_match.
 
-Raw string comparison between the alias domain (config) and the full-ID domain
-(API response) is a structural false-positive source. This guard prevents
-regression where someone modifies detect_model_drift without going through
-normalization and prefix matching.
+profile_name suppression guard must call _is_non_anthropic exactly once, on observed_model only.
 """
 
 from __future__ import annotations
@@ -127,6 +124,20 @@ def test_detect_model_drift_has_profile_suppression_guard():
                             "profile_name suppression guard must normalize observed_model "
                             "before calling _is_non_anthropic — raw-string check misclassifies "
                             "Anthropic short aliases ('sonnet', 'opus', 'haiku') as non-Anthropic"
+                        )
+                        non_anthropic_count = test_src.count("_is_non_anthropic")
+                        assert non_anthropic_count == 1, (
+                            f"profile_name suppression guard calls _is_non_anthropic "
+                            f"{non_anthropic_count} times — must be exactly 1 (on observed_model "
+                            f"only). Checking configured_model makes the guard dead for the "
+                            f"standard production case (Anthropic alias configured + "
+                            f"non-Anthropic observed via profile routing)"
+                        )
+                        assert "observed_model" in test_src, (
+                            "profile_name suppression guard must call _is_non_anthropic "
+                            "on observed_model, not configured_model — checking configured_model "
+                            "reintroduces the production-blindness bug since configured_model "
+                            "is always a Claude alias in production"
                         )
                         return
             pytest.fail(

--- a/tests/execution/test_anomaly_detection.py
+++ b/tests/execution/test_anomaly_detection.py
@@ -510,33 +510,32 @@ def test_normalize_model_id_strips_context_window_suffix():
     assert normalize_model_id("claude-sonnet-4-6-20250514[200k]") == "claude-sonnet-4-6"
 
 
-def test_detect_model_drift_fires_when_profile_and_cross_vendor():
-    """Profile-routed session with Anthropic configured + non-Anthropic observed fires drift."""
+def test_detect_model_drift_suppressed_when_profile_routed_cross_vendor():
+    """Profile-routed session: Anthropic configured + non-Anthropic observed suppresses drift."""
     anomalies = detect_model_drift("opus", "MiniMax-M2.7", profile_name="minimax")
-    assert len(anomalies) == 1
-    assert anomalies[0]["detail"]["configured_model"] == "opus"
-    assert anomalies[0]["detail"]["observed_model"] == "MiniMax-M2.7"
-
-
-def test_detect_model_drift_suppressed_when_profile_both_non_anthropic():
-    """Profile-routed sessions with both models non-Anthropic suppress MODEL_DRIFT."""
-    anomalies = detect_model_drift("MiniMax-M1", "MiniMax-M2.7", profile_name="minimax")
     assert anomalies == []
 
 
-def test_detect_model_drift_fires_when_profile_routes_to_anthropic():
-    """Profile-routed session with Anthropic observed model (full ID) still detects drift."""
-    anomalies = detect_model_drift("sonnet", "claude-opus-4-6", profile_name="alt-anthropic")
-    assert len(anomalies) == 1
-    assert anomalies[0]["detail"]["profile_name"] == "alt-anthropic"
-    assert anomalies[0]["detail"]["configured_model"] == "sonnet"
-    assert anomalies[0]["detail"]["observed_model"] == "claude-opus-4-6"
-
-
-def test_detect_model_drift_fires_when_profile_and_observed_is_anthropic_alias():
-    """Profile-routed session with Anthropic observed model (short alias) still detects drift."""
-    anomalies = detect_model_drift("sonnet", "opus", profile_name="my-profile")
-    assert len(anomalies) == 1
+@pytest.mark.parametrize(
+    "configured, observed, profile, expect_drift",
+    [
+        # Profile-routed to non-Anthropic: suppress (standard production case)
+        ("opus", "MiniMax-M2.7", "minimax", False),
+        ("opus[1m]", "MiniMax-M2.7", "minimax", False),
+        ("claude-opus-4-6", "gpt-4o", "openai", False),
+        ("sonnet", "MiniMax-M2.7", "minimax", False),
+        # Profile-routed, both non-Anthropic: suppress
+        ("MiniMax-M1", "MiniMax-M2.7", "minimax", False),
+        # No profile, cross-vendor: real drift
+        ("opus", "MiniMax-M2.7", "", True),
+        # No profile, same family: no drift
+        ("sonnet", "claude-sonnet-4-6", "", False),
+    ],
+)
+def test_detect_model_drift_profile_routing_matrix(configured, observed, profile, expect_drift):
+    """Full decision matrix for profile-routed model drift detection."""
+    anomalies = detect_model_drift(configured, observed, profile_name=profile)
+    assert bool(anomalies) == expect_drift
 
 
 def test_detect_model_drift_no_drift_when_profile_and_models_match():

--- a/tests/execution/test_anomaly_detection.py
+++ b/tests/execution/test_anomaly_detection.py
@@ -526,8 +526,12 @@ def test_detect_model_drift_suppressed_when_profile_routed_cross_vendor():
         ("sonnet", "MiniMax-M2.7", "minimax", False),
         # Profile-routed, both non-Anthropic: suppress
         ("MiniMax-M1", "MiniMax-M2.7", "minimax", False),
+        # Profile set, observed is Anthropic: guard does NOT suppress, drift fires
+        ("sonnet", "claude-opus-4-6", "alt-anthropic", True),
+        ("sonnet", "opus", "my-profile", True),
         # No profile, cross-vendor: real drift
         ("opus", "MiniMax-M2.7", "", True),
+        ("opus", "MiniMax-M2.7", None, True),
         # No profile, same family: no drift
         ("sonnet", "claude-sonnet-4-6", "", False),
     ],

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -425,6 +425,7 @@ class TestChannelBDrainRacePipelineAdjudication:
     provenance bypass (data_confirmed=False → success=True without calling _compute_success).
     """
 
+    @pytest.mark.timeout(150)
     @pytest.mark.anyio
     async def test_channel_b_drain_timeout_produces_success_skill_result(self, tmp_path):
         """COMPLETED + data_confirmed=False + empty stdout → success=True, needs_retry=False.

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -1605,13 +1605,13 @@ class TestModelAliasDriftIntegration:
         )
         assert tu["profile_name"] == "minimax"
 
-    def test_no_false_drift_with_profile_routed_both_non_anthropic(self, tmp_path):
-        """flush_session_log with both configured and observed non-Anthropic produces zero MODEL_DRIFT."""
+    def test_no_false_drift_with_profile_routed(self, tmp_path):
+        """flush_session_log with profile-routed non-Anthropic observed produces zero MODEL_DRIFT."""
         _flush(
             tmp_path,
             session_id="profile-non-anthropic-001",
             proc_snapshots=None,
-            model_identifier="MiniMax-M1",
+            model_identifier="opus[1m]",
             profile_name="minimax",
             token_usage={
                 "input_tokens": 1000,


### PR DESCRIPTION
## Summary

`detect_model_drift()` in `src/autoskillit/execution/anomaly_detection.py` fires false MODEL_DRIFT anomalies on every profile-routed non-Anthropic session because its suppression guard requires BOTH `observed_model` AND `configured_model` to be non-Anthropic. In production, `configured_model` is always a Claude alias (e.g., `"opus[1m]"` normalizes to `"claude-opus"`), so `_is_non_anthropic(normalize_model_id(configured_model))` is always `False` and the guard never fires.

The over-correction was introduced by the automated `resolve_review` step (session `36e9f5c3`) which accepted a defense-dimension warning from `review_pr` and added a second `_is_non_anthropic` condition. Tests then locked in the false positive as correct behavior. The AST contract (`test_detect_model_drift_has_profile_suppression_guard`) checks for structural presence of `normalize_model_id` in the guard but enforces neither guard shape (number of `_is_non_anthropic` calls) nor argument identity (which parameter is checked).

This is the 7th intervention on model identity in `anomaly_detection.py` in 3 days (PRs #3262, #3306, #3320, #3365, #3465, #3475), indicating a deeper architectural weakness: no behavioral contract enforces that the profile suppression guard actually suppresses in production scenarios, and the review pipeline has no vocabulary to reject guard over-restrictions.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

| File | Conflict Type | Resolution |
|------|---------------|------------|
| — | — | — |

Closes #3481

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260531-181453-849143/.autoskillit/temp/rectify/rectify_model_drift_profile_guard_over_correction_2026-05-31_181453.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 58 | 17.4k | 881.2k | 99.8k | 34 | 89.6k | 20m 20s |
| review_approach* | sonnet | 1 | 7.6k | 8.3k | 230.6k | 50.9k | 18 | 40.2k | 8m 23s |
| dry_walkthrough* | opus | 1 | 45 | 8.9k | 350.5k | 52.2k | 23 | 35.5k | 5m 7s |
| implement* | sonnet | 1 | 166 | 12.9k | 935.4k | 60.0k | 60 | 44.2k | 4m 0s |
| audit_impl* | sonnet | 1 | 553 | 9.2k | 239.1k | 37.9k | 21 | 30.4k | 4m 3s |
| prepare_pr* | sonnet | 1 | 169.1k | 4.1k | 337.9k | 28.2k | 27 | 41.2k | 1m 47s |
| compose_pr* | sonnet | 1 | 47.0k | 1.5k | 194.2k | 28.2k | 14 | 15.6k | 47s |
| review_pr* | sonnet | 1 | 110 | 33.1k | 615.2k | 76.6k | 44 | 61.4k | 7m 38s |
| resolve_review* | opus | 1 | 44 | 9.1k | 1.1M | 77.8k | 40 | 61.8k | 5m 48s |
| **Total** | | | 224.8k | 104.5k | 4.9M | 99.8k | | 419.9k | 57m 57s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 79 | 11841.0 | 559.0 | 163.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 268220.5 | 15438.0 | 2286.2 |
| **Total** | **83** | 58518.6 | 5058.7 | 1258.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 58 | 17.4k | 881.2k | 89.6k | 20m 20s |
| sonnet | 6 | 224.6k | 69.1k | 2.6M | 233.0k | 26m 41s |
| opus | 2 | 89 | 18.1k | 1.4M | 97.3k | 10m 55s |