### PR TITLE
Rectify: ProcessStaleError False-Positive on Resume — mtime-Based Detection

### DIFF
--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -35,6 +35,7 @@ from autoskillit.recipe._api_cache import (  # noqa: F401
     _compute_registry_hash,
     _LoadCacheEntry,
     _path_mtime_ns,
+    _refresh_staleness_baseline,
 )
 from autoskillit.recipe._api_listing import (  # noqa: F401
     format_recipe_list_response,
@@ -548,4 +549,6 @@ def load_and_validate(
         )
         _api_cache._LOAD_CACHE.put(cache_key, entry)
 
+    if result.get("valid", False):
+        _api_cache._refresh_staleness_baseline()
     return cast(LoadRecipeResult, _api_cache._LOAD_CACHE.copy_result(result))

--- a/src/autoskillit/recipe/_api_cache.py
+++ b/src/autoskillit/recipe/_api_cache.py
@@ -19,8 +19,9 @@ _STALENESS_LAST_CHECK: float = 0.0
 _STALENESS_IS_STALE: bool = False
 _STALENESS_CACHES_CLEARED: bool = False
 _STALENESS_TTL: float = 30.0
-_STALENESS_SCAN_DIRS: tuple[str, ...] = ("recipe/rules",)
-_DEEP_MTIME_BASELINE: int | None = None
+_STALENESS_SCAN_DIRS: tuple[str, ...] = ("recipe",)
+_DEEP_CONTENT_BASELINE: str | None = None
+_STALENESS_LOCK = threading.Lock()
 
 
 @_dc(frozen=True, slots=True)
@@ -100,46 +101,47 @@ def _get_pkg_version() -> str:
 
 
 def _compute_registry_hash(experiment_types_dir: Path) -> str:
-    """Compute md5 hash of sorted (path, mtime_ns) pairs for experiment-type YAMLs."""
+    """Compute md5 hash of sorted YAML file contents for experiment-type registry."""
     if not experiment_types_dir.exists():
         return ""
-    entries: list[tuple[str, int]] = []
+    h = hashlib.md5(usedforsecurity=False)
     for p in sorted(experiment_types_dir.glob("*.yaml")):
         try:
-            entries.append((p.name, p.stat().st_mtime_ns))
+            h.update(p.name.encode())
+            h.update(p.read_bytes())
         except OSError:
             continue
-    return hashlib.md5(str(entries).encode(), usedforsecurity=False).hexdigest()
+    return h.hexdigest()
 
 
-def _compute_deep_mtime() -> int:
-    """Return max mtime_ns across all .py files in staleness-scanned subdirectories."""
+def _compute_content_hash() -> str:
+    """Return SHA-256 hex digest of all .py files in staleness-scanned subdirectories."""
     root = pkg_root()
-    max_mt = 0
+    h = hashlib.sha256()
     for subdir in _STALENESS_SCAN_DIRS:
         d = root / subdir
         if d.is_dir():
-            for f in d.rglob("*.py"):
+            for f in sorted(d.rglob("*.py")):
                 if f.is_file():
                     try:
-                        mt = f.stat().st_mtime_ns
-                        if mt > max_mt:
-                            max_mt = mt
+                        rel = f.relative_to(root)
+                        h.update(f"{rel}\n".encode())
+                        h.update(f.read_bytes())
                     except OSError:
                         continue
-    return max_mt
+    return h.hexdigest()
 
 
 def _get_process_start_mtime() -> int:
-    global _PROCESS_START_PKG_MTIME, _DEEP_MTIME_BASELINE  # noqa: PLW0603
+    global _PROCESS_START_PKG_MTIME, _DEEP_CONTENT_BASELINE  # noqa: PLW0603
     if _PROCESS_START_PKG_MTIME is None:
         _PROCESS_START_PKG_MTIME = _path_mtime_ns(pkg_root())
-        _DEEP_MTIME_BASELINE = _compute_deep_mtime()
+        _DEEP_CONTENT_BASELINE = _compute_content_hash()
     return _PROCESS_START_PKG_MTIME
 
 
 def _check_process_staleness() -> bool:
-    """Return True if the package directory or rule files were modified after process start.
+    """Return True if recipe Python source content changed since process start.
 
     Fleet sessions always return False — dispatched subprocesses have fresh
     baselines and revalidate independently.
@@ -152,17 +154,28 @@ def _check_process_staleness() -> bool:
     now = time.monotonic()
     if now - _STALENESS_LAST_CHECK < _STALENESS_TTL:
         return _STALENESS_IS_STALE
-    _STALENESS_LAST_CHECK = now
-    try:
-        pkg_stale = _path_mtime_ns(pkg_root()) != _get_process_start_mtime()
-        if not pkg_stale:
-            current_deep = _compute_deep_mtime()
-            pkg_stale = current_deep != _DEEP_MTIME_BASELINE
-        _STALENESS_IS_STALE = pkg_stale
-    except (OSError, RuntimeError):
-        logger.warning("pkg_root() unavailable during staleness check; assuming non-stale")
-        _STALENESS_IS_STALE = False
+    with _STALENESS_LOCK:
+        _STALENESS_LAST_CHECK = now
+        try:
+            _get_process_start_mtime()
+            current_hash = _compute_content_hash()
+            pkg_stale = current_hash != _DEEP_CONTENT_BASELINE
+            _STALENESS_IS_STALE = pkg_stale
+        except (OSError, RuntimeError):
+            logger.warning("pkg_root() unavailable during staleness check; assuming non-stale")
+            _STALENESS_IS_STALE = False
     return _STALENESS_IS_STALE
+
+
+def _refresh_staleness_baseline() -> None:
+    """Re-capture baselines after a confirmed-good load."""
+    global _PROCESS_START_PKG_MTIME, _DEEP_CONTENT_BASELINE  # noqa: PLW0603
+    global _STALENESS_LAST_CHECK, _STALENESS_IS_STALE  # noqa: PLW0603
+    with _STALENESS_LOCK:
+        _PROCESS_START_PKG_MTIME = _path_mtime_ns(pkg_root())
+        _DEEP_CONTENT_BASELINE = _compute_content_hash()
+        _STALENESS_LAST_CHECK = 0.0
+        _STALENESS_IS_STALE = False
 
 
 def _clear_stale_caches() -> None:

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -859,8 +859,8 @@ def test_path_mtime_ns_exists_and_old_helpers_removed() -> None:
     assert isinstance(api._path_mtime_ns(Path(".")), int), "_path_mtime_ns must return int"
 
 
-def test_compute_registry_hash_changes_on_mtime(tmp_path: Path) -> None:
-    """Registry hash changes when a YAML file's mtime changes."""
+def test_compute_registry_hash_content_based(tmp_path: Path) -> None:
+    """Registry hash is stable when content is identical regardless of mtime."""
     import os
 
     from autoskillit.recipe._api import _compute_registry_hash
@@ -876,7 +876,11 @@ def test_compute_registry_hash_changes_on_mtime(tmp_path: Path) -> None:
     os.utime(f, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000))  # +1 second
     h2 = _compute_registry_hash(d)
 
-    assert h1 != h2
+    assert h1 == h2
+
+    f.write_text("name: changed\n")
+    h3 = _compute_registry_hash(d)
+    assert h1 != h3
 
 
 def test_load_and_validate_reuses_content_hash_from_recipe_info(tmp_path, monkeypatch):
@@ -1014,17 +1018,8 @@ def test_load_and_validate_detects_stale_process(tmp_path, monkeypatch):
     monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
     monkeypatch.setattr(cache_mod, "_STALENESS_IS_STALE", False)
     monkeypatch.setattr(cache_mod, "_STALENESS_CACHES_CLEARED", False)
-
-    real_mtime = api_mod._path_mtime_ns
-
-    def fake_mtime(path):
-        from autoskillit.core import pkg_root
-
-        if path == pkg_root():
-            return 2000
-        return real_mtime(path)
-
-    monkeypatch.setattr(cache_mod, "_path_mtime_ns", fake_mtime)
+    monkeypatch.setattr(cache_mod, "_DEEP_CONTENT_BASELINE", "fakehash_baseline")
+    monkeypatch.setattr(cache_mod, "_compute_content_hash", lambda: "fakehash_changed")
 
     recipes_dir = tmp_path / ".autoskillit" / "recipes"
     recipes_dir.mkdir(parents=True)
@@ -1070,17 +1065,8 @@ def test_lru_cache_helpers_cleared_on_process_staleness(tmp_path, monkeypatch):
     monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
     monkeypatch.setattr(cache_mod, "_STALENESS_IS_STALE", False)
     monkeypatch.setattr(cache_mod, "_STALENESS_CACHES_CLEARED", False)
-
-    real_mtime = api_mod._path_mtime_ns
-
-    def fake_mtime(path):
-        from autoskillit.core import pkg_root
-
-        if path == pkg_root():
-            return 2000
-        return real_mtime(path)
-
-    monkeypatch.setattr(cache_mod, "_path_mtime_ns", fake_mtime)
+    monkeypatch.setattr(cache_mod, "_DEEP_CONTENT_BASELINE", "fakehash_baseline")
+    monkeypatch.setattr(cache_mod, "_compute_content_hash", lambda: "fakehash_changed")
 
     recipes_dir = tmp_path / ".autoskillit" / "recipes"
     recipes_dir.mkdir(parents=True)

--- a/tests/recipe/test_deep_staleness.py
+++ b/tests/recipe/test_deep_staleness.py
@@ -1,6 +1,8 @@
-"""Tests for deep staleness detection in recipe/_api.py."""
+"""Tests for deep staleness detection in recipe/_api_cache.py."""
 
 from __future__ import annotations
+
+import os
 
 import pytest
 
@@ -8,7 +10,7 @@ pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def test_deep_staleness_detects_rule_file_changes(tmp_path, monkeypatch):
-    """Rule file changes trigger staleness even when pkg_root() mtime is unchanged."""
+    """Rule file content changes trigger staleness."""
     import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
@@ -17,33 +19,22 @@ def test_deep_staleness_detects_rule_file_changes(tmp_path, monkeypatch):
     monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
     monkeypatch.setattr(cache_mod, "_STALENESS_IS_STALE", False)
     monkeypatch.setattr(cache_mod, "_STALENESS_CACHES_CLEARED", False)
-    monkeypatch.setattr(cache_mod, "_DEEP_MTIME_BASELINE", 5000)
-
-    real_mtime = api_mod._path_mtime_ns
-
-    def fake_mtime(path):
-        from autoskillit.core import pkg_root
-
-        if path == pkg_root():
-            return 1000
-        return real_mtime(path)
-
-    monkeypatch.setattr(cache_mod, "_path_mtime_ns", fake_mtime)
-    monkeypatch.setattr(cache_mod, "_compute_deep_mtime", lambda: 9999)
+    monkeypatch.setattr(cache_mod, "_DEEP_CONTENT_BASELINE", "fakehash_baseline")
+    monkeypatch.setattr(cache_mod, "_compute_content_hash", lambda: "fakehash_changed")
 
     assert api_mod._check_process_staleness() is True
 
 
 def test_deep_staleness_baseline_initialized_eagerly(tmp_path, monkeypatch):
-    """_get_process_start_mtime eagerly sets the deep mtime baseline."""
+    """_get_process_start_mtime eagerly sets the content hash baseline."""
     import autoskillit.recipe._api_cache as cache_mod
 
     monkeypatch.setattr(cache_mod, "_PROCESS_START_PKG_MTIME", None)
-    monkeypatch.setattr(cache_mod, "_DEEP_MTIME_BASELINE", None)
-    monkeypatch.setattr(cache_mod, "_compute_deep_mtime", lambda: 5000)
+    monkeypatch.setattr(cache_mod, "_DEEP_CONTENT_BASELINE", None)
+    monkeypatch.setattr(cache_mod, "_compute_content_hash", lambda: "fakehash_init")
 
     cache_mod._get_process_start_mtime()
-    assert cache_mod._DEEP_MTIME_BASELINE == 5000
+    assert cache_mod._DEEP_CONTENT_BASELINE == "fakehash_init"
 
 
 def test_staleness_check_skipped_for_fleet_sessions(monkeypatch):
@@ -52,9 +43,8 @@ def test_staleness_check_skipped_for_fleet_sessions(monkeypatch):
     import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
-    # Force stale baselines
     monkeypatch.setattr(cache_mod, "_PROCESS_START_PKG_MTIME", 1)
-    monkeypatch.setattr(cache_mod, "_DEEP_MTIME_BASELINE", 1)
+    monkeypatch.setattr(cache_mod, "_DEEP_CONTENT_BASELINE", "fakehash_a")
     monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
     monkeypatch.setattr(cache_mod, "_STALENESS_IS_STALE", False)
 
@@ -68,10 +58,119 @@ def test_fleet_guard_still_initializes_baseline(monkeypatch):
     import autoskillit.recipe._api_cache as cache_mod
 
     monkeypatch.setattr(cache_mod, "_PROCESS_START_PKG_MTIME", None)
-    monkeypatch.setattr(cache_mod, "_DEEP_MTIME_BASELINE", None)
+    monkeypatch.setattr(cache_mod, "_DEEP_CONTENT_BASELINE", None)
     monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
 
     api_mod._check_process_staleness()
 
     assert cache_mod._PROCESS_START_PKG_MTIME is not None
-    assert cache_mod._DEEP_MTIME_BASELINE is not None
+    assert cache_mod._DEEP_CONTENT_BASELINE is not None
+
+
+def test_content_hash_ignores_mtime_only_change(tmp_path, monkeypatch):
+    """mtime change with identical content must NOT trigger staleness."""
+    import autoskillit.recipe._api_cache as cache_mod
+
+    rule_dir = tmp_path / "recipe"
+    rule_dir.mkdir()
+    (rule_dir / "module_a.py").write_text("x = 1\n")
+    (rule_dir / "module_b.py").write_text("y = 2\n")
+
+    monkeypatch.setattr(cache_mod, "_STALENESS_SCAN_DIRS", ("recipe",))
+    monkeypatch.setattr(cache_mod, "pkg_root", lambda: tmp_path)
+    monkeypatch.setattr(cache_mod, "_PROCESS_START_PKG_MTIME", None)
+    monkeypatch.setattr(cache_mod, "_DEEP_CONTENT_BASELINE", None)
+    monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
+    monkeypatch.setattr(cache_mod, "_STALENESS_IS_STALE", False)
+
+    cache_mod._get_process_start_mtime()
+    baseline = cache_mod._DEEP_CONTENT_BASELINE
+
+    for f in rule_dir.glob("*.py"):
+        st = f.stat()
+        os.utime(f, ns=(st.st_atime_ns, st.st_mtime_ns + 2_000_000_000))
+
+    current = cache_mod._compute_content_hash()
+    assert current == baseline
+
+    monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
+    assert cache_mod._check_process_staleness() is False
+
+
+def test_content_hash_detects_real_code_change(tmp_path, monkeypatch):
+    """Byte-level change to a rule file must trigger staleness."""
+    import autoskillit.recipe._api_cache as cache_mod
+
+    rule_dir = tmp_path / "recipe"
+    rule_dir.mkdir()
+    (rule_dir / "module_a.py").write_text("x = 1\n")
+
+    monkeypatch.setattr(cache_mod, "_STALENESS_SCAN_DIRS", ("recipe",))
+    monkeypatch.setattr(cache_mod, "pkg_root", lambda: tmp_path)
+    monkeypatch.setattr(cache_mod, "_PROCESS_START_PKG_MTIME", None)
+    monkeypatch.setattr(cache_mod, "_DEEP_CONTENT_BASELINE", None)
+    monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
+    monkeypatch.setattr(cache_mod, "_STALENESS_IS_STALE", False)
+
+    cache_mod._get_process_start_mtime()
+
+    (rule_dir / "module_a.py").write_text("x = 999\n")
+
+    monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
+    assert cache_mod._check_process_staleness() is True
+
+
+def test_baseline_refresh_after_successful_load(tmp_path, monkeypatch):
+    """After _refresh_staleness_baseline, subsequent checks return non-stale."""
+    import autoskillit.recipe._api_cache as cache_mod
+
+    rule_dir = tmp_path / "recipe"
+    rule_dir.mkdir()
+    (rule_dir / "module_a.py").write_text("x = 1\n")
+
+    monkeypatch.setattr(cache_mod, "_STALENESS_SCAN_DIRS", ("recipe",))
+    monkeypatch.setattr(cache_mod, "pkg_root", lambda: tmp_path)
+    monkeypatch.setattr(cache_mod, "_PROCESS_START_PKG_MTIME", None)
+    monkeypatch.setattr(cache_mod, "_DEEP_CONTENT_BASELINE", None)
+    monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
+    monkeypatch.setattr(cache_mod, "_STALENESS_IS_STALE", False)
+
+    cache_mod._get_process_start_mtime()
+
+    (rule_dir / "module_a.py").write_text("x = 999\n")
+    monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
+    assert cache_mod._check_process_staleness() is True
+
+    cache_mod._refresh_staleness_baseline()
+
+    monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
+    assert cache_mod._check_process_staleness() is False
+
+
+def test_registry_hash_content_based(tmp_path):
+    """Registry hash must be identical for same-content files regardless of mtime."""
+    from autoskillit.recipe._api_cache import _compute_registry_hash
+
+    d = tmp_path / "types"
+    d.mkdir()
+    f = d / "test.yaml"
+    f.write_text("name: test\n")
+    h1 = _compute_registry_hash(d)
+
+    f.write_text("name: test\n")
+    stat = f.stat()
+    os.utime(f, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000))
+    h2 = _compute_registry_hash(d)
+
+    assert h1 == h2
+
+    f.write_text("name: changed\n")
+    h3 = _compute_registry_hash(d)
+    assert h1 != h3
+
+
+def test_staleness_scan_covers_recipe_top_level(monkeypatch):
+    """_STALENESS_SCAN_DIRS must include recipe/ root, not just recipe/rules/."""
+    import autoskillit.recipe._api_cache as cache_mod
+
+    assert "recipe" in cache_mod._STALENESS_SCAN_DIRS


### PR DESCRIPTION
## Summary

`_check_process_staleness()` in `recipe/_api_cache.py` uses filesystem mtime to detect whether Python code changed on disk during a session. This fires `ProcessStaleError` from `git pull` operations that touch file timestamps without changing any file content — a false positive that forces an unnecessary `reload_session` + `/exit` cycle mid-pipeline.

The architectural weakness is that mtime is a proxy for content change, but filesystem operations (git checkout, uv sync, editor saves) update mtimes without altering bytes. The codebase already has a mature content-hash pattern (`hashlib.sha256(path.read_bytes())`) used in `staleness_cache.py`, `identity.py`, and `diagrams.py`. The fix replaces the mtime proxy with the direct signal (content hash) and adds a baseline-refresh mechanism so successful loads don't leave stale baselines that trap future calls.

## Changed Files

- `src/autoskillit/recipe/_api.py`
- `src/autoskillit/recipe/_api_cache.py`
- `tests/recipe/test_api.py`
- `tests/recipe/test_deep_staleness.py`

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260531-182021-181220/.autoskillit/temp/rectify/rectify_process_staleness_false_positive_2026-05-31_182500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 77 | 21.5k | 1.9M | 118.7k | 51 | 110.6k | 19m 31s |
| review_approach* | opus[1m] | 1 | 3.8k | 6.0k | 233.1k | 46.6k | 13 | 33.3k | 4m 10s |
| dry_walkthrough* | opus | 1 | 51 | 24.0k | 1.8M | 92.2k | 49 | 75.5k | 8m 45s |
| implement* | opus[1m] | 1 | 55 | 14.1k | 1.5M | 74.3k | 52 | 58.4k | 5m 20s |
| audit_impl* | opus[1m] | 1 | 33 | 12.9k | 164.2k | 40.8k | 15 | 57.1k | 5m 44s |
| prepare_pr* | opus[1m] | 1 | 129.2k | 3.8k | 184.0k | 50.6k | 20 | 0 | 1m 51s |
| compose_pr* | opus[1m] | 1 | 70.0k | 1.2k | 155.8k | 38.7k | 12 | 0 | 46s |
| review_pr* | opus[1m] | 1 | 34 | 32.8k | 1.0M | 92.4k | 37 | 76.5k | 8m 38s |
| resolve_review* | opus[1m] | 1 | 50 | 6.0k | 668.5k | 54.6k | 26 | 38.6k | 3m 36s |
| **Total** | | | 203.3k | 122.3k | 7.6M | 118.7k | | 450.0k | 58m 26s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 251 | 6015.6 | 232.7 | 56.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **251** | 30389.8 | 1792.7 | 487.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 8 | 203.2k | 98.3k | 5.8M | 374.5k | 49m 40s |
| opus | 1 | 51 | 24.0k | 1.8M | 75.5k | 8m 45s |