### PR TITLE
Migrate _llm_triage.py from agent_backend: str to backend: CodingAgentBackend

### DIFF
--- a/src/autoskillit/_llm_triage.py
+++ b/src/autoskillit/_llm_triage.py
@@ -13,13 +13,14 @@ from typing import Any
 
 from autoskillit.core import (
     ClaudeFlags,
+    CodingAgentBackend,
     OutputFormat,
     SubprocessResult,
     TerminationReason,
     build_agent_env,
     get_logger,
 )
-from autoskillit.execution import get_backend, parse_session_result, run_managed_async
+from autoskillit.execution import parse_session_result, run_managed_async
 from autoskillit.recipe import StaleItem, load_bundled_manifest
 from autoskillit.workspace import bundled_skills_dir
 
@@ -30,7 +31,7 @@ _SKILL_MD_TRUNCATE = 1500
 
 
 async def triage_staleness(
-    stale_items: list[StaleItem], *, agent_backend: str = "claude-code"
+    stale_items: list[StaleItem], *, backend: CodingAgentBackend
 ) -> list[dict[str, Any]]:
     """Use Haiku to determine if stale contracts changed meaningfully.
 
@@ -71,13 +72,13 @@ async def triage_staleness(
             if skill_md_path.is_file():
                 skill_md_cache[item.skill] = skill_md_path.read_text()
 
-    results.extend(await _triage_batch(hash_items, skill_md_cache, agent_backend=agent_backend))
+    results.extend(await _triage_batch(hash_items, skill_md_cache, backend=backend))
 
     return results
 
 
 async def _triage_batch(
-    batch: list[StaleItem], skill_md_cache: dict[str, str], *, agent_backend: str = "claude-code"
+    batch: list[StaleItem], skill_md_cache: dict[str, str], *, backend: CodingAgentBackend
 ) -> list[dict[str, Any]]:
     """Triage one batch of hash_mismatch items with a single Haiku subprocess call.
 
@@ -103,12 +104,12 @@ async def _triage_batch(
     if not triageable:
         return pre_results
 
-    if not get_backend(agent_backend).capabilities.triage_capable:
+    if not backend.capabilities.triage_capable:
         return pre_results + [
             {
                 "skill": i.skill,
                 "meaningful": True,
-                "summary": f"Skipped LLM triage (backend={agent_backend}).",
+                "summary": f"Skipped LLM triage (backend={backend.name}).",
             }
             for i in triageable
         ]
@@ -120,7 +121,7 @@ async def _triage_batch(
         # Build the command manually — triage is a read-only Haiku query with no
         # tool use, so it must NOT receive --dangerously-skip-permissions.
         triage_cmd: list[str] = [
-            get_backend(agent_backend).binary_name(),
+            backend.binary_name(),
             ClaudeFlags.PRINT,
             prompt,
             ClaudeFlags.MODEL,

--- a/src/autoskillit/server/_misc.py
+++ b/src/autoskillit/server/_misc.py
@@ -196,11 +196,8 @@ async def _apply_triage_gate(
 
     from autoskillit._llm_triage import triage_staleness
 
-    agent_backend = _ctx.config.agent_backend.backend
-    _triage_capable = _ctx.backend is not None and _ctx.backend.capabilities.triage_capable
-
-    if _triage_capable:
-        triage_fn = functools.partial(triage_staleness, agent_backend=agent_backend)
+    if _ctx.backend is not None and _ctx.backend.capabilities.triage_capable:
+        triage_fn = functools.partial(triage_staleness, backend=_ctx.backend)
     else:
         triage_fn = None
 

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -201,7 +201,9 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "_type_resume": frozenset({"core", "cli", "execution", "fleet"}),
     "_type_helpers": frozenset({"core", "execution", "fleet", "pipeline", "recipe", "server"}),
     "_type_protocols_workspace": frozenset({"core", "pipeline", "recipe", "workspace"}),
-    "_type_protocols_backend": frozenset({"cli", "core", "execution", "pipeline", "workspace"}),
+    "_type_protocols_backend": frozenset(
+        {"_llm_triage", "cli", "core", "execution", "pipeline", "workspace"}
+    ),
     "_install_detect": frozenset({"core", "cli", "config"}),
     "_linux_proc": frozenset({"core", "execution", "fleet", "cli"}),
     "_type_plugin_source": frozenset({"core", "execution", "pipeline", "server", "cli"}),

--- a/tests/test_backend_gating_root.py
+++ b/tests/test_backend_gating_root.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from autoskillit._llm_triage import _triage_batch, triage_staleness
+from autoskillit.execution.backends import ClaudeCodeBackend, CodexBackend
 from autoskillit.execution.process import SubprocessResult, TerminationReason
 from autoskillit.recipe.contracts import StaleItem
 
@@ -35,7 +36,7 @@ async def test_triage_batch_non_claude_backend_returns_all_meaningful(
     mock_run = AsyncMock()
     monkeypatch.setattr("autoskillit._llm_triage.run_managed_async", mock_run)
 
-    results = await _triage_batch(items, cache, agent_backend="codex")
+    results = await _triage_batch(items, cache, backend=CodexBackend())
 
     assert len(results) == 1
     assert results[0]["meaningful"] is True
@@ -66,7 +67,7 @@ async def test_triage_staleness_non_claude_backend_returns_all_meaningful(
         ),
     ]
 
-    results = await triage_staleness(items, agent_backend="codex")
+    results = await triage_staleness(items, backend=CodexBackend())
 
     assert len(results) == 1
     assert results[0]["meaningful"] is True
@@ -124,7 +125,7 @@ async def test_triage_batch_claude_code_backend_does_call_subprocess(
     mock_run = AsyncMock(return_value=fake_result)
     monkeypatch.setattr("autoskillit._llm_triage.run_managed_async", mock_run)
 
-    results = await _triage_batch(items, cache, agent_backend="claude-code")
+    results = await _triage_batch(items, cache, backend=ClaudeCodeBackend())
 
     mock_run.assert_called_once()
     assert len(results) == 1

--- a/tests/test_llm_triage.py
+++ b/tests/test_llm_triage.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from autoskillit.execution.backends import ClaudeCodeBackend
 from autoskillit.recipe.contracts import StaleItem
 
 # ---------------------------------------------------------------------------
@@ -65,7 +66,7 @@ async def test_triage_staleness_reads_skill_md_once_per_unique_skill(
             current_value="new2",
         ),
     ]
-    await triage_staleness(items, agent_backend="claude-code")
+    await triage_staleness(items, backend=ClaudeCodeBackend())
     assert len(read_calls) == 1, (
         f"SKILL.md read {len(read_calls)} times; expected exactly 1 (cache hit on second item)"
     )
@@ -113,7 +114,7 @@ class TestTriageStaleness:
             stored_value="abc123",
             current_value="def456",
         )
-        result = await triage_staleness([item], agent_backend="claude-code")
+        result = await triage_staleness([item], backend=ClaudeCodeBackend())
 
         assert len(result) == 1
         assert result[0]["meaningful"] is True
@@ -157,7 +158,7 @@ class TestTriageStaleness:
         )
 
         with structlog.testing.capture_logs() as logs:
-            await triage_staleness([item], agent_backend="claude-code")
+            await triage_staleness([item], backend=ClaudeCodeBackend())
 
         assert any(log["log_level"] == "warning" for log in logs), (
             "A warning log must be emitted on timeout"
@@ -205,7 +206,7 @@ class TestTriageStaleness:
         )
 
         with structlog.testing.capture_logs() as logs:
-            result = await triage_staleness([item], agent_backend="claude-code")
+            result = await triage_staleness([item], backend=ClaudeCodeBackend())
 
         assert result[0]["meaningful"] is True
         assert any(log["log_level"] == "warning" for log in logs), (
@@ -270,7 +271,7 @@ class TestTriageStaleness:
             stored_value="abc123",
             current_value="def456",
         )
-        result = await triage_staleness([item], agent_backend="claude-code")
+        result = await triage_staleness([item], backend=ClaudeCodeBackend())
 
         assert result[0]["meaningful"] is False
         assert result[0]["summary"] == "ok"
@@ -295,7 +296,7 @@ class TestTriageStaleness:
             stored_value="abc123",
             current_value="def456",
         )
-        result = await triage_staleness([item], agent_backend="claude-code")
+        result = await triage_staleness([item], backend=ClaudeCodeBackend())
 
         assert len(result) == 1
         assert result[0]["meaningful"] is True
@@ -368,7 +369,7 @@ class TestTriageStaleness:
             stored_value="abc123",
             current_value="def456",
         )
-        result = await triage_staleness([item], agent_backend="claude-code")
+        result = await triage_staleness([item], backend=ClaudeCodeBackend())
 
         assert result[0]["meaningful"] is False, (
             f"triage_staleness must parse NDJSON via parse_session_result, not json.loads. "
@@ -435,7 +436,7 @@ async def test_triage_staleness_batch_fallback_on_malformed_response(
         )
         for i in range(n)
     ]
-    results = await triage_staleness(items, agent_backend="claude-code")
+    results = await triage_staleness(items, backend=ClaudeCodeBackend())
 
     assert len(results) == n
     assert all(r["meaningful"] is True for r in results), (
@@ -484,7 +485,7 @@ async def test_triage_command_includes_format_required_flags(
     item = StaleItem(
         skill="test-skill", reason="hash_mismatch", stored_value="old", current_value="new"
     )
-    await triage_staleness([item], agent_backend="claude-code")
+    await triage_staleness([item], backend=ClaudeCodeBackend())
 
     # Verify the command passed to run_managed_async includes format-required flags
     cmd = mock_run.call_args.kwargs["cmd"]
@@ -538,7 +539,7 @@ async def test_triage_env_excludes_ide_vars(tmp_path: Path, monkeypatch: pytest.
     item = StaleItem(
         skill="test-skill", reason="hash_mismatch", stored_value="old", current_value="new"
     )
-    await triage_staleness([item], agent_backend="claude-code")
+    await triage_staleness([item], backend=ClaudeCodeBackend())
 
     env = mock_run.call_args.kwargs["env"]
     assert env is not None
@@ -556,11 +557,10 @@ async def test_triage_env_excludes_ide_vars(tmp_path: Path, monkeypatch: pytest.
 async def test_triage_command_uses_backend_binary_name(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """The triage command first element must equal get_backend('claude-code').binary_name()."""
+    """The triage command first element must equal ClaudeCodeBackend().binary_name()."""
     from unittest.mock import AsyncMock
 
     from autoskillit._llm_triage import triage_staleness
-    from autoskillit.execution import get_backend
     from autoskillit.execution.process import SubprocessResult, TerminationReason
 
     skill_dir = tmp_path / "test-skill"
@@ -597,10 +597,10 @@ async def test_triage_command_uses_backend_binary_name(
     item = StaleItem(
         skill="test-skill", reason="hash_mismatch", stored_value="old", current_value="new"
     )
-    await triage_staleness([item], agent_backend="claude-code")
+    await triage_staleness([item], backend=ClaudeCodeBackend())
 
     cmd = mock_run.call_args.kwargs["cmd"]
-    expected_binary = get_backend("claude-code").binary_name()
+    expected_binary = ClaudeCodeBackend().binary_name()
     assert cmd[0] == expected_binary, (
         f"triage_cmd[0] must equal get_backend().binary_name(), got {cmd[0]!r}"
     )
@@ -651,7 +651,7 @@ async def test_triage_staleness_does_not_use_pty(
     item = StaleItem(
         skill="test-skill", reason="hash_mismatch", stored_value="old", current_value="new"
     )
-    await triage_staleness([item], agent_backend="claude-code")
+    await triage_staleness([item], backend=ClaudeCodeBackend())
 
     assert mock_run.called
     pty_mode = mock_run.call_args.kwargs.get("pty_mode")

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -174,7 +174,7 @@ class TestModuleCascadeCore:
 
     def test_type_protocols_backend_cascade(self) -> None:
         assert MODULE_CASCADE_CORE["_type_protocols_backend"] == frozenset(
-            {"core", "execution", "pipeline", "cli", "workspace"}
+            {"core", "execution", "pipeline", "cli", "workspace", "_llm_triage"}
         )
 
     def test_json_cascade(self) -> None:


### PR DESCRIPTION
## Summary

Replace the agent_backend: str parameter in triage_staleness() and _triage_batch() with backend: CodingAgentBackend. Remove the get_backend() indirection — callers now pass typed backend instances directly. Update the production caller in server/_misc.py and all test call sites in test_backend_gating_root.py and test_llm_triage.py.

Closes #3493

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260531-195110-920145/.autoskillit/temp/make-plan/backend_migrate_llm_triage_plan_2026-05-31_195510.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 79 | 10.1k | 1.2M | 67.4k | 47 | 50.6k | 8m 51s |
| verify* | opus[1m] | 1 | 48 | 9.5k | 455.4k | 51.8k | 30 | 67.5k | 4m 51s |
| implement* | opus[1m] | 1 | 220.4k | 10.5k | 1.6M | 75.5k | 83 | 0 | 6m 39s |
| audit_impl* | opus[1m] | 1 | 26 | 7.9k | 250.8k | 39.6k | 18 | 32.2k | 2m 56s |
| prepare_pr* | opus[1m] | 1 | 84.2k | 3.2k | 163.1k | 45.5k | 18 | 0 | 1m 32s |
| compose_pr* | opus[1m] | 1 | 69.3k | 1.4k | 157.1k | 39.0k | 13 | 0 | 54s |
| review_pr* | sonnet | 2 | 276 | 57.5k | 1.7M | 77.4k | 95 | 118.3k | 13m 0s |
| resolve_review* | sonnet | 1 | 149 | 8.9k | 831.1k | 59.7k | 48 | 44.1k | 4m 29s |
| diagnose_ci* | opus[1m] | 1 | 82.6k | 2.0k | 224.3k | 51.2k | 13 | 0 | 1m 13s |
| resolve_ci* | opus[1m] | 1 | 43 | 4.3k | 685.8k | 52.7k | 35 | 36.1k | 4m 31s |
| **Total** | | | 457.2k | 115.3k | 7.3M | 77.4k | | 348.8k | 49m 0s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 59 | 27555.0 | 0.0 | 178.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 2 | 342890.5 | 18070.0 | 2145.5 |
| **Total** | **61** | 119553.2 | 5717.7 | 1889.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 8 | 456.7k | 48.8k | 4.8M | 186.5k | 31m 31s |
| sonnet | 2 | 425 | 66.5k | 2.5M | 162.3k | 17m 29s |