### PR TITLE
Rectify: Origin Remote Identity Mismatch in Clone Pipeline

### DIFF
--- a/scripts/recipe/create_artifact_branch.sh
+++ b/scripts/recipe/create_artifact_branch.sh
@@ -7,22 +7,28 @@ EXPERIMENT_BRANCH="$2"
 BASE_BRANCH="$3"
 RESEARCH_DIR="$4"
 
+REMOTE=$(git -C "${WORKTREE_PATH}" remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo "")
+if [ -z "$REMOTE" ]; then
+    REMOTE=$(git -C "${WORKTREE_PATH}" remote get-url origin 2>/dev/null | grep -qv "^file://" && echo origin || echo "")
+fi
+: "${REMOTE:=origin}"
+
 SLUG=$(printf '%s' "${EXPERIMENT_BRANCH}" | sed 's/^research-//')
 ARTIFACT_BRANCH="research-artifacts-${SLUG}"
 
 ARTIFACT_DIR="$(mktemp -d)"
 trap 'git -C "${WORKTREE_PATH}" worktree remove "${ARTIFACT_DIR}" --force 2>/dev/null; rm -rf "${ARTIFACT_DIR}"' EXIT
 
-git -C "${WORKTREE_PATH}" fetch origin "${BASE_BRANCH}"
+git -C "${WORKTREE_PATH}" fetch "$REMOTE" "${BASE_BRANCH}"
 git -C "${WORKTREE_PATH}" branch -D "${ARTIFACT_BRANCH}" 2>/dev/null || true
-git -C "${WORKTREE_PATH}" worktree add "${ARTIFACT_DIR}" -b "${ARTIFACT_BRANCH}" "origin/${BASE_BRANCH}"
+git -C "${WORKTREE_PATH}" worktree add "${ARTIFACT_DIR}" -b "${ARTIFACT_BRANCH}" "${REMOTE}/${BASE_BRANCH}"
 
 RESEARCH_SUBDIR="research/$(basename "${RESEARCH_DIR}")"
 git -C "${ARTIFACT_DIR}" checkout "${EXPERIMENT_BRANCH}" -- "${RESEARCH_SUBDIR}"
 cd "${ARTIFACT_DIR}"
 git add research/
 git commit -m "Add research artifacts: ${SLUG}"
-git push -u origin "${ARTIFACT_BRANCH}"
+git push -u "$REMOTE" "${ARTIFACT_BRANCH}"
 cd - > /dev/null
 
 git -C "${WORKTREE_PATH}" worktree remove "${ARTIFACT_DIR}" --force

--- a/scripts/recipe/push_branch.sh
+++ b/scripts/recipe/push_branch.sh
@@ -10,4 +10,13 @@ if [ "${OUTPUT_MODE}" = "local" ]; then
     exit 0
 fi
 
-cd "${WORKTREE_PATH}" && git push -u origin HEAD
+cd "${WORKTREE_PATH}"
+
+# Prefer upstream (real GitHub URL) over origin (may be file:// in clones).
+REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo "")
+if [ -z "$REMOTE" ]; then
+    REMOTE=$(git remote get-url origin 2>/dev/null | grep -qv "^file://" && echo origin || echo "")
+fi
+: "${REMOTE:=origin}"
+
+git push -u "$REMOTE" HEAD

--- a/src/autoskillit/core/CLAUDE.md
+++ b/src/autoskillit/core/CLAUDE.md
@@ -18,6 +18,7 @@ Sub-packages: types/ (see types/CLAUDE.md) and runtime/ (see runtime/CLAUDE.md).
 | `_version_snapshot.py` | Process-scoped version snapshot for session telemetry (`lru_cache`'d) |
 | `branch_guard.py` | Branch protection helpers |
 | `claude_conventions.py` | Skill discovery directory layout constants |
+| `git_remote.py` | `resolve_clone_remote_name_sync`, `REMOTE_PRECEDENCE` — IL-0 canonical remote precedence |
 | `github_url.py` | `parse_github_repo` |
 | `_plugin_cache.py` | Plugin cache lifecycle: retiring cache, install locking, kitchen registry |
 | `_plugin_ids.py` | `DIRECT_PREFIX`, `MARKETPLACE_PREFIX`, `detect_autoskillit_mcp_prefix` (stdlib-only) |

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -43,6 +43,8 @@ from .claude_conventions import (
 from .claude_conventions import validate_worktree_path as validate_worktree_path
 from .feature_flags import _collect_disabled_feature_tags as _collect_disabled_feature_tags
 from .feature_flags import is_feature_enabled as is_feature_enabled
+from .git_remote import REMOTE_PRECEDENCE as REMOTE_PRECEDENCE
+from .git_remote import resolve_clone_remote_name_sync as resolve_clone_remote_name_sync
 from .github_url import _parse_issue_ref as _parse_issue_ref
 from .github_url import normalize_owner_repo as normalize_owner_repo
 from .github_url import parse_github_repo as parse_github_repo

--- a/src/autoskillit/core/git_remote.py
+++ b/src/autoskillit/core/git_remote.py
@@ -1,0 +1,40 @@
+"""IL-0 canonical remote precedence for clone-isolated repositories.
+
+Provides a synchronous resolver usable from any import layer (including
+hooks that cannot use asyncio) and the single-source-of-truth constant
+for remote probe ordering.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REMOTE_PRECEDENCE: tuple[str, ...] = ("upstream", "origin")
+
+
+def resolve_clone_remote_name_sync(cwd: str | Path) -> str:
+    """Return the git remote name to use for fetch/push operations (sync).
+
+    Tries remotes in precedence order (upstream before origin).
+    Rejects file:// URLs — those indicate a clone-isolation origin.
+    Falls back to "origin" if no remote qualifies.
+    """
+    for name in REMOTE_PRECEDENCE:
+        try:
+            result = subprocess.run(
+                ["git", "remote", "get-url", name],
+                cwd=str(cwd),
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if result.returncode != 0:
+                continue
+            url = result.stdout.strip()
+            if url.startswith("file://"):
+                continue
+            return name
+        except (subprocess.TimeoutExpired, OSError):
+            continue
+    return "origin"

--- a/src/autoskillit/execution/CLAUDE.md
+++ b/src/autoskillit/execution/CLAUDE.md
@@ -22,7 +22,7 @@ backends/ (see backends/CLAUDE.md).
 | `quota.py` | `QuotaStatus`, cache, `check_and_sleep_if_needed` |
 | `ci.py` | GitHub Actions CI watcher (httpx, never raises) |
 | `github.py` | GitHub issue fetcher |
-| `remote_resolver.py` | Upstream > origin, clone-aware remote resolution |
+| `remote_resolver.py` | Upstream > origin, clone-aware remote resolution (`REMOTE_PRECEDENCE` imported from `core/git_remote.py`) |
 | `testing.py` | Pytest output parsing, pass/fail adjudication, output condensation |
 | `clone_guard.py` | Clone contamination guard — detect and revert direct changes to clone CWD |
 | `pr_analysis.py` | `extract_linked_issues`, `DOMAIN_PATHS`, `partition_files_by_domain` |

--- a/src/autoskillit/execution/headless/_headless_git.py
+++ b/src/autoskillit/execution/headless/_headless_git.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import subprocess
 
-from autoskillit.core import get_logger
+from autoskillit.core import get_logger, resolve_clone_remote_name_sync
 
 logger = get_logger(__name__)
 
@@ -90,7 +90,8 @@ def _detect_branch_divergence(cwd: str) -> bool:
     remaining refs are only tried when merge-base or rev-list fails.
     Returns False on any error or non-git directory.
     """
-    for ref in ("origin/HEAD", "origin/main", "origin/master"):
+    remote = resolve_clone_remote_name_sync(cwd)
+    for ref in (f"{remote}/HEAD", f"{remote}/main", f"{remote}/master"):
         try:
             mb = subprocess.run(
                 ["git", "merge-base", "HEAD", ref],

--- a/src/autoskillit/execution/remote_resolver.py
+++ b/src/autoskillit/execution/remote_resolver.py
@@ -8,13 +8,14 @@ from __future__ import annotations
 
 import asyncio
 
-from autoskillit.core import get_logger, normalize_owner_repo, parse_github_repo
+from autoskillit.core import (
+    REMOTE_PRECEDENCE,
+    get_logger,
+    normalize_owner_repo,
+    parse_github_repo,
+)
 
 logger = get_logger(__name__)
-
-# Canonical remote precedence order: upstream before origin encodes the clone
-# isolation contract (upstream = real GitHub URL; origin = file:// local path).
-REMOTE_PRECEDENCE: tuple[str, ...] = ("upstream", "origin")
 
 
 async def resolve_remote_repo(

--- a/src/autoskillit/hooks/guards/remove_clone_guard.py
+++ b/src/autoskillit/hooks/guards/remove_clone_guard.py
@@ -21,6 +21,26 @@ import sys
 REMOVE_CLONE_DENY_TRIGGER: str = "Clone at"
 
 
+def _resolve_push_remote(clone_path: str) -> str:
+    """Return the git remote name for real (non-file://) push operations."""
+    for name in ("upstream", "origin"):
+        try:
+            result = subprocess.run(
+                ["git", "-C", clone_path, "remote", "get-url", name],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if result.returncode != 0:
+                continue
+            if result.stdout.strip().startswith("file://"):
+                continue
+            return name
+        except (subprocess.TimeoutExpired, OSError):
+            continue
+    return "origin"
+
+
 def _git(clone_path: str, *args: str, timeout: int = 10) -> tuple[int, str]:
     """Run a git command in clone_path. Returns (returncode, stdout.strip())."""
     try:
@@ -63,8 +83,14 @@ def _check_sync(clone_path: str) -> tuple[bool, str]:
     rc, count_str = _git(clone_path, "rev-list", "--count", "@{upstream}..HEAD")
     if rc != 0:
         # No tracking branch — try ls-remote fallback to check if branch exists on remote
+        resolved_remote = _resolve_push_remote(clone_path)
         ls_rc, ls_out = _git(
-            clone_path, "ls-remote", "--exit-code", "origin", f"refs/heads/{branch}", timeout=15
+            clone_path,
+            "ls-remote",
+            "--exit-code",
+            resolved_remote,
+            f"refs/heads/{branch}",
+            timeout=15,
         )
         if ls_rc == 0:
             # Branch is on remote — compare SHA to verify fully pushed
@@ -79,7 +105,7 @@ def _check_sync(clone_path: str) -> tuple[bool, str]:
         return False, (
             f"Clone at {clone_path!r} (branch: {branch!r}) has no remote "
             "tracking branch. Push the branch first before removing the clone:\n"
-            f"  git -C {clone_path} push -u origin {branch}"
+            f"  git -C {clone_path} push -u {resolved_remote} {branch}"
         )
 
     try:

--- a/src/autoskillit/recipe/_cmd_rpc_merge.py
+++ b/src/autoskillit/recipe/_cmd_rpc_merge.py
@@ -136,11 +136,11 @@ def create_persistent_integration(
 ) -> dict[str, str]:
     """Create and push persistent integration branch from default branch."""
     remote = _detect_remote(work_dir)
-    result = run_git(["symbolic-ref", "refs/remotes/origin/HEAD"], cwd=work_dir)
+    result = run_git(["symbolic-ref", f"refs/remotes/{remote}/HEAD"], cwd=work_dir)
     default_branch = "main"
     if result.returncode == 0:
         ref = result.stdout.strip()
-        default_branch = ref.replace("refs/remotes/origin/", "")
+        default_branch = ref.replace(f"refs/remotes/{remote}/", "")
     run_git(["checkout", default_branch], cwd=work_dir, check=True)
     run_git(["pull"], cwd=work_dir, check=True)
     run_git(["checkout", "-b", base_branch], cwd=work_dir, check=True)

--- a/src/autoskillit/recipe/_cmd_rpc_merge.py
+++ b/src/autoskillit/recipe/_cmd_rpc_merge.py
@@ -140,7 +140,7 @@ def create_persistent_integration(
     default_branch = "main"
     if result.returncode == 0:
         ref = result.stdout.strip()
-        default_branch = ref.replace(f"refs/remotes/{remote}/", "")
+        default_branch = ref.removeprefix(f"refs/remotes/{remote}/")
     run_git(["checkout", default_branch], cwd=work_dir, check=True)
     run_git(["pull"], cwd=work_dir, check=True)
     run_git(["checkout", "-b", base_branch], cwd=work_dir, check=True)

--- a/src/autoskillit/recipes/scripts/create_artifact_branch.sh
+++ b/src/autoskillit/recipes/scripts/create_artifact_branch.sh
@@ -7,22 +7,29 @@ EXPERIMENT_BRANCH="$2"
 BASE_BRANCH="$3"
 RESEARCH_DIR="$4"
 
+# Prefer upstream (real GitHub URL) over origin (may be file:// in clones).
+REMOTE=$(git -C "${WORKTREE_PATH}" remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo "")
+if [ -z "$REMOTE" ]; then
+    REMOTE=$(git -C "${WORKTREE_PATH}" remote get-url origin 2>/dev/null | grep -qv "^file://" && echo origin || echo "")
+fi
+: "${REMOTE:=origin}"
+
 SLUG=$(printf '%s' "${EXPERIMENT_BRANCH}" | sed 's/^research-//')
 ARTIFACT_BRANCH="research-artifacts-${SLUG}"
 
 ARTIFACT_DIR="$(mktemp -d)"
 trap 'git -C "${WORKTREE_PATH}" worktree remove "${ARTIFACT_DIR}" --force 2>/dev/null; rm -rf "${ARTIFACT_DIR}"' EXIT
 
-git -C "${WORKTREE_PATH}" fetch origin "${BASE_BRANCH}"
+git -C "${WORKTREE_PATH}" fetch "$REMOTE" "${BASE_BRANCH}"
 git -C "${WORKTREE_PATH}" branch -D "${ARTIFACT_BRANCH}" 2>/dev/null || true
-git -C "${WORKTREE_PATH}" worktree add "${ARTIFACT_DIR}" -b "${ARTIFACT_BRANCH}" "origin/${BASE_BRANCH}"
+git -C "${WORKTREE_PATH}" worktree add "${ARTIFACT_DIR}" -b "${ARTIFACT_BRANCH}" "${REMOTE}/${BASE_BRANCH}"
 
 RESEARCH_SUBDIR="research/$(basename "${RESEARCH_DIR}")"
 git -C "${ARTIFACT_DIR}" checkout "${EXPERIMENT_BRANCH}" -- "${RESEARCH_SUBDIR}"
 cd "${ARTIFACT_DIR}"
 git add research/
 git commit -m "Add research artifacts: ${SLUG}"
-git push -u origin "${ARTIFACT_BRANCH}"
+git push -u "$REMOTE" "${ARTIFACT_BRANCH}"
 cd - > /dev/null
 
 git -C "${WORKTREE_PATH}" worktree remove "${ARTIFACT_DIR}" --force

--- a/src/autoskillit/recipes/scripts/create_impl_worktree.sh
+++ b/src/autoskillit/recipes/scripts/create_impl_worktree.sh
@@ -58,9 +58,10 @@ os.replace(tmp, str(sidecar_file))
 " >/dev/null 2>&1
 
 # Detect remote and set upstream tracking (non-fatal).
-REMOTE=$(git remote get-url origin >/dev/null 2>&1 && echo origin || echo "")
+# Prefer upstream (real GitHub URL) over origin (may be file:// in clones).
+REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo "")
 if [ -z "$REMOTE" ]; then
-    REMOTE=$(git remote get-url upstream >/dev/null 2>&1 && echo upstream || echo "")
+    REMOTE=$(git remote get-url origin 2>/dev/null | grep -qv "^file://" && echo origin || echo "")
 fi
 
 if [ -n "$REMOTE" ]; then

--- a/src/autoskillit/recipes/scripts/push_branch.sh
+++ b/src/autoskillit/recipes/scripts/push_branch.sh
@@ -10,4 +10,13 @@ if [ "${OUTPUT_MODE}" = "local" ]; then
     exit 0
 fi
 
-cd "${WORKTREE_PATH}" && git push -u origin HEAD
+cd "${WORKTREE_PATH}"
+
+# Prefer upstream (real GitHub URL) over origin (may be file:// in clones).
+REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo "")
+if [ -z "$REMOTE" ]; then
+    REMOTE=$(git remote get-url origin 2>/dev/null | grep -qv "^file://" && echo origin || echo "")
+fi
+: "${REMOTE:=origin}"
+
+git push -u "$REMOTE" HEAD

--- a/src/autoskillit/server/tools/tools_git.py
+++ b/src/autoskillit/server/tools/tools_git.py
@@ -562,8 +562,11 @@ async def create_and_publish_branch(
             base_name = _compute_branch_name(issue_slug, run_name, issue_number)
             compute_ms = int((time.monotonic() - _compute_start) * 1000)
 
+            from autoskillit.server._misc import resolve_remote_name
+
             _branch_start = time.monotonic()
-            branch_result = await _resolve_and_create_branch(base_name, "origin", work_dir)
+            resolved_remote = await resolve_remote_name(work_dir)
+            branch_result = await _resolve_and_create_branch(base_name, resolved_remote, work_dir)
             branch_create_ms = int((time.monotonic() - _branch_start) * 1000)
 
             if "error" in branch_result:

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -177,6 +177,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "_plugin_ids": frozenset({"core", "cli", "hook_registry", "server"}),
     "_terminal_table": frozenset({"core", "cli", "pipeline", "recipe"}),
     "_plugin_cache": frozenset({"core", "cli", "server"}),
+    "git_remote": frozenset({"core", "execution"}),
     "github_url": frozenset({"core", "cli", "execution", "fleet", "server"}),
     "paths": frozenset(
         {

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -90,6 +90,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_cmd_spec_resume_no_string_match.py` | AST guard: no `"--resume" in <expr>` patterns in production code — use CmdSpec.is_resume instead |
 | `test_subagent_filter_guard.py` | AST guard: all assistant-record NDJSON processing sites must use _is_parent_assistant_record or _is_parent_assistant predicate |
 | `test_enqueue_ready_type_enforcement.py` | AST guard: mutation methods (_enqueue_direct, _enable_auto_merge_direct) must accept EnqueueReady, not str |
+| `test_origin_isolation_contract.py` | AST + shell lint guard: no hardcoded "origin" in git remote operations outside allowlist; shell scripts must try upstream before origin |
 
 ## Architecture Notes
 

--- a/tests/arch/test_origin_isolation_contract.py
+++ b/tests/arch/test_origin_isolation_contract.py
@@ -1,0 +1,182 @@
+"""Architectural test: no hardcoded "origin" in git remote operations.
+
+Enforces the clone isolation contract: code that performs git remote operations
+(ls-remote, push, fetch, remote get-url) must not hardcode "origin" as the
+remote name, since _ensure_origin_isolated rewrites it to a file:// URL.
+
+Two guards:
+  1. AST scan of Python files for string literals "origin" passed to git commands.
+  2. Shell script lint for origin-before-upstream precedence in remote detection.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+SRC_ROOT = Path(__file__).parent.parent.parent / "src" / "autoskillit"
+
+GIT_REMOTE_COMMANDS = {"ls-remote", "push", "fetch", "remote"}
+
+PYTHON_SCAN_DIRS = (
+    SRC_ROOT / "server",
+    SRC_ROOT / "hooks",
+    SRC_ROOT / "execution" / "headless",
+    SRC_ROOT / "recipe",
+)
+
+PYTHON_ALLOWLIST: set[tuple[str, str]] = {
+    ("_clone_remote.py", "_ensure_origin_isolated"),
+    ("_clone_remote.py", "_probe_single_remote"),
+    ("_clone_remote.py", "_probe_clone_source_url"),
+    ("_clone_remote.py", "_add_or_set_upstream"),
+}
+
+SHELL_SCAN_DIR = SRC_ROOT / "recipes" / "scripts"
+
+
+def _find_enclosing_function(node: ast.AST, tree: ast.Module) -> str:
+    """Walk parents to find the enclosing function name."""
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            if child is node and isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                return parent.name
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for desc in ast.walk(child):
+                    if desc is node:
+                        return child.name
+    return "<module>"
+
+
+def _is_git_remote_context(node: ast.AST, tree: ast.Module) -> bool:
+    """Check if a string "origin" appears in a context that looks like a git command."""
+    parent_list = None
+    for candidate in ast.walk(tree):
+        if isinstance(candidate, ast.List):
+            for elt in candidate.elts:
+                if elt is node:
+                    parent_list = candidate
+                    break
+    if parent_list is None:
+        return False
+
+    for elt in parent_list.elts:
+        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+            if elt.value in GIT_REMOTE_COMMANDS or elt.value.startswith("refs/remotes/origin"):
+                return True
+    return False
+
+
+class TestNoHardcodedOriginInPython:
+    """AST scan: Python files must not pass 'origin' as a remote to git commands."""
+
+    def test_no_origin_in_git_commands(self) -> None:
+        violations: list[str] = []
+
+        for scan_dir in PYTHON_SCAN_DIRS:
+            if not scan_dir.exists():
+                continue
+            for py_file in sorted(scan_dir.rglob("*.py")):
+                try:
+                    tree = ast.parse(py_file.read_text(), filename=str(py_file))
+                except SyntaxError:
+                    continue
+
+                for node in ast.walk(tree):
+                    if not isinstance(node, ast.Constant):
+                        continue
+                    if not isinstance(node.value, str):
+                        continue
+                    if node.value != "origin":
+                        continue
+
+                    if not _is_git_remote_context(node, tree):
+                        continue
+
+                    fn_name = _find_enclosing_function(node, tree)
+                    if (py_file.name, fn_name) in PYTHON_ALLOWLIST:
+                        continue
+
+                    rel = py_file.relative_to(SRC_ROOT)
+                    violations.append(f"  {rel}:{node.lineno} in {fn_name}()")
+
+        assert not violations, (
+            "Hardcoded 'origin' in git remote operations violates the clone isolation contract.\n"
+            "Use resolve_remote_name (async) or resolve_clone_remote_name_sync (sync) instead.\n"
+            + "\n".join(violations)
+        )
+
+    def test_no_refs_remotes_origin_hardcoded(self) -> None:
+        """Catch refs/remotes/origin/ string literals that bypass the resolved remote."""
+        violations: list[str] = []
+        pattern = re.compile(r"refs/remotes/origin")
+
+        for scan_dir in PYTHON_SCAN_DIRS:
+            if not scan_dir.exists():
+                continue
+            for py_file in sorted(scan_dir.rglob("*.py")):
+                try:
+                    tree = ast.parse(py_file.read_text(), filename=str(py_file))
+                except SyntaxError:
+                    continue
+
+                for node in ast.walk(tree):
+                    if not isinstance(node, ast.Constant):
+                        continue
+                    if not isinstance(node.value, str):
+                        continue
+                    if not pattern.search(node.value):
+                        continue
+
+                    fn_name = _find_enclosing_function(node, tree)
+                    if (py_file.name, fn_name) in PYTHON_ALLOWLIST:
+                        continue
+
+                    rel = py_file.relative_to(SRC_ROOT)
+                    violations.append(f"  {rel}:{node.lineno} in {fn_name}()")
+
+        assert not violations, (
+            "Hardcoded 'refs/remotes/origin' bypasses the remote resolver.\n"
+            "Use f'refs/remotes/{remote}/...' with the resolved remote name.\n"
+            + "\n".join(violations)
+        )
+
+
+class TestShellScriptRemotePrecedence:
+    """Shell scripts must try upstream before origin in remote detection."""
+
+    @pytest.mark.parametrize(
+        "script",
+        sorted(SHELL_SCAN_DIR.glob("*.sh")) if SHELL_SCAN_DIR.exists() else [],
+        ids=lambda p: p.name,
+    )
+    def test_no_origin_before_upstream(self, script: Path) -> None:
+        content = script.read_text()
+
+        origin_match = re.search(r"git\s+remote\s+get-url\s+origin", content)
+        upstream_match = re.search(r"git\s+remote\s+get-url\s+upstream", content)
+
+        if origin_match and upstream_match:
+            assert upstream_match.start() < origin_match.start(), (
+                f"{script.name}: tries 'origin' before 'upstream' in remote detection. "
+                "The clone isolation contract requires upstream-first precedence."
+            )
+
+    @pytest.mark.parametrize(
+        "script",
+        sorted(SHELL_SCAN_DIR.glob("*.sh")) if SHELL_SCAN_DIR.exists() else [],
+        ids=lambda p: p.name,
+    )
+    def test_no_bare_push_origin(self, script: Path) -> None:
+        content = script.read_text()
+
+        bare_push = re.search(r"git\s+push\s+(-u\s+)?origin\b", content)
+
+        assert bare_push is None, (
+            f"{script.name}:{content[: bare_push.start()].count(chr(10)) + 1}: "
+            f"hardcoded 'git push origin' bypasses clone isolation. "
+            "Use a resolved $REMOTE variable instead."
+        )

--- a/tests/arch/test_origin_isolation_contract.py
+++ b/tests/arch/test_origin_isolation_contract.py
@@ -35,20 +35,22 @@ PYTHON_ALLOWLIST: set[tuple[str, str]] = {
     ("_clone_remote.py", "_add_or_set_upstream"),
 }
 
-SHELL_SCAN_DIR = SRC_ROOT / "recipes" / "scripts"
+SHELL_SCAN_DIRS = (
+    SRC_ROOT / "recipes" / "scripts",
+    Path(__file__).parent.parent.parent / "scripts" / "recipe",
+)
 
 
 def _find_enclosing_function(node: ast.AST, tree: ast.Module) -> str:
-    """Walk parents to find the enclosing function name."""
-    for parent in ast.walk(tree):
-        for child in ast.iter_child_nodes(parent):
-            if child is node and isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                return parent.name
-            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                for desc in ast.walk(child):
-                    if desc is node:
-                        return child.name
-    return "<module>"
+    """Return the innermost enclosing function name for *node*."""
+    result = "<module>"
+    for item in ast.walk(tree):
+        if not isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for desc in ast.walk(item):
+            if desc is node:
+                result = item.name
+    return result
 
 
 def _is_git_remote_context(node: ast.AST, tree: ast.Module) -> bool:
@@ -150,7 +152,7 @@ class TestShellScriptRemotePrecedence:
 
     @pytest.mark.parametrize(
         "script",
-        sorted(SHELL_SCAN_DIR.glob("*.sh")) if SHELL_SCAN_DIR.exists() else [],
+        sorted(s for d in SHELL_SCAN_DIRS if d.exists() for s in d.glob("*.sh")),
         ids=lambda p: p.name,
     )
     def test_no_origin_before_upstream(self, script: Path) -> None:
@@ -167,7 +169,7 @@ class TestShellScriptRemotePrecedence:
 
     @pytest.mark.parametrize(
         "script",
-        sorted(SHELL_SCAN_DIR.glob("*.sh")) if SHELL_SCAN_DIR.exists() else [],
+        sorted(s for d in SHELL_SCAN_DIRS if d.exists() for s in d.glob("*.sh")),
         ids=lambda p: p.name,
     )
     def test_no_bare_push_origin(self, script: Path) -> None:

--- a/tests/hooks/CLAUDE.md
+++ b/tests/hooks/CLAUDE.md
@@ -34,6 +34,7 @@ Hook script behavior, registration, and bridge tests.
 | `test_pr_create_guard.py` | Tests for pr_create_guard.py interpreter bypass detection |
 | `test_planner_gh_discovery_guard.py` | Tests for planner_gh_discovery_guard.py interpreter bypass detection |
 | `test_ingredient_lock_guard.py` | Tests for ingredient_lock_guard.py PreToolUse hook: deny/allow, fail-open, pipeline scoping |
+| `test_remove_clone_guard_isolation.py` | Integration tests for remove_clone_guard _check_sync with clone-isolated origin topology |
 | `test_pipeline_step_post_hook.py` | Tests for pipeline_step_post_hook.py PostToolUse hook — step completion marking, progress banner, fail-open paths |
 | `test_pipeline_step_guard.py` | Tests for pipeline_step_guard.py PreToolUse advisory guard — dep-unmet warning, fail-open paths |
 

--- a/tests/hooks/test_remove_clone_guard_isolation.py
+++ b/tests/hooks/test_remove_clone_guard_isolation.py
@@ -13,7 +13,7 @@ import pytest
 
 from autoskillit.hooks.guards.remove_clone_guard import _check_sync
 
-pytestmark = [pytest.mark.layer("infra"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("infra"), pytest.mark.medium]
 
 
 def _git(cwd: Path, *args: str) -> str:

--- a/tests/hooks/test_remove_clone_guard_isolation.py
+++ b/tests/hooks/test_remove_clone_guard_isolation.py
@@ -1,0 +1,139 @@
+"""Integration test: remove_clone_guard with clone-isolated origin topology.
+
+Verifies that _check_sync queries the real remote (upstream) instead of the
+file:// origin URL when no tracking branch is configured.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from autoskillit.hooks.guards.remove_clone_guard import _check_sync
+
+pytestmark = [pytest.mark.layer("infra"), pytest.mark.small]
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _setup_isolated_clone_with_branch(tmp_path: Path) -> tuple[Path, Path, str]:
+    """Create a bare remote + clone with origin-isolated topology and a local-only branch.
+
+    Returns (bare_remote, clone_path, branch_name).
+    """
+    bare = tmp_path / "remote.git"
+    bare.mkdir()
+    subprocess.run(["git", "init", "--bare", str(bare)], check=True, capture_output=True)
+
+    source = tmp_path / "source"
+    source.mkdir()
+    subprocess.run(["git", "init", str(source)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(source), "config", "user.email", "test@test.com"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(source), "config", "user.name", "Test"],
+        check=True,
+        capture_output=True,
+    )
+    (source / "file.txt").write_text("content")
+    _git(source, "add", ".")
+    _git(source, "commit", "-m", "init")
+    _git(source, "remote", "add", "origin", str(bare))
+    _git(source, "push", "-u", "origin", "HEAD")
+
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "clone", str(bare), str(clone)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(clone), "config", "user.email", "test@test.com"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(clone), "config", "user.name", "Test"],
+        check=True,
+        capture_output=True,
+    )
+
+    _git(clone, "remote", "set-url", "origin", f"file://{clone}")
+    _git(clone, "remote", "add", "upstream", str(bare))
+
+    branch = "feat/local-only"
+    _git(clone, "checkout", "-b", branch)
+    (clone / "new.txt").write_text("local work")
+    _git(clone, "add", ".")
+    _git(clone, "commit", "-m", "local work")
+
+    return bare, clone, branch
+
+
+class TestCheckSyncIsolation:
+    """_check_sync must resolve the real remote when no tracking branch exists."""
+
+    def test_unpushed_branch_detected_via_upstream(self, tmp_path: Path) -> None:
+        _bare, clone, _branch = _setup_isolated_clone_with_branch(tmp_path)
+
+        approved, reason = _check_sync(str(clone))
+
+        assert not approved, "Branch not pushed to upstream should be denied"
+        assert "upstream" in reason, f"Deny message should reference 'upstream', got: {reason}"
+        assert "origin" not in reason.split("push -u")[1] if "push -u" in reason else True, (
+            f"Deny push command should not hardcode 'origin': {reason}"
+        )
+
+    def test_pushed_branch_approved_via_upstream(self, tmp_path: Path) -> None:
+        _bare, clone, branch = _setup_isolated_clone_with_branch(tmp_path)
+
+        _git(clone, "push", "upstream", branch)
+
+        approved, _reason = _check_sync(str(clone))
+
+        assert approved, "Branch pushed to upstream should be approved"
+
+    def test_falls_back_to_origin_without_upstream(self, tmp_path: Path) -> None:
+        """When no upstream remote exists, origin is used."""
+        bare = tmp_path / "remote.git"
+        bare.mkdir()
+        subprocess.run(["git", "init", "--bare", str(bare)], check=True, capture_output=True)
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        (repo / "f.txt").write_text("x")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "init")
+        _git(repo, "remote", "add", "origin", str(bare))
+        _git(repo, "push", "-u", "origin", "HEAD")
+
+        _git(repo, "checkout", "-b", "feat/test")
+        (repo / "g.txt").write_text("y")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "work")
+        _git(repo, "push", "origin", "feat/test")
+
+        approved, _reason = _check_sync(str(repo))
+
+        assert approved, "Branch pushed to origin (no upstream) should be approved"

--- a/tests/infra/test_remove_clone_guard.py
+++ b/tests/infra/test_remove_clone_guard.py
@@ -119,7 +119,9 @@ def test_deny_when_no_tracking_branch():
             (0, ".git"),  # rev-parse --git-dir
             (0, "feat/thing"),  # rev-parse --abbrev-ref HEAD
             (128, ""),  # rev-list --count (no upstream)
-            (2, ""),  # ls-remote --exit-code origin (no matching ref)
+            (128, ""),  # _resolve_push_remote: get-url upstream (not found)
+            (0, "https://github.com/example/repo.git"),  # _resolve_push_remote: get-url origin
+            (2, ""),  # ls-remote --exit-code resolved_remote (no matching ref)
         ],
     )
     data = json.loads(out)
@@ -192,7 +194,9 @@ def test_approve_when_no_upstream_but_sha_matches_remote():
             (0, ".git"),  # rev-parse --git-dir
             (0, "feat/thing"),  # rev-parse --abbrev-ref HEAD
             (128, ""),  # rev-list --count @{upstream}..HEAD → no upstream
-            (0, f"{sha}\trefs/heads/feat/thing\n"),  # ls-remote --exit-code origin
+            (128, ""),  # _resolve_push_remote: get-url upstream (not found)
+            (0, "https://github.com/example/repo.git"),  # _resolve_push_remote: get-url origin
+            (0, f"{sha}\trefs/heads/feat/thing\n"),  # ls-remote --exit-code resolved_remote
             (0, sha),  # rev-parse HEAD → matches remote
         ],
     )
@@ -208,7 +212,9 @@ def test_deny_when_no_upstream_and_not_on_remote():
             (0, ".git"),  # rev-parse --git-dir
             (0, "feat/thing"),  # rev-parse --abbrev-ref HEAD
             (128, ""),  # rev-list --count → no upstream
-            (2, ""),  # ls-remote --exit-code origin (rc=2: no matching ref)
+            (128, ""),  # _resolve_push_remote: get-url upstream (not found)
+            (0, "https://github.com/example/repo.git"),  # _resolve_push_remote: get-url origin
+            (2, ""),  # ls-remote --exit-code resolved_remote (rc=2: no matching ref)
         ],
     )
     data = json.loads(out)

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -124,6 +124,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_track_response_size.py` | Tests for the track_response_size decorator in autoskillit.server._notify |
 | `test_wire_compat.py` | Wire compatibility tests |
 
+| `test_tools_git_branch_isolation.py` | Integration tests for create_and_publish_branch with clone-isolated origin topology |
 | `test_tools_observability_scope.py` | Tests for bound_contextvars exception scope completeness: exception-path coverage, AST structural guard, any() assertion ban |
 ## Architecture Notes
 

--- a/tests/server/test_tools_git_branch_isolation.py
+++ b/tests/server/test_tools_git_branch_isolation.py
@@ -15,7 +15,7 @@ import pytest
 from autoskillit.server.tools.tools_git import create_and_publish_branch
 from tests.conftest import _make_result
 
-pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.medium]
 
 
 def _git(cwd: Path, *args: str) -> str:

--- a/tests/server/test_tools_git_branch_isolation.py
+++ b/tests/server/test_tools_git_branch_isolation.py
@@ -1,0 +1,163 @@
+"""Integration test: create_and_publish_branch with clone-isolated origin topology.
+
+Verifies that the MCP tool resolves the correct remote (upstream) when origin
+has been rewritten to a file:// URL by _ensure_origin_isolated.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from autoskillit.server.tools.tools_git import create_and_publish_branch
+from tests.conftest import _make_result
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _setup_isolated_clone(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a bare remote and a clone with the origin-isolated topology.
+
+    Returns (bare_remote, clone_path).
+    """
+    bare = tmp_path / "remote.git"
+    bare.mkdir()
+    subprocess.run(["git", "init", "--bare", str(bare)], check=True, capture_output=True)
+
+    source = tmp_path / "source"
+    source.mkdir()
+    subprocess.run(["git", "init", str(source)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(source), "config", "user.email", "test@test.com"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(source), "config", "user.name", "Test"],
+        check=True,
+        capture_output=True,
+    )
+    (source / "file.txt").write_text("content")
+    _git(source, "add", ".")
+    _git(source, "commit", "-m", "init")
+    _git(source, "remote", "add", "origin", str(bare))
+    _git(source, "push", "-u", "origin", "HEAD")
+
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "clone", str(bare), str(clone)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(clone), "config", "user.email", "test@test.com"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(clone), "config", "user.name", "Test"],
+        check=True,
+        capture_output=True,
+    )
+
+    _git(clone, "remote", "set-url", "origin", f"file://{clone}")
+    _git(clone, "remote", "add", "upstream", str(bare))
+
+    return bare, clone
+
+
+class TestCreateAndPublishBranchIsolation:
+    """create_and_publish_branch must resolve the real remote, not file:// origin."""
+
+    @pytest.mark.anyio
+    async def test_detects_collision_via_upstream(
+        self, tool_ctx_kitchen_open, tmp_path: Path
+    ) -> None:
+        bare, clone = _setup_isolated_clone(tmp_path)
+
+        _git(clone, "checkout", "-b", "impl/42")
+        (clone / "change.txt").write_text("work")
+        _git(clone, "add", ".")
+        _git(clone, "commit", "-m", "work")
+        _git(clone, "push", "upstream", "impl/42")
+        _git(clone, "checkout", "main")
+
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "abc123\trefs/heads/impl/42\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "main\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+
+        result_str = await create_and_publish_branch(
+            issue_slug="42",
+            run_name="impl",
+            issue_number="42",
+            work_dir=str(clone),
+            remote_url=str(bare),
+        )
+        json.loads(result_str)
+
+        calls = tool_ctx_kitchen_open.runner.call_args_list
+        ls_remote_call = calls[0]
+        assert ls_remote_call[0][1] == "ls-remote", (
+            f"First subprocess call should be ls-remote, got: {ls_remote_call[0]}"
+        )
+        remote_arg = ls_remote_call[0][2]
+        assert remote_arg == "upstream", f"ls-remote should target 'upstream', not '{remote_arg}'"
+
+    @pytest.mark.anyio
+    async def test_falls_back_to_origin_without_upstream(
+        self, tool_ctx_kitchen_open, tmp_path: Path
+    ) -> None:
+        """When no upstream remote exists, origin is used as fallback."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.email", "test@test.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "config", "user.name", "Test"],
+            check=True,
+            capture_output=True,
+        )
+        (repo / "f.txt").write_text("x")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "init")
+
+        bare = tmp_path / "remote.git"
+        bare.mkdir()
+        subprocess.run(["git", "init", "--bare", str(bare)], check=True, capture_output=True)
+        _git(repo, "remote", "add", "origin", str(bare))
+        _git(repo, "push", "-u", "origin", "HEAD")
+
+        tool_ctx_kitchen_open.runner.push(_make_result(2, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "main\n", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+
+        await create_and_publish_branch(
+            issue_slug="42",
+            run_name="impl",
+            issue_number="42",
+            work_dir=str(repo),
+            remote_url=str(bare),
+        )
+
+        calls = tool_ctx_kitchen_open.runner.call_args_list
+        ls_remote_call = calls[0]
+        remote_arg = ls_remote_call[0][2]
+        assert remote_arg == "origin", (
+            f"Without upstream, ls-remote should target 'origin', got '{remote_arg}'"
+        )

--- a/tests/server/test_tools_git_branch_isolation.py
+++ b/tests/server/test_tools_git_branch_isolation.py
@@ -36,11 +36,13 @@ def _setup_isolated_clone(tmp_path: Path) -> tuple[Path, Path]:
     """
     bare = tmp_path / "remote.git"
     bare.mkdir()
-    subprocess.run(["git", "init", "--bare", str(bare)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "init", "--bare", "-b", "main", str(bare)], check=True, capture_output=True
+    )
 
     source = tmp_path / "source"
     source.mkdir()
-    subprocess.run(["git", "init", str(source)], check=True, capture_output=True)
+    subprocess.run(["git", "init", "-b", "main", str(source)], check=True, capture_output=True)
     subprocess.run(
         ["git", "-C", str(source), "config", "user.email", "test@test.com"],
         check=True,
@@ -121,7 +123,7 @@ class TestCreateAndPublishBranchIsolation:
         """When no upstream remote exists, origin is used as fallback."""
         repo = tmp_path / "repo"
         repo.mkdir()
-        subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+        subprocess.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True)
         subprocess.run(
             ["git", "-C", str(repo), "config", "user.email", "test@test.com"],
             check=True,
@@ -138,7 +140,9 @@ class TestCreateAndPublishBranchIsolation:
 
         bare = tmp_path / "remote.git"
         bare.mkdir()
-        subprocess.run(["git", "init", "--bare", str(bare)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "init", "--bare", "-b", "main", str(bare)], check=True, capture_output=True
+        )
         _git(repo, "remote", "add", "origin", str(bare))
         _git(repo, "push", "-u", "origin", "HEAD")
 

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -107,6 +107,7 @@ class TestModuleCascadeCore:
             "_type_exceptions",
             "_step_context",
             "_execution_marker",
+            "git_remote",
         }
         assert set(MODULE_CASCADE_CORE.keys()) == expected_stems
 


### PR DESCRIPTION
## Summary

The clone isolation contract (`_ensure_origin_isolated`) rewrites `origin` to `file://<clone_path>` and stores the real GitHub URL under `upstream`. Code throughout the codebase inconsistently uses `"origin"` vs `"upstream"` when referring to the real remote — the same class of bug appears in at least 5 independent locations. The architectural solution centralizes remote resolution behind a single synchronous function in `core/` (IL-0) with a single `REMOTE_PRECEDENCE` constant as the single source of truth, then uses an architectural test to prevent any new code from hardcoding `"origin"` in git remote operations within clone contexts.

Closes #3489

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260531-192207-303507/.autoskillit/temp/rectify/rectify_origin_remote_identity_mismatch_2026-05-31_230000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 66 | 23.9k | 1.6M | 108.3k | 47 | 91.6k | 25m 3s |
| review_approach* | opus | 1 | 34 | 5.1k | 229.9k | 46.9k | 13 | 32.9k | 3m 57s |
| dry_walkthrough* | opus | 1 | 46 | 7.0k | 394.3k | 50.8k | 23 | 34.1k | 5m 41s |
| implement* | opus | 1 | 104 | 19.5k | 2.7M | 98.5k | 93 | 180.9k | 8m 45s |
| audit_impl* | opus | 1 | 26 | 11.9k | 278.6k | 51.8k | 18 | 48.2k | 7m 6s |
| prepare_pr* | opus | 1 | 86.5k | 5.8k | 260.1k | 50.9k | 22 | 0 | 2m 31s |
| compose_pr* | opus | 1 | 71.3k | 1.7k | 115.5k | 38.9k | 11 | 0 | 54s |
| review_pr* | opus | 1 | 5.1k | 51.6k | 803.2k | 116.3k | 32 | 103.7k | 14m 10s |
| resolve_review* | opus | 1 | 2.7k | 14.6k | 1.9M | 89.7k | 59 | 74.3k | 16m 29s |
| diagnose_ci* | opus | 2 | 229.2k | 5.7k | 806.7k | 66.0k | 37 | 0 | 3m 29s |
| resolve_ci* | opus | 2 | 105 | 9.0k | 1.6M | 61.4k | 68 | 83.9k | 9m 38s |
| **Total** | | | 395.2k | 155.8k | 10.6M | 116.3k | | 649.7k | 1h 37m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 615 | 4461.6 | 294.1 | 31.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 46 | 41093.8 | 1614.7 | 316.7 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 13 | 120485.1 | 6451.2 | 690.3 |
| **Total** | **674** | 15789.9 | 963.9 | 231.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 66 | 23.9k | 1.6M | 91.6k | 25m 3s |
| opus | 10 | 395.1k | 131.9k | 9.1M | 558.0k | 1h 12m |