### PR TITLE
Rectify: Forward-Declared Exemption Staleness Immunity

### DIFF
--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -30,8 +30,9 @@ class BackendCapabilities:
 
     Every field must have at least one production read site in src/ —
     enforced by tests/arch/test_capability_consumption.py. Fields without
-    a consumer must be added to the _FORWARD_DECLARED exemption set with
-    a linked issue justifying the exception.
+    a consumer must be added to the _FORWARD_DECLARED exemption set as a
+    ForwardDeclaredField(issue=NNNN, rationale="...", added_date=date(...))
+    entry with a linked tracking issue.
     """
 
     # True when backend streams a side-channel JSONL log (Channel B)

--- a/tests/arch/test_capability_consumption.py
+++ b/tests/arch/test_capability_consumption.py
@@ -1,25 +1,55 @@
 """Architectural invariant: every BackendCapabilities field must be consumed in production."""
 
+from __future__ import annotations
+
 import ast
 import dataclasses
-import re
+from datetime import date
 from pathlib import Path
 
 import pytest
 
 pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 
-# Fields that are explicitly forward-declared and have no consumer yet.
-# Every entry must reference a tracking issue: 'field_name': '#NNNN'.
-_FORWARD_DECLARED: dict[str, str] = {
-    "supports_thinking_blocks": "#3298",  # planned for thinking-block rendering
-    "supports_context_exhaustion_detection": "#3299",  # planned for context exhaustion handling
-    "min_version": "#3300",  # planned for version validation in doctor
-    "version_check_command": "#3301",  # planned for version validation in doctor
-    "mcp_env_forward_vars": "#3458",  # consumed by tests/arch/test_mcp_env_forward_coverage.py
-}
 
-_ISSUE_REF_RE = re.compile(r"#\d+")
+@dataclasses.dataclass(frozen=True)
+class ForwardDeclaredField:
+    """Structured forward-declaration for a BackendCapabilities field without a consumer."""
+
+    issue: int
+    rationale: str
+    added_date: date
+
+
+_STALENESS_THRESHOLD_DAYS = 180
+
+_FORWARD_DECLARED: dict[str, ForwardDeclaredField] = {
+    "supports_thinking_blocks": ForwardDeclaredField(
+        issue=3497,
+        rationale="thinking-block rendering gating",
+        added_date=date(2026, 5, 31),
+    ),
+    "supports_context_exhaustion_detection": ForwardDeclaredField(
+        issue=3384,
+        rationale="context exhaustion and recovery paths",
+        added_date=date(2026, 5, 31),
+    ),
+    "min_version": ForwardDeclaredField(
+        issue=3122,
+        rationale="version validation via BackendCapabilities fields",
+        added_date=date(2026, 5, 31),
+    ),
+    "version_check_command": ForwardDeclaredField(
+        issue=3122,
+        rationale="version validation via BackendCapabilities fields",
+        added_date=date(2026, 5, 31),
+    ),
+    "mcp_env_forward_vars": ForwardDeclaredField(
+        issue=3458,
+        rationale="MCP env forwarding — enforcement arch test exists, awaiting src/ consumer",
+        added_date=date(2026, 5, 31),
+    ),
+}
 
 
 def _collect_attribute_reads(src_root: Path, field_names: frozenset[str]) -> dict[str, list[str]]:
@@ -53,16 +83,66 @@ def test_all_capability_fields_have_production_consumers():
     }
     assert not unconsumed, (
         f"BackendCapabilities fields with zero production read sites "
-        f"(add a consumer or add to _FORWARD_DECLARED as 'field_name': '#NNNN' dict entry): "
+        f"(add a consumer or add to _FORWARD_DECLARED as "
+        f"ForwardDeclaredField(issue=NNNN, rationale='...', added_date=date(YYYY, M, D))): "
         f"{sorted(unconsumed)}"
     )
 
 
 def test_forward_declared_has_linked_issues():
-    """Every _FORWARD_DECLARED entry must have a linked issue reference matching #\\d+."""
-    missing = {
-        field: ref for field, ref in _FORWARD_DECLARED.items() if not _ISSUE_REF_RE.search(ref)
+    """Every _FORWARD_DECLARED entry must have a positive issue number."""
+    invalid = {
+        field: entry.issue for field, entry in _FORWARD_DECLARED.items() if entry.issue <= 0
     }
-    assert not missing, (
-        f"_FORWARD_DECLARED entries missing issue reference (need '#NNNN'): {missing}"
+    assert not invalid, (
+        f"_FORWARD_DECLARED entries with invalid issue number (need positive int): {invalid}"
+    )
+
+
+def test_forward_declared_fields_have_no_consumers():
+    """_FORWARD_DECLARED entries must NOT have production consumers.
+
+    If a field gains a consumer in src/, it must be removed from
+    _FORWARD_DECLARED — the exemption is no longer needed.
+    """
+    from autoskillit.core import BackendCapabilities, paths
+
+    src_root = paths.pkg_root()
+    field_names = frozenset(f.name for f in dataclasses.fields(BackendCapabilities))
+    reads = _collect_attribute_reads(src_root, field_names)
+
+    stale = {name: sites for name, sites in reads.items() if name in _FORWARD_DECLARED and sites}
+    assert not stale, (
+        f"_FORWARD_DECLARED entries that now have production consumers "
+        f"(remove from _FORWARD_DECLARED): {stale}"
+    )
+
+
+def test_forward_declared_fields_exist_on_dataclass():
+    """Every _FORWARD_DECLARED key must be a real field on BackendCapabilities."""
+    from autoskillit.core import BackendCapabilities
+
+    real_fields = frozenset(f.name for f in dataclasses.fields(BackendCapabilities))
+    unknown = frozenset(_FORWARD_DECLARED.keys()) - real_fields
+    assert not unknown, (
+        f"_FORWARD_DECLARED keys that are not BackendCapabilities fields: {sorted(unknown)}"
+    )
+
+
+def test_forward_declared_entries_not_stale():
+    """Time-bomb: forward-declared fields older than 180 days require re-justification.
+
+    If a field has been forward-declared for > 180 days, either:
+    - add a production consumer and remove from _FORWARD_DECLARED, or
+    - update the added_date to reset the clock (with a current tracking issue)
+    """
+    today = date.today()
+    stale = [
+        f"{name} (added={entry.added_date}, age={(today - entry.added_date).days}d)"
+        for name, entry in _FORWARD_DECLARED.items()
+        if (today - entry.added_date).days > _STALENESS_THRESHOLD_DAYS
+    ]
+    assert not stale, (
+        f"_FORWARD_DECLARED entries older than {_STALENESS_THRESHOLD_DAYS} days "
+        f"(add a consumer, or update added_date with a fresh tracking issue): {stale}"
     )


### PR DESCRIPTION
## Summary

The `_FORWARD_DECLARED` dict in `tests/arch/test_capability_consumption.py` had 4 of 5 issue references pointing to wrong/unrelated GitHub issues. The test `test_forward_declared_has_linked_issues` only validated regex format (`#\d+`), not semantic correctness. The architectural weakness is two-fold: (1) no reverse guard verifies that forward-declared fields still lack consumers, and (2) no staleness mechanism forces periodic review of exemptions. This plan replaces the free-text `dict[str, str]` with a structured `ForwardDeclaredField` dataclass carrying a `date`-typed `added_date`, adds a reverse phantom-entity guard, adds a date-based staleness time-bomb, and fixes the stale references — making this class of bug structurally impossible.

Closes #3497

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260531-202841-343024/.autoskillit/temp/rectify/rectify_forward_declared_staleness_immunity_2026-05-31_203500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 9.6k | 17.4k | 2.1M | 104.6k | 57 | 94.6k | 20m 32s |
| review_approach* | opus[1m] | 1 | 1.5k | 5.4k | 385.3k | 47.4k | 18 | 30.6k | 3m 46s |
| dry_walkthrough* | opus | 1 | 28 | 5.1k | 424.4k | 55.0k | 20 | 38.3k | 4m 9s |
| implement* | opus[1m] | 1 | 42 | 5.6k | 581.1k | 47.5k | 28 | 30.9k | 2m 52s |
| audit_impl* | opus[1m] | 1 | 33 | 6.2k | 178.9k | 37.3k | 14 | 27.0k | 3m 22s |
| prepare_pr* | opus[1m] | 1 | 87.6k | 3.8k | 167.6k | 48.0k | 20 | 0 | 1m 46s |
| compose_pr* | opus[1m] | 1 | 104.6k | 1.3k | 121.3k | 38.8k | 12 | 0 | 48s |
| review_pr* | opus[1m] | 1 | 27 | 13.6k | 371.7k | 55.9k | 23 | 41.8k | 4m 7s |
| resolve_review* | opus[1m] | 1 | 27 | 5.8k | 397.4k | 54.7k | 19 | 75.6k | 5m 26s |
| **Total** | | | 203.4k | 64.2k | 4.7M | 104.6k | | 338.7k | 46m 52s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 119 | 4883.6 | 259.5 | 47.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **119** | 39336.8 | 2846.2 | 539.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 8 | 203.4k | 59.1k | 4.3M | 300.4k | 42m 42s |
| opus | 1 | 28 | 5.1k | 424.4k | 38.3k | 4m 9s |