### PR TITLE
Rectify: Clone Guard Failure-Path Exemption Gap

### DIFF
--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -109,13 +109,12 @@ class CloneGuardPolicy:
     """Structured session permission policy for the clone guard."""
 
     _fire_on_success: bool
+    _fire_on_failure: bool
     selective_revert: bool
     should_snapshot: bool
 
     def should_fire(self, success: bool) -> bool:
-        if not success:
-            return True
-        return self._fire_on_success
+        return self._fire_on_success if success else self._fire_on_failure
 
 
 def build_clone_guard_policy(
@@ -133,10 +132,12 @@ def build_clone_guard_policy(
         and not writes_under_exclude
         and (readonly_skill or has_write_scope)
     )
+    fire_on_failure = not is_clone_commit and not is_worktree
     selective_revert = readonly_skill or has_write_scope
     should_snapshot = is_worktree or readonly_skill or has_write_scope
     return CloneGuardPolicy(
         _fire_on_success=fire_on_success,
+        _fire_on_failure=fire_on_failure,
         selective_revert=selective_revert,
         should_snapshot=should_snapshot,
     )

--- a/tests/execution/test_clone_guard.py
+++ b/tests/execution/test_clone_guard.py
@@ -294,7 +294,8 @@ async def test_guard_full_flow_contamination_detected(tmp_path):
     # detect_contamination: rev-parse HEAD (moved), status (dirty)
     runner.push(_git_result(stdout="def456\n"))
     runner.push(_git_result(stdout=" M file.py\n"))
-    # revert_contamination: reset --hard, clean -fd
+    # revert_contamination (selective, direct_commits=True): reset --hard, checkout --, clean -fd
+    runner.push(_git_result())
     runner.push(_git_result())
     runner.push(_git_result())
 
@@ -311,13 +312,13 @@ async def test_guard_full_flow_contamination_detected(tmp_path):
         skill_command="/autoskillit:implement-worktree-no-merge plan.md",
         policy=build_clone_guard_policy(
             readonly_skill=False,
-            has_write_scope=False,
+            has_write_scope=True,
             is_clone_commit=False,
-            is_worktree=True,
+            is_worktree=False,
         ),
     )
     assert reverted
-    assert len(runner.call_args_list) == 4  # 2 detect + 2 revert
+    assert len(runner.call_args_list) == 5  # 2 detect + 3 selective revert
     assert len(audit.get_report()) == 1
     record = audit.get_report()[0]
     assert record.subtype == "clone_contamination"
@@ -446,9 +447,9 @@ async def test_audit_log_records_contamination(tmp_path):
         skill_command="/autoskillit:implement-worktree-no-merge plan.md",
         policy=build_clone_guard_policy(
             readonly_skill=False,
-            has_write_scope=False,
+            has_write_scope=True,
             is_clone_commit=False,
-            is_worktree=True,
+            is_worktree=False,
         ),
     )
 
@@ -735,9 +736,9 @@ async def test_result_needs_retry_set_on_revert(tmp_path):
         None,
         policy=build_clone_guard_policy(
             readonly_skill=False,
-            has_write_scope=False,
+            has_write_scope=True,
             is_clone_commit=False,
-            is_worktree=True,
+            is_worktree=False,
         ),
     )
     assert reverted
@@ -801,9 +802,9 @@ async def test_original_retry_reason_preserved_on_revert(tmp_path):
         None,
         policy=build_clone_guard_policy(
             readonly_skill=False,
-            has_write_scope=False,
+            has_write_scope=True,
             is_clone_commit=False,
-            is_worktree=True,
+            is_worktree=False,
         ),
     )
     assert reverted
@@ -843,9 +844,9 @@ async def test_original_subtype_preserved_on_revert(tmp_path):
         None,
         policy=build_clone_guard_policy(
             readonly_skill=False,
-            has_write_scope=False,
+            has_write_scope=True,
             is_clone_commit=False,
-            is_worktree=True,
+            is_worktree=False,
         ),
     )
     assert result.contamination.subtype == "context_exhaustion"
@@ -1047,12 +1048,12 @@ async def test_worktree_recovery_skipped_when_snapshot_worktree_set_none(tmp_pat
         str(tmp_path),
         runner,
         None,
-        skill_command="/autoskillit:implement-worktree-no-merge plan.md",
+        skill_command="/autoskillit:rectify plan.md",
         policy=build_clone_guard_policy(
             readonly_skill=False,
-            has_write_scope=False,
+            has_write_scope=True,
             is_clone_commit=False,
-            is_worktree=True,
+            is_worktree=False,
         ),
     )
     assert reverted
@@ -1091,6 +1092,35 @@ async def test_worktree_recovery_on_success_path(tmp_path):
     )
     assert not reverted
     assert result.worktree_path == str(wt_dir)
+
+
+# ---------------------------------------------------------------------------
+# T29: clone-commit skill failure does not revert
+# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_clone_commit_skill_failure_does_not_revert(tmp_path):
+    """Guard must not revert when policy has is_clone_commit=True and success=False."""
+    runner = MockSubprocessRunner()
+    snapshot = CloneSnapshot(head_sha="abc123")
+    skill_result = _make_skill_result(success=False, worktree_path=None)
+
+    result, reverted = await check_and_revert_clone_contamination(
+        snapshot,
+        skill_result,
+        str(tmp_path),
+        runner,
+        None,
+        skill_command="/autoskillit:resolve-failures",
+        policy=build_clone_guard_policy(
+            readonly_skill=False,
+            has_write_scope=True,
+            is_clone_commit=True,
+            is_worktree=False,
+        ),
+    )
+    assert not reverted
+    assert result is skill_result
+    assert len(runner.call_args_list) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_clone_guard_policy.py
+++ b/tests/execution/test_clone_guard_policy.py
@@ -56,6 +56,7 @@ def test_policy_for_normal_write_skill():
 
 
 def test_policy_for_worktree_skill():
+    """Worktree skill: fire_on_failure=False because is_worktree=True."""
     policy = build_clone_guard_policy(
         is_worktree=True,
         readonly_skill=False,

--- a/tests/execution/test_clone_guard_policy.py
+++ b/tests/execution/test_clone_guard_policy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from autoskillit.execution.clone_guard import build_clone_guard_policy
+from autoskillit.execution.clone_guard import build_clone_guard_policy, is_clone_commit_skill
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -29,7 +29,7 @@ def test_policy_for_clone_commit_skill_success():
         is_worktree=False,
     )
     assert policy.should_fire(success=True) is False
-    assert policy.should_fire(success=False) is True
+    assert policy.should_fire(success=False) is False
 
 
 def test_policy_for_clone_commit_skill_readonly_success():
@@ -40,7 +40,7 @@ def test_policy_for_clone_commit_skill_readonly_success():
         is_worktree=False,
     )
     assert policy.should_fire(success=True) is False
-    assert policy.should_fire(success=False) is True
+    assert policy.should_fire(success=False) is False
 
 
 def test_policy_for_normal_write_skill():
@@ -63,7 +63,7 @@ def test_policy_for_worktree_skill():
         is_clone_commit=False,
     )
     assert policy.should_fire(success=True) is False
-    assert policy.should_fire(success=False) is True
+    assert policy.should_fire(success=False) is False
 
 
 def test_policy_should_snapshot():
@@ -182,3 +182,48 @@ def test_policy_output_dir_outside_cwd_does_not_suppress_guard():
     )
     assert policy.should_fire(success=True) is True
     assert policy.should_fire(success=False) is True
+
+
+def test_policy_for_worktree_skill_failure_no_fire():
+    """Worktree skill must not fire the guard on failure regardless of write scope."""
+    policy = build_clone_guard_policy(
+        is_worktree=True,
+        readonly_skill=False,
+        has_write_scope=False,
+        is_clone_commit=False,
+    )
+    assert policy.should_fire(success=False) is False
+
+
+class TestIsCloneCommitSkillPositive:
+    def test_resolve_failures(self):
+        assert is_clone_commit_skill("/autoskillit:resolve-failures")
+
+    def test_resolve_failures_with_args(self):
+        assert is_clone_commit_skill("/autoskillit:resolve-failures issue=42")
+
+    def test_resolve_review(self):
+        assert is_clone_commit_skill("/autoskillit:resolve-review")
+
+    def test_resolve_review_with_args(self):
+        assert is_clone_commit_skill("/autoskillit:resolve-review pr=99")
+
+    def test_resolve_merge_conflicts(self):
+        assert is_clone_commit_skill("/autoskillit:resolve-merge-conflicts")
+
+    def test_resolve_merge_conflicts_with_args(self):
+        assert is_clone_commit_skill("/autoskillit:resolve-merge-conflicts branch=main")
+
+
+class TestIsCloneCommitSkillNegative:
+    def test_resolve_ci(self):
+        assert not is_clone_commit_skill("/autoskillit:resolve-ci")
+
+    def test_review_pr(self):
+        assert not is_clone_commit_skill("/autoskillit:review-pr")
+
+    def test_rectify(self):
+        assert not is_clone_commit_skill("/autoskillit:rectify plan.md")
+
+    def test_plain_resolve(self):
+        assert not is_clone_commit_skill("resolve")


### PR DESCRIPTION
## Summary

`CloneGuardPolicy.should_fire(success=False)` returns `True` unconditionally, ignoring all skill-type exemptions that ARE respected on the success path via `_fire_on_success`. This causes clone-commit skills (resolve-failures, resolve-review, resolve-merge-conflicts) that fail mid-session to have their legitimate commits reverted and stamped as `clone_contamination`, routing to `on_failure` with no recovery.

The architectural weakness is a **split-decision anti-pattern**: `_fire_on_success` is a pre-computed field incorporating all exemptions, but the failure path is a hardcoded `return True` inline in the method body. The fix is to make `CloneGuardPolicy` store both `_fire_on_success` and `_fire_on_failure` as pre-computed fields, eliminating the method's ability to introduce exemption asymmetry. Two existing tests encode the buggy behavior as expected — they assert `should_fire(success=False) is True` for clone-commit skills.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260531-221444-534464/.autoskillit/temp/rectify/rectify_clone_guard_failure_path_exemption_2026-05-31_222500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 2.4k | 23.0k | 2.8M | 115.9k | 67 | 153.4k | 21m 49s |
| review_approach* | sonnet | 1 | 52 | 6.6k | 177.7k | 46.6k | 15 | 50.9k | 6m 9s |
| dry_walkthrough* | opus | 1 | 48 | 11.5k | 601.1k | 75.0k | 38 | 58.3k | 6m 43s |
| implement* | sonnet | 1 | 396 | 32.8k | 3.0M | 89.1k | 120 | 72.8k | 10m 18s |
| audit_impl* | sonnet | 1 | 54 | 11.0k | 172.3k | 37.9k | 19 | 33.4k | 4m 53s |
| prepare_pr* | sonnet | 1 | 87.8k | 3.7k | 119.7k | 47.7k | 18 | 0 | 3m 0s |
| compose_pr* | sonnet | 1 | 71.9k | 1.2k | 110.9k | 38.0k | 11 | 0 | 49s |
| review_pr* | sonnet | 2 | 314 | 42.0k | 1.9M | 70.5k | 106 | 101.0k | 10m 29s |
| resolve_review* | opus | 1 | 43 | 3.8k | 778.5k | 56.0k | 26 | 39.7k | 3m 50s |
| **Total** | | | 163.0k | 135.7k | 9.7M | 115.9k | | 509.6k | 1h 8m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 120 | 25401.0 | 606.5 | 273.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 1 | 778479.0 | 39746.0 | 3842.0 |
| **Total** | **121** | 79913.6 | 4211.3 | 1121.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.4k | 23.0k | 2.8M | 153.4k | 21m 49s |
| sonnet | 6 | 160.5k | 97.3k | 5.5M | 258.1k | 35m 39s |
| opus | 2 | 91 | 15.4k | 1.4M | 98.1k | 10m 34s |