### PR TITLE
Implementation Plan: pre_remediation_merge Missing path_validation Route

### DIFF
--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -592,6 +592,10 @@
           "route": "remediate"
         },
         {
+          "when": "result.failed_step == 'path_validation'",
+          "route": "remediate"
+        },
+        {
           "when": "result.error",
           "route": "release_issue_failure"
         },
@@ -600,7 +604,7 @@
         }
       ],
       "on_failure": "release_issue_failure",
-      "note": "Merges the current worktree before the remediation cycle creates a new one. Audit NO GO means the implementation is incomplete, not wrong — merge it first, then remediate on top. This prevents orphaning the original worktree when implement re-runs. dirty_tree routes to commit_guard_pre_remediation to auto-commit before retrying merge. dirty_main_repo routes to main_repo_guard_pre_remediation to stash. test_gate and rebase route to remediate — the remediation plan will address these. Only hard errors escalate to release_issue_failure.\n"
+      "note": "Merges the current worktree before the remediation cycle creates a new one. Audit NO GO means the implementation is incomplete, not wrong — merge it first, then remediate on top. This prevents orphaning the original worktree when implement re-runs. dirty_tree routes to commit_guard_pre_remediation to auto-commit before retrying merge. dirty_main_repo routes to main_repo_guard_pre_remediation to stash. test_gate, rebase, and path_validation route to remediate — the remediation plan will address these. path_validation means the worktree was already merged in a prior session. Only hard errors escalate to release_issue_failure.\n"
     },
     "commit_guard_pre_remediation": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -556,6 +556,8 @@ steps:
       route: main_repo_guard_pre_remediation
     - when: result.failed_step == 'ref_coherence'
       route: remediate
+    - when: result.failed_step == 'path_validation'
+      route: remediate
     - when: result.error
       route: release_issue_failure
     - route: remediate
@@ -567,8 +569,10 @@ steps:
       original worktree when implement re-runs. dirty_tree routes to
       commit_guard_pre_remediation to auto-commit before retrying merge.
       dirty_main_repo routes to main_repo_guard_pre_remediation to stash.
-      test_gate and rebase route to remediate — the remediation plan will
-      address these. Only hard errors escalate to release_issue_failure.
+      test_gate, rebase, and path_validation route to remediate — the
+      remediation plan will address these. path_validation means the worktree
+      was already merged in a prior session. Only hard errors escalate to
+      release_issue_failure.
   commit_guard_pre_remediation:
     tool: run_python
     with:

--- a/tests/recipe/test_remediation_recipe.py
+++ b/tests/recipe/test_remediation_recipe.py
@@ -59,6 +59,23 @@ def test_re_push_review_routes_to_check_review_loop(recipe) -> None:
     assert step.on_success == "check_review_loop"
 
 
+def test_pre_remediation_merge_routes_path_validation_to_remediate(recipe) -> None:
+    """path_validation on pre_remediation_merge must route to remediate, not fall
+    through to result.error — a missing worktree on resume means the prior session
+    already merged it."""
+    step = recipe.steps["pre_remediation_merge"]
+    assert step.on_result is not None
+    pv_routes = [
+        c.route for c in step.on_result.conditions if c.when and "path_validation" in c.when
+    ]
+    assert pv_routes, (
+        "pre_remediation_merge must explicitly route path_validation; "
+        "without it, a missing worktree on resume falls through to "
+        "release_issue_failure"
+    )
+    assert pv_routes[0] == "remediate"
+
+
 # T_REM_LOOP3
 def test_check_review_loop_routes_to_annotate_pr_diff_when_had_blocking(
     recipe,


### PR DESCRIPTION
## Summary

Add an explicit `path_validation → remediate` route to the `pre_remediation_merge` step in `remediation.yaml`. Currently, when a remediation pipeline resumes after a prior failure and `context.implementation_ref` points to a worktree that no longer exists (already merged or cleaned up), `merge_worktree` returns `failed_step: "path_validation"`. This falls through to the `result.error` catch-all, routing to `release_issue_failure` — killing the pipeline instead of proceeding to the remediation cycle that would create a fresh worktree.

The fix is a single routing condition inserted before the `result.error` catch-all. No changes to `rules_merge.py` classification sets are needed: `PATH_VALIDATION` correctly remains in `_TERMINAL_FAILED_STEPS` (it IS terminal for the final `merge` step where there's nothing to recover). The `pre_remediation_merge` step is a special case — a missing worktree here simply means the prior session already merged it, and `remediate → make_plan → implement` will create a fresh one.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260531-232534-260188/.autoskillit/temp/make-plan/pre_remediation_merge_path_validation_plan_2026-05-31_233000.md`

Closes #3417

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 49 | 6.2k | 654.4k | 66.0k | 29 | 68.5k | 4m 26s |
| verify* | opus[1m] | 1 | 38 | 6.2k | 479.9k | 60.3k | 26 | 43.7k | 4m 3s |
| implement* | opus[1m] | 1 | 92.3k | 3.1k | 786.4k | 48.6k | 34 | 0 | 2m 36s |
| audit_impl* | opus[1m] | 1 | 838 | 5.6k | 206.4k | 35.7k | 18 | 22.9k | 3m 4s |
| prepare_pr* | opus[1m] | 1 | 82.6k | 3.4k | 157.7k | 44.1k | 17 | 0 | 2m 2s |
| compose_pr* | opus[1m] | 1 | 71.6k | 1.8k | 307.2k | 40.1k | 20 | 0 | 1m 23s |
| review_pr* | opus[1m] | 3 | 99 | 26.8k | 1.0M | 49.2k | 76 | 98.5k | 7m 15s |
| **Total** | | | 247.5k | 53.1k | 3.6M | 66.0k | | 233.6k | 24m 52s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 31 | 25366.6 | 0.0 | 99.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **31** | 117391.2 | 7534.6 | 1712.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 7 | 247.5k | 53.1k | 3.6M | 233.6k | 24m 52s |