### PR TITLE
Implementation Plan: Strengthen compose-pr and review-pr SKILL.md Instructions for Cross-Provider Compliance

### DIFF
--- a/src/autoskillit/skills_extended/compose-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-pr/SKILL.md
@@ -41,6 +41,7 @@ decomposed PR flow (prepare → run_arch_lenses → compose).
   Using ONLY classDef styles from the mermaid skill (no invented colors).
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
+- Generate, fabricate, or create any diagrams or mermaid code blocks — the ONLY diagrams permitted in the PR body are those read from `all_diagram_paths` files that passed ★/● marker validation in Step 2. If no diagram paths are provided or all fail validation, the Architecture Impact section must not exist in the output.
 - NEVER re-derive, override, or substitute `task_title` from any source other than the prep file's `## Title` section. The title in the prep file is authoritative — do NOT use issue metadata, branch names, or ambient context to modify it.
 
 **ALWAYS:**
@@ -111,6 +112,8 @@ For each path:
    - If not found → discard silently
 
 If `all_diagram_paths` is empty or all diagrams fail → `validated_diagrams = []`.
+
+**HARD RULE — Do not generate diagrams.** Every mermaid block in the PR body must originate from a file in `all_diagram_paths` that passed ★/● validation above. If `validated_diagrams` is empty, omit the entire Architecture Impact section — no placeholder, no generated diagrams, no mermaid blocks of any kind.
 
 ### Step 3: Compose PR Body (SINGLE MESSAGE)
 

--- a/src/autoskillit/skills_extended/compose-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-pr/SKILL.md
@@ -113,7 +113,7 @@ For each path:
 
 If `all_diagram_paths` is empty or all diagrams fail → `validated_diagrams = []`.
 
-**HARD RULE — Do not generate diagrams.** Every mermaid block in the PR body must originate from a file in `all_diagram_paths` that passed ★/● validation above. If `validated_diagrams` is empty, omit the entire Architecture Impact section — no placeholder, no generated diagrams, no mermaid blocks of any kind.
+**HARD RULE — Do not generate, fabricate, or create diagrams.** Every mermaid block in the PR body must originate from a file in `all_diagram_paths` that passed ★/● validation above. If `validated_diagrams` is empty, omit the entire Architecture Impact section — no placeholder, no generated, fabricated, or created diagrams, no mermaid blocks of any kind.
 
 ### Step 3: Compose PR Body (SINGLE MESSAGE)
 

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -49,6 +49,7 @@ by the recipe pipeline after `open_pr_step` opens the PR.
 - Modify any source code
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
+- Specify `subagent_type` when spawning audit subagents — these are ephemeral agents, not registered agent definitions. Use `Agent(model="sonnet")` exactly as shown, with no `subagent_type` parameter.
 
 **ALWAYS:**
 - Find the PR by feature branch at invocation time (not from a pre-captured URL)

--- a/tests/contracts/test_prepare_compose_pr_contracts.py
+++ b/tests/contracts/test_prepare_compose_pr_contracts.py
@@ -181,3 +181,27 @@ def test_prepare_pr_plan_summary_prohibits_nested_heading():
         "prepare-pr/SKILL.md must contain a proximity-anchored prohibition: "
         "'do NOT include the ## Summary heading' or 'NEVER include the ## Summary heading'"
     )
+
+
+def test_compose_pr_never_fabricate_diagrams():
+    """compose-pr NEVER block must contain unconditional diagram fabrication prohibition."""
+    text = COMPOSE_PR.read_text()
+    never_idx = text.find("**NEVER:**")
+    always_idx = text.find("**ALWAYS:**")
+    assert never_idx != -1 and always_idx != -1
+    never_block = text[never_idx:always_idx]
+    assert "fabricat" in never_block.lower(), (
+        "NEVER block must contain an unconditional prohibition against fabricating diagrams"
+    )
+
+
+def test_compose_pr_unconditional_diagram_gate_before_step3():
+    """compose-pr must have an unconditional no-fabrication rule between Step 2 and Step 3."""
+    text = COMPOSE_PR.read_text()
+    step2_idx = text.find("### Step 2")
+    step3_idx = text.find("### Step 3")
+    assert step2_idx != -1 and step3_idx != -1
+    between = text[step2_idx:step3_idx]
+    assert "do not" in between.lower() and (
+        "generat" in between.lower() or "fabricat" in between.lower() or "creat" in between.lower()
+    ), "Must have unconditional no-fabrication instruction between Step 2 and Step 3"

--- a/tests/contracts/test_prepare_compose_pr_contracts.py
+++ b/tests/contracts/test_prepare_compose_pr_contracts.py
@@ -202,6 +202,8 @@ def test_compose_pr_unconditional_diagram_gate_before_step3():
     step3_idx = text.find("### Step 3")
     assert step2_idx != -1 and step3_idx != -1
     between = text[step2_idx:step3_idx]
-    assert "do not" in between.lower() and (
-        "generat" in between.lower() or "fabricat" in between.lower() or "creat" in between.lower()
-    ), "Must have unconditional no-fabrication instruction between Step 2 and Step 3"
+    lower = between.lower()
+    assert "do not" in lower, "Must have 'do not' instruction between Step 2 and Step 3"
+    assert "generat" in lower, "Must prohibit 'generate' between Step 2 and Step 3"
+    assert "fabricat" in lower, "Must prohibit 'fabricate' between Step 2 and Step 3"
+    assert "creat" in lower, "Must prohibit 'create' between Step 2 and Step 3"

--- a/tests/contracts/test_review_pr_diff_annotation.py
+++ b/tests/contracts/test_review_pr_diff_annotation.py
@@ -156,3 +156,15 @@ def test_annotate_pr_diff_callable_contract_has_head_sha() -> None:
     )
     names = [o["name"] for o in outputs]
     assert "head_sha" in names, "annotate_pr_diff contract must declare head_sha output"
+
+
+def test_review_pr_never_specify_subagent_type() -> None:
+    """review-pr NEVER block must prohibit specifying subagent_type on audit subagents."""
+    text = _SKILL_MD.read_text()
+    never_idx = text.find("**NEVER:**")
+    always_idx = text.find("**ALWAYS:**")
+    assert never_idx != -1 and always_idx != -1
+    never_block = text[never_idx:always_idx]
+    assert "subagent_type" in never_block, (
+        "NEVER block must contain explicit prohibition against specifying subagent_type"
+    )


### PR DESCRIPTION
## Summary

Two SKILL.md instruction compliance failures were observed in pipeline kitchen `c5eecf4d`:

1. **compose-pr** fabricated three mermaid diagrams when `all_diagram_paths` was empty, despite four existing conditional guards. The root cause is instruction FORMAT — conditional template guards are unreliable with weaker instruction-following providers (MiniMax was the configured provider, not drift). Fix: add a concise, unconditional prohibition in the NEVER block and a hard gate before PR body composition.

2. **review-pr** had a session hallucinate `subagent_type: 'autoskillit:pr-review-auditor-baseline'`, wasting 6 API calls. The SKILL.md shows `Agent(model="sonnet")` but never explicitly prohibits adding `subagent_type`. Fix: add explicit negative guidance in the NEVER block. (Note: overlaps with staged issue #3367 which proposes positive guidance — this fix is compatible and complementary.)

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260531-232411-106334/.autoskillit/temp/make-plan/strengthen_compose_review_pr_skillmd_plan_2026-05-31_232900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 59 | 14.8k | 713.9k | 72.9k | 32 | 85.7k | 12m 13s |
| verify* | opus[1m] | 1 | 43 | 7.4k | 981.9k | 76.3k | 35 | 59.6k | 3m 48s |
| implement* | opus[1m] | 1 | 172.2k | 5.2k | 882.5k | 72.1k | 38 | 0 | 4m 34s |
| audit_impl* | opus[1m] | 1 | 331 | 8.1k | 210.2k | 37.9k | 16 | 27.3k | 3m 28s |
| prepare_pr* | opus[1m] | 1 | 114.7k | 2.8k | 168.0k | 44.5k | 18 | 0 | 1m 49s |
| compose_pr* | opus[1m] | 1 | 67.1k | 1.5k | 193.9k | 38.6k | 14 | 0 | 1m 26s |
| review_pr* | opus[1m] | 3 | 100 | 38.4k | 1.6M | 55.8k | 87 | 116.0k | 10m 19s |
| resolve_review* | opus[1m] | 1 | 43 | 6.4k | 1.4M | 68.2k | 45 | 52.1k | 5m 38s |
| **Total** | | | 354.6k | 84.5k | 6.1M | 76.3k | | 340.6k | 43m 18s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 40 | 22063.5 | 0.0 | 129.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 10 | 138932.1 | 5210.1 | 635.6 |
| **Total** | **50** | 122259.9 | 6812.7 | 1689.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 8 | 354.6k | 84.5k | 6.1M | 340.6k | 43m 18s |