### PR TITLE
Implementation Plan: Make validate_project_local_skill_dir Backend-Agnostic

### DIFF
--- a/tests/core/test_add_dir_validation.py
+++ b/tests/core/test_add_dir_validation.py
@@ -66,48 +66,59 @@ class TestValidateAddDir:
 
 
 class TestValidateProjectLocalSkillDir:
-    """validate_project_local_skill_dir: None for codex,
-    delegates to validate_add_dir for claude."""
+    """validate_project_local_skill_dir: None when not project_local_skills_capable,
+    delegates to validate_add_dir otherwise."""
 
     @staticmethod
-    def _make_backend(name: str) -> MagicMock:
+    def _make_backend(*, project_local_skills_capable: bool) -> MagicMock:
         b = MagicMock()
-        b.name = name
-        b.capabilities.project_local_skills_capable = name != "codex"
+        b.capabilities.project_local_skills_capable = project_local_skills_capable
         return b
 
     def test_claude_backend_claude_layout_returns_validated_add_dir(self, tmp_path: Path) -> None:
         skill_dir = tmp_path / ".claude" / "skills" / "test-skill"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("# Test")
-        result = validate_project_local_skill_dir(tmp_path, self._make_backend("claude-code"))
+        result = validate_project_local_skill_dir(
+            tmp_path, self._make_backend(project_local_skills_capable=True)
+        )
         assert isinstance(result, ValidatedAddDir)
 
     def test_codex_backend_returns_none(self, tmp_path: Path) -> None:
         skill_dir = tmp_path / ".claude" / "skills" / "test-skill"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("# Test")
-        result = validate_project_local_skill_dir(tmp_path, self._make_backend("codex"))
+        result = validate_project_local_skill_dir(
+            tmp_path, self._make_backend(project_local_skills_capable=False)
+        )
         assert result is None
 
     def test_claude_backend_codex_layout_returns_none(self, tmp_path: Path) -> None:
         codex_skill = tmp_path / ".codex" / "skills" / "test-skill"
         codex_skill.mkdir(parents=True)
         (codex_skill / "SKILL.md").write_text("# Test")
-        result = validate_project_local_skill_dir(tmp_path, self._make_backend("claude-code"))
+        result = validate_project_local_skill_dir(
+            tmp_path, self._make_backend(project_local_skills_capable=True)
+        )
         assert result is None
 
     def test_codex_backend_claude_layout_returns_none(self, tmp_path: Path) -> None:
         skill_dir = tmp_path / ".claude" / "skills" / "test-skill"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text("# Test")
-        result = validate_project_local_skill_dir(tmp_path, self._make_backend("codex"))
+        result = validate_project_local_skill_dir(
+            tmp_path, self._make_backend(project_local_skills_capable=False)
+        )
         assert result is None
 
     def test_empty_dir_returns_none_claude(self, tmp_path: Path) -> None:
-        result = validate_project_local_skill_dir(tmp_path, self._make_backend("claude-code"))
+        result = validate_project_local_skill_dir(
+            tmp_path, self._make_backend(project_local_skills_capable=True)
+        )
         assert result is None
 
     def test_empty_dir_returns_none_codex(self, tmp_path: Path) -> None:
-        result = validate_project_local_skill_dir(tmp_path, self._make_backend("codex"))
+        result = validate_project_local_skill_dir(
+            tmp_path, self._make_backend(project_local_skills_capable=False)
+        )
         assert result is None


### PR DESCRIPTION
## Summary

The production code in `claude_conventions.py` is already backend-agnostic — it uses `backend.capabilities.project_local_skills_capable` with no `AGENT_BACKEND_CODEX` import. The remaining work is in the test file: rewrite `_make_backend` to accept a boolean capability flag instead of a backend name string, update all 6 call sites, and update the class docstring.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260601-064934-931705/.autoskillit/temp/make-plan/p3_a5_wp1_validate_project_local_skill_dir_plan_2026-06-01_070300.md`

Closes #3113

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 923 | 6.6k | 450.5k | 58.0k | 25 | 44.1k | 3m 36s |
| verify* | sonnet | 1 | 533 | 6.1k | 321.6k | 48.9k | 25 | 49.1k | 2m 56s |
| implement* | sonnet | 1 | 172.2k | 3.4k | 572.8k | 49.4k | 32 | 0 | 4m 4s |
| audit_impl* | sonnet | 1 | 313 | 3.7k | 171.0k | 34.4k | 15 | 21.0k | 2m 22s |
| prepare_pr* | sonnet | 1 | 113.6k | 2.8k | 119.1k | 43.0k | 14 | 0 | 1m 44s |
| compose_pr* | sonnet | 1 | 36.0k | 1.1k | 146.4k | 37.8k | 12 | 0 | 55s |
| review_pr* | sonnet | 3 | 292 | 32.0k | 1.4M | 51.4k | 106 | 104.7k | 9m 0s |
| **Total** | | | 323.8k | 55.8k | 3.2M | 58.0k | | 218.9k | 24m 39s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 33 | 17357.7 | 0.0 | 102.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **33** | 96257.9 | 6634.4 | 1690.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 923 | 6.6k | 450.5k | 44.1k | 3m 36s |
| sonnet | 6 | 322.9k | 49.2k | 2.7M | 174.9k | 21m 3s |