### PR TITLE
Implementation Plan: Eliminate backend-name string comparison in session_skills.py tests

### DIFF
--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -19,7 +19,6 @@ pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
 
 def _make_codex_backend() -> MagicMock:
     b = MagicMock()
-    b.name = "codex"
     b.capabilities = _CODEX_CAPABILITIES
     b.ensure_pre_launch.return_value = []
     return b

--- a/tests/workspace/test_session_skills_provider.py
+++ b/tests/workspace/test_session_skills_provider.py
@@ -100,7 +100,6 @@ def test_session_skill_manager_creates_ephemeral_dir(
         monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
 
         backend = MagicMock()
-        backend.name = "codex"
         backend.capabilities = _CODEX_CAPABILITIES
         backend.ensure_pre_launch.return_value = []
 
@@ -140,7 +139,6 @@ def test_session_manager_injects_disable_for_tier2(
         monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
 
         backend = MagicMock()
-        backend.name = "codex"
         backend.capabilities = _CODEX_CAPABILITIES
         backend.ensure_pre_launch.return_value = []
 
@@ -345,12 +343,11 @@ def test_init_session_backend_none_uses_claude_skills_subdir(tmp_path: Path) -> 
 def test_init_session_codex_backend_uses_codex_skills_subdir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """When backend.name == 'codex', skills_base resolves to skills/ (not .claude/skills/)."""
+    """When capabilities.skills_subdir == 'skills', skills_base resolves to skills/."""
 
     from autoskillit.workspace.session_skills import CODEX_SKILLS_SUBDIR
 
     codex_backend = MagicMock()
-    codex_backend.name = "codex"
     codex_backend.capabilities = _CODEX_CAPABILITIES
     codex_backend.ensure_pre_launch.return_value = []
 


### PR DESCRIPTION
## Summary

The production-side work for this issue is **already complete**: `BackendCapabilities` has the `skills_subdir` field, both backend implementations set it, `session_skills.py` reads from `backend.capabilities.skills_subdir`, and the `_is_codex` guard has been replaced with capability-driven checks. The remaining deliverable is removing vestigial `backend.name = "codex"` assignments from test mocks in `test_session_skills_codex.py` and `test_session_skills_provider.py`, and updating one docstring.

Closes #3112

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260601-064956-800790/.autoskillit/temp/make-plan/p3_a4_wp1_eliminate_backend_name_plan_2026-06-01_070300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 62 | 8.7k | 864.8k | 64.8k | 43 | 52.0k | 4m 22s |
| verify* | sonnet | 1 | 92 | 13.6k | 456.6k | 55.9k | 30 | 39.4k | 5m 9s |
| implement* | sonnet | 1 | 98.3k | 3.5k | 624.4k | 51.2k | 34 | 0 | 2m 37s |
| audit_impl* | sonnet | 1 | 815 | 3.6k | 136.9k | 32.7k | 16 | 19.9k | 2m 10s |
| prepare_pr* | sonnet | 1 | 115.8k | 3.8k | 206.1k | 44.5k | 19 | 0 | 2m 50s |
| compose_pr* | sonnet | 1 | 68.3k | 1.1k | 151.6k | 37.9k | 11 | 0 | 60s |
| review_pr* | sonnet | 3 | 398 | 28.8k | 1.9M | 51.4k | 128 | 99.8k | 8m 39s |
| **Total** | | | 283.8k | 63.1k | 4.4M | 64.8k | | 211.1k | 26m 51s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 6 | 104058.5 | 0.0 | 575.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **6** | 728421.2 | 35180.5 | 10524.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 62 | 8.7k | 864.8k | 52.0k | 4m 22s |
| sonnet | 6 | 283.7k | 54.5k | 3.5M | 159.1k | 22m 28s |