### PR TITLE
P3-A6-WP1 — Add Tests for channel_b_capable Codex Log Dispatch

### DIFF
--- a/tests/execution/test_backend_dispatch.py
+++ b/tests/execution/test_backend_dispatch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -271,3 +272,121 @@ class TestStepBackendOverride:
         executor = InMemoryHeadlessExecutor()
         await executor.run("/test", "/tmp", backend_override="codex")
         assert executor.calls[0].backend_override == "codex"
+
+
+def _patch_for_flush(monkeypatch, tmp_path, skill_result):
+    """Monkeypatch internals so _execute_claude_headless reaches flush_session_log.
+
+    Mirrors _patch_common from test_flush_provider_integration.py, minus the ctx
+    argument and the unused _sub_result shared state.
+    """
+    import autoskillit.execution.session_log as _sl_mod
+    from autoskillit.execution.headless import PostSessionMetrics
+
+    sub_result = SubprocessResult(
+        returncode=1,
+        stdout="",
+        stderr="",
+        termination=TerminationReason.NATURAL_EXIT,
+        pid=99,
+    )
+
+    async def fake_runner(cmd, **kwargs):  # noqa: ARG001
+        return sub_result
+
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._headless_execute._build_skill_result",
+        lambda *a, **kw: skill_result,  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._headless_execute._compute_post_session_metrics",
+        lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._headless_execute._capture_git_head_sha",
+        lambda *a: "",  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._headless_execute.collect_version_snapshot",
+        lambda: {},
+    )
+
+    flush_calls: list[dict] = []
+    monkeypatch.setattr(_sl_mod, "flush_session_log", lambda **kw: flush_calls.append(kw))
+    return fake_runner, flush_calls
+
+
+class TestCodexLogDispatch:
+    """Verify channel_b_capable drives codex log dispatch to flush_session_log."""
+
+    @pytest.mark.anyio
+    async def test_channel_b_false_dispatches_codex_log_via_locate_session(
+        self, minimal_ctx, tmp_path, monkeypatch
+    ):
+        from autoskillit.core.types import CmdSpec
+        from autoskillit.execution.headless._headless_execute import _execute_claude_headless
+
+        result = SkillResult(
+            success=False,
+            result="",
+            session_id="sid-1",
+            subtype="error",
+            is_error=True,
+            exit_code=1,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+            stderr="",
+        )
+        backend = _mock_backend(channel_b_capable=False, process_name="codex")
+        backend.name = "codex"
+        sentinel = Path("/sentinel/codex.jsonl")
+        backend.session_locator().locate_session.return_value = sentinel
+
+        fake_runner, flush_calls = _patch_for_flush(monkeypatch, tmp_path, result)
+        minimal_ctx.runner = fake_runner  # type: ignore[assignment]
+        minimal_ctx.backend = _mock_backend()
+
+        await _execute_claude_headless(
+            CmdSpec(cmd=("codex", "--quiet", "test"), env={}),
+            str(tmp_path),
+            minimal_ctx,
+            timeout=30.0,
+            stale_threshold=5.0,
+            step_backend=backend,
+        )
+
+        backend.session_locator().locate_session.assert_called_once_with("sid-1")
+        assert flush_calls[0]["codex_log_path"] == sentinel
+
+    @pytest.mark.anyio
+    async def test_channel_b_true_skips_session_locator(self, minimal_ctx, tmp_path, monkeypatch):
+        from autoskillit.core.types import CmdSpec
+        from autoskillit.execution.headless._headless_execute import _execute_claude_headless
+
+        result = SkillResult(
+            success=False,
+            result="",
+            session_id="sid-2",
+            subtype="error",
+            is_error=True,
+            exit_code=1,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+            stderr="",
+        )
+        backend = _mock_backend(channel_b_capable=True)
+        fake_runner, flush_calls = _patch_for_flush(monkeypatch, tmp_path, result)
+        minimal_ctx.runner = fake_runner  # type: ignore[assignment]
+        minimal_ctx.backend = backend
+
+        await _execute_claude_headless(
+            CmdSpec(cmd=("claude", "--print", "test"), env={}),
+            str(tmp_path),
+            minimal_ctx,
+            timeout=30.0,
+            stale_threshold=5.0,
+            step_backend=backend,
+        )
+
+        backend.session_locator.assert_not_called()
+        assert flush_calls[0]["codex_log_path"] is None


### PR DESCRIPTION
## Summary

The production code change described in issue #3114 is **already implemented**: line 488 of `_headless_execute.py` already reads `if not _step_backend.capabilities.channel_b_capable and skill_result.session_id:` and `AGENT_BACKEND_CODEX` does not appear anywhere in the file (no import, no usage). The remaining deliverable is the two test methods in `tests/execution/test_backend_dispatch.py` that verify the capability-driven codex log dispatch branch.

The two tests will:
1. **`channel_b_capable=False`**: Given a backend without Channel B and a session-ID-bearing `SkillResult`, assert `session_locator().locate_session()` is called exactly once and its return value reaches `flush_session_log` as `codex_log_path`.
2. **`channel_b_capable=True`**: Given a Channel-B-capable backend, assert `session_locator()` is never called and `flush_session_log` receives `codex_log_path=None`.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260601-064946-582554/.autoskillit/temp/make-plan/p3-a6-wp1-replace-string-identity-guard_plan_2026-06-01_070300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 3.6k | 9.8k | 1.1M | 70.4k | 48 | 58.0k | 5m 7s |
| verify* | sonnet | 1 | 62 | 11.4k | 250.1k | 52.6k | 21 | 36.1k | 5m 28s |
| implement* | sonnet | 1 | 261.8k | 11.5k | 1.2M | 75.1k | 62 | 0 | 12m 52s |
| audit_impl* | sonnet | 1 | 36 | 3.3k | 104.0k | 31.3k | 12 | 21.0k | 1m 0s |
| prepare_pr* | sonnet | 1 | 82.3k | 2.6k | 318.8k | 43.5k | 14 | 0 | 1m 53s |
| compose_pr* | sonnet | 1 | 105.9k | 1.2k | 77.1k | 37.8k | 12 | 0 | 56s |
| review_pr* | sonnet | 1 | 116 | 16.6k | 608.6k | 60.0k | 35 | 44.4k | 4m 48s |
| resolve_review* | sonnet | 1 | 157 | 13.0k | 1.1M | 75.6k | 42 | 59.9k | 5m 12s |
| **Total** | | | 454.1k | 69.4k | 4.7M | 75.6k | | 219.4k | 37m 19s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 119 | 10159.3 | 0.0 | 96.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **119** | 39651.4 | 1844.1 | 583.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 3.6k | 9.8k | 1.1M | 58.0k | 5m 7s |
| sonnet | 7 | 450.5k | 59.6k | 3.6M | 161.5k | 32m 12s |