### PR TITLE
P3-A7-WP1: replace env-var backend check in recording.py with capability

### DIFF
--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -15,7 +15,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from autoskillit.core import (
-    AGENT_BACKEND_ENV_VAR,
+    CLAUDE_CODE_CAPABILITIES,
+    BackendCapabilities,
     SubprocessResult,
     SubprocessRunner,
     TerminationReason,
@@ -79,10 +80,11 @@ class RecordingSubprocessRunner(SubprocessRunner):
        delegates to ``ScenarioRecorder.record_step()`` which spawns the real subprocess
        under PTY capture, then constructs a ``SubprocessResult`` from the cassette.
     2. **Non-PTY Codex session** (``step_name`` + ``pty_mode=False`` +
-       ``AUTOSKILLIT_AGENT_BACKEND=codex``): delegates to the inner runner, writes
+       ``capabilities.pty_required=False``): delegates to the inner runner, writes
        ``codex_stdout.ndjson`` and ``step_meta.json`` cassette files, then records via
        ``recorder.record_non_session_step(tool='run_skill')``.
-    3. **Non-session command** (``step_name`` + ``pty_mode=False`` + non-Codex backend):
+    3. **Non-session command** (``step_name`` + ``pty_mode=False`` +
+       ``capabilities.pty_required=True``):
        delegates to the inner runner, then records a summary via
        ``recorder.record_non_session_step(tool='run_cmd')``.
     4. **Untracked** (no ``step_name``): passes through to inner runner unrecorded.
@@ -99,9 +101,12 @@ class RecordingSubprocessRunner(SubprocessRunner):
         inner: SubprocessRunner | None = None,
         *,
         scenario_dir: Path | None = None,
+        capabilities: BackendCapabilities = CLAUDE_CODE_CAPABILITIES,
     ) -> None:
         self.recorder = recorder
         self._scenario_dir = scenario_dir
+        self._capabilities = capabilities
+        self._backend_name = "claude-code" if capabilities.pty_required else "codex"
         if inner is None:
             from autoskillit.execution.process import DefaultSubprocessRunner
 
@@ -144,12 +149,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
                     session_log_dir=session_log_dir,
                 )
 
-            # Non-PTY session step — use AUTOSKILLIT_AGENT_BACKEND as the
-            # discriminator; it is the most explicit signal and avoids cmd[0]
-            # fragility.  Codex backends are definitionally non-PTY
-            # (CodexBackend.capabilities.pty_required=False), so this branch
-            # is only reachable when pty_mode=False.
-            if (env or {}).get(AGENT_BACKEND_ENV_VAR, "") == "codex":
+            if not self._capabilities.pty_required:
                 return await self._record_non_pty_session(
                     cmd=cmd,
                     cwd=cwd,
@@ -347,7 +347,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
             atomic_write(cassette_dir / "codex_stdout.ndjson", ndjson_content)
 
             meta = {
-                "backend": "codex",
+                "backend": self._backend_name,
                 "model": _extract_model(cmd),
                 "exit_code": result.returncode,
                 "duration_ms": int(result.elapsed_seconds * 1000),

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -207,6 +207,28 @@ def make_context(
 
         runner = DefaultSubprocessRunner()
 
+    from autoskillit.execution import get_backend  # lazy: avoids execution init on server import
+    from autoskillit.fleet import (  # lazy: avoids fleet init on server import
+        FleetSemaphore,
+        build_protected_campaign_ids,
+    )
+
+    backend = get_backend(config.agent_backend.backend)
+
+    if is_feature_enabled(
+        "codex_backend", config.features, experimental_enabled=config.experimental_enabled
+    ):
+        if config.agent_backend.backend == "codex":
+            from autoskillit.execution import CodexBackend
+
+            backend = CodexBackend()
+        else:
+            logger.warning(
+                "codex_backend_flag_ignored",
+                reason="config.agent_backend.backend is not 'codex'",
+                configured_backend=config.agent_backend.backend,
+            )
+
     if runner is not None and os.environ.get(REPLAY_SCENARIO_ENV):
         if config.agent_backend.backend != "claude-code":
             logger.warning(
@@ -264,6 +286,7 @@ def make_context(
                             recorder=recorder,
                             inner=runner,
                             scenario_dir=Path(scenario_dir),
+                            capabilities=backend.capabilities,
                         )
 
     # Lazy token resolution: config → GITHUB_TOKEN env var → gh CLI → None.
@@ -305,28 +328,6 @@ def make_context(
     )
     ephemeral_root = resolve_ephemeral_root()
     session_mgr = DefaultSessionSkillManager(provider, ephemeral_root)
-
-    from autoskillit.execution import get_backend  # lazy: avoids execution init on server import
-    from autoskillit.fleet import (  # lazy: avoids fleet init on server import
-        FleetSemaphore,
-        build_protected_campaign_ids,
-    )
-
-    backend = get_backend(config.agent_backend.backend)
-
-    if is_feature_enabled(
-        "codex_backend", config.features, experimental_enabled=config.experimental_enabled
-    ):
-        if config.agent_backend.backend == "codex":
-            from autoskillit.execution import CodexBackend
-
-            backend = CodexBackend()
-        else:
-            logger.warning(
-                "codex_backend_flag_ignored",
-                reason="config.agent_backend.backend is not 'codex'",
-                configured_backend=config.agent_backend.backend,
-            )
 
     audit = DefaultAuditLog()
     github_api_log = DefaultGitHubApiLog()

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -18,6 +18,7 @@ from typing import Any
 from autoskillit.config import AutomationConfig
 from autoskillit.core import (
     MARKETPLACE_PREFIX,
+    CodingAgentBackend,
     DirectInstall,
     FleetLock,
     MarketplaceInstall,
@@ -213,16 +214,16 @@ def make_context(
         build_protected_campaign_ids,
     )
 
-    backend = get_backend(config.agent_backend.backend)
-
-    if is_feature_enabled(
+    _codex_feature_enabled = is_feature_enabled(
         "codex_backend", config.features, experimental_enabled=config.experimental_enabled
-    ):
-        if config.agent_backend.backend == "codex":
-            from autoskillit.execution import CodexBackend
+    )
+    if _codex_feature_enabled and config.agent_backend.backend == "codex":
+        from autoskillit.execution import CodexBackend
 
-            backend = CodexBackend()
-        else:
+        backend: CodingAgentBackend = CodexBackend()
+    else:
+        backend = get_backend(config.agent_backend.backend)
+        if _codex_feature_enabled:
             logger.warning(
                 "codex_backend_flag_ignored",
                 reason="config.agent_backend.backend is not 'codex'",

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -203,7 +203,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "_type_helpers": frozenset({"core", "execution", "fleet", "pipeline", "recipe", "server"}),
     "_type_protocols_workspace": frozenset({"core", "pipeline", "recipe", "workspace"}),
     "_type_protocols_backend": frozenset(
-        {"_llm_triage", "cli", "core", "execution", "pipeline", "workspace"}
+        {"_llm_triage", "cli", "core", "execution", "pipeline", "server", "workspace"}
     ),
     "_install_detect": frozenset({"core", "cli", "config"}),
     "_linux_proc": frozenset({"core", "execution", "fleet", "cli"}),

--- a/tests/arch/test_no_backend_name_bypass.py
+++ b/tests/arch/test_no_backend_name_bypass.py
@@ -15,7 +15,7 @@ _EXEMPT_FILES: frozenset[str] = frozenset(
         "cli/doctor/_doctor_mcp.py",  # MCP config path checks
         "cli/_init_helpers.py",  # CLI init — string config, no CodingAgentBackend
         "cli/_marketplace.py",  # Marketplace — Claude Code-only install guard
-        "execution/recording.py",  # Cassette format detection + env-var PTY guard
+        "execution/recording.py",  # Replay setup: fmt == "codex" Compare for player selection
         "execution/headless/_headless_evidence.py",  # Claude-specific evidence extraction
         "execution/headless/_headless_result.py",  # Claude-specific result parsing
         "server/tools/tools_execution.py",  # Provider-override backend routing

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from autoskillit.core import AGENT_BACKEND_ENV_VAR
+from autoskillit.core import CLAUDE_CODE_CAPABILITIES, BackendCapabilities
 from autoskillit.core.types import (
     DirectInstall,
     OutputFormat,
@@ -31,6 +31,20 @@ from tests.fakes import MockSubprocessRunner
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 _api_sim_claude = pytest.importorskip("api_simulator.claude")
+
+_NON_PTY_CAPABILITIES = BackendCapabilities(
+    pty_required=False,
+    channel_b_capable=False,
+    session_resume_capable=True,
+    skill_injection_capable=True,
+    supports_thinking_blocks=False,
+    supports_claude_format_stdout=False,
+    exit_code_is_terminal=True,
+    mcp_config_capable=True,
+    food_truck_capable=True,
+    completion_record_types=frozenset({"turn.completed", "turn.failed", "error"}),
+    session_record_types=frozenset({"item.completed"}),
+)
 
 
 @dataclass
@@ -420,6 +434,36 @@ def test_recording_runner_recorder_is_public():
     assert runner.recorder is mock_recorder
 
 
+# --- T-CAPABILITIES-STORED: capabilities stored on construction ---
+
+
+def test_recording_runner_stores_capabilities():
+    """RecordingSubprocessRunner stores capabilities as _capabilities."""
+    mock_recorder = Mock()
+    runner = RecordingSubprocessRunner(recorder=mock_recorder)
+    assert runner._capabilities is CLAUDE_CODE_CAPABILITIES
+
+
+# --- T-BACKEND-NAME-PTY: default capabilities derives 'claude-code' ---
+
+
+def test_recording_runner_backend_name_pty():
+    """Default CLAUDE_CODE_CAPABILITIES derives _backend_name='claude-code'."""
+    mock_recorder = Mock()
+    runner = RecordingSubprocessRunner(recorder=mock_recorder)
+    assert runner._backend_name == "claude-code"
+
+
+# --- T-BACKEND-NAME-NONPTY: non-PTY capabilities derives 'codex' ---
+
+
+def test_recording_runner_backend_name_nonpty():
+    """BackendCapabilities(pty_required=False) derives _backend_name='codex'."""
+    mock_recorder = Mock()
+    runner = RecordingSubprocessRunner(recorder=mock_recorder, capabilities=_NON_PTY_CAPABILITIES)
+    assert runner._backend_name == "codex"
+
+
 # --- T-REPLAY-PLAYER: player attribute stored ---
 
 
@@ -750,12 +794,16 @@ async def test_nonpty_dispatch_routes_to_record_non_pty_session(tmp_path):
     mock_recorder = Mock()
     inner = MockSubprocessRunner()
     inner.set_default(_make_result(returncode=0, stdout="codex output"))
-    runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner, scenario_dir=tmp_path)
+    runner = RecordingSubprocessRunner(
+        recorder=mock_recorder,
+        inner=inner,
+        scenario_dir=tmp_path,
+        capabilities=_NON_PTY_CAPABILITIES,
+    )
 
     cmd = ["codex", "exec", "--model", "o3", "implement the thing"]
     env = {
         "SCENARIO_STEP_NAME": "codex-step",
-        AGENT_BACKEND_ENV_VAR: "codex",
     }
 
     result = await runner(cmd, cwd=Path("/tmp"), timeout=300, env=env, pty_mode=False)
@@ -791,11 +839,14 @@ async def test_nonpty_cassettes_written(tmp_path):
     inner = MockSubprocessRunner()
     inner.set_default(expected)
     runner = RecordingSubprocessRunner(
-        recorder=mock_recorder, inner=inner, scenario_dir=scenario_dir
+        recorder=mock_recorder,
+        inner=inner,
+        scenario_dir=scenario_dir,
+        capabilities=_NON_PTY_CAPABILITIES,
     )
 
     cmd = ["codex", "exec", "--model", "o3", "go"]
-    env = {"SCENARIO_STEP_NAME": "codex-step", AGENT_BACKEND_ENV_VAR: "codex"}
+    env = {"SCENARIO_STEP_NAME": "codex-step"}
 
     await runner(cmd, cwd=Path("/tmp"), timeout=300, env=env, pty_mode=False)
 
@@ -828,10 +879,15 @@ async def test_nonpty_result_passthrough(tmp_path):
     expected = _make_result(returncode=42, stdout="raw codex out")
     inner = MockSubprocessRunner()
     inner.set_default(expected)
-    runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner, scenario_dir=tmp_path)
+    runner = RecordingSubprocessRunner(
+        recorder=mock_recorder,
+        inner=inner,
+        scenario_dir=tmp_path,
+        capabilities=_NON_PTY_CAPABILITIES,
+    )
 
     cmd = ["codex", "exec", "--model", "o3", "go"]
-    env = {"SCENARIO_STEP_NAME": "step", AGENT_BACKEND_ENV_VAR: "codex"}
+    env = {"SCENARIO_STEP_NAME": "step"}
 
     result = await runner(cmd, cwd=Path("/tmp"), timeout=300, env=env, pty_mode=False)
 
@@ -875,10 +931,14 @@ async def test_nonpty_no_step_name_skips_recording():
     mock_recorder = Mock()
     inner = MockSubprocessRunner()
     inner.set_default(_make_result(returncode=0))
-    runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
+    runner = RecordingSubprocessRunner(
+        recorder=mock_recorder,
+        inner=inner,
+        capabilities=_NON_PTY_CAPABILITIES,
+    )
 
     cmd = ["codex", "exec", "do something"]
-    env = {AGENT_BACKEND_ENV_VAR: "codex"}
+    env = {}
 
     await runner(cmd, cwd=Path("/tmp"), timeout=60, env=env, pty_mode=False)
 

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -177,7 +177,7 @@ class TestModuleCascadeCore:
 
     def test_type_protocols_backend_cascade(self) -> None:
         assert MODULE_CASCADE_CORE["_type_protocols_backend"] == frozenset(
-            {"core", "execution", "pipeline", "cli", "workspace", "_llm_triage"}
+            {"core", "execution", "pipeline", "cli", "workspace", "_llm_triage", "server"}
         )
 
     def test_json_cascade(self) -> None:
@@ -554,7 +554,7 @@ class TestBuildTestScopeCoreCascade:
 
     def test_type_protocols_backend_narrow_cascade(self, tmp_path: Path) -> None:
         """_type_protocols_backend -> cascade of
-        {"core", "execution", "pipeline", "cli", "workspace"} only."""
+        {"core", "execution", "pipeline", "cli", "workspace", "server"} only."""
         tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
         result = build_test_scope(
             changed_files={"src/autoskillit/core/types/_type_protocols_backend.py"},


### PR DESCRIPTION
## Summary

Replace the env-var string comparison `(env or {}).get(AGENT_BACKEND_ENV_VAR, "") == "codex"` at `recording.py:152` with a capability-field check `not self._capabilities.pty_required`. Add a `capabilities: BackendCapabilities` parameter to `RecordingSubprocessRunner.__init__` (defaulting to `CLAUDE_CODE_CAPABILITIES`), derive `_backend_name` from it for the step_meta `"backend"` field, move the backend resolution block in `_factory.py` before the runner setup so `backend.capabilities` is available at construction time, and update tests to pass capabilities via the constructor instead of injecting the env var.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260601-084532-395521/.autoskillit/temp/make-plan/p3_a7_wp1_eliminate_backend_env_var_check_plan_2026-06-01_090500.md`

Closes #3115

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 80 | 20.4k | 1.3M | 110.8k | 40 | 100.2k | 11m 50s |
| verify* | sonnet | 1 | 84 | 11.0k | 422.1k | 54.9k | 30 | 38.4k | 5m 40s |
| implement* | sonnet | 1 | 206.1k | 10.5k | 3.2M | 81.8k | 102 | 0 | 9m 53s |
| audit_impl* | sonnet | 1 | 935 | 4.8k | 104.9k | 32.8k | 12 | 24.1k | 2m 32s |
| prepare_pr* | sonnet | 1 | 124.2k | 3.8k | 289.1k | 47.1k | 16 | 0 | 2m 22s |
| compose_pr* | sonnet | 1 | 108.7k | 1.0k | 117.5k | 39.4k | 12 | 0 | 1m 3s |
| review_pr* | sonnet | 1 | 172 | 29.0k | 1.0M | 74.1k | 48 | 58.2k | 7m 51s |
| resolve_review* | sonnet | 1 | 325 | 27.2k | 3.8M | 123.0k | 103 | 107.6k | 17m 14s |
| **Total** | | | 440.7k | 107.8k | 10.3M | 123.0k | | 328.5k | 58m 28s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 145 | 22372.4 | 0.0 | 72.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 23 | 165220.7 | 4676.5 | 1182.3 |
| **Total** | **168** | 61090.6 | 1955.4 | 641.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 80 | 20.4k | 1.3M | 100.2k | 11m 50s |
| sonnet | 7 | 440.6k | 87.4k | 9.0M | 228.3k | 46m 38s |