### PR TITLE
Rectify: `.pyi` Stub Format Immunity — Pre-commit Structural Gate and Test Hardening

### DIFF
--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -212,6 +212,8 @@ scripts/recipe_contract_freshness.py:
   - hooks/
 scripts/regen_contracts.py:
   - infra/
+scripts/check_pyi_stub_format.py:
+  - infra/
 scripts/sync_versions.py:
   - infra/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,13 @@ repos:
         files: ^src/autoskillit/recipes/(?!contracts/).*\.yaml$
         pass_filenames: false
 
+      - id: check-pyi-stub-format
+        name: Check __init__.pyi stub format
+        language: system
+        entry: python scripts/check_pyi_stub_format.py
+        files: __init__\.pyi$
+        pass_filenames: false
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/scripts/check_pyi_stub_format.py
+++ b/scripts/check_pyi_stub_format.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Validate __init__.pyi stub files contain only relative re-export imports.
+
+AST-scans __init__.pyi files and rejects any top-level statement that is not
+an ast.ImportFrom with level == 1 (relative) and alias.asname == alias.name
+(explicit re-export form).
+
+lazy_loader.attach_stub() uses _StubVisitor which only implements visit_ImportFrom.
+Any other AST node type is silently ignored — the symbol is absent from __all__
+and invisible at runtime.
+
+Exit 0 if all stubs are valid. Exit 1 with details on violations.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "autoskillit"
+
+
+def check_file(path: Path) -> list[str]:
+    violations = []
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            if node.level != 1:
+                violations.append(
+                    f"{path.name}:{node.lineno}: import level {node.level} "
+                    f"(must be 1: from .X import Y as Y)"
+                )
+            for alias in node.names:
+                if alias.asname != alias.name:
+                    violations.append(
+                        f"{path.name}:{node.lineno}: '{alias.name}' missing 'as' form "
+                        f"(must be: from .{node.module} import {alias.name} as {alias.name})"
+                    )
+        else:
+            violations.append(
+                f"{path.name}:{node.lineno}: {type(node).__name__} not allowed. "
+                f"Only 'from .module import Name as Name' lines are valid. "
+                f"lazy_loader.attach_stub() silently ignores {type(node).__name__} statements. "
+                f"Add: from .module import {_guess_name(node)} as {_guess_name(node)}"
+            )
+    return violations
+
+
+def _guess_name(node: ast.stmt) -> str:
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return node.name
+    return "<Name>"
+
+
+def check() -> list[str]:
+    violations = []
+    for path in sorted(SRC_ROOT.rglob("__init__.pyi")):
+        violations.extend(check_file(path))
+    return violations
+
+
+def main() -> int:
+    violations = check()
+    if violations:
+        print("__init__.pyi stub format violations:\n")
+        for v in violations:
+            print(f"  {v}")
+        print(
+            "\n__init__.pyi stubs used with lazy_loader.attach_stub() must contain ONLY:\n"
+            "  from .module import Name as Name\n\n"
+            "def/class/assign statements are silently ignored by lazy_loader._StubVisitor."
+        )
+        return 1
+    print("All __init__.pyi stubs valid: re-export only.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -13,7 +13,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `conftest.py` | Arch conftest — shared fixtures for AST-based tests |
 | `test_anyio_migration.py` | Regression guards for the asyncio→anyio migration (C-6) |
 | `test_arch_deselection.py` | Tests for diff-aware parametrized deselection — REQ-ARCH-004 |
-| `test_ast_rules.py` | Architectural enforcement: AST-based visitor rules (ARCH-001 through ARCH-009) |
+| `test_ast_rules.py` | Architectural enforcement: AST-based visitor rules (ARCH-001 through ARCH-011) |
 | `test_backend_flag_isolation.py` | AST guard: ClaudeFlags must not appear in _session_launch.py — backend-specific flags belong inside each backend's build_interactive_cmd() |
 | `test_backend_coherence.py` | Architectural tests for backend coherence enforcement |
 | `test_canonical_constant_consumption.py` | Architectural invariant: every *_ENV_FORWARD_VARS constant must have a production consumer |

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -173,7 +173,7 @@ _DISPATCH_TABLE_EXEMPT_FUNCTIONS = frozenset(
     }
 )
 
-# ── RULES tuple — 10 entries ──────────────────────────────────────────────────
+# ── RULES tuple — 11 entries ──────────────────────────────────────────────────
 
 RULES: tuple[RuleDescriptor, ...] = (
     RuleDescriptor(
@@ -354,6 +354,26 @@ RULES: tuple[RuleDescriptor, ...] = (
         exemptions=frozenset(),
         severity="error",
         defense_standard="DS-010",
+    ),
+    RuleDescriptor(
+        rule_id="ARCH-011",
+        name="pyi-stub-reexport-only",
+        lens="development",
+        description=(
+            "__init__.pyi stub files must contain only 'from .X import Y as Y' re-export lines. "
+            "No def, class, assign, or other statement types."
+        ),
+        rationale=(
+            "lazy_loader.attach_stub() uses _StubVisitor which only implements visit_ImportFrom. "
+            "Any other AST node type (FunctionDef, ClassDef, Assign, AnnAssign) is silently "
+            "ignored by ast.NodeVisitor.generic_visit — the symbol is absent from __all__ and "
+            "invisible at runtime. An agent inserting 'def foo(): ...' gets no feedback from "
+            "the existing tests (which only iterate ImportFrom nodes) and spirals through retries."
+            " This rule makes the constraint AST-enforceable at the development layer."
+        ),
+        exemptions=frozenset(),
+        severity="error",
+        defense_standard="DS-011",
     ),
 )
 

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -1008,3 +1008,43 @@ class TestArch010Enforcement:
             f"ARCH-010 violations in {test_file.relative_to(Path(__file__).parent.parent)}:\n"
             + "\n".join(f"  {v}" for v in violations)
         )
+
+
+# ── ARCH-011: pyi stub re-export only ─────────────────────────────────────────
+
+
+def test_pyi_stub_only_reexports() -> None:
+    """ARCH-011: __init__.pyi stub files must contain only 'from .X import Y as Y' lines.
+
+    lazy_loader.attach_stub() uses _StubVisitor which only processes ImportFrom nodes.
+    Any other statement type (def, class, assign) is silently ignored, causing the
+    symbol to be absent from __all__ and invisible at runtime.
+    """
+    violations: list[str] = []
+    for pyi_file in SRC_ROOT.rglob("__init__.pyi"):
+        source = pyi_file.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(pyi_file))
+        for node in tree.body:
+            if isinstance(node, ast.ImportFrom):
+                if node.level != 1:
+                    violations.append(
+                        f"  {_rel(pyi_file)}:{node.lineno}: "
+                        f"import level {node.level} (must be 1: from .X import Y as Y)"
+                    )
+                for alias in node.names:
+                    if alias.asname != alias.name:
+                        violations.append(
+                            f"  {_rel(pyi_file)}:{node.lineno}: "
+                            f"missing 'as' form: {alias.name} "
+                            f"(must be {alias.name} as {alias.name})"
+                        )
+            else:
+                violations.append(
+                    f"  {_rel(pyi_file)}:{node.lineno}: "
+                    f"{type(node).__name__} not allowed — only 'from .X import Y as Y' lines. "
+                    f"lazy_loader.attach_stub() silently ignores {type(node).__name__} statements."
+                )
+    assert not violations, (
+        "ARCH-011: __init__.pyi stubs must contain only relative re-export imports "
+        "(from .module import Name as Name):\n" + "\n".join(violations)
+    )

--- a/tests/arch/test_registry.py
+++ b/tests/arch/test_registry.py
@@ -101,6 +101,7 @@ def test_rule_registry_completeness() -> None:
             "ARCH-008",
             "ARCH-009",
             "ARCH-010",
+            "ARCH-011",
         }
     )
     actual_ids = frozenset(rule_ids)

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -89,6 +89,16 @@ def test_core_pyi_uses_as_form():
 
     pyi = pkg_root() / "core" / "__init__.pyi"
     tree = ast.parse(pyi.read_text())
+
+    # Guard: no non-import statements allowed (lazy_loader ignores them)
+    for node in tree.body:
+        assert isinstance(node, ast.ImportFrom), (
+            f"core/__init__.pyi line {node.lineno}: {type(node).__name__} not allowed. "
+            f"Only 'from .module import Name as Name' lines are valid. "
+            f"lazy_loader.attach_stub() silently ignores {type(node).__name__} statements."
+        )
+
+    # Existing: verify all imports use 'as' form
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             for alias in node.names:

--- a/tests/infra/CLAUDE.md
+++ b/tests/infra/CLAUDE.md
@@ -17,6 +17,7 @@ CI/CD configuration, security, guard coverage, and release sanity tests.
 | `test_ask_user_question_guard.py` | Tests for the ask_user_question_guard PreToolUse hook |
 | `test_branch_protection_guard.py` | Tests for hooks/branch_protection_guard.py — PreToolUse branch protection |
 | `test_claude_md_critical_rules.py` | Tests that CLAUDE.md contains required critical rules from friction analysis |
+| `test_check_pyi_stub_format.py` | Unit tests for scripts/check_pyi_stub_format.py pre-commit hook — validates FunctionDef, ClassDef, and non-relative import rejection |
 | `test_ci_dev_config.py` | Structural enforcement: CI workflow and pre-commit configuration must contain required quality gates |
 | `test_ci_workflow.py` | CI workflow structural tests |
 | `test_ci_shard_config.py` | Tests for CI shard directory configuration consistency |

--- a/tests/infra/test_check_pyi_stub_format.py
+++ b/tests/infra/test_check_pyi_stub_format.py
@@ -1,0 +1,66 @@
+"""Tests for scripts/check_pyi_stub_format.py pre-commit hook."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from autoskillit.core.paths import pkg_root
+
+pytestmark = [pytest.mark.layer("infra"), pytest.mark.small]
+
+
+def _load_check_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_pyi_stub_format",
+        pkg_root().parent.parent / "scripts" / "check_pyi_stub_format.py",
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+def test_check_pyi_rejects_function_def(tmp_path):
+    """The pre-commit hook must reject def statements in __init__.pyi."""
+    pyi = tmp_path / "__init__.pyi"
+    pyi.write_text("from .foo import bar as bar\ndef baz(): ...\n")
+
+    mod = _load_check_module()
+    violations = mod.check_file(pyi)
+    assert len(violations) == 1
+    assert "FunctionDef" in violations[0]
+
+
+def test_check_pyi_accepts_valid_file(tmp_path):
+    """The pre-commit hook must accept a valid re-export-only pyi."""
+    pyi = tmp_path / "__init__.pyi"
+    pyi.write_text("from .foo import bar as bar\nfrom .baz import qux as qux\n")
+
+    mod = _load_check_module()
+    violations = mod.check_file(pyi)
+    assert violations == []
+
+
+def test_check_pyi_rejects_class_def(tmp_path):
+    """The pre-commit hook must reject class statements in __init__.pyi."""
+    pyi = tmp_path / "__init__.pyi"
+    pyi.write_text("from .foo import bar as bar\nclass Baz: ...\n")
+
+    mod = _load_check_module()
+    violations = mod.check_file(pyi)
+    assert len(violations) == 1
+    assert "ClassDef" in violations[0]
+
+
+def test_check_pyi_rejects_non_relative_import(tmp_path):
+    """The pre-commit hook must reject absolute imports in __init__.pyi."""
+    pyi = tmp_path / "__init__.pyi"
+    pyi.write_text("from typing import Any\n")
+
+    mod = _load_check_module()
+    violations = mod.check_file(pyi)
+    assert len(violations) == 1
+    assert "level 0" in violations[0]

--- a/tests/infra/test_check_pyi_stub_format.py
+++ b/tests/infra/test_check_pyi_stub_format.py
@@ -62,5 +62,5 @@ def test_check_pyi_rejects_non_relative_import(tmp_path):
 
     mod = _load_check_module()
     violations = mod.check_file(pyi)
-    assert len(violations) == 1
-    assert "level 0" in violations[0]
+    assert len(violations) >= 1
+    assert any("level 0" in v for v in violations)


### PR DESCRIPTION
## Summary

An agent inserted a `def collect_version_snapshot(...)` statement into `core/__init__.pyi` instead of the required `from ._version_snapshot import collect_version_snapshot as collect_version_snapshot` re-export line. The `lazy_loader._StubVisitor` silently ignores non-`ImportFrom` AST nodes, so the function was invisible at runtime. Six existing tests in `tests/core/test_core.py` all missed the bug because they only iterate `ast.ImportFrom` nodes — a `FunctionDef` or `ClassDef` is invisible to them. No pre-commit hook validates `.pyi` structure. The `lint_after_edit_hook.py` explicitly skips `.pyi` files. Ruff hooks use `types: [python]` which excludes `.pyi` files (tagged `pyi`, not `python`). The agent spiraled through ~8 retries over 600s with no actionable guidance.

The fix is a three-layer structural immunity:

1. **Test hardening** — A new `ARCH-011` rule that asserts every top-level node in any `__init__.pyi` file is `ast.ImportFrom` with `level == 1` and `alias.asname == alias.name`. This catches the bug class in `task test-all` with an actionable error message.
2. **Pre-commit gate** — A new `scripts/check_pyi_stub_format.py` hook (modeled on `check_tool_annotations.py`) that fires at commit time, before the full test suite, with a clear error message telling the agent the exact pattern to use.
3. **Existing test fix** — Strengthen `test_core_pyi_uses_as_form` to also reject non-`ImportFrom` nodes (closing the blind spot where `ast.walk` + `isinstance(node, ast.ImportFrom)` silently skips everything else).

Closes #3528

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260601-083107-398106/.autoskillit/temp/rectify/rectify_pyi_stub_format_immunity_2026-06-01_160000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 77 | 20.1k | 2.3M | 109.5k | 71 | 144.0k | 19m 58s |
| review_approach* | sonnet | 1 | 52 | 7.7k | 204.4k | 51.3k | 16 | 37.9k | 9m 1s |
| dry_walkthrough* | opus | 1 | 48 | 13.0k | 554.9k | 59.8k | 28 | 43.1k | 5m 36s |
| implement* | sonnet | 1 | 268 | 19.4k | 2.3M | 93.5k | 93 | 77.7k | 6m 48s |
| audit_impl* | sonnet | 1 | 52 | 11.6k | 174.3k | 38.8k | 16 | 34.3k | 4m 49s |
| prepare_pr* | sonnet | 1 | 93.1k | 3.3k | 118.8k | 48.6k | 15 | 0 | 1m 56s |
| compose_pr* | sonnet | 1 | 73.9k | 1.8k | 150.2k | 39.0k | 12 | 0 | 1m 16s |
| review_pr* | sonnet | 3 | 378 | 112.9k | 2.3M | 89.7k | 139 | 202.4k | 25m 35s |
| resolve_review* | opus | 1 | 34 | 5.5k | 801.7k | 60.3k | 35 | 44.0k | 2m 27s |
| **Total** | | | 167.8k | 195.2k | 9.0M | 109.5k | | 583.5k | 1h 17m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 229 | 10125.9 | 339.5 | 84.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **229** | 39253.6 | 2548.0 | 852.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 77 | 20.1k | 2.3M | 144.0k | 19m 58s |
| sonnet | 6 | 167.7k | 156.7k | 5.3M | 352.3k | 49m 27s |
| opus | 2 | 82 | 18.4k | 1.4M | 87.1k | 8m 3s |