### PR TITLE
Rectify: Model Identity Provider-Awareness Immunity

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -265,6 +265,7 @@ from .types import MergeFailedStep as MergeFailedStep
 from .types import MergeQueueWatcher as MergeQueueWatcher
 from .types import MergeState as MergeState
 from .types import MigrationService as MigrationService
+from .types import ModelIdentity as ModelIdentity
 from .types import ModelTotalEntry as ModelTotalEntry
 from .types import NamedResume as NamedResume
 from .types import NoResume as NoResume

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -23,6 +23,7 @@ __all__ = [
     "InputSpec",
     "LoadReport",
     "LoadResult",
+    "ModelIdentity",
     "TestResult",
     "ValidatedAddDir",
     "ValidatedWorktreePath",
@@ -205,6 +206,35 @@ class ProviderOutcome:
     def none_used(cls) -> ProviderOutcome:
         """Sentinel for paths where no provider selection occurred."""
         return cls(provider_used="", fallback_activated=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ModelIdentity:
+    """Typed bundle of model identity for a headless session.
+
+    Carries both the configured Anthropic alias and the effective provider model,
+    preventing provider-unaware resolution from silently producing wrong-but-truthy values.
+    """
+
+    configured_model: str
+    effective_model: str
+    profile_name: str
+
+    @property
+    def is_anthropic(self) -> bool:
+        return not self.profile_name or self.profile_name == "anthropic"
+
+    @classmethod
+    def anthropic(cls, model: str) -> ModelIdentity:
+        return cls(configured_model=model, effective_model=model, profile_name="")
+
+    @classmethod
+    def for_provider(cls, *, configured: str, effective: str, profile: str) -> ModelIdentity:
+        return cls(configured_model=configured, effective_model=effective, profile_name=profile)
+
+    @classmethod
+    def unknown(cls) -> ModelIdentity:
+        return cls(configured_model="", effective_model="", profile_name="")
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -48,12 +48,13 @@ from autoskillit.execution.headless._headless_helpers import (
     PostSessionMetrics,
     _compute_post_session_metrics,  # noqa: F401
     _derive_step_name_from_skill_command,
-    _resolve_model,
+    _resolve_model,  # noqa: F401
     _resolve_pty_mode,  # noqa: F401
     _resolve_session_log_dir,
     _session_log_dir,  # noqa: F401
     _stat_snapshot,  # noqa: F401
     assert_interactive_ordering,
+    resolve_model_identity,
 )
 from autoskillit.execution.headless._headless_path_tokens import (  # noqa: F401
     _INTENTIONALLY_EXCLUDED_PATH_TOKENS,
@@ -155,8 +156,12 @@ async def run_headless_core(
         skill_command=original_skill_command[:SKILL_COMMAND_DISPLAY_MAX],
         step_name=step_name or None,
     ):
-        resolved_model = _resolve_model(
-            model, ctx.config, step_name=step_name, recipe_name=recipe_name
+        model_identity = resolve_model_identity(
+            model,
+            ctx.config,
+            step_name=step_name,
+            recipe_name=recipe_name,
+            profile_name=profile_name,
         )
         add_dirs_tuple = tuple(add_dirs)
         assert ctx.backend is not None, (
@@ -164,7 +169,7 @@ async def run_headless_core(
         )
         config = SkillSessionConfig(
             completion_marker=effective_marker,
-            model=resolved_model,
+            model=model_identity.configured_model or None,
             plugin_source=ctx.plugin_source,
             output_format=cfg.output_format,
             add_dirs=add_dirs_tuple,
@@ -200,7 +205,7 @@ async def run_headless_core(
         logger.debug(
             "run_headless_core_entry",
             cwd=cwd,
-            resolved_model=resolved_model,
+            resolved_model=model_identity.configured_model,
             timeout=effective_timeout,
             stale_threshold=effective_stale,
             plugin_source=repr(ctx.plugin_source),
@@ -237,8 +242,7 @@ async def run_headless_core(
             provider_fallback_name=provider_fallback_name,
             provider_extras=provider_extras,
             step_backend=step_backend,
-            model_identifier=resolved_model or "",
-            profile_name=profile_name,
+            model_identity=model_identity,
             marker_dir=marker_dir,
             session_id=caller_session_id,
         )
@@ -368,7 +372,9 @@ class DefaultHeadlessExecutor:
                 f"(food_truck_capable=False); got {self._ctx.backend.name!r}"
             )
         cfg = self._ctx.config
-        resolved_model = _resolve_model(model, cfg, step_name=step_name)
+        model_identity = resolve_model_identity(
+            model, cfg, step_name=step_name, profile_name=profile_name
+        )
         fleet_cfg = cfg.fleet
 
         merged_extras: dict[str, str] = dict(env_extras) if env_extras else {}
@@ -399,7 +405,7 @@ class DefaultHeadlessExecutor:
             completion_marker=completion_marker,
             resume_session_id=resume_session_id,
             resume_checkpoint=resume_checkpoint,
-            model=resolved_model,
+            model=model_identity.configured_model or None,
             env_extras=merged_extras or None,
             output_format=cfg.run_skill.output_format,
             exit_after_stop_delay_ms=cfg.run_skill.exit_after_stop_delay_ms,
@@ -461,6 +467,5 @@ class DefaultHeadlessExecutor:
             max_extension_seconds=effective_max_ext,
             marker_dir=effective_marker_dir,
             session_id=session_id,
-            model_identifier=resolved_model or "",
-            profile_name=profile_name,
+            model_identity=model_identity,
         )

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -19,6 +19,7 @@ from autoskillit.core import (
     CmdSpec,
     CodingAgentBackend,
     KillReason,
+    ModelIdentity,
     ProviderOutcome,
     RecipeIdentity,
     RetryReason,
@@ -107,8 +108,7 @@ async def _execute_claude_headless(
     marker_dir: Path | None = None,
     session_id: str | None = None,
     step_backend: CodingAgentBackend | None = None,
-    model_identifier: str = "",
-    profile_name: str = "",
+    model_identity: ModelIdentity = ModelIdentity.unknown(),
 ) -> SkillResult:
     """Shared subprocess execution for headless Claude sessions.
 
@@ -299,8 +299,7 @@ async def _execute_claude_headless(
                         version=recipe_version,
                     ),
                     max_sessions=ctx.config.linux_tracing.max_sessions,
-                    model_identifier=model_identifier,
-                    profile_name=profile_name,
+                    model_identity=model_identity,
                     telemetry=_build_error_path_telemetry(
                         ctx.github_api_log,
                         session_id="",
@@ -361,8 +360,7 @@ async def _execute_claude_headless(
                             version=recipe_version,
                         ),
                         max_sessions=ctx.config.linux_tracing.max_sessions,
-                        model_identifier=model_identifier,
-                        profile_name=profile_name,
+                        model_identity=model_identity,
                         telemetry=_build_error_path_telemetry(
                             ctx.github_api_log,
                             session_id="",
@@ -559,8 +557,7 @@ async def _execute_claude_headless(
                     version=recipe_version,
                 ),
                 max_sessions=ctx.config.linux_tracing.max_sessions,
-                model_identifier=model_identifier,
-                profile_name=profile_name,
+                model_identity=model_identity,
                 is_resume=spec.is_resume,
                 codex_log_path=_codex_log,
             )
@@ -588,7 +585,7 @@ async def _execute_claude_headless(
             order_id=order_id,
             loc_insertions=_metrics.loc_insertions,
             loc_deletions=_metrics.loc_deletions,
-            model=model_identifier,
+            model=model_identity.effective_model,
         )
     except Exception:
         logger.debug("token_log_record_failed", exc_info=True)

--- a/src/autoskillit/execution/headless/_headless_helpers.py
+++ b/src/autoskillit/execution/headless/_headless_helpers.py
@@ -12,6 +12,7 @@ from autoskillit.core import (
     ClaudeFlags,
     CmdSpec,
     CodingAgentBackend,
+    ModelIdentity,
     SkillResult,
     claude_code_project_dir,
     get_logger,
@@ -143,6 +144,31 @@ def _resolve_model(
         return config.model.default_model
     logger.debug("model_resolved", tier="none", model=None)
     return None
+
+
+def resolve_model_identity(
+    step_model: str,
+    config: AutomationConfig,
+    *,
+    step_name: str = "",
+    recipe_name: str = "",
+    profile_name: str = "",
+) -> ModelIdentity:
+    """Wrap _resolve_model() with provider awareness.
+
+    For non-Anthropic providers, effective_model is left empty so the downstream
+    argmax fallback in flush_session_log fires and extracts the real provider model
+    from model_breakdown.
+    """
+    resolved = _resolve_model(step_model, config, step_name=step_name, recipe_name=recipe_name)
+    configured = resolved or ""
+    if profile_name and profile_name != "anthropic":
+        return ModelIdentity.for_provider(
+            configured=configured, effective="", profile=profile_name
+        )
+    if configured:
+        return ModelIdentity.anthropic(configured)
+    return ModelIdentity.unknown()
 
 
 def _derive_step_name_from_skill_command(skill_command: str) -> str:

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 
 from autoskillit.core import (
+    ModelIdentity,
     atomic_write,
     claude_code_log_path,
     default_log_dir,
@@ -147,8 +148,7 @@ def flush_session_log(
     api_retry_last_status: int | None = None,
     api_retry_exhausted: bool = False,
     versions: dict[str, Any] | None = None,
-    model_identifier: str = "",
-    profile_name: str = "",
+    model_identity: ModelIdentity = ModelIdentity.unknown(),
     max_sessions: int | None = None,
     is_resume: bool = False,
     codex_log_path: Path | None = None,
@@ -306,9 +306,25 @@ def flush_session_log(
             }
         )
 
-    effective_model_id = model_identifier or _primary_model_identifier(token_usage)
+    effective_model_id = model_identity.effective_model or _primary_model_identifier(token_usage)
     _observed = _primary_model_identifier(token_usage) if token_usage else ""
-    anomalies.extend(detect_model_drift(model_identifier, _observed, profile_name=profile_name))
+    anomalies.extend(
+        detect_model_drift(
+            model_identity.configured_model, _observed, profile_name=model_identity.profile_name
+        )
+    )
+    if model_identity.profile_name and model_identity.profile_name != "anthropic":
+        if effective_model_id.startswith("claude-") or effective_model_id in (
+            "sonnet",
+            "opus",
+            "haiku",
+        ):
+            logger.warning(
+                "model_identity_mismatch",
+                effective_model_id=effective_model_id,
+                profile_name=model_identity.profile_name,
+                configured_model=model_identity.configured_model,
+            )
 
     # Write anomalies.jsonl (only if anomalies exist)
     if anomalies:
@@ -443,8 +459,8 @@ def flush_session_log(
             "turn_count": token_usage.get("turn_count", 0),
             "provider_used": provider_outcome.provider_used,
             "model_identifier": effective_model_id,
-            "configured_model": model_identifier,
-            "profile_name": profile_name,
+            "configured_model": model_identity.configured_model,
+            "profile_name": model_identity.profile_name,
             "dispatch_id": dispatch_id,
             "campaign_id": campaign_id,
         }
@@ -514,8 +530,8 @@ def flush_session_log(
         "api_retry_last_error": api_retry_last_error,
         "api_retry_last_status": api_retry_last_status,
         "model_identifier": effective_model_id,
-        "configured_model": model_identifier,
-        "profile_name": profile_name,
+        "configured_model": model_identity.configured_model,
+        "profile_name": model_identity.profile_name,
         "schema_version": 3,
     }
     index_path = log_root / "sessions.jsonl"

--- a/src/autoskillit/pipeline/tokens.py
+++ b/src/autoskillit/pipeline/tokens.py
@@ -318,7 +318,11 @@ class DefaultTokenLog:
             if key not in self._entries:
                 self._entries[key] = TokenEntry(step_name=step_name)
             e = self._entries[key]
-            _model = data.get("configured_model") or data.get("model_identifier", "")
+            _profile = data.get("profile_name", "")
+            if _profile and _profile != "anthropic":
+                _model = data.get("model_identifier", "") or data.get("configured_model", "")
+            else:
+                _model = data.get("configured_model") or data.get("model_identifier", "")
             if _model and not e.model:
                 e.model = _model
             e.input_tokens += data.get("input_tokens", 0)

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -657,6 +657,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "execution/test_idle_output_env.py",
             "execution/test_write_evidence.py",
             "execution/test_zero_write_detection.py",
+            "execution/test_session_log_fields.py",
             "server",
             "infra",
             "cli",
@@ -819,6 +820,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "server/test_tools_kitchen_gate.py",
             "server/test_tools_kitchen_gate_hook_config.py",
             "execution/test_quota_sleep.py",
+            "execution/test_session_log_fields.py",
         }
     ),
     "hook_registry": frozenset(

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -16,7 +16,7 @@ NEW_HEADLESS_MODULES = [
     "_headless_execute.py",
 ]
 HEADLESS_SIZE_BUDGETS = {
-    "headless/__init__.py": 470,
+    "headless/__init__.py": 472,
     "headless/_headless_helpers.py": 220,
     "headless/_headless_execute.py": 605,
     "headless/_headless_recovery.py": 366,

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -1313,6 +1313,11 @@ _TEST_LAYER_ALLOWLIST: dict[str, frozenset[str]] = {
     "tests/execution/test_headless_clone_guard_integration.py": frozenset(
         {"autoskillit.pipeline"}
     ),
+    # reader-agreement test verifies that token_summary_hook._load_sessions and
+    # DefaultTokenLog.load_from_log_dir agree on model identity after flush_session_log
+    "tests/execution/test_session_log_fields.py": frozenset(
+        {"autoskillit.hooks", "autoskillit.pipeline"}
+    ),
 }
 
 

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -321,7 +321,7 @@ def _subagent_assistant_ndjson(
 
 
 def _flush(tmp_path: Path, **overrides) -> None:
-    from autoskillit.core.types._type_results import ProviderOutcome
+    from autoskillit.core.types._type_results import ModelIdentity, ProviderOutcome
     from autoskillit.core.types._type_results_execution import (
         RecipeIdentity,
         SessionTelemetry,
@@ -347,9 +347,24 @@ def _flush(tmp_path: Path, **overrides) -> None:
         "audit_record": None,
         "loc_insertions": 0,
         "loc_deletions": 0,
-        "profile_name": "",
+        "model_identity": ModelIdentity.unknown(),
     }
     defaults.update(overrides)
+
+    # Convert legacy model_identifier + profile_name to ModelIdentity if callers pass them
+    _model_identifier = defaults.pop("model_identifier", None)
+    _profile_name = defaults.pop("profile_name", None)
+    if _model_identifier is not None or _profile_name is not None:
+        _mid = _model_identifier or ""
+        _pn = _profile_name or ""
+        if _pn and _pn != "anthropic":
+            defaults["model_identity"] = ModelIdentity.for_provider(
+                configured=_mid, effective="", profile=_pn
+            )
+        elif _mid:
+            defaults["model_identity"] = ModelIdentity.anthropic(_mid)
+        else:
+            defaults["model_identity"] = ModelIdentity.unknown()
 
     # Extract telemetry kwargs and build SessionTelemetry before forwarding
     _github_api_log = defaults.pop("github_api_log")

--- a/tests/execution/test_flush_provider_integration.py
+++ b/tests/execution/test_flush_provider_integration.py
@@ -258,7 +258,8 @@ class TestProviderFieldsReachFlush:
     async def test_model_identifier_reaches_flush_session_log(
         self, minimal_ctx, tmp_path, monkeypatch
     ):
-        """model_identifier must be forwarded to flush_session_log — not silently dropped."""
+        """model_identity must be forwarded to flush_session_log — not silently dropped."""
+        from autoskillit.core.types._type_results import ModelIdentity
         from autoskillit.execution.commands import ClaudeHeadlessCmd
         from autoskillit.execution.headless import _execute_claude_headless
 
@@ -275,8 +276,8 @@ class TestProviderFieldsReachFlush:
             timeout=30.0,
             stale_threshold=5.0,
             step_name="implement",
-            model_identifier="claude-opus-4-6",
+            model_identity=ModelIdentity.anthropic("claude-opus-4-6"),
         )
 
         assert len(flush_calls) == 1
-        assert flush_calls[0].get("model_identifier") == "claude-opus-4-6"
+        assert flush_calls[0]["model_identity"].configured_model == "claude-opus-4-6"

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -58,7 +58,7 @@ async def test_run_headless_core_forwards_provider_extras_to_build_cmd(
     assert config.provider_extras == {"AWS_REGION": "us-east-1"}
     assert config.profile_name == "bedrock"
     assert execute_kwargs.get("provider_extras") == {"AWS_REGION": "us-east-1"}
-    assert execute_kwargs.get("model_identity").profile_name == "bedrock"
+    assert execute_kwargs["model_identity"].profile_name == "bedrock"
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -58,7 +58,7 @@ async def test_run_headless_core_forwards_provider_extras_to_build_cmd(
     assert config.provider_extras == {"AWS_REGION": "us-east-1"}
     assert config.profile_name == "bedrock"
     assert execute_kwargs.get("provider_extras") == {"AWS_REGION": "us-east-1"}
-    assert execute_kwargs.get("profile_name") == "bedrock"
+    assert execute_kwargs.get("model_identity").profile_name == "bedrock"
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -1694,3 +1694,38 @@ def test_flush_session_log_minimax_message_id_turn_dedup(tmp_path, monkeypatch):
     assert len(summary["turn_timestamps"]) == 2
     assert len(summary["turn_tool_calls"]) == 2
     assert summary["turn_timestamps"][0] == "2026-05-30T08:33:53.843Z"
+
+
+@pytest.mark.parametrize(
+    "provider_model",
+    ["MiniMax-M2.7-highspeed", "gpt-4o"],
+)
+def test_non_anthropic_provider_model_identity_round_trip(tmp_path, provider_model):
+    """Non-Anthropic provider sessions must write the effective provider model, not the Anthropic alias."""
+    from autoskillit.core.types._type_results import ModelIdentity
+
+    session_id = f"non-anthropic-rt-{provider_model[:8]}"
+    _flush(
+        tmp_path,
+        session_id=session_id,
+        proc_snapshots=None,
+        step_name="implement",
+        model_identity=ModelIdentity.for_provider(
+            configured="sonnet", effective="", profile="minimax"
+        ),
+        token_usage={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_write_tokens": 0,
+            "cache_read_tokens": 0,
+            "model_breakdown": {provider_model: {"output_tokens": 50}},
+        },
+    )
+    tu_path = tmp_path / "sessions" / session_id / "token_usage.json"
+    assert tu_path.exists()
+    data = json.loads(tu_path.read_text())
+    assert data["model_identifier"] == provider_model, (
+        f"expected provider model {provider_model!r}, got {data['model_identifier']!r}"
+    )
+    assert data["configured_model"] == "sonnet"
+    assert data["profile_name"] == "minimax"

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from autoskillit.core.types._type_results import ProviderOutcome
+from autoskillit.core.types._type_results import ModelIdentity, ProviderOutcome
 from autoskillit.core.types._type_results_execution import (
     RecipeIdentity,
     SessionTelemetry,
@@ -1702,7 +1702,6 @@ def test_flush_session_log_minimax_message_id_turn_dedup(tmp_path, monkeypatch):
 )
 def test_non_anthropic_provider_model_identity_round_trip(tmp_path, provider_model):
     """Non-Anthropic provider sessions must write the effective provider model, not the Anthropic alias."""
-    from autoskillit.core.types._type_results import ModelIdentity
 
     session_id = f"non-anthropic-rt-{provider_model[:8]}"
     _flush(
@@ -1729,3 +1728,56 @@ def test_non_anthropic_provider_model_identity_round_trip(tmp_path, provider_mod
     )
     assert data["configured_model"] == "sonnet"
     assert data["profile_name"] == "minimax"
+
+
+@pytest.mark.parametrize(
+    "model_identity,expected_model",
+    [
+        (
+            ModelIdentity.anthropic("claude-sonnet-4-6"),
+            "claude-sonnet-4-6",
+        ),
+        (
+            ModelIdentity.for_provider(configured="sonnet", effective="", profile="minimax"),
+            # effective model comes from model_breakdown argmax when effective=""
+            "MiniMax-M2.7-highspeed",
+        ),
+    ],
+)
+def test_model_identity_readers_agree(tmp_path, model_identity, expected_model):
+    """Both disk readers must produce the same model string after flush_session_log writes."""
+    from autoskillit.hooks.token_summary_hook import _load_sessions
+    from autoskillit.pipeline.tokens import DefaultTokenLog
+
+    session_id = f"reader-agree-{model_identity.profile_name or 'anthropic'}"
+    kitchen_id = f"kitchen-ra-{session_id}"
+    _flush(
+        tmp_path,
+        session_id=session_id,
+        proc_snapshots=None,
+        step_name="implement",
+        model_identity=model_identity,
+        token_usage={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_write_tokens": 0,
+            "cache_read_tokens": 0,
+            "model_breakdown": {"MiniMax-M2.7-highspeed": {"output_tokens": 50}},
+        },
+        kitchen_id=kitchen_id,
+    )
+
+    log_root = tmp_path
+
+    disk_log = DefaultTokenLog()
+    disk_log.load_from_log_dir(log_root)
+    disk_entries = disk_log.get_report()
+    assert disk_entries, "DefaultTokenLog should have at least one entry"
+    disk_model = disk_entries[0]["model"]
+
+    hook_agg = _load_sessions(log_root, kitchen_id)
+    assert hook_agg, "_load_sessions should return at least one entry"
+    hook_model = next(iter(hook_agg.values()))["model"]
+
+    assert disk_model == hook_model, f"readers disagree: disk={disk_model!r}, hook={hook_model!r}"
+    assert disk_model == expected_model

--- a/tests/infra/_token_summary_helpers.py
+++ b/tests/infra/_token_summary_helpers.py
@@ -102,4 +102,8 @@ def _write_sessions(log_root: Path, entries: list[dict]) -> None:
         }
         if "model_identifier" in entry:
             token_data["model_identifier"] = entry["model_identifier"]
+        if "configured_model" in entry:
+            token_data["configured_model"] = entry["configured_model"]
+        if "profile_name" in entry:
+            token_data["profile_name"] = entry["profile_name"]
         (session_dir / "token_usage.json").write_text(json.dumps(token_data))

--- a/tests/infra/test_token_summary_core.py
+++ b/tests/infra/test_token_summary_core.py
@@ -1112,3 +1112,97 @@ def test_efficiency_table_zero_loc_step_shows_dash(tmp_path: Path) -> None:
     )
     assert plan_row is not None, "No '| plan |' row found in efficiency section"
     assert "—" in plan_row
+
+
+def test_non_anthropic_session_shows_provider_model_name(tmp_path: Path) -> None:
+    """Non-Anthropic sessions must show the effective provider model, not the Anthropic alias."""
+    from autoskillit.hooks.token_summary_hook import _format_table, _load_sessions
+
+    kitchen_id = "kitchen-non-anthropic-001"
+    log_root = tmp_path / "logs"
+    log_root.mkdir()
+    _write_sessions(
+        log_root,
+        [
+            {
+                "session_id": "s1",
+                "dir_name": "s1",
+                "timestamp": "2026-06-01T00:00:00Z",
+                "kitchen_id": kitchen_id,
+                "model_identifier": "MiniMax-M2.7-highspeed",
+                "configured_model": "sonnet",
+                "profile_name": "minimax",
+                "input_tokens": 1000,
+                "output_tokens": 500,
+            }
+        ],
+    )
+
+    aggregated = _load_sessions(log_root, kitchen_id)
+    assert aggregated, "Expected at least one aggregated session entry"
+
+    step_entry = next(iter(aggregated.values()))
+    assert step_entry["model"] == "MiniMax-M2.7-highspeed"
+    assert step_entry["model"] != "sonnet"
+
+    table = _format_table(aggregated)
+    assert "MiniMax-M2.7-highspeed" in table
+    assert "sonnet" not in table.split("## Token Usage Summary")[1].split("|")[2]
+    assert "*" in table
+
+
+@pytest.mark.parametrize(
+    "scenario,model_identifier,configured_model,profile_name,expected_model",
+    [
+        ("anthropic", "claude-sonnet-4-6", "claude-sonnet-4-6", "", "claude-sonnet-4-6"),
+        ("non-anthropic", "MiniMax-M2.7-highspeed", "sonnet", "minimax", "MiniMax-M2.7-highspeed"),
+    ],
+)
+def test_reader_agreement_contract(
+    tmp_path: Path,
+    scenario,
+    model_identifier,
+    configured_model,
+    profile_name,
+    expected_model,
+) -> None:
+    """Both readers must agree and non-Anthropic sessions must not show Anthropic aliases."""
+    from autoskillit.hooks.token_summary_hook import _load_sessions
+    from autoskillit.pipeline.tokens import DefaultTokenLog
+
+    kitchen_id = f"kitchen-rac-{scenario}"
+    log_root = tmp_path / f"rac-logs-{scenario}"
+    log_root.mkdir()
+    _write_sessions(
+        log_root,
+        [
+            {
+                "session_id": f"rac-{scenario}",
+                "dir_name": f"rac-{scenario}",
+                "timestamp": "2026-06-01T00:00:00Z",
+                "kitchen_id": kitchen_id,
+                "model_identifier": model_identifier,
+                "configured_model": configured_model,
+                "profile_name": profile_name,
+                "input_tokens": 100,
+                "output_tokens": 50,
+            },
+        ],
+    )
+
+    disk_log = DefaultTokenLog()
+    disk_log.load_from_log_dir(log_root)
+    disk_entries = disk_log.get_report()
+    assert disk_entries
+    disk_model = disk_entries[0]["model"]
+
+    hook_agg = _load_sessions(log_root, kitchen_id)
+    assert hook_agg
+    hook_model = next(iter(hook_agg.values()))["model"]
+
+    assert disk_model == hook_model, f"readers disagree: disk={disk_model!r}, hook={hook_model!r}"
+    assert disk_model == expected_model
+
+    if scenario == "non-anthropic":
+        assert not disk_model.startswith("claude-")
+        assert disk_model not in ("sonnet", "opus", "haiku")

--- a/tests/pipeline/test_tokens_model.py
+++ b/tests/pipeline/test_tokens_model.py
@@ -293,3 +293,32 @@ def test_primary_model_warns_on_non_dict_breakdown() -> None:
         result = _primary_model(token_usage)
     assert result == "claude-opus-4-6"
     assert any("Unexpected model_breakdown entry type" in entry.get("event", "") for entry in cap)
+
+
+def test_load_from_log_dir_non_anthropic_model_uses_effective_model(tmp_path: Path) -> None:
+    """Non-Anthropic: load_from_log_dir prefers model_identifier over configured_model."""
+    sessions_dir = tmp_path / "sessions" / "s1"
+    sessions_dir.mkdir(parents=True)
+    (sessions_dir / "token_usage.json").write_text(
+        json.dumps(
+            {
+                "step_name": "implement",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_write_tokens": 0,
+                "cache_read_tokens": 0,
+                "timing_seconds": 10.0,
+                "model_identifier": "MiniMax-M2.7-highspeed",
+                "configured_model": "sonnet",
+                "profile_name": "minimax",
+            }
+        )
+    )
+    index_entry = {"session_id": "s1", "dir_name": "s1", "timestamp": "2026-01-01T00:00:00Z"}
+    (tmp_path / "sessions.jsonl").write_text(json.dumps(index_entry) + "\n")
+
+    log = DefaultTokenLog()
+    log.load_from_log_dir(tmp_path)
+    report = log.get_report()
+    assert len(report) == 1
+    assert report[0]["model"] == "MiniMax-M2.7-highspeed"


### PR DESCRIPTION
## Summary

The model identity system has a structural fragmentation: `_resolve_model()` in `_headless_helpers.py` is Anthropic-only, but its output feeds every downstream consumer — the session log writer, two disk readers, and the in-memory token log. When a non-Anthropic provider (MiniMax) is active, `_resolve_model()` produces a truthy-but-wrong Anthropic alias (`"sonnet"`) that suppresses the argmax fallback (`_primary_model_identifier()`) which would have extracted the correct provider model name from the NDJSON `model_breakdown` data.

The architectural fix introduces a `ModelIdentity` frozen dataclass that bundles configured model, effective model, and provider context into a single value object — eliminating the fragmented `(model_identifier: str, profile_name: str)` parameter pair that currently flows through five functions. This makes it structurally impossible for a provider-unaware model resolution to silently produce a wrong-but-truthy value.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260601-082331-883468/.autoskillit/temp/rectify/rectify_model_identity_provider_immunity_2026-06-01_172000.md`

Closes #3527

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 108 | 29.6k | 4.0M | 137.9k | 98 | 202.8k | 24m 26s |
| review_approach* | sonnet | 1 | 52 | 7.9k | 195.8k | 56.6k | 16 | 44.7k | 6m 38s |
| dry_walkthrough* | opus | 2 | 101 | 31.3k | 3.0M | 89.7k | 105 | 128.1k | 16m 48s |
| implement* | sonnet | 2 | 610 | 50.0k | 8.3M | 176.3k | 204 | 186.6k | 17m 36s |
| audit_impl* | sonnet | 2 | 2.1k | 35.0k | 791.9k | 73.7k | 57 | 91.4k | 18m 40s |
| make_plan* | sonnet | 1 | 113 | 14.4k | 588.4k | 64.4k | 36 | 51.7k | 12m 5s |
| prepare_pr* | sonnet | 1 | 125.9k | 4.2k | 135.2k | 50.1k | 19 | 0 | 2m 12s |
| compose_pr* | sonnet | 1 | 37.3k | 1.4k | 222.5k | 38.4k | 13 | 0 | 1m 3s |
| review_pr* | sonnet | 1 | 166 | 53.7k | 1.4M | 112.0k | 59 | 96.5k | 13m 48s |
| resolve_review* | opus | 1 | 35 | 6.5k | 1.0M | 71.5k | 33 | 56.0k | 5m 26s |
| **Total** | | | 166.5k | 234.0k | 19.8M | 176.3k | | 857.8k | 1h 58m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 453 | 18415.7 | 412.0 | 110.3 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 509557.5 | 27997.5 | 3266.0 |
| **Total** | **455** | 43469.3 | 1885.2 | 514.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 108 | 29.6k | 4.0M | 202.8k | 24m 26s |
| sonnet | 7 | 166.2k | 166.6k | 11.7M | 470.9k | 1h 12m |
| opus | 2 | 136 | 37.8k | 4.1M | 184.0k | 22m 14s |