### PR TITLE
Implementation Plan: [P2-A4-WP1] Write Phoropter Adjacency Tests

### DIFF
--- a/tests/recipe/test_rules_phoropter_adjacency.py
+++ b/tests/recipe/test_rules_phoropter_adjacency.py
@@ -69,6 +69,24 @@ def test_synthesize_before_apply_produces_error():
     assert "expected phase 'apply'" in findings[0].message
 
 
+def test_wrong_order_dial_synthesize_apply():
+    """dial→synthesize→apply: synthesize arrives when apply is expected."""
+    import autoskillit.recipe  # noqa: F401
+
+    recipe = _make_recipe(
+        {
+            "dial": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+            "synthesize": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+            "apply": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-phase-order"]
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.ERROR
+    assert findings[0].step_name == "synthesize"
+    assert "expected phase 'apply'" in findings[0].message
+
+
 def test_no_phoropter_family_produces_no_phase_findings():
     import autoskillit.recipe  # noqa: F401
 
@@ -125,6 +143,24 @@ def test_non_family_step_between_dial_and_apply_produces_error():
             "dial": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
             "plain-step": RecipeStep(tool="run_cmd"),
             "apply": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+            "synthesize": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-step-interleaving"]
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.ERROR
+    assert findings[0].step_name == "plain-step"
+    assert "vis-lens" in findings[0].message
+
+
+def test_non_family_step_between_apply_and_synthesize_produces_error():
+    import autoskillit.recipe  # noqa: F401
+
+    recipe = _make_recipe(
+        {
+            "dial": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+            "apply": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+            "plain-step": RecipeStep(tool="run_cmd"),
             "synthesize": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
         }
     )


### PR DESCRIPTION
## Summary

Add missing phoropter-adjacency test cases to the existing `tests/recipe/test_rules_phoropter_adjacency.py` module. The issue asks to create `tests/recipe/test_phoropter_adjacency_rule.py`, but the existing file at `test_rules_phoropter_adjacency.py` already contains 11 tests covering both `phoropter-phase-order` and `phoropter-step-interleaving` rules. Creating a duplicate file would fragment coverage and violate the project's "avoid redundancy" guideline. Instead, the plan adds the genuinely missing test cases to the existing module.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260601-105404-748961/.autoskillit/temp/make-plan/task-1-p2-a4-wp1-write-tests-phoropter-adjacency_plan_2026-06-01_110600.md`

Closes #3087

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 58 | 9.3k | 669.4k | 66.5k | 30 | 55.1k | 5m 32s |
| verify* | opus[1m] | 1 | 27 | 4.1k | 361.0k | 53.2k | 17 | 36.5k | 3m 26s |
| implement* | opus[1m] | 1 | 129.7k | 4.0k | 402.3k | 50.4k | 29 | 0 | 6m 24s |
| audit_impl* | opus[1m] | 1 | 23 | 3.4k | 139.1k | 34.6k | 10 | 20.5k | 1m 57s |
| prepare_pr* | opus[1m] | 1 | 74.0k | 3.4k | 208.6k | 43.9k | 18 | 0 | 1m 56s |
| compose_pr* | opus[1m] | 1 | 38.0k | 1.5k | 186.2k | 38.7k | 12 | 0 | 1m 0s |
| review_pr* | opus[1m] | 1 | 31 | 10.9k | 526.0k | 51.7k | 28 | 35.3k | 4m 5s |
| resolve_review* | opus[1m] | 1 | 27 | 2.2k | 371.7k | 42.4k | 22 | 26.0k | 57s |
| **Total** | | | 241.9k | 38.7k | 2.9M | 66.5k | | 173.3k | 25m 20s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 36 | 11175.1 | 0.0 | 109.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **36** | 79565.5 | 4813.6 | 1075.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 8 | 241.9k | 38.7k | 2.9M | 173.3k | 25m 20s |