### PR TITLE
Implementation Plan: Hoist Backend Construction and Replace String Comparisons with Capability Lookups

### DIFF
--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -89,6 +89,10 @@ class BackendCapabilities:
     skills_subdir: str = ""
     # Env vars that must appear in CmdSpec.env for all cmd-builders (MCP forwarding)
     mcp_env_forward_vars: frozenset[str] = field(default_factory=frozenset)
+    # True when backend supports api_simulator-based REPLAY_SCENARIO runner wrapping
+    replay_capable: bool = field(default=False)
+    # True when backend supports api_simulator-based RECORD_SCENARIO runner wrapping
+    record_capable: bool = field(default=False)
 
 
 _CONTEXT_WINDOW_SUFFIX_RE: _re.Pattern[str] = _re.compile(r"\[\d+[mk]?\]$", _re.IGNORECASE)
@@ -135,6 +139,8 @@ CLAUDE_CODE_CAPABILITIES: BackendCapabilities = BackendCapabilities(
     version_check_command="claude --version",
     process_name="claude",
     skills_subdir=".claude/skills",
+    replay_capable=True,
+    record_capable=True,
 )
 
 

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -326,6 +326,8 @@ class CodexBackend:
             process_name="codex",
             skills_subdir="skills",
             mcp_env_forward_vars=frozenset({MCP_CLIENT_BACKEND_ENV_VAR}),
+            replay_capable=False,
+            record_capable=False,
         )
 
     def build_cmd(self, skill_command: str, cwd: str) -> CmdSpec:

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -225,9 +225,9 @@ def make_context(
     backend = get_backend(config.agent_backend.backend)
 
     if runner is not None and os.environ.get(REPLAY_SCENARIO_ENV):
-        if config.agent_backend.backend != "claude-code":
+        if not backend.capabilities.replay_capable:
             logger.warning(
-                "REPLAY_SCENARIO is set but agent_backend=%r is not claude-code "
+                "REPLAY_SCENARIO is set but backend %r is not replay-capable "
                 "— skipping replay runner construction",
                 config.agent_backend.backend,
             )
@@ -246,9 +246,9 @@ def make_context(
                 runner = build_replay_runner(replay_dir)
 
     elif runner is not None and os.environ.get(RECORD_SCENARIO_ENV):
-        if config.agent_backend.backend != "claude-code":
+        if not backend.capabilities.record_capable:
             logger.warning(
-                "RECORD_SCENARIO is set but agent_backend=%r is not claude-code "
+                "RECORD_SCENARIO is set but backend %r is not record-capable "
                 "— skipping record runner construction",
                 config.agent_backend.backend,
             )

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -73,6 +73,8 @@ def test_backend_capabilities_field_count():
         "supports_context_exhaustion_detection",
         "project_local_skills_capable",
         "supports_tool_list_changed",
+        "replay_capable",
+        "record_capable",
     }
     assert frozenset_fields == {
         "completion_record_types",
@@ -117,6 +119,8 @@ def test_backend_capabilities_field_names_locked():
         "skills_subdir",
         "supports_tool_list_changed",
         "mcp_env_forward_vars",
+        "replay_capable",
+        "record_capable",
     }
     actual = {f.name for f in dataclasses.fields(BackendCapabilities)}
     assert actual == expected
@@ -151,6 +155,8 @@ def test_claude_code_capabilities_field_values():
     assert CLAUDE_CODE_CAPABILITIES.skills_subdir == ".claude/skills"
     assert CLAUDE_CODE_CAPABILITIES.supports_tool_list_changed is True
     assert CLAUDE_CODE_CAPABILITIES.mcp_env_forward_vars == frozenset()
+    assert CLAUDE_CODE_CAPABILITIES.replay_capable is True
+    assert CLAUDE_CODE_CAPABILITIES.record_capable is True
 
 
 def test_backend_capabilities_frozenset_defaults():

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -156,6 +156,12 @@ class TestCodexBackend:
             {MCP_CLIENT_BACKEND_ENV_VAR}
         )
 
+    def test_capabilities_replay_capable_false(self) -> None:
+        assert CodexBackend().capabilities.replay_capable is False
+
+    def test_capabilities_record_capable_false(self) -> None:
+        assert CodexBackend().capabilities.record_capable is False
+
     def test_binary_name(self) -> None:
         assert CodexBackend().binary_name() == "codex"
 

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -589,9 +589,9 @@ def test_tool_ctx_kitchen_open_fixture_gate_starts_open(tool_ctx_kitchen_open) -
 
 @pytest.fixture()
 def _register_aider_backend(monkeypatch):
-    from autoskillit.execution.backends import BACKEND_REGISTRY, ClaudeCodeBackend
+    from autoskillit.execution.backends import BACKEND_REGISTRY, CodexBackend
 
-    monkeypatch.setitem(BACKEND_REGISTRY, "aider", ClaudeCodeBackend)
+    monkeypatch.setitem(BACKEND_REGISTRY, "aider", CodexBackend)
 
 
 def test_make_context_skips_replay_runner_for_non_claude_backend(

--- a/tests/server/test_factory_recording.py
+++ b/tests/server/test_factory_recording.py
@@ -196,6 +196,61 @@ def test_replay_takes_precedence_over_record(monkeypatch, tmp_path):
     mock_atexit.assert_not_called()
 
 
+# --- T-REPLAY-CODEX: codex backend is not replay-capable, so replay runner wrapping is skipped ---
+
+
+def test_make_context_replay_skipped_for_codex_backend(monkeypatch, tmp_path):
+    """REPLAY_SCENARIO with codex backend must NOT wrap runner in ReplayingSubprocessRunner."""
+    from autoskillit.config import AutomationConfig
+    from autoskillit.config._config_dataclasses import AgentBackendConfig
+    from autoskillit.execution import DefaultSubprocessRunner
+    from autoskillit.execution.recording import ReplayingSubprocessRunner
+    from autoskillit.server._factory import make_context
+
+    replay_dir = tmp_path / "replay"
+    replay_dir.mkdir()
+
+    monkeypatch.setenv("REPLAY_SCENARIO", "1")
+    monkeypatch.setenv("REPLAY_SCENARIO_DIR", str(replay_dir))
+    monkeypatch.delenv("RECORD_SCENARIO", raising=False)
+
+    config = AutomationConfig()
+    config.agent_backend = AgentBackendConfig(backend="codex")
+
+    ctx = make_context(config, plugin_dir=str(tmp_path), project_dir=tmp_path)
+
+    assert isinstance(ctx.runner, DefaultSubprocessRunner)
+    assert not isinstance(ctx.runner, ReplayingSubprocessRunner)
+
+
+# --- T-RECORD-CODEX: codex backend is not record-capable, so record runner wrapping is skipped ---
+
+
+def test_make_context_record_skipped_for_codex_backend(monkeypatch, tmp_path):
+    """RECORD_SCENARIO with codex backend must NOT wrap runner in RecordingSubprocessRunner."""
+    from autoskillit.config import AutomationConfig
+    from autoskillit.config._config_dataclasses import AgentBackendConfig
+    from autoskillit.execution import DefaultSubprocessRunner
+    from autoskillit.execution.recording import RecordingSubprocessRunner
+    from autoskillit.server._factory import make_context
+
+    scenario_dir = tmp_path / "record"
+    scenario_dir.mkdir()
+
+    monkeypatch.setenv("RECORD_SCENARIO", "1")
+    monkeypatch.setenv("RECORD_SCENARIO_DIR", str(scenario_dir))
+    monkeypatch.setenv("RECORD_SCENARIO_RECIPE", "smoke-test")
+    monkeypatch.delenv("REPLAY_SCENARIO", raising=False)
+
+    config = AutomationConfig()
+    config.agent_backend = AgentBackendConfig(backend="codex")
+
+    ctx = make_context(config, plugin_dir=str(tmp_path), project_dir=tmp_path)
+
+    assert isinstance(ctx.runner, DefaultSubprocessRunner)
+    assert not isinstance(ctx.runner, RecordingSubprocessRunner)
+
+
 # --- T-BUILD-REPLAY-SNAP: build_replay_runner scans and surfaces skill_snapshots ---
 
 


### PR DESCRIPTION
## Summary

Replace the two `config.agent_backend.backend != "claude-code"` string comparisons in `server/_factory.py`'s REPLAY/RECORD guard blocks with capability-field lookups (`backend.capabilities.replay_capable` and `backend.capabilities.record_capable`). The `backend` object is already resolved before the guards (hoisted by P3-A7-WP1), so the change is purely replacing the guard conditions and adding the two new capability fields to `BackendCapabilities`. Two new tests verify that a Codex backend suppresses both replay and record runner wrapping. Exhaustive arch/unit test registries are updated to include the new fields.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260601-113132-110451/.autoskillit/temp/make-plan/p4_a1_wp1_hoist_backend_capability_plan_2026-06-01_113900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

Closes #3116

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.9k | 20.0k | 1.4M | 107.9k | 60 | 91.1k | 12m 31s |
| verify* | sonnet | 1 | 70 | 10.2k | 314.0k | 53.9k | 27 | 37.4k | 4m 20s |
| implement* | MiniMax-M3 | 1 | 142.1k | 9.5k | 1.2M | 73.5k | 79 | 0 | 10m 47s |
| fix* | sonnet | 1 | 174 | 7.8k | 980.6k | 59.2k | 59 | 42.8k | 7m 43s |
| audit_impl* | sonnet | 1 | 505 | 7.3k | 174.4k | 37.1k | 17 | 28.1k | 4m 18s |
| prepare_pr* | MiniMax-M3 | 1 | 86.4k | 5.5k | 422.3k | 48.1k | 32 | 0 | 3m 0s |
| compose_pr* | MiniMax-M3 | 1 | 37.3k | 1.2k | 146.0k | 38.1k | 12 | 0 | 53s |
| review_pr* | sonnet | 2 | 210 | 62.0k | 1.1M | 77.2k | 71 | 117.3k | 12m 58s |
| resolve_review* | sonnet | 1 | 117 | 8.0k | 586.5k | 50.5k | 35 | 35.2k | 5m 12s |
| **Total** | | | 268.8k | 131.4k | 6.4M | 107.9k | | 351.8k | 1h 1m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 83 | 14394.8 | 0.0 | 114.3 |
| fix | 4 | 245153.2 | 10691.0 | 1955.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **87** | 73012.4 | 4044.0 | 1510.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.9k | 20.0k | 1.4M | 91.1k | 12m 31s |
| sonnet | 5 | 1.1k | 95.2k | 3.2M | 260.7k | 34m 33s |
| MiniMax-M3 | 3 | 265.8k | 16.2k | 1.8M | 0 | 14m 40s |