### PR TITLE
Implementation Plan: Upgrade FastMCP from 3.2.4 to 3.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.11"
 dependencies = [
     "anyio>=4.6.0",
     "dynaconf>=3.2.13,<4.0",
-    "fastmcp>=3.2.0,<4.0",
+    "fastmcp>=3.3.1,<4.0",
     "httpx>=0.28,<1.0",
     "networkx>=3.6,<4.0",
     "lazy-loader>=0.4",

--- a/tests/infra/CLAUDE.md
+++ b/tests/infra/CLAUDE.md
@@ -26,6 +26,7 @@ CI/CD configuration, security, guard coverage, and release sanity tests.
 | `test_coverage_audit.py` | Tests for scripts/compare-coverage-ast.py — AST extraction and coverage comparison |
 | `test_dependency_pins.py` | Dependency pin guards (REQ-DEP-001, REQ-DEP-002) — pytest 9.x, networkx bounds |
 | `test_docstring_labels.py` | Tests for correct docstring layer labels across the codebase |
+| `test_fastmcp_version_floor.py` | FastMCP version floor and internal API surface guard |
 | `test_filter_activation.py` | Infrastructure tests: verify test path filtering is activated in project config |
 | `test_fleet_dispatch_guard.py` | Tests for fleet_dispatch_guard.py PreToolUse hook |
 | `test_generated_file_write_guard.py` | Tests for generated_file_write_guard.py PreToolUse hook |

--- a/tests/infra/test_fastmcp_version_floor.py
+++ b/tests/infra/test_fastmcp_version_floor.py
@@ -1,0 +1,41 @@
+"""FastMCP version floor and internal API surface guard.
+
+Ensures the installed FastMCP version meets the project's minimum requirement
+and that internal attributes used by test fixtures remain accessible.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import version as pkg_version
+from unittest.mock import MagicMock
+
+import pytest
+from packaging.version import Version
+
+pytestmark = [pytest.mark.layer("infra"), pytest.mark.medium]
+
+
+def test_fastmcp_version_floor():
+    """Installed FastMCP must be >= 3.3.1."""
+    installed = Version(pkg_version("fastmcp"))
+    assert installed >= Version("3.3.1"), f"FastMCP {installed} is below the project minimum 3.3.1"
+
+
+def test_transforms_attribute_is_list():
+    """mcp._transforms must be a list — test fixtures depend on .clear()."""
+    from autoskillit.server import mcp
+
+    assert isinstance(mcp._transforms, list)
+
+
+def test_middleware_context_constructor_stable():
+    """MiddlewareContext must accept the kwargs used in test_wire_compat.py."""
+    from fastmcp.server.middleware import MiddlewareContext
+
+    ctx = MiddlewareContext(
+        message=MagicMock(),
+        method="tools/list",
+        type="request",
+    )
+    assert ctx.method == "tools/list"
+    assert ctx.type == "request"

--- a/tests/infra/test_fastmcp_version_floor.py
+++ b/tests/infra/test_fastmcp_version_floor.py
@@ -25,6 +25,11 @@ def test_transforms_attribute_is_list():
     """mcp._transforms must be a list — test fixtures depend on .clear()."""
     from autoskillit.server import mcp
 
+    assert hasattr(mcp, "_transforms"), (
+        "FastMCP server instance lost the '_transforms' attribute — "
+        "test fixtures across conftest.py, server/, and fleet/ depend on "
+        "mcp._transforms.clear() for visibility state cleanup"
+    )
     assert isinstance(mcp._transforms, list)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -113,7 +113,7 @@ requires-dist = [
     { name = "api-simulator", marker = "sys_platform == 'linux' and extra == 'dev'", git = "https://github.com/TalonT-Org/api-simulator?subdirectory=crates%2Fapi-simulator-py&rev=8f711f958d4d93a8e53a3c3b51279fb420870f3a" },
     { name = "cyclopts", specifier = ">=4.0" },
     { name = "dynaconf", specifier = ">=3.2.13,<4.0" },
-    { name = "fastmcp", specifier = ">=3.2.0,<4.0" },
+    { name = "fastmcp", specifier = ">=3.3.1,<4.0" },
     { name = "httpx", specifier = ">=0.28,<1.0" },
     { name = "import-linter", marker = "extra == 'dev'", specifier = ">=2.1" },
     { name = "lazy-loader", specifier = ">=0.4" },


### PR DESCRIPTION
Upgrade FastMCP from 3.2.4 to 3.3.1 by tightening the `pyproject.toml` lower bound from `>=3.2.0` to `>=3.3.1`, regenerating the lockfile, and adding a version-floor guard test. All existing FastMCP integration points have been verified compatible with 3.3.1 through source-level analysis:

- **Import paths**: All production import paths (`fastmcp`, `fastmcp.dependencies`, `fastmcp.exceptions`, `fastmcp.server.middleware`, `fastmcp.tools.tool`) are unchanged in 3.3.1. Test-only imports (`fastmcp.client`, `fastmcp.client.transports`) are also stable.
- **`mcp._transforms`**: Still a `list` attribute on `FastMCP` instances — test fixtures and arch guards remain valid.
- **`MiddlewareContext`**: Constructor signature unchanged (`message`, `fastmcp_context`, `source`, `type`, `method`, `timestamp` — all `kw_only=True`).
- **`ClaudeCodeCompatMiddleware`**: Still necessary — 3.3.1's `_list_tools_mcp` handler still emits `outputSchema` and `title` in the `tools/list` wire response.
- **`FastMCP()` constructor**: Only passes `name` + `lifespan` — unaffected by 3.3.0's removal of transport kwargs from the constructor.
- **Lifespan generator**: AutoSkillit uses a single root server with no mounted sub-servers; the lifespan system is unaffected by 3.3.x changes.
- **`run_in_thread=False`**: Not applicable — all 57 MCP tools are `async def` functions.
- **Transitive deps**: FastMCP 3.3.1 ships via `fastmcp-slim[client,server]`. The transitive package set (`authlib`, `cyclopts`, `griffelib`, `jsonref`, etc.) is unchanged from 3.2.4 — the 3.3.0 change is structural (packages moved from direct deps to optional extras of `fastmcp-slim`), not additive. No conflicts with existing pins (`httpx>=0.28,<1.0` resolves to 0.28.1).

Closes #3514

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260601-122614-172310/.autoskillit/temp/make-plan/upgrade_fastmcp_3_3_1_plan_2026-06-01_123257.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 52 | 9.9k | 869.9k | 75.8k | 44 | 64.0k | 8m 43s |
| review_approach* | opus[1m] | 1 | 10.4k | 5.8k | 321.9k | 51.7k | 17 | 38.0k | 9m 44s |
| verify* | opus[1m] | 1 | 62 | 11.5k | 1.4M | 64.1k | 49 | 47.4k | 6m 46s |
| implement* | MiniMax-M3 | 1 | 134.1k | 7.4k | 1.9M | 66.4k | 82 | 0 | 6m 55s |
| audit_impl* | opus[1m] | 1 | 23 | 4.0k | 139.1k | 34.5k | 11 | 22.6k | 2m 16s |
| prepare_pr* | MiniMax-M3 | 1 | 72.8k | 5.3k | 170.5k | 47.2k | 18 | 0 | 1m 57s |
| compose_pr* | MiniMax-M3 | 1 | 73.7k | 1.6k | 151.6k | 39.2k | 14 | 0 | 58s |
| review_pr* | opus[1m] | 3 | 86 | 37.5k | 1.3M | 60.1k | 80 | 135.0k | 8m 57s |
| resolve_review* | opus[1m] | 1 | 47 | 4.8k | 1.0M | 57.0k | 37 | 40.5k | 5m 32s |
| **Total** | | | 291.3k | 87.8k | 7.3M | 75.8k | | 347.5k | 51m 50s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 46 | 41893.5 | 0.0 | 160.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 5 | 201100.8 | 8101.2 | 964.6 |
| **Total** | **51** | 143169.9 | 6813.7 | 1722.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 10.7k | 73.5k | 5.1M | 347.5k | 41m 59s |
| MiniMax-M3 | 3 | 280.6k | 14.3k | 2.2M | 0 | 9m 50s |