### PR TITLE
Implementation Plan: Remove Hardcoded Development Lens Guard

### DIFF
--- a/.claude/skills/promote-to-main/SKILL.md
+++ b/.claude/skills/promote-to-main/SKILL.md
@@ -322,9 +322,10 @@ repository-access, scenarios, security, state-lifecycle
 
 Return 1-3 lens names. Apply the same selection criteria as open-pr:
 
-**Development lens guard:** Only select `development` if at least one changed file matches:
-`pyproject.toml`, `Taskfile*`, `conftest.py`, `.github/workflows/*`, `Makefile`,
-`setup.cfg`, `setup.py`, `tox.ini`, `noxfile.py`, or files under `ci/`.
+**Development lens criteria:** Select `development` when the changed files include
+build configuration, test infrastructure, CI/CD pipeline definitions, quality gate
+configuration, or developer tooling setup. Assess by file purpose, not filename —
+the codebase may use any build system, CI platform, or test framework.
 
 For a promotion PR, prefer lenses that show the broadest architectural impact:
 - `module-dependency` if changes span multiple packages

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -480,6 +480,9 @@ skills:
     - name: conflict_report_path
       type: file_path
       required: false
+    - name: arch_lenses
+      type: string
+      required: false
     outputs:
     - name: prep_path
       type: file_path

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -805,11 +805,10 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }}",
+        "skill_command": "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }} ${{ inputs.arch_lenses }}",
         "cwd": "${{ context.work_dir }}",
         "output_dir": ".",
-        "step_name": "prepare_pr",
-        "issue_number": "${{ context.issue_number }}"
+        "step_name": "prepare_pr"
       },
       "capture": {
         "prep_path": "${{ result.prep_path }}",
@@ -833,7 +832,7 @@
       "on_context_limit": "release_issue_failure",
       "optional": true,
       "skip_when_false": "inputs.open_pr",
-      "note": "Reads plan(s), runs git diff, classifies changed files, selects 1–3 arch-lens slugs, writes one PR context file per lens, and writes a PR prep file. Does NOT invoke arch-lens skills. If context.issue_number is a non-empty string, append it as the 4th positional argument so prepare-pr fetches requirements from the closing issue. MULTI-GROUP: context.all_plan_paths may contain comma-separated plan paths accumulated across group iterations.\n"
+      "note": "Reads plan(s), runs git diff, classifies changed files, selects 1–3 arch-lens slugs (or skips lens selection when arch_lenses is false), writes one PR context file per lens, and writes a PR prep file. Does NOT invoke arch-lens skills. MULTI-GROUP: context.all_plan_paths may contain comma-separated plan paths accumulated across group iterations.\n"
     },
     "run_arch_lenses": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -726,11 +726,10 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }}"
+      skill_command: "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }} ${{ inputs.arch_lenses }}"
       cwd: "${{ context.work_dir }}"
       output_dir: '.'
       step_name: "prepare_pr"
-      issue_number: "${{ context.issue_number }}"
     capture:
       prep_path: "${{ result.prep_path }}"
       selected_lenses: "${{ result.selected_lenses }}"
@@ -746,10 +745,9 @@ steps:
     optional: true
     skip_when_false: "inputs.open_pr"
     note: >
-      Reads plan(s), runs git diff, classifies changed files, selects 1–3 arch-lens slugs,
-      writes one PR context file per lens, and writes a PR prep file. Does NOT invoke
-      arch-lens skills. If context.issue_number is a non-empty string, append it as the
-      4th positional argument so prepare-pr fetches requirements from the closing issue.
+      Reads plan(s), runs git diff, classifies changed files, selects 1–3 arch-lens slugs
+      (or skips lens selection when arch_lenses is false), writes one PR context file per
+      lens, and writes a PR prep file. Does NOT invoke arch-lens skills.
       MULTI-GROUP: context.all_plan_paths may contain comma-separated plan paths
       accumulated across group iterations.
 

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -863,7 +863,7 @@
       "model": "",
       "retries": 1,
       "with": {
-        "skill_command": "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }}",
+        "skill_command": "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }} ${{ inputs.arch_lenses }}",
         "cwd": "${{ context.work_dir }}",
         "output_dir": ".",
         "step_name": "prepare_pr"

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -798,7 +798,7 @@ steps:
     retries: 1
     with:
       skill_command: /autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name
-        }} ${{ inputs.base_branch }} ${{ context.issue_number }}
+        }} ${{ inputs.base_branch }} ${{ context.issue_number }} ${{ inputs.arch_lenses }}
       cwd: ${{ context.work_dir }}
       output_dir: '.'
       step_name: prepare_pr

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -1000,7 +1000,7 @@
       "model": "",
       "retries": 1,
       "with": {
-        "skill_command": "/autoskillit:prepare-pr ${{ context.plan_path }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }}",
+        "skill_command": "/autoskillit:prepare-pr ${{ context.plan_path }} ${{ inputs.run_name }} ${{ inputs.base_branch }} ${{ context.issue_number }} ${{ inputs.arch_lenses }}",
         "cwd": "${{ context.work_dir }}",
         "output_dir": ".",
         "step_name": "prepare_pr"

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -905,7 +905,7 @@ steps:
     retries: 1
     with:
       skill_command: /autoskillit:prepare-pr ${{ context.plan_path }} ${{ inputs.run_name
-        }} ${{ inputs.base_branch }} ${{ context.issue_number }}
+        }} ${{ inputs.base_branch }} ${{ context.issue_number }} ${{ inputs.arch_lenses }}
       cwd: ${{ context.work_dir }}
       output_dir: '.'
       step_name: prepare_pr

--- a/src/autoskillit/skills_extended/prepare-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-pr/SKILL.md
@@ -154,9 +154,9 @@ repository-access, scenarios, security, state-lifecycle
 Instruct the subagent to return 1–3 lens slugs. Only include a lens if at least one
 changed file maps to that lens's concern.
 
-**Development lens criteria:** Select the `development` lens when the changed files
-include build configuration, test infrastructure, CI/CD pipeline definitions, or
-quality gate configuration and developer tooling setup. Assess by file purpose, not
+**Development lens criteria:** Select `development` when the changed files include
+build configuration, test infrastructure, CI/CD pipeline definitions, quality gate
+configuration, or developer tooling setup. Assess by file purpose, not
 filename. The codebase may use any build system, CI platform, or test framework.
 
 Output: comma-separated slug list → `selected_lens_slugs`.

--- a/src/autoskillit/skills_extended/prepare-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-pr/SKILL.md
@@ -22,13 +22,15 @@ in the decomposed PR flow (prepare → run_arch_lenses → compose).
 
 ## Arguments
 
-`/autoskillit:prepare-pr {plan_paths} {run_name} {base_branch} [closing_issue] [conflict_report_path]`
+`/autoskillit:prepare-pr {plan_paths} {run_name} {base_branch} [closing_issue] [arch_lenses] [conflict_report_path]`
 
 - **plan_paths** — Comma-separated absolute paths to implementation plan markdown files
 - **run_name** — Branch name prefix (e.g. `impl`, `feature/123`, `fix/653`); determines
   `[FEATURE]`/`[FIX]` prefix
 - **base_branch** — PR target branch
 - **closing_issue** (optional) — GitHub issue number for requirements fetch + `Closes #N`
+- **arch_lenses** (optional) — `true` or `false`; when not `true`, lens selection
+  (Steps 5–6) is skipped and `none` is emitted for lens tokens. Defaults to `false`.
 - **conflict_report_path** (optional) — Absolute path to conflict resolution report
 
 ## Critical Constraints
@@ -67,7 +69,8 @@ Parse positional arguments:
 - arg[2] = `run_name`
 - arg[3] = `base_branch`
 - arg[4] = `closing_issue` (optional — may be absent or empty string)
-- arg[5] = `conflict_report_path` (optional — may be absent or empty string)
+- arg[5] = `arch_lenses` (optional — `true` or `false`; defaults to `false`)
+- arg[6] = `conflict_report_path` (optional — may be absent or empty string)
 
 Derive `feature_branch` (`git rev-parse --abbrev-ref HEAD`).
 Create temp dir (relative to the current working directory):
@@ -135,6 +138,10 @@ Store as separate lists: `new_files` (added, ★) and `modified_files` (modified
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
+**arch_lenses gate:** If `arch_lenses` is not `true`, skip Steps 5 and 6 — set
+`selected_lenses` to `none` and `lens_context_paths` to `none`, then proceed directly
+to Step 7.
+
 Spawn a subagent via `Agent(model="sonnet")` with the list of changed file paths and the
 following lens menu:
 
@@ -147,11 +154,10 @@ repository-access, scenarios, security, state-lifecycle
 Instruct the subagent to return 1–3 lens slugs. Only include a lens if at least one
 changed file maps to that lens's concern.
 
-**Development lens guard:** The `development` lens must ONLY be selected if at least one
-changed file matches a build/test configuration pattern: `pyproject.toml`, `Taskfile*`,
-`conftest.py`, `.github/workflows/*`, `Makefile`, `setup.cfg`, `setup.py`, `tox.ini`,
-`noxfile.py`, or files under a `ci/` directory. If no changed file matches these patterns,
-do NOT select the `development` lens regardless of other criteria.
+**Development lens criteria:** Select the `development` lens when the changed files
+include build configuration, test infrastructure, CI/CD pipeline definitions, or
+quality gate configuration and developer tooling setup. Assess by file purpose, not
+filename. The codebase may use any build system, CI platform, or test framework.
 
 Output: comma-separated slug list → `selected_lens_slugs`.
 

--- a/src/autoskillit/skills_extended/promote-to-main/SKILL.md
+++ b/src/autoskillit/skills_extended/promote-to-main/SKILL.md
@@ -371,9 +371,10 @@ repository-access, scenarios, security, state-lifecycle
 
 Return 1-3 lens names. Apply the same selection criteria as open-pr:
 
-**Development lens guard:** Only select `development` if at least one changed file matches:
-`pyproject.toml`, `Taskfile*`, `conftest.py`, `.github/workflows/*`, `Makefile`,
-`setup.cfg`, `setup.py`, `tox.ini`, `noxfile.py`, or files under `ci/`.
+**Development lens criteria:** Select `development` when the changed files include
+build configuration, test infrastructure, CI/CD pipeline definitions, quality gate
+configuration, or developer tooling setup. Assess by file purpose, not filename —
+the codebase may use any build system, CI platform, or test framework.
 
 For a promotion PR, prefer lenses that show the broadest architectural impact:
 - `module-dependency` if changes span multiple packages

--- a/tests/contracts/test_prepare_compose_pr_contracts.py
+++ b/tests/contracts/test_prepare_compose_pr_contracts.py
@@ -183,6 +183,85 @@ def test_prepare_pr_plan_summary_prohibits_nested_heading():
     )
 
 
+def test_prepare_pr_no_hardcoded_lens_file_patterns():
+    """Development lens selection must not enumerate specific build tool filenames."""
+    text = PREPARE_PR.read_text()
+    for pattern in ["pyproject.toml", "Taskfile*", "setup.cfg", "tox.ini", "noxfile.py"]:
+        assert pattern not in text, (
+            f"prepare-pr must not contain hardcoded file pattern '{pattern}' — "
+            "lens selection should use codebase-agnostic criteria"
+        )
+
+
+def test_prepare_pr_codebase_agnostic_development_lens_criteria():
+    """Development lens prompt must use intent-based criteria, not filenames."""
+    text = PREPARE_PR.read_text().lower()
+    assert "build configuration" in text
+    assert "test infrastructure" in text
+    assert "ci" in text
+    assert "quality gate" in text
+    assert "file purpose" in text or "purpose, not filename" in text
+
+
+def test_prepare_pr_documents_arch_lenses_argument():
+    """prepare-pr must document arch_lenses as a positional argument."""
+    text = PREPARE_PR.read_text()
+    args_idx = text.find("## Arguments")
+    step0_idx = text.find("### Step 0")
+    assert args_idx != -1 and step0_idx != -1
+    args_section = text[args_idx:step0_idx]
+    assert "arch_lenses" in args_section, (
+        "prepare-pr Arguments section must document the arch_lenses parameter"
+    )
+
+
+def test_prepare_pr_skips_lens_work_when_arch_lenses_false():
+    """prepare-pr must skip Steps 5-6 when arch_lenses is not true."""
+    text = PREPARE_PR.read_text()
+    step5_idx = text.find("### Step 5")
+    step7_idx = text.find("### Step 7")
+    assert step5_idx != -1 and step7_idx != -1
+    step5_section = text[step5_idx:step7_idx]
+    assert "arch_lenses" in step5_section, "Step 5 must reference arch_lenses for the skip gate"
+    assert "none" in step5_section.lower(), "Step 5 skip path must emit 'none' for lens tokens"
+
+
+@pytest.mark.parametrize(
+    "recipe_name",
+    [
+        "implementation.yaml",
+        "remediation.yaml",
+        "implementation-groups.yaml",
+    ],
+)
+def test_recipe_prepare_pr_passes_arch_lenses(recipe_name: str) -> None:
+    """Every recipe's prepare_pr step must pass arch_lenses and issue_number in skill_command."""
+    from autoskillit.core.io import load_yaml
+
+    data = load_yaml(RECIPES_DIR / recipe_name)
+    skill_command = data["steps"]["prepare_pr"]["with"]["skill_command"]
+    assert "${{ inputs.arch_lenses }}" in skill_command, (
+        f"{recipe_name}: prepare_pr skill_command must include "
+        "${{ inputs.arch_lenses }} as a positional argument"
+    )
+    assert "${{ context.issue_number }}" in skill_command, (
+        f"{recipe_name}: prepare_pr skill_command must include "
+        "${{ context.issue_number }} as a positional argument, "
+        "not in a separate with: key (ADR-0003)"
+    )
+
+
+def test_prepare_pr_contract_includes_arch_lenses_input() -> None:
+    """prepare-pr contract must declare arch_lenses as an optional input."""
+    from autoskillit.recipe.contracts import load_bundled_manifest
+
+    manifest = load_bundled_manifest()
+    inputs = manifest["skills"]["prepare-pr"]["inputs"]
+    assert any(i["name"] == "arch_lenses" for i in inputs), (
+        "prepare-pr must declare arch_lenses in skill_contracts.yaml inputs"
+    )
+
+
 def test_compose_pr_never_fabricate_diagrams():
     """compose-pr NEVER block must contain unconditional diagram fabrication prohibition."""
     text = COMPOSE_PR.read_text()

--- a/tests/skills/test_promote_split_contracts.py
+++ b/tests/skills/test_promote_split_contracts.py
@@ -70,6 +70,22 @@ class TestPromoteToMainProjectLocal:
             "for review-promotion's analysis report"
         )
 
+    def test_no_hardcoded_lens_file_patterns(self):
+        """Project-local promote-to-main dev lens must not enumerate build tool filenames."""
+        content = self._content()
+        marker = "**Development lens"
+        start = content.find(marker)
+        assert start != -1, "promote-to-main must have a 'Development lens' section"
+        end = content.find("\n\n", start)
+        if end == -1:
+            end = len(content)
+        section = content[start:end]
+        patterns = ["pyproject.toml", "Taskfile*", "setup.cfg", "tox.ini", "noxfile.py"]
+        for pattern in patterns:
+            assert pattern not in section, (
+                f"lens section must not contain hardcoded file pattern '{pattern}'"
+            )
+
 
 class TestReviewPromotionProjectLocal:
     def _content(self) -> str:
@@ -137,3 +153,19 @@ class TestPromoteToMainCanonical:
         assert "Subagent Autonomy Grant" not in content
         assert "spawn additional subagents" not in content.lower()
         assert "spawn their own sub-subagents" not in content.lower()
+
+    def test_no_hardcoded_lens_file_patterns(self):
+        """Canonical promote-to-main dev lens section must not enumerate build tool filenames."""
+        content = self._content()
+        marker = "**Development lens"
+        start = content.find(marker)
+        assert start != -1, "promote-to-main must have a 'Development lens' section"
+        end = content.find("\n\n", start)
+        if end == -1:
+            end = len(content)
+        section = content[start:end]
+        patterns = ["pyproject.toml", "Taskfile*", "setup.cfg", "tox.ini", "noxfile.py"]
+        for pattern in patterns:
+            assert pattern not in section, (
+                f"lens section must not contain hardcoded file pattern '{pattern}'"
+            )


### PR DESCRIPTION
## Summary

Remove the hardcoded development lens file-pattern guard from `prepare-pr/SKILL.md` (lines 150–154), `promote-to-main/SKILL.md` (lines 374–377), and the project-local `.claude/skills/promote-to-main/SKILL.md` (lines 325–327). Replace all three with codebase-agnostic, intent-based selection criteria that describe what the `development` lens covers by purpose rather than filename. Add `arch_lenses` as a positional argument to `prepare-pr` so it skips the lens-selection subagent spawn and context file writes when `arch_lenses` is not `true`, saving tokens and disk writes on every run where lenses are disabled (the default).

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260601-122856-684562/.autoskillit/temp/make-plan/remove_hardcoded_dev_lens_guard_plan_2026-06-01_122856.md`

Closes #3541

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 2.0k | 31.3k | 1.9M | 119.0k | 58 | 103.3k | 16m 25s |
| review_approach* | opus[1m] | 1 | 25 | 4.4k | 225.3k | 42.9k | 15 | 28.3k | 2m 56s |
| verify* | opus[1m] | 1 | 36 | 7.1k | 584.4k | 112.6k | 28 | 95.9k | 3m 59s |
| implement* | MiniMax-M3 | 1 | 185.1k | 19.1k | 3.7M | 91.0k | 122 | 0 | 11m 2s |
| audit_impl* | opus[1m] | 1 | 23 | 9.6k | 145.7k | 41.1k | 12 | 36.3k | 5m 13s |
| prepare_pr* | MiniMax-M3 | 1 | 79.7k | 3.5k | 260.6k | 48.2k | 19 | 0 | 1m 48s |
| compose_pr* | MiniMax-M3 | 1 | 72.5k | 1.3k | 151.2k | 38.6k | 13 | 0 | 48s |
| review_pr* | opus[1m] | 1 | 990 | 29.3k | 558.1k | 80.7k | 31 | 64.7k | 7m 50s |
| resolve_review* | opus[1m] | 1 | 585 | 14.0k | 930.8k | 65.0k | 39 | 49.1k | 7m 49s |
| **Total** | | | 340.9k | 119.7k | 8.4M | 119.0k | | 377.6k | 57m 54s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 173 | 21162.2 | 0.0 | 110.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 155134.8 | 8178.7 | 2337.5 |
| **Total** | **179** | 46970.6 | 2109.3 | 668.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 3.6k | 95.8k | 4.3M | 377.6k | 44m 15s |
| MiniMax-M3 | 3 | 337.3k | 23.9k | 4.1M | 0 | 13m 38s |