### PR TITLE
Rectify: configure_fleet Snapshot Diverges from Live Semaphore

### DIFF
--- a/src/autoskillit/server/tools/tools_config.py
+++ b/src/autoskillit/server/tools/tools_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import fields as dc_fields
 
-from autoskillit.core import atomic_write, get_logger
+from autoskillit.core import FleetLock, atomic_write, get_logger
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_orchestrator_exact
 from autoskillit.server._misc import _hook_config_overlay_path, _hook_config_path
@@ -49,7 +49,9 @@ def _write_session_config(
     return (True, existing)
 
 
-def _build_config_snapshot(config, domain: str, overlay: dict) -> dict:
+def _build_config_snapshot(
+    config, domain: str, overlay: dict, *, fleet_lock: FleetLock | None = None
+) -> dict:
     """Build complete config snapshot: dataclass defaults + overlay overrides."""
     if domain == "fleet":
         defaults = {f.name: getattr(config.fleet, f.name) for f in dc_fields(config.fleet)}
@@ -63,6 +65,11 @@ def _build_config_snapshot(config, domain: str, overlay: dict) -> dict:
 
     domain_overrides = overlay.get(domain, {})
     snapshot_domain = {**defaults, **domain_overrides}
+
+    if domain == "fleet" and fleet_lock is not None:
+        snapshot_domain["max_concurrent_dispatches"] = fleet_lock.max_concurrent
+        if fleet_lock.timeout is not None:
+            snapshot_domain["acquire_timeout_sec"] = fleet_lock.timeout
 
     return {domain: snapshot_domain, "core": {**core_defaults, **core_overrides}}
 
@@ -189,11 +196,28 @@ async def configure_fleet(
         if not ok:
             return json.dumps({"success": False, "error": result})
 
-        if max_concurrent_dispatches is not None:
-            _replace_fleet_semaphore(ctx, max_concurrent_dispatches, acquire_timeout_sec)
+        if max_concurrent_dispatches is not None or acquire_timeout_sec is not None:
+            effective_max = (
+                max_concurrent_dispatches
+                if max_concurrent_dispatches is not None
+                else (
+                    ctx.fleet_lock.max_concurrent
+                    if ctx.fleet_lock is not None
+                    else ctx.config.fleet.max_concurrent_dispatches
+                )
+            )
+            _pre_timeout = ctx.fleet_lock.timeout if ctx.fleet_lock is not None else None
+            _replace_fleet_semaphore(ctx, effective_max, acquire_timeout_sec)
+            if ctx.fleet_lock is not None:
+                if max_concurrent_dispatches is not None:
+                    assert ctx.fleet_lock.max_concurrent == max_concurrent_dispatches
+                if acquire_timeout_sec is not None:
+                    assert ctx.fleet_lock.timeout == acquire_timeout_sec
+                else:
+                    assert ctx.fleet_lock.timeout == _pre_timeout
 
         assert isinstance(result, dict)
-        snapshot = _build_config_snapshot(ctx.config, "fleet", result)
+        snapshot = _build_config_snapshot(ctx.config, "fleet", result, fleet_lock=ctx.fleet_lock)
         return json.dumps({"success": True, "config": snapshot})
     except Exception as exc:
         logger.error("configure_fleet unhandled exception", exc_info=True)

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -324,7 +324,7 @@ def _close_kitchen_handler() -> None:
             timeout=ctx.config.fleet.acquire_timeout_sec,
         )
     except (TypeError, ValueError):
-        logger.warning("fleet_lock_reset_skipped")
+        logger.warning("fleet_lock_reset_skipped", exc_info=True)
     tracker_dir = _pipeline_tracker_dir(ctx.project_dir)
     try:
         if tracker_dir.is_dir():

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -316,12 +316,15 @@ def _close_kitchen_handler() -> None:
         overlay_path.unlink(missing_ok=True)
     except OSError:
         logger.warning("hook_config_overlay_remove_failed", path=str(overlay_path))
-    from autoskillit.fleet import FleetSemaphore  # noqa: PLC0415
+    try:
+        from autoskillit.fleet import FleetSemaphore  # noqa: PLC0415
 
-    ctx.fleet_lock = FleetSemaphore(
-        max_concurrent=ctx.config.fleet.max_concurrent_dispatches,
-        timeout=ctx.config.fleet.acquire_timeout_sec,
-    )
+        ctx.fleet_lock = FleetSemaphore(
+            max_concurrent=ctx.config.fleet.max_concurrent_dispatches,
+            timeout=ctx.config.fleet.acquire_timeout_sec,
+        )
+    except (TypeError, ValueError):
+        logger.warning("fleet_lock_reset_skipped")
     tracker_dir = _pipeline_tracker_dir(ctx.project_dir)
     try:
         if tracker_dir.is_dir():

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -316,6 +316,12 @@ def _close_kitchen_handler() -> None:
         overlay_path.unlink(missing_ok=True)
     except OSError:
         logger.warning("hook_config_overlay_remove_failed", path=str(overlay_path))
+    from autoskillit.fleet import FleetSemaphore  # noqa: PLC0415
+
+    ctx.fleet_lock = FleetSemaphore(
+        max_concurrent=ctx.config.fleet.max_concurrent_dispatches,
+        timeout=ctx.config.fleet.acquire_timeout_sec,
+    )
     tracker_dir = _pipeline_tracker_dir(ctx.project_dir)
     try:
         if tracker_dir.is_dir():

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -122,8 +122,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools/tools_kitchen.py", 132),
     ("src/autoskillit/server/tools/tools_kitchen.py", 151),
     ("src/autoskillit/server/tools/tools_kitchen.py", 185),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 799),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 859),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 808),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 868),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 164),
     # tools_status.py — mcp_data dict

--- a/tests/server/test_tools_config.py
+++ b/tests/server/test_tools_config.py
@@ -304,3 +304,186 @@ async def test_configure_fleet_semaphore_null_fleet_lock(tmp_path, monkeypatch) 
     assert payload["success"] is True
     assert mock_ctx.fleet_lock.max_concurrent == 4
     assert mock_ctx.fleet_lock.timeout is None
+
+
+@pytest.mark.anyio
+async def test_configure_fleet_snapshot_matches_live_semaphore(tmp_path, monkeypatch) -> None:
+    """Snapshot max_concurrent_dispatches must equal ctx.fleet_lock.max_concurrent."""
+    from autoskillit.fleet._semaphore import FleetSemaphore
+    from autoskillit.server import _state
+
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(json.dumps({}))
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+    mock_ctx.fleet_lock = FleetSemaphore(max_concurrent=3)
+    mock_ctx.config = AutomationConfig()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_fleet
+
+    result = await configure_fleet(max_concurrent_dispatches=5)
+    payload = json.loads(result)
+
+    assert payload["success"] is True
+    assert mock_ctx.fleet_lock.max_concurrent == 5
+    assert payload["config"]["fleet"]["max_concurrent_dispatches"] == 5
+
+
+@pytest.mark.anyio
+async def test_configure_fleet_acquire_timeout_only_updates_semaphore(
+    tmp_path, monkeypatch
+) -> None:
+    """acquire_timeout_sec-only call must update the live semaphore."""
+    from autoskillit.fleet._semaphore import FleetSemaphore
+    from autoskillit.server import _state
+
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(json.dumps({}))
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+    mock_ctx.fleet_lock = FleetSemaphore(max_concurrent=3)
+    mock_ctx.config = AutomationConfig()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_fleet
+
+    result = await configure_fleet(acquire_timeout_sec=30.0)
+    payload = json.loads(result)
+
+    assert payload["success"] is True
+    assert mock_ctx.fleet_lock.timeout == 30.0
+    assert payload["config"]["fleet"]["acquire_timeout_sec"] == 30.0
+
+
+@pytest.mark.anyio
+async def test_configure_fleet_snapshot_reads_semaphore_not_overlay(tmp_path, monkeypatch) -> None:
+    """Snapshot acquire_timeout_sec must reflect the live semaphore's carried-forward timeout."""
+    from autoskillit.fleet._semaphore import FleetSemaphore
+    from autoskillit.server import _state
+
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(json.dumps({}))
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+    mock_ctx.fleet_lock = FleetSemaphore(max_concurrent=3, timeout=60.0)
+    mock_ctx.config = AutomationConfig()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_fleet
+
+    result = await configure_fleet(max_concurrent_dispatches=5)
+    payload = json.loads(result)
+
+    assert payload["success"] is True
+    assert mock_ctx.fleet_lock.timeout == 60.0
+    assert payload["config"]["fleet"]["acquire_timeout_sec"] == 60.0
+
+
+@pytest.mark.anyio
+async def test_configure_fleet_close_reopen_resets_semaphore_to_defaults(
+    tmp_path, monkeypatch
+) -> None:
+    """After close/reopen, semaphore must return to config defaults."""
+    from unittest.mock import patch
+
+    from autoskillit.fleet._semaphore import FleetSemaphore
+    from autoskillit.server import _state
+
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(json.dumps({}))
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+    mock_ctx.fleet_lock = FleetSemaphore(max_concurrent=3)
+    mock_ctx.config = AutomationConfig()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_fleet
+
+    result = await configure_fleet(max_concurrent_dispatches=6)
+    payload = json.loads(result)
+    assert payload["success"] is True
+    assert mock_ctx.fleet_lock.max_concurrent == 6
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            from autoskillit.server.tools.tools_kitchen import _close_kitchen_handler
+
+            _close_kitchen_handler()
+
+    assert mock_ctx.fleet_lock.max_concurrent == mock_ctx.config.fleet.max_concurrent_dispatches
+
+    hook_cfg_path.write_text(json.dumps({}))
+    result2 = await configure_fleet()
+    payload2 = json.loads(result2)
+    assert payload2["success"] is True
+    assert (
+        payload2["config"]["fleet"]["max_concurrent_dispatches"]
+        == mock_ctx.config.fleet.max_concurrent_dispatches
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "calls",
+    [
+        [{"max_concurrent_dispatches": 4}],
+        [{"acquire_timeout_sec": 15.0}],
+        [{"max_concurrent_dispatches": 4, "acquire_timeout_sec": 15.0}],
+        [{"max_concurrent_dispatches": 4}, {"acquire_timeout_sec": 25.0}],
+    ],
+    ids=["max_only", "timeout_only", "both", "sequential"],
+)
+async def test_configure_fleet_snapshot_semaphore_invariant(tmp_path, monkeypatch, calls) -> None:
+    """Snapshot must always match the live semaphore for semaphore-managed fields."""
+    from autoskillit.fleet._semaphore import FleetSemaphore
+    from autoskillit.server import _state
+
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(json.dumps({}))
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+    mock_ctx.fleet_lock = FleetSemaphore(max_concurrent=3)
+    mock_ctx.config = AutomationConfig()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_fleet
+
+    payload = None
+    for call_kwargs in calls:
+        result = await configure_fleet(**call_kwargs)
+        payload = json.loads(result)
+        assert payload["success"] is True
+
+    assert payload is not None
+    assert (
+        payload["config"]["fleet"]["max_concurrent_dispatches"]
+        == mock_ctx.fleet_lock.max_concurrent
+    )
+    if mock_ctx.fleet_lock.timeout is not None:
+        assert payload["config"]["fleet"]["acquire_timeout_sec"] == mock_ctx.fleet_lock.timeout
+    else:
+        assert (
+            payload["config"]["fleet"]["acquire_timeout_sec"]
+            == mock_ctx.config.fleet.acquire_timeout_sec
+        )

--- a/tests/server/test_tools_config.py
+++ b/tests/server/test_tools_config.py
@@ -7,6 +7,7 @@ import json
 import pytest
 
 from autoskillit.config import AutomationConfig
+from autoskillit.fleet._semaphore import FleetSemaphore
 from tests.server.conftest import _make_mock_ctx
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
@@ -28,6 +29,7 @@ async def test_configure_fleet_writes_overlay(tmp_path, monkeypatch) -> None:
     mock_ctx = _make_mock_ctx()
     mock_ctx.project_dir = tmp_path
     mock_ctx.config = AutomationConfig()
+    mock_ctx.fleet_lock = FleetSemaphore(max_concurrent=3)
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(_state, "_ctx", mock_ctx)
@@ -50,7 +52,6 @@ async def test_configure_fleet_writes_overlay(tmp_path, monkeypatch) -> None:
 @pytest.mark.anyio
 async def test_configure_fleet_replaces_semaphore(tmp_path, monkeypatch) -> None:
     """configure_fleet replaces ctx.fleet_lock with resized FleetSemaphore."""
-    from autoskillit.fleet._semaphore import FleetSemaphore
     from autoskillit.server import _state
 
     hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
@@ -91,6 +92,7 @@ async def test_configure_fleet_preserves_existing_overlay(tmp_path, monkeypatch)
     mock_ctx = _make_mock_ctx()
     mock_ctx.project_dir = tmp_path
     mock_ctx.config = AutomationConfig()
+    mock_ctx.fleet_lock = FleetSemaphore(max_concurrent=3)
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(_state, "_ctx", mock_ctx)
@@ -240,6 +242,7 @@ async def test_configure_fleet_no_params_returns_defaults(tmp_path, monkeypatch)
     mock_ctx = _make_mock_ctx()
     mock_ctx.project_dir = tmp_path
     mock_ctx.config = AutomationConfig()
+    mock_ctx.fleet_lock = FleetSemaphore(max_concurrent=3)
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(_state, "_ctx", mock_ctx)
@@ -309,7 +312,6 @@ async def test_configure_fleet_semaphore_null_fleet_lock(tmp_path, monkeypatch) 
 @pytest.mark.anyio
 async def test_configure_fleet_snapshot_matches_live_semaphore(tmp_path, monkeypatch) -> None:
     """Snapshot max_concurrent_dispatches must equal ctx.fleet_lock.max_concurrent."""
-    from autoskillit.fleet._semaphore import FleetSemaphore
     from autoskillit.server import _state
 
     hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
@@ -339,7 +341,6 @@ async def test_configure_fleet_acquire_timeout_only_updates_semaphore(
     tmp_path, monkeypatch
 ) -> None:
     """acquire_timeout_sec-only call must update the live semaphore."""
-    from autoskillit.fleet._semaphore import FleetSemaphore
     from autoskillit.server import _state
 
     hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
@@ -367,7 +368,6 @@ async def test_configure_fleet_acquire_timeout_only_updates_semaphore(
 @pytest.mark.anyio
 async def test_configure_fleet_snapshot_reads_semaphore_not_overlay(tmp_path, monkeypatch) -> None:
     """Snapshot acquire_timeout_sec must reflect the live semaphore's carried-forward timeout."""
-    from autoskillit.fleet._semaphore import FleetSemaphore
     from autoskillit.server import _state
 
     hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
@@ -399,7 +399,6 @@ async def test_configure_fleet_close_reopen_resets_semaphore_to_defaults(
     """After close/reopen, semaphore must return to config defaults."""
     from unittest.mock import patch
 
-    from autoskillit.fleet._semaphore import FleetSemaphore
     from autoskillit.server import _state
 
     hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
@@ -452,7 +451,6 @@ async def test_configure_fleet_close_reopen_resets_semaphore_to_defaults(
 )
 async def test_configure_fleet_snapshot_semaphore_invariant(tmp_path, monkeypatch, calls) -> None:
     """Snapshot must always match the live semaphore for semaphore-managed fields."""
-    from autoskillit.fleet._semaphore import FleetSemaphore
     from autoskillit.server import _state
 
     hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)

--- a/tests/server/test_tools_kitchen_gate_features.py
+++ b/tests/server/test_tools_kitchen_gate_features.py
@@ -93,6 +93,28 @@ def test_close_kitchen_cancels_quota_refresh_task(tmp_path, monkeypatch):
     assert mock_ctx.quota_refresh_task is None
 
 
+def test_close_kitchen_resets_fleet_lock(tmp_path, monkeypatch):
+    """_close_kitchen_handler resets ctx.fleet_lock to config defaults."""
+    from autoskillit.config import AutomationConfig
+    from autoskillit.fleet._semaphore import FleetSemaphore
+
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+    mock_ctx.config = AutomationConfig()
+    mock_ctx.fleet_lock = FleetSemaphore(max_concurrent=6, timeout=42.0)
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            from autoskillit.server.tools.tools_kitchen import _close_kitchen_handler
+
+            _close_kitchen_handler()
+
+    assert mock_ctx.fleet_lock is not None
+    assert mock_ctx.fleet_lock.max_concurrent == mock_ctx.config.fleet.max_concurrent_dispatches
+    assert mock_ctx.fleet_lock.timeout == mock_ctx.config.fleet.acquire_timeout_sec
+
+
 @pytest.mark.anyio
 async def test_open_kitchen_ingredients_only_strips_content(tmp_path, monkeypatch):
     """open_kitchen(name=X, ingredients_only=True) must omit content from result."""


### PR DESCRIPTION
## Summary

The `configure_fleet` and `configure_order` MCP tools return config snapshots built from an overlay file + static dataclass defaults, but the live runtime objects (`ctx.fleet_lock`, `ctx.config.fleet`, `ctx.config.run_skill`) may diverge from those snapshots. The snapshot is documented as "the single source of truth for session limits" but it lies in multiple scenarios. This Part A addresses the core semaphore divergence (Defects 1 and 2 from the investigation) and the `acquire_timeout_sec`-only call gap. Part B will address the broader overlay-only parameter divergence for all 6 fleet params and all 4 order params that never reach the execution layer.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260601-123956-046517/.autoskillit/temp/rectify/rectify_configure_fleet_snapshot_diverges_from_live_semaphore_2026-06-01_124500.md`

Closes #3547

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 2.9k | 22.0k | 3.1M | 127.8k | 74 | 112.9k | 19m 2s |
| review_approach* | opus[1m] | 1 | 24 | 5.1k | 183.1k | 40.2k | 11 | 26.5k | 2m 58s |
| dry_walkthrough* | opus | 1 | 27 | 10.6k | 376.5k | 56.6k | 26 | 39.9k | 4m 56s |
| implement* | opus[1m] | 1 | 56 | 12.0k | 1.2M | 83.8k | 43 | 67.4k | 4m 15s |
| audit_impl* | opus[1m] | 1 | 1.0k | 10.1k | 281.4k | 40.9k | 19 | 35.3k | 4m 16s |
| prepare_pr* | MiniMax-M3 | 1 | 122.3k | 4.0k | 216.9k | 48.1k | 20 | 0 | 1m 51s |
| compose_pr* | MiniMax-M3 | 1 | 39.8k | 1.8k | 185.9k | 39.1k | 15 | 0 | 1m 2s |
| review_pr* | opus[1m] | 1 | 29 | 33.7k | 626.6k | 88.8k | 38 | 72.1k | 8m 7s |
| resolve_review* | opus[1m] | 1 | 42 | 4.6k | 791.9k | 60.3k | 33 | 43.9k | 3m 31s |
| **Total** | | | 166.2k | 103.8k | 7.0M | 127.8k | | 397.9k | 50m 3s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 245 | 4804.1 | 274.9 | 48.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 395948.5 | 21969.5 | 2282.0 |
| **Total** | **247** | 28199.5 | 1611.0 | 420.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 4.0k | 87.4k | 6.2M | 358.0k | 42m 12s |
| opus | 1 | 27 | 10.6k | 376.5k | 39.9k | 4m 56s |
| MiniMax-M3 | 2 | 162.1k | 5.7k | 402.8k | 0 | 2m 54s |