### PR TITLE
Replace String-Comparison Backend Dispatch Guard with Capability Lookup

### DIFF
--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -93,6 +93,9 @@ class BackendCapabilities:
     replay_capable: bool = field(default=False)
     # True when backend supports api_simulator-based RECORD_SCENARIO runner wrapping
     record_capable: bool = field(default=False)
+    # True when backend is the Anthropic provider (Claude Code) — used to gate
+    # provider-override routing in run_skill() on capability rather than backend name.
+    anthropic_provider_capable: bool = field(default=False)
 
 
 _CONTEXT_WINDOW_SUFFIX_RE: _re.Pattern[str] = _re.compile(r"\[\d+[mk]?\]$", _re.IGNORECASE)
@@ -141,6 +144,7 @@ CLAUDE_CODE_CAPABILITIES: BackendCapabilities = BackendCapabilities(
     skills_subdir=".claude/skills",
     replay_capable=True,
     record_capable=True,
+    anthropic_provider_capable=True,
 )
 
 

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -328,6 +328,7 @@ class CodexBackend:
             mcp_env_forward_vars=frozenset({MCP_CLIENT_BACKEND_ENV_VAR}),
             replay_capable=False,
             record_capable=False,
+            anthropic_provider_capable=False,
         )
 
     def build_cmd(self, skill_command: str, cwd: str) -> CmdSpec:

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -568,7 +568,6 @@ async def run_skill(
 
             from autoskillit.core import (
                 AGENT_BACKEND_CLAUDE_CODE,
-                AGENT_BACKEND_CODEX,
                 is_feature_enabled,
             )
 
@@ -626,7 +625,7 @@ async def run_skill(
                     provider_extras
                     and "ANTHROPIC_BASE_URL" in provider_extras
                     and tool_ctx.backend is not None
-                    and tool_ctx.backend.name == AGENT_BACKEND_CODEX
+                    and not tool_ctx.backend.capabilities.anthropic_provider_capable
                 )
                 else None
             )

--- a/tests/arch/test_no_backend_name_bypass.py
+++ b/tests/arch/test_no_backend_name_bypass.py
@@ -18,7 +18,6 @@ _EXEMPT_FILES: frozenset[str] = frozenset(
         "execution/recording.py",  # Replay setup: fmt == "codex" Compare for player selection
         "execution/headless/_headless_evidence.py",  # Claude-specific evidence extraction
         "execution/headless/_headless_result.py",  # Claude-specific result parsing
-        "server/tools/tools_execution.py",  # Provider-override backend routing
         "core/_version_snapshot.py",  # Version snapshot — routes codex_version by backend name
         "execution/headless/_headless_helpers.py",  # assert_headless_cmd claude -p flag check
         "server/_session_type.py",  # Codex pre-reveal — env var dispatch, no capabilities

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -75,6 +75,7 @@ def test_backend_capabilities_field_count():
         "supports_tool_list_changed",
         "replay_capable",
         "record_capable",
+        "anthropic_provider_capable",
     }
     assert frozenset_fields == {
         "completion_record_types",
@@ -121,6 +122,7 @@ def test_backend_capabilities_field_names_locked():
         "mcp_env_forward_vars",
         "replay_capable",
         "record_capable",
+        "anthropic_provider_capable",
     }
     actual = {f.name for f in dataclasses.fields(BackendCapabilities)}
     assert actual == expected
@@ -157,6 +159,7 @@ def test_claude_code_capabilities_field_values():
     assert CLAUDE_CODE_CAPABILITIES.mcp_env_forward_vars == frozenset()
     assert CLAUDE_CODE_CAPABILITIES.replay_capable is True
     assert CLAUDE_CODE_CAPABILITIES.record_capable is True
+    assert CLAUDE_CODE_CAPABILITIES.anthropic_provider_capable is True
 
 
 def test_backend_capabilities_frozenset_defaults():

--- a/tests/server/test_tools_execution_backend_mixing.py
+++ b/tests/server/test_tools_execution_backend_mixing.py
@@ -60,10 +60,10 @@ async def test_codex_backend_minimax_profile_with_anthropic_base_url_derives_ove
 
 
 @pytest.mark.anyio
-async def test_codex_backend_non_anthropic_profile_without_base_url_no_override(
+async def test_anthropic_capable_backend_profile_without_base_url_no_override(
     tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
-    """Codex backend + non-Anthropic profile without ANTHROPIC_BASE_URL -> no override."""
+    """Anthropic-capable backend + profile without ANTHROPIC_BASE_URL -> no override."""
     from unittest.mock import MagicMock
 
     from autoskillit.core.types._type_protocols_backend import CodingAgentBackend

--- a/tests/server/test_tools_execution_backend_mixing.py
+++ b/tests/server/test_tools_execution_backend_mixing.py
@@ -28,7 +28,7 @@ async def test_codex_backend_minimax_profile_with_anthropic_base_url_derives_ove
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     fake_backend = MagicMock(spec=CodingAgentBackend)
-    type(fake_backend).name = property(lambda self: "codex")
+    fake_backend.capabilities.anthropic_provider_capable = False
     tool_ctx_kitchen_open.backend = fake_backend
     tool_ctx_kitchen_open.session_skill_manager = None
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
@@ -72,7 +72,7 @@ async def test_codex_backend_non_anthropic_profile_without_base_url_no_override(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     fake_backend = MagicMock(spec=CodingAgentBackend)
-    type(fake_backend).name = property(lambda self: "codex")
+    fake_backend.capabilities.anthropic_provider_capable = True
     tool_ctx_kitchen_open.backend = fake_backend
     tool_ctx_kitchen_open.session_skill_manager = None
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)

--- a/tests/server/test_tools_execution_provider.py
+++ b/tests/server/test_tools_execution_provider.py
@@ -449,7 +449,7 @@ async def test_run_skill_backend_override_codex_with_anthropic_base_url(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     fake_backend = MagicMock(spec=CodingAgentBackend)
-    type(fake_backend).name = property(lambda self: "codex")
+    fake_backend.capabilities.anthropic_provider_capable = False
     tool_ctx_kitchen_open.backend = fake_backend
     # Skip Codex session init: copies ~/.codex/config.toml which is absent in CI
     tool_ctx_kitchen_open.session_skill_manager = None
@@ -492,7 +492,7 @@ async def test_run_skill_backend_override_none_no_anthropic_base_url(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     fake_backend = MagicMock(spec=CodingAgentBackend)
-    type(fake_backend).name = property(lambda self: "codex")
+    fake_backend.capabilities.anthropic_provider_capable = True
     tool_ctx_kitchen_open.backend = fake_backend
     tool_ctx_kitchen_open.session_skill_manager = None
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
@@ -528,7 +528,7 @@ async def test_run_skill_backend_override_none_claude_code_backend(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     fake_backend = MagicMock(spec=CodingAgentBackend)
-    type(fake_backend).name = property(lambda self: "claude-code")
+    fake_backend.capabilities.anthropic_provider_capable = True
     tool_ctx_kitchen_open.backend = fake_backend
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
@@ -566,7 +566,7 @@ async def test_run_skill_backend_override_none_providers_disabled(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     fake_backend = MagicMock(spec=CodingAgentBackend)
-    type(fake_backend).name = property(lambda self: "codex")
+    fake_backend.capabilities.anthropic_provider_capable = False
     tool_ctx_kitchen_open.backend = fake_backend
     tool_ctx_kitchen_open.session_skill_manager = None
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)


### PR DESCRIPTION
## Summary

Replace the `tool_ctx.backend.name == AGENT_BACKEND_CODEX` string comparison in `run_skill()` with `not tool_ctx.backend.capabilities.anthropic_provider_capable`. This requires re-adding the `anthropic_provider_capable` field to `BackendCapabilities` (it was added in P1-A1-WP1 but removed in #3281 for lacking a consumer), wiring it into both backend implementations, updating the two existing tests to use capability-based mocks, updating the `test_backend_capabilities.py` field registries, and removing `tools_execution.py` from the arch-test exemption list.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260601-131140-981157/.autoskillit/temp/make-plan/p4_a1_wp3_replace_string_comparison_backend_dispatch_plan_2026-06-01_131500.md`

Closes #3118

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.4k | 17.1k | 1.7M | 98.0k | 69 | 153.8k | 9m 38s |
| verify* | sonnet | 1 | 748 | 11.7k | 432.3k | 49.3k | 31 | 32.9k | 4m 36s |
| implement* | MiniMax-M3 | 1 | 419.8k | 13.4k | 2.6M | 85.4k | 115 | 0 | 11m 49s |
| audit_impl* | sonnet | 1 | 619 | 10.5k | 177.1k | 38.5k | 15 | 32.6k | 4m 33s |
| prepare_pr* | MiniMax-M3 | 1 | 115.7k | 2.5k | 362.3k | 43.2k | 15 | 0 | 1m 41s |
| compose_pr* | MiniMax-M3 | 1 | 69.0k | 897 | 113.4k | 37.8k | 10 | 0 | 42s |
| **Total** | | | 607.4k | 56.2k | 5.4M | 98.0k | | 219.3k | 33m 0s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 24 | 106789.6 | 0.0 | 557.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **24** | 224373.0 | 9135.8 | 2340.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.4k | 17.1k | 1.7M | 153.8k | 9m 38s |
| sonnet | 2 | 1.4k | 22.3k | 609.4k | 65.5k | 9m 9s |
| MiniMax-M3 | 3 | 604.6k | 16.8k | 3.0M | 0 | 14m 12s |