### PR TITLE
Rectify: Write Guard Path Resolution Immunity

### DIFF
--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -7,6 +7,7 @@ _INTERPRETER_LINE_RE.
 
 from __future__ import annotations
 
+import os
 import re
 import shlex
 from collections.abc import Sequence
@@ -49,6 +50,16 @@ _REDIRECT_OP_ONLY_RE = re.compile(r"^(\d*)>{1,2}$")
 _TRAILING_SHELL_CLOSERS = frozenset({")", "`", "}", "'", '"', ";", "&", "|"})
 
 
+def resolve_write_target(path: str, cwd: str = "") -> str | None:
+    if not path:
+        return None
+    if os.path.isabs(path):
+        return path
+    if cwd:
+        return os.path.join(cwd, path)
+    return None
+
+
 def tokenize_command_segments(command: str) -> list[list[str]]:
     """Split a shell command into segments of (verb, args...) token lists.
 
@@ -73,10 +84,11 @@ def tokenize_command_segments(command: str) -> list[list[str]]:
     return segments
 
 
-def extract_redirect_targets(tokens: list[str]) -> list[str]:
-    """Extract absolute redirect target paths from shlex-tokenized command tokens.
+def extract_redirect_targets(tokens: list[str], cwd: str = "") -> list[str]:
+    """Extract redirect target paths from shlex-tokenized command tokens.
 
-    Returns ALL absolute paths including pseudo-devices — caller filters.
+    Returns resolved paths including pseudo-devices — caller filters.
+    Relative paths are resolved against cwd when provided.
 
     Handles three redirect forms at depth 0 only:
     - Separate:  ['>', '/path'] or ['>>', '/path']
@@ -115,8 +127,9 @@ def extract_redirect_targets(tokens: list[str]) -> list[str]:
                 path = tokens[i + 1]
                 while path and path[-1] in _TRAILING_SHELL_CLOSERS:
                     path = path[:-1]
-                if path.startswith("/"):
-                    targets.append(path)
+                resolved = resolve_write_target(path, cwd)
+                if resolved is not None:
+                    targets.append(resolved)
                 i += 2
                 continue
         elif _REDIRECT_OP_ONLY_RE.match(tok):
@@ -124,8 +137,9 @@ def extract_redirect_targets(tokens: list[str]) -> list[str]:
                 path = tokens[i + 1]
                 while path and path[-1] in _TRAILING_SHELL_CLOSERS:
                     path = path[:-1]
-                if path.startswith("/"):
-                    targets.append(path)
+                resolved = resolve_write_target(path, cwd)
+                if resolved is not None:
+                    targets.append(resolved)
                 i += 2
                 continue
         else:
@@ -134,8 +148,9 @@ def extract_redirect_targets(tokens: list[str]) -> list[str]:
                 path = m.group(2)
                 while path and path[-1] in _TRAILING_SHELL_CLOSERS:
                     path = path[:-1]
-                if path.startswith("/"):
-                    targets.append(path)
+                resolved = resolve_write_target(path, cwd)
+                if resolved is not None:
+                    targets.append(resolved)
         i += 1
     return targets
 

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -18,6 +18,7 @@ from _command_classification import (  # type: ignore[import-not-found]  # noqa:
     extract_interpreter_write_paths,
     extract_redirect_targets,
     is_gh_command,
+    resolve_write_target,
     tokenize_command_segments,
 )
 
@@ -79,11 +80,9 @@ def _extract_segment_targets(segment: list[str], cwd: str) -> list[str] | None:
                 found_write = True
                 double_dash = segment.index("--", idx + 1)
                 for t in segment[double_dash + 1 :]:
-                    if t.startswith("/"):
-                        if t not in _PSEUDO_DEVICE_PATHS:
-                            targets.append(t)
-                    elif cwd:
-                        targets.append(os.path.join(cwd, t))
+                    resolved = resolve_write_target(t, cwd)
+                    if resolved is not None and resolved not in _PSEUDO_DEVICE_PATHS:
+                        targets.append(resolved)
             elif subcmd == "reset" and "--hard" in segment[idx + 1 :]:
                 found_write = True
     elif verb in _WRITE_VERBS:
@@ -94,45 +93,34 @@ def _extract_segment_targets(segment: list[str], cwd: str) -> list[str] | None:
             flags = [t for t in segment[1:] if t.startswith("-")]
             has_inplace = any(t.startswith("-i") or t == "--in-place" for t in flags)
             if has_inplace and non_flag:
-                # non_flag: first element is typically the sed expression, last is file
                 path = non_flag[-1]
-                if path.startswith("/"):
-                    if path not in _PSEUDO_DEVICE_PATHS:
-                        targets.append(path)
-                elif cwd:
-                    targets.append(os.path.join(cwd, path))
+                resolved = resolve_write_target(path, cwd)
+                if resolved is not None and resolved not in _PSEUDO_DEVICE_PATHS:
+                    targets.append(resolved)
         elif verb == "tee":
             if non_flag:
                 path = non_flag[0]
-                if path.startswith("/"):
-                    if path not in _PSEUDO_DEVICE_PATHS:
-                        targets.append(path)
-                elif cwd:
-                    targets.append(os.path.join(cwd, path))
+                resolved = resolve_write_target(path, cwd)
+                if resolved is not None and resolved not in _PSEUDO_DEVICE_PATHS:
+                    targets.append(resolved)
         elif verb in ("mv", "cp"):
             if len(non_flag) >= 2:
                 path = non_flag[-1]
-                if path.startswith("/"):
-                    if path not in _PSEUDO_DEVICE_PATHS:
-                        targets.append(path)
-                elif cwd:
-                    targets.append(os.path.join(cwd, path))
+                resolved = resolve_write_target(path, cwd)
+                if resolved is not None and resolved not in _PSEUDO_DEVICE_PATHS:
+                    targets.append(resolved)
         elif verb == "patch":
             for t in non_flag:
-                if t.startswith("/"):
-                    if t not in _PSEUDO_DEVICE_PATHS:
-                        targets.append(t)
-                    break
-                elif cwd:
-                    targets.append(os.path.join(cwd, t))
+                resolved = resolve_write_target(t, cwd)
+                if resolved is not None:
+                    if resolved not in _PSEUDO_DEVICE_PATHS:
+                        targets.append(resolved)
                     break
         elif verb in ("rm", "unlink"):
             for t in non_flag:
-                if t.startswith("/"):
-                    if t not in _PSEUDO_DEVICE_PATHS:
-                        targets.append(t)
-                elif cwd:
-                    targets.append(os.path.join(cwd, t))
+                resolved = resolve_write_target(t, cwd)
+                if resolved is not None and resolved not in _PSEUDO_DEVICE_PATHS:
+                    targets.append(resolved)
 
     if found_write:
         return targets
@@ -159,19 +147,15 @@ def _extract_bash_write_targets(command: str) -> list[str] | None:
             found_any_write = True
             all_targets.extend(result)
 
-    # Apply redirect regex to full command; skip only when all segments are gh.
-    has_non_gh = any(not is_gh_command(seg) for seg in segments)
-
-    if not segments or has_non_gh:
-        try:
-            flat_tokens = shlex.split(command)
-        except (ValueError, TypeError, AttributeError):
-            flat_tokens = []
-        redirect_paths = extract_redirect_targets(flat_tokens)
-        for path in redirect_paths:
-            found_any_write = True
-            if path not in _PSEUDO_DEVICE_PATHS:
-                all_targets.append(path)
+    try:
+        flat_tokens = shlex.split(command)
+    except (ValueError, TypeError, AttributeError):
+        flat_tokens = []
+    redirect_paths = extract_redirect_targets(flat_tokens, cwd)
+    for path in redirect_paths:
+        found_any_write = True
+        if path not in _PSEUDO_DEVICE_PATHS:
+            all_targets.append(path)
 
     if not found_any_write:
         return None

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -96,6 +96,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_enqueue_ready_type_enforcement.py` | AST guard: mutation methods (_enqueue_direct, _enable_auto_merge_direct) must accept EnqueueReady, not str |
 | `test_origin_isolation_contract.py` | AST + shell lint guard: no hardcoded "origin" in git remote operations outside allowlist; shell scripts must try upstream before origin |
 | `test_skill_backend_annotations.py` | Architectural invariant: skills using Claude-Code-only features must declare backend_requirements: [claude-code] |
+| `test_write_guard_resolution.py` | Arch test: extract_redirect_targets must use resolve_write_target, not inline startswith |
 
 ## Architecture Notes
 

--- a/tests/arch/test_write_guard_resolution.py
+++ b/tests/arch/test_write_guard_resolution.py
@@ -25,7 +25,8 @@ def _has_path_startswith_slash(func_node: ast.FunctionDef) -> bool:
 def test_extract_redirect_targets_uses_resolve_write_target():
     import autoskillit.hooks._command_classification as mod
 
-    source = ast.parse(open(mod.__file__).read())
+    with open(mod.__file__) as f:
+        source = ast.parse(f.read())
     for node in ast.walk(source):
         if isinstance(node, ast.FunctionDef) and node.name == "extract_redirect_targets":
             assert not _has_path_startswith_slash(node), (

--- a/tests/arch/test_write_guard_resolution.py
+++ b/tests/arch/test_write_guard_resolution.py
@@ -1,0 +1,23 @@
+"""Arch test: extract_redirect_targets must use resolve_write_target, not inline startswith."""
+
+import ast
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+def test_extract_redirect_targets_uses_resolve_write_target():
+    import autoskillit.hooks._command_classification as mod
+
+    source = ast.parse(open(mod.__file__).read())
+    for node in ast.walk(source):
+        if isinstance(node, ast.FunctionDef) and node.name == "extract_redirect_targets":
+            body_src = ast.dump(node)
+            assert "startswith" not in body_src, (
+                "extract_redirect_targets must use resolve_write_target() "
+                "instead of inline path.startswith checks"
+            )
+            break
+    else:
+        pytest.fail("extract_redirect_targets function not found")

--- a/tests/arch/test_write_guard_resolution.py
+++ b/tests/arch/test_write_guard_resolution.py
@@ -7,16 +7,30 @@ import pytest
 pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 
 
+def _has_path_startswith_slash(func_node: ast.FunctionDef) -> bool:
+    """Detect inline ``<expr>.startswith("/")`` inside a function body."""
+    for node in ast.walk(func_node):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "startswith"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == "/"
+        ):
+            return True
+    return False
+
+
 def test_extract_redirect_targets_uses_resolve_write_target():
     import autoskillit.hooks._command_classification as mod
 
     source = ast.parse(open(mod.__file__).read())
     for node in ast.walk(source):
         if isinstance(node, ast.FunctionDef) and node.name == "extract_redirect_targets":
-            body_src = ast.dump(node)
-            assert "startswith" not in body_src, (
+            assert not _has_path_startswith_slash(node), (
                 "extract_redirect_targets must use resolve_write_target() "
-                "instead of inline path.startswith checks"
+                'instead of inline path.startswith("/") checks'
             )
             break
     else:

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -280,3 +280,61 @@ class TestExtractRedirectTargets:
     )
     def test_extract_redirect_targets(self, tokens, expected):
         assert extract_redirect_targets(tokens) == expected
+
+
+class TestResolveWriteTarget:
+    @pytest.mark.parametrize(
+        "path,cwd,expected",
+        [
+            ("/tmp/out.txt", "/workspace", "/tmp/out.txt"),
+            ("output.txt", "/workspace", "/workspace/output.txt"),
+            ("output.txt", "", None),
+            ("./output.txt", "/workspace", "/workspace/./output.txt"),
+            ("/tmp/out.txt", "", "/tmp/out.txt"),
+            ("", "/workspace", None),
+            ("", "", None),
+        ],
+        ids=[
+            "absolute_with_cwd",
+            "relative_with_cwd",
+            "relative_no_cwd",
+            "dotslash_relative_with_cwd",
+            "absolute_no_cwd",
+            "empty_path_with_cwd",
+            "empty_path_no_cwd",
+        ],
+    )
+    def test_resolve_write_target(self, path, cwd, expected):
+        from autoskillit.hooks._command_classification import resolve_write_target
+
+        assert resolve_write_target(path, cwd) == expected
+
+
+class TestExtractRedirectTargetsCwd:
+    @pytest.mark.parametrize(
+        "tokens,cwd,expected",
+        [
+            (["cmd", ">", "output.txt"], "/workspace", ["/workspace/output.txt"]),
+            (
+                ["cmd", ">>", ".autoskillit/temp/out.txt"],
+                "/workspace",
+                ["/workspace/.autoskillit/temp/out.txt"],
+            ),
+            (["cmd", "2>", "err.log"], "/workspace", ["/workspace/err.log"]),
+            (["cmd", ">", "output.txt"], "", []),
+            (["cmd", ">", "/abs/path"], "/workspace", ["/abs/path"]),
+            (["cmd", "2>output.txt"], "/workspace", ["/workspace/output.txt"]),
+        ],
+        ids=[
+            "relative_with_cwd",
+            "relative_append_with_cwd",
+            "relative_fd_with_cwd",
+            "relative_no_cwd",
+            "absolute_ignores_cwd",
+            "merged_relative_with_cwd",
+        ],
+    )
+    def test_extract_redirect_targets_with_cwd(self, tokens, cwd, expected):
+        from autoskillit.hooks._command_classification import extract_redirect_targets
+
+        assert extract_redirect_targets(tokens, cwd) == expected

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -912,7 +912,7 @@ class TestRedirectRelativePathResolution:
 
         monkeypatch.delenv("AUTOSKILLIT_CWD", raising=False)
         result = _extract_bash_write_targets("echo foo > output.txt")
-        assert result is None or result == []
+        assert result == []
 
 
 class TestGhCommandRedirectChecking:

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -912,7 +912,7 @@ class TestRedirectRelativePathResolution:
 
         monkeypatch.delenv("AUTOSKILLIT_CWD", raising=False)
         result = _extract_bash_write_targets("echo foo > output.txt")
-        assert result == []
+        assert result is None
 
 
 class TestGhCommandRedirectChecking:

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -879,3 +879,106 @@ class TestExtractBashWriteTargetsNewFamilies:
 
         result = _extract_bash_write_targets("git -C /repo reset --hard")
         assert result is not None
+
+
+class TestRedirectRelativePathResolution:
+    """Tests for redirect relative path resolution via AUTOSKILLIT_CWD."""
+
+    def test_relative_redirect_resolved_against_cwd(self, monkeypatch: pytest.MonkeyPatch):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        monkeypatch.setenv("AUTOSKILLIT_CWD", "/workspace")
+        result = _extract_bash_write_targets("echo foo > output.txt")
+        assert result is not None
+        assert "/workspace/output.txt" in result
+
+    def test_relative_redirect_within_prefix_allowed(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/workspace/.autoskillit/temp/")
+        monkeypatch.setenv("AUTOSKILLIT_CWD", "/workspace")
+        result = _run_hook(_build_bash_event("echo foo > .autoskillit/temp/out.txt"))
+        assert result == ""
+
+    def test_relative_redirect_outside_prefix_denied(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/workspace/.autoskillit/temp/")
+        monkeypatch.setenv("AUTOSKILLIT_CWD", "/workspace")
+        result = _run_hook(_build_bash_event("echo foo > src/main.py"))
+        parsed = json.loads(result)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_no_cwd_relative_redirect_fails_open(self, monkeypatch: pytest.MonkeyPatch):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        monkeypatch.delenv("AUTOSKILLIT_CWD", raising=False)
+        result = _extract_bash_write_targets("echo foo > output.txt")
+        assert result is None or result == []
+
+
+class TestGhCommandRedirectChecking:
+    """gh commands with redirects must have their redirect targets checked."""
+
+    def test_gh_with_absolute_redirect_outside_prefix_denied(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/workspace/.autoskillit/temp/")
+        result = _run_hook(_build_bash_event("gh pr diff 123 > /outside/file.txt"))
+        parsed = json.loads(result)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_gh_with_redirect_to_dev_null_allowed(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/workspace/.autoskillit/temp/")
+        result = _run_hook(_build_bash_event("gh pr diff 123 > /dev/null"))
+        assert result == ""
+
+    def test_gh_with_relative_redirect_resolved(self, monkeypatch: pytest.MonkeyPatch):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        monkeypatch.setenv("AUTOSKILLIT_CWD", "/workspace")
+        result = _extract_bash_write_targets("gh pr diff 123 > output.txt")
+        assert result is not None
+        assert "/workspace/output.txt" in result
+
+    def test_gh_with_redirect_within_prefix_allowed(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/workspace/.autoskillit/temp/")
+        monkeypatch.setenv("AUTOSKILLIT_CWD", "/workspace")
+        result = _run_hook(_build_bash_event("gh pr diff 123 > .autoskillit/temp/diff.txt"))
+        assert result == ""
+
+
+class TestWriteGuardCrossProductMatrix:
+    """Cross-product test: every write mechanism resolves every path type."""
+
+    @pytest.mark.parametrize(
+        "cmd_template",
+        [
+            "echo x > {path}",
+            "echo x >> {path}",
+            "sed -i 's/x/y/' {path}",
+            "rm {path}",
+            "tee {path}",
+            "mv /src {path}",
+            "cp /src {path}",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "path_type,expected_resolved",
+        [
+            ("/workspace/src/main.py", "/workspace/src/main.py"),
+            ("src/main.py", "/workspace/src/main.py"),
+            ("./src/main.py", "/workspace/./src/main.py"),
+        ],
+    )
+    def test_all_write_mechanisms_resolve_all_path_types(
+        self, cmd_template, path_type, expected_resolved, monkeypatch: pytest.MonkeyPatch
+    ):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        monkeypatch.setenv("AUTOSKILLIT_CWD", "/workspace")
+        cmd = cmd_template.format(path=path_type)
+        result = _extract_bash_write_targets(cmd)
+        assert result is not None, f"Expected write detection for: {cmd}"
+        assert expected_resolved in result, f"Expected {expected_resolved} in {result} for: {cmd}"


### PR DESCRIPTION
## Summary

The write guard has three independent path extraction pathways for Bash commands: segment-verb extraction (`sed`, `tee`, `mv`...), redirect extraction (`>`, `>>`, `2>`...), and interpreter extraction (`python3 -c "open(...)"`). Each pathway independently implements CWD-relative path resolution — or fails to. The redirect pathway silently drops relative paths, and a vestigial `has_non_gh` gate bypasses redirect checking entirely for gh-only commands.

The architectural weakness is **decentralized path resolution** — each extraction function must independently implement the same `if path.startswith("/") ... elif cwd: os.path.join(cwd, path)` pattern, and new or modified extraction functions routinely miss it. The write guard has been rectified 10+ times in 90 days; each fix addresses one bypass while leaving adjacent ones open.

The immunity plan introduces a centralized `resolve_write_target()` function that all extraction pathways must use, eliminates the vestigial `has_non_gh` gate, and adds a cross-product test matrix that catches missing resolution by design.

Closes #3549

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260601-132207-687449/.autoskillit/temp/rectify/rectify_write_guard_path_resolution_immunity_2026-06-01_140500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 80 | 38.3k | 2.5M | 146.7k | 61 | 130.0k | 19m 1s |
| review_approach* | opus[1m] | 1 | 7.8k | 6.0k | 196.5k | 49.9k | 12 | 37.1k | 5m 39s |
| dry_walkthrough* | opus | 1 | 30 | 7.1k | 776.7k | 89.9k | 29 | 73.3k | 4m 54s |
| implement* | opus[1m] | 1 | 68 | 12.3k | 2.1M | 86.7k | 65 | 70.1k | 4m 47s |
| audit_impl* | opus[1m] | 1 | 33 | 10.5k | 179.9k | 41.0k | 15 | 36.2k | 6m 28s |
| prepare_pr* | MiniMax-M3 | 1 | 45.5k | 3.2k | 165.5k | 48.9k | 16 | 0 | 1m 23s |
| compose_pr* | MiniMax-M3 | 1 | 106.4k | 1.7k | 118.6k | 39.0k | 13 | 0 | 58s |
| review_pr* | opus[1m] | 1 | 41 | 38.3k | 812.7k | 91.6k | 40 | 76.0k | 9m 3s |
| resolve_review* | opus[1m] | 1 | 42 | 14.0k | 1.5M | 74.5k | 52 | 58.5k | 10m 15s |
| **Total** | | | 159.9k | 131.3k | 8.4M | 146.7k | | 481.2k | 1h 2m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 292 | 7285.4 | 240.1 | 42.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 5 | 301561.2 | 11693.4 | 2801.0 |
| **Total** | **297** | 28128.0 | 1620.1 | 442.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 8.0k | 119.4k | 7.3M | 407.9k | 55m 17s |
| opus | 1 | 30 | 7.1k | 776.7k | 73.3k | 4m 54s |
| MiniMax-M3 | 2 | 151.9k | 4.8k | 284.1k | 0 | 2m 21s |