### PR TITLE
Implementation Plan: Skills Declare write_paths in Frontmatter for Session Guard Composition

### DIFF
--- a/src/autoskillit/server/_misc.py
+++ b/src/autoskillit/server/_misc.py
@@ -41,6 +41,9 @@ from autoskillit.execution import (
 )
 from autoskillit.hooks import _HOOK_CONFIG_PATH_COMPONENTS
 from autoskillit.workspace import clone_registry as clone_registry
+from autoskillit.workspace import (
+    resolve_closure_write_dirs as resolve_closure_write_dirs,
+)
 
 if TYPE_CHECKING:
     from autoskillit.config import QuotaGuardConfig

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -39,11 +39,11 @@ from autoskillit.server._misc import (
     SCENARIO_STEP_NAME_ENV,
     _hook_config_overlay_path,
     _pipeline_tracker_path,
+    resolve_closure_write_dirs,
 )
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._subprocess import _run_subprocess
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
-from autoskillit.workspace import collect_closure_write_paths
 
 logger = get_logger(__name__)
 
@@ -816,17 +816,11 @@ async def run_skill(
                     # snapshot — they don't need re-augmentation because the snapshot
                     # was built from a live session that already had the full prefix set.
                     if closure and tool_ctx.skill_resolver is not None:
-                        _raw_write_paths = collect_closure_write_paths(
-                            closure, tool_ctx.skill_resolver
+                        write_watch_dirs.extend(
+                            resolve_closure_write_dirs(
+                                closure, tool_ctx.skill_resolver, cwd, write_watch_dirs
+                            )
                         )
-                        if _raw_write_paths:
-                            _temp_prefix = os.path.join(cwd, ".autoskillit", "temp")
-                            for _rwp in _raw_write_paths:
-                                _resolved_wp = Path(
-                                    _rwp.replace("{{AUTOSKILLIT_TEMP}}", _temp_prefix)
-                                )
-                                if _resolved_wp not in write_watch_dirs:
-                                    write_watch_dirs.append(_resolved_wp)
 
             allowed_write_prefix = ""
             allowed_write_prefixes: tuple[str, ...] = ()

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -43,6 +43,7 @@ from autoskillit.server._misc import (
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._subprocess import _run_subprocess
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
+from autoskillit.workspace import collect_closure_write_paths
 
 logger = get_logger(__name__)
 
@@ -731,24 +732,6 @@ async def run_skill(
                 tool_ctx.completion_required_resolver
                 and tool_ctx.completion_required_resolver(skill_command)
             )
-            allowed_write_prefix = ""
-            allowed_write_prefixes: tuple[str, ...] = ()
-            if write_watch_dirs:
-                allowed_write_prefix, allowed_write_prefixes = _compute_write_prefixes(
-                    write_watch_dirs, cwd, skill_command
-                )
-            elif is_read_only:
-                _skill_temp_name = target_name or ""
-                if _skill_temp_name:
-                    allowed_write_prefix = os.path.join(
-                        cwd, ".autoskillit", "temp", _skill_temp_name, ""
-                    )
-                else:
-                    logger.warning(
-                        "read_only_skill_no_target_name",
-                        skill_command=skill_command[:SKILL_COMMAND_DISPLAY_MAX],
-                    )
-
             invocation_marker = f"%%ORDER_UP::{uuid4().hex[:8]}%%"
 
             skill_add_dirs: list[ValidatedAddDir] = []
@@ -778,6 +761,7 @@ async def run_skill(
 
             if not replay_snapshot_used and tool_ctx.session_skill_manager is not None:
                 allow_only: frozenset[str] | None = None
+                closure: frozenset[str] = frozenset()
                 if target_name:
                     closure = tool_ctx.session_skill_manager.compute_skill_closure(target_name)
                     allow_only = closure if closure else None
@@ -827,6 +811,41 @@ async def run_skill(
                                 session_id=session_id,
                                 order_id=effective_order_id,
                             ).to_json()
+                    # Extend write_watch_dirs with write_paths from the closure.
+                    # Replay-path sessions inherit write scope from their original
+                    # snapshot — they don't need re-augmentation because the snapshot
+                    # was built from a live session that already had the full prefix set.
+                    if closure and tool_ctx.skill_resolver is not None:
+                        _raw_write_paths = collect_closure_write_paths(
+                            closure, tool_ctx.skill_resolver
+                        )
+                        if _raw_write_paths:
+                            _temp_prefix = os.path.join(cwd, ".autoskillit", "temp")
+                            for _rwp in _raw_write_paths:
+                                _resolved_wp = Path(
+                                    _rwp.replace("{{AUTOSKILLIT_TEMP}}", _temp_prefix)
+                                )
+                                if _resolved_wp not in write_watch_dirs:
+                                    write_watch_dirs.append(_resolved_wp)
+
+            allowed_write_prefix = ""
+            allowed_write_prefixes: tuple[str, ...] = ()
+            if write_watch_dirs:
+                allowed_write_prefix, allowed_write_prefixes = _compute_write_prefixes(
+                    write_watch_dirs, cwd, skill_command
+                )
+            elif is_read_only:
+                _skill_temp_name = target_name or ""
+                if _skill_temp_name:
+                    allowed_write_prefix = os.path.join(
+                        cwd, ".autoskillit", "temp", _skill_temp_name, ""
+                    )
+                else:
+                    logger.warning(
+                        "read_only_skill_no_target_name",
+                        skill_command=skill_command[:SKILL_COMMAND_DISPLAY_MAX],
+                    )
+
             _local_dir = validate_project_local_skill_dir(Path(cwd), tool_ctx.backend)
             if _local_dir is not None:
                 skill_add_dirs.append(_local_dir)

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -811,7 +811,6 @@ async def run_skill(
                                 session_id=session_id,
                                 order_id=effective_order_id,
                             ).to_json()
-                    # Extend write_watch_dirs with write_paths from the closure.
                     # Replay-path sessions inherit write scope from their original
                     # snapshot — they don't need re-augmentation because the snapshot
                     # was built from a live session that already had the full prefix set.

--- a/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
@@ -3,6 +3,7 @@ name: arch-lens-c4-container
 categories: [arch-lens]
 backend_requirements: [claude-code]
 activate_deps: [mermaid]
+write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-c4-container/"]
 description: Create C4 Container architecture diagram showing static structure, building blocks, and technology choices. Anatomical lens answering "How is it built?"
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
@@ -3,6 +3,7 @@ name: arch-lens-concurrency
 categories: [arch-lens]
 backend_requirements: [claude-code]
 activate_deps: [mermaid]
+write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-concurrency/"]
 description: Create Concurrency architecture diagram showing parallel execution patterns, thread pools, synchronization, and barriers. Physiological lens answering "How does parallelism work?"
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
@@ -3,6 +3,7 @@ name: arch-lens-data-lineage
 categories: [arch-lens]
 backend_requirements: [claude-code]
 activate_deps: [mermaid]
+write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-data-lineage/"]
 description: Create Data Lineage architecture diagram showing information flow, transformations, and storage destinations. Data-centric lens answering "Where is the data?"
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
@@ -3,6 +3,7 @@ name: arch-lens-deployment
 categories: [arch-lens]
 backend_requirements: [claude-code]
 activate_deps: [mermaid]
+write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-deployment/"]
 description: Create Deployment/Physical architecture diagram showing infrastructure topology, process boundaries, and network communication. Physical lens answering "Where does it run?"
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
@@ -3,6 +3,7 @@ name: arch-lens-development
 categories: [arch-lens]
 backend_requirements: [claude-code]
 activate_deps: [mermaid]
+write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-development/"]
 description: Create Development architecture diagram showing project structure, build tools, and quality gates. Development lens answering "How is it built and tested?"
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
@@ -3,6 +3,7 @@ name: arch-lens-error-resilience
 categories: [arch-lens]
 backend_requirements: [claude-code]
 activate_deps: [mermaid]
+write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-error-resilience/"]
 description: Create Error/Resilience architecture diagram showing failure handling, recovery mechanisms, and circuit breakers. Diagnostic lens answering "How are failures handled?"
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
@@ -3,6 +3,7 @@ name: arch-lens-module-dependency
 categories: [arch-lens]
 backend_requirements: [claude-code]
 activate_deps: [mermaid]
+write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-module-dependency/"]
 description: Create Module Dependency architecture diagram showing package coupling, layering, and fan-in/fan-out. Structural lens answering "How are modules coupled?"
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
@@ -3,6 +3,7 @@ name: arch-lens-operational
 categories: [arch-lens]
 backend_requirements: [claude-code]
 activate_deps: [mermaid]
+write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-operational/"]
 description: Create Operational architecture diagram showing CLI workflows, configuration, and observability. Administration lens answering "How is it run and monitored?"
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
@@ -3,6 +3,7 @@ name: arch-lens-process-flow
 categories: [arch-lens]
 backend_requirements: [claude-code]
 activate_deps: [mermaid]
+write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-process-flow/"]
 description: Create Process/Execution Flow architecture diagram showing runtime behavior, state transitions, and decision points. Physiological lens answering "How does it behave?"
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
@@ -3,6 +3,7 @@ name: arch-lens-repository-access
 categories: [arch-lens]
 backend_requirements: [claude-code]
 activate_deps: [mermaid]
+write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-repository-access/"]
 description: Create Repository/Data Access architecture diagram showing the repository pattern, entity relationships, and data access patterns. Data-centric lens answering "How is data accessed?"
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
@@ -3,6 +3,7 @@ name: arch-lens-scenarios
 categories: [arch-lens]
 backend_requirements: [claude-code]
 activate_deps: [mermaid]
+write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-scenarios/"]
 description: Create Scenarios architecture diagram showing end-to-end user journeys and component cooperation validation. Validation lens answering "Do the components work together?"
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
@@ -3,6 +3,7 @@ name: arch-lens-security
 categories: [arch-lens]
 backend_requirements: [claude-code]
 activate_deps: [mermaid]
+write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-security/"]
 description: Create Security architecture diagram showing trust boundaries, validation layers, and process isolation. Security lens answering "Where are the trust boundaries?"
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
@@ -3,6 +3,7 @@ name: arch-lens-state-lifecycle
 categories: [arch-lens]
 backend_requirements: [claude-code]
 activate_deps: [mermaid]
+write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-state-lifecycle/"]
 description: Create State Lifecycle architecture diagram showing field contracts, validation gates, and resume safety. Contract overlay lens answering "How is state corruption prevented?"
 hooks:
   PreToolUse:

--- a/src/autoskillit/workspace/__init__.py
+++ b/src/autoskillit/workspace/__init__.py
@@ -42,6 +42,7 @@ from autoskillit.workspace.session_skills import (
     DefaultSessionSkillManager,
     SkillsDirectoryProvider,
     collect_closure_write_paths,
+    resolve_closure_write_dirs,
     resolve_ephemeral_root,
 )
 from autoskillit.workspace.skill_format import (
@@ -90,6 +91,7 @@ __all__ = [
     "clone_repo",
     "CloneSourceResolution",
     "collect_closure_write_paths",
+    "resolve_closure_write_dirs",
     "detect_branch",
     "detect_source_dir",
     "detect_uncommitted_changes",

--- a/src/autoskillit/workspace/__init__.py
+++ b/src/autoskillit/workspace/__init__.py
@@ -41,6 +41,7 @@ from autoskillit.workspace.session_skills import (
     CODEX_SKILLS_SUBDIR,
     DefaultSessionSkillManager,
     SkillsDirectoryProvider,
+    collect_closure_write_paths,
     resolve_ephemeral_root,
 )
 from autoskillit.workspace.skill_format import (
@@ -88,6 +89,7 @@ __all__ = [
     "detect_project_local_overrides",
     "clone_repo",
     "CloneSourceResolution",
+    "collect_closure_write_paths",
     "detect_branch",
     "detect_source_dir",
     "detect_uncommitted_changes",

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -8,6 +8,7 @@ Provides three components:
 
 from __future__ import annotations
 
+import os
 import shutil
 import tempfile
 import time
@@ -407,6 +408,32 @@ def collect_closure_write_paths(
                 seen.add(wp)
                 paths.append(wp)
     return tuple(paths)
+
+
+def resolve_closure_write_dirs(
+    closure: frozenset[str],
+    resolver: SkillResolver,
+    cwd: str,
+    existing: list[Path] | None = None,
+) -> list[Path]:
+    """Collect and resolve write_paths from closure skills into absolute Paths.
+
+    Substitutes ``{{AUTOSKILLIT_TEMP}}`` with ``cwd/.autoskillit/temp`` and
+    returns deduplicated resolved Paths ready to extend ``write_watch_dirs``.
+    Paths already present in ``existing`` are excluded from the result.
+    """
+    raw_paths = collect_closure_write_paths(closure, resolver)
+    if not raw_paths:
+        return []
+    temp_prefix = os.path.join(cwd, ".autoskillit", "temp")
+    seen: set[Path] = set(existing) if existing else set()
+    result: list[Path] = []
+    for rwp in raw_paths:
+        resolved = Path(rwp.replace("{{AUTOSKILLIT_TEMP}}", temp_prefix))
+        if resolved not in seen:
+            seen.add(resolved)
+            result.append(resolved)
+    return result
 
 
 class SkillsDirectoryProvider:

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -175,6 +175,20 @@ def _parse_activate_deps(content: str) -> list[str]:
     return [item.strip() for item in items.split(",") if item.strip()]
 
 
+def _parse_write_paths(content: str) -> list[str]:
+    """Extract write_paths list from SKILL.md content.
+
+    Uses proper YAML parsing via ``parse_frontmatter_content`` to handle
+    both inline ``write_paths: ["path1", "path2"]`` and multi-line YAML
+    list syntax. Returns raw template strings (may contain ``{{AUTOSKILLIT_TEMP}}``).
+    """
+    fm = parse_frontmatter_content(content)
+    raw = fm.get("write_paths", [])
+    if not isinstance(raw, list):
+        return []
+    return [str(p) for p in raw if p and isinstance(p, str)]
+
+
 def _is_skill_disabled(
     skill_info: SkillInfo,
     disabled: list[str],
@@ -366,6 +380,33 @@ def compute_skill_closure(
             elif dep not in visited:
                 queue.append(dep)
     return frozenset(resolved)
+
+
+def collect_closure_write_paths(
+    closure: frozenset[str],
+    resolver: SkillResolver,
+) -> tuple[str, ...]:
+    """Collect write_paths from all skills in a pre-computed closure.
+
+    Returns a deduplicated tuple of raw template paths (may contain
+    ``{{AUTOSKILLIT_TEMP}}``). Unresolvable or unreadable skills are
+    silently skipped.
+    """
+    paths: list[str] = []
+    seen: set[str] = set()
+    for name in sorted(closure):
+        info = resolver.resolve(name)
+        if info is None:
+            continue
+        try:
+            content = info.path.read_text()
+        except OSError:
+            continue
+        for wp in _parse_write_paths(content):
+            if wp not in seen:
+                seen.add(wp)
+                paths.append(wp)
+    return tuple(paths)
 
 
 class SkillsDirectoryProvider:

--- a/src/autoskillit/workspace/skill_format.py
+++ b/src/autoskillit/workspace/skill_format.py
@@ -85,7 +85,9 @@ def validate_skill_frontmatter(frontmatter: dict[str, Any], skill_name: str) -> 
                     errors.append(f"'write_paths[{i}]' must be a non-empty string")
                 elif ".." in wp:
                     errors.append(f"'write_paths[{i}]' must not contain '..' (path traversal)")
-                elif not wp.startswith("{{AUTOSKILLIT_TEMP}}/"):
+                elif not (
+                    wp.startswith("{{AUTOSKILLIT_TEMP}}/") or wp.startswith(".autoskillit/temp/")
+                ):
                     errors.append(
                         f"'write_paths[{i}]' must start with "
                         "'{{AUTOSKILLIT_TEMP}}/' "

--- a/src/autoskillit/workspace/skill_format.py
+++ b/src/autoskillit/workspace/skill_format.py
@@ -75,4 +75,21 @@ def validate_skill_frontmatter(frontmatter: dict[str, Any], skill_name: str) -> 
         if "<" in desc or ">" in desc:
             errors.append("'description' must not contain '<' or '>' characters")
 
+    write_paths = frontmatter.get("write_paths")
+    if write_paths is not None:
+        if not isinstance(write_paths, list):
+            errors.append("'write_paths' must be a list of strings")
+        else:
+            for i, wp in enumerate(write_paths):
+                if not isinstance(wp, str) or not wp:
+                    errors.append(f"'write_paths[{i}]' must be a non-empty string")
+                elif ".." in wp:
+                    errors.append(f"'write_paths[{i}]' must not contain '..' (path traversal)")
+                elif not wp.startswith("{{AUTOSKILLIT_TEMP}}/"):
+                    errors.append(
+                        f"'write_paths[{i}]' must start with "
+                        "'{{AUTOSKILLIT_TEMP}}/' "
+                        f"(got {wp!r})"
+                    )
+
     return errors

--- a/tests/arch/test_python_no_hardcoded_temp.py
+++ b/tests/arch/test_python_no_hardcoded_temp.py
@@ -68,6 +68,7 @@ _TEMP_PATH_WHITELIST: dict[str, str] = {
     "hooks/skill_load_post_hook.py": "stdlib-only hook; cannot use resolve_temp_dir()",
     "hooks/guards/skill_load_guard.py": "stdlib-only guard; cannot use resolve_temp_dir()",
     "core/runtime/session_provenance.py": "IL-0 stdlib-only module; cannot use resolve_temp_dir()",
+    "workspace/skill_format.py": "write_paths validation accepts resolved canonical temp prefix",
 }
 
 _LITERAL = ".autoskillit/temp"

--- a/tests/contracts/test_activate_deps_completeness.py
+++ b/tests/contracts/test_activate_deps_completeness.py
@@ -17,6 +17,7 @@ from autoskillit.core.types._type_constants import SKILL_ACTIVATE_DEPS_REQUIRED
 from autoskillit.core.types._type_constants_registries import PACK_REGISTRY
 from autoskillit.workspace.session_skills import (
     SkillsDirectoryProvider,
+    _parse_write_paths,
     compute_skill_closure,
 )
 from autoskillit.workspace.skills import bundled_skills_dir, bundled_skills_extended_dir
@@ -161,3 +162,21 @@ def test_all_activate_deps_resolve() -> None:
                         f"{dep!r} which does not resolve to a skill or pack"
                     )
     assert not failures, "Unresolvable activate_deps entries:\n" + "\n".join(failures)
+
+
+def test_write_paths_use_autoskillit_temp_prefix() -> None:
+    """All bundled skills declaring write_paths must use {{AUTOSKILLIT_TEMP}}/ prefix."""
+    from autoskillit.workspace.skills import DefaultSkillResolver
+
+    resolver = DefaultSkillResolver()
+    violations: list[str] = []
+    for info in resolver.list_all():
+        try:
+            content = info.path.read_text()
+        except OSError:
+            continue
+        paths = _parse_write_paths(content)
+        for wp in paths:
+            if not wp.startswith("{{AUTOSKILLIT_TEMP}}/"):
+                violations.append(f"{info.name}: {wp!r}")
+    assert not violations, f"write_paths must start with {{{{AUTOSKILLIT_TEMP}}}}/: {violations}"

--- a/tests/integration/test_write_guard_worktree_integration.py
+++ b/tests/integration/test_write_guard_worktree_integration.py
@@ -158,9 +158,16 @@ class TestWriteGuardWorktreeIntegration:
         # Mock session_skill_manager to return a closure containing dep-skill
         mock_ssm = MagicMock()
         mock_ssm.compute_skill_closure.return_value = frozenset({"target-skill", "dep-skill"})
-        mock_ssm.init_session.return_value = MagicMock(path=str(tmp_path / "session"))
+        session_dir = tmp_path / "session"
+        mock_ssm.init_session.return_value = MagicMock(path=str(session_dir))
         mock_ssm.activate_skill_deps.return_value = True
         tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+
+        # Create the expected skill file in the session directory
+        (session_dir / ".claude" / "skills" / "target-skill").mkdir(parents=True)
+        (session_dir / ".claude" / "skills" / "target-skill" / "SKILL.md").write_text(
+            "---\nname: target-skill\ndescription: Target.\n---\nbody\n"
+        )
 
         monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
 

--- a/tests/integration/test_write_guard_worktree_integration.py
+++ b/tests/integration/test_write_guard_worktree_integration.py
@@ -114,3 +114,67 @@ class TestWriteGuardWorktreeIntegration:
         prefixes = executor.calls[0].allowed_write_prefixes
         worktree_parent = str((clone_dir.parent / "worktrees").resolve()) + "/"
         assert worktree_parent not in prefixes
+
+    @pytest.mark.anyio
+    async def test_closure_write_paths_extend_allowed_prefixes(
+        self, tmp_path: Path, tool_ctx_kitchen_open, monkeypatch: pytest.MonkeyPatch
+    ):
+        """run_skill for a skill with deps declaring write_paths includes dep paths in prefixes."""
+        monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
+        from unittest.mock import MagicMock
+
+        from autoskillit.workspace.skills import SkillInfo, SkillSource
+        from tests.fakes import InMemoryHeadlessExecutor
+
+        executor = InMemoryHeadlessExecutor()
+        tool_ctx_kitchen_open.executor = executor
+
+        # Create a synthetic SKILL.md for the dep skill with write_paths
+        dep_dir = tmp_path / "dep-skill"
+        dep_dir.mkdir()
+        dep_skill_md = dep_dir / "SKILL.md"
+        dep_skill_md.write_text(
+            "---\nname: dep-skill\ndescription: A dep.\n"
+            'write_paths: ["{{AUTOSKILLIT_TEMP}}/dep-skill/"]\n---\nbody\n'
+        )
+
+        # Mock skill_resolver to return the dep's SkillInfo
+        mock_resolver = MagicMock()
+        mock_resolver.resolve.side_effect = lambda name: (
+            SkillInfo(
+                name="dep-skill",
+                source=SkillSource.BUNDLED_EXTENDED,
+                path=dep_skill_md,
+            )
+            if name == "dep-skill"
+            else SkillInfo(
+                name=name,
+                source=SkillSource.BUNDLED_EXTENDED,
+                path=dep_dir / "SKILL.md",
+            )
+        )
+        tool_ctx_kitchen_open.skill_resolver = mock_resolver
+
+        # Mock session_skill_manager to return a closure containing dep-skill
+        mock_ssm = MagicMock()
+        mock_ssm.compute_skill_closure.return_value = frozenset({"target-skill", "dep-skill"})
+        mock_ssm.init_session.return_value = MagicMock(path=str(tmp_path / "session"))
+        mock_ssm.activate_skill_deps.return_value = True
+        tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+
+        monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+        clone_dir = tmp_path / "clone"
+        clone_dir.mkdir()
+        (clone_dir / ".autoskillit" / "temp" / "target-skill").mkdir(parents=True)
+
+        from autoskillit.server.tools.tools_execution import run_skill
+
+        await run_skill(skill_command="/autoskillit:target-skill", cwd=str(clone_dir))
+
+        assert len(executor.calls) == 1
+        prefixes = executor.calls[0].allowed_write_prefixes
+        expected_dep_prefix = (
+            str((clone_dir / ".autoskillit" / "temp" / "dep-skill").resolve()) + "/"
+        )
+        assert expected_dep_prefix in prefixes

--- a/tests/workspace/test_session_skills_allow_only_and_closure.py
+++ b/tests/workspace/test_session_skills_allow_only_and_closure.py
@@ -10,6 +10,8 @@ from autoskillit.core import FEATURE_REGISTRY
 from autoskillit.workspace.session_skills import (
     DefaultSessionSkillManager,
     SkillsDirectoryProvider,
+    _parse_write_paths,
+    collect_closure_write_paths,
 )
 
 pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
@@ -49,6 +51,10 @@ def _make_synthetic_provider(
             fm_lines.append(f"categories: [{', '.join(categories)}]")
         if deps:
             fm_lines.append(f"activate_deps: [{', '.join(deps)}]")
+        write_paths = spec.get("write_paths", [])
+        if write_paths:
+            quoted = ", ".join(f'"{wp}"' for wp in write_paths)
+            fm_lines.append(f"write_paths: [{quoted}]")
         content = "---\n" + "\n".join(fm_lines) + "\n---\nbody\n"
         (skill_dir / "SKILL.md").write_text(content)
         skill_infos.append(
@@ -460,3 +466,104 @@ class TestComputeSkillClosure:
             {"target": {"deps": ["audit"]}},
         )
         assert compute_skill_closure("target", provider) == frozenset({"target"})
+
+
+class TestParseWritePaths:
+    """Unit tests for _parse_write_paths frontmatter parser."""
+
+    def test_no_write_paths_returns_empty(self) -> None:
+        content = "---\nname: skill-a\ndescription: A.\n---\nbody"
+        assert _parse_write_paths(content) == []
+
+    def test_single_path(self) -> None:
+        content = (
+            '---\nname: a\ndescription: A.\nwrite_paths: ["{{AUTOSKILLIT_TEMP}}/a/"]\n---\nbody'
+        )
+        assert _parse_write_paths(content) == ["{{AUTOSKILLIT_TEMP}}/a/"]
+
+    def test_multiple_paths(self) -> None:
+        content = (
+            "---\nname: a\ndescription: A.\n"
+            'write_paths: ["{{AUTOSKILLIT_TEMP}}/a/", "{{AUTOSKILLIT_TEMP}}/b/"]\n---\nbody'
+        )
+        assert _parse_write_paths(content) == [
+            "{{AUTOSKILLIT_TEMP}}/a/",
+            "{{AUTOSKILLIT_TEMP}}/b/",
+        ]
+
+    def test_no_frontmatter(self) -> None:
+        assert _parse_write_paths("no frontmatter here") == []
+
+    def test_empty_list(self) -> None:
+        content = "---\nname: a\ndescription: A.\nwrite_paths: []\n---\nbody"
+        assert _parse_write_paths(content) == []
+
+    def test_multiline_yaml_list(self) -> None:
+        content = (
+            "---\nname: a\ndescription: A.\nwrite_paths:\n"
+            '  - "{{AUTOSKILLIT_TEMP}}/a/"\n'
+            '  - "{{AUTOSKILLIT_TEMP}}/b/"\n---\nbody'
+        )
+        assert _parse_write_paths(content) == [
+            "{{AUTOSKILLIT_TEMP}}/a/",
+            "{{AUTOSKILLIT_TEMP}}/b/",
+        ]
+
+    def test_non_list_returns_empty(self) -> None:
+        content = '---\nname: a\ndescription: A.\nwrite_paths: "bad"\n---\nbody'
+        assert _parse_write_paths(content) == []
+
+
+class TestCollectClosureWritePaths:
+    """Unit tests for collect_closure_write_paths."""
+
+    def test_standalone_skill_with_write_paths(self, tmp_path: Path) -> None:
+        provider = _make_synthetic_provider(
+            tmp_path,
+            {"alpha": {"write_paths": ["{{AUTOSKILLIT_TEMP}}/alpha/"]}},
+        )
+        closure = frozenset({"alpha"})
+        result = collect_closure_write_paths(closure, provider.resolver)
+        assert result == ("{{AUTOSKILLIT_TEMP}}/alpha/",)
+
+    def test_skill_without_write_paths(self, tmp_path: Path) -> None:
+        provider = _make_synthetic_provider(tmp_path, {"beta": {}})
+        closure = frozenset({"beta"})
+        assert collect_closure_write_paths(closure, provider.resolver) == ()
+
+    def test_closure_unions_write_paths(self, tmp_path: Path) -> None:
+        provider = _make_synthetic_provider(
+            tmp_path,
+            {
+                "root": {
+                    "deps": ["dep-a"],
+                    "write_paths": ["{{AUTOSKILLIT_TEMP}}/root/"],
+                },
+                "dep-a": {"write_paths": ["{{AUTOSKILLIT_TEMP}}/dep-a/"]},
+            },
+        )
+        closure = frozenset({"root", "dep-a"})
+        result = collect_closure_write_paths(closure, provider.resolver)
+        assert "{{AUTOSKILLIT_TEMP}}/root/" in result
+        assert "{{AUTOSKILLIT_TEMP}}/dep-a/" in result
+
+    def test_dedup_across_skills(self, tmp_path: Path) -> None:
+        provider = _make_synthetic_provider(
+            tmp_path,
+            {
+                "a": {"write_paths": ["{{AUTOSKILLIT_TEMP}}/shared/"]},
+                "b": {"write_paths": ["{{AUTOSKILLIT_TEMP}}/shared/"]},
+            },
+        )
+        closure = frozenset({"a", "b"})
+        result = collect_closure_write_paths(closure, provider.resolver)
+        assert result.count("{{AUTOSKILLIT_TEMP}}/shared/") == 1
+
+    def test_unresolvable_skill_skipped(self, tmp_path: Path) -> None:
+        provider = _make_synthetic_provider(
+            tmp_path,
+            {"real": {"write_paths": ["{{AUTOSKILLIT_TEMP}}/real/"]}},
+        )
+        closure = frozenset({"real", "ghost"})
+        result = collect_closure_write_paths(closure, provider.resolver)
+        assert result == ("{{AUTOSKILLIT_TEMP}}/real/",)

--- a/tests/workspace/test_skill_format.py
+++ b/tests/workspace/test_skill_format.py
@@ -135,3 +135,11 @@ class TestWritePathsValidation:
     def test_write_paths_absent_is_valid(self) -> None:
         fm = {"name": "skill-a", "description": "A skill."}
         assert validate_skill_frontmatter(fm, "skill-a") == []
+
+    def test_write_paths_resolved_prefix_accepted(self) -> None:
+        fm = {
+            "name": "skill-a",
+            "description": "A skill.",
+            "write_paths": [".autoskillit/temp/skill-a/"],
+        }
+        assert validate_skill_frontmatter(fm, "skill-a") == []

--- a/tests/workspace/test_skill_format.py
+++ b/tests/workspace/test_skill_format.py
@@ -96,3 +96,42 @@ class TestParseFrontmatterContent:
         content = "---\n: invalid\n---\nBody"
         result = parse_frontmatter_content(content)
         assert result == {}
+
+
+class TestWritePathsValidation:
+    """Tests for write_paths validation in validate_skill_frontmatter."""
+
+    def test_valid_write_paths(self) -> None:
+        fm = {
+            "name": "skill-a",
+            "description": "A skill.",
+            "write_paths": ["{{AUTOSKILLIT_TEMP}}/skill-a/"],
+        }
+        assert validate_skill_frontmatter(fm, "skill-a") == []
+
+    def test_write_paths_not_list(self) -> None:
+        fm = {"name": "skill-a", "description": "A skill.", "write_paths": "bad"}
+        errors = validate_skill_frontmatter(fm, "skill-a")
+        assert any("list" in e for e in errors)
+
+    def test_write_paths_traversal_rejected(self) -> None:
+        fm = {
+            "name": "skill-a",
+            "description": "A skill.",
+            "write_paths": ["{{AUTOSKILLIT_TEMP}}/../etc/"],
+        }
+        errors = validate_skill_frontmatter(fm, "skill-a")
+        assert any(".." in e for e in errors)
+
+    def test_write_paths_wrong_prefix_rejected(self) -> None:
+        fm = {
+            "name": "skill-a",
+            "description": "A skill.",
+            "write_paths": ["/absolute/path/"],
+        }
+        errors = validate_skill_frontmatter(fm, "skill-a")
+        assert any("AUTOSKILLIT_TEMP" in e for e in errors)
+
+    def test_write_paths_absent_is_valid(self) -> None:
+        fm = {"name": "skill-a", "description": "A skill."}
+        assert validate_skill_frontmatter(fm, "skill-a") == []


### PR DESCRIPTION
## Summary

Add a `write_paths` field to SKILL.md frontmatter that declares which directories a skill writes to. At session launch, `run_skill` collects `write_paths` from all skills in the transitive `activate_deps` closure and unions them into `AUTOSKILLIT_ALLOWED_WRITE_PREFIXES`. This lets sub-skills (e.g., `arch-lens-process-flow` invoked via `rectify`) write to their declared directories without being blocked by the write guard.

The implementation adds:
1. A `_parse_write_paths()` function in `session_skills.py` using `parse_frontmatter_content` (proper YAML parser)
2. A `collect_closure_write_paths()` function that reads `write_paths` from each skill in a closure
3. Integration in `tools_execution.py` that extends `write_watch_dirs` with closure write paths before computing prefixes
4. Validation in `skill_format.py` to reject paths outside `{{AUTOSKILLIT_TEMP}}/`
5. `write_paths` declarations on all 13 `arch-lens-*` SKILL.md files

Closes #3492

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260601-143048-666608/.autoskillit/temp/make-plan/write_paths_frontmatter_plan_2026-06-01_144200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.2k | 38.8k | 2.7M | 133.0k | 66 | 180.8k | 19m 42s |
| review_approach* | opus[1m] | 1 | 24 | 5.4k | 203.6k | 48.9k | 11 | 35.9k | 5m 14s |
| verify* | opus[1m] | 1 | 53 | 14.8k | 903.0k | 69.6k | 45 | 52.8k | 7m 30s |
| implement* | MiniMax-M3 | 1 | 160.9k | 15.4k | 3.2M | 80.2k | 108 | 0 | 8m 39s |
| audit_impl* | opus[1m] | 1 | 32 | 11.9k | 149.9k | 46.2k | 14 | 43.0k | 7m 45s |
| prepare_pr* | MiniMax-M3 | 1 | 93.8k | 4.0k | 166.4k | 51.8k | 18 | 0 | 1m 36s |
| compose_pr* | MiniMax-M3 | 1 | 39.9k | 1.3k | 185.3k | 38.9k | 12 | 0 | 43s |
| review_pr* | opus[1m] | 2 | 808 | 70.1k | 1.4M | 95.7k | 66 | 221.6k | 19m 46s |
| resolve_review* | opus[1m] | 1 | 35 | 7.5k | 1.1M | 74.4k | 39 | 58.8k | 5m 24s |
| **Total** | | | 296.8k | 169.2k | 9.9M | 133.0k | | 592.9k | 1h 16m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 357 | 8868.8 | 0.0 | 43.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 1 | 1055264.0 | 58788.0 | 7506.0 |
| **Total** | **358** | 27632.8 | 1656.2 | 472.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 2.1k | 148.5k | 6.4M | 592.9k | 1h 5m |
| MiniMax-M3 | 3 | 294.7k | 20.7k | 3.5M | 0 | 10m 59s |