### PR TITLE
Implementation Plan: Hoist Cross-Layer Deferred Imports in server/

### DIFF
--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -214,6 +214,8 @@ scripts/regen_contracts.py:
   - infra/
 scripts/check_pyi_stub_format.py:
   - infra/
+scripts/check_pyi_stub_symbols.py:
+  - infra/
 scripts/sync_versions.py:
   - infra/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,13 @@ repos:
         files: __init__\.pyi$
         pass_filenames: false
 
+      - id: check-pyi-stub-symbols
+        name: Check __init__.pyi stub symbol completeness
+        language: system
+        entry: python scripts/check_pyi_stub_symbols.py
+        files: __init__\.pyi$
+        pass_filenames: false
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/scripts/check_pyi_stub_symbols.py
+++ b/scripts/check_pyi_stub_symbols.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Validate __init__.pyi stub files export all public symbols from their submodules.
+
+AST-scans __init__.pyi files, maps each re-exported symbol to its source submodule,
+then checks that every public symbol in the submodule appears in the stub.
+
+A symbol added to a submodule but missing from the stub is invisible to
+lazy_loader.attach_stub() and will cause ImportError at runtime.
+
+Exit 0 if all stubs are complete. Exit 1 with details on missing symbols.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "autoskillit"
+
+_PRIVATE_REEXPORTS = frozenset(
+    {
+        "_InstallLock",
+        "_is_release_tag",
+        "_is_stable_track",
+        "_retire_old_versions",
+        "_collect_disabled_feature_tags",
+        "_AUTOSKILLIT_GITIGNORE_ENTRIES",
+        "_COMMITTED_BY_DESIGN",
+    }
+)
+
+
+def _extract_all(tree: ast.Module) -> set[str] | None:
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                if isinstance(target, ast.Name) and target.id == "__all__":
+                    if isinstance(stmt.value, (ast.List, ast.Tuple)):
+                        return {
+                            elt.value
+                            for elt in stmt.value.elts
+                            if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                        }
+    return None
+
+
+def check_file(pyi_path: Path) -> list[str]:
+    violations: list[str] = []
+    try:
+        pyi_tree = ast.parse(pyi_path.read_text(encoding="utf-8"), filename=str(pyi_path))
+    except (SyntaxError, UnicodeDecodeError, OSError) as exc:
+        violations.append(f"{pyi_path.name}: could not parse — {exc}")
+        return violations
+
+    pkg_dir = pyi_path.parent
+
+    stub_by_submod: dict[str, set[str]] = {}
+    for node in pyi_tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module:
+            names = {alias.name for alias in node.names}
+            stub_by_submod.setdefault(node.module, set()).update(names)
+
+    for submod_rel, stub_names in sorted(stub_by_submod.items()):
+        parts = submod_rel.split(".")
+        submod_path = pkg_dir.joinpath(*parts)
+
+        if submod_path.is_dir():
+            py_file = submod_path / "__init__.py"
+        else:
+            py_file = submod_path.with_suffix(".py")
+
+        if not py_file.exists():
+            continue
+
+        try:
+            submod_tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        except (SyntaxError, UnicodeDecodeError, OSError):
+            continue
+
+        submod_all = _extract_all(submod_tree)
+        if submod_all is None:
+            continue
+        public_names = submod_all
+
+        for name in sorted(public_names - stub_names):
+            if name.startswith("_"):
+                continue
+            if name in _PRIVATE_REEXPORTS:
+                continue
+            violations.append(
+                f"{pyi_path.name}: {submod_rel}.{name} defined in submodule "
+                f"but missing from stub re-exports"
+            )
+
+    return violations
+
+
+def check() -> list[str]:
+    violations: list[str] = []
+    for path in sorted(SRC_ROOT.rglob("__init__.pyi")):
+        violations.extend(check_file(path))
+    return violations
+
+
+def main() -> int:
+    violations = check()
+    if violations:
+        print("__init__.pyi stub symbol completeness violations:\n")
+        for v in violations:
+            print(f"  {v}")
+        print(
+            "\nEvery public symbol in a submodule referenced by __init__.pyi must appear\n"
+            "as a re-export in the stub. Add: from .module import Name as Name"
+        )
+        return 1
+    print("All __init__.pyi stubs complete: no missing symbols.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_pyi_stub_symbols.py
+++ b/scripts/check_pyi_stub_symbols.py
@@ -16,17 +16,25 @@ from pathlib import Path
 
 SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "autoskillit"
 
-_PRIVATE_REEXPORTS = frozenset(
-    {
-        "_InstallLock",
-        "_is_release_tag",
-        "_is_stable_track",
-        "_retire_old_versions",
-        "_collect_disabled_feature_tags",
-        "_AUTOSKILLIT_GITIGNORE_ENTRIES",
-        "_COMMITTED_BY_DESIGN",
-    }
-)
+
+def _load_private_reexports() -> frozenset[str]:
+    """Load _PRIVATE_REEXPORTS from core/__init__.py via AST to avoid duplication."""
+    init_path = SRC_ROOT / "core" / "__init__.py"
+    source = init_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(init_path))
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                if isinstance(target, ast.Name) and target.id == "_PRIVATE_REEXPORTS":
+                    call = stmt.value
+                    if isinstance(call, ast.Call) and call.args:
+                        arg_src = ast.get_source_segment(source, call.args[0])
+                        if arg_src is not None:
+                            return frozenset(ast.literal_eval(arg_src))
+    return frozenset()
+
+
+_PRIVATE_REEXPORTS = _load_private_reexports()
 
 
 def _extract_all(tree: ast.Module) -> set[str] | None:

--- a/scripts/check_pyi_stub_symbols.py
+++ b/scripts/check_pyi_stub_symbols.py
@@ -77,9 +77,16 @@ def check_file(pyi_path: Path) -> list[str]:
             continue
 
         submod_all = _extract_all(submod_tree)
-        if submod_all is None:
-            continue
-        public_names = submod_all
+        if submod_all is not None:
+            public_names = submod_all
+        else:
+            public_names = set()
+            for stmt in submod_tree.body:
+                if isinstance(stmt, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                    if not stmt.name.startswith("_"):
+                        public_names.add(stmt.name)
+            if not public_names:
+                continue
 
         for name in sorted(public_names - stub_names):
             if name.startswith("_"):

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -82,9 +82,11 @@ from .runtime.kitchen_state import KitchenMarker as KitchenMarker
 from .runtime.kitchen_state import find_caller_session_id as find_caller_session_id
 from .runtime.kitchen_state import get_state_dir as get_state_dir
 from .runtime.kitchen_state import is_marker_fresh as is_marker_fresh
+from .runtime.kitchen_state import marker_path as marker_path
 from .runtime.kitchen_state import read_marker as read_marker
 from .runtime.kitchen_state import resolve_kitchen_id as resolve_kitchen_id
 from .runtime.kitchen_state import sweep_stale_markers as sweep_stale_markers
+from .runtime.kitchen_state import write_marker as write_marker
 from .runtime.readiness import cleanup_readiness_sentinel as cleanup_readiness_sentinel
 from .runtime.readiness import readiness_sentinel_path as readiness_sentinel_path
 from .runtime.readiness import write_readiness_sentinel as write_readiness_sentinel

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -24,6 +24,7 @@ from autoskillit.core import (
     PluginSource,
     SubprocessRunner,
     WriteBehaviorSpec,
+    _get_autoskillit_install_path,
     detect_autoskillit_mcp_prefix,
     get_logger,
     is_feature_enabled,
@@ -110,7 +111,6 @@ def _default_plugin_dir() -> Path:
 
 def _resolve_marketplace_cache_path() -> Path:
     """Read the installPath for autoskillit from installed_plugins.json."""
-    from autoskillit.core import _get_autoskillit_install_path
 
     return _get_autoskillit_install_path()
 
@@ -203,12 +203,12 @@ def make_context(
         passed explicitly, tester is left as None.
     """
     if runner is _UNSET:
-        from autoskillit.execution import DefaultSubprocessRunner
+        from autoskillit.execution import DefaultSubprocessRunner  # circular-break: lazy-load
 
         runner = DefaultSubprocessRunner()
 
-    from autoskillit.execution import get_backend  # lazy: avoids execution init on server import
-    from autoskillit.fleet import (  # lazy: avoids fleet init on server import
+    from autoskillit.execution import get_backend  # circular-break: lazy-load
+    from autoskillit.fleet import (  # circular-break: lazy-load fleet
         FleetSemaphore,
         build_protected_campaign_ids,
     )
@@ -272,7 +272,9 @@ def make_context(
                         make_scenario_recorder = None  # type: ignore[assignment]
 
                     if make_scenario_recorder is not None:
-                        from autoskillit.execution import RecordingSubprocessRunner
+                        from autoskillit.execution import (  # circular-break
+                            RecordingSubprocessRunner,
+                        )
 
                         recorder = make_scenario_recorder(
                             output_dir=scenario_dir, recipe_name=recipe_name

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -43,9 +43,13 @@ from autoskillit.execution import (
     DefaultGitHubFetcher,
     DefaultHeadlessExecutor,
     DefaultMergeQueueWatcher,
+    DefaultSubprocessRunner,
     DefaultTestRunner,
+    RecordingSubprocessRunner,
     build_replay_runner,
+    get_backend,
 )
+from autoskillit.fleet import FleetSemaphore, build_protected_campaign_ids
 from autoskillit.migration import DefaultMigrationService, default_migration_engine
 from autoskillit.pipeline import (
     DefaultAuditLog,
@@ -203,15 +207,7 @@ def make_context(
         passed explicitly, tester is left as None.
     """
     if runner is _UNSET:
-        from autoskillit.execution import DefaultSubprocessRunner  # circular-break: lazy-load
-
         runner = DefaultSubprocessRunner()
-
-    from autoskillit.execution import get_backend  # circular-break: lazy-load
-    from autoskillit.fleet import (  # circular-break: lazy-load fleet
-        FleetSemaphore,
-        build_protected_campaign_ids,
-    )
 
     _codex_feature_enabled = is_feature_enabled(
         "codex_backend", config.features, experimental_enabled=config.experimental_enabled
@@ -272,10 +268,6 @@ def make_context(
                         make_scenario_recorder = None  # type: ignore[assignment]
 
                     if make_scenario_recorder is not None:
-                        from autoskillit.execution import (  # circular-break
-                            RecordingSubprocessRunner,
-                        )
-
                         recorder = make_scenario_recorder(
                             output_dir=scenario_dir, recipe_name=recipe_name
                         )

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -25,13 +25,13 @@ logger = get_logger(__name__)
 
 
 def _get_ctx():  # type: ignore[return]
-    from autoskillit.server._state import _get_ctx as _ctx_fn
+    from autoskillit.server._state import _get_ctx as _ctx_fn  # circular-break
 
     return _ctx_fn()
 
 
 def _get_config():  # type: ignore[return]
-    from autoskillit.server._state import _get_config as _cfg_fn
+    from autoskillit.server._state import _get_config as _cfg_fn  # circular-break
 
     return _cfg_fn()
 

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -45,9 +45,9 @@ def run_startup_drift_check() -> None:
     try:
         import json
 
-        import autoskillit.core.paths as _core_paths
-        from autoskillit.core import atomic_write
-        from autoskillit.hook_registry import (
+        import autoskillit.core.paths as _core_paths  # circular-break
+        from autoskillit.core import atomic_write  # circular-break
+        from autoskillit.hook_registry import (  # circular-break
             HOOK_REGISTRY_HASH,
             generate_hooks_json,
             load_hooks_json_hash,
@@ -79,7 +79,7 @@ def run_startup_hook_health_check() -> list[str]:
     Returns list of broken hook commands. Any failure is logged and swallowed.
     """
     try:
-        from autoskillit.hook_registry import (
+        from autoskillit.hook_registry import (  # circular-break
             find_broken_hook_scripts,
             iter_all_scope_paths,
             validate_plugin_cache_hooks,
@@ -127,7 +127,7 @@ async def _run_drift_check_async() -> None:
 
 async def _run_retiring_sweep_async() -> None:
     """Offload blocking retiring cache sweep to a thread."""
-    from autoskillit.core import sweep_retiring_cache  # noqa: PLC0415
+    from autoskillit.core import sweep_retiring_cache  # circular-break
 
     loop = _asyncio.get_running_loop()
     await loop.run_in_executor(None, sweep_retiring_cache)
@@ -195,15 +195,18 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
     logger.info("fleet_auto_gate_boot", gate_state="open", kitchen_id=ctx.kitchen_id)
 
     try:
-        from autoskillit.core import _collect_disabled_feature_tags, register_active_kitchen
-        from autoskillit.pipeline import create_background_task
-        from autoskillit.server import mcp as _mcp
-        from autoskillit.server._misc import (
+        from autoskillit.core import (  # circular-break
+            _collect_disabled_feature_tags,
+            register_active_kitchen,
+        )
+        from autoskillit.pipeline import create_background_task  # circular-break
+        from autoskillit.server import mcp as _mcp  # circular-break
+        from autoskillit.server._misc import (  # circular-break
             _prime_quota_cache,
             _quota_refresh_loop,
             resolve_provider,
         )
-        from autoskillit.server.tools.tools_kitchen import _write_hook_config
+        from autoskillit.server.tools.tools_kitchen import _write_hook_config  # circular-break
 
         _features = ctx.config.features if ctx.config is not None else {}
         _exp_enabled = ctx.config.experimental_enabled if ctx.config is not None else False
@@ -240,7 +243,7 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
 
     _campaign_state_paths: list[Path] = []
     try:
-        from autoskillit.fleet import discover_campaign_state_files  # noqa: PLC0415
+        from autoskillit.fleet import discover_campaign_state_files  # circular-break
 
         _campaign_state_paths = discover_campaign_state_files(ctx.project_dir)
     except Exception:
@@ -248,7 +251,7 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
 
     if _campaign_state_paths:
         try:
-            from autoskillit.fleet import reap_stale_dispatches_async  # noqa: PLC0415
+            from autoskillit.fleet import reap_stale_dispatches_async  # circular-break
 
             await reap_stale_dispatches_async(
                 _campaign_state_paths,
@@ -262,7 +265,7 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
 
     if _campaign_state_paths and ctx.github_client is not None:
         try:
-            from autoskillit.fleet import sweep_stale_dispatch_labels  # noqa: PLC0415
+            from autoskillit.fleet import sweep_stale_dispatch_labels  # circular-break
 
             create_background_task(
                 sweep_stale_dispatch_labels(_campaign_state_paths, ctx.github_client),
@@ -274,13 +277,13 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
 
 async def _pre_reveal_kitchen(ctx: Any) -> None:
     """Pre-reveal kitchen for non-notification backends (no tools/list_changed support)."""
-    from autoskillit.core import (  # noqa: PLC0415
+    from autoskillit.core import (  # circular-break
         _collect_disabled_feature_tags,
         register_active_kitchen,
     )
-    from autoskillit.server import mcp as _mcp  # noqa: PLC0415
-    from autoskillit.server._misc import _prime_quota_cache  # noqa: PLC0415
-    from autoskillit.server.tools.tools_kitchen import _write_hook_config  # noqa: PLC0415
+    from autoskillit.server import mcp as _mcp  # circular-break
+    from autoskillit.server._misc import _prime_quota_cache  # circular-break
+    from autoskillit.server.tools.tools_kitchen import _write_hook_config  # circular-break
 
     ctx.kitchen_id = resolve_kitchen_id()
     ctx.active_recipe_packs = frozenset()
@@ -305,18 +308,18 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
     AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS is set. No-ops for interactive
     ORCHESTRATOR sessions (open_kitchen handles the gate there).
     """
-    from autoskillit.core import (
+    from autoskillit.core import (  # circular-break
         FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
         HEADLESS_ENV_VAR,
         register_active_kitchen,
     )
-    from autoskillit.pipeline import create_background_task
-    from autoskillit.server._misc import (
+    from autoskillit.pipeline import create_background_task  # circular-break
+    from autoskillit.server._misc import (  # circular-break
         _prime_quota_cache,
         _quota_refresh_loop,
         resolve_provider,
     )
-    from autoskillit.server.tools.tools_kitchen import _write_hook_config
+    from autoskillit.server.tools.tools_kitchen import _write_hook_config  # circular-break
 
     if os.environ.get(HEADLESS_ENV_VAR) != "1":
         if ctx.backend is not None and not ctx.backend.capabilities.supports_tool_list_changed:
@@ -346,8 +349,8 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
     )
 
     try:
-        from autoskillit.core import _collect_disabled_feature_tags
-        from autoskillit.server import mcp as _mcp
+        from autoskillit.core import _collect_disabled_feature_tags  # circular-break
+        from autoskillit.server import mcp as _mcp  # circular-break
 
         _features = ctx.config.features if ctx.config is not None else {}
         _exp_enabled = ctx.config.experimental_enabled if ctx.config is not None else False
@@ -384,7 +387,7 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
         logger.warning("food_truck_auto_gate_boot_registry_failed", exc_info=True)
 
     try:
-        from autoskillit.fleet import discover_campaign_state_files  # noqa: PLC0415
+        from autoskillit.fleet import discover_campaign_state_files  # circular-break
 
         _campaign_state_paths = discover_campaign_state_files(ctx.project_dir)
     except Exception:
@@ -393,12 +396,12 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
 
     if _campaign_state_paths:
         try:
-            from autoskillit.fleet import reap_stale_dispatches_async  # noqa: PLC0415
+            from autoskillit.fleet import reap_stale_dispatches_async  # circular-break
 
             _skip: frozenset[str] | None = None
             _own_campaign_id: str | None = None
             try:
-                from autoskillit.core import (  # noqa: PLC0415
+                from autoskillit.core import (  # circular-break
                     CAMPAIGN_ID_ENV_VAR,
                     DISPATCH_ID_ENV_VAR,
                 )
@@ -422,7 +425,7 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
 
     try:
         if _campaign_state_paths and ctx.github_client is not None:
-            from autoskillit.fleet import sweep_stale_dispatch_labels  # noqa: PLC0415
+            from autoskillit.fleet import sweep_stale_dispatch_labels  # circular-break
 
             create_background_task(
                 sweep_stale_dispatch_labels(_campaign_state_paths, ctx.github_client),
@@ -440,7 +443,7 @@ async def _skill_auto_gate_boot(ctx: Any) -> None:
     Omits quota-refresh loop and campaign state recovery — SKILL sessions
     are short-lived.
     """
-    from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR
+    from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR  # circular-break
 
     if os.environ.get(HEADLESS_ENV_VAR) != "1":
         if ctx.backend is not None and not ctx.backend.capabilities.supports_tool_list_changed:
@@ -467,8 +470,8 @@ async def _skill_auto_gate_boot(ctx: Any) -> None:
     )
 
     try:
-        from autoskillit.core import _collect_disabled_feature_tags
-        from autoskillit.server import mcp as _mcp
+        from autoskillit.core import _collect_disabled_feature_tags  # circular-break
+        from autoskillit.server import mcp as _mcp  # circular-break
 
         _features = ctx.config.features if ctx.config is not None else {}
         _exp_enabled = ctx.config.experimental_enabled if ctx.config is not None else False
@@ -478,21 +481,21 @@ async def _skill_auto_gate_boot(ctx: Any) -> None:
         logger.warning("skill_auto_gate_boot_feature_suppression_failed", exc_info=True)
 
     try:
-        from autoskillit.server.tools.tools_kitchen import _write_hook_config
+        from autoskillit.server.tools.tools_kitchen import _write_hook_config  # circular-break
 
         _write_hook_config()
     except Exception:
         logger.warning("skill_auto_gate_boot_hook_config_failed", exc_info=True)
 
     try:
-        from autoskillit.server._misc import _prime_quota_cache
+        from autoskillit.server._misc import _prime_quota_cache  # circular-break
 
         await _prime_quota_cache()
     except Exception:
         logger.warning("skill_auto_gate_boot_quota_cache_failed", exc_info=True)
 
     try:
-        from autoskillit.core import register_active_kitchen
+        from autoskillit.core import register_active_kitchen  # circular-break
 
         register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
     except Exception:
@@ -509,7 +512,7 @@ _LIFESPAN_BOOT_REGISTRY: dict[SessionType, Callable[[Any], Awaitable[None]] | No
 async def _run_codex_mcp_registration_async() -> None:
     """Offload ensure_codex_mcp_registered() to a thread executor — fail-open."""
     try:
-        from autoskillit.execution import ensure_codex_mcp_registered  # noqa: PLC0415
+        from autoskillit.execution import ensure_codex_mcp_registered  # circular-break
 
         loop = _asyncio.get_running_loop()
         written = await loop.run_in_executor(None, ensure_codex_mcp_registered)
@@ -543,8 +546,8 @@ async def _autoskillit_lifespan(server: Any) -> Any:
     """
     bg_tasks: list[_asyncio.Task[None]] = []
     try:
-        from autoskillit.pipeline import create_background_task
-        from autoskillit.server import _state
+        from autoskillit.pipeline import create_background_task  # circular-break
+        from autoskillit.server import _state  # circular-break
 
         event = _asyncio.Event()
         _state._startup_ready = event
@@ -570,7 +573,7 @@ async def _autoskillit_lifespan(server: Any) -> Any:
                 )
             )
 
-        from autoskillit.core import session_type as _resolve_session_type
+        from autoskillit.core import session_type as _resolve_session_type  # circular-break
 
         _boot_fn = _LIFESPAN_BOOT_REGISTRY.get(_resolve_session_type())
         if _boot_fn is not None and _boot_ctx is not None:
@@ -587,7 +590,7 @@ async def _autoskillit_lifespan(server: Any) -> Any:
         except Exception:
             logger.exception("lifespan sentinel cleanup error")
         try:
-            from autoskillit.core import clear_kitchens_for_pid  # noqa: PLC0415
+            from autoskillit.core import clear_kitchens_for_pid  # circular-break
 
             clear_kitchens_for_pid(os.getpid())
         except Exception:

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -23,14 +23,45 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
+import autoskillit.core.paths as _core_paths
 from autoskillit.core import (
+    CAMPAIGN_ID_ENV_VAR,
+    DISPATCH_ID_ENV_VAR,
+    FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
+    HEADLESS_AUTO_GATE_ENV_VAR,
+    HEADLESS_ENV_VAR,
     SessionType,
+    _collect_disabled_feature_tags,
+    atomic_write,
     cleanup_readiness_sentinel,
+    clear_kitchens_for_pid,
     get_logger,
+    register_active_kitchen,
     resolve_kitchen_id,
+    sweep_retiring_cache,
     write_readiness_sentinel,
 )
-from autoskillit.execution import RecordingSubprocessRunner
+from autoskillit.core import (
+    session_type as _resolve_session_type,
+)
+from autoskillit.execution import (
+    RecordingSubprocessRunner,
+    ensure_codex_mcp_registered,
+)
+from autoskillit.fleet import (
+    discover_campaign_state_files,
+    reap_stale_dispatches_async,
+    sweep_stale_dispatch_labels,
+)
+from autoskillit.hook_registry import (
+    HOOK_REGISTRY_HASH,
+    find_broken_hook_scripts,
+    generate_hooks_json,
+    iter_all_scope_paths,
+    load_hooks_json_hash,
+    validate_plugin_cache_hooks,
+)
+from autoskillit.pipeline import create_background_task
 from autoskillit.server._state import _get_ctx_or_none, deferred_initialize
 
 logger = get_logger(__name__)
@@ -44,14 +75,6 @@ def run_startup_drift_check() -> None:
     """
     try:
         import json
-
-        import autoskillit.core.paths as _core_paths  # circular-break
-        from autoskillit.core import atomic_write  # circular-break
-        from autoskillit.hook_registry import (  # circular-break
-            HOOK_REGISTRY_HASH,
-            generate_hooks_json,
-            load_hooks_json_hash,
-        )
 
         hooks_json_path = _core_paths.pkg_root() / "hooks" / "hooks.json"
         on_disk_hash = load_hooks_json_hash(hooks_json_path)
@@ -79,12 +102,6 @@ def run_startup_hook_health_check() -> list[str]:
     Returns list of broken hook commands. Any failure is logged and swallowed.
     """
     try:
-        from autoskillit.hook_registry import (  # circular-break
-            find_broken_hook_scripts,
-            iter_all_scope_paths,
-            validate_plugin_cache_hooks,
-        )
-
         broken: list[str] = []
         for scope_label, settings_path in iter_all_scope_paths(None):
             scope_broken = find_broken_hook_scripts(settings_path)
@@ -127,7 +144,6 @@ async def _run_drift_check_async() -> None:
 
 async def _run_retiring_sweep_async() -> None:
     """Offload blocking retiring cache sweep to a thread."""
-    from autoskillit.core import sweep_retiring_cache  # circular-break
 
     loop = _asyncio.get_running_loop()
     await loop.run_in_executor(None, sweep_retiring_cache)
@@ -195,11 +211,6 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
     logger.info("fleet_auto_gate_boot", gate_state="open", kitchen_id=ctx.kitchen_id)
 
     try:
-        from autoskillit.core import (  # circular-break
-            _collect_disabled_feature_tags,
-            register_active_kitchen,
-        )
-        from autoskillit.pipeline import create_background_task  # circular-break
         from autoskillit.server import mcp as _mcp  # circular-break
         from autoskillit.server._misc import (  # circular-break
             _prime_quota_cache,
@@ -243,16 +254,12 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
 
     _campaign_state_paths: list[Path] = []
     try:
-        from autoskillit.fleet import discover_campaign_state_files  # circular-break
-
         _campaign_state_paths = discover_campaign_state_files(ctx.project_dir)
     except Exception:
         logger.warning("fleet_auto_gate_boot_state_discovery_failed", exc_info=True)
 
     if _campaign_state_paths:
         try:
-            from autoskillit.fleet import reap_stale_dispatches_async  # circular-break
-
             await reap_stale_dispatches_async(
                 _campaign_state_paths,
                 own_campaign_id=ctx.kitchen_id,
@@ -265,8 +272,6 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
 
     if _campaign_state_paths and ctx.github_client is not None:
         try:
-            from autoskillit.fleet import sweep_stale_dispatch_labels  # circular-break
-
             create_background_task(
                 sweep_stale_dispatch_labels(_campaign_state_paths, ctx.github_client),
                 label="startup_label_recovery_sweep",
@@ -277,10 +282,6 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
 
 async def _pre_reveal_kitchen(ctx: Any) -> None:
     """Pre-reveal kitchen for non-notification backends (no tools/list_changed support)."""
-    from autoskillit.core import (  # circular-break
-        _collect_disabled_feature_tags,
-        register_active_kitchen,
-    )
     from autoskillit.server import mcp as _mcp  # circular-break
     from autoskillit.server._misc import _prime_quota_cache  # circular-break
     from autoskillit.server.tools.tools_kitchen import _write_hook_config  # circular-break
@@ -308,12 +309,6 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
     AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS is set. No-ops for interactive
     ORCHESTRATOR sessions (open_kitchen handles the gate there).
     """
-    from autoskillit.core import (  # circular-break
-        FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
-        HEADLESS_ENV_VAR,
-        register_active_kitchen,
-    )
-    from autoskillit.pipeline import create_background_task  # circular-break
     from autoskillit.server._misc import (  # circular-break
         _prime_quota_cache,
         _quota_refresh_loop,
@@ -349,7 +344,6 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
     )
 
     try:
-        from autoskillit.core import _collect_disabled_feature_tags  # circular-break
         from autoskillit.server import mcp as _mcp  # circular-break
 
         _features = ctx.config.features if ctx.config is not None else {}
@@ -387,8 +381,6 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
         logger.warning("food_truck_auto_gate_boot_registry_failed", exc_info=True)
 
     try:
-        from autoskillit.fleet import discover_campaign_state_files  # circular-break
-
         _campaign_state_paths = discover_campaign_state_files(ctx.project_dir)
     except Exception:
         logger.warning("food_truck_auto_gate_boot_state_discovery_failed", exc_info=True)
@@ -396,16 +388,9 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
 
     if _campaign_state_paths:
         try:
-            from autoskillit.fleet import reap_stale_dispatches_async  # circular-break
-
             _skip: frozenset[str] | None = None
             _own_campaign_id: str | None = None
             try:
-                from autoskillit.core import (  # circular-break
-                    CAMPAIGN_ID_ENV_VAR,
-                    DISPATCH_ID_ENV_VAR,
-                )
-
                 _own_dispatch_id = os.environ.get(DISPATCH_ID_ENV_VAR, "")
                 _skip = frozenset({_own_dispatch_id}) if _own_dispatch_id else None
                 _own_campaign_id = os.environ.get(CAMPAIGN_ID_ENV_VAR, "") or None
@@ -425,8 +410,6 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
 
     try:
         if _campaign_state_paths and ctx.github_client is not None:
-            from autoskillit.fleet import sweep_stale_dispatch_labels  # circular-break
-
             create_background_task(
                 sweep_stale_dispatch_labels(_campaign_state_paths, ctx.github_client),
                 label="startup_label_recovery_sweep",
@@ -443,7 +426,6 @@ async def _skill_auto_gate_boot(ctx: Any) -> None:
     Omits quota-refresh loop and campaign state recovery — SKILL sessions
     are short-lived.
     """
-    from autoskillit.core import HEADLESS_AUTO_GATE_ENV_VAR, HEADLESS_ENV_VAR  # circular-break
 
     if os.environ.get(HEADLESS_ENV_VAR) != "1":
         if ctx.backend is not None and not ctx.backend.capabilities.supports_tool_list_changed:
@@ -470,7 +452,6 @@ async def _skill_auto_gate_boot(ctx: Any) -> None:
     )
 
     try:
-        from autoskillit.core import _collect_disabled_feature_tags  # circular-break
         from autoskillit.server import mcp as _mcp  # circular-break
 
         _features = ctx.config.features if ctx.config is not None else {}
@@ -495,8 +476,6 @@ async def _skill_auto_gate_boot(ctx: Any) -> None:
         logger.warning("skill_auto_gate_boot_quota_cache_failed", exc_info=True)
 
     try:
-        from autoskillit.core import register_active_kitchen  # circular-break
-
         register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
     except Exception:
         logger.warning("skill_auto_gate_boot_registry_failed", exc_info=True)
@@ -512,8 +491,6 @@ _LIFESPAN_BOOT_REGISTRY: dict[SessionType, Callable[[Any], Awaitable[None]] | No
 async def _run_codex_mcp_registration_async() -> None:
     """Offload ensure_codex_mcp_registered() to a thread executor — fail-open."""
     try:
-        from autoskillit.execution import ensure_codex_mcp_registered  # circular-break
-
         loop = _asyncio.get_running_loop()
         written = await loop.run_in_executor(None, ensure_codex_mcp_registered)
         if written:
@@ -546,7 +523,6 @@ async def _autoskillit_lifespan(server: Any) -> Any:
     """
     bg_tasks: list[_asyncio.Task[None]] = []
     try:
-        from autoskillit.pipeline import create_background_task  # circular-break
         from autoskillit.server import _state  # circular-break
 
         event = _asyncio.Event()
@@ -573,8 +549,6 @@ async def _autoskillit_lifespan(server: Any) -> Any:
                 )
             )
 
-        from autoskillit.core import session_type as _resolve_session_type  # circular-break
-
         _boot_fn = _LIFESPAN_BOOT_REGISTRY.get(_resolve_session_type())
         if _boot_fn is not None and _boot_ctx is not None:
             await _boot_fn(_boot_ctx)
@@ -590,8 +564,6 @@ async def _autoskillit_lifespan(server: Any) -> Any:
         except Exception:
             logger.exception("lifespan sentinel cleanup error")
         try:
-            from autoskillit.core import clear_kitchens_for_pid  # circular-break
-
             clear_kitchens_for_pid(os.getpid())
         except Exception:
             logger.exception("lifespan kitchen registry cleanup error")

--- a/src/autoskillit/server/_misc.py
+++ b/src/autoskillit/server/_misc.py
@@ -134,12 +134,12 @@ def _extract_block(text: str, start_delim: str, end_delim: str) -> list[str]:
 
 def _build_hook_diagnostic_warning() -> str | None:
     """Run hook health and drift checks. Return a warning string if issues are found."""
-    from autoskillit.core import (
+    from autoskillit.core import (  # circular-break
         DIRECT_INSTALL_CACHE_SUBDIR,
         MARKETPLACE_PREFIX,
         detect_autoskillit_mcp_prefix,
     )
-    from autoskillit.hook_registry import (
+    from autoskillit.hook_registry import (  # circular-break
         _claude_settings_path,
         _count_hook_registry_drift,
         find_broken_hook_scripts,
@@ -190,14 +190,14 @@ async def _apply_triage_gate(
 
     Delegates to the RecipeRepository implementation via the Composition Root.
     """
-    from autoskillit.server._state import _ctx
+    from autoskillit.server._state import _ctx  # circular-break
 
     if _ctx is None or _ctx.recipes is None:
         return result
 
     import functools
 
-    from autoskillit._llm_triage import triage_staleness
+    from autoskillit._llm_triage import triage_staleness  # circular-break
 
     if _ctx.backend is not None and _ctx.backend.capabilities.triage_capable:
         triage_fn = functools.partial(triage_staleness, backend=_ctx.backend)
@@ -223,7 +223,7 @@ async def resolve_repo_from_remote(cwd: str, hint: str | None = None) -> str:
     hint: optional owner/repo string or full GitHub URL; parsed before
           git remote inference. Passes through to resolve_remote_repo.
     """
-    from autoskillit.execution import resolve_remote_repo
+    from autoskillit.execution import resolve_remote_repo  # circular-break
 
     return await resolve_remote_repo(cwd, hint=hint) or ""
 
@@ -239,7 +239,7 @@ async def _prime_quota_cache() -> None:
     Called at open_kitchen so the cache is primed before any run_skill hook fires.
     Fails open: a quota fetch failure must not abort kitchen open.
     """
-    from autoskillit.server._state import _get_ctx as _ctx_fn
+    from autoskillit.server._state import _get_ctx as _ctx_fn  # circular-break
 
     try:
         _ctx = _ctx_fn()
@@ -281,8 +281,8 @@ async def _quota_refresh_loop(config: QuotaGuardConfig, *, provider: str = "anth
 def persist_run_skill_state(skill_result: SkillResult, project_dir: Path) -> None:
     import os  # noqa: PLC0415
 
-    from autoskillit.core import ensure_project_temp  # noqa: PLC0415
-    from autoskillit.execution import (  # noqa: PLC0415
+    from autoskillit.core import ensure_project_temp  # circular-break
+    from autoskillit.execution import (  # circular-break
         SessionState,
         persist_session_state,
     )
@@ -306,8 +306,8 @@ def persist_run_skill_state(skill_result: SkillResult, project_dir: Path) -> Non
 
 
 def clear_run_skill_state(project_dir: Path) -> None:
-    from autoskillit.core import ensure_project_temp  # noqa: PLC0415
-    from autoskillit.execution import (  # noqa: PLC0415
+    from autoskillit.core import ensure_project_temp  # circular-break
+    from autoskillit.execution import (  # circular-break
         clear_session_state,
     )
 

--- a/src/autoskillit/server/_misc.py
+++ b/src/autoskillit/server/_misc.py
@@ -11,9 +11,22 @@ import asyncio
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from autoskillit.core import get_logger
+from autoskillit._llm_triage import triage_staleness
+from autoskillit.core import (
+    DIRECT_INSTALL_CACHE_SUBDIR,
+    MARKETPLACE_PREFIX,
+    detect_autoskillit_mcp_prefix,
+    ensure_project_temp,
+    get_logger,
+)
 from autoskillit.execution import (
     SCENARIO_STEP_NAME_ENV as SCENARIO_STEP_NAME_ENV,
+)
+from autoskillit.execution import (
+    SessionState,
+    clear_session_state,
+    persist_session_state,
+    resolve_remote_repo,
 )
 from autoskillit.execution import (
     _refresh_quota_cache as _refresh_quota_cache,
@@ -38,6 +51,12 @@ from autoskillit.execution import (
 )
 from autoskillit.execution import (
     write_telemetry_clear_marker as write_telemetry_clear_marker,
+)
+from autoskillit.hook_registry import (
+    _claude_settings_path,
+    _count_hook_registry_drift,
+    find_broken_hook_scripts,
+    validate_plugin_cache_hooks,
 )
 from autoskillit.hooks import _HOOK_CONFIG_PATH_COMPONENTS
 from autoskillit.workspace import clone_registry as clone_registry
@@ -134,17 +153,6 @@ def _extract_block(text: str, start_delim: str, end_delim: str) -> list[str]:
 
 def _build_hook_diagnostic_warning() -> str | None:
     """Run hook health and drift checks. Return a warning string if issues are found."""
-    from autoskillit.core import (  # circular-break
-        DIRECT_INSTALL_CACHE_SUBDIR,
-        MARKETPLACE_PREFIX,
-        detect_autoskillit_mcp_prefix,
-    )
-    from autoskillit.hook_registry import (  # circular-break
-        _claude_settings_path,
-        _count_hook_registry_drift,
-        find_broken_hook_scripts,
-        validate_plugin_cache_hooks,
-    )
 
     issues: list[str] = []
 
@@ -197,8 +205,6 @@ async def _apply_triage_gate(
 
     import functools
 
-    from autoskillit._llm_triage import triage_staleness  # circular-break
-
     if _ctx.backend is not None and _ctx.backend.capabilities.triage_capable:
         triage_fn = functools.partial(triage_staleness, backend=_ctx.backend)
     else:
@@ -223,7 +229,6 @@ async def resolve_repo_from_remote(cwd: str, hint: str | None = None) -> str:
     hint: optional owner/repo string or full GitHub URL; parsed before
           git remote inference. Passes through to resolve_remote_repo.
     """
-    from autoskillit.execution import resolve_remote_repo  # circular-break
 
     return await resolve_remote_repo(cwd, hint=hint) or ""
 
@@ -281,12 +286,6 @@ async def _quota_refresh_loop(config: QuotaGuardConfig, *, provider: str = "anth
 def persist_run_skill_state(skill_result: SkillResult, project_dir: Path) -> None:
     import os  # noqa: PLC0415
 
-    from autoskillit.core import ensure_project_temp  # circular-break
-    from autoskillit.execution import (  # circular-break
-        SessionState,
-        persist_session_state,
-    )
-
     if not skill_result.session_id:
         return
     try:
@@ -306,10 +305,6 @@ def persist_run_skill_state(skill_result: SkillResult, project_dir: Path) -> Non
 
 
 def clear_run_skill_state(project_dir: Path) -> None:
-    from autoskillit.core import ensure_project_temp  # circular-break
-    from autoskillit.execution import (  # circular-break
-        clear_session_state,
-    )
 
     try:
         state_dir = ensure_project_temp(project_dir) / "session_state"

--- a/src/autoskillit/server/_notify.py
+++ b/src/autoskillit/server/_notify.py
@@ -19,7 +19,7 @@ logger = get_logger(__name__)
 
 
 def _get_ctx_or_none():  # type: ignore[return]
-    from autoskillit.server._state import _get_ctx_or_none as _ctx_none_fn
+    from autoskillit.server._state import _get_ctx_or_none as _ctx_none_fn  # circular-break
 
     return _ctx_none_fn()
 

--- a/src/autoskillit/server/_session_type.py
+++ b/src/autoskillit/server/_session_type.py
@@ -42,7 +42,7 @@ def _apply_session_type_visibility() -> None:
     Non-notification backends (e.g. Codex) do not process notifications/tools/list_changed
     so kitchen tools are pre-revealed at startup when AUTOSKILLIT_MCP_CLIENT_BACKEND=codex.
     """
-    from autoskillit.server import mcp
+    from autoskillit.server import mcp  # circular-break
 
     _session = _resolve_session_type()
     _headless = os.environ.get(HEADLESS_ENV_VAR) == "1"

--- a/src/autoskillit/server/_state.py
+++ b/src/autoskillit/server/_state.py
@@ -40,7 +40,7 @@ def _initialize(ctx: ToolContext) -> None:
     # (server/__init__.py imports from _state.py at module level).
     if ctx.config.subsets.disabled:
         try:
-            from autoskillit.server import mcp  # noqa: PLC0415
+            from autoskillit.server import mcp  # circular-break
 
             for subset in ctx.config.subsets.disabled:
                 mcp.disable(tags={subset})
@@ -56,11 +56,11 @@ def _initialize(ctx: ToolContext) -> None:
     # surfaces as an error rather than being silently swallowed as a middleware warning.
     # The _mcp_middleware_registered flag on the runner prevents double-registration
     # if _initialize() is called more than once with the same runner instance.
-    from autoskillit.execution import (  # noqa: PLC0415
+    from autoskillit.execution import (  # circular-break
         RecordingSubprocessRunner,
         ReplayingSubprocessRunner,
     )
-    from autoskillit.server import mcp  # noqa: PLC0415
+    from autoskillit.server import mcp  # circular-break
 
     if isinstance(ctx.runner, RecordingSubprocessRunner) and not getattr(
         ctx.runner, "_mcp_middleware_registered", False
@@ -100,7 +100,7 @@ async def deferred_initialize(ctx: ToolContext, *, ready_event: asyncio.Event) -
     """
     try:
         try:
-            from autoskillit.execution import recover_crashed_sessions  # noqa: PLC0415
+            from autoskillit.execution import recover_crashed_sessions  # circular-break
 
             cfg = ctx.config.linux_tracing
             n = recover_crashed_sessions(
@@ -115,7 +115,7 @@ async def deferred_initialize(ctx: ToolContext, *, ready_event: asyncio.Event) -
         try:
             from datetime import datetime, timedelta  # noqa: PLC0415
 
-            from autoskillit.execution import (  # noqa: PLC0415
+            from autoskillit.execution import (  # circular-break
                 read_telemetry_clear_marker,
                 resolve_log_dir,
             )
@@ -189,8 +189,8 @@ def _check_rerun(log_dir: str, composite_hash: str) -> dict[str, object] | None:
     """Check sessions.jsonl for prior runs with the same composite hash."""
     if not composite_hash:
         return None
-    from autoskillit.execution import resolve_log_dir  # noqa: PLC0415
-    from autoskillit.recipe import check_rerun_detection  # noqa: PLC0415
+    from autoskillit.execution import resolve_log_dir  # circular-break
+    from autoskillit.recipe import check_rerun_detection  # circular-break
 
     sessions_path = resolve_log_dir(log_dir) / "sessions.jsonl"
     return check_rerun_detection(sessions_path, composite_hash=composite_hash)
@@ -198,7 +198,7 @@ def _check_rerun(log_dir: str, composite_hash: str) -> dict[str, object] | None:
 
 def version_info() -> dict:
     """Return version health information for the running server."""
-    from autoskillit.version import version_info as _compute_version
+    from autoskillit.version import version_info as _compute_version  # circular-break
 
     plugin_dir = _get_plugin_dir()
     return _compute_version(plugin_dir)

--- a/src/autoskillit/server/_state.py
+++ b/src/autoskillit/server/_state.py
@@ -22,7 +22,16 @@ from datetime import UTC
 
 from autoskillit.config import AutomationConfig
 from autoskillit.core import DirectInstall, MarketplaceInstall, get_logger
+from autoskillit.execution import (
+    RecordingSubprocessRunner,
+    ReplayingSubprocessRunner,
+    read_telemetry_clear_marker,
+    recover_crashed_sessions,
+    resolve_log_dir,
+)
 from autoskillit.pipeline import ToolContext
+from autoskillit.recipe import check_rerun_detection
+from autoskillit.version import version_info as _compute_version
 
 logger = get_logger(__name__)
 
@@ -56,10 +65,6 @@ def _initialize(ctx: ToolContext) -> None:
     # surfaces as an error rather than being silently swallowed as a middleware warning.
     # The _mcp_middleware_registered flag on the runner prevents double-registration
     # if _initialize() is called more than once with the same runner instance.
-    from autoskillit.execution import (  # circular-break
-        RecordingSubprocessRunner,
-        ReplayingSubprocessRunner,
-    )
     from autoskillit.server import mcp  # circular-break
 
     if isinstance(ctx.runner, RecordingSubprocessRunner) and not getattr(
@@ -100,8 +105,6 @@ async def deferred_initialize(ctx: ToolContext, *, ready_event: asyncio.Event) -
     """
     try:
         try:
-            from autoskillit.execution import recover_crashed_sessions  # circular-break
-
             cfg = ctx.config.linux_tracing
             n = recover_crashed_sessions(
                 tmpfs_path=cfg.tmpfs_path,
@@ -114,11 +117,6 @@ async def deferred_initialize(ctx: ToolContext, *, ready_event: asyncio.Event) -
 
         try:
             from datetime import datetime, timedelta  # noqa: PLC0415
-
-            from autoskillit.execution import (  # circular-break
-                read_telemetry_clear_marker,
-                resolve_log_dir,
-            )
 
             cfg = ctx.config.linux_tracing
             log_root = resolve_log_dir(cfg.log_dir)
@@ -189,8 +187,6 @@ def _check_rerun(log_dir: str, composite_hash: str) -> dict[str, object] | None:
     """Check sessions.jsonl for prior runs with the same composite hash."""
     if not composite_hash:
         return None
-    from autoskillit.execution import resolve_log_dir  # circular-break
-    from autoskillit.recipe import check_rerun_detection  # circular-break
 
     sessions_path = resolve_log_dir(log_dir) / "sessions.jsonl"
     return check_rerun_detection(sessions_path, composite_hash=composite_hash)
@@ -198,7 +194,6 @@ def _check_rerun(log_dir: str, composite_hash: str) -> dict[str, object] | None:
 
 def version_info() -> dict:
     """Return version health information for the running server."""
-    from autoskillit.version import version_info as _compute_version  # circular-break
 
     plugin_dir = _get_plugin_dir()
     return _compute_version(plugin_dir)

--- a/src/autoskillit/server/_subprocess.py
+++ b/src/autoskillit/server/_subprocess.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from autoskillit.core import TerminationReason
+from autoskillit.core import TerminationReason, current_order_id, current_step_name
 
 if TYPE_CHECKING:
     from autoskillit.core import SubprocessResult
@@ -71,8 +71,6 @@ async def _run_subprocess(
     returncode, stdout, stderr = _process_runner_result(result, timeout)
 
     if is_gh:
-        from autoskillit.core import current_order_id, current_step_name  # circular-break
-
         latency_ms = (time.monotonic() - start) * 1000.0
         log = _get_ctx().github_api_log
         if log is not None:

--- a/src/autoskillit/server/_subprocess.py
+++ b/src/autoskillit/server/_subprocess.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 def _get_ctx():  # type: ignore[return]
     """Deferred import of _get_ctx from _state to avoid circular imports."""
-    from autoskillit.server._state import _get_ctx as _ctx_fn
+    from autoskillit.server._state import _get_ctx as _ctx_fn  # circular-break
 
     return _ctx_fn()
 
@@ -71,7 +71,7 @@ async def _run_subprocess(
     returncode, stdout, stderr = _process_runner_result(result, timeout)
 
     if is_gh:
-        from autoskillit.core import current_order_id, current_step_name
+        from autoskillit.core import current_order_id, current_step_name  # circular-break
 
         latency_ms = (time.monotonic() - start) * 1000.0
         log = _get_ctx().github_api_log

--- a/src/autoskillit/server/tools/_cancellation_shield.py
+++ b/src/autoskillit/server/tools/_cancellation_shield.py
@@ -16,7 +16,7 @@ from typing import Any, Literal, TypeVar
 
 import anyio
 
-from autoskillit.core import get_logger
+from autoskillit.core import FleetErrorCode, fleet_error, get_logger
 
 logger = get_logger(__name__)
 
@@ -54,8 +54,6 @@ def _build_cancellation_response(result_type: str) -> str:
     """Build a structured JSON error response for transport-level CancelledError."""
     msg = "CancelledError: transport teardown"
     if result_type == "fleet_error":
-        from autoskillit.core import FleetErrorCode, fleet_error  # noqa: PLC0415
-
         return fleet_error(FleetErrorCode.FLEET_L3_STARTUP_OR_CRASH, msg)
     if result_type in ("run_cmd", "run_python"):
         return json.dumps({"success": False, "exit_code": -1, "stdout": "", "stderr": msg})

--- a/src/autoskillit/server/tools/_claim_helpers.py
+++ b/src/autoskillit/server/tools/_claim_helpers.py
@@ -7,6 +7,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from autoskillit.core import get_logger
+from autoskillit.fleet import (
+    TERMINAL_UNCLEANED_STATUSES,
+    CampaignStateMutator,
+    cleanup_orphaned_labels,
+    discover_campaign_state_files,
+    find_dispatch_for_issue,
+    is_dispatch_session_alive,
+)
 
 if TYPE_CHECKING:
     from autoskillit.core import GitHubFetcher
@@ -24,14 +32,12 @@ class ClaimDecision:
 
 
 def _get_campaign_state_paths(tool_ctx: ToolContext) -> list[Path]:
-    from autoskillit.fleet import discover_campaign_state_files  # circular-break: lazy-load fleet
 
     return discover_campaign_state_files(tool_ctx.project_dir)
 
 
 def _mark_dispatch_labels_cleaned(dispatch_name: str, campaign_state_paths: list[Path]) -> None:
     """Persist labels_cleaned=True for a dispatch after claim-time label cleanup."""
-    from autoskillit.fleet import CampaignStateMutator  # circular-break: lazy-load fleet
 
     for state_path in campaign_state_paths:
         try:
@@ -68,12 +74,6 @@ async def _try_claim_with_liveness(
     indicating whether to proceed with the claim. When the owning dispatch session is
     dead, cleans up the stale label inline and returns claimed=True.
     """
-    from autoskillit.fleet import (  # circular-break: lazy-load fleet
-        TERMINAL_UNCLEANED_STATUSES,
-        cleanup_orphaned_labels,
-        find_dispatch_for_issue,
-        is_dispatch_session_alive,
-    )
 
     if effective_label not in current_labels:
         return ClaimDecision(claimed=True)

--- a/src/autoskillit/server/tools/_claim_helpers.py
+++ b/src/autoskillit/server/tools/_claim_helpers.py
@@ -24,14 +24,14 @@ class ClaimDecision:
 
 
 def _get_campaign_state_paths(tool_ctx: ToolContext) -> list[Path]:
-    from autoskillit.fleet import discover_campaign_state_files  # noqa: PLC0415
+    from autoskillit.fleet import discover_campaign_state_files  # circular-break: lazy-load fleet
 
     return discover_campaign_state_files(tool_ctx.project_dir)
 
 
 def _mark_dispatch_labels_cleaned(dispatch_name: str, campaign_state_paths: list[Path]) -> None:
     """Persist labels_cleaned=True for a dispatch after claim-time label cleanup."""
-    from autoskillit.fleet import CampaignStateMutator  # noqa: PLC0415
+    from autoskillit.fleet import CampaignStateMutator  # circular-break: lazy-load fleet
 
     for state_path in campaign_state_paths:
         try:
@@ -68,7 +68,7 @@ async def _try_claim_with_liveness(
     indicating whether to proceed with the claim. When the owning dispatch session is
     dead, cleans up the stale label inline and returns claimed=True.
     """
-    from autoskillit.fleet import (  # noqa: PLC0415
+    from autoskillit.fleet import (  # circular-break: lazy-load fleet
         TERMINAL_UNCLEANED_STATUSES,
         cleanup_orphaned_labels,
         find_dispatch_for_issue,

--- a/src/autoskillit/server/tools/tools_ci.py
+++ b/src/autoskillit/server/tools/tools_ci.py
@@ -66,7 +66,9 @@ async def set_commit_status(
         )
 
     try:
-        from autoskillit.server import _get_ctx
+        from autoskillit.server import (  # circular-break
+            _get_ctx,
+        )  # circular-break: server-internal circular dependency
 
         tool_ctx = _get_ctx()
         if cwd:
@@ -153,7 +155,9 @@ async def check_repo_merge_state(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        from autoskillit.server import _get_ctx
+        from autoskillit.server import (  # circular-break
+            _get_ctx,
+        )  # circular-break: server-internal circular dependency
 
         tool_ctx = _get_ctx()
         _start = time.monotonic()

--- a/src/autoskillit/server/tools/tools_ci_merge_queue.py
+++ b/src/autoskillit/server/tools/tools_ci_merge_queue.py
@@ -63,7 +63,9 @@ async def toggle_auto_merge(
                 extra={"pr_number": pr_number, "target_branch": target_branch},
             )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
 
@@ -136,7 +138,9 @@ async def enqueue_pr(
                 extra={"pr_number": pr_number, "target_branch": target_branch},
             )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
 
@@ -255,7 +259,9 @@ async def wait_for_merge_queue(
                 extra={"pr_number": pr_number, "target_branch": target_branch},
             )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
 

--- a/src/autoskillit/server/tools/tools_ci_watch.py
+++ b/src/autoskillit/server/tools/tools_ci_watch.py
@@ -101,7 +101,9 @@ async def wait_for_ci(
         with structlog.contextvars.bound_contextvars(tool="wait_for_ci"):
             logger.info("wait_for_ci", branch=branch, repo=repo or "(infer)")
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             _timing_ctx = tool_ctx
@@ -264,7 +266,9 @@ async def get_ci_status(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
-        from autoskillit.server import _get_ctx
+        from autoskillit.server import (  # circular-break
+            _get_ctx,
+        )  # circular-break: server-internal circular dependency
 
         tool_ctx = _get_ctx()
         if tool_ctx.ci_watcher is None:

--- a/src/autoskillit/server/tools/tools_clone.py
+++ b/src/autoskillit/server/tools/tools_clone.py
@@ -90,7 +90,9 @@ async def clone_repo(
                 },
             )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             if tool_ctx.clone_mgr is None:
@@ -161,7 +163,9 @@ async def remove_clone(
                 extra={"clone_path": clone_path, "keep": keep},
             )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             if tool_ctx.clone_mgr is None:
@@ -238,7 +242,9 @@ async def push_to_remote(
                 },
             )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             clone_mgr = tool_ctx.clone_mgr
@@ -337,7 +343,9 @@ async def register_clone_status(
                     }
                 )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             owner = os.environ.get(CAMPAIGN_ID_ENV_VAR, "") or tool_ctx.kitchen_id
@@ -414,7 +422,9 @@ async def batch_cleanup_clones(
         with structlog.contextvars.bound_contextvars(tool="batch_cleanup_clones"):
             logger.info("batch_cleanup_clones", registry_path=registry_path, all_owners=all_owners)
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             if tool_ctx.clone_mgr is None:
@@ -551,7 +561,9 @@ async def bootstrap_clone(
                 },
             )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             if tool_ctx.clone_mgr is None:

--- a/src/autoskillit/server/tools/tools_config.py
+++ b/src/autoskillit/server/tools/tools_config.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 from dataclasses import fields as dc_fields
 
+from autoskillit.config import _MAX_CONCURRENT_DISPATCHES
 from autoskillit.core import FleetLock, atomic_write, get_logger
+from autoskillit.fleet import FleetSemaphore
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_orchestrator_exact
 from autoskillit.server._misc import _hook_config_overlay_path, _hook_config_path
@@ -119,8 +121,6 @@ def _collect_order_params(
 
 
 def _validate_max_concurrent(value: int) -> str | None:
-    from autoskillit.config import _MAX_CONCURRENT_DISPATCHES  # circular-break: lazy-load config
-
     if value < 1 or value > _MAX_CONCURRENT_DISPATCHES:
         return (
             f"max_concurrent_dispatches must be between 1 and "
@@ -130,8 +130,6 @@ def _validate_max_concurrent(value: int) -> str | None:
 
 
 def _replace_fleet_semaphore(ctx, max_concurrent: int, acquire_timeout_sec: float | None) -> None:
-    from autoskillit.fleet import FleetSemaphore  # circular-break: lazy-load fleet
-
     existing_timeout = ctx.fleet_lock.timeout if ctx.fleet_lock is not None else None
     timeout = acquire_timeout_sec if acquire_timeout_sec is not None else existing_timeout
     ctx.fleet_lock = FleetSemaphore(max_concurrent=max_concurrent, timeout=timeout)

--- a/src/autoskillit/server/tools/tools_config.py
+++ b/src/autoskillit/server/tools/tools_config.py
@@ -119,7 +119,7 @@ def _collect_order_params(
 
 
 def _validate_max_concurrent(value: int) -> str | None:
-    from autoskillit.config import _MAX_CONCURRENT_DISPATCHES
+    from autoskillit.config import _MAX_CONCURRENT_DISPATCHES  # circular-break: lazy-load config
 
     if value < 1 or value > _MAX_CONCURRENT_DISPATCHES:
         return (
@@ -130,7 +130,7 @@ def _validate_max_concurrent(value: int) -> str | None:
 
 
 def _replace_fleet_semaphore(ctx, max_concurrent: int, acquire_timeout_sec: float | None) -> None:
-    from autoskillit.fleet import FleetSemaphore
+    from autoskillit.fleet import FleetSemaphore  # circular-break: lazy-load fleet
 
     existing_timeout = ctx.fleet_lock.timeout if ctx.fleet_lock is not None else None
     timeout = acquire_timeout_sec if acquire_timeout_sec is not None else existing_timeout
@@ -171,7 +171,7 @@ async def configure_fleet(
     try:
         if (h := _require_orchestrator_exact("configure_fleet")) is not None:
             return h
-        from autoskillit.server import _get_ctx
+        from autoskillit.server import _get_ctx  # circular-break
 
         ctx = _get_ctx()
 
@@ -266,7 +266,7 @@ async def configure_order(
     try:
         if (h := _require_orchestrator_exact("configure_order")) is not None:
             return h
-        from autoskillit.server import _get_ctx
+        from autoskillit.server import _get_ctx  # circular-break
 
         ctx = _get_ctx()
 

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -68,7 +68,7 @@ def _is_backend_incompatible(skill_info: object, effective_backend: str) -> bool
 
 def _check_ingredient_locks(step_name: str, order_id: str) -> str | None:
     """Check if step_name is locked out by ingredient locks. Returns deny JSON or None."""
-    from autoskillit.server import _get_ctx
+    from autoskillit.server import _get_ctx  # circular-break
 
     ctx = _get_ctx()
     overlay_path = _hook_config_overlay_path(ctx.project_dir)
@@ -115,12 +115,12 @@ def _check_ingredient_locks(step_name: str, order_id: str) -> str | None:
 
 def _check_pipeline_deps(step_name: str, order_id: str) -> str | None:
     """Check if step_name's dependencies are satisfied. Returns deny JSON or None."""
-    from autoskillit.pipeline import canonical_step_name
+    from autoskillit.pipeline import canonical_step_name  # circular-break
 
     effective_oid = order_id or os.environ.get(DISPATCH_ID_ENV_VAR, "")
     if not effective_oid:
         return None
-    from autoskillit.server import _get_ctx
+    from autoskillit.server import _get_ctx  # circular-break
 
     ctx = _get_ctx()
     tracker_path = _pipeline_tracker_path(ctx.project_dir, effective_oid)
@@ -180,7 +180,7 @@ def _resolve_step_name_from_recipe(
 
 def _has_active_locks(order_id: str) -> bool:
     """Return True if any ingredient locks are actively denying steps."""
-    from autoskillit.server import _get_ctx
+    from autoskillit.server import _get_ctx  # circular-break
 
     ctx = _get_ctx()
     overlay_path = _hook_config_overlay_path(ctx.project_dir)
@@ -230,7 +230,7 @@ async def run_cmd(
                 ctx, "info", f"run_cmd: {cmd[:80]}", "autoskillit.run_cmd", extra={"cwd": cwd}
             )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx  # circular-break
 
             tool_ctx = _get_ctx()
             _start = time.monotonic()
@@ -324,7 +324,7 @@ async def run_python(
                 "autoskillit.run_python",
                 extra={"callable": callable},
             )
-            from autoskillit.server.tools._execution_helpers import (
+            from autoskillit.server.tools._execution_helpers import (  # circular-break
                 _import_and_call,  # noqa: PLC0415
                 resolve_relative_path_args,  # noqa: PLC0415
                 validate_path_arg_anchoring,  # noqa: PLC0415
@@ -359,13 +359,13 @@ async def run_python(
 
 
 def _persist_run_skill_state(skill_result: SkillResult, project_dir: Path) -> None:
-    from autoskillit.server._misc import persist_run_skill_state  # noqa: PLC0415
+    from autoskillit.server._misc import persist_run_skill_state  # circular-break
 
     persist_run_skill_state(skill_result, project_dir)
 
 
 def _clear_run_skill_state(project_dir: Path) -> None:
-    from autoskillit.server._misc import clear_run_skill_state  # noqa: PLC0415
+    from autoskillit.server._misc import clear_run_skill_state  # circular-break
 
     clear_run_skill_state(project_dir)
 
@@ -495,7 +495,7 @@ async def run_skill(
         return _dep_denial
     try:
         _sn_token = _oid_token = None
-        from autoskillit.server import _get_ctx
+        from autoskillit.server import _get_ctx  # circular-break
 
         _cleanup_session_id: str | None = None
         tool_ctx = _get_ctx()
@@ -539,7 +539,7 @@ async def run_skill(
                 extra={"cwd": cwd, "model": model or "default"},
             )
 
-            from autoskillit.server import _get_config
+            from autoskillit.server import _get_config  # circular-break
 
             # Auto-enrich order_id from the fleet dispatcher's env variable when the
             # caller did not pass an explicit value. AUTOSKILLIT_DISPATCH_ID is injected
@@ -567,7 +567,7 @@ async def run_skill(
             profile_name_out: str = ""
             effective_model = model
 
-            from autoskillit.core import (
+            from autoskillit.core import (  # circular-break
                 AGENT_BACKEND_CLAUDE_CODE,
                 is_feature_enabled,
             )
@@ -586,7 +586,7 @@ async def run_skill(
             if is_feature_enabled(
                 "providers", _cfg.features, experimental_enabled=_cfg.experimental_enabled
             ):
-                from autoskillit.server._guards import (
+                from autoskillit.server._guards import (  # circular-break
                     _resolve_model_as_profile,
                     _resolve_provider_profile,
                 )
@@ -637,7 +637,7 @@ async def run_skill(
                 expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
 
             # Look up write-expectation metadata from skill contract
-            from autoskillit.core import WriteBehaviorSpec
+            from autoskillit.core import WriteBehaviorSpec  # circular-break
 
             write_spec: WriteBehaviorSpec | None = None
             if tool_ctx.write_expected_resolver:
@@ -647,7 +647,7 @@ async def run_skill(
             from pathlib import Path
             from uuid import uuid4
 
-            from autoskillit.core import resolve_target_skill
+            from autoskillit.core import resolve_target_skill  # circular-break
 
             # Resolve correct namespace and prepare for tier2 activation
             resolved_command = skill_command
@@ -843,20 +843,20 @@ async def run_skill(
             if _local_dir is not None:
                 skill_add_dirs.append(_local_dir)
 
-            from autoskillit.pipeline.context import (  # noqa: PLC0415
+            from autoskillit.pipeline.context import (  # circular-break
                 current_order_id as _current_order_id,
             )
-            from autoskillit.pipeline.context import (  # noqa: PLC0415
+            from autoskillit.pipeline.context import (  # circular-break
                 current_step_name as _current_step_name,
             )
-            from autoskillit.pipeline.tokens import (  # noqa: PLC0415
+            from autoskillit.pipeline.tokens import (  # circular-break
                 canonical_step_name as _canonical_step_name,
             )
 
             _sn_token = _current_step_name.set(_canonical_step_name(step_name))
             _oid_token = _current_order_id.set(effective_order_id)
 
-            from autoskillit.core import (  # noqa: PLC0415
+            from autoskillit.core import (  # circular-break
                 claude_code_project_dir,
                 execution_marker,
                 find_caller_session_id,
@@ -927,7 +927,7 @@ async def run_skill(
                     _persist_run_skill_state(skill_result, tool_ctx.project_dir)
                 if effective_order_id:
                     skill_result.order_id = effective_order_id
-                from autoskillit.server._misc import (  # noqa: PLC0415
+                from autoskillit.server._misc import (  # circular-break
                     _refresh_quota_cache,
                 )
 

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -37,7 +37,6 @@ from autoskillit.core import (
 from autoskillit.core import current_order_id as _current_order_id
 from autoskillit.core import current_step_name as _current_step_name
 from autoskillit.core import resolve_skill_temp_dir as _resolve_skill_temp_dir
-from autoskillit.pipeline import canonical_step_name
 from autoskillit.pipeline import canonical_step_name as _canonical_step_name
 from autoskillit.server import mcp
 from autoskillit.server._guards import (
@@ -146,7 +145,7 @@ def _check_pipeline_deps(step_name: str, order_id: str) -> str | None:
         tracker = json.loads(tracker_path.read_text())
     except (json.JSONDecodeError, OSError):
         return None
-    canonical = canonical_step_name(step_name)
+    canonical = _canonical_step_name(step_name)
     deps = tracker.get("dependencies", {}).get(canonical, [])
     if not deps:
         return None

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -17,7 +17,6 @@ from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import (
     AGENT_BACKEND_CLAUDE_CODE,
-    AGENT_BACKEND_CODEX,
     DISPATCH_ID_ENV_VAR,
     SKILL_COMMAND_DISPLAY_MAX,
     WORKTREE_SKILLS,

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -16,17 +16,29 @@ from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import (
+    AGENT_BACKEND_CLAUDE_CODE,
+    AGENT_BACKEND_CODEX,
     DISPATCH_ID_ENV_VAR,
     SKILL_COMMAND_DISPLAY_MAX,
     WORKTREE_SKILLS,
     SkillResult,
     ValidatedAddDir,
+    WriteBehaviorSpec,
+    claude_code_project_dir,
+    execution_marker,
     extract_skill_name,
+    find_caller_session_id,
     get_logger,
+    is_feature_enabled,
+    resolve_target_skill,
     truncate_text,
     validate_project_local_skill_dir,
 )
+from autoskillit.core import current_order_id as _current_order_id
+from autoskillit.core import current_step_name as _current_step_name
 from autoskillit.core import resolve_skill_temp_dir as _resolve_skill_temp_dir
+from autoskillit.pipeline import canonical_step_name
+from autoskillit.pipeline import canonical_step_name as _canonical_step_name
 from autoskillit.server import mcp
 from autoskillit.server._guards import (
     _check_dry_walkthrough,
@@ -44,6 +56,11 @@ from autoskillit.server._misc import (
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._subprocess import _run_subprocess
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
+from autoskillit.server.tools._execution_helpers import (
+    _import_and_call,
+    resolve_relative_path_args,
+    validate_path_arg_anchoring,
+)
 
 logger = get_logger(__name__)
 
@@ -115,7 +132,6 @@ def _check_ingredient_locks(step_name: str, order_id: str) -> str | None:
 
 def _check_pipeline_deps(step_name: str, order_id: str) -> str | None:
     """Check if step_name's dependencies are satisfied. Returns deny JSON or None."""
-    from autoskillit.pipeline import canonical_step_name  # circular-break
 
     effective_oid = order_id or os.environ.get(DISPATCH_ID_ENV_VAR, "")
     if not effective_oid:
@@ -324,12 +340,6 @@ async def run_python(
                 "autoskillit.run_python",
                 extra={"callable": callable},
             )
-            from autoskillit.server.tools._execution_helpers import (  # circular-break
-                _import_and_call,  # noqa: PLC0415
-                resolve_relative_path_args,  # noqa: PLC0415
-                validate_path_arg_anchoring,  # noqa: PLC0415
-            )
-
             if work_dir and not Path(work_dir).is_absolute():
                 return json.dumps(
                     {
@@ -567,11 +577,6 @@ async def run_skill(
             profile_name_out: str = ""
             effective_model = model
 
-            from autoskillit.core import (  # circular-break
-                AGENT_BACKEND_CLAUDE_CODE,
-                is_feature_enabled,
-            )
-
             _cfg = _get_config()
             if not step_provider and step_name and tool_ctx.active_recipe_steps is not None:
                 _recipe_step_pre = tool_ctx.active_recipe_steps.get(step_name)
@@ -637,17 +642,12 @@ async def run_skill(
                 expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
 
             # Look up write-expectation metadata from skill contract
-            from autoskillit.core import WriteBehaviorSpec  # circular-break
-
             write_spec: WriteBehaviorSpec | None = None
             if tool_ctx.write_expected_resolver:
                 write_spec = tool_ctx.write_expected_resolver(skill_command)
 
             # Build validated add_dirs via DefaultSessionSkillManager
-            from pathlib import Path
             from uuid import uuid4
-
-            from autoskillit.core import resolve_target_skill  # circular-break
 
             # Resolve correct namespace and prepare for tier2 activation
             resolved_command = skill_command
@@ -843,24 +843,8 @@ async def run_skill(
             if _local_dir is not None:
                 skill_add_dirs.append(_local_dir)
 
-            from autoskillit.pipeline.context import (  # circular-break
-                current_order_id as _current_order_id,
-            )
-            from autoskillit.pipeline.context import (  # circular-break
-                current_step_name as _current_step_name,
-            )
-            from autoskillit.pipeline.tokens import (  # circular-break
-                canonical_step_name as _canonical_step_name,
-            )
-
             _sn_token = _current_step_name.set(_canonical_step_name(step_name))
             _oid_token = _current_order_id.set(effective_order_id)
-
-            from autoskillit.core import (  # circular-break
-                claude_code_project_dir,
-                execution_marker,
-                find_caller_session_id,
-            )
 
             _marker_dir: Path | None = None
             try:

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -16,7 +16,33 @@ if TYPE_CHECKING:
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit.core import get_logger
+from autoskillit.core import (
+    FleetErrorCode,
+    SessionCheckpoint,
+    detect_autoskillit_mcp_prefix,
+    find_caller_session_id,
+    fleet_error,
+    get_logger,
+    is_feature_enabled,
+)
+from autoskillit.fleet import (
+    _INFRASTRUCTURE_FAILURE_REASONS,
+    DispatchCompleted,
+    DispatchRecord,
+    DispatchRejected,
+    DispatchResult,
+    DispatchStatus,
+    _build_food_truck_prompt,
+    evaluate_skip_when,
+    execute_dispatch,
+    find_completed_dispatch,
+    has_blocking_dispatch,
+    read_all_campaign_captures,
+    read_state,
+    record_gate_outcome,
+    reset_blocking_dispatch,
+    upsert_dispatch_record_by_name,
+)
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled, _require_fleet
 from autoskillit.server._misc import resolve_log_dir
@@ -57,14 +83,6 @@ def _write_dispatch_to_campaign_state(
     field reconstruction and eliminating double-normalization of token_usage.
     """
     try:
-        from autoskillit.fleet import (  # circular-break
-            DispatchCompleted,
-            DispatchRecord,
-            DispatchRejected,
-            read_state,
-            upsert_dispatch_record_by_name,
-        )
-
         match outcome:
             case DispatchRejected(error_code=code, message=msg):
                 upsert_dispatch_record_by_name(
@@ -115,8 +133,6 @@ def _write_dispatch_to_campaign_state(
 
 def _get_food_truck_prompt_builder() -> Callable[..., str]:
     """Return the food truck prompt builder with mcp_prefix pre-bound."""
-    from autoskillit.core import detect_autoskillit_mcp_prefix  # circular-break
-    from autoskillit.fleet import _build_food_truck_prompt  # circular-break
 
     mcp_prefix = detect_autoskillit_mcp_prefix()
     return functools.partial(_build_food_truck_prompt, mcp_prefix=mcp_prefix)
@@ -196,11 +212,6 @@ async def dispatch_food_truck(
         # Feature guard: config authority check independent of MCP visibility state.
         # Fleet sessions open the gate unconditionally at boot; this catch-all ensures
         # dispatch_food_truck never executes when features.fleet is disabled in config.
-        from autoskillit.core import (  # circular-break
-            FleetErrorCode,
-            fleet_error,
-            is_feature_enabled,
-        )
         from autoskillit.server import _get_ctx as _get_ctx_for_feature_check  # circular-break
 
         _feature_ctx = _get_ctx_for_feature_check()
@@ -219,11 +230,6 @@ async def dispatch_food_truck(
             os.environ.get("AUTOSKILLIT_CONTINUE_ON_FAILURE", "false").lower() == "true"
         )
         if campaign_state_path_str and not continue_on_failure:
-            from autoskillit.fleet import (  # circular-break
-                has_blocking_dispatch,
-                reset_blocking_dispatch,
-            )
-
             campaign_sp = Path(campaign_state_path_str)
             if dispatch_name:
                 if not reset_blocking_dispatch(campaign_sp, dispatch_name):
@@ -250,18 +256,6 @@ async def dispatch_food_truck(
                     "No further dispatches permitted.",
                 )
 
-        from autoskillit.core import SessionCheckpoint  # circular-break
-        from autoskillit.fleet import (  # circular-break
-            _INFRASTRUCTURE_FAILURE_REASONS,
-            DispatchCompleted,
-            DispatchRecord,
-            DispatchResult,
-            DispatchStatus,
-            evaluate_skip_when,
-            execute_dispatch,
-            read_all_campaign_captures,
-            upsert_dispatch_record_by_name,
-        )
         from autoskillit.server import _get_ctx  # circular-break
         from autoskillit.server._misc import (  # circular-break
             _refresh_quota_cache,
@@ -274,14 +268,10 @@ async def dispatch_food_truck(
             SessionCheckpoint.from_dict(resume_checkpoint) if resume_checkpoint else None
         )
         tool_ctx = _get_ctx()
-        from autoskillit.core import find_caller_session_id  # circular-break
-
         caller_session_id = find_caller_session_id(project_dir=tool_ctx.project_dir)
         effective_name = dispatch_name or recipe
 
         if campaign_state_path_str:
-            from autoskillit.fleet import find_completed_dispatch  # circular-break
-
             prior_record = find_completed_dispatch(Path(campaign_state_path_str), effective_name)
             if prior_record is not None:
                 return DispatchCompleted(
@@ -395,8 +385,6 @@ async def dispatch_food_truck(
         return outcome.to_envelope()
     except Exception as exc:
         logger.error("dispatch_food_truck unhandled exception", exc_info=True)
-        from autoskillit.core import FleetErrorCode, fleet_error  # circular-break
-
         return fleet_error(
             FleetErrorCode.FLEET_L3_STARTUP_OR_CRASH,
             f"{type(exc).__name__}: {exc}",
@@ -432,12 +420,6 @@ async def record_gate_dispatch(
         return fleet_gate
 
     try:
-        from autoskillit.core import (  # circular-break
-            FleetErrorCode,
-            fleet_error,
-            is_feature_enabled,
-        )
-        from autoskillit.fleet import record_gate_outcome  # circular-break
         from autoskillit.server import _get_ctx as _get_ctx_for_feature_check  # circular-break
 
         _feature_ctx = _get_ctx_for_feature_check()
@@ -471,8 +453,6 @@ async def record_gate_dispatch(
         )
     except Exception as exc:
         logger.error("record_gate_dispatch unhandled exception", exc_info=True)
-        from autoskillit.core import FleetErrorCode, fleet_error  # circular-break
-
         return fleet_error(
             FleetErrorCode.FLEET_L3_STARTUP_OR_CRASH,
             f"{type(exc).__name__}: {exc}",

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -57,7 +57,7 @@ def _write_dispatch_to_campaign_state(
     field reconstruction and eliminating double-normalization of token_usage.
     """
     try:
-        from autoskillit.fleet import (  # noqa: PLC0415
+        from autoskillit.fleet import (  # circular-break
             DispatchCompleted,
             DispatchRecord,
             DispatchRejected,
@@ -115,8 +115,8 @@ def _write_dispatch_to_campaign_state(
 
 def _get_food_truck_prompt_builder() -> Callable[..., str]:
     """Return the food truck prompt builder with mcp_prefix pre-bound."""
-    from autoskillit.core import detect_autoskillit_mcp_prefix
-    from autoskillit.fleet import _build_food_truck_prompt
+    from autoskillit.core import detect_autoskillit_mcp_prefix  # circular-break
+    from autoskillit.fleet import _build_food_truck_prompt  # circular-break
 
     mcp_prefix = detect_autoskillit_mcp_prefix()
     return functools.partial(_build_food_truck_prompt, mcp_prefix=mcp_prefix)
@@ -196,8 +196,12 @@ async def dispatch_food_truck(
         # Feature guard: config authority check independent of MCP visibility state.
         # Fleet sessions open the gate unconditionally at boot; this catch-all ensures
         # dispatch_food_truck never executes when features.fleet is disabled in config.
-        from autoskillit.core import FleetErrorCode, fleet_error, is_feature_enabled
-        from autoskillit.server import _get_ctx as _get_ctx_for_feature_check
+        from autoskillit.core import (  # circular-break
+            FleetErrorCode,
+            fleet_error,
+            is_feature_enabled,
+        )
+        from autoskillit.server import _get_ctx as _get_ctx_for_feature_check  # circular-break
 
         _feature_ctx = _get_ctx_for_feature_check()
         if not is_feature_enabled(
@@ -215,7 +219,7 @@ async def dispatch_food_truck(
             os.environ.get("AUTOSKILLIT_CONTINUE_ON_FAILURE", "false").lower() == "true"
         )
         if campaign_state_path_str and not continue_on_failure:
-            from autoskillit.fleet import (  # noqa: PLC0415
+            from autoskillit.fleet import (  # circular-break
                 has_blocking_dispatch,
                 reset_blocking_dispatch,
             )
@@ -246,8 +250,8 @@ async def dispatch_food_truck(
                     "No further dispatches permitted.",
                 )
 
-        from autoskillit.core import SessionCheckpoint  # noqa: PLC0415
-        from autoskillit.fleet import (  # noqa: PLC0415
+        from autoskillit.core import SessionCheckpoint  # circular-break
+        from autoskillit.fleet import (  # circular-break
             _INFRASTRUCTURE_FAILURE_REASONS,
             DispatchCompleted,
             DispatchRecord,
@@ -258,8 +262,8 @@ async def dispatch_food_truck(
             read_all_campaign_captures,
             upsert_dispatch_record_by_name,
         )
-        from autoskillit.server import _get_ctx
-        from autoskillit.server._misc import (  # noqa: PLC0415
+        from autoskillit.server import _get_ctx  # circular-break
+        from autoskillit.server._misc import (  # circular-break
             _refresh_quota_cache,
             check_and_sleep_if_needed,
             invalidate_cache,
@@ -270,13 +274,13 @@ async def dispatch_food_truck(
             SessionCheckpoint.from_dict(resume_checkpoint) if resume_checkpoint else None
         )
         tool_ctx = _get_ctx()
-        from autoskillit.core import find_caller_session_id
+        from autoskillit.core import find_caller_session_id  # circular-break
 
         caller_session_id = find_caller_session_id(project_dir=tool_ctx.project_dir)
         effective_name = dispatch_name or recipe
 
         if campaign_state_path_str:
-            from autoskillit.fleet import find_completed_dispatch  # noqa: PLC0415
+            from autoskillit.fleet import find_completed_dispatch  # circular-break
 
             prior_record = find_completed_dispatch(Path(campaign_state_path_str), effective_name)
             if prior_record is not None:
@@ -391,7 +395,7 @@ async def dispatch_food_truck(
         return outcome.to_envelope()
     except Exception as exc:
         logger.error("dispatch_food_truck unhandled exception", exc_info=True)
-        from autoskillit.core import FleetErrorCode, fleet_error
+        from autoskillit.core import FleetErrorCode, fleet_error  # circular-break
 
         return fleet_error(
             FleetErrorCode.FLEET_L3_STARTUP_OR_CRASH,
@@ -428,9 +432,13 @@ async def record_gate_dispatch(
         return fleet_gate
 
     try:
-        from autoskillit.core import FleetErrorCode, fleet_error, is_feature_enabled
-        from autoskillit.fleet import record_gate_outcome
-        from autoskillit.server import _get_ctx as _get_ctx_for_feature_check
+        from autoskillit.core import (  # circular-break
+            FleetErrorCode,
+            fleet_error,
+            is_feature_enabled,
+        )
+        from autoskillit.fleet import record_gate_outcome  # circular-break
+        from autoskillit.server import _get_ctx as _get_ctx_for_feature_check  # circular-break
 
         _feature_ctx = _get_ctx_for_feature_check()
         if not is_feature_enabled(
@@ -463,7 +471,7 @@ async def record_gate_dispatch(
         )
     except Exception as exc:
         logger.error("record_gate_dispatch unhandled exception", exc_info=True)
-        from autoskillit.core import FleetErrorCode, fleet_error
+        from autoskillit.core import FleetErrorCode, fleet_error  # circular-break
 
         return fleet_error(
             FleetErrorCode.FLEET_L3_STARTUP_OR_CRASH,

--- a/src/autoskillit/server/tools/tools_fleet_reset.py
+++ b/src/autoskillit/server/tools/tools_fleet_reset.py
@@ -8,6 +8,16 @@ from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import FleetErrorCode, IssueLabelState, fleet_error, get_logger
+from autoskillit.fleet import (
+    _RESETTABLE_STATUSES,
+    DispatchStatus,
+    discover_campaign_state_files,
+    find_dispatch_in_campaigns,
+    format_resettable_statuses,
+    reset_dispatch_artifacts,
+    resolve_worktrees_dir,
+    update_campaign_state,
+)
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled, _require_fleet
 from autoskillit.server._notify import track_response_size
@@ -56,17 +66,7 @@ async def reset_dispatch(
         )
 
     try:
-        from autoskillit.fleet import (  # circular-break: lazy-load fleet
-            _RESETTABLE_STATUSES,
-            DispatchStatus,
-            discover_campaign_state_files,
-            find_dispatch_in_campaigns,
-            format_resettable_statuses,
-            reset_dispatch_artifacts,
-            resolve_worktrees_dir,
-            update_campaign_state,
-        )
-        from autoskillit.server import _get_ctx  # circular-break: server.__init__ cycle
+        from autoskillit.server import _get_ctx  # circular-break
 
         tool_ctx = _get_ctx()
         project_dir = tool_ctx.project_dir

--- a/src/autoskillit/server/tools/tools_fleet_reset.py
+++ b/src/autoskillit/server/tools/tools_fleet_reset.py
@@ -56,7 +56,7 @@ async def reset_dispatch(
         )
 
     try:
-        from autoskillit.fleet import (
+        from autoskillit.fleet import (  # circular-break: lazy-load fleet
             _RESETTABLE_STATUSES,
             DispatchStatus,
             discover_campaign_state_files,
@@ -66,7 +66,7 @@ async def reset_dispatch(
             resolve_worktrees_dir,
             update_campaign_state,
         )
-        from autoskillit.server import _get_ctx
+        from autoskillit.server import _get_ctx  # circular-break: server.__init__ cycle
 
         tool_ctx = _get_ctx()
         project_dir = tool_ctx.project_dir

--- a/src/autoskillit/server/tools/tools_git.py
+++ b/src/autoskillit/server/tools/tools_git.py
@@ -71,9 +71,9 @@ async def merge_worktree(
                 extra={"worktree": worktree_path, "base": base_branch},
             )
 
-            from autoskillit.server import _get_config, _get_ctx
-            from autoskillit.server._misc import resolve_remote_name
-            from autoskillit.server.git import perform_merge
+            from autoskillit.server import _get_config, _get_ctx  # circular-break
+            from autoskillit.server._misc import resolve_remote_name  # circular-break
+            from autoskillit.server.git import perform_merge  # circular-break
 
             tool_ctx = _get_ctx()
             runner = tool_ctx.runner
@@ -162,9 +162,9 @@ async def classify_fix(
                     }
                 )
 
-            from autoskillit.server import _get_config, _get_ctx
-            from autoskillit.server._misc import resolve_remote_name
-            from autoskillit.server.git import _filter_changed_files
+            from autoskillit.server import _get_config, _get_ctx  # circular-break
+            from autoskillit.server._misc import resolve_remote_name  # circular-break
+            from autoskillit.server.git import _filter_changed_files  # circular-break
 
             tool_ctx = _get_ctx()
             _start = time.monotonic()
@@ -325,7 +325,7 @@ async def create_unique_branch(
                 extra={"remote": remote},
             )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx  # circular-break
 
             tool_ctx = _get_ctx()
             _start = time.monotonic()
@@ -546,7 +546,7 @@ async def create_and_publish_branch(
                 extra={"run_name": run_name, "issue_number": issue_number},
             )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx  # circular-break
 
             tool_ctx = _get_ctx()
             clone_mgr = tool_ctx.clone_mgr
@@ -562,7 +562,7 @@ async def create_and_publish_branch(
             base_name = _compute_branch_name(issue_slug, run_name, issue_number)
             compute_ms = int((time.monotonic() - _compute_start) * 1000)
 
-            from autoskillit.server._misc import resolve_remote_name
+            from autoskillit.server._misc import resolve_remote_name  # circular-break
 
             _branch_start = time.monotonic()
             resolved_remote = await resolve_remote_name(work_dir)

--- a/src/autoskillit/server/tools/tools_github.py
+++ b/src/autoskillit/server/tools/tools_github.py
@@ -21,7 +21,7 @@ from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 if TYPE_CHECKING:
-    from autoskillit.core import GitHubFetcher, HeadlessExecutor
+    from autoskillit.core import GitHubFetcher, HeadlessExecutor, WriteBehaviorSpec
 
 logger = get_logger(__name__)
 
@@ -71,7 +71,10 @@ async def fetch_github_issue(
     structlog.contextvars.clear_contextvars()
     with structlog.contextvars.bound_contextvars(tool="fetch_github_issue", issue_url=issue_url):
         try:
-            from autoskillit.server import _get_config, _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_config,
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             logger.info("fetch_github_issue", include_comments=include_comments)
 
@@ -134,7 +137,10 @@ async def get_issue_title(issue_url: str) -> str:
     structlog.contextvars.clear_contextvars()
     with structlog.contextvars.bound_contextvars(tool="get_issue_title"):
         try:
-            from autoskillit.server import _get_config, _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_config,
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             if tool_ctx.github_client is None:
@@ -210,7 +216,10 @@ async def report_bug(
                 extra={"severity": severity, "cwd": cwd},
             )
 
-            from autoskillit.server import _get_config, _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_config,
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             if tool_ctx.executor is None:
@@ -232,14 +241,14 @@ async def report_bug(
             report_provider_extras: dict[str, str] | None = None
             report_profile_name: str = ""
 
-            from autoskillit.core import is_feature_enabled
+            from autoskillit.core import is_feature_enabled  # circular-break
 
             if is_feature_enabled(
                 "providers",
                 config.features,
                 experimental_enabled=config.experimental_enabled,
             ):
-                from autoskillit.server._guards import (
+                from autoskillit.server._guards import (  # circular-break: server.__init__ cycle
                     _resolve_model_as_profile,
                     _resolve_provider_profile,
                 )
@@ -267,8 +276,6 @@ async def report_bug(
             expected_output_patterns: list[str] = []
             if tool_ctx.output_pattern_resolver:
                 expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
-
-            from autoskillit.core import WriteBehaviorSpec
 
             write_spec: WriteBehaviorSpec | None = None
             if tool_ctx.write_expected_resolver:

--- a/src/autoskillit/server/tools/tools_github.py
+++ b/src/autoskillit/server/tools/tools_github.py
@@ -12,7 +12,7 @@ import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit.core import atomic_write, get_logger
+from autoskillit.core import atomic_write, get_logger, is_feature_enabled
 from autoskillit.pipeline import write_status
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
@@ -240,8 +240,6 @@ async def report_bug(
             effective_model = model or cfg.model or ""
             report_provider_extras: dict[str, str] | None = None
             report_profile_name: str = ""
-
-            from autoskillit.core import is_feature_enabled  # circular-break
 
             if is_feature_enabled(
                 "providers",

--- a/src/autoskillit/server/tools/tools_issue_composite.py
+++ b/src/autoskillit/server/tools/tools_issue_composite.py
@@ -63,7 +63,9 @@ async def claim_and_resolve_issue(
         ):
             logger.info("claim_and_resolve_issue", issue_url=issue_url)
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             if tool_ctx.github_client is None:

--- a/src/autoskillit/server/tools/tools_issue_headless.py
+++ b/src/autoskillit/server/tools/tools_issue_headless.py
@@ -194,7 +194,9 @@ async def prepare_issue(
                 extra={"dry_run": dry_run, "split": split},
             )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             if tool_ctx.executor is None:
@@ -306,7 +308,9 @@ async def enrich_issues(
                 extra={"dry_run": dry_run},
             )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             if tool_ctx.executor is None:

--- a/src/autoskillit/server/tools/tools_issue_labels.py
+++ b/src/autoskillit/server/tools/tools_issue_labels.py
@@ -65,7 +65,9 @@ async def claim_issue(
         with structlog.contextvars.bound_contextvars(tool="claim_issue", issue_url=issue_url):
             logger.info("claim_issue", issue_url=issue_url)
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             if tool_ctx.github_client is None:
@@ -218,7 +220,9 @@ async def release_issue(
         with structlog.contextvars.bound_contextvars(tool="release_issue", issue_url=issue_url):
             logger.info("release_issue", issue_url=issue_url)
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             if tool_ctx.github_client is None:

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -39,6 +39,7 @@ from autoskillit.core import (
     resolve_kitchen_id,
     unregister_active_kitchen,
 )
+from autoskillit.fleet import FleetSemaphore
 from autoskillit.pipeline import create_background_task
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_orchestrator_exact
@@ -122,10 +123,7 @@ def _write_hook_config() -> None:
     The hook subprocess (quota_guard.py) reads this file to apply user settings
     without importing the autoskillit package.
     """
-    from autoskillit.server import (  # circular-break
-        _get_ctx,
-        logger,
-    )  # circular-break: server-internal circular dependency
+    from autoskillit.server import _get_ctx, logger  # circular-break
 
     ctx = _get_ctx()
     cfg = ctx.config.quota_guard
@@ -144,10 +142,7 @@ def _write_hook_config() -> None:
 
 def _update_hook_config_with_recipe() -> None:
     """Enrich .hook_config.json with recipe-level authorization after recipe loading."""
-    from autoskillit.server import (  # circular-break
-        _get_ctx,
-        logger,
-    )  # circular-break: server-internal circular dependency
+    from autoskillit.server import _get_ctx, logger  # circular-break
 
     ctx = _get_ctx()
     hook_cfg_path = _hook_config_path(ctx.project_dir)
@@ -172,10 +167,7 @@ def _update_hook_config_with_git_ops_policy() -> None:
     mechanism exists for future recipes that legitimately need destructive git ops
     (e.g. allow_push for a release automation recipe).
     """
-    from autoskillit.server import (  # circular-break
-        _get_ctx,
-        logger,
-    )  # circular-break: server-internal circular dependency
+    from autoskillit.server import _get_ctx, logger  # circular-break
 
     ctx = _get_ctx()
     hook_cfg_path = _hook_config_path(ctx.project_dir)
@@ -206,10 +198,7 @@ async def _open_kitchen_handler() -> str | None:
 
     Returns ``None`` on success, or a JSON failure envelope string on error.
     """
-    from autoskillit.server import (  # circular-break
-        _get_ctx,
-        logger,
-    )  # circular-break: server-internal circular dependency
+    from autoskillit.server import _get_ctx, logger  # circular-break
 
     ctx = _get_ctx()
     ctx.gate.enable()
@@ -290,10 +279,7 @@ async def _redisable_subsets(
 
 def _close_kitchen_handler() -> None:
     """Clear the tools-enabled flag. Extracted for testability."""
-    from autoskillit.server import (  # circular-break
-        _get_ctx,
-        logger,
-    )  # circular-break: server-internal circular dependency
+    from autoskillit.server import _get_ctx, logger  # circular-break
 
     ctx = _get_ctx()
     if ctx.quota_refresh_task is not None:
@@ -334,8 +320,6 @@ def _close_kitchen_handler() -> None:
         logger.warning("hook_config_overlay_remove_failed", path=str(overlay_path))
     ctx.fleet_lock = None
     try:
-        from autoskillit.fleet import FleetSemaphore  # noqa: PLC0415
-
         ctx.fleet_lock = FleetSemaphore(
             max_concurrent=ctx.config.fleet.max_concurrent_dispatches,
             timeout=ctx.config.fleet.acquire_timeout_sec,
@@ -379,9 +363,7 @@ def _close_kitchen_handler() -> None:
 @mcp.resource("recipe://{name}")
 def get_recipe(name: str) -> str:
     """Return recipe YAML for the orchestrating agent to follow."""
-    from autoskillit.server._state import (  # circular-break
-        _get_ctx_or_none,
-    )  # circular-break: server-internal circular dependency
+    from autoskillit.server._state import _get_ctx_or_none  # circular-break
 
     ctx = _get_ctx_or_none()
     match = ctx.recipes.find(name, ctx.project_dir) if ctx and ctx.recipes else None
@@ -466,9 +448,7 @@ async def open_kitchen(
                 }
             )
 
-        from autoskillit.server import (  # circular-break
-            _get_ctx,
-        )  # circular-break: server-internal circular dependency
+        from autoskillit.server import _get_ctx  # circular-break
 
         disabled_subsets = _get_ctx().config.subsets.disabled
 
@@ -648,9 +628,7 @@ async def open_kitchen(
                 logger.warning("open_kitchen_failure", stage="update_hook_config", exc_info=True)
 
             composite = result.get("composite_hash", "")
-            from autoskillit.server._state import (  # circular-break
-                _check_rerun,
-            )  # circular-break: server-internal circular dependency
+            from autoskillit.server._state import _check_rerun  # circular-break
 
             rerun_suggestion = _check_rerun(tool_ctx.config.linux_tracing.log_dir, composite)
             if rerun_suggestion:
@@ -808,9 +786,7 @@ async def disable_quota_guard() -> str:
     try:
         if (h := _require_orchestrator_exact("disable_quota_guard")) is not None:
             return h
-        from autoskillit.server import (  # circular-break
-            _get_ctx,
-        )  # circular-break: server-internal circular dependency
+        from autoskillit.server import _get_ctx  # circular-break
 
         ctx = _get_ctx()
         hook_cfg_path = _hook_config_path(ctx.project_dir)
@@ -963,9 +939,7 @@ async def lock_ingredients(
     try:
         if (h := _require_orchestrator_exact("lock_ingredients")) is not None:
             return h
-        from autoskillit.server import (  # circular-break
-            _get_ctx,
-        )  # circular-break: server-internal circular dependency
+        from autoskillit.server import _get_ctx  # circular-break
 
         ctx = _get_ctx()
         hook_cfg_path = _hook_config_path(ctx.project_dir)

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -31,8 +31,13 @@ from autoskillit.core import (
     fast_dumps,
     find_latest_session_id,
     get_logger,
+    get_state_dir,
+    is_marker_fresh,
     pkg_root,
+    read_marker,
+    register_active_kitchen,
     resolve_kitchen_id,
+    unregister_active_kitchen,
 )
 from autoskillit.pipeline import create_background_task
 from autoskillit.server import mcp
@@ -117,7 +122,10 @@ def _write_hook_config() -> None:
     The hook subprocess (quota_guard.py) reads this file to apply user settings
     without importing the autoskillit package.
     """
-    from autoskillit.server import _get_ctx, logger
+    from autoskillit.server import (  # circular-break
+        _get_ctx,
+        logger,
+    )  # circular-break: server-internal circular dependency
 
     ctx = _get_ctx()
     cfg = ctx.config.quota_guard
@@ -136,7 +144,10 @@ def _write_hook_config() -> None:
 
 def _update_hook_config_with_recipe() -> None:
     """Enrich .hook_config.json with recipe-level authorization after recipe loading."""
-    from autoskillit.server import _get_ctx, logger
+    from autoskillit.server import (  # circular-break
+        _get_ctx,
+        logger,
+    )  # circular-break: server-internal circular dependency
 
     ctx = _get_ctx()
     hook_cfg_path = _hook_config_path(ctx.project_dir)
@@ -161,7 +172,10 @@ def _update_hook_config_with_git_ops_policy() -> None:
     mechanism exists for future recipes that legitimately need destructive git ops
     (e.g. allow_push for a release automation recipe).
     """
-    from autoskillit.server import _get_ctx, logger
+    from autoskillit.server import (  # circular-break
+        _get_ctx,
+        logger,
+    )  # circular-break: server-internal circular dependency
 
     ctx = _get_ctx()
     hook_cfg_path = _hook_config_path(ctx.project_dir)
@@ -192,7 +206,10 @@ async def _open_kitchen_handler() -> str | None:
 
     Returns ``None`` on success, or a JSON failure envelope string on error.
     """
-    from autoskillit.server import _get_ctx, logger
+    from autoskillit.server import (  # circular-break
+        _get_ctx,
+        logger,
+    )  # circular-break: server-internal circular dependency
 
     ctx = _get_ctx()
     ctx.gate.enable()
@@ -233,8 +250,6 @@ async def _open_kitchen_handler() -> str | None:
         return _kitchen_failure_envelope(exc, stage="start_quota_refresh")
 
     try:
-        from autoskillit.core import register_active_kitchen  # noqa: PLC0415
-
         register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
     except Exception:
         logger.warning("open_kitchen_registry_failed", exc_info=True)
@@ -275,7 +290,10 @@ async def _redisable_subsets(
 
 def _close_kitchen_handler() -> None:
     """Clear the tools-enabled flag. Extracted for testability."""
-    from autoskillit.server import _get_ctx, logger
+    from autoskillit.server import (  # circular-break
+        _get_ctx,
+        logger,
+    )  # circular-break: server-internal circular dependency
 
     ctx = _get_ctx()
     if ctx.quota_refresh_task is not None:
@@ -283,8 +301,6 @@ def _close_kitchen_handler() -> None:
         ctx.quota_refresh_task = None
     ctx.gate.disable()
     try:
-        from autoskillit.core import unregister_active_kitchen  # noqa: PLC0415
-
         unregister_active_kitchen(ctx.kitchen_id)
     except Exception:
         logger.warning("close_kitchen_registry_failed", exc_info=True)
@@ -363,7 +379,9 @@ def _close_kitchen_handler() -> None:
 @mcp.resource("recipe://{name}")
 def get_recipe(name: str) -> str:
     """Return recipe YAML for the orchestrating agent to follow."""
-    from autoskillit.server._state import _get_ctx_or_none
+    from autoskillit.server._state import (  # circular-break
+        _get_ctx_or_none,
+    )  # circular-break: server-internal circular dependency
 
     ctx = _get_ctx_or_none()
     match = ctx.recipes.find(name, ctx.project_dir) if ctx and ctx.recipes else None
@@ -448,7 +466,9 @@ async def open_kitchen(
                 }
             )
 
-        from autoskillit.server import _get_ctx  # noqa: PLC0415
+        from autoskillit.server import (  # circular-break
+            _get_ctx,
+        )  # circular-break: server-internal circular dependency
 
         disabled_subsets = _get_ctx().config.subsets.disabled
 
@@ -628,7 +648,9 @@ async def open_kitchen(
                 logger.warning("open_kitchen_failure", stage="update_hook_config", exc_info=True)
 
             composite = result.get("composite_hash", "")
-            from autoskillit.server._state import _check_rerun  # noqa: PLC0415
+            from autoskillit.server._state import (  # circular-break
+                _check_rerun,
+            )  # circular-break: server-internal circular dependency
 
             rerun_suggestion = _check_rerun(tool_ctx.config.linux_tracing.log_dir, composite)
             if rerun_suggestion:
@@ -786,7 +808,9 @@ async def disable_quota_guard() -> str:
     try:
         if (h := _require_orchestrator_exact("disable_quota_guard")) is not None:
             return h
-        from autoskillit.server import _get_ctx
+        from autoskillit.server import (  # circular-break
+            _get_ctx,
+        )  # circular-break: server-internal circular dependency
 
         ctx = _get_ctx()
         hook_cfg_path = _hook_config_path(ctx.project_dir)
@@ -939,7 +963,9 @@ async def lock_ingredients(
     try:
         if (h := _require_orchestrator_exact("lock_ingredients")) is not None:
             return h
-        from autoskillit.server import _get_ctx
+        from autoskillit.server import (  # circular-break
+            _get_ctx,
+        )  # circular-break: server-internal circular dependency
 
         ctx = _get_ctx()
         hook_cfg_path = _hook_config_path(ctx.project_dir)
@@ -1019,8 +1045,6 @@ async def lock_ingredients(
 
 def _find_session_id_for_reload(cwd: Path) -> str | None:
     """Return the session_id to use for reload; kitchen marker preferred, mtime fallback."""
-    from autoskillit.core import get_state_dir, is_marker_fresh, read_marker
-
     state_dir = get_state_dir()
     if state_dir.is_dir():
 

--- a/src/autoskillit/server/tools/tools_pipeline_tracker.py
+++ b/src/autoskillit/server/tools/tools_pipeline_tracker.py
@@ -88,7 +88,9 @@ async def record_pipeline_step(
                 }
             )
 
-        from autoskillit.server import _get_ctx
+        from autoskillit.server import (  # circular-break
+            _get_ctx,
+        )  # circular-break: server-internal circular dependency
 
         ctx = _get_ctx()
         tracker_path = _pipeline_tracker_path(ctx.project_dir, effective_pipeline_id)

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -318,7 +318,10 @@ async def migrate_recipe(name: str, ctx: Context = CurrentContext()) -> str:
                 extra={"recipe_name": name},
             )
 
-            from autoskillit.server import _get_config, _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_config,
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
 

--- a/src/autoskillit/server/tools/tools_status.py
+++ b/src/autoskillit/server/tools/tools_status.py
@@ -11,7 +11,17 @@ import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit.core import atomic_write, get_logger
+from autoskillit.core import (
+    atomic_write,
+    compute_analysis,
+    filter_sessions_by_recipe,
+    format_top_bigrams,
+    get_logger,
+    parse_sessions_from_summary_dir,
+    render_adjacency_table,
+    render_dot,
+    render_mermaid,
+)
 from autoskillit.pipeline import TelemetryFormatter
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled, _require_fleet
@@ -28,7 +38,7 @@ logger = get_logger(__name__)
 
 def _get_log_root() -> Path:
     """Return the resolved log root directory for the current context."""
-    from autoskillit.server import _get_ctx
+    from autoskillit.server import _get_ctx  # circular-break: server-internal circular dependency
 
     return resolve_log_dir(_get_ctx().config.linux_tracing.log_dir)
 
@@ -52,7 +62,11 @@ async def kitchen_status() -> str:
     structlog.contextvars.clear_contextvars()
     with structlog.contextvars.bound_contextvars(tool="kitchen_status"):
         try:
-            from autoskillit.server import _get_config, _get_ctx, version_info
+            from autoskillit.server import (  # circular-break
+                _get_config,
+                _get_ctx,
+                version_info,
+            )  # circular-break: server-internal circular dependency
 
             info = version_info()
             status = {
@@ -110,7 +124,9 @@ async def get_pipeline_report(clear: bool = False) -> str:
     structlog.contextvars.clear_contextvars()
     with structlog.contextvars.bound_contextvars(tool="get_pipeline_report"):
         try:
-            from autoskillit.server._state import _startup_ready
+            from autoskillit.server._state import (  # circular-break
+                _startup_ready,
+            )  # circular-break: server-internal circular dependency
 
             if _startup_ready is not None and not _startup_ready.is_set():
                 try:
@@ -125,7 +141,9 @@ async def get_pipeline_report(clear: bool = False) -> str:
                         }
                     )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             failures = _get_ctx().audit.get_report_as_dicts()
             if clear:
@@ -194,7 +212,9 @@ async def get_token_summary(clear: bool = False, format: str = "json", order_id:
     structlog.contextvars.clear_contextvars()
     with structlog.contextvars.bound_contextvars(tool="get_token_summary"):
         try:
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             ctx = _get_ctx()
             steps = _merge_wall_clock_seconds(
@@ -259,7 +279,9 @@ async def get_timing_summary(clear: bool = False, format: str = "json", order_id
     structlog.contextvars.clear_contextvars()
     with structlog.contextvars.bound_contextvars(tool="get_timing_summary"):
         try:
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             steps = _get_ctx().timing_log.get_report(order_id=order_id)
             total = _get_ctx().timing_log.compute_total(order_id=order_id)
@@ -322,16 +344,6 @@ async def analyze_tool_sequences(
                 return json.dumps(
                     {"success": False, "error": f"min_count must be >= 1, got {min_count}"}
                 )
-            from autoskillit.core import (
-                compute_analysis,
-                filter_sessions_by_recipe,
-                format_top_bigrams,
-                parse_sessions_from_summary_dir,
-                render_adjacency_table,
-                render_dot,
-                render_mermaid,
-            )
-
             log_root = _get_log_root()
             sessions = list(parse_sessions_from_summary_dir(log_root))
             if recipe:
@@ -422,7 +434,9 @@ async def get_quota_events(n: int = 50) -> str:
     structlog.contextvars.clear_contextvars()
     with structlog.contextvars.bound_contextvars(tool="get_quota_events"):
         try:
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             ctx = _get_ctx()
             log_root = resolve_log_dir(ctx.config.linux_tracing.log_dir)
@@ -476,7 +490,9 @@ async def write_telemetry_files(
                 extra={"output_dir": output_dir},
             )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             out = Path(output_dir)
@@ -607,7 +623,10 @@ async def read_db(
                 )
                 return json.dumps({"success": False, "error": f"Path is not a file: {db}"})
 
-            from autoskillit.server import _get_config, _get_ctx
+            from autoskillit.server import (  # circular-break
+                _get_config,
+                _get_ctx,
+            )  # circular-break: server-internal circular dependency
 
             tool_ctx = _get_ctx()
             if tool_ctx.db_reader is None:

--- a/src/autoskillit/server/tools/tools_workspace.py
+++ b/src/autoskillit/server/tools/tools_workspace.py
@@ -63,7 +63,7 @@ async def test_check(
                 extra={"worktree": worktree_path},
             )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx  # circular-break
 
             tool_ctx = _get_ctx()
             if tool_ctx.tester is None:
@@ -164,7 +164,7 @@ async def reset_test_dir(
                 extra={"resolved": resolved, "force": force},
             )
 
-            from autoskillit.server import _get_config, _get_ctx
+            from autoskillit.server import _get_config, _get_ctx  # circular-break
 
             tool_ctx = _get_ctx()
             _start = time.monotonic()
@@ -250,7 +250,7 @@ async def reset_workspace(test_dir: str, ctx: Context = CurrentContext()) -> str
                 )
                 return json.dumps({"error": f"Directory does not exist: {resolved}"})
 
-            from autoskillit.server import _get_config
+            from autoskillit.server import _get_config  # circular-break
 
             marker_name = _get_config().safety.reset_guard_marker
             marker_path = Path(resolved) / marker_name
@@ -302,7 +302,7 @@ async def reset_workspace(test_dir: str, ctx: Context = CurrentContext()) -> str
                     }
                 )
 
-            from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx  # circular-break
 
             tool_ctx = _get_ctx()
             if tool_ctx.workspace_mgr is None:

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -54,6 +54,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_kitchen_guard_scoping.py` | Architectural enforcement: any_kitchen_open call-site scoping and test helper isolation |
 | `test_kitchen_id_assignment.py` | AST guard: ctx.kitchen_id assignment only via resolve_kitchen_id() |
 | `test_layer_enforcement.py` | MCP tool registry + import layer contracts + cross-package rules |
+| `test_pyi_stub_completeness.py` | Stub-symbol completeness: verifies core submodule public symbols appear in __init__.pyi |
 | `test_layer_markers.py` | Enforce pytestmark layer markers on all in-scope test files |
 | `test_conftest_env_coverage.py` | Structural guard: root conftest _clear_private_env fixture must reference AUTOSKILLIT_PRIVATE_ENV_VARS and _HEADLESS_EXCLUSIVE_VARS programmatically |
 | `test_make_context_env_boundary.py` | AST guard: _factory.py functions must not read AUTOSKILLIT_PRIVATE_ENV_VARS from os.environ |

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -467,6 +467,107 @@ def test_il2_no_deferred_upward_imports(pkg_name: str) -> None:
     assert not violations, f"Deferred layer violations in {pkg_name}/:\n" + "\n".join(violations)
 
 
+def test_il3_unnecessary_deferred_imports() -> None:
+    """IL-3 server/ must not defer imports from lower-layer packages.
+
+    Deferred imports of IL-0/IL-1/IL-2 from IL-3 cannot be circular (lower layers
+    never import server/), so they are unnecessary and create hot-upgrade race
+    conditions when the MCP server reloads modules after uv tool install.
+    """
+    server_dir = SRC_ROOT / "server"
+    assert server_dir.exists(), "server/ package must exist"
+    violations: list[str] = []
+
+    for py_file in sorted(server_dir.rglob("*.py")):
+        source = py_file.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(py_file))
+        deferred_nodes = _collect_deferred_imports(tree)
+        tc_lines = _type_checking_lines(tree)
+        source_lines = source.splitlines()
+
+        for node in deferred_nodes:
+            if node.lineno in tc_lines:
+                continue
+
+            stems: list[str] = []
+            if isinstance(node, ast.ImportFrom) and node.module:
+                parts = node.module.split(".")
+                if parts[0] == "autoskillit" and len(parts) > 1:
+                    stems = [parts[1]]
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    parts = alias.name.split(".")
+                    if parts[0] == "autoskillit" and len(parts) > 1:
+                        stems.append(parts[1])
+
+            for imported_stem in stems:
+                if imported_stem not in SUBPACKAGE_LAYERS:
+                    continue
+                imported_layer = SUBPACKAGE_LAYERS[imported_stem]
+                if imported_layer >= SUBPACKAGE_LAYERS["server"]:
+                    continue
+                line_text = source_lines[node.lineno - 1]
+                if "# circular-break" in line_text:
+                    continue
+                violations.append(
+                    f"  {_rel(py_file)}:{node.lineno}: server (IL-3) "
+                    f"deferred-imports {imported_stem} (IL-{imported_layer})"
+                    f" — hoist to module level or add # circular-break"
+                )
+
+    assert not violations, "Unnecessary deferred cross-layer imports in server/:\n" + "\n".join(
+        violations
+    )
+
+
+def test_il3_deferred_autoskillit_imports_tagged() -> None:
+    """Every autoskillit.* deferred import in server/ must carry a # circular-break tag.
+
+    Generalizes the single-site check test_workspace_deferred_import_has_comment into a
+    universal policy for IL-3. Ensures all deferred imports document their justification.
+    """
+    server_dir = SRC_ROOT / "server"
+    assert server_dir.exists(), "server/ package must exist"
+    violations: list[str] = []
+
+    for py_file in sorted(server_dir.rglob("*.py")):
+        source = py_file.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(py_file))
+        deferred_nodes = _collect_deferred_imports(tree)
+        tc_lines = _type_checking_lines(tree)
+        source_lines = source.splitlines()
+
+        for node in deferred_nodes:
+            if node.lineno in tc_lines:
+                continue
+
+            is_autoskillit = False
+            if isinstance(node, ast.ImportFrom) and node.module:
+                parts = node.module.split(".")
+                if parts[0] == "autoskillit" and len(parts) > 1:
+                    is_autoskillit = True
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    parts = alias.name.split(".")
+                    if parts[0] == "autoskillit" and len(parts) > 1:
+                        is_autoskillit = True
+
+            if not is_autoskillit:
+                continue
+
+            line_text = source_lines[node.lineno - 1]
+            if "# circular-break" not in line_text:
+                violations.append(
+                    f"  {_rel(py_file)}:{node.lineno}: deferred autoskillit import "
+                    f"missing # circular-break tag"
+                )
+
+    assert not violations, (
+        "Deferred autoskillit.* imports in server/ without # circular-break tag:\n"
+        + "\n".join(violations)
+    )
+
+
 def test_workspace_deferred_import_has_comment() -> None:
     """P14-F2: deferred import in cli/app.py must carry a rationale comment."""
     src = (SRC_ROOT / "cli" / "app.py").read_text()

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -568,6 +568,38 @@ def test_il3_deferred_autoskillit_imports_tagged() -> None:
     )
 
 
+def test_il3_cross_layer_imports_hoisted() -> None:
+    """Cross-layer deferred imports in server/ must be hoisted to module level."""
+    server_root = SRC_ROOT / "server"
+    violations: list[str] = []
+    for py_path in sorted(server_root.rglob("*.py")):
+        source = py_path.read_text()
+        tree = ast.parse(source, filename=str(py_path))
+        tc = _type_checking_lines(tree)
+        for node in _collect_deferred_imports(tree):
+            if node.lineno in tc:
+                continue
+            if isinstance(node, ast.ImportFrom) and node.module:
+                parts = node.module.split(".")
+            elif isinstance(node, ast.Import):
+                parts = node.names[0].name.split(".")
+            else:
+                continue
+            if parts[0] != "autoskillit" or len(parts) < 2:
+                continue
+            if parts[1] == "server":
+                continue
+            rel = _rel(py_path)
+            violations.append(
+                f"  {rel}:{node.lineno}: deferred cross-layer import of autoskillit.{parts[1]}"
+            )
+    assert not violations, (
+        "Cross-layer deferred imports in server/ must be hoisted to module "
+        "level (lower layers cannot cause circular imports with server/):\n"
+        + "\n".join(violations)
+    )
+
+
 def test_workspace_deferred_import_has_comment() -> None:
     """P14-F2: deferred import in cli/app.py must carry a rationale comment."""
     src = (SRC_ROOT / "cli" / "app.py").read_text()

--- a/tests/arch/test_pyi_stub_completeness.py
+++ b/tests/arch/test_pyi_stub_completeness.py
@@ -33,6 +33,7 @@ def test_pyi_stub_covers_submodule_public_symbols() -> None:
             names = {alias.name for alias in node.names}
             stub_by_submod.setdefault(node.module, set()).update(names)
 
+    assert hasattr(core, "_PRIVATE_REEXPORTS"), "core._PRIVATE_REEXPORTS must exist"
     private_reexports: frozenset[str] = getattr(core, "_PRIVATE_REEXPORTS")
 
     missing: list[str] = []

--- a/tests/arch/test_pyi_stub_completeness.py
+++ b/tests/arch/test_pyi_stub_completeness.py
@@ -1,0 +1,81 @@
+"""Stub-symbol completeness tests for core/__init__.pyi.
+
+Verifies that every public symbol defined in a core submodule appears in the
+__init__.pyi stub. This catches the case where a developer adds a public symbol
+to a submodule but forgets to add it to the stub — the symbol becomes invisible
+to lazy_loader and causes ImportError at runtime.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from tests.arch._helpers import SRC_ROOT
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+_CORE_DIR = SRC_ROOT / "core"
+
+
+def test_pyi_stub_covers_submodule_public_symbols() -> None:
+    """Every public symbol in a core submodule must appear in __init__.pyi."""
+    import autoskillit.core as core
+
+    pyi_path = _CORE_DIR / "__init__.pyi"
+    assert pyi_path.exists(), "core/__init__.pyi must exist"
+
+    pyi_tree = ast.parse(pyi_path.read_text(encoding="utf-8"), filename=str(pyi_path))
+    stub_by_submod: dict[str, set[str]] = {}
+    for node in pyi_tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module:
+            names = {alias.name for alias in node.names}
+            stub_by_submod.setdefault(node.module, set()).update(names)
+
+    private_reexports: frozenset[str] = getattr(core, "_PRIVATE_REEXPORTS")
+
+    missing: list[str] = []
+    for submod_rel, stub_names in sorted(stub_by_submod.items()):
+        parts = submod_rel.split(".")
+        submod_path = _CORE_DIR.joinpath(*parts)
+
+        if submod_path.is_dir():
+            py_file = submod_path / "__init__.py"
+        else:
+            py_file = submod_path.with_suffix(".py")
+
+        if not py_file.exists():
+            continue
+
+        submod_tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+
+        submod_all = _extract_all(submod_tree)
+        if submod_all is None:
+            continue
+
+        for name in sorted(submod_all - stub_names):
+            if name.startswith("_"):
+                continue
+            if name in private_reexports:
+                continue
+            missing.append(f"  {submod_rel}: {name} defined but not in stub")
+
+    assert not missing, (
+        "Public symbols in core submodules missing from __init__.pyi:\n" + "\n".join(missing)
+    )
+
+
+def _extract_all(tree: ast.Module) -> set[str] | None:
+    """Extract __all__ list if defined as a simple assignment."""
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                if isinstance(target, ast.Name) and target.id == "__all__":
+                    if isinstance(stmt.value, (ast.List, ast.Tuple)):
+                        return {
+                            elt.value
+                            for elt in stmt.value.elts
+                            if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                        }
+    return None

--- a/tests/arch/test_tools_execution_decomposition.py
+++ b/tests/arch/test_tools_execution_decomposition.py
@@ -31,11 +31,10 @@ class TestToolsExecutionDecomposition:
         assert callable(record_gate_dispatch)
 
     def test_import_and_call_in_helpers(self):
-        """_import_and_call must be importable from _execution_helpers, not tools_execution."""
+        """_import_and_call must be defined in _execution_helpers."""
         from autoskillit.server.tools._execution_helpers import _import_and_call
 
         assert callable(_import_and_call)
-        assert not hasattr(tools_execution, "_import_and_call")
 
     def test_coerce_scalar_in_helpers(self):
         """_coerce_scalar must be importable from _execution_helpers, not tools_execution."""

--- a/tests/core/test_import_isolation.py
+++ b/tests/core/test_import_isolation.py
@@ -10,21 +10,21 @@ import pytest
 pytestmark = [pytest.mark.layer("core"), pytest.mark.medium]
 
 
-def test_server_import_does_not_load_fleet_package_lazily() -> None:
+def test_server_import_loads_fleet_package_eagerly() -> None:
     """
-    Fleet module loading is deferred to lifespan/tool-call time via lazy imports.
-    A bare `import autoskillit.server` must not pull in autoskillit.fleet.* —
-    not because of an env-var gate, but because no top-level fleet import exists.
+    Fleet imports in server/ are hoisted to module level so they bind at startup
+    before core's lazy_loader freezes the symbol map. Importing autoskillit.server
+    must pull in autoskillit.fleet.
     """
     code = (
         "import sys; import autoskillit.server; "
         "fleet_modules = [k for k in sys.modules if k.startswith('autoskillit.fleet')]; "
-        "print(fleet_modules)"
+        "print(bool(fleet_modules))"
     )
     result = subprocess.run(
         [sys.executable, "-c", code], capture_output=True, text=True, check=True
     )
-    assert result.stdout.strip() == "[]", f"Fleet modules leaked: {result.stdout}"
+    assert result.stdout.strip() == "True", f"Fleet modules not loaded: {result.stdout}"
 
 
 def test_cli_app_import_does_not_load_fleet_package() -> None:

--- a/tests/fleet/test_fleet_e2e.py
+++ b/tests/fleet/test_fleet_e2e.py
@@ -1103,10 +1103,10 @@ async def test_fleet_auto_gate_boot_reaps_orphan(tmp_path: Path) -> None:
             patch("autoskillit.fleet._dispatch_reaper.kill_process_tree"),
             patch("autoskillit.server._lifespan.resolve_kitchen_id", return_value="kitchen-test"),
             patch(
-                "autoskillit.fleet.discover_campaign_state_files",
+                "autoskillit.server._lifespan.discover_campaign_state_files",
                 return_value=[sp],
             ),
-            patch("autoskillit.core.register_active_kitchen"),
+            patch("autoskillit.server._lifespan.register_active_kitchen"),
         ):
             await _fleet_auto_gate_boot(ctx)
 

--- a/tests/fleet/test_gate_state_persistence.py
+++ b/tests/fleet/test_gate_state_persistence.py
@@ -165,9 +165,8 @@ class TestDispatchFoodTruckCampaignState:
                 per_dispatch_state_path=None,
             )
 
-        import autoskillit.fleet
-
-        monkeypatch.setattr(autoskillit.fleet, "execute_dispatch", _fake_execute)
+        _exec_path = "autoskillit.server.tools.tools_fleet_dispatch.execute_dispatch"
+        monkeypatch.setattr(_exec_path, _fake_execute)
 
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
@@ -199,9 +198,8 @@ class TestDispatchFoodTruckCampaignState:
                 per_dispatch_state_path=None,
             )
 
-        import autoskillit.fleet
-
-        monkeypatch.setattr(autoskillit.fleet, "execute_dispatch", _fake_execute)
+        _exec_path = "autoskillit.server.tools.tools_fleet_dispatch.execute_dispatch"
+        monkeypatch.setattr(_exec_path, _fake_execute)
 
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
@@ -232,9 +230,8 @@ class TestDispatchFoodTruckCampaignState:
                 per_dispatch_state_path=None,
             )
 
-        import autoskillit.fleet
-
-        monkeypatch.setattr(autoskillit.fleet, "execute_dispatch", _fake_execute)
+        _exec_path = "autoskillit.server.tools.tools_fleet_dispatch.execute_dispatch"
+        monkeypatch.setattr(_exec_path, _fake_execute)
 
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
@@ -268,9 +265,8 @@ class TestDispatchFoodTruckCampaignState:
                 per_dispatch_state_path=None,
             )
 
-        import autoskillit.fleet
-
-        monkeypatch.setattr(autoskillit.fleet, "execute_dispatch", _fake_execute)
+        _exec_path = "autoskillit.server.tools.tools_fleet_dispatch.execute_dispatch"
+        monkeypatch.setattr(_exec_path, _fake_execute)
 
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
@@ -346,9 +342,8 @@ class TestCampaignStateFieldCompleteness:
                 per_dispatch_state_path=per_dispatch_sp,
             )
 
-        import autoskillit.fleet
-
-        monkeypatch.setattr(autoskillit.fleet, "execute_dispatch", _fake_execute)
+        _exec_path = "autoskillit.server.tools.tools_fleet_dispatch.execute_dispatch"
+        monkeypatch.setattr(_exec_path, _fake_execute)
 
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
@@ -415,9 +410,8 @@ class TestCampaignStateFieldCompleteness:
                 per_dispatch_state_path=per_dispatch_sp,
             )
 
-        import autoskillit.fleet
-
-        monkeypatch.setattr(autoskillit.fleet, "execute_dispatch", _fake_execute)
+        _exec_path = "autoskillit.server.tools.tools_fleet_dispatch.execute_dispatch"
+        monkeypatch.setattr(_exec_path, _fake_execute)
 
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
@@ -486,9 +480,8 @@ class TestCampaignStateFieldCompleteness:
                 per_dispatch_state_path=per_dispatch_sp,
             )
 
-        import autoskillit.fleet
-
-        monkeypatch.setattr(autoskillit.fleet, "execute_dispatch", _fake_execute)
+        _exec_path = "autoskillit.server.tools.tools_fleet_dispatch.execute_dispatch"
+        monkeypatch.setattr(_exec_path, _fake_execute)
 
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
@@ -525,9 +518,8 @@ class TestCampaignStateFieldCompleteness:
                 per_dispatch_state_path=None,
             )
 
-        import autoskillit.fleet
-
-        monkeypatch.setattr(autoskillit.fleet, "execute_dispatch", _fake_execute)
+        _exec_path = "autoskillit.server.tools.tools_fleet_dispatch.execute_dispatch"
+        monkeypatch.setattr(_exec_path, _fake_execute)
 
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
@@ -772,9 +764,8 @@ class TestValidationFailureCampaignState:
                 per_dispatch_state_path=None,
             )
 
-        import autoskillit.fleet
-
-        monkeypatch.setattr(autoskillit.fleet, "execute_dispatch", _fake_execute)
+        _exec_path = "autoskillit.server.tools.tools_fleet_dispatch.execute_dispatch"
+        monkeypatch.setattr(_exec_path, _fake_execute)
 
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 

--- a/tests/infra/CLAUDE.md
+++ b/tests/infra/CLAUDE.md
@@ -18,6 +18,7 @@ CI/CD configuration, security, guard coverage, and release sanity tests.
 | `test_branch_protection_guard.py` | Tests for hooks/branch_protection_guard.py — PreToolUse branch protection |
 | `test_claude_md_critical_rules.py` | Tests that CLAUDE.md contains required critical rules from friction analysis |
 | `test_check_pyi_stub_format.py` | Unit tests for scripts/check_pyi_stub_format.py pre-commit hook — validates FunctionDef, ClassDef, and non-relative import rejection |
+| `test_check_pyi_stub_symbols.py` | Unit tests for scripts/check_pyi_stub_symbols.py pre-commit hook — validates missing symbol detection, completeness acceptance, underscore skipping, and __all__ usage |
 | `test_ci_dev_config.py` | Structural enforcement: CI workflow and pre-commit configuration must contain required quality gates |
 | `test_ci_workflow.py` | CI workflow structural tests |
 | `test_ci_shard_config.py` | Tests for CI shard directory configuration consistency |

--- a/tests/infra/test_check_pyi_stub_symbols.py
+++ b/tests/infra/test_check_pyi_stub_symbols.py
@@ -1,0 +1,88 @@
+"""Tests for scripts/check_pyi_stub_symbols.py pre-commit hook."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from autoskillit.core.paths import pkg_root
+
+pytestmark = [pytest.mark.layer("infra"), pytest.mark.small]
+
+
+def _load_check_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_pyi_stub_symbols",
+        pkg_root().parent.parent / "scripts" / "check_pyi_stub_symbols.py",
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+def test_check_pyi_symbols_detects_missing_symbol(tmp_path):
+    """The hook must report a public symbol present in a submodule but absent from the stub."""
+    pkg = tmp_path / "mypkg"
+    pkg.mkdir()
+
+    submod = pkg / "foo.py"
+    submod.write_text("class Bar:\n    pass\n\nclass Baz:\n    pass\n")
+
+    pyi = pkg / "__init__.pyi"
+    pyi.write_text("from .foo import Bar as Bar\n")
+
+    mod = _load_check_module()
+    violations = mod.check_file(pyi)
+    assert len(violations) == 1
+    assert "Baz" in violations[0]
+
+
+def test_check_pyi_symbols_accepts_complete_stub(tmp_path):
+    """The hook must accept a stub that covers all public symbols."""
+    pkg = tmp_path / "mypkg"
+    pkg.mkdir()
+
+    submod = pkg / "foo.py"
+    submod.write_text("class Bar:\n    pass\n\ndef baz():\n    pass\n")
+
+    pyi = pkg / "__init__.pyi"
+    pyi.write_text("from .foo import Bar as Bar\nfrom .foo import baz as baz\n")
+
+    mod = _load_check_module()
+    violations = mod.check_file(pyi)
+    assert violations == []
+
+
+def test_check_pyi_symbols_skips_underscore_names(tmp_path):
+    """Private names (starting with _) should not be flagged as missing."""
+    pkg = tmp_path / "mypkg"
+    pkg.mkdir()
+
+    submod = pkg / "foo.py"
+    submod.write_text("class Bar:\n    pass\n\ndef _helper():\n    pass\n")
+
+    pyi = pkg / "__init__.pyi"
+    pyi.write_text("from .foo import Bar as Bar\n")
+
+    mod = _load_check_module()
+    violations = mod.check_file(pyi)
+    assert violations == []
+
+
+def test_check_pyi_symbols_uses_all_when_defined(tmp_path):
+    """When __all__ is defined, only __all__ members count as public."""
+    pkg = tmp_path / "mypkg"
+    pkg.mkdir()
+
+    submod = pkg / "foo.py"
+    submod.write_text('__all__ = ["Bar"]\n\nclass Bar:\n    pass\n\nclass Baz:\n    pass\n')
+
+    pyi = pkg / "__init__.pyi"
+    pyi.write_text("from .foo import Bar as Bar\n")
+
+    mod = _load_check_module()
+    violations = mod.check_file(pyi)
+    assert violations == []

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -117,7 +117,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # staleness_cache.py — cache dict
     ("src/autoskillit/recipe/staleness_cache.py", 67),
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
-    ("src/autoskillit/server/_lifespan.py", 64),
+    ("src/autoskillit/server/_lifespan.py", 87),
     # tools_kitchen.py — hook config, quota guard, git_ops_policy, ingredient locks overlay
     ("src/autoskillit/server/tools/tools_kitchen.py", 140),
     ("src/autoskillit/server/tools/tools_kitchen.py", 162),
@@ -129,7 +129,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools/tools_status.py", 529),
     # tools_github.py — bug report dict
-    ("src/autoskillit/server/tools/tools_github.py", 314),
+    ("src/autoskillit/server/tools/tools_github.py", 312),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 24),
     # _init_helpers.py — ~/.claude.json (co-owned)
@@ -143,7 +143,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _marketplace.py — hooks.json (co-owned)
     ("src/autoskillit/cli/_marketplace.py", 188),
     # tools_config.py — hook config overlay dict (session-scoped, not schema-versioned)
-    ("src/autoskillit/server/tools/tools_config.py", 48),
+    ("src/autoskillit/server/tools/tools_config.py", 50),
     # _update_checks.py — dismissal state file
     ("src/autoskillit/cli/update/_update_checks.py", 77),
     # _update_checks_fetch.py — fetch cache (extracted from _update_checks.py)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -119,11 +119,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 87),
     # tools_kitchen.py — hook config, quota guard, git_ops_policy, ingredient locks overlay
-    ("src/autoskillit/server/tools/tools_kitchen.py", 140),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 162),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 199),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 833),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 893),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 138),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 157),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 191),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 809),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 869),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -119,17 +119,17 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 64),
     # tools_kitchen.py — hook config, quota guard, git_ops_policy, ingredient locks overlay
-    ("src/autoskillit/server/tools/tools_kitchen.py", 132),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 151),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 185),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 809),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 869),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 140),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 162),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 199),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 833),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 893),
     # tools_pipeline_tracker.py — tracker_data dict
-    ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 164),
+    ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict
-    ("src/autoskillit/server/tools/tools_status.py", 513),
+    ("src/autoskillit/server/tools/tools_status.py", 529),
     # tools_github.py — bug report dict
-    ("src/autoskillit/server/tools/tools_github.py", 307),
+    ("src/autoskillit/server/tools/tools_github.py", 314),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 24),
     # _init_helpers.py — ~/.claude.json (co-owned)

--- a/tests/server/test_claim_liveness.py
+++ b/tests/server/test_claim_liveness.py
@@ -14,7 +14,7 @@ from autoskillit.server.tools.tools_issue_labels import claim_issue
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 _ISSUE_URL = "https://github.com/owner/repo/issues/42"
-_FLEET_MODULE = "autoskillit.fleet"
+_CLAIM_MODULE = "autoskillit.server.tools._claim_helpers"
 
 
 def _make_dead_dispatch() -> DispatchRecord:
@@ -55,9 +55,9 @@ class TestClaimIssueLiveness:
         tool_ctx_kitchen_open.github_client = _mock_client_with_in_progress_label()
 
         with (
-            patch(f"{_FLEET_MODULE}.find_dispatch_for_issue", return_value=dead_dispatch),
-            patch(f"{_FLEET_MODULE}.is_dispatch_session_alive", return_value=False),
-            patch(f"{_FLEET_MODULE}.cleanup_orphaned_labels", cleanup_mock),
+            patch(f"{_CLAIM_MODULE}.find_dispatch_for_issue", return_value=dead_dispatch),
+            patch(f"{_CLAIM_MODULE}.is_dispatch_session_alive", return_value=False),
+            patch(f"{_CLAIM_MODULE}.cleanup_orphaned_labels", cleanup_mock),
         ):
             result = json.loads(await claim_issue(_ISSUE_URL))
 
@@ -74,9 +74,9 @@ class TestClaimIssueLiveness:
         tool_ctx_kitchen_open.github_client = _mock_client_with_in_progress_label()
 
         with (
-            patch(f"{_FLEET_MODULE}.find_dispatch_for_issue", return_value=dispatch),
-            patch(f"{_FLEET_MODULE}.is_dispatch_session_alive", return_value=True),
-            patch(f"{_FLEET_MODULE}.cleanup_orphaned_labels", AsyncMock()),
+            patch(f"{_CLAIM_MODULE}.find_dispatch_for_issue", return_value=dispatch),
+            patch(f"{_CLAIM_MODULE}.is_dispatch_session_alive", return_value=True),
+            patch(f"{_CLAIM_MODULE}.cleanup_orphaned_labels", AsyncMock()),
         ):
             result = json.loads(await claim_issue(_ISSUE_URL))
 
@@ -88,7 +88,7 @@ class TestClaimIssueLiveness:
         """When no dispatch found for issue, claiming is blocked (manual label or unknown)."""
         tool_ctx_kitchen_open.github_client = _mock_client_with_in_progress_label()
 
-        with patch(f"{_FLEET_MODULE}.find_dispatch_for_issue", return_value=None):
+        with patch(f"{_CLAIM_MODULE}.find_dispatch_for_issue", return_value=None):
             result = json.loads(await claim_issue(_ISSUE_URL))
 
         assert result["success"] is True
@@ -103,9 +103,9 @@ class TestClaimIssueLiveness:
         tool_ctx_kitchen_open.github_client = _mock_client_with_in_progress_label()
 
         with (
-            patch(f"{_FLEET_MODULE}.find_dispatch_for_issue", return_value=dispatch),
-            patch(f"{_FLEET_MODULE}.is_dispatch_session_alive", return_value=True),
-            patch(f"{_FLEET_MODULE}.cleanup_orphaned_labels", cleanup_mock),
+            patch(f"{_CLAIM_MODULE}.find_dispatch_for_issue", return_value=dispatch),
+            patch(f"{_CLAIM_MODULE}.is_dispatch_session_alive", return_value=True),
+            patch(f"{_CLAIM_MODULE}.cleanup_orphaned_labels", cleanup_mock),
         ):
             await claim_issue(_ISSUE_URL)
 
@@ -123,9 +123,9 @@ class TestClaimAndResolveIssueLiveness:
         tool_ctx_kitchen_open.github_client = _mock_client_with_in_progress_label()
 
         with (
-            patch(f"{_FLEET_MODULE}.find_dispatch_for_issue", return_value=dead_dispatch),
-            patch(f"{_FLEET_MODULE}.is_dispatch_session_alive", return_value=False),
-            patch(f"{_FLEET_MODULE}.cleanup_orphaned_labels", cleanup_mock),
+            patch(f"{_CLAIM_MODULE}.find_dispatch_for_issue", return_value=dead_dispatch),
+            patch(f"{_CLAIM_MODULE}.is_dispatch_session_alive", return_value=False),
+            patch(f"{_CLAIM_MODULE}.cleanup_orphaned_labels", cleanup_mock),
         ):
             result = json.loads(await claim_and_resolve_issue(_ISSUE_URL))
 
@@ -142,9 +142,9 @@ class TestClaimAndResolveIssueLiveness:
         tool_ctx_kitchen_open.github_client = _mock_client_with_in_progress_label()
 
         with (
-            patch(f"{_FLEET_MODULE}.find_dispatch_for_issue", return_value=dispatch),
-            patch(f"{_FLEET_MODULE}.is_dispatch_session_alive", return_value=True),
-            patch(f"{_FLEET_MODULE}.cleanup_orphaned_labels", AsyncMock()),
+            patch(f"{_CLAIM_MODULE}.find_dispatch_for_issue", return_value=dispatch),
+            patch(f"{_CLAIM_MODULE}.is_dispatch_session_alive", return_value=True),
+            patch(f"{_CLAIM_MODULE}.cleanup_orphaned_labels", AsyncMock()),
         ):
             result = json.loads(await claim_and_resolve_issue(_ISSUE_URL))
 
@@ -164,9 +164,9 @@ class TestClaimHelperParity:
         cleanup_mock = AsyncMock(return_value=True)
 
         with (
-            patch(f"{_FLEET_MODULE}.find_dispatch_for_issue", return_value=dead_dispatch),
-            patch(f"{_FLEET_MODULE}.is_dispatch_session_alive", return_value=False),
-            patch(f"{_FLEET_MODULE}.cleanup_orphaned_labels", cleanup_mock),
+            patch(f"{_CLAIM_MODULE}.find_dispatch_for_issue", return_value=dead_dispatch),
+            patch(f"{_CLAIM_MODULE}.is_dispatch_session_alive", return_value=False),
+            patch(f"{_CLAIM_MODULE}.cleanup_orphaned_labels", cleanup_mock),
         ):
             decision = await _try_claim_with_liveness(
                 issue_url=_ISSUE_URL,
@@ -190,8 +190,8 @@ class TestClaimHelperParity:
         dispatch = _make_dead_dispatch()
 
         with (
-            patch(f"{_FLEET_MODULE}.find_dispatch_for_issue", return_value=dispatch),
-            patch(f"{_FLEET_MODULE}.is_dispatch_session_alive", return_value=True),
+            patch(f"{_CLAIM_MODULE}.find_dispatch_for_issue", return_value=dispatch),
+            patch(f"{_CLAIM_MODULE}.is_dispatch_session_alive", return_value=True),
         ):
             decision = await _try_claim_with_liveness(
                 issue_url=_ISSUE_URL,
@@ -222,8 +222,8 @@ class TestClaimHelperTerminalDispatchRecovery:
         cleanup_mock = AsyncMock(return_value=True)
 
         with (
-            patch(f"{_FLEET_MODULE}.find_dispatch_for_issue", return_value=failure_dispatch),
-            patch(f"{_FLEET_MODULE}.cleanup_orphaned_labels", cleanup_mock),
+            patch(f"{_CLAIM_MODULE}.find_dispatch_for_issue", return_value=failure_dispatch),
+            patch(f"{_CLAIM_MODULE}.cleanup_orphaned_labels", cleanup_mock),
         ):
             decision = await _try_claim_with_liveness(
                 issue_url=_ISSUE_URL,
@@ -255,8 +255,8 @@ class TestClaimHelperTerminalDispatchRecovery:
         mark_cleaned_mock = AsyncMock()
 
         with (
-            patch(f"{_FLEET_MODULE}.find_dispatch_for_issue", return_value=failure_dispatch),
-            patch(f"{_FLEET_MODULE}.cleanup_orphaned_labels", cleanup_mock),
+            patch(f"{_CLAIM_MODULE}.find_dispatch_for_issue", return_value=failure_dispatch),
+            patch(f"{_CLAIM_MODULE}.cleanup_orphaned_labels", cleanup_mock),
             patch(
                 "autoskillit.server.tools._claim_helpers._mark_dispatch_labels_cleaned",
                 mark_cleaned_mock,
@@ -290,9 +290,9 @@ class TestClaimHelperTerminalDispatchRecovery:
         liveness_mock = AsyncMock(return_value=True)
 
         with (
-            patch(f"{_FLEET_MODULE}.find_dispatch_for_issue", return_value=failure_dispatch),
-            patch(f"{_FLEET_MODULE}.is_dispatch_session_alive", liveness_mock),
-            patch(f"{_FLEET_MODULE}.cleanup_orphaned_labels", AsyncMock(return_value=True)),
+            patch(f"{_CLAIM_MODULE}.find_dispatch_for_issue", return_value=failure_dispatch),
+            patch(f"{_CLAIM_MODULE}.is_dispatch_session_alive", liveness_mock),
+            patch(f"{_CLAIM_MODULE}.cleanup_orphaned_labels", AsyncMock(return_value=True)),
         ):
             decision = await _try_claim_with_liveness(
                 issue_url=_ISSUE_URL,

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -139,7 +139,7 @@ def test_startup_broken_hook_detection(tmp_path: Path, monkeypatch) -> None:
     )
 
     monkeypatch.setattr(
-        "autoskillit.hook_registry.iter_all_scope_paths",
+        "autoskillit.server._lifespan.iter_all_scope_paths",
         lambda project_root=None: iter([("user", user_settings)]),
     )
 
@@ -157,11 +157,11 @@ def test_startup_hook_health_checks_plugin_cache(tmp_path: Path, monkeypatch) ->
     ]
 
     monkeypatch.setattr(
-        "autoskillit.hook_registry.iter_all_scope_paths",
+        "autoskillit.server._lifespan.iter_all_scope_paths",
         lambda project_root=None: iter([]),
     )
     monkeypatch.setattr(
-        "autoskillit.hook_registry.validate_plugin_cache_hooks",
+        "autoskillit.server._lifespan.validate_plugin_cache_hooks",
         lambda cache_dir=None: stale_commands,
     )
 

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -507,11 +507,11 @@ class TestFleetAutoGateBoot:
                 "autoskillit.server._misc._prime_quota_cache", new=AsyncMock()
             ) as mock_prime_quota_cache:
                 with patch(
-                    "autoskillit.pipeline.create_background_task",
+                    "autoskillit.server._lifespan.create_background_task",
                     return_value=MagicMock(),
                 ) as mock_create_bg_task:
                     with patch(
-                        "autoskillit.core.register_active_kitchen"
+                        "autoskillit.server._lifespan.register_active_kitchen"
                     ) as mock_register_kitchen:
                         await _fleet_auto_gate_boot(tool_ctx)
 
@@ -555,10 +555,10 @@ class TestFleetAutoGateBoot:
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
                 with patch(
-                    "autoskillit.pipeline.create_background_task",
+                    "autoskillit.server._lifespan.create_background_task",
                     return_value=MagicMock(),
                 ):
-                    with patch("autoskillit.core.register_active_kitchen"):
+                    with patch("autoskillit.server._lifespan.register_active_kitchen"):
                         await boot_fn(tool_ctx)
 
         assert tool_ctx.kitchen_id == expected_id
@@ -587,13 +587,13 @@ class TestFleetAutoGateBoot:
         with (
             patch("autoskillit.server.tools.tools_kitchen._write_hook_config"),
             patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()),
-            patch("autoskillit.pipeline.create_background_task", return_value=MagicMock()),
-            patch("autoskillit.core.register_active_kitchen"),
+            patch("autoskillit.server._lifespan.create_background_task", return_value=MagicMock()),
+            patch("autoskillit.server._lifespan.register_active_kitchen"),
             patch(
-                "autoskillit.fleet.discover_campaign_state_files",
+                "autoskillit.server._lifespan.discover_campaign_state_files",
                 return_value=[dispatches_dir / "campaign1.json"],
             ),
-            patch("autoskillit.fleet.reap_stale_dispatches_async", mock_reap),
+            patch("autoskillit.server._lifespan.reap_stale_dispatches_async", mock_reap),
         ):
             await _fleet_auto_gate_boot(tool_ctx)
 
@@ -629,11 +629,11 @@ class TestFleetAutoGateBootProjectDir:
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
                 with patch(
-                    "autoskillit.pipeline.create_background_task",
+                    "autoskillit.server._lifespan.create_background_task",
                     return_value=MagicMock(),
                 ):
                     with patch(
-                        "autoskillit.core.register_active_kitchen"
+                        "autoskillit.server._lifespan.register_active_kitchen"
                     ) as mock_register_kitchen:
                         await _fleet_auto_gate_boot(ctx)
 
@@ -666,11 +666,11 @@ class TestFleetAutoGateBootProjectDir:
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
                 with patch(
-                    "autoskillit.pipeline.create_background_task",
+                    "autoskillit.server._lifespan.create_background_task",
                     return_value=MagicMock(),
                 ):
                     with patch(
-                        "autoskillit.core.register_active_kitchen"
+                        "autoskillit.server._lifespan.register_active_kitchen"
                     ) as mock_register_kitchen:
                         await _food_truck_auto_gate_boot(ctx)
 
@@ -695,10 +695,10 @@ class TestFleetAutoGateBootProjectDir:
         ):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
                 with patch(
-                    "autoskillit.pipeline.create_background_task",
+                    "autoskillit.server._lifespan.create_background_task",
                     return_value=MagicMock(),
                 ):
-                    with patch("autoskillit.core.register_active_kitchen"):
+                    with patch("autoskillit.server._lifespan.register_active_kitchen"):
                         await _fleet_auto_gate_boot(tool_ctx)
 
         assert tool_ctx.gate.enabled is True  # gate stays open despite hook_config failure
@@ -720,10 +720,10 @@ class TestFleetAutoGateBootProjectDir:
                 new=AsyncMock(side_effect=RuntimeError("quota cache error")),
             ):
                 with patch(
-                    "autoskillit.pipeline.create_background_task",
+                    "autoskillit.server._lifespan.create_background_task",
                     return_value=MagicMock(),
                 ):
-                    with patch("autoskillit.core.register_active_kitchen"):
+                    with patch("autoskillit.server._lifespan.register_active_kitchen"):
                         await _fleet_auto_gate_boot(tool_ctx)
 
         assert tool_ctx.gate.enabled is True  # gate stays open despite quota cache failure
@@ -742,10 +742,10 @@ class TestFleetAutoGateBootProjectDir:
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
                 with patch(
-                    "autoskillit.pipeline.create_background_task",
+                    "autoskillit.server._lifespan.create_background_task",
                     side_effect=RuntimeError("task creation error"),
                 ):
-                    with patch("autoskillit.core.register_active_kitchen"):
+                    with patch("autoskillit.server._lifespan.register_active_kitchen"):
                         await _fleet_auto_gate_boot(tool_ctx)
 
         assert tool_ctx.gate.enabled is True  # gate stays open despite background task failure
@@ -764,11 +764,11 @@ class TestFleetAutoGateBootProjectDir:
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
                 with patch(
-                    "autoskillit.pipeline.create_background_task",
+                    "autoskillit.server._lifespan.create_background_task",
                     return_value=MagicMock(),
                 ):
                     with patch(
-                        "autoskillit.core.register_active_kitchen",
+                        "autoskillit.server._lifespan.register_active_kitchen",
                         side_effect=OSError("registry write error"),
                     ):
                         await _fleet_auto_gate_boot(tool_ctx)
@@ -789,10 +789,10 @@ class TestFleetAutoGateBootProjectDir:
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
                 with patch(
-                    "autoskillit.pipeline.create_background_task",
+                    "autoskillit.server._lifespan.create_background_task",
                     return_value=MagicMock(),
                 ):
-                    with patch("autoskillit.core.register_active_kitchen"):
+                    with patch("autoskillit.server._lifespan.register_active_kitchen"):
                         with structlog.testing.capture_logs() as logs:
                             await _fleet_auto_gate_boot(tool_ctx)
 
@@ -828,10 +828,10 @@ class TestFleetAutoGateBootProjectDir:
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
                 with patch(
-                    "autoskillit.pipeline.create_background_task",
+                    "autoskillit.server._lifespan.create_background_task",
                     return_value=MagicMock(),
                 ):
-                    with patch("autoskillit.core.register_active_kitchen"):
+                    with patch("autoskillit.server._lifespan.register_active_kitchen"):
                         await _fleet_auto_gate_boot(tool_ctx)
 
         async with Client(mcp) as client:
@@ -856,15 +856,15 @@ class TestFleetAutoGateBootProjectDir:
 
         monkeypatch.setattr("autoskillit.server._lifespan._get_ctx_or_none", lambda: tool_ctx)
 
-        with patch("autoskillit.core._collect_disabled_feature_tags") as mock_helper:
+        with patch("autoskillit.server._lifespan._collect_disabled_feature_tags") as mock_helper:
             mock_helper.return_value = frozenset({"fleet"})
             with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
                 with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
                     with patch(
-                        "autoskillit.pipeline.create_background_task",
+                        "autoskillit.server._lifespan.create_background_task",
                         return_value=MagicMock(),
                     ):
-                        with patch("autoskillit.core.register_active_kitchen"):
+                        with patch("autoskillit.server._lifespan.register_active_kitchen"):
                             await _fleet_auto_gate_boot(tool_ctx)
 
         mock_helper.assert_called_once_with(
@@ -894,9 +894,9 @@ class TestFoodTruckAutoGateBoot:
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
                 with patch(
-                    "autoskillit.pipeline.create_background_task", return_value=MagicMock()
+                    "autoskillit.server._lifespan.create_background_task", return_value=MagicMock()
                 ):
-                    with patch("autoskillit.core.register_active_kitchen"):
+                    with patch("autoskillit.server._lifespan.register_active_kitchen"):
                         await _food_truck_auto_gate_boot(tool_ctx)
 
         assert tool_ctx.gate.enabled is True
@@ -919,9 +919,9 @@ class TestFoodTruckAutoGateBoot:
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
                 with patch(
-                    "autoskillit.pipeline.create_background_task", return_value=MagicMock()
+                    "autoskillit.server._lifespan.create_background_task", return_value=MagicMock()
                 ):
-                    with patch("autoskillit.core.register_active_kitchen"):
+                    with patch("autoskillit.server._lifespan.register_active_kitchen"):
                         await _food_truck_auto_gate_boot(tool_ctx)
 
         assert tool_ctx.active_recipe_packs == frozenset({"kitchen-core", "rectify"})
@@ -1002,9 +1002,9 @@ class TestFoodTruckAutoGateBoot:
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
                 with patch(
-                    "autoskillit.pipeline.create_background_task", return_value=MagicMock()
+                    "autoskillit.server._lifespan.create_background_task", return_value=MagicMock()
                 ):
-                    with patch("autoskillit.core.register_active_kitchen"):
+                    with patch("autoskillit.server._lifespan.register_active_kitchen"):
                         await _food_truck_auto_gate_boot(tool_ctx)
 
         result = json.loads(await run_skill("/some-skill", "/tmp"))
@@ -1036,14 +1036,16 @@ class TestFoodTruckAutoGateBoot:
 
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
-                with patch("autoskillit.pipeline.create_background_task", mock_create_bg_task):
-                    with patch("autoskillit.core.register_active_kitchen"):
+                _bg = "autoskillit.server._lifespan.create_background_task"
+                with patch(_bg, mock_create_bg_task):
+                    _rk = "autoskillit.server._lifespan.register_active_kitchen"
+                    with patch(_rk):
                         with patch(
-                            "autoskillit.fleet.sweep_stale_dispatch_labels",
+                            "autoskillit.server._lifespan.sweep_stale_dispatch_labels",
                             new_callable=AsyncMock,
                         ):
                             with patch(
-                                "autoskillit.fleet.discover_campaign_state_files",
+                                "autoskillit.server._lifespan.discover_campaign_state_files",
                                 return_value=[dispatches_dir / "campaign1.json"],
                             ):
                                 await _food_truck_auto_gate_boot(tool_ctx)
@@ -1089,13 +1091,13 @@ class TestFoodTruckAutoGateBoot:
         with (
             patch("autoskillit.server.tools.tools_kitchen._write_hook_config"),
             patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()),
-            patch("autoskillit.pipeline.create_background_task", return_value=MagicMock()),
-            patch("autoskillit.core.register_active_kitchen"),
+            patch("autoskillit.server._lifespan.create_background_task", return_value=MagicMock()),
+            patch("autoskillit.server._lifespan.register_active_kitchen"),
             patch(
-                "autoskillit.fleet.discover_campaign_state_files",
+                "autoskillit.server._lifespan.discover_campaign_state_files",
                 return_value=[dispatches_dir / "campaign1.json"],
             ),
-            patch("autoskillit.fleet.reap_stale_dispatches_async", mock_reap),
+            patch("autoskillit.server._lifespan.reap_stale_dispatches_async", mock_reap),
         ):
             await _food_truck_auto_gate_boot(tool_ctx)
 
@@ -1141,13 +1143,13 @@ class TestFoodTruckAutoGateBoot:
         with (
             patch("autoskillit.server.tools.tools_kitchen._write_hook_config"),
             patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()),
-            patch("autoskillit.pipeline.create_background_task", return_value=MagicMock()),
-            patch("autoskillit.core.register_active_kitchen"),
+            patch("autoskillit.server._lifespan.create_background_task", return_value=MagicMock()),
+            patch("autoskillit.server._lifespan.register_active_kitchen"),
             patch(
-                "autoskillit.fleet.discover_campaign_state_files",
+                "autoskillit.server._lifespan.discover_campaign_state_files",
                 return_value=[dispatches_dir / "campaign1.json"],
             ),
-            patch("autoskillit.fleet.reap_stale_dispatches_async", mock_reap),
+            patch("autoskillit.server._lifespan.reap_stale_dispatches_async", mock_reap),
         ):
             await _food_truck_auto_gate_boot(tool_ctx)
 
@@ -1180,7 +1182,7 @@ class TestSkillAutoGateBoot:
 
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
-                with patch("autoskillit.core.register_active_kitchen"):
+                with patch("autoskillit.server._lifespan.register_active_kitchen"):
                     await _skill_auto_gate_boot(tool_ctx)
 
         assert tool_ctx.gate.enabled is True
@@ -1252,12 +1254,12 @@ class TestSkillAutoGateBoot:
         monkeypatch.setenv(HEADLESS_AUTO_GATE_ENV_VAR, "1")
 
         with patch(
-            "autoskillit.core._collect_disabled_feature_tags",
+            "autoskillit.server._lifespan._collect_disabled_feature_tags",
             side_effect=RuntimeError("feature error"),
         ):
             with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
                 with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
-                    with patch("autoskillit.core.register_active_kitchen"):
+                    with patch("autoskillit.server._lifespan.register_active_kitchen"):
                         await _skill_auto_gate_boot(tool_ctx)
 
         assert tool_ctx.gate.enabled is True
@@ -1282,7 +1284,7 @@ class TestSkillAutoGateBoot:
             side_effect=OSError("disk full"),
         ):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
-                with patch("autoskillit.core.register_active_kitchen"):
+                with patch("autoskillit.server._lifespan.register_active_kitchen"):
                     await _skill_auto_gate_boot(tool_ctx)
 
         assert tool_ctx.gate.enabled is True
@@ -1307,7 +1309,7 @@ class TestSkillAutoGateBoot:
                 "autoskillit.server._misc._prime_quota_cache",
                 new=AsyncMock(side_effect=RuntimeError("quota cache error")),
             ):
-                with patch("autoskillit.core.register_active_kitchen"):
+                with patch("autoskillit.server._lifespan.register_active_kitchen"):
                     await _skill_auto_gate_boot(tool_ctx)
 
         assert tool_ctx.gate.enabled is True
@@ -1328,7 +1330,7 @@ class TestSkillAutoGateBoot:
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
                 with patch(
-                    "autoskillit.core.register_active_kitchen",
+                    "autoskillit.server._lifespan.register_active_kitchen",
                     side_effect=OSError("registry write error"),
                 ):
                     await _skill_auto_gate_boot(tool_ctx)
@@ -1351,10 +1353,10 @@ class TestSkillAutoGateBoot:
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
                 with patch(
-                    "autoskillit.pipeline.create_background_task",
+                    "autoskillit.server._lifespan.create_background_task",
                     return_value=MagicMock(),
                 ) as mock_create_bg_task:
-                    with patch("autoskillit.core.register_active_kitchen"):
+                    with patch("autoskillit.server._lifespan.register_active_kitchen"):
                         await _skill_auto_gate_boot(tool_ctx)
 
         quota_loop_calls = [
@@ -1390,7 +1392,8 @@ class TestSkillAutoGateBoot:
 
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
-                with patch("autoskillit.core.register_active_kitchen") as mock_register_kitchen:
+                _rk = "autoskillit.server._lifespan.register_active_kitchen"
+                with patch(_rk) as mock_register_kitchen:
                     await _skill_auto_gate_boot(ctx)
 
         mock_register_kitchen.assert_called_once_with(
@@ -1412,7 +1415,7 @@ class TestSkillAutoGateBoot:
 
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
-                with patch("autoskillit.core.register_active_kitchen"):
+                with patch("autoskillit.server._lifespan.register_active_kitchen"):
                     with structlog.testing.capture_logs() as logs:
                         await _skill_auto_gate_boot(tool_ctx)
 
@@ -1440,7 +1443,7 @@ class TestSkillAutoGateBoot:
             "autoskillit.server.tools.tools_kitchen._write_hook_config"
         ) as mock_write_hook_config:
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
-                with patch("autoskillit.core.register_active_kitchen"):
+                with patch("autoskillit.server._lifespan.register_active_kitchen"):
                     await _skill_auto_gate_boot(tool_ctx)
 
         mock_write_hook_config.assert_called_once_with()
@@ -1462,7 +1465,8 @@ class TestSkillAutoGateBoot:
         with patch(
             "autoskillit.server.tools.tools_kitchen._write_hook_config"
         ) as mock_write_hook_config:
-            with patch("autoskillit.core.register_active_kitchen") as mock_register_kitchen:
+            _rk = "autoskillit.server._lifespan.register_active_kitchen"
+            with patch(_rk) as mock_register_kitchen:
                 await _skill_auto_gate_boot(tool_ctx)
 
         assert tool_ctx.gate.enabled is False
@@ -1488,7 +1492,7 @@ class TestSkillAutoGateBoot:
 
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
-                with patch("autoskillit.core.register_active_kitchen"):
+                with patch("autoskillit.server._lifespan.register_active_kitchen"):
                     await _skill_auto_gate_boot(ctx)
 
         assert ctx.gate.enabled is True, "Gate should be open for non-notification backend"
@@ -1521,7 +1525,7 @@ class TestSkillAutoGateBoot:
 
         with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
             with patch("autoskillit.server._misc._prime_quota_cache", new=AsyncMock()):
-                with patch("autoskillit.core.register_active_kitchen"):
+                with patch("autoskillit.server._lifespan.register_active_kitchen"):
                     await _skill_auto_gate_boot(ctx)
 
         # plan-review resources should remain hidden

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -308,18 +308,14 @@ class TestDispatchFoodTruckExecution:
         caught at the MCP tool boundary and returned as a structured JSON response rather
         than propagating to the MCP transport and dropping the session.
         """
-        import autoskillit.fleet as _fleet_mod
         from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
 
-        # Bypass fleet-session gate — test focuses on the CancelledError path, not the gate
         monkeypatch.setattr(
             "autoskillit.server.tools.tools_fleet_dispatch._require_fleet",
             lambda _name: None,
         )
-        # execute_dispatch is dynamically imported inside the function; patch the module attr
         monkeypatch.setattr(
-            _fleet_mod,
-            "execute_dispatch",
+            "autoskillit.server.tools.tools_fleet_dispatch.execute_dispatch",
             AsyncMock(side_effect=asyncio.CancelledError()),
         )
 

--- a/tests/server/test_tools_dispatch_halt.py
+++ b/tests/server/test_tools_dispatch_halt.py
@@ -139,7 +139,7 @@ class TestDispatchFoodTruckHaltEnforcement:
         from autoskillit.fleet import DispatchStatus as _DS
 
         monkeypatch.setattr(
-            "autoskillit.fleet.execute_dispatch",
+            "autoskillit.server.tools.tools_fleet_dispatch.execute_dispatch",
             AsyncMock(
                 return_value=DispatchResult(
                     outcome=DispatchCompleted(
@@ -230,7 +230,7 @@ class TestPostDispatchHaltOnFailure:
 
         mock_execute = AsyncMock()
         monkeypatch.setattr(
-            "autoskillit.fleet.execute_dispatch",
+            "autoskillit.server.tools.tools_fleet_dispatch.execute_dispatch",
             mock_execute,
         )
 

--- a/tests/server/test_tools_execution_backend_mixing.py
+++ b/tests/server/test_tools_execution_backend_mixing.py
@@ -32,7 +32,8 @@ async def test_codex_backend_minimax_profile_with_anthropic_base_url_derives_ove
     tool_ctx_kitchen_open.backend = fake_backend
     tool_ctx_kitchen_open.session_skill_manager = None
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
         lambda *a, **kw: (
@@ -76,7 +77,8 @@ async def test_anthropic_capable_backend_profile_without_base_url_no_override(
     tool_ctx_kitchen_open.backend = fake_backend
     tool_ctx_kitchen_open.session_skill_manager = None
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
         lambda *a, **kw: (

--- a/tests/server/test_tools_execution_provider.py
+++ b/tests/server/test_tools_execution_provider.py
@@ -18,7 +18,8 @@ async def test_run_skill_provider_extras_none_when_feature_disabled(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: False)
 
     captured: dict = {}
     original_run = executor.run
@@ -44,7 +45,8 @@ async def test_run_skill_provider_extras_none_for_anthropic_sentinel(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
         lambda *a, **kw: ("anthropic", {"SOME_KEY": "val"}),
@@ -74,7 +76,8 @@ async def test_run_skill_provider_extras_forwarded_for_non_anthropic(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
         lambda *a, **kw: ("bedrock", {"AWS_REGION": "us-east-1"}),
@@ -105,7 +108,8 @@ async def test_run_skill_model_as_profile_resolves_provider(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
         lambda *a, **kw: ("anthropic", {}),
@@ -141,7 +145,8 @@ async def test_run_skill_step_overrides_win_over_model_as_profile(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
         lambda *a, **kw: ("bedrock", {"AWS_REGION": "us-east-1"}),
@@ -177,7 +182,8 @@ async def test_run_skill_model_as_profile_disabled_when_feature_off(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: False)
 
     captured: dict = {}
     original_run = executor.run
@@ -203,7 +209,8 @@ async def test_run_skill_model_as_profile_no_anthropic_model_falls_through(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
         lambda *a, **kw: ("anthropic", {}),
@@ -239,7 +246,8 @@ async def test_run_skill_model_overrides_applied(
     tool_ctx_kitchen_open.executor = executor
     tool_ctx_kitchen_open.recipe_name = "implementation"
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: False)
     tool_ctx_kitchen_open.config.providers = ProvidersConfig(
         model_overrides={"implementation": {"implement": "opus"}}
     )
@@ -269,7 +277,8 @@ async def test_run_skill_model_overrides_wildcard_step(
     tool_ctx_kitchen_open.executor = executor
     tool_ctx_kitchen_open.recipe_name = "implementation"
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: False)
     tool_ctx_kitchen_open.config.providers = ProvidersConfig(
         model_overrides={"implementation": {"*": "opus"}}
     )
@@ -299,7 +308,8 @@ async def test_run_skill_model_overrides_exact_over_wildcard(
     tool_ctx_kitchen_open.executor = executor
     tool_ctx_kitchen_open.recipe_name = "implementation"
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: False)
     tool_ctx_kitchen_open.config.providers = ProvidersConfig(
         model_overrides={"implementation": {"implement": "opus", "*": "haiku"}}
     )
@@ -329,7 +339,8 @@ async def test_run_skill_model_overrides_without_providers_feature(
     tool_ctx_kitchen_open.executor = executor
     tool_ctx_kitchen_open.recipe_name = "implementation"
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: False)
     tool_ctx_kitchen_open.config.providers = ProvidersConfig(
         model_overrides={"implementation": {"implement": "opus"}}
     )
@@ -359,7 +370,8 @@ async def test_run_skill_model_overrides_no_match_passthrough(
     tool_ctx_kitchen_open.executor = executor
     tool_ctx_kitchen_open.recipe_name = "implementation"
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: False)
     tool_ctx_kitchen_open.config.providers = ProvidersConfig(
         model_overrides={"remediation": {"implement": "opus"}}
     )
@@ -389,7 +401,8 @@ async def test_run_skill_global_override_beats_model_overrides(
     tool_ctx_kitchen_open.executor = executor
     tool_ctx_kitchen_open.recipe_name = "implementation"
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: False)
     tool_ctx_kitchen_open.config.providers = ProvidersConfig(
         model_overrides={"implementation": {"implement": "opus"}}
     )
@@ -420,7 +433,8 @@ async def test_run_skill_no_provider_profile_injected_for_default_step(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
 
     captured: dict = {}
     original_run = executor.run
@@ -454,7 +468,8 @@ async def test_run_skill_backend_override_codex_with_anthropic_base_url(
     # Skip Codex session init: copies ~/.codex/config.toml which is absent in CI
     tool_ctx_kitchen_open.session_skill_manager = None
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
         lambda *a, **kw: (
@@ -496,7 +511,8 @@ async def test_run_skill_backend_override_none_no_anthropic_base_url(
     tool_ctx_kitchen_open.backend = fake_backend
     tool_ctx_kitchen_open.session_skill_manager = None
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
         lambda *a, **kw: ("minimax", {"BASE_URL": "https://api.minimax.chat/v1"}),
@@ -531,7 +547,8 @@ async def test_run_skill_backend_override_none_claude_code_backend(
     fake_backend.capabilities.anthropic_provider_capable = True
     tool_ctx_kitchen_open.backend = fake_backend
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
         lambda *a, **kw: (
@@ -570,7 +587,8 @@ async def test_run_skill_backend_override_none_providers_disabled(
     tool_ctx_kitchen_open.backend = fake_backend
     tool_ctx_kitchen_open.session_skill_manager = None
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: False)
 
     captured: dict = {}
     original_run = executor.run
@@ -596,7 +614,8 @@ async def test_run_skill_forwards_provider_name_matching_profile(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
         lambda *a, **kw: ("minimax", {"BASE_URL": "https://api.minimax.chat/v1"}),

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -363,7 +363,8 @@ async def test_run_skill_injects_provider_extras_when_feature_enabled(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
         lambda *a, **kw: ("vertex", {"ANTHROPIC_API_KEY": "test-key-xyz"}),
@@ -386,7 +387,8 @@ async def test_run_skill_provider_extras_none_when_feature_disabled(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: False)
 
     await run_skill("/autoskillit:probe", str(tmp_path))
 
@@ -405,7 +407,8 @@ async def test_run_skill_provider_extras_none_when_default_profile(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
         lambda *a, **kw: ("anthropic", {}),

--- a/tests/server/test_tools_execution_step_resolution.py
+++ b/tests/server/test_tools_execution_step_resolution.py
@@ -227,7 +227,8 @@ async def test_run_skill_resolves_step_provider_from_recipe_step(
     step = RecipeStep(name="run_canaries", provider="minimax")
     tool_ctx_kitchen_open.active_recipe_steps = {"run_canaries": step}
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
 
     captured_kwargs: dict = {}
 
@@ -261,7 +262,8 @@ async def test_run_skill_llm_step_provider_overrides_recipe_step(
     step = RecipeStep(name="run_canaries", provider="minimax")
     tool_ctx_kitchen_open.active_recipe_steps = {"run_canaries": step}
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
 
     captured_kwargs: dict = {}
 
@@ -297,7 +299,8 @@ async def test_run_skill_logs_warning_when_step_provider_resolved_from_recipe(
     step = RecipeStep(name="run_canaries", provider="minimax")
     tool_ctx_kitchen_open.active_recipe_steps = {"run_canaries": step}
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
         lambda *a, **kw: ("minimax", {"ANTHROPIC_BASE_URL": "https://api.minimax.chat/v1"}),

--- a/tests/server/test_tools_fleet_reset.py
+++ b/tests/server/test_tools_fleet_reset.py
@@ -74,7 +74,7 @@ def _setup_tool(tool_ctx, monkeypatch, state_path: Path) -> None:
         lambda _name: None,
     )
     monkeypatch.setattr(
-        "autoskillit.fleet.discover_campaign_state_files",
+        "autoskillit.server.tools.tools_fleet_reset.discover_campaign_state_files",
         lambda _project_dir: [state_path],
     )
 
@@ -176,7 +176,7 @@ class TestResetDispatchErrors:
             lambda _name: json.dumps({"success": False, "error": "not_fleet"}),
         )
         monkeypatch.setattr(
-            "autoskillit.fleet.discover_campaign_state_files",
+            "autoskillit.server.tools.tools_fleet_reset.discover_campaign_state_files",
             lambda _project_dir: [state_path],
         )
 
@@ -199,7 +199,7 @@ class TestResetDispatchErrors:
             lambda: json.dumps({"success": False, "error": "gate_closed"}),
         )
         monkeypatch.setattr(
-            "autoskillit.fleet.discover_campaign_state_files",
+            "autoskillit.server.tools.tools_fleet_reset.discover_campaign_state_files",
             lambda _project_dir: [state_path],
         )
 
@@ -247,7 +247,7 @@ class TestResetDispatchEdgeCases:
             lambda _name: None,
         )
         monkeypatch.setattr(
-            "autoskillit.fleet.discover_campaign_state_files",
+            "autoskillit.server.tools.tools_fleet_reset.discover_campaign_state_files",
             lambda _project_dir: [state_path],
         )
 
@@ -301,7 +301,7 @@ class TestResetDispatchEdgeCases:
             lambda _name: None,
         )
         monkeypatch.setattr(
-            "autoskillit.fleet.discover_campaign_state_files",
+            "autoskillit.server.tools.tools_fleet_reset.discover_campaign_state_files",
             lambda _project_dir: [state_path],
         )
 

--- a/tests/server/test_tools_github_provider.py
+++ b/tests/server/test_tools_github_provider.py
@@ -24,7 +24,8 @@ async def test_report_bug_forwards_provider_name_as_distinct_parameter(
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor
 
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _feat = "autoskillit.server.tools.tools_github.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
         lambda *a, **kw: ("bedrock", {"AWS_REGION": "us-east-1"}),

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -30,15 +30,15 @@ async def test_open_kitchen_warns_on_orphaned_hooks(tmp_path, monkeypatch):
     (settings_dir / "settings.json").write_text("{}")
 
     monkeypatch.setattr(
-        "autoskillit.hook_registry._claude_settings_path",
+        "autoskillit.server._misc._claude_settings_path",
         lambda scope: settings_dir / "settings.json",
     )
     monkeypatch.setattr(
-        "autoskillit.hook_registry._count_hook_registry_drift",
+        "autoskillit.server._misc._count_hook_registry_drift",
         lambda _: HookDriftResult(missing=0, orphaned=1),
     )
     monkeypatch.setattr(
-        "autoskillit.hook_registry.find_broken_hook_scripts",
+        "autoskillit.server._misc.find_broken_hook_scripts",
         lambda _: [],
     )
 
@@ -73,15 +73,15 @@ async def test_open_kitchen_warns_on_missing_hook_scripts(tmp_path, monkeypatch)
     (settings_dir / "settings.json").write_text("{}")
 
     monkeypatch.setattr(
-        "autoskillit.hook_registry._claude_settings_path",
+        "autoskillit.server._misc._claude_settings_path",
         lambda scope: settings_dir / "settings.json",
     )
     monkeypatch.setattr(
-        "autoskillit.hook_registry.find_broken_hook_scripts",
+        "autoskillit.server._misc.find_broken_hook_scripts",
         lambda _: ["python3 /missing/status_health_guard.py"],
     )
     monkeypatch.setattr(
-        "autoskillit.hook_registry._count_hook_registry_drift",
+        "autoskillit.server._misc._count_hook_registry_drift",
         lambda _: HookDriftResult(missing=0, orphaned=0),
     )
 
@@ -118,12 +118,12 @@ async def test_build_hook_diagnostic_warning_skips_missing_when_plugin_active(
     (settings_dir / "settings.json").write_text('{"hooks": {}}')
 
     monkeypatch.setattr(
-        "autoskillit.hook_registry._claude_settings_path",
+        "autoskillit.server._misc._claude_settings_path",
         lambda scope: settings_dir / "settings.json",
     )
-    monkeypatch.setattr("autoskillit.hook_registry.validate_plugin_cache_hooks", lambda **_: [])
+    monkeypatch.setattr("autoskillit.server._misc.validate_plugin_cache_hooks", lambda **_: [])
     monkeypatch.setattr(
-        "autoskillit.core.detect_autoskillit_mcp_prefix", lambda: MARKETPLACE_PREFIX
+        "autoskillit.server._misc.detect_autoskillit_mcp_prefix", lambda: MARKETPLACE_PREFIX
     )
 
     from autoskillit.server._misc import _build_hook_diagnostic_warning
@@ -146,17 +146,17 @@ async def test_build_hook_diagnostic_warning_orphaned_still_fires_when_plugin_ac
     (settings_dir / "settings.json").write_text('{"hooks": {}}')
 
     monkeypatch.setattr(
-        "autoskillit.hook_registry._claude_settings_path",
+        "autoskillit.server._misc._claude_settings_path",
         lambda scope: settings_dir / "settings.json",
     )
     monkeypatch.setattr(
-        "autoskillit.hook_registry._count_hook_registry_drift",
+        "autoskillit.server._misc._count_hook_registry_drift",
         lambda _: HookDriftResult(missing=0, orphaned=1),
     )
-    monkeypatch.setattr("autoskillit.hook_registry.find_broken_hook_scripts", lambda _: [])
-    monkeypatch.setattr("autoskillit.hook_registry.validate_plugin_cache_hooks", lambda **_: [])
+    monkeypatch.setattr("autoskillit.server._misc.find_broken_hook_scripts", lambda _: [])
+    monkeypatch.setattr("autoskillit.server._misc.validate_plugin_cache_hooks", lambda **_: [])
     monkeypatch.setattr(
-        "autoskillit.core.detect_autoskillit_mcp_prefix", lambda: MARKETPLACE_PREFIX
+        "autoskillit.server._misc.detect_autoskillit_mcp_prefix", lambda: MARKETPLACE_PREFIX
     )
 
     from autoskillit.server._misc import _build_hook_diagnostic_warning

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -412,7 +412,7 @@ class TestApplyTriageGate:
         mock_triage = AsyncMock(
             return_value=[{"meaningful": False, "summary": "ok", "skill": "investigate"}]
         )
-        with patch("autoskillit._llm_triage.triage_staleness", mock_triage):
+        with patch("autoskillit.server._misc.triage_staleness", mock_triage):
             # First call: triage_staleness invoked once
             await _apply_triage_gate(copy.deepcopy(result_template), name, recipe_info=recipe_info)
 
@@ -424,7 +424,7 @@ class TestApplyTriageGate:
         assert cached is not None
         assert cached.triage_result == "cosmetic"
 
-        with patch("autoskillit._llm_triage.triage_staleness", mock_triage):
+        with patch("autoskillit.server._misc.triage_staleness", mock_triage):
             # Second call: must read from cache and skip triage_staleness entirely
             await _apply_triage_gate(copy.deepcopy(result_template), name, recipe_info=recipe_info)
 

--- a/tests/server/test_tools_report_bug.py
+++ b/tests/server/test_tools_report_bug.py
@@ -718,7 +718,8 @@ async def test_report_bug_model_as_profile_resolves_provider(
     tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
     tool_ctx_kitchen_open.config.report_bug.github_filing = False
 
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _is_feat = "autoskillit.server.tools.tools_github.is_feature_enabled"
+    monkeypatch.setattr(_is_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_model_as_profile",
         lambda *a: (
@@ -753,7 +754,8 @@ async def test_report_bug_model_as_profile_disabled_when_feature_off(
     tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
     tool_ctx_kitchen_open.config.report_bug.github_filing = False
 
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+    _is_feat = "autoskillit.server.tools.tools_github.is_feature_enabled"
+    monkeypatch.setattr(_is_feat, lambda *a, **kw: False)
 
     mock_executor = AsyncMock()
     mock_executor.run.return_value = _skill_ok("report text")
@@ -781,7 +783,8 @@ async def test_report_bug_config_model_as_profile(tool_ctx_kitchen_open, tmp_pat
         map_calls.append(model_value)
         return ("MiniMax-M2.7", "minimax", {"ANTHROPIC_BASE_URL": "https://api.minimax.chat/v1"})
 
-    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    _is_feat = "autoskillit.server.tools.tools_github.is_feature_enabled"
+    monkeypatch.setattr(_is_feat, lambda *a, **kw: True)
     monkeypatch.setattr("autoskillit.server._guards._resolve_model_as_profile", fake_resolve)
 
     mock_executor = AsyncMock()


### PR DESCRIPTION
## Summary

The MCP server uses `lazy_loader.attach_stub()` to freeze `autoskillit.core`'s symbol map at first import. During a hot-upgrade (`uv tool install`), deferred cross-layer imports inside function bodies load new code against the frozen map, causing `ImportError` when new symbols are referenced (the bug site: `run_python` → `_execution_helpers` → `core.RUN_PYTHON_SENTINEL_KEYS`).

Fix: hoist all cross-layer deferred imports (IL-3 → IL-0/IL-1/IL-2 and package-root modules) to module level so they bind at startup before the symbol map freezes. Also hoist the specific bug-site same-layer import (`_execution_helpers` in `tools_execution.py`, which is IL-3 → IL-3 but triggers the failure chain because `_execution_helpers` internally imports from core). Intra-server deferred imports (`autoskillit.server.*`) that break genuine circular dependencies remain deferred with `# circular-break` tags — these are explicitly preserved.

source files, ~65 cross-layer import sites + 1 same-layer bug-site import. Lower layers never import `server/`, so all cross-layer hoists are guaranteed cycle-free. The `_execution_helpers` hoist is safe because `_execution_helpers.py` imports only from `autoskillit.core` (no back-reference to `tools_execution.py`).

**Constraint: preserve all intra-server `# circular-break` tags.** The existing `test_il3_deferred_autoskillit_imports_tagged` (line 523 of `test_layer_enforcement.py`) requires that every remaining deferred `autoskillit.*` import carries `# circular-break`. When removing cross-layer deferred imports from function bodies, do NOT alter any intra-server deferred imports or their tags. Every `from autoskillit.server import ...  # circular-break` line that stays deferred must keep its tag exactly as-is.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260601-122510-057889/.autoskillit/temp/make-plan/hoist_cross_layer_deferred_imports_plan_2026-06-01_140000.md`

Closes #3501

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 83 | 28.6k | 3.2M | 129.6k | 81 | 113.2k | 26m 7s |
| review_approach* | opus[1m] | 1 | 35 | 6.1k | 276.6k | 45.1k | 16 | 31.8k | 3m 32s |
| dry_walkthrough* | opus | 2 | 124 | 34.9k | 3.3M | 80.3k | 96 | 122.9k | 21m 33s |
| implement* | opus[1m] | 2 | 279 | 75.4k | 13.9M | 174.6k | 283 | 389.8k | 33m 21s |
| audit_impl* | opus[1m] | 2 | 82 | 23.7k | 750.3k | 74.0k | 46 | 106.8k | 19m 18s |
| make_plan* | opus[1m] | 1 | 782 | 51.8k | 1.2M | 135.7k | 43 | 236.6k | 21m 14s |
| prepare_pr* | MiniMax-M3 | 1 | 163.6k | 3.2k | 88.4k | 49.5k | 15 | 0 | 1m 15s |
| compose_pr* | MiniMax-M3 | 1 | 69.2k | 1.4k | 157.4k | 39.3k | 13 | 0 | 48s |
| review_pr* | opus[1m] | 1 | 48 | 23.5k | 1.5M | 136.4k | 43 | 238.4k | 11m 32s |
| resolve_review* | opus[1m] | 1 | 887 | 15.8k | 2.4M | 87.3k | 69 | 71.3k | 9m 13s |
| resolve_pre_review_conflicts* | opus[1m] | 1 | 54 | 13.9k | 2.3M | 83.6k | 76 | 67.4k | 5m 3s |
| ci_conflict_fix* | opus[1m] | 2 | 76 | 9.1k | 1.6M | 49.2k | 77 | 61.7k | 3m 20s |
| diagnose_ci* | MiniMax-M3 | 1 | 107.7k | 2.5k | 377.7k | 39.4k | 27 | 0 | 1m 39s |
| resolve_ci* | opus[1m] | 1 | 53 | 11.8k | 1.7M | 92.2k | 55 | 75.6k | 12m 4s |
| **Total** | | | 343.0k | 301.6k | 32.9M | 174.6k | | 1.5M | 2h 50m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 1272 | 10932.7 | 306.5 | 59.3 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 34 | 72015.3 | 2097.8 | 463.4 |
| resolve_pre_review_conflicts | 1413 | 1663.0 | 47.7 | 9.9 |
| ci_conflict_fix | 892 | 1820.8 | 69.2 | 10.2 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 58 | 28700.5 | 1303.0 | 203.4 |
| **Total** | **3669** | 8977.6 | 413.1 | 82.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 10 | 2.4k | 259.6k | 29.0M | 1.4M | 2h 24m |
| opus | 1 | 124 | 34.9k | 3.3M | 122.9k | 21m 33s |
| MiniMax-M3 | 3 | 340.5k | 7.1k | 623.5k | 0 | 3m 42s |