### PR TITLE
Implementation Plan: P2-A7-WP1 — Update recipe/_analysis_detectors.py

### DIFF
--- a/scripts/recipe/create_worktree.sh
+++ b/scripts/recipe/create_worktree.sh
@@ -68,8 +68,8 @@ fi
 
 if [ -n "${VIS_TRACE_PATH}" ] && [ -f "${VIS_TRACE_PATH}" ]; then
     cp "${VIS_TRACE_PATH}" "${AUDIT_DIR}/visualization-plan-trace.md"
-elif [ -f "${SRC_TEMP}/plan-visualization/visualization-plan-trace.md" ]; then
-    cp "${SRC_TEMP}/plan-visualization/visualization-plan-trace.md" "${AUDIT_DIR}/visualization-plan-trace.md"
+elif [ -f "${SRC_TEMP}/synthesize-vis-plan/visualization-plan-trace.md" ]; then
+    cp "${SRC_TEMP}/synthesize-vis-plan/visualization-plan-trace.md" "${AUDIT_DIR}/visualization-plan-trace.md"
 fi
 
 cd "${RESOLVED}" && git add research/ && git commit -m "Add experiment plan and scope to research/"

--- a/src/autoskillit/recipe/_analysis_detectors.py
+++ b/src/autoskillit/recipe/_analysis_detectors.py
@@ -122,10 +122,10 @@ _OBSERVABILITY_CAPTURES: frozenset[tuple[str, str]] = frozenset(
         ("download_report", "download-data"),
         ("alignment_findings_path", "planner-validate-task-alignment"),
         ("review_approach_assessment_path", "planner-assess-review-approach"),
-        # plan-visualization terminal handoff captures: emitted in food-truck sentinel,
+        # synthesize-vis-plan terminal handoff captures: emitted in food-truck sentinel,
         # not consumed by downstream recipe steps (route → stop action).
-        ("visualization_plan_path", "plan-visualization"),
-        ("report_plan_path", "plan-visualization"),
+        ("visualization_plan_path", "synthesize-vis-plan"),
+        ("report_plan_path", "synthesize-vis-plan"),
     }
 )
 

--- a/src/autoskillit/recipes/scripts/create_worktree.sh
+++ b/src/autoskillit/recipes/scripts/create_worktree.sh
@@ -76,8 +76,8 @@ fi
 
 if [ -n "${VIS_TRACE_PATH}" ] && [ -f "${VIS_TRACE_PATH}" ]; then
     cp "${VIS_TRACE_PATH}" "${AUDIT_DIR}/visualization-plan-trace.md"
-elif [ -f "${SRC_TEMP}/plan-visualization/visualization-plan-trace.md" ]; then
-    cp "${SRC_TEMP}/plan-visualization/visualization-plan-trace.md" "${AUDIT_DIR}/visualization-plan-trace.md"
+elif [ -f "${SRC_TEMP}/synthesize-vis-plan/visualization-plan-trace.md" ]; then
+    cp "${SRC_TEMP}/synthesize-vis-plan/visualization-plan-trace.md" "${AUDIT_DIR}/visualization-plan-trace.md"
 fi
 
 cd "${RESOLVED}" && git add research/ && git commit -m "Add experiment plan and scope to research/"

--- a/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
@@ -174,7 +174,7 @@ requires_decision: false
 ```
 
 3. **Write** the advisory to `visualization-plan-trace.md` in the output directory
-   (`{{AUTOSKILLIT_TEMP}}/plan-visualization/visualization-plan-trace.md`), appended
+   (`{{AUTOSKILLIT_TEMP}}/synthesize-vis-plan/visualization-plan-trace.md`), appended
    after any existing Tier-C routing metadata
 4. **Also write** the advisory into the vis_spec output file
    (`{{AUTOSKILLIT_TEMP}}/vis-lens-methodology-norms/vis_spec_methodology_norms_{timestamp}.md`)
@@ -426,7 +426,7 @@ Before creating the diagram, verify:
 
 ## Related Skills
 
-- `/autoskillit:plan-visualization` - Parent skill for lens selection
+- `/autoskillit:synthesize-vis-plan` - Parent skill for lens selection
 - `/autoskillit:mermaid` - MUST BE LOADED before creating diagram
 - `/autoskillit:vis-lens-multi-compare` - For multi-condition comparison layouts
 - `/autoskillit:vis-lens-reproducibility` - For reproducibility and data provenance checks

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -206,6 +206,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_validator_structural.py` | Tests for recipe validator structural analysis |
 
 | `test_audit_impl_defaults.py` | Contract test: implementation.yaml and remediation.yaml must default inputs.audit_impl to 'true' |
+| `test_analysis_detectors_rename.py` | Tests for plan-visualization → synthesize-vis-plan rename in _OBSERVABILITY_CAPTURES |
 | `test_false_positive_escape_valve.py` | Tests for false-positive escape valve routing in recipes that invoke make-plan |
 ## Architecture Notes
 

--- a/tests/recipe/test_analysis_detectors_rename.py
+++ b/tests/recipe/test_analysis_detectors_rename.py
@@ -1,0 +1,20 @@
+"""Verify plan-visualization → synthesize-vis-plan rename in _OBSERVABILITY_CAPTURES."""
+
+import pytest
+
+from autoskillit.recipe._analysis_detectors import _OBSERVABILITY_CAPTURES
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def test_observability_captures_uses_synthesize_vis_plan():
+    """synthesize-vis-plan fragment replaces plan-visualization."""
+    fragments = {frag for _, frag in _OBSERVABILITY_CAPTURES}
+    assert "synthesize-vis-plan" in fragments
+    assert "plan-visualization" not in fragments
+
+
+def test_observability_captures_vis_plan_tuples():
+    """Both visualization_plan_path and report_plan_path map to synthesize-vis-plan."""
+    assert ("visualization_plan_path", "synthesize-vis-plan") in _OBSERVABILITY_CAPTURES
+    assert ("report_plan_path", "synthesize-vis-plan") in _OBSERVABILITY_CAPTURES

--- a/tests/recipe/test_audit_trail_artifacts.py
+++ b/tests/recipe/test_audit_trail_artifacts.py
@@ -15,7 +15,7 @@ def test_create_worktree_creates_audit_directory(tmp_path: Path):
     dashboard = temp_dir / "evaluation_dashboard_test_2026-05-07_120000.md"
     dashboard.write_text("# Evaluation Dashboard\nverdict: GO\n")
 
-    vis_dir = tmp_path / "temp" / "plan-visualization"
+    vis_dir = tmp_path / "temp" / "synthesize-vis-plan"
     vis_dir.mkdir(parents=True)
     trace = vis_dir / "visualization-plan-trace.md"
     trace.write_text("# Visualization Plan Trace\nprimary_tradition: controlled_intervention\n")
@@ -49,7 +49,7 @@ def test_audit_dashboard_copied_to_audit_dir(tmp_path: Path):
 
 def test_visualization_trace_copied_to_audit_dir(tmp_path: Path):
     """visualization-plan-trace.md is copied to audit/ with content preserved."""
-    vis_dir = tmp_path / "temp" / "plan-visualization"
+    vis_dir = tmp_path / "temp" / "synthesize-vis-plan"
     vis_dir.mkdir(parents=True)
     trace = vis_dir / "visualization-plan-trace.md"
     trace.write_text("# Visualization Plan Trace\nprimary_tradition: controlled_intervention\n")


### PR DESCRIPTION
## Summary

Replace all `plan-visualization` references with `synthesize-vis-plan` in three source files plus one additional script copy found by registry trace, as part of the broader skill rename. The touch points are: the `_OBSERVABILITY_CAPTURES` frozenset in `_analysis_detectors.py` (comment + two tuple entries), the fallback artifact path in both copies of `create_worktree.sh`, and the output directory reference plus related-skills entry in `vis-lens-methodology-norms/SKILL.md`.

**Sequencing prerequisite:** This WP declares a dependency on P2-A2-WP1 (per the issue). The `_is_observability_capture()` function matches by checking if the fragment string is a substring of the step's `skill_command`. Currently, `research.yaml:189` and `research-design.yaml:132` still set `skill_command: "/autoskillit:plan-visualization"`. After this WP changes the fragment to `"synthesize-vis-plan"`, the substring check `"synthesize-vis-plan" in "/autoskillit:plan-visualization"` will return `False`, causing `visualization_plan_path` and `report_plan_path` to appear as dead-output violations. P2-A2-WP1 must update the recipe YAML files to use `/autoskillit:synthesize-vis-plan` **before** this WP is applied, or the two must merge atomically.

Closes #3090

## Implementation Plan

Plan file: `/tmp/autoskillit-runs/impl-20260601-160914-324395/.autoskillit/temp/make-plan/p2_a7_wp1_update_analysis_detectors_plan_2026-06-01_161600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 71 | 18.8k | 939.6k | 79.4k | 38 | 66.9k | 10m 13s |
| verify* | sonnet | 1 | 825 | 5.5k | 265.9k | 41.5k | 24 | 25.1k | 1m 55s |
| implement* | MiniMax-M3 | 1 | 124.0k | 5.3k | 2.2M | 56.6k | 67 | 0 | 4m 30s |
| audit_impl* | sonnet | 1 | 36 | 2.6k | 107.6k | 35.1k | 8 | 22.1k | 1m 36s |
| prepare_pr* | MiniMax-M3 | 1 | 81.4k | 2.2k | 156.1k | 44.8k | 14 | 0 | 1m 5s |
| compose_pr* | MiniMax-M3 | 1 | 74.8k | 1.7k | 150.0k | 39.4k | 14 | 0 | 53s |
| review_pr* | sonnet | 3 | 538 | 82.8k | 3.1M | 74.5k | 162 | 166.5k | 18m 4s |
| ci_conflict_fix* | opus | 1 | 33 | 4.0k | 597.8k | 50.8k | 33 | 34.3k | 1m 55s |
| **Total** | | | 281.7k | 122.9k | 7.6M | 79.4k | | 314.8k | 40m 13s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 43 | 51610.4 | 0.0 | 122.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| ci_conflict_fix | 1424 | 419.8 | 24.1 | 2.8 |
| **Total** | **1467** | 5167.3 | 214.6 | 83.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 71 | 18.8k | 939.6k | 66.9k | 10m 13s |
| sonnet | 3 | 1.4k | 90.9k | 3.5M | 213.6k | 21m 35s |
| MiniMax-M3 | 3 | 280.2k | 9.2k | 2.5M | 0 | 6m 28s |
| opus | 1 | 33 | 4.0k | 597.8k | 34.3k | 1m 55s |