### PR TITLE
Implementation Plan: P2-A5-WP1 — Decompose research-design.yaml

### DIFF
--- a/src/autoskillit/recipe/_analysis_detectors.py
+++ b/src/autoskillit/recipe/_analysis_detectors.py
@@ -189,6 +189,12 @@ def _detect_dead_outputs(recipe: Recipe, graph: dict[str, set[str]]) -> list[Dat
                 for cond in reachable_step.on_result.conditions:
                     if cond.when and isinstance(cond.when, str):
                         consumed.update(_CONTEXT_REF_RE.findall(cond.when))
+            # optional_context_refs declares that a step may receive and use these
+            # context variables even when they are not expressed via ${{ context.X }}
+            # template syntax (e.g., phoropter steps that consume captures via engine
+            # template expansion like {slug} or {context_path}).
+            if reachable_step.optional_context_refs:
+                consumed.update(reachable_step.optional_context_refs)
 
         # on_result routing — both legacy field and predicate conditions count
         # as structural consumption of captured variables.

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1971,8 +1971,9 @@ skills:
     - name: methodology_tradition
       type: string
     expected_output_patterns:
-    - "selected_lenses[ \\t]*=[ \\t]*.+"
-    - "lens_context_paths[ \\t]*=[ \\t]*.+"
+    - "selected_lenses[ \\t]*=[ \\t]*(\\S[^\\n]*)"
+    - "lens_context_paths[ \\t]*=[ \\t]*(\\S[^\\n]*)"
+    - "%%ORDER_UP"
     pattern_examples:
     - "selected_lenses = always-on chart-select\nlens_context_paths = /tmp/always-on.md /tmp/chart-select.md\ndisambiguation_rule_applied = null\ntier_c_lens = null\nmethodology_tradition = null\n%%ORDER_UP%%"
     write_behavior: always
@@ -1990,6 +1991,7 @@ skills:
     - "visualization_plan_path[ \\t]*=[ \\t]*/.+"
     - "report_plan_path[ \\t]*=[ \\t]*/.+"
     - "visualization_plan_trace_path[ \\t]*=[ \\t]*/.+"
+    - "%%ORDER_UP"
     pattern_examples:
     - "visualization_plan_path = /tmp/vis-plan.md\nreport_plan_path = /tmp/report-plan.md\nvisualization_plan_trace_path = /tmp/trace.md\n%%ORDER_UP%%"
     write_behavior: always

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1947,6 +1947,53 @@ skills:
     - "diagram_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
+
+  select-vis-lenses:
+    inputs:
+    - name: source_dir
+      type: string
+      required: true
+    - name: experiment_plan_path
+      type: file_path
+      required: true
+    - name: scope_report_path
+      type: file_path
+      required: true
+    outputs:
+    - name: selected_lenses
+      type: string
+    - name: lens_context_paths
+      type: string
+    - name: disambiguation_rule_applied
+      type: string
+    - name: tier_c_lens
+      type: string
+    - name: methodology_tradition
+      type: string
+    expected_output_patterns:
+    - "selected_lenses[ \\t]*=[ \\t]*.+"
+    - "lens_context_paths[ \\t]*=[ \\t]*.+"
+    pattern_examples:
+    - "selected_lenses = always-on chart-select\nlens_context_paths = /tmp/always-on.md /tmp/chart-select.md\ndisambiguation_rule_applied = null\ntier_c_lens = null\nmethodology_tradition = null\n%%ORDER_UP%%"
+    write_behavior: always
+
+  synthesize-vis-plan:
+    inputs: []
+    outputs:
+    - name: visualization_plan_path
+      type: file_path
+    - name: report_plan_path
+      type: file_path
+    - name: visualization_plan_trace_path
+      type: file_path
+    expected_output_patterns:
+    - "visualization_plan_path[ \\t]*=[ \\t]*/.+"
+    - "report_plan_path[ \\t]*=[ \\t]*/.+"
+    - "visualization_plan_trace_path[ \\t]*=[ \\t]*/.+"
+    pattern_examples:
+    - "visualization_plan_path = /tmp/vis-plan.md\nreport_plan_path = /tmp/report-plan.md\nvisualization_plan_trace_path = /tmp/trace.md\n%%ORDER_UP%%"
+    write_behavior: always
+
   build-execution-map:
     inputs: []
     outputs:

--- a/src/autoskillit/recipes/research-design.json
+++ b/src/autoskillit/recipes/research-design.json
@@ -11,7 +11,7 @@
   ],
   "description": "Scope a research question and plan the experiment question, plans an experiment, optionally reviews the design (bounded by check_design_review_loop, max 3 iterations), plans visualizations, then terminates with a cross-dispatch handoff sentinel containing the design artifacts. Dispatched as a food truck by campaign recipes that separate design from execution.\n",
   "dispatch_only": true,
-  "summary": "scope > plan > [review?] > visualize > design_complete",
+  "summary": "scope > plan > [review?] > dial > apply > synthesize > design_complete",
   "ingredients": {
     "task": {
       "description": "Research question or topic to investigate",
@@ -28,7 +28,7 @@
       "authority": "config"
     },
     "review_design": {
-      "description": "When 'true' (the default), run the review-design skill after plan_experiment to validate the experiment plan before execution. Emits a verdict: GO proceeds, REVISE loops back to plan_experiment with revision guidance (bounded by check_design_review_loop at 3 iterations), STOP triggers resolve_design_review for triage — addressable findings loop back, structural findings halt the pipeline. When 'false', skip directly to plan_visualization.\n",
+      "description": "When 'true' (the default), run the review-design skill after plan_experiment to validate the experiment plan before execution. Emits a verdict: GO proceeds, REVISE loops back to plan_experiment with revision guidance (bounded by check_design_review_loop at 3 iterations), STOP triggers resolve_design_review for triage — addressable findings loop back, structural findings halt the pipeline. When 'false', skip directly to dial.\n",
       "default": "true"
     },
     "issue_url": {
@@ -115,13 +115,13 @@
       ],
       "skip_when_false": "inputs.review_design",
       "retries": 2,
-      "on_exhausted": "plan_visualization",
-      "on_context_limit": "plan_visualization",
-      "on_failure": "plan_visualization",
+      "on_exhausted": "dial",
+      "on_context_limit": "dial",
+      "on_failure": "dial",
       "on_result": [
         {
           "when": "${{ result.verdict }} == GO",
-          "route": "plan_visualization"
+          "route": "dial"
         },
         {
           "when": "${{ result.verdict }} == REVISE",
@@ -132,18 +132,53 @@
           "route": "resolve_design_review"
         },
         {
-          "route": "plan_visualization"
+          "route": "dial"
         }
       ]
     },
-    "plan_visualization": {
+    "dial": {
       "tool": "run_skill",
       "model": "",
+      "phoropter_family": "vis-lens",
       "with": {
-        "skill_command": "/autoskillit:plan-visualization ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}",
+        "skill_command": "/autoskillit:select-vis-lenses ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}",
         "cwd": "${{ inputs.source_dir }}",
-        "step_name": "plan_visualization",
-        "output_dir": "{{AUTOSKILLIT_TEMP}}/plan-visualization"
+        "step_name": "dial",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/dial"
+      },
+      "capture": {
+        "selected_lenses": "${{ result.selected_lenses }}",
+        "lens_context_paths": "${{ result.lens_context_paths }}"
+      },
+      "on_success": "apply",
+      "on_failure": "escalate_stop"
+    },
+    "apply": {
+      "tool": "run_skill",
+      "model": "",
+      "phoropter_family": "vis-lens",
+      "with": {
+        "skill_command": "/autoskillit:vis-lens-{slug} {context_path} ${{ context.experiment_plan }}",
+        "cwd": "${{ inputs.source_dir }}",
+        "step_name": "apply",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/apply"
+      },
+      "capture_list": {
+        "all_figure_spec_paths": "${{ result.figure_spec_path }}"
+      },
+      "retries": 0,
+      "on_success": "synthesize",
+      "on_failure": "synthesize"
+    },
+    "synthesize": {
+      "tool": "run_skill",
+      "model": "",
+      "phoropter_family": "vis-lens",
+      "with": {
+        "skill_command": "/autoskillit:synthesize-vis-plan",
+        "cwd": "${{ inputs.source_dir }}",
+        "step_name": "synthesize",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/synthesize"
       },
       "capture": {
         "visualization_plan_path": "${{ result.visualization_plan_path }}",
@@ -151,8 +186,7 @@
         "visualization_plan_trace_path": "${{ result.visualization_plan_trace_path }}"
       },
       "on_success": "create_worktree",
-      "on_failure": "escalate_stop",
-      "note": "Selects 2–4 vis-lens skills via three-tier logic, runs them in parallel, and synthesizes outputs into visualization-plan.md and report-plan.md. Runs before worktree creation so outputs can be committed into the research dir.\n"
+      "on_failure": "escalate_stop"
     },
     "revise_design": {
       "action": "route",
@@ -175,17 +209,17 @@
       "on_result": [
         {
           "when": "${{ result.max_exceeded }} == true",
-          "route": "plan_visualization"
+          "route": "dial"
         },
         {
           "route": "plan_experiment"
         }
       ],
-      "on_failure": "plan_visualization",
+      "on_failure": "dial",
       "optional_context_refs": [
         "design_review_count"
       ],
-      "note": "Iteration guard for the review_design → revise_design → plan_experiment cycle. Caps design revision loops at 3 iterations. Both REVISE and STOP→resolve→revised paths flow through revise_design and hit this guard. On exhaustion, proceeds to plan_visualization with the best available design.\n"
+      "note": "Iteration guard for the review_design → revise_design → plan_experiment cycle. Caps design revision loops at 3 iterations. Both REVISE and STOP→resolve→revised paths flow through revise_design and hit this guard. On exhaustion, proceeds to dial with the best available design.\n"
     },
     "resolve_design_review": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/research-design.json
+++ b/src/autoskillit/recipes/research-design.json
@@ -166,6 +166,10 @@
       "capture_list": {
         "all_figure_spec_paths": "${{ result.figure_spec_path }}"
       },
+      "optional_context_refs": [
+        "selected_lenses",
+        "lens_context_paths"
+      ],
       "retries": 0,
       "on_success": "synthesize",
       "on_failure": "synthesize"

--- a/src/autoskillit/recipes/research-design.yaml
+++ b/src/autoskillit/recipes/research-design.yaml
@@ -151,6 +151,7 @@ steps:
       output_dir: "{{AUTOSKILLIT_TEMP}}/apply"
     capture_list:
       all_figure_spec_paths: "${{ result.figure_spec_path }}"
+    optional_context_refs: [selected_lenses, lens_context_paths]
     retries: 0
     on_success: synthesize
     on_failure: synthesize

--- a/src/autoskillit/recipes/research-design.yaml
+++ b/src/autoskillit/recipes/research-design.yaml
@@ -11,7 +11,7 @@ description: >
   artifacts. Dispatched as a food truck by campaign recipes that separate
   design from execution.
 dispatch_only: true
-summary: scope > plan > [review?] > visualize > design_complete
+summary: scope > plan > [review?] > dial > apply > synthesize > design_complete
 
 ingredients:
   task:
@@ -32,7 +32,7 @@ ingredients:
       REVISE loops back to plan_experiment with revision guidance (bounded by
       check_design_review_loop at 3 iterations), STOP triggers resolve_design_review
       for triage — addressable findings loop back, structural findings halt the
-      pipeline. When 'false', skip directly to plan_visualization.
+      pipeline. When 'false', skip directly to dial.
     default: "true"
   issue_url:
     description: >
@@ -113,36 +113,63 @@ steps:
     pass_through: [experiment_type]
     skip_when_false: inputs.review_design
     retries: 2
-    on_exhausted: plan_visualization
-    on_context_limit: plan_visualization
-    on_failure: plan_visualization
+    on_exhausted: dial
+    on_context_limit: dial
+    on_failure: dial
     on_result:
     - when: "${{ result.verdict }} == GO"
-      route: plan_visualization
+      route: dial
     - when: "${{ result.verdict }} == REVISE"
       route: revise_design
     - when: "${{ result.verdict }} == STOP"
       route: resolve_design_review
-    - route: plan_visualization
+    - route: dial
 
-  plan_visualization:
+  dial:
     tool: run_skill
     model: ""
+    phoropter_family: vis-lens
     with:
-      skill_command: "/autoskillit:plan-visualization ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}"
+      skill_command: "/autoskillit:select-vis-lenses ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}"
       cwd: "${{ inputs.source_dir }}"
-      step_name: plan_visualization
-      output_dir: "{{AUTOSKILLIT_TEMP}}/plan-visualization"
+      step_name: dial
+      output_dir: "{{AUTOSKILLIT_TEMP}}/dial"
+    capture:
+      selected_lenses: "${{ result.selected_lenses }}"
+      lens_context_paths: "${{ result.lens_context_paths }}"
+    on_success: apply
+    on_failure: escalate_stop
+
+  apply:
+    tool: run_skill
+    model: ""
+    phoropter_family: vis-lens
+    with:
+      skill_command: "/autoskillit:vis-lens-{slug} {context_path} ${{ context.experiment_plan }}"
+      cwd: "${{ inputs.source_dir }}"
+      step_name: apply
+      output_dir: "{{AUTOSKILLIT_TEMP}}/apply"
+    capture_list:
+      all_figure_spec_paths: "${{ result.figure_spec_path }}"
+    retries: 0
+    on_success: synthesize
+    on_failure: synthesize
+
+  synthesize:
+    tool: run_skill
+    model: ""
+    phoropter_family: vis-lens
+    with:
+      skill_command: "/autoskillit:synthesize-vis-plan"
+      cwd: "${{ inputs.source_dir }}"
+      step_name: synthesize
+      output_dir: "{{AUTOSKILLIT_TEMP}}/synthesize"
     capture:
       visualization_plan_path: "${{ result.visualization_plan_path }}"
       report_plan_path: "${{ result.report_plan_path }}"
       visualization_plan_trace_path: "${{ result.visualization_plan_trace_path }}"
     on_success: create_worktree
     on_failure: escalate_stop
-    note: >
-      Selects 2–4 vis-lens skills via three-tier logic, runs them in parallel, and
-      synthesizes outputs into visualization-plan.md and report-plan.md.
-      Runs before worktree creation so outputs can be committed into the research dir.
 
   revise_design:
     action: route
@@ -159,16 +186,16 @@ steps:
       design_review_count: "${{ result.next_iteration }}"
     on_result:
     - when: "${{ result.max_exceeded }} == true"
-      route: plan_visualization
+      route: dial
     - route: plan_experiment
-    on_failure: plan_visualization
+    on_failure: dial
     optional_context_refs:
     - design_review_count
     note: >
       Iteration guard for the review_design → revise_design → plan_experiment cycle.
       Caps design revision loops at 3 iterations. Both REVISE and
       STOP→resolve→revised paths flow through revise_design and hit this guard.
-      On exhaustion, proceeds to plan_visualization with the best available design.
+      On exhaustion, proceeds to dial with the best available design.
 
   resolve_design_review:
     tool: run_skill

--- a/tests/recipe/test_bundled_recipes_research_design.py
+++ b/tests/recipe/test_bundled_recipes_research_design.py
@@ -58,7 +58,7 @@ class TestResearchDesignRecipeStructure:
         assert recipe.ingredients["issue_url"].required is False
 
     def test_step_count(self, recipe) -> None:
-        assert len(recipe.steps) == 12
+        assert len(recipe.steps) == 14
 
     def test_step_names(self, recipe) -> None:
         expected = {
@@ -66,7 +66,9 @@ class TestResearchDesignRecipeStructure:
             "select_directions",
             "plan_experiment",
             "review_design",
-            "plan_visualization",
+            "dial",
+            "apply",
+            "synthesize",
             "create_worktree",
             "revise_design",
             "check_design_review_loop",
@@ -108,20 +110,20 @@ class TestResearchDesignRecipeStructure:
         assert recipe.steps["review_design"].retries == 2
 
     def test_review_design_on_exhausted(self, recipe) -> None:
-        assert recipe.steps["review_design"].on_exhausted == "plan_visualization"
+        assert recipe.steps["review_design"].on_exhausted == "dial"
 
     def test_review_design_on_context_limit(self, recipe) -> None:
-        assert recipe.steps["review_design"].on_context_limit == "plan_visualization"
+        assert recipe.steps["review_design"].on_context_limit == "dial"
 
     def test_review_design_on_failure(self, recipe) -> None:
-        assert recipe.steps["review_design"].on_failure == "plan_visualization"
+        assert recipe.steps["review_design"].on_failure == "dial"
 
     def test_review_design_on_result_go(self, recipe) -> None:
         step = recipe.steps["review_design"]
         assert step.on_result is not None
         go_cond = next((c for c in step.on_result.conditions if c.when and "GO" in c.when), None)
         assert go_cond is not None, "Missing GO route"
-        assert go_cond.route == "plan_visualization"
+        assert go_cond.route == "dial"
 
     def test_review_design_on_result_revise(self, recipe) -> None:
         step = recipe.steps["review_design"]
@@ -146,7 +148,7 @@ class TestResearchDesignRecipeStructure:
         assert step.on_result is not None
         fallback = next((c for c in step.on_result.conditions if c.when is None), None)
         assert fallback is not None, "Missing fallback route"
-        assert fallback.route == "plan_visualization"
+        assert fallback.route == "dial"
 
     def test_review_design_no_on_success(self, recipe) -> None:
         assert recipe.steps["review_design"].on_success is None
@@ -162,16 +164,52 @@ class TestResearchDesignRecipeStructure:
         cmd = step.with_args["skill_command"]
         assert "${{ context.scope_report }}" in cmd
 
-    def test_plan_visualization_on_success(self, recipe) -> None:
-        assert recipe.steps["plan_visualization"].on_success == "create_worktree"
+    def test_dial_phoropter_family(self, recipe) -> None:
+        assert recipe.steps["dial"].phoropter_family == "vis-lens"
 
-    def test_plan_visualization_on_failure(self, recipe) -> None:
-        assert recipe.steps["plan_visualization"].on_failure == "escalate_stop"
+    def test_dial_on_success(self, recipe) -> None:
+        assert recipe.steps["dial"].on_success == "apply"
 
-    def test_plan_visualization_captures(self, recipe) -> None:
-        capture = recipe.steps["plan_visualization"].capture
+    def test_dial_on_failure(self, recipe) -> None:
+        assert recipe.steps["dial"].on_failure == "escalate_stop"
+
+    def test_dial_captures(self, recipe) -> None:
+        capture = recipe.steps["dial"].capture
+        assert "selected_lenses" in capture
+        assert "lens_context_paths" in capture
+
+    def test_apply_phoropter_family(self, recipe) -> None:
+        assert recipe.steps["apply"].phoropter_family == "vis-lens"
+
+    def test_apply_capture_list(self, recipe) -> None:
+        assert "all_figure_spec_paths" in recipe.steps["apply"].capture_list
+
+    def test_apply_retries_zero(self, recipe) -> None:
+        assert recipe.steps["apply"].retries == 0
+
+    def test_apply_on_success(self, recipe) -> None:
+        assert recipe.steps["apply"].on_success == "synthesize"
+
+    def test_apply_on_failure(self, recipe) -> None:
+        assert recipe.steps["apply"].on_failure == "synthesize"
+
+    def test_synthesize_phoropter_family(self, recipe) -> None:
+        assert recipe.steps["synthesize"].phoropter_family == "vis-lens"
+
+    def test_synthesize_on_success(self, recipe) -> None:
+        assert recipe.steps["synthesize"].on_success == "create_worktree"
+
+    def test_synthesize_on_failure(self, recipe) -> None:
+        assert recipe.steps["synthesize"].on_failure == "escalate_stop"
+
+    def test_synthesize_captures(self, recipe) -> None:
+        capture = recipe.steps["synthesize"].capture
         assert "visualization_plan_path" in capture
         assert "report_plan_path" in capture
+        assert "visualization_plan_trace_path" in capture
+
+    def test_no_plan_visualization_step(self, recipe) -> None:
+        assert "plan_visualization" not in recipe.steps
 
     def test_revise_design_is_route_action(self, recipe) -> None:
         assert recipe.steps["revise_design"].action == "route"

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -783,8 +783,10 @@ ALWAYS_WRITE_SKILLS = {
     "run-experiment",
     "scope",
     "select-directions",
+    "select-vis-lenses",
     "setup-environment",
     "stage-data",
+    "synthesize-vis-plan",
     "troubleshoot-experiment",
     "write-recipe",
 }

--- a/tests/recipe/test_rules_packs.py
+++ b/tests/recipe/test_rules_packs.py
@@ -214,5 +214,5 @@ class TestUndeclaredPackRequirement:
         ]
         assert len(findings) >= 1, "Expected vis-lens to be flagged as missing"
         vis_lens_findings = [f for f in findings if "vis-lens" in f.message]
-        assert len(vis_lens_findings) == 1
-        assert vis_lens_findings[0].severity == Severity.ERROR
+        assert len(vis_lens_findings) == 2
+        assert all(f.severity == Severity.ERROR for f in vis_lens_findings)


### PR DESCRIPTION
## Summary

Delete the monolithic `plan_visualization` step from `src/autoskillit/recipes/research-design.yaml` and replace it with three consecutive phoropter steps — `dial`, `apply`, `synthesize` — each carrying `phoropter_family: vis-lens`. Repoint every routing reference that previously targeted `plan_visualization` to target `dial` instead. Update the test file to reflect the new step structure and phoropter semantics.

Closes #3088

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260601-160842-041943/.autoskillit/temp/make-plan/P2-A5-WP1_decompose_research_design_yaml_plan_2026-06-01_163000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 2.4k | 17.2k | 1.1M | 85.3k | 49 | 74.6k | 12m 16s |
| verify* | sonnet | 1 | 84 | 6.5k | 365.7k | 44.8k | 25 | 28.5k | 2m 49s |
| implement* | MiniMax-M3 | 1 | 200.0k | 12.3k | 2.1M | 85.1k | 93 | 0 | 8m 39s |
| fix* | sonnet | 1 | 438 | 47.5k | 4.8M | 133.4k | 147 | 117.1k | 18m 22s |
| audit_impl* | sonnet | 1 | 454 | 9.9k | 122.3k | 32.8k | 13 | 59.3k | 5m 38s |
| prepare_pr* | MiniMax-M3 | 1 | 84.4k | 2.3k | 117.9k | 44.9k | 13 | 0 | 1m 4s |
| compose_pr* | MiniMax-M3 | 1 | 71.1k | 1.4k | 112.5k | 38.2k | 12 | 0 | 57s |
| review_pr* | sonnet | 1 | 198 | 46.0k | 1.4M | 100.0k | 57 | 84.2k | 11m 7s |
| resolve_review* | sonnet | 1 | 135 | 9.9k | 693.9k | 53.0k | 39 | 37.1k | 5m 52s |
| **Total** | | | 359.2k | 153.0k | 10.9M | 133.4k | | 400.7k | 1h 6m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 193 | 10824.9 | 0.0 | 63.5 |
| fix | 66 | 72844.3 | 1773.5 | 719.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **259** | 41921.8 | 1547.2 | 590.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.4k | 17.2k | 1.1M | 74.6k | 12m 16s |
| sonnet | 5 | 1.3k | 119.8k | 7.4M | 326.1k | 43m 50s |
| MiniMax-M3 | 3 | 355.6k | 16.0k | 2.3M | 0 | 10m 41s |