### PR TITLE
Implementation Plan: Refactor install() Guard to Capability-Driven Dispatch

### DIFF
--- a/src/autoskillit/cli/_marketplace.py
+++ b/src/autoskillit/cli/_marketplace.py
@@ -145,11 +145,20 @@ def install(*, scope: str = "user") -> bool:
         sys.exit(1)
 
     from autoskillit.config import load_config
+    from autoskillit.execution import get_backend
 
     cfg = load_config(Path.cwd())
-    if cfg.agent_backend.backend != "claude-code":
+    try:
+        backend = get_backend(cfg.agent_backend.backend)
+    except ValueError:
         print(
-            f"\nautoskillit install is only supported with the claude-code backend.\n"
+            f"\nPlugin install requires a plugin_install_capable backend.\n"
+            f"Current backend: {cfg.agent_backend.backend!r}\n"
+        )
+        return False
+    if not backend.capabilities.plugin_install_capable:
+        print(
+            f"\nPlugin install requires a plugin_install_capable backend.\n"
             f"Current backend: {cfg.agent_backend.backend!r}\n"
         )
         return False

--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -96,6 +96,8 @@ class BackendCapabilities:
     # True when backend is the Anthropic provider (Claude Code) — used to gate
     # provider-override routing in run_skill() on capability rather than backend name.
     anthropic_provider_capable: bool = field(default=False)
+    # True when backend supports `autoskillit install` plugin installation via marketplace
+    plugin_install_capable: bool = field(default=False)
 
 
 _CONTEXT_WINDOW_SUFFIX_RE: _re.Pattern[str] = _re.compile(r"\[\d+[mk]?\]$", _re.IGNORECASE)
@@ -145,6 +147,7 @@ CLAUDE_CODE_CAPABILITIES: BackendCapabilities = BackendCapabilities(
     replay_capable=True,
     record_capable=True,
     anthropic_provider_capable=True,
+    plugin_install_capable=True,
 )
 
 

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -329,6 +329,7 @@ class CodexBackend:
             replay_capable=False,
             record_capable=False,
             anthropic_provider_capable=False,
+            plugin_install_capable=False,
         )
 
     def build_cmd(self, skill_command: str, cwd: str) -> CmdSpec:

--- a/tests/arch/test_no_backend_name_bypass.py
+++ b/tests/arch/test_no_backend_name_bypass.py
@@ -14,7 +14,6 @@ _EXEMPT_FILES: frozenset[str] = frozenset(
         "cli/doctor/_doctor_runtime.py",  # Binary existence checks
         "cli/doctor/_doctor_mcp.py",  # MCP config path checks
         "cli/_init_helpers.py",  # CLI init — string config, no CodingAgentBackend
-        "cli/_marketplace.py",  # Marketplace — Claude Code-only install guard
         "execution/recording.py",  # Replay setup: fmt == "codex" Compare for player selection
         "execution/headless/_headless_evidence.py",  # Claude-specific evidence extraction
         "execution/headless/_headless_result.py",  # Claude-specific result parsing

--- a/tests/cli/test_cli_marketplace.py
+++ b/tests/cli/test_cli_marketplace.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
@@ -66,3 +68,79 @@ def test_upgrade_is_registered_as_cli_command():
 def test_marketplace_module_still_importable():
     """_marketplace module is still importable (not deleted)."""
     import autoskillit.cli._marketplace  # noqa: F401
+
+
+class TestInstallPluginInstallCapableGuard:
+    """Verify install() gates on backend.capabilities.plugin_install_capable."""
+
+    def test_install_rejects_when_plugin_install_not_capable(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        from autoskillit.config import AgentBackendConfig, AutomationConfig
+
+        mock_cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="test-backend"))
+        monkeypatch.setattr("autoskillit.config.load_config", lambda _: mock_cfg)
+
+        mock_backend = MagicMock()
+        mock_backend.capabilities.plugin_install_capable = False
+        monkeypatch.setattr("autoskillit.execution.get_backend", lambda _: mock_backend)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: tmp_path))
+
+        from autoskillit.cli._marketplace import install
+
+        result = install(scope="user")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert "plugin_install_capable" in captured.out
+        assert "test-backend" in captured.out
+
+    def test_install_passes_guard_when_plugin_install_capable(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import importlib
+        import subprocess
+        from unittest.mock import MagicMock
+
+        from autoskillit.config import AgentBackendConfig, AutomationConfig
+
+        mock_cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="claude-code"))
+        monkeypatch.setattr("autoskillit.config.load_config", lambda _: mock_cfg)
+
+        mock_backend = MagicMock()
+        mock_backend.capabilities.plugin_install_capable = True
+        monkeypatch.setattr("autoskillit.execution.get_backend", lambda _: mock_backend)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: tmp_path))
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+        monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/claude")
+
+        _app_mod = importlib.import_module("autoskillit.cli._marketplace")
+        monkeypatch.setattr(_app_mod, "is_git_worktree", lambda path: False)
+        monkeypatch.setattr(_app_mod, "evict_direct_mcp_entry", lambda _: False)
+        monkeypatch.setattr(
+            "autoskillit.cli._hooks._evict_stale_autoskillit_hooks", lambda _: None
+        )
+        monkeypatch.setattr(_app_mod, "generate_hooks_json", lambda: {})
+        monkeypatch.setattr(_app_mod, "atomic_write", lambda *a, **kw: None)
+
+        called = []
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *a, **kw: (
+                called.append(a),
+                subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr=""),
+            )[1],
+        )
+
+        from autoskillit.cli._marketplace import install
+
+        result = install(scope="user")
+
+        assert result is True
+        assert len(called) >= 1

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -177,10 +177,17 @@ class TestCLIInstall:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
         """install() returns False with message when backend != 'claude-code'."""
+        from unittest.mock import MagicMock
+
         from autoskillit.config import AgentBackendConfig, AutomationConfig
 
         mock_cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="aider"))
         monkeypatch.setattr("autoskillit.config.load_config", lambda _: mock_cfg)
+
+        mock_backend = MagicMock()
+        mock_backend.capabilities.plugin_install_capable = False
+        monkeypatch.setattr("autoskillit.execution.get_backend", lambda _: mock_backend)
+
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
         monkeypatch.setattr(Path, "cwd", staticmethod(lambda: tmp_path))
 
@@ -190,7 +197,7 @@ class TestCLIInstall:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "only supported with the claude-code backend" in captured.out.lower()
+        assert "plugin_install_capable" in captured.out
 
     def test_install_backend_guard_allows_claude_code(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -76,6 +76,7 @@ def test_backend_capabilities_field_count():
         "replay_capable",
         "record_capable",
         "anthropic_provider_capable",
+        "plugin_install_capable",
     }
     assert frozenset_fields == {
         "completion_record_types",
@@ -123,6 +124,7 @@ def test_backend_capabilities_field_names_locked():
         "replay_capable",
         "record_capable",
         "anthropic_provider_capable",
+        "plugin_install_capable",
     }
     actual = {f.name for f in dataclasses.fields(BackendCapabilities)}
     assert actual == expected
@@ -160,6 +162,7 @@ def test_claude_code_capabilities_field_values():
     assert CLAUDE_CODE_CAPABILITIES.replay_capable is True
     assert CLAUDE_CODE_CAPABILITIES.record_capable is True
     assert CLAUDE_CODE_CAPABILITIES.anthropic_provider_capable is True
+    assert CLAUDE_CODE_CAPABILITIES.plugin_install_capable is True
 
 
 def test_backend_capabilities_frozenset_defaults():

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -334,6 +334,7 @@ class TestCodexBackendProtocol:
             ("mcp_config_capable", True),
             ("food_truck_capable", True),
             ("supports_tool_list_changed", False),
+            ("plugin_install_capable", False),
         ],
     )
     def test_capability_flag(self, attr: str, expected: bool) -> None:

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -141,7 +141,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _marketplace.py — marketplace.json (co-owned)
     ("src/autoskillit/cli/_marketplace.py", 96),
     # _marketplace.py — hooks.json (co-owned)
-    ("src/autoskillit/cli/_marketplace.py", 188),
+    ("src/autoskillit/cli/_marketplace.py", 197),
     # tools_config.py — hook config overlay dict (session-scoped, not schema-versioned)
     ("src/autoskillit/server/tools/tools_config.py", 50),
     # _update_checks.py — dismissal state file


### PR DESCRIPTION
## Summary

Add a `plugin_install_capable` field to `BackendCapabilities`, set it `True` for Claude Code and `False` for Codex, then replace the string-comparison guard in `cli/_marketplace.py:install()` with a capability-driven check via `get_backend()`. Wrap the `get_backend()` call in a `ValueError` handler to preserve `install()`'s `-> bool` contract for unknown backend names. Remove the now-stale `_EXEMPT_FILES` entry for `cli/_marketplace.py` from the arch guard. Update all affected test registries.

Closes #3120

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-3120-20260601-184251-689141/.autoskillit/temp/make-plan/p4_a2_wp4_refactor_install_guard_plan_2026-06-01_190000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 89 | 20.4k | 965.3k | 86.0k | 43 | 74.8k | 10m 35s |
| verify* | sonnet | 1 | 86 | 11.5k | 401.7k | 52.2k | 26 | 35.6k | 6m 17s |
| implement* | MiniMax-M3 | 1 | 160.4k | 11.0k | 1.8M | 81.5k | 90 | 0 | 9m 43s |
| fix* | sonnet | 1 | 134 | 4.5k | 643.3k | 50.5k | 39 | 34.0k | 5m 41s |
| audit_impl* | sonnet | 1 | 52 | 11.0k | 179.1k | 40.5k | 16 | 35.9k | 4m 35s |
| prepare_pr* | MiniMax-M3 | 1 | 86.5k | 2.3k | 114.4k | 44.6k | 14 | 0 | 1m 27s |
| compose_pr* | MiniMax-M3 | 1 | 69.7k | 1.0k | 113.3k | 37.9k | 11 | 0 | 51s |
| **Total** | | | 317.0k | 61.7k | 4.2M | 86.0k | | 180.3k | 39m 13s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 109 | 16711.2 | 0.0 | 100.8 |
| fix | 2 | 321664.0 | 16992.5 | 2257.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **111** | 38184.7 | 1624.2 | 555.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 89 | 20.4k | 965.3k | 74.8k | 10m 35s |
| sonnet | 3 | 272 | 26.9k | 1.2M | 105.5k | 16m 35s |
| MiniMax-M3 | 3 | 316.7k | 14.4k | 2.0M | 0 | 12m 2s |