### PR TITLE
Implementation Plan: P4-A2-WP2 Capability-Driven Plugin Guard

### DIFF
--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -10,10 +10,17 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
 from autoskillit.config import write_config_layer
-from autoskillit.core import YAMLError, atomic_write, dump_yaml_str, get_logger, load_yaml
+from autoskillit.core import (
+    CLAUDE_CODE_CAPABILITIES,
+    YAMLError,
+    atomic_write,
+    dump_yaml_str,
+    get_logger,
+    load_yaml,
+)
 
 if TYPE_CHECKING:
-    from autoskillit.core import CodingAgentBackend
+    from autoskillit.core import BackendCapabilities, CodingAgentBackend
 
 logger = get_logger(__name__)
 
@@ -283,13 +290,13 @@ def _check_secret_scanning(project_dir: Path) -> _ScanResult:
     return _ScanResult(True, bypass_accepted=True)
 
 
-def _is_plugin_installed(*, agent_backend: str = "claude-code") -> bool:
+def _is_plugin_installed(*, capabilities: BackendCapabilities = CLAUDE_CODE_CAPABILITIES) -> bool:
     """Return True if autoskillit is installed as a Claude plugin.
 
     Returns False when claude CLI is not on PATH, times out, or is otherwise unavailable.
-    Non-claude-code backends return False immediately without subprocess.
+    Backends without plugin_install_capable return False immediately without subprocess.
     """
-    if agent_backend != "claude-code":
+    if not capabilities.plugin_install_capable:
         return False
     try:
         result = subprocess.run(
@@ -438,7 +445,8 @@ def _register_all(
         sync_hooks_to_settings,
     )
     from autoskillit.config import load_config
-    from autoskillit.core import AGENT_BACKEND_CODEX, ensure_project_temp
+    from autoskillit.core import ensure_project_temp
+    from autoskillit.execution import get_backend
 
     # Refuse to register from inside the autoskillit source tree — this would
     # plant source-tree absolute paths in the project scope.
@@ -469,12 +477,14 @@ def _register_all(
 
     try:
         _cfg = load_config(project_dir)
-        _backend_name = _cfg.agent_backend.backend
+        if backend is None:
+            backend = get_backend(_cfg.agent_backend.backend)
     except Exception:
-        logger.warning("load_config failed, defaulting to claude-code backend", exc_info=True)
-        _backend_name = "claude-code"
+        logger.warning("backend resolution failed, defaulting to claude-code", exc_info=True)
+        if backend is None:
+            backend = get_backend("claude-code")
 
-    if _backend_name == AGENT_BACKEND_CODEX:
+    if backend.capabilities.mcp_config_capable:
         from autoskillit.cli._hooks_codex import sync_hooks_to_codex_config
 
         sync_hooks_to_codex_config()
@@ -484,7 +494,7 @@ def _register_all(
         _evict_stale_autoskillit_hooks(settings_path)
         sync_hooks_to_settings(settings_path)
 
-        plugin_ok = _is_plugin_installed(agent_backend=_backend_name)
+        plugin_ok = _is_plugin_installed(capabilities=backend.capabilities)
         if not plugin_ok:
             _register_mcp_server(_user_claude_json_path())
         else:
@@ -537,7 +547,7 @@ def _register_all(
         print(f"  {_Y}{'gh auth':>12}{_R}  {_G}authenticated{_R}")
     else:
         print(f"  {_Y}{'gh auth':>12}{_R}  {_D}not found — run{_R} {_G}gh auth login{_R}")
-    if _backend_name == AGENT_BACKEND_CODEX:
+    if backend.capabilities.mcp_config_capable:
         print(f"  {_Y}{'hooks':>12}{_R}  {_G}synced{_R} {_D}(codex){_R}")
     else:
         if plugin_ok:

--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -96,6 +96,8 @@ class BackendCapabilities:
     # True when backend is the Anthropic provider (Claude Code) — used to gate
     # provider-override routing in run_skill() on capability rather than backend name.
     anthropic_provider_capable: bool = field(default=False)
+    # True when backend supports Claude plugin install/list CLI
+    plugin_install_capable: bool = field(default=False)
 
 
 _CONTEXT_WINDOW_SUFFIX_RE: _re.Pattern[str] = _re.compile(r"\[\d+[mk]?\]$", _re.IGNORECASE)
@@ -145,6 +147,7 @@ CLAUDE_CODE_CAPABILITIES: BackendCapabilities = BackendCapabilities(
     replay_capable=True,
     record_capable=True,
     anthropic_provider_capable=True,
+    plugin_install_capable=True,
 )
 
 

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -232,7 +232,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
         }
     ),
     "_type_results_execution": frozenset({"core", "execution", "server", "pipeline"}),
-    "_type_backend": frozenset({"core", "execution"}),
+    "_type_backend": frozenset({"core", "execution", "cli"}),
     "_type_dispatch_identity": frozenset({"core", "fleet", "execution"}),
     "_type_figure_spec": frozenset({"core", "report"}),
     "_type_session_env": frozenset({"core", "cli"}),

--- a/tests/arch/test_no_backend_name_bypass.py
+++ b/tests/arch/test_no_backend_name_bypass.py
@@ -13,7 +13,6 @@ _EXEMPT_FILES: frozenset[str] = frozenset(
         "server/_factory.py",  # Feature-gated backend swap (pre-capabilities)
         "cli/doctor/_doctor_runtime.py",  # Binary existence checks
         "cli/doctor/_doctor_mcp.py",  # MCP config path checks
-        "cli/_init_helpers.py",  # CLI init — string config, no CodingAgentBackend
         "cli/_marketplace.py",  # Marketplace — Claude Code-only install guard
         "execution/recording.py",  # Replay setup: fmt == "codex" Compare for player selection
         "execution/headless/_headless_evidence.py",  # Claude-specific evidence extraction

--- a/tests/cli/test_fleet_campaign.py
+++ b/tests/cli/test_fleet_campaign.py
@@ -79,7 +79,7 @@ def test_fleet_run_exit_code_passthrough(monkeypatch: pytest.MonkeyPatch, tmp_pa
     _stub_guards(monkeypatch)
     monkeypatch.chdir(tmp_path)
     _stub_campaign_resolution(monkeypatch, tmp_path, "test-campaign")
-    monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: True)
+    monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda **_: True)
     monkeypatch.setattr(
         subprocess,
         "run",

--- a/tests/cli/test_init_helpers.py
+++ b/tests/cli/test_init_helpers.py
@@ -17,10 +17,17 @@ class TestIsPluginInstalledBackendGuard:
     """Backend guard returns False without subprocess for non-claude-code."""
 
     def test_non_claude_code_backend_returns_false(self):
-        result = _is_plugin_installed(agent_backend="aider")
+        from dataclasses import replace
+
+        from autoskillit.core import CLAUDE_CODE_CAPABILITIES
+
+        caps = replace(CLAUDE_CODE_CAPABILITIES, plugin_install_capable=False)
+        result = _is_plugin_installed(capabilities=caps)
         assert result is False
 
     def test_claude_code_backend_calls_subprocess(self, monkeypatch):
+        from autoskillit.core import CLAUDE_CODE_CAPABILITIES
+
         called = []
 
         def fake_run(*args, **kwargs):
@@ -28,7 +35,7 @@ class TestIsPluginInstalledBackendGuard:
             return subprocess.CompletedProcess(args=[], returncode=0, stdout="autoskillit\n")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        result = _is_plugin_installed(agent_backend="claude-code")
+        result = _is_plugin_installed(capabilities=CLAUDE_CODE_CAPABILITIES)
         assert result is True
         assert len(called) == 1
 
@@ -73,7 +80,9 @@ class TestRegisterAllBackendKwarg:
         (tmp_path / "pkg").mkdir()
 
         # Should not raise TypeError
-        _register_all("user", tmp_path, backend=MagicMock())
+        mock_backend = MagicMock()
+        mock_backend.capabilities.mcp_config_capable = False
+        _register_all("user", tmp_path, backend=mock_backend)
 
 
 class TestInitBackendResolution:
@@ -178,6 +187,11 @@ class TestRegisterAllBackendDispatch:
         mock_config = MagicMock()
         mock_config.agent_backend.backend = backend_name
         monkeypatch.setattr("autoskillit.config.load_config", lambda p=None: mock_config)
+
+        mock_backend = MagicMock()
+        mock_backend.capabilities.mcp_config_capable = backend_name == "codex"
+        mock_backend.capabilities.plugin_install_capable = backend_name != "codex"
+        monkeypatch.setattr("autoskillit.execution.get_backend", lambda name: mock_backend)
 
         (tmp_path / "pkg").mkdir(exist_ok=True)
 
@@ -317,6 +331,11 @@ class TestRegisterAllCodexHookWiring:
         mock_config = MagicMock()
         mock_config.agent_backend.backend = backend_name
         monkeypatch.setattr("autoskillit.config.load_config", lambda p=None: mock_config)
+
+        mock_backend = MagicMock()
+        mock_backend.capabilities.mcp_config_capable = backend_name == "codex"
+        mock_backend.capabilities.plugin_install_capable = backend_name != "codex"
+        monkeypatch.setattr("autoskillit.execution.get_backend", lambda name: mock_backend)
 
         (tmp_path / "pkg").mkdir(exist_ok=True)
 
@@ -505,6 +524,11 @@ class TestRegisterAllCodexMcpRegistration:
         mock_config.agent_backend.backend = backend_name
         monkeypatch.setattr("autoskillit.config.load_config", lambda p=None: mock_config)
 
+        mock_backend = MagicMock()
+        mock_backend.capabilities.mcp_config_capable = backend_name == "codex"
+        mock_backend.capabilities.plugin_install_capable = backend_name != "codex"
+        monkeypatch.setattr("autoskillit.execution.get_backend", lambda name: mock_backend)
+
         if backend_name == "codex":
             monkeypatch.setattr(
                 "autoskillit.cli._hooks_codex.sync_hooks_to_codex_config",
@@ -584,6 +608,11 @@ class TestRegisterAllDualRegistration:
         mock_config = MagicMock()
         mock_config.agent_backend.backend = "claude-code"
         monkeypatch.setattr("autoskillit.config.load_config", lambda p=None: mock_config)
+
+        mock_backend = MagicMock()
+        mock_backend.capabilities.mcp_config_capable = False
+        mock_backend.capabilities.plugin_install_capable = True
+        monkeypatch.setattr("autoskillit.execution.get_backend", lambda name: mock_backend)
 
         if isinstance(codex_side_effect, type) and issubclass(codex_side_effect, BaseException):
             codex_mock = MagicMock(side_effect=codex_side_effect("boom"))

--- a/tests/cli/test_reload_loop.py
+++ b/tests/cli/test_reload_loop.py
@@ -180,7 +180,7 @@ def test_interactive_session_reload_uses_named_resume(
     monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/claude")
     monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _make_result(0))
     monkeypatch.setattr("autoskillit.cli.ui._terminal.terminal_guard", _noop_terminal_guard)
-    monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: True)
+    monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda **_: True)
 
     from autoskillit.cli.session._session_launch import _run_interactive_session
 

--- a/tests/cli/test_terminal.py
+++ b/tests/cli/test_terminal.py
@@ -440,7 +440,9 @@ class TestCookTerminalGuard:
             lambda *a, **kw: (_ for _ in ()).throw(KeyboardInterrupt()),
         )
         monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/claude")
-        monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: False)
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._is_plugin_installed", lambda **_: False
+        )
         # is_first_run is imported inside cook() body — patch the source module
         monkeypatch.setattr("autoskillit.cli._onboarding.is_first_run", lambda _: False)
         # cook() calls input() for launch confirmation before subprocess.run
@@ -485,7 +487,9 @@ class TestCookTerminalGuard:
             lambda fd, when, attrs: tcsetattr_calls.append(attrs),
         )
         monkeypatch.setattr("autoskillit.cli.ui._terminal.termios.error", termios.error)
-        monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: False)
+        monkeypatch.setattr(
+            "autoskillit.cli._init_helpers._is_plugin_installed", lambda **_: False
+        )
         monkeypatch.setattr(
             "autoskillit.cli.session._session_launch.subprocess.run",
             lambda *a, **kw: (_ for _ in ()).throw(KeyboardInterrupt()),

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -76,6 +76,7 @@ def test_backend_capabilities_field_count():
         "replay_capable",
         "record_capable",
         "anthropic_provider_capable",
+        "plugin_install_capable",
     }
     assert frozenset_fields == {
         "completion_record_types",
@@ -123,6 +124,7 @@ def test_backend_capabilities_field_names_locked():
         "replay_capable",
         "record_capable",
         "anthropic_provider_capable",
+        "plugin_install_capable",
     }
     actual = {f.name for f in dataclasses.fields(BackendCapabilities)}
     assert actual == expected
@@ -160,6 +162,7 @@ def test_claude_code_capabilities_field_values():
     assert CLAUDE_CODE_CAPABILITIES.replay_capable is True
     assert CLAUDE_CODE_CAPABILITIES.record_capable is True
     assert CLAUDE_CODE_CAPABILITIES.anthropic_provider_capable is True
+    assert CLAUDE_CODE_CAPABILITIES.plugin_install_capable is True
 
 
 def test_backend_capabilities_frozenset_defaults():

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -133,9 +133,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 24),
     # _init_helpers.py — ~/.claude.json (co-owned)
-    ("src/autoskillit/cli/_init_helpers.py", 385),
+    ("src/autoskillit/cli/_init_helpers.py", 392),
     # _init_helpers.py — evict_direct_mcp_entry write-back to ~/.claude.json (co-owned)
-    ("src/autoskillit/cli/_init_helpers.py", 404),
+    ("src/autoskillit/cli/_init_helpers.py", 411),
     # _installed_plugins.py — installed_plugins.json (co-owned with Claude plugin system)
     ("src/autoskillit/cli/_installed_plugins.py", 81),
     # _marketplace.py — marketplace.json (co-owned)

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -154,7 +154,7 @@ class TestModuleCascadeCore:
         )
 
     def test_type_backend_cascade(self) -> None:
-        assert MODULE_CASCADE_CORE["_type_backend"] == frozenset({"core", "execution"})
+        assert MODULE_CASCADE_CORE["_type_backend"] == frozenset({"core", "execution", "cli"})
 
     def test_type_dispatch_identity_cascade(self) -> None:
         assert MODULE_CASCADE_CORE["_type_dispatch_identity"] == frozenset(


### PR DESCRIPTION
## Summary

Replace string-based backend dispatch in `cli/_init_helpers.py` with capability-driven dispatch using `BackendCapabilities`. This involves: (1) adding the `plugin_install_capable` field to `BackendCapabilities` (prerequisite from P1-A1-WP1 which is still OPEN — this WP adds the field directly since it is the first consumer), (2) refactoring `_is_plugin_installed` to accept `BackendCapabilities` instead of a string, (3) refactoring `_register_all` to resolve a `CodingAgentBackend` via `get_backend()` and use `capabilities.mcp_config_capable` / `capabilities.plugin_install_capable` instead of `AGENT_BACKEND_CODEX` string comparisons, and (4) updating all tests to use capability-based mocks. After these changes, `_init_helpers.py` is removed from the `test_no_backend_name_bypass.py` exemption list — zero backend-name string comparisons remain.

Closes #3119

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-3119-20260601-184247-583652/.autoskillit/temp/make-plan/p4_a2_wp2_capability_driven_plugin_guard_plan_2026-06-01_190000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 18 | 5.5k | 1.4M | 158.4k | 108 | 19.0k | 20m 41s |
| verify* | sonnet | 1 | 76 | 10.3k | 353.7k | 54.8k | 25 | 38.3k | 4m 27s |
| implement* | MiniMax-M3 | 1 | 295.5k | 15.0k | 5.5M | 100.8k | 138 | 0 | 17m 21s |
| fix* | sonnet | 1 | 150 | 6.0k | 1.0M | 82.0k | 51 | 65.6k | 5m 56s |
| audit_impl* | sonnet | 1 | 44 | 11.7k | 146.7k | 40.6k | 15 | 37.7k | 5m 31s |
| prepare_pr* | MiniMax-M3 | 1 | 84.7k | 2.0k | 121.4k | 46.0k | 12 | 0 | 1m 14s |
| compose_pr* | MiniMax-M3 | 1 | 72.8k | 1.3k | 148.5k | 38.3k | 13 | 0 | 1m 0s |
| review_pr* | sonnet | 1 | 134 | 41.7k | 898.3k | 90.5k | 50 | 74.7k | 10m 35s |
| resolve_review* | sonnet | 1 | 167 | 10.6k | 910.9k | 56.2k | 47 | 40.4k | 7m 3s |
| diagnose_ci* | MiniMax-M3 | 1 | 116.9k | 2.1k | 183.3k | 50.7k | 16 | 0 | 1m 40s |
| resolve_ci* | sonnet | 1 | 158 | 4.2k | 771.4k | 48.8k | 45 | 32.6k | 4m 25s |
| **Total** | | | 570.6k | 110.4k | 11.5M | 158.4k | | 308.3k | 1h 19m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 88 | 62932.4 | 0.0 | 170.0 |
| fix | 6 | 172121.0 | 10929.2 | 1004.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 2 | 385711.5 | 16300.0 | 2112.5 |
| **Total** | **96** | 119657.6 | 3211.0 | 1149.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 18 | 5.5k | 1.4M | 19.0k | 20m 41s |
| sonnet | 6 | 729 | 84.5k | 4.1M | 289.3k | 37m 59s |
| MiniMax-M3 | 4 | 569.8k | 20.4k | 6.0M | 0 | 21m 17s |