### PR TITLE
Rectify: SKILL.md GraphQL Query-Without-Invocation Immunity

### DIFF
--- a/src/autoskillit/recipe/_skill_placeholder_parser.py
+++ b/src/autoskillit/recipe/_skill_placeholder_parser.py
@@ -3,6 +3,7 @@
 Used by:
   - src/autoskillit/recipe/rules/rules_skill_content.py (semantic rules)
   - tests/skills/test_skill_placeholder_contracts.py (structural linter)
+  - tests/skills/test_graphql_invocation_completeness.py (graphql invocation linter)
   - tests/contracts/test_no_interpreter_writes_in_skills.py (write safety linter)
 """
 
@@ -11,12 +12,21 @@ from __future__ import annotations
 import regex as re
 
 
+def extract_fenced_blocks(content: str, language: str) -> list[str]:
+    """Extract fenced code blocks for the given language identifier."""
+    return re.findall(rf"```{re.escape(language)}\s*\n(.*?)```", content, re.DOTALL)
+
+
 def extract_bash_blocks(content: str) -> list[str]:
-    return re.findall(r"```bash\s*\n(.*?)```", content, re.DOTALL)
+    return extract_fenced_blocks(content, "bash")
 
 
 def extract_python_blocks(content: str) -> list[str]:
-    return re.findall(r"```python\s*\n(.*?)```", content, re.DOTALL)
+    return extract_fenced_blocks(content, "python")
+
+
+def extract_graphql_blocks(content: str) -> list[str]:
+    return extract_fenced_blocks(content, "graphql")
 
 
 def extract_bash_placeholders(bash_blocks: list[str]) -> set[str]:

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -884,11 +884,11 @@ def _check_graphql_query_requires_shell_invocation(ctx: ValidationContext) -> li
                         ),
                     )
                 )
-                continue
+                break
 
             for var in variable_names:
                 flag_found = any(
-                    re.search(rf"-[Ff]\s+{re.escape(var)}=", b) for b in bash_with_graphql
+                    re.search(rf"-[Ff]\s*{re.escape(var)}=", b) for b in bash_with_graphql
                 )
                 if not flag_found:
                     findings.append(

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -18,6 +18,7 @@ from autoskillit.recipe._skill_placeholder_parser import (
     extract_bash_blocks,
     extract_bash_placeholders,
     extract_declared_ingredients,
+    extract_graphql_blocks,
     extract_python_blocks,
     shell_vars_assigned,
 )
@@ -758,6 +759,9 @@ def _check_reviews_post_requires_input_flag(ctx: ValidationContext) -> list[Rule
     return findings
 
 
+_GRAPHQL_VARIABLE_RE = re.compile(r"\$([a-zA-Z_]\w*)")
+_GH_API_GRAPHQL_BLOCK_RE = re.compile(r"gh\s+api\s+graphql\b")
+
 _SOURCE_PROHIBITION_RE = re.compile(
     r"(?:NOT|NEVER|DO NOT)[\s\S]{0,120}?"
     r"(?:issue\s+title|issue\s+body|issue\s+metadata|closing_issue|"
@@ -818,4 +822,86 @@ def _check_source_attribution_directive(ctx: ValidationContext) -> list[RuleFind
                     ),
                 )
             )
+    return findings
+
+
+@semantic_rule(
+    name="graphql-query-requires-shell-invocation",
+    description=(
+        "A SKILL.md contains a ```graphql block with parameterized $variables "
+        "but no ```bash block with a concrete `gh api graphql` invocation. "
+        "Agents will improvise the invocation and may use the wrong variable-passing "
+        "pattern (-f variables=<json blob> instead of individual -F key=value flags)."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_graphql_query_requires_shell_invocation(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        skill_cmd = step.with_args.get("skill_command", "")
+        if not skill_cmd:
+            continue
+
+        skill_name = resolve_skill_name(skill_cmd)
+        if skill_name is None:
+            continue
+
+        skill_md = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
+        if skill_md is None:
+            continue
+
+        try:
+            content = skill_md.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        graphql_blocks = extract_graphql_blocks(content)
+        if not graphql_blocks:
+            continue
+
+        bash_blocks = extract_bash_blocks(content)
+        bash_with_graphql = [b for b in bash_blocks if _GH_API_GRAPHQL_BLOCK_RE.search(b)]
+
+        for block in graphql_blocks:
+            variable_names = set(_GRAPHQL_VARIABLE_RE.findall(block))
+            if not variable_names:
+                continue
+
+            if not bash_with_graphql:
+                findings.append(
+                    RuleFinding(
+                        rule="graphql-query-requires-shell-invocation",
+                        severity=Severity.ERROR,
+                        step_name=step_name,
+                        message=(
+                            f"Skill '{skill_name}' has a graphql block declaring variables "
+                            f"{sorted(variable_names)} but no bash block with a concrete "
+                            f"`gh api graphql` invocation. Add a bash block with individual "
+                            f"-F key=value flag bindings for each variable."
+                        ),
+                    )
+                )
+                continue
+
+            for var in variable_names:
+                flag_found = any(
+                    re.search(rf"-[Ff]\s+{re.escape(var)}=", b) for b in bash_with_graphql
+                )
+                if not flag_found:
+                    findings.append(
+                        RuleFinding(
+                            rule="graphql-query-requires-shell-invocation",
+                            severity=Severity.ERROR,
+                            step_name=step_name,
+                            message=(
+                                f"Skill '{skill_name}' graphql variable '${var}' has no "
+                                f"'-F {var}=' or '-f {var}=' binding in any "
+                                f"`gh api graphql` bash block."
+                            ),
+                        )
+                    )
+
     return findings

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -361,6 +361,12 @@ When dispatching from an execution map:
    }
    ```
 
+   Build the alias query from the `gated_by` issue numbers and invoke:
+   ```bash
+   LABEL_QUERY="query { $(for NUM in $BLOCKER_NUMS; do echo "i${NUM}: repository(owner:\"$OWNER\", name:\"$REPO\") { issue(number:${NUM}) { labels(first:20) { nodes { name } } } }"; done) }"
+   gh api graphql -f query="$LABEL_QUERY"
+   ```
+
    For each blocker, check whether the `in-progress` label is still present. If a
    blocker's label has been removed since the map was built, remove it from that deferred
    group's `gated_by` array. If all blockers for a deferred group have cleared,

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -129,7 +129,7 @@ implemented. Identify review debt before it compounds.
    ```
    Build the alias query string in a shell variable and invoke:
    ```bash
-   BATCH_QUERY="query { rateLimit { cost remaining resetAt } pr1: repository(owner:\"$OWNER\", name:\"$REPO\") { pullRequest(number:$N1) { number title mergedAt reviews(first:100){nodes{author{login}body state submittedAt}} reviewThreads(first:100){pageInfo{hasNextPage endCursor}nodes{isResolved comments(first:100){nodes{databaseId author{login}body path line createdAt}}}} } } pr2: repository(owner:\"$OWNER\", name:\"$REPO\") { pullRequest(number:$N2) { ... } } }"
+   BATCH_QUERY="query { rateLimit { cost remaining resetAt } pr1: repository(owner:\"$OWNER\", name:\"$REPO\") { pullRequest(number:$N1) { number title mergedAt reviews(first:100){nodes{author { login } body state submittedAt}} reviewThreads(first:100){pageInfo{hasNextPage endCursor}nodes{isResolved comments(first:100){nodes{databaseId author { login } body path line createdAt}}}} } } pr2: repository(owner:\"$OWNER\", name:\"$REPO\") { pullRequest(number:$N2) { ... } } }"
    gh api graphql -f query="$BATCH_QUERY"
    ```
    Include `rateLimit { cost remaining resetAt }` at query root.

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -127,6 +127,11 @@ implemented. Identify review debt before it compounds.
      }
    }
    ```
+   Build the alias query string in a shell variable and invoke:
+   ```bash
+   BATCH_QUERY="query { rateLimit { cost remaining resetAt } pr1: repository(owner:\"$OWNER\", name:\"$REPO\") { pullRequest(number:$N1) { number title mergedAt reviews(first:100){nodes{author{login}body state submittedAt}} reviewThreads(first:100){pageInfo{hasNextPage endCursor}nodes{isResolved comments(first:100){nodes{databaseId author{login}body path line createdAt}}}} } } pr2: repository(owner:\"$OWNER\", name:\"$REPO\") { pullRequest(number:$N2) { ... } } }"
+   gh api graphql -f query="$BATCH_QUERY"
+   ```
    Include `rateLimit { cost remaining resetAt }` at query root.
    After the initial fetch, for each PR where `reviewThreads.pageInfo.hasNextPage` is
    `true`, issue additional aliased queries with `reviewThreads(first:100, after:$endCursor)`

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -147,7 +147,7 @@ query($owner:String!, $repo:String!, $number:Int!, $after:String) {
 ```bash
 # Fetch all pages; repeat with after=$endCursor while hasNextPage is true
 gh api graphql \
-  -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor}nodes{isResolved path line originalLine comments(first:5){nodes{databaseId body author{login}}}}}}}}' \
+  -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor}nodes{isResolved path line originalLine comments(first:5){nodes{databaseId body author { login }}}}}}}}' \
   -F owner="$OWNER" \
   -F repo="$REPO" \
   -F number=$PR_NUMBER \

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -144,6 +144,16 @@ query($owner:String!, $repo:String!, $number:Int!, $after:String) {
 }
 ```
 
+```bash
+# Fetch all pages; repeat with after=$endCursor while hasNextPage is true
+gh api graphql \
+  -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor}nodes{isResolved path line originalLine comments(first:5){nodes{databaseId body author{login}}}}}}}}' \
+  -F owner="$OWNER" \
+  -F repo="$REPO" \
+  -F number=$PR_NUMBER \
+  -F after=""
+```
+
 Build two lists from the thread nodes. Do not output prose between iterations. For each thread, resolve line via:
 `line = thread.get("line") or thread.get("originalLine")` — `line` is nullable for
 outdated threads where new commits have shifted the diff anchor; `originalLine` is

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -151,7 +151,7 @@ gh api graphql \
   -F owner="$OWNER" \
   -F repo="$REPO" \
   -F number=$PR_NUMBER \
-  -F after=""
+  -f after=null
 ```
 
 Build two lists from the thread nodes. Do not output prose between iterations. For each thread, resolve line via:

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -768,7 +768,9 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             # Other file-level entries:
             "infra/test_pretty_output_recipe.py",
             "infra/test_generated_files.py",
+            "skills/test_graphql_invocation_completeness.py",
             "skills/test_planner_skill_contracts.py",
+            "skills/test_review_pr_prior_thread_awareness.py",
             "skills/test_skill_placeholder_contracts.py",
             "skills/test_make_campaign_compliance.py",
             "skills/test_review_design_guards.py",

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -441,6 +441,7 @@ MODULE_CASCADE_RECIPE: dict[str, frozenset[str]] = {
     "rules_skill_content": frozenset(
         {
             "recipe",
+            "skills/test_graphql_invocation_completeness.py",
             "skills/test_skill_placeholder_contracts.py",
             "skills/test_skill_tool_syntax_contracts.py",
             "contracts/test_no_interpreter_writes_in_skills.py",
@@ -459,6 +460,7 @@ MODULE_CASCADE_RECIPE: dict[str, frozenset[str]] = {
         {
             "recipe",
             "arch/test_write_restriction_coverage.py",
+            "skills/test_graphql_invocation_completeness.py",
             "skills/test_make_campaign_compliance.py",
             "skills/test_skill_placeholder_contracts.py",
             "skills/test_skill_tool_syntax_contracts.py",

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -462,6 +462,7 @@ MODULE_CASCADE_RECIPE: dict[str, frozenset[str]] = {
             "arch/test_write_restriction_coverage.py",
             "skills/test_graphql_invocation_completeness.py",
             "skills/test_make_campaign_compliance.py",
+            "skills/test_review_pr_prior_thread_awareness.py",
             "skills/test_skill_placeholder_contracts.py",
             "skills/test_skill_tool_syntax_contracts.py",
             "skills/test_audit_impl_diff_discipline.py",

--- a/tests/recipe/test_rules_skill_content.py
+++ b/tests/recipe/test_rules_skill_content.py
@@ -1578,6 +1578,34 @@ def test_graphql_rule_does_not_fire_when_bash_invocation_present(tmp_path: Path)
     assert _GRAPHQL_RULE_ID not in rule_ids
 
 
+def test_graphql_rule_fires_for_case_mismatched_variable_bindings(tmp_path: Path) -> None:
+    skill_md = textwrap.dedent(
+        """\
+        # graphql-skill
+
+        ### Step 1
+        ```graphql
+        query($owner:String!, $repo:String!, $number:Int!) {
+          repository(owner:$owner, name:$repo) {
+            pullRequest(number:$number) { title }
+          }
+        }
+        ```
+
+        ```bash
+        gh api graphql \\
+          -f query='...' \\
+          -F OWNER="$OWNER" \\
+          -F REPO="$REPO" \\
+          -F NUMBER=$NUMBER
+        ```
+        """
+    )
+    findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+    rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+    assert _GRAPHQL_RULE_ID in rule_ids
+
+
 def test_graphql_rule_does_not_fire_for_display_only_fragment(tmp_path: Path) -> None:
     skill_md = textwrap.dedent(
         """\

--- a/tests/recipe/test_rules_skill_content.py
+++ b/tests/recipe/test_rules_skill_content.py
@@ -1501,3 +1501,97 @@ def test_python_block_read_only_does_not_fire(tmp_path: Path) -> None:
     findings = _write_skill_and_run_rules(tmp_path, skill_md)
     rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
     assert _INTERP_WRITE_RULE_ID not in rule_ids
+
+
+# ---------------------------------------------------------------------------
+# graphql-query-requires-shell-invocation tests
+# ---------------------------------------------------------------------------
+
+_GRAPHQL_RULE_ID = "graphql-query-requires-shell-invocation"
+
+
+def _write_graphql_skill_and_run_rules(tmp_path: Path, skill_md_content: str) -> list[object]:
+    skill_name = "graphql-skill"
+    skill_dir = tmp_path / skill_name
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(skill_md_content)
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_make_recipe_for_skill(skill_name, {}))
+    recipe = load_recipe(recipe_path)
+    with patch.object(_sh, "SKILL_SEARCH_DIRS", [tmp_path]):
+        return run_semantic_rules(recipe)
+
+
+def test_graphql_query_requires_shell_invocation_rule_registered() -> None:
+    import autoskillit.recipe.rules.rules_skill_content  # noqa: F401
+    from autoskillit.recipe.registry import _RULE_REGISTRY
+
+    rule_names = [r.name for r in _RULE_REGISTRY]
+    assert _GRAPHQL_RULE_ID in rule_names
+
+
+def test_graphql_rule_fires_when_no_bash_invocation(tmp_path: Path) -> None:
+    skill_md = textwrap.dedent(
+        """\
+        # graphql-skill
+
+        ### Step 1
+        ```graphql
+        query($owner:String!, $repo:String!, $number:Int!) {
+          repository(owner:$owner, name:$repo) {
+            pullRequest(number:$number) { title }
+          }
+        }
+        ```
+        """
+    )
+    findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+    rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+    assert _GRAPHQL_RULE_ID in rule_ids
+
+
+def test_graphql_rule_does_not_fire_when_bash_invocation_present(tmp_path: Path) -> None:
+    skill_md = textwrap.dedent(
+        """\
+        # graphql-skill
+
+        ### Step 1
+        ```graphql
+        query($owner:String!, $repo:String!, $number:Int!) {
+          repository(owner:$owner, name:$repo) {
+            pullRequest(number:$number) { title }
+          }
+        }
+        ```
+
+        ```bash
+        gh api graphql \\
+          -f query='...' \\
+          -F owner="$OWNER" \\
+          -F repo="$REPO" \\
+          -F number=$NUMBER
+        ```
+        """
+    )
+    findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+    rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+    assert _GRAPHQL_RULE_ID not in rule_ids
+
+
+def test_graphql_rule_does_not_fire_for_display_only_fragment(tmp_path: Path) -> None:
+    skill_md = textwrap.dedent(
+        """\
+        # graphql-skill
+
+        ### Step 1
+        ```graphql
+        number title mergedAt
+        reviews(first: 100) {
+          nodes { author { login } body state submittedAt }
+        }
+        ```
+        """
+    )
+    findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+    rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+    assert _GRAPHQL_RULE_ID not in rule_ids

--- a/tests/skills/CLAUDE.md
+++ b/tests/skills/CLAUDE.md
@@ -22,6 +22,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 | `test_deletion_regression_guards.py` | Structural guards for deletion regression detection in merge-pr and review-pr skills |
 | `test_dry_walkthrough_contracts.py` | Structural contracts for the dry-walkthrough historical regression check step |
 | `test_generate_report_guards.py` | Guards for generate-report SKILL.md: blind git add prevention |
+| `test_graphql_invocation_completeness.py` | SKILL.md GraphQL invocation completeness: every parameterized graphql block must have a matching `gh api graphql` bash invocation with individual -F flag bindings |
 | `test_file_audit_issues_contracts.py` | Contract tests for file-audit-issues SKILL.md behavioral invariants |
 | `test_investigate_contracts.py` | Structural contracts for the investigate historical recurrence check step |
 | `test_investigate_deep_mode_contracts.py` | Structural contracts for the investigate deep analysis mode |

--- a/tests/skills/test_graphql_invocation_completeness.py
+++ b/tests/skills/test_graphql_invocation_completeness.py
@@ -1,0 +1,118 @@
+"""SKILL.md GraphQL invocation completeness contract.
+
+Every ```graphql block that declares parameterized variables ($owner, $repo, etc.)
+must have a corresponding ```bash block with a concrete `gh api graphql` invocation
+that binds those variables via individual -F flags.
+
+This prevents the "schema without invocation" anti-pattern where agents must
+improvise gh api graphql variable-passing syntax — which is non-obvious and
+error-prone (the -f variables=<json blob> pattern silently fails).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core.paths import pkg_root
+from autoskillit.recipe._skill_placeholder_parser import (
+    extract_bash_blocks,
+    extract_graphql_blocks,
+)
+
+pytestmark = [pytest.mark.layer("skills"), pytest.mark.medium]
+
+_SKILLS_DIRS = [pkg_root() / "skills", pkg_root() / "skills_extended"]
+
+_GH_API_GRAPHQL_RE = re.compile(r"gh\s+api\s+graphql\b")
+
+
+def _all_skill_dirs() -> list[Path]:
+    dirs = []
+    for base in _SKILLS_DIRS:
+        if base.exists():
+            dirs.extend(d for d in base.iterdir() if d.is_dir())
+    return dirs
+
+
+def test_graphql_blocks_have_matching_bash_invocations() -> None:
+    """Every parameterized graphql block must have a matching gh api graphql bash invocation."""
+    failures: list[str] = []
+
+    for skill_dir in _all_skill_dirs():
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.exists():
+            continue
+
+        content = skill_md.read_text(encoding="utf-8")
+        graphql_blocks = extract_graphql_blocks(content)
+        if not graphql_blocks:
+            continue
+
+        bash_blocks = extract_bash_blocks(content)
+        bash_with_graphql = [b for b in bash_blocks if _GH_API_GRAPHQL_RE.search(b)]
+
+        for block in graphql_blocks:
+            variable_names = set(re.findall(r"\$([a-zA-Z_]\w*)", block))
+            if not variable_names:
+                continue
+
+            skill_name = skill_dir.name
+
+            if not bash_with_graphql:
+                failures.append(
+                    f"{skill_name}: graphql block declares variables "
+                    f"{sorted(variable_names)} but no ```bash block contains "
+                    f"'gh api graphql'"
+                )
+                continue
+
+            for var in variable_names:
+                flag_found = any(
+                    re.search(rf"-[Ff]\s+{re.escape(var)}=", b) for b in bash_with_graphql
+                )
+                if not flag_found:
+                    failures.append(
+                        f"{skill_name}: graphql variable '${var}' has no "
+                        f"'-F {var}=' or '-f {var}=' binding in any "
+                        f"'gh api graphql' bash block"
+                    )
+
+    assert not failures, (
+        "SKILL.md files with parameterized graphql blocks must have concrete "
+        "'gh api graphql' bash invocations binding each variable via -F flags:\n"
+        + "\n".join(f"  - {f}" for f in failures)
+    )
+
+
+def test_graphql_blocks_use_individual_F_flags_not_json_blob() -> None:
+    """gh api graphql invocations must not use -f variables=<json blob> anti-pattern."""
+    failures: list[str] = []
+
+    for skill_dir in _all_skill_dirs():
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.exists():
+            continue
+
+        content = skill_md.read_text(encoding="utf-8")
+        bash_blocks = extract_bash_blocks(content)
+
+        for block in bash_blocks:
+            if not _GH_API_GRAPHQL_RE.search(block):
+                continue
+
+            skill_name = skill_dir.name
+
+            if re.search(r"-f\s+variables=", block) or re.search(r"--field\s+variables=", block):
+                failures.append(
+                    f"{skill_name}: gh api graphql uses '-f variables=' or "
+                    f"'--field variables=' (json blob anti-pattern); use individual "
+                    f"-F key=value flags instead"
+                )
+
+    assert not failures, (
+        "gh api graphql invocations must bind variables via individual -F flags, "
+        "not a single -f variables=<json blob>:\n" + "\n".join(f"  - {f}" for f in failures)
+    )

--- a/tests/skills/test_graphql_invocation_completeness.py
+++ b/tests/skills/test_graphql_invocation_completeness.py
@@ -71,7 +71,7 @@ def test_graphql_blocks_have_matching_bash_invocations() -> None:
 
             for var in variable_names:
                 flag_found = any(
-                    re.search(rf"-[Ff]\s+{re.escape(var)}=", b) for b in bash_with_graphql
+                    re.search(rf"-[Ff]\s*{re.escape(var)}=", b) for b in bash_with_graphql
                 )
                 if not flag_found:
                     failures.append(
@@ -105,7 +105,9 @@ def test_graphql_blocks_use_individual_F_flags_not_json_blob() -> None:
 
             skill_name = skill_dir.name
 
-            if re.search(r"-f\s+variables=", block) or re.search(r"--field\s+variables=", block):
+            if re.search(r"-[fF]\s+variables=", block) or re.search(
+                r"--field\s+variables=", block
+            ):
                 failures.append(
                     f"{skill_name}: gh api graphql uses '-f variables=' or "
                     f"'--field variables=' (json blob anti-pattern); use individual "

--- a/tests/skills/test_review_pr_prior_thread_awareness.py
+++ b/tests/skills/test_review_pr_prior_thread_awareness.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pytest
 
+from autoskillit.recipe._skill_placeholder_parser import extract_step_sections
+
 pytestmark = [pytest.mark.layer("skills"), pytest.mark.medium]
 
 SKILL_PATH = (
@@ -41,13 +43,16 @@ def test_skill_contains_step_1_5_section() -> None:
 def test_step_1_5_references_graphql_review_threads() -> None:
     """Step 1.5 must reference 'gh api graphql' and 'reviewThreads' for fetching threads."""
     text = _skill_text()
-    assert "reviewThreads" in text, (
+    step_sections = extract_step_sections(text)
+    step_1_5 = step_sections.get("Step 1.5", "")
+    assert "gh api graphql" in step_1_5, (
+        "review-pr/SKILL.md Step 1.5 must contain a concrete 'gh api graphql' "
+        "invocation template — not just the query schema. Without it, the agent "
+        "must improvise the invocation and may use the wrong variable-passing pattern."
+    )
+    assert "reviewThreads" in step_1_5, (
         "review-pr/SKILL.md Step 1.5 must reference 'reviewThreads' in the GraphQL "
         "query used to fetch prior review thread context."
-    )
-    # Step 1.5 should reference graphql (the query is embedded inline)
-    assert "graphql" in text.lower(), (
-        "review-pr/SKILL.md Step 1.5 must use a GraphQL query to fetch review threads."
     )
 
 


### PR DESCRIPTION
## Summary

Three SKILL.md files contain `` ```graphql `` fenced blocks showing GraphQL query schemas without accompanying concrete `gh api graphql` shell invocation templates. When an agent encounters a schema-only block, it must improvise the shell invocation — and the `gh api graphql` variable-passing syntax is non-obvious (each variable must be a separate `-F key=value` flag; passing a `-f variables=<json blob>` silently fails). This caused thread context loss in a production pipeline run.

The root architectural weakness is that **all existing SKILL.md validators operate only on `` ```bash `` blocks** — `` ```graphql `` blocks are completely invisible to the validation pipeline. There is no cross-language-block contract enforcement: a schema block can exist without a corresponding implementation block, and no test or semantic rule detects this.

**Affected files:**
- `src/autoskillit/skills_extended/review-pr/SKILL.md` — Step 1.5 (lines 126–145): GraphQL query schema, zero `gh api graphql` invocation
- `src/autoskillit/skills_extended/audit-review-decisions/SKILL.md` — Step 1.3 (lines 115–129): GraphQL field-selection fragment, no batch-loop `gh api graphql` invocation
- `src/autoskillit/skills/sous-chef/SKILL.md` — Steps 6a/6c/6d (lines 353–362): GraphQL alias query schema, no `gh api graphql` invocation for deferred-group label re-query

Closes #3542

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260601-194344-010883/.autoskillit/temp/rectify/rectify_graphql_invocation_template_2026-06-01_194344.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 5.2k | 20.3k | 2.4M | 124.0k | 62 | 113.9k | 21m 27s |
| review_approach* | sonnet | 1 | 52 | 4.8k | 183.1k | 40.3k | 15 | 26.2k | 2m 55s |
| dry_walkthrough* | opus | 2 | 89 | 21.9k | 640.4k | 64.6k | 47 | 76.4k | 13m 11s |
| implement* | sonnet | 2 | 5.4k | 27.4k | 3.3M | 93.7k | 138 | 94.0k | 9m 12s |
| audit_impl* | sonnet | 2 | 1.3k | 22.1k | 705.1k | 61.0k | 50 | 75.4k | 9m 25s |
| make_plan* | sonnet | 1 | 79 | 3.4k | 303.7k | 43.7k | 19 | 28.6k | 1m 17s |
| prepare_pr* | MiniMax-M3 | 1 | 73.7k | 2.9k | 87.9k | 46.5k | 12 | 0 | 1m 27s |
| compose_pr* | MiniMax-M3 | 1 | 36.3k | 1.4k | 148.2k | 38.5k | 12 | 0 | 55s |
| review_pr* | sonnet | 1 | 190 | 47.9k | 1.3M | 99.7k | 58 | 84.4k | 11m 51s |
| resolve_review* | opus | 1 | 2.3k | 17.8k | 2.0M | 90.6k | 62 | 74.6k | 8m 10s |
| **Total** | | | 124.5k | 169.9k | 11.0M | 124.0k | | 573.5k | 1h 19m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 351 | 9335.7 | 267.8 | 78.0 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 40 | 49659.1 | 1864.1 | 446.1 |
| **Total** | **391** | 28207.0 | 1466.7 | 434.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 5.2k | 20.3k | 2.4M | 113.9k | 21m 27s |
| sonnet | 5 | 6.9k | 105.6k | 5.8M | 308.7k | 34m 42s |
| opus | 2 | 2.4k | 39.8k | 2.6M | 150.9k | 21m 21s |
| MiniMax-M3 | 2 | 110.0k | 4.3k | 236.1k | 0 | 2m 22s |