### PR TITLE
Refactor install() to Use Capability-Driven Guard

### DIFF
--- a/src/autoskillit/cli/_marketplace.py
+++ b/src/autoskillit/cli/_marketplace.py
@@ -147,9 +147,13 @@ def install(*, scope: str = "user") -> bool:
     from autoskillit.config import load_config
 
     cfg = load_config(Path.cwd())
-    if cfg.agent_backend.backend != "claude-code":
+
+    from autoskillit.execution import get_backend
+
+    backend = get_backend(cfg.agent_backend.backend)
+    if not backend.capabilities.plugin_install_capable:
         print(
-            f"\nautoskillit install is only supported with the claude-code backend.\n"
+            f"\nPlugin install requires a plugin_install_capable backend.\n"
             f"Current backend: {cfg.agent_backend.backend!r}\n"
         )
         return False

--- a/tests/cli/test_cli_marketplace.py
+++ b/tests/cli/test_cli_marketplace.py
@@ -66,3 +66,53 @@ def test_upgrade_is_registered_as_cli_command():
 def test_marketplace_module_still_importable():
     """_marketplace module is still importable (not deleted)."""
     import autoskillit.cli._marketplace  # noqa: F401
+
+
+class TestInstallPluginInstallCapableGuard:
+    def test_rejects_when_plugin_install_not_capable(self, monkeypatch, capsys):
+        """install() returns False with rejection message when capability is False."""
+        from unittest.mock import MagicMock
+
+        mock_cfg = MagicMock()
+        mock_cfg.agent_backend.backend = "some-backend"
+        monkeypatch.setattr("autoskillit.config.load_config", lambda _: mock_cfg)
+
+        mock_backend = MagicMock()
+        mock_backend.capabilities.plugin_install_capable = False
+        monkeypatch.setattr("autoskillit.execution.get_backend", lambda name: mock_backend)
+
+        from autoskillit.cli._marketplace import install
+
+        result = install(scope="user")
+
+        assert result is False
+        captured = capsys.readouterr()
+        assert (
+            "plugin_install_capable" in captured.out
+            or "plugin-install-capable" in captured.out.lower()
+        )
+
+    def test_passes_guard_when_plugin_install_capable(self, monkeypatch, capsys):
+        """install() does not reject at capability guard when True."""
+        from unittest.mock import MagicMock
+
+        mock_cfg = MagicMock()
+        mock_cfg.agent_backend.backend = "claude-code"
+        monkeypatch.setattr("autoskillit.config.load_config", lambda _: mock_cfg)
+
+        mock_backend = MagicMock()
+        mock_backend.capabilities.plugin_install_capable = True
+        monkeypatch.setattr("autoskillit.execution.get_backend", lambda name: mock_backend)
+
+        # Stub CLAUDECODE env to trigger the next guard (deferred exit)
+        monkeypatch.setenv("CLAUDECODE", "1")
+
+        from autoskillit.cli._marketplace import install
+
+        result = install(scope="user")
+
+        # Should reach the CLAUDECODE guard (returns False for deferred),
+        # NOT the capability guard
+        assert result is False
+        captured = capsys.readouterr()
+        assert "plugin_install_capable" not in captured.out

--- a/tests/cli/test_cli_marketplace.py
+++ b/tests/cli/test_cli_marketplace.py
@@ -87,10 +87,7 @@ class TestInstallPluginInstallCapableGuard:
 
         assert result is False
         captured = capsys.readouterr()
-        assert (
-            "plugin_install_capable" in captured.out
-            or "plugin-install-capable" in captured.out.lower()
-        )
+        assert "plugin_install_capable" in captured.out
 
     def test_passes_guard_when_plugin_install_capable(self, monkeypatch, capsys):
         """install() does not reject at capability guard when True."""

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -176,13 +176,19 @@ class TestCLIInstall:
     def test_install_backend_guard_returns_false_for_non_claude_code(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        """install() returns False with message when backend != 'claude-code'."""
+        """install() returns False with message when capability is False."""
+        from unittest.mock import MagicMock
+
         from autoskillit.config import AgentBackendConfig, AutomationConfig
 
-        mock_cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="aider"))
+        mock_cfg = AutomationConfig(agent_backend=AgentBackendConfig(backend="codex"))
         monkeypatch.setattr("autoskillit.config.load_config", lambda _: mock_cfg)
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
         monkeypatch.setattr(Path, "cwd", staticmethod(lambda: tmp_path))
+
+        mock_backend = MagicMock()
+        mock_backend.capabilities.plugin_install_capable = False
+        monkeypatch.setattr("autoskillit.execution.get_backend", lambda name: mock_backend)
 
         from autoskillit.cli._marketplace import install
 
@@ -190,7 +196,7 @@ class TestCLIInstall:
 
         assert result is False
         captured = capsys.readouterr()
-        assert "only supported with the claude-code backend" in captured.out.lower()
+        assert "plugin_install_capable" in captured.out
 
     def test_install_backend_guard_allows_claude_code(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -141,7 +141,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _marketplace.py — marketplace.json (co-owned)
     ("src/autoskillit/cli/_marketplace.py", 96),
     # _marketplace.py — hooks.json (co-owned)
-    ("src/autoskillit/cli/_marketplace.py", 188),
+    ("src/autoskillit/cli/_marketplace.py", 192),
     # tools_config.py — hook config overlay dict (session-scoped, not schema-versioned)
     ("src/autoskillit/server/tools/tools_config.py", 50),
     # _update_checks.py — dismissal state file


### PR DESCRIPTION
## Summary

Replace the string comparison `cfg.agent_backend.backend != "claude-code"` in `cli/_marketplace.py:install()` with a capability check `backend.capabilities.plugin_install_capable`, resolving the backend via `get_backend()` with a lazy import. Add tests asserting the guard is driven by the capability flag.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260601-220833-993213/.autoskillit/temp/make-plan/p4-a2-wp4-refactor-install-capability-guard_plan_2026-06-01_220900.md`

Closes #3120

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.3k | 4.7k | 351.7k | 45.4k | 19 | 31.4k | 2m 37s |
| verify* | sonnet | 1 | 76 | 9.9k | 330.4k | 47.8k | 24 | 31.3k | 3m 47s |
| implement* | MiniMax-M3 | 1 | 60.1k | 7.1k | 1.1M | 58.4k | 60 | 0 | 4m 17s |
| audit_impl* | sonnet | 1 | 44 | 8.7k | 142.0k | 36.5k | 13 | 29.0k | 3m 25s |
| prepare_pr* | MiniMax-M3 | 1 | 37.6k | 3.7k | 197.5k | 43.2k | 15 | 0 | 1m 52s |
| compose_pr* | MiniMax-M3 | 1 | 34.5k | 895 | 258.5k | 37.7k | 11 | 0 | 55s |
| review_pr* | sonnet | 1 | 132 | 22.0k | 678.6k | 63.9k | 39 | 48.3k | 5m 41s |
| resolve_review* | opus | 1 | 37 | 13.1k | 1.1M | 75.2k | 38 | 89.9k | 8m 34s |
| **Total** | | | 133.9k | 70.2k | 4.2M | 75.2k | | 229.9k | 31m 11s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 58 | 19264.9 | 0.0 | 121.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 5 | 229939.0 | 17980.0 | 2629.4 |
| **Total** | **63** | 67075.8 | 3649.2 | 1113.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.3k | 4.7k | 351.7k | 31.4k | 2m 37s |
| sonnet | 3 | 252 | 40.7k | 1.2M | 108.6k | 12m 54s |
| MiniMax-M3 | 3 | 132.2k | 11.6k | 1.6M | 0 | 7m 4s |
| opus | 1 | 37 | 13.1k | 1.1M | 89.9k | 8m 34s |