### PR TITLE
Rectify: Signal Guard Activity Blindness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ select = ["E", "F", "I", "UP", "TID251"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "logging.getLogger" = {msg = "Use get_logger() from autoskillit._logging instead."}
-"signal.signal" = {msg = "Use anyio.open_signal_receiver instead of signal.signal — see _serve_with_signal_guard in cli/app.py."}
+"signal.signal" = {msg = "Use anyio.open_signal_receiver instead of signal.signal — see serve_with_signal_guard in cli/_serve_guard.py."}
 "yaml.safe_load" = {msg = "Use load_yaml() from autoskillit.core.io instead — CSafeLoader is 9-11x faster."}
 "yaml.safe_dump" = {msg = "Use dump_yaml_str() from autoskillit.core.io instead — CDumper is faster."}
 

--- a/src/autoskillit/cli/_serve_guard.py
+++ b/src/autoskillit/cli/_serve_guard.py
@@ -27,7 +27,7 @@ logger = get_logger(__name__)
 async def serve_with_signal_guard(
     mcp_server: Any,
     *,
-    dispatch_activity_check: Callable[[], bool] | None = None,
+    activity_check: Callable[[], bool] | None = None,
     deferral_timeout: float = 30.0,
 ) -> None:
     """Run the MCP server with event-loop-routed SIGTERM/SIGINT handling.
@@ -46,17 +46,17 @@ async def serve_with_signal_guard(
             task_status.started()  # signal receiver is now armed
             async for sig in signals:
                 logger.info("serve_with_signal_guard: received %s — initiating shutdown", sig.name)
-                if dispatch_activity_check is not None and dispatch_activity_check():
+                if activity_check is not None and activity_check():
                     logger.info(
-                        "serve_with_signal_guard: dispatch active — deferring up to %.0fs",
+                        "serve_with_signal_guard: activity detected — deferring up to %.0fs",
                         deferral_timeout,
                     )
                     deadline = anyio.current_time() + deferral_timeout
                     while anyio.current_time() < deadline:
                         await anyio.sleep(1.0)
-                        if not dispatch_activity_check():
+                        if not activity_check():
                             logger.info(
-                                "serve_with_signal_guard: dispatch completed — shutting down"
+                                "serve_with_signal_guard: activity completed — shutting down"
                             )
                             break
                     else:

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -8,7 +8,7 @@ import os
 import sys
 from datetime import UTC
 from pathlib import Path
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 import anyio
 from cyclopts import App, Parameter
@@ -23,6 +23,10 @@ from autoskillit.cli._init_helpers import (
     _register_all,
 )
 from autoskillit.cli._serve_guard import serve_with_signal_guard
+from autoskillit.execution.process import _has_active_execution_marker
+
+if TYPE_CHECKING:
+    from autoskillit.core import FleetLock
 from autoskillit.cli._sessions import sessions_app
 from autoskillit.cli._validate import validate_app
 from autoskillit.cli.fleet import fleet_app
@@ -31,6 +35,7 @@ from autoskillit.cli.session._order import _recipes_dir_for, order
 from autoskillit.core import (
     RecipeSource,
     atomic_write,
+    claude_code_project_dir,
 )
 
 app = App(
@@ -52,6 +57,17 @@ app.command(features_app)
 app.command(sessions_app)
 app.command(validate_app)
 app.command(order)
+
+
+def is_server_active(
+    marker_dir: Path | None,
+    fleet_lock: FleetLock | None,
+) -> bool:
+    if fleet_lock is not None and fleet_lock.active_count > 0:
+        return True
+    if marker_dir is not None and _has_active_execution_marker(marker_dir):
+        return True
+    return False
 
 
 class CliError(Exception):
@@ -136,13 +152,17 @@ def serve(*, verbose: Annotated[bool, Parameter(name=["--verbose", "-v"])] = Fal
     try:
         backend_options = {"use_uvloop": sys.platform != "win32"}
 
-        def _check_dispatch_active() -> bool:
-            if ctx.fleet_lock is None:
-                return False
-            return ctx.fleet_lock.active_count > 0
+        _marker_dir: Path | None = None
+        try:
+            _marker_dir = claude_code_project_dir(str(ctx.project_dir))
+        except OSError:
+            pass
 
         async def _guarded_serve() -> None:
-            await serve_with_signal_guard(mcp, dispatch_activity_check=_check_dispatch_active)
+            await serve_with_signal_guard(
+                mcp,
+                activity_check=lambda: is_server_active(_marker_dir, ctx.fleet_lock),
+            )
 
         anyio.run(
             _guarded_serve,

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -23,7 +23,7 @@ from autoskillit.cli._init_helpers import (
     _register_all,
 )
 from autoskillit.cli._serve_guard import serve_with_signal_guard
-from autoskillit.execution.process import _has_active_execution_marker
+from autoskillit.execution import _has_active_execution_marker
 
 if TYPE_CHECKING:
     from autoskillit.core import FleetLock

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -23,10 +23,6 @@ from autoskillit.cli._init_helpers import (
     _register_all,
 )
 from autoskillit.cli._serve_guard import serve_with_signal_guard
-from autoskillit.execution import _has_active_execution_marker
-
-if TYPE_CHECKING:
-    from autoskillit.core import FleetLock
 from autoskillit.cli._sessions import sessions_app
 from autoskillit.cli._validate import validate_app
 from autoskillit.cli.fleet import fleet_app
@@ -37,6 +33,10 @@ from autoskillit.core import (
     atomic_write,
     claude_code_project_dir,
 )
+from autoskillit.execution import _has_active_execution_marker
+
+if TYPE_CHECKING:
+    from autoskillit.core import FleetLock
 
 app = App(
     name="autoskillit",

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -81,6 +81,7 @@ from autoskillit.execution.pr_analysis import (
 )
 from autoskillit.execution.process import (
     DefaultSubprocessRunner,
+    _has_active_execution_marker,  # noqa: F401 — re-exported for cli/app.py signal guard
     async_kill_process_tree,
     kill_process_tree,
     run_managed_async,

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -505,7 +505,7 @@ async def _autoskillit_lifespan(server: Any) -> Any:
 
     Readiness model: the sentinel file is written as the first statement inside
     the ``try:`` block. By the time the lifespan body runs,
-    ``_serve_with_signal_guard()`` in ``cli/app.py`` has already armed the anyio
+    ``serve_with_signal_guard()`` in ``cli/_serve_guard.py`` has already armed the anyio
     signal receiver via ``tg.start()``. A SIGTERM delivered after the sentinel
     appears is guaranteed to be caught by the armed receiver — no race window.
 

--- a/tests/arch/test_watcher_signal_consistency.py
+++ b/tests/arch/test_watcher_signal_consistency.py
@@ -9,6 +9,7 @@ import pytest
 
 pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 
+_CLI_APP = Path("src/autoskillit/cli/app.py")
 _PROCESS_RACE = Path("src/autoskillit/execution/process/_process_race.py")
 _PROCESS_MONITOR = Path("src/autoskillit/execution/process/_process_monitor.py")
 
@@ -48,4 +49,16 @@ def test_watcher_calls_has_active_execution_marker(watcher: str) -> None:
     assert watcher in all_callers, (
         f"{watcher} does not call _has_active_execution_marker. "
         f"Functions that do: {sorted(all_callers)}"
+    )
+
+
+_SIGNAL_GUARD_ACTIVITY_MUST_CHECK_MARKER = frozenset({"is_server_active"})
+
+
+@pytest.mark.parametrize("fn_name", sorted(_SIGNAL_GUARD_ACTIVITY_MUST_CHECK_MARKER))
+def test_signal_guard_activity_check_calls_has_active_execution_marker(fn_name: str) -> None:
+    callers = _functions_calling_predicate(_CLI_APP, "_has_active_execution_marker")
+    assert fn_name in callers, (
+        f"{fn_name} in cli/app.py does not call _has_active_execution_marker. "
+        f"Functions that do: {sorted(callers)}"
     )

--- a/tests/cli/test_serve_guard_deferral.py
+++ b/tests/cli/test_serve_guard_deferral.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import inspect
 import os
 import signal
+import time
+import uuid
+from pathlib import Path
 
 import anyio
 import pytest
 
 from autoskillit.cli._serve_guard import serve_with_signal_guard
+from autoskillit.cli.app import is_server_active
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
 
@@ -40,13 +45,13 @@ class TestServeGuardDeferral:
             tg.start_soon(_send_signal_then_release)
             await serve_with_signal_guard(
                 server,
-                dispatch_activity_check=lambda: _active[0],
+                activity_check=lambda: _active[0],
                 deferral_timeout=3.0,
             )
 
         elapsed = anyio.current_time() - started_at
         assert elapsed >= 1.5
-        assert not _active[0], "dispatch_activity_check should report inactive after deferral"
+        assert not _active[0], "activity_check should report inactive after deferral"
 
     @pytest.mark.anyio
     async def test_cancels_immediately_when_no_dispatch(self) -> None:
@@ -62,7 +67,7 @@ class TestServeGuardDeferral:
             tg.start_soon(_send_signal)
             await serve_with_signal_guard(
                 server,
-                dispatch_activity_check=lambda: False,
+                activity_check=lambda: False,
                 deferral_timeout=3.0,
             )
 
@@ -85,9 +90,50 @@ class TestServeGuardDeferral:
             tg.start_soon(_send_signal)
             await serve_with_signal_guard(
                 server,
-                dispatch_activity_check=lambda: True,
+                activity_check=lambda: True,
                 deferral_timeout=2.0,
             )
 
         elapsed = anyio.current_time() - started_at
         assert 2.0 <= elapsed < 3.5
+
+
+class TestActivityCheckCompleteness:
+    def test_activity_check_true_when_execution_marker_exists(self, tmp_path: Path) -> None:
+        marker_name = f"run-skill-in-progress-sess-{uuid.uuid4()}.marker"
+        (tmp_path / marker_name).touch()
+        assert is_server_active(marker_dir=tmp_path, fleet_lock=None) is True
+
+    @pytest.mark.anyio
+    async def test_activity_check_true_when_fleet_lock_active(self) -> None:
+        from autoskillit.fleet import FleetSemaphore
+
+        sem = FleetSemaphore()
+        await sem.acquire()
+        try:
+            assert is_server_active(marker_dir=None, fleet_lock=sem) is True
+        finally:
+            sem.release()
+
+    def test_activity_check_false_when_both_idle(self, tmp_path: Path) -> None:
+        from autoskillit.fleet import FleetSemaphore
+
+        assert is_server_active(marker_dir=tmp_path, fleet_lock=FleetSemaphore()) is False
+
+    def test_activity_check_true_when_marker_within_age(self, tmp_path: Path) -> None:
+        marker = tmp_path / f"run-skill-in-progress-sess-{uuid.uuid4()}.marker"
+        marker.touch()
+        os.utime(marker, (time.time() - 50, time.time() - 50))
+        assert is_server_active(marker_dir=tmp_path, fleet_lock=None) is True
+
+    def test_activity_check_false_when_marker_expired(self, tmp_path: Path) -> None:
+        marker = tmp_path / f"run-skill-in-progress-sess-{uuid.uuid4()}.marker"
+        marker.touch()
+        os.utime(marker, (time.time() - 120, time.time() - 120))
+        assert is_server_active(marker_dir=tmp_path, fleet_lock=None) is False
+
+
+class TestParameterNaming:
+    def test_serve_with_signal_guard_accepts_activity_check_param(self) -> None:
+        sig = inspect.signature(serve_with_signal_guard)
+        assert "activity_check" in sig.parameters

--- a/tests/server/test_no_raw_signal_handler.py
+++ b/tests/server/test_no_raw_signal_handler.py
@@ -57,7 +57,8 @@ class TestNoRawSignalHandler:
         ]
         assert not bad_calls, (
             f"Found {len(bad_calls)} raw signal.signal(SIGTERM, ...) call(s) in cli/app.py. "
-            "Use anyio.open_signal_receiver instead — see _serve_with_signal_guard."
+            "Use anyio.open_signal_receiver instead "
+            "— see serve_with_signal_guard in cli/_serve_guard.py."
         )
 
     def test_grep_no_signal_signal_sigterm_in_src(self):
@@ -72,5 +73,6 @@ class TestNoRawSignalHandler:
         assert not violations, (
             "Found raw signal.signal(SIGTERM, ...) usage in src/autoskillit:\n"
             + "\n".join(f"  {v}" for v in violations)
-            + "\nUse anyio.open_signal_receiver(signal.SIGTERM) — see _serve_with_signal_guard."
+            + "\nUse anyio.open_signal_receiver(signal.SIGTERM) "
+            "— see serve_with_signal_guard in cli/_serve_guard.py."
         )


### PR DESCRIPTION
## Summary

The signal guard's `dispatch_activity_check` callback (`cli/app.py:139-142`) checks only `fleet_lock.active_count > 0`, making it blind to `run_skill` calls. When SIGTERM arrives during a `run_skill` execution, the guard sees zero active work and immediately cancels the process, killing the subprocess mid-execution. The fix is to unify activity detection so the signal guard reads execution markers (which both `run_skill` and `dispatch_food_truck` already write) via the existing `_has_active_execution_marker` function, and to add an architectural AST guard that enforces this permanently.

Closes #3584

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260601-220024-918720/.autoskillit/temp/rectify/rectify_signal_guard_activity_blindness_2026-06-01_220500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 10.1k | 20.7k | 1.6M | 118.8k | 51 | 102.1k | 17m 38s |
| review_approach* | opus[1m] | 1 | 4.3k | 4.4k | 189.1k | 45.5k | 11 | 31.5k | 5m 18s |
| dry_walkthrough* | opus | 1 | 1.1k | 13.0k | 2.2M | 105.5k | 66 | 88.7k | 5m 54s |
| implement* | opus[1m] | 1 | 55 | 11.1k | 1.5M | 68.3k | 68 | 51.6k | 5m 42s |
| audit_impl* | opus[1m] | 1 | 33 | 8.9k | 178.3k | 39.0k | 15 | 32.5k | 5m 16s |
| prepare_pr* | MiniMax-M3 | 1 | 42.1k | 3.3k | 166.2k | 46.8k | 16 | 0 | 1m 51s |
| compose_pr* | MiniMax-M3 | 1 | 36.2k | 1.5k | 265.1k | 38.8k | 14 | 0 | 1m 12s |
| review_pr* | opus[1m] | 1 | 45 | 30.2k | 1.0M | 85.3k | 42 | 69.0k | 7m 7s |
| resolve_review* | opus[1m] | 1 | 36 | 5.1k | 846.1k | 52.4k | 36 | 36.2k | 5m 33s |
| **Total** | | | 94.0k | 98.1k | 7.9M | 118.8k | | 411.7k | 55m 36s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 119 | 12284.6 | 434.0 | 93.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 105767.5 | 4530.1 | 631.4 |
| **Total** | **127** | 62507.3 | 3241.4 | 772.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 14.6k | 80.3k | 5.3M | 322.9k | 46m 37s |
| opus | 1 | 1.1k | 13.0k | 2.2M | 88.7k | 5m 54s |
| MiniMax-M3 | 2 | 78.3k | 4.8k | 431.3k | 0 | 3m 3s |