### PR TITLE
Rectify: Fleet Dispatch Progress Evidence Gap

### DIFF
--- a/src/autoskillit/fleet/CLAUDE.md
+++ b/src/autoskillit/fleet/CLAUDE.md
@@ -21,7 +21,7 @@ IL-2 fleet campaign layer — parallel issue dispatch, semaphore, sidecar, liven
 | `_semaphore.py` | `FleetSemaphore` — configurable `asyncio.BoundedSemaphore` implementing `FleetLock` |
 | `_sidecar_rpc.py` | `run_python`-callable entry points: `write_sidecar_entry`, `get_remaining_issues` |
 | `_findings_rpc.py` | `run_python`-callable entry points: `parse_and_resume`, `load_execution_map` |
-| `_checkpoint_bridge.py` | `checkpoint_from_sidecar` — converts `IssueSidecarEntry` list to `SessionCheckpoint` |
+| `_checkpoint_bridge.py` | `checkpoint_from_sidecar` — converts `IssueSidecarEntry` list to `SessionCheckpoint`; `checkpoint_from_tracker` — converts pipeline tracker dict to `SessionCheckpoint | None` |
 | `_sidecar_synthesis.py` | Sidecar-based result synthesis — upgrades `no_sentinel` to `completed_clean` when sidecar evidence is sufficient |
 | `state.py` | Campaign state I/O and mutations — `CampaignStateMutator`, `read_state`, `mark_dispatch_*`, re-exports from `state_types`, `state_gates`, `state_recovery` |
 | `state_types.py` | Campaign state types — `DispatchStatus`, `DispatchRecord`, `CampaignState`, `ResumeDecision`, `GateRecordResult`, constants |

--- a/src/autoskillit/fleet/__init__.py
+++ b/src/autoskillit/fleet/__init__.py
@@ -7,7 +7,7 @@ Gateway exports per REQ-IMP-001 — consumers import from
 from ._api import _write_pid as _write_pid
 from ._api import execute_dispatch
 from ._capture import CaptureCompletenessError
-from ._checkpoint_bridge import checkpoint_from_sidecar
+from ._checkpoint_bridge import checkpoint_from_sidecar, checkpoint_from_tracker
 from ._dispatch_reaper import reap_stale_dispatches, reap_stale_dispatches_async
 from ._expressions import evaluate_skip_when
 from ._label_cleanup import (
@@ -161,6 +161,7 @@ __all__ = [
     "derive_orchestrator_resume_spec",
     "find_dispatch_for_issue",
     "checkpoint_from_sidecar",
+    "checkpoint_from_tracker",
     "is_dispatch_session_alive",
     "reap_stale_dispatches",
     "reap_stale_dispatches_async",

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -738,7 +738,7 @@ async def _run_dispatch(
             )
 
             tracker_checkpoint = checkpoint_from_tracker(_tracker_data)
-        except (OSError, ValueError):
+        except (OSError, ValueError, TypeError, AttributeError):
             logger.debug("tracker read failed for %s", dispatch_id, exc_info=True)
 
     if dispatch_checkpoint is None and tracker_checkpoint is not None:

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -724,6 +724,26 @@ async def _run_dispatch(
         if sidecar_entries:
             dispatch_checkpoint = checkpoint_from_sidecar(sidecar_entries)
 
+    tracker_checkpoint: SessionCheckpoint | None = None
+    _tracker_path = (
+        tool_ctx.project_dir / ".autoskillit" / "temp" / "pipeline_tracker" / f"{dispatch_id}.json"
+    )
+    if _tracker_path.exists():
+        try:
+            import json as _json_mod  # noqa: PLC0415
+
+            _tracker_data = _json_mod.loads(_tracker_path.read_text())
+            from autoskillit.fleet._checkpoint_bridge import (
+                checkpoint_from_tracker,  # noqa: PLC0415
+            )
+
+            tracker_checkpoint = checkpoint_from_tracker(_tracker_data)
+        except (OSError, ValueError):
+            logger.debug("tracker read failed for %s", dispatch_id, exc_info=True)
+
+    if dispatch_checkpoint is None and tracker_checkpoint is not None:
+        dispatch_checkpoint = tracker_checkpoint
+
     extended_chain = prior_session_chain[:]
     additional_jsonl_paths: list[Path] = []
     if skill_result.subtype == "timeout":

--- a/src/autoskillit/fleet/_checkpoint_bridge.py
+++ b/src/autoskillit/fleet/_checkpoint_bridge.py
@@ -28,6 +28,8 @@ def checkpoint_from_tracker(tracker_data: dict[str, Any] | None) -> SessionCheck
     if tracker_data is None:
         return None
     steps = tracker_data.get("steps", {})
+    if not isinstance(steps, dict):
+        return None
     completed = [
         name
         for name, info in steps.items()
@@ -40,7 +42,7 @@ def checkpoint_from_tracker(tracker_data: dict[str, Any] | None) -> SessionCheck
     last_step_name = completed_with_ts[-1][0]
     last_ts = completed_with_ts[-1][1]
     return SessionCheckpoint(
-        completed_items=completed,
+        completed_items=[name for name, _ in completed_with_ts],
         step_name=last_step_name,
         progress_pct=len(completed) / len(steps),
         ts=last_ts,

--- a/src/autoskillit/fleet/_checkpoint_bridge.py
+++ b/src/autoskillit/fleet/_checkpoint_bridge.py
@@ -1,6 +1,13 @@
-"""Bridge from fleet IssueSidecarEntry to core SessionCheckpoint."""
+"""Bridge from fleet progress sources to core SessionCheckpoint.
+
+Two progress sources feed into SessionCheckpoint:
+- Sidecar (issue-level): completed issue URLs from IssueSidecarEntry
+- Pipeline tracker (step-level): completed recipe steps from tracker JSON
+"""
 
 from __future__ import annotations
+
+from typing import Any
 
 from autoskillit.core import SessionCheckpoint
 from autoskillit.fleet.sidecar import IssueSidecarEntry
@@ -14,4 +21,27 @@ def checkpoint_from_sidecar(entries: list[IssueSidecarEntry]) -> SessionCheckpoi
         step_name="fleet_dispatch",
         progress_pct=0.0,
         ts=ts,
+    )
+
+
+def checkpoint_from_tracker(tracker_data: dict[str, Any] | None) -> SessionCheckpoint | None:
+    if tracker_data is None:
+        return None
+    steps = tracker_data.get("steps", {})
+    completed = [
+        name
+        for name, info in steps.items()
+        if isinstance(info, dict) and info.get("status") == "complete"
+    ]
+    if not completed:
+        return None
+    completed_with_ts = [(name, steps[name].get("completed_at", "")) for name in completed]
+    completed_with_ts.sort(key=lambda x: x[1])
+    last_step_name = completed_with_ts[-1][0]
+    last_ts = completed_with_ts[-1][1]
+    return SessionCheckpoint(
+        completed_items=completed,
+        step_name=last_step_name,
+        progress_pct=len(completed) / len(steps),
+        ts=last_ts,
     )

--- a/tests/arch/test_python_no_hardcoded_temp.py
+++ b/tests/arch/test_python_no_hardcoded_temp.py
@@ -69,7 +69,6 @@ _TEMP_PATH_WHITELIST: dict[str, str] = {
     "hooks/guards/skill_load_guard.py": "stdlib-only guard; cannot use resolve_temp_dir()",
     "core/runtime/session_provenance.py": "IL-0 stdlib-only module; cannot use resolve_temp_dir()",
     "workspace/skill_format.py": "write_paths validation accepts resolved canonical temp prefix",
-    "fleet/_api.py": "tracker checkpoint read; server._misc is IL-3, fleet is IL-2",
 }
 
 _LITERAL = ".autoskillit/temp"

--- a/tests/arch/test_python_no_hardcoded_temp.py
+++ b/tests/arch/test_python_no_hardcoded_temp.py
@@ -69,6 +69,7 @@ _TEMP_PATH_WHITELIST: dict[str, str] = {
     "hooks/guards/skill_load_guard.py": "stdlib-only guard; cannot use resolve_temp_dir()",
     "core/runtime/session_provenance.py": "IL-0 stdlib-only module; cannot use resolve_temp_dir()",
     "workspace/skill_format.py": "write_paths validation accepts resolved canonical temp prefix",
+    "fleet/_api.py": "tracker checkpoint read; server._misc is IL-3, fleet is IL-2",
 }
 
 _LITERAL = ".autoskillit/temp"

--- a/tests/fleet/CLAUDE.md
+++ b/tests/fleet/CLAUDE.md
@@ -15,7 +15,7 @@ Fleet campaign dispatch, state persistence, and sidecar tests.
 | `test_api_dispatch_marker.py` | Tests for _run_dispatch marker lifecycle via execution_marker context manager |
 | `test_campaign_capture.py` | Tests for campaign capture extraction and ingredient interpolation (Group J) |
 | `test_capture_roundtrip.py` | Tests for prompt-extractor field name alignment — verifies sentinel examples use bare names matching `_extract_captures` expectations |
-| `test_checkpoint_bridge.py` | Tests for checkpoint_from_sidecar converting IssueSidecarEntry to SessionCheckpoint |
+| `test_checkpoint_bridge.py` | Tests for checkpoint_from_sidecar and checkpoint_from_tracker converting progress sources to SessionCheckpoint |
 | `test_dispatch_failure_semantics.py` | Group F: Core failure path semantics — timeout, no-sentinel, completed-dirty, completed-clean |
 | `test_dispatch_envelope_fields.py` | Dispatch envelope field persistence — elapsed_seconds and dispatch_status |
 | `test_dispatch_stderr_forwarding.py` | Stderr envelope forwarding and truncation tests |

--- a/tests/fleet/test_checkpoint_bridge.py
+++ b/tests/fleet/test_checkpoint_bridge.py
@@ -68,7 +68,11 @@ class TestCheckpointFromTracker:
         }
         checkpoint = checkpoint_from_tracker(tracker_data)
         assert checkpoint is not None
-        assert checkpoint.completed_items == ["plan", "verify", "implement"]
+        assert checkpoint.completed_items == [
+            "plan",
+            "verify",
+            "implement",
+        ]  # sorted by completed_at
         assert checkpoint.step_name == "implement"
         assert checkpoint.progress_pct == pytest.approx(0.75)
 

--- a/tests/fleet/test_checkpoint_bridge.py
+++ b/tests/fleet/test_checkpoint_bridge.py
@@ -1,10 +1,10 @@
-"""T1 (cont.): checkpoint_from_sidecar bridge."""
+"""Tests for checkpoint_from_sidecar and checkpoint_from_tracker bridge functions."""
 
 from __future__ import annotations
 
 import pytest
 
-from autoskillit.fleet._checkpoint_bridge import checkpoint_from_sidecar
+from autoskillit.fleet._checkpoint_bridge import checkpoint_from_sidecar, checkpoint_from_tracker
 from autoskillit.fleet.sidecar import IssueSidecarEntry
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
@@ -53,3 +53,85 @@ class TestCheckpointFromSidecar:
 
         restored = SessionCheckpoint.from_dict(d)
         assert restored == cp
+
+
+class TestCheckpointFromTracker:
+    def test_tracker_with_completed_steps_produces_checkpoint(self) -> None:
+        tracker_data = {
+            "pipeline_id": "dispatch-123",
+            "steps": {
+                "plan": {"status": "complete", "completed_at": "2026-06-01T00:00:00Z"},
+                "verify": {"status": "complete", "completed_at": "2026-06-01T00:01:00Z"},
+                "implement": {"status": "complete", "completed_at": "2026-06-01T00:02:00Z"},
+                "review-pr": {"status": "pending"},
+            },
+        }
+        checkpoint = checkpoint_from_tracker(tracker_data)
+        assert checkpoint is not None
+        assert checkpoint.completed_items == ["plan", "verify", "implement"]
+        assert checkpoint.step_name == "implement"
+        assert checkpoint.progress_pct == pytest.approx(0.75)
+
+    def test_tracker_with_no_completed_steps_returns_none(self) -> None:
+        tracker_data = {
+            "pipeline_id": "dispatch-123",
+            "steps": {
+                "plan": {"status": "pending"},
+                "verify": {"status": "pending"},
+            },
+        }
+        checkpoint = checkpoint_from_tracker(tracker_data)
+        assert checkpoint is None
+
+    def test_tracker_empty_steps_returns_none(self) -> None:
+        tracker_data = {
+            "pipeline_id": "dispatch-123",
+            "steps": {},
+        }
+        checkpoint = checkpoint_from_tracker(tracker_data)
+        assert checkpoint is None
+
+    def test_tracker_missing_file_returns_none(self) -> None:
+        checkpoint = checkpoint_from_tracker(None)
+        assert checkpoint is None
+
+    def test_tracker_sorts_by_completed_at(self) -> None:
+        tracker_data = {
+            "pipeline_id": "dispatch-456",
+            "steps": {
+                "implement": {"status": "complete", "completed_at": "2026-06-01T00:02:00Z"},
+                "plan": {"status": "complete", "completed_at": "2026-06-01T00:00:00Z"},
+            },
+        }
+        checkpoint = checkpoint_from_tracker(tracker_data)
+        assert checkpoint is not None
+        assert checkpoint.step_name == "implement"
+        assert checkpoint.ts == "2026-06-01T00:02:00Z"
+
+    def test_tracker_produces_valid_checkpoint(self) -> None:
+        from autoskillit.core.types._type_checkpoint import SessionCheckpoint
+
+        tracker_data = {
+            "pipeline_id": "dispatch-789",
+            "steps": {
+                "plan": {"status": "complete", "completed_at": "2026-06-01T00:00:00Z"},
+            },
+        }
+        checkpoint = checkpoint_from_tracker(tracker_data)
+        assert checkpoint is not None
+        d = checkpoint.to_dict()
+        restored = SessionCheckpoint.from_dict(d)
+        assert restored == checkpoint
+
+    def test_tracker_ignores_non_dict_step_entries(self) -> None:
+        tracker_data = {
+            "pipeline_id": "dispatch-corrupt",
+            "steps": {
+                "plan": {"status": "complete", "completed_at": "2026-06-01T00:00:00Z"},
+                "verify": "bad_data",
+            },
+        }
+        checkpoint = checkpoint_from_tracker(tracker_data)
+        assert checkpoint is not None
+        assert checkpoint.completed_items == ["plan"]
+        assert checkpoint.progress_pct == pytest.approx(0.5)

--- a/tests/fleet/test_dispatch_failure_semantics.py
+++ b/tests/fleet/test_dispatch_failure_semantics.py
@@ -464,3 +464,75 @@ class TestSidecarBasedResultSynthesis:
         )
         envelope = json.loads(result.outcome.to_envelope())
         assert envelope["dispatch_status"] == "success"
+
+
+class TestTrackerBridgeIntegration:
+    @pytest.mark.anyio
+    async def test_single_issue_killed_with_tracker_progress_is_resumable(
+        self, tool_ctx, monkeypatch
+    ):
+        """process_killed + no sidecar + populated tracker file → RESUMABLE via checkpoint bridge."""
+        import dataclasses
+        import json
+
+        from autoskillit.core import DispatchIdentity, InfraOutcome
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx, monkeypatch)
+
+        fixed_dispatch_id = "aaaabbbb-aaaa-bbbb-cccc-111111111111"
+        _fixed_identity = DispatchIdentity.from_dispatch_id(fixed_dispatch_id)
+
+        class _FixedDispatchIdentity:
+            @classmethod
+            def fresh(cls) -> DispatchIdentity:
+                return _fixed_identity
+
+        monkeypatch.setattr("autoskillit.fleet.state.DispatchIdentity", _FixedDispatchIdentity)
+
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(
+                _DEFAULT_SKILL_RESULT,
+                success=False,
+                session_id="sess-tracker-001",
+                lifespan_started=True,
+                retry_reason="resume",
+                infra=InfraOutcome(exit_category="process_killed"),
+            )
+        )
+
+        monkeypatch.setattr(
+            "autoskillit.fleet._api.parse_l3_result_block",
+            lambda **_: _make_no_sentinel(),
+        )
+
+        tracker_dir = tool_ctx.project_dir / ".autoskillit" / "temp" / "pipeline_tracker"
+        tracker_dir.mkdir(parents=True, exist_ok=True)
+        tracker_file = tracker_dir / f"{fixed_dispatch_id}.json"
+        tracker_file.write_text(
+            json.dumps(
+                {
+                    "pipeline_id": fixed_dispatch_id,
+                    "kitchen_id": "k-test",
+                    "initialized_at": "2026-06-01T00:00:00Z",
+                    "steps": {
+                        "plan": {
+                            "status": "complete",
+                            "completed_at": "2026-06-01T00:01:00Z",
+                        },
+                        "implement": {
+                            "status": "complete",
+                            "completed_at": "2026-06-01T00:02:00Z",
+                        },
+                        "review-pr": {"status": "pending"},
+                    },
+                    "dependencies": {},
+                }
+            )
+        )
+
+        await _run(tool_ctx)
+
+        record = _read_dispatch_record(tool_ctx)
+        assert record["status"] == "resumable"
+        assert record["reason"] == "fleet_l3_no_result_block"

--- a/tests/fleet/test_dispatch_failure_semantics.py
+++ b/tests/fleet/test_dispatch_failure_semantics.py
@@ -536,3 +536,5 @@ class TestTrackerBridgeIntegration:
         record = _read_dispatch_record(tool_ctx)
         assert record["status"] == "resumable"
         assert record["reason"] == "fleet_l3_no_result_block"
+        assert record.get("resume_checkpoint") is not None
+        assert "plan" in record["resume_checkpoint"].get("completed_items", [])

--- a/tests/fleet/test_dispatch_failure_semantics.py
+++ b/tests/fleet/test_dispatch_failure_semantics.py
@@ -537,4 +537,4 @@ class TestTrackerBridgeIntegration:
         assert record["status"] == "resumable"
         assert record["reason"] == "fleet_l3_no_result_block"
         assert record.get("resume_checkpoint") is not None
-        assert "plan" in record["resume_checkpoint"].get("completed_items", [])
+        assert "plan" in record["resume_checkpoint"]["completed_items"]

--- a/tests/fleet/test_dispatch_outcome_classifier.py
+++ b/tests/fleet/test_dispatch_outcome_classifier.py
@@ -6,7 +6,7 @@ import dataclasses
 
 import pytest
 
-from autoskillit.core import FleetErrorCode, InfraOutcome, SkillResult
+from autoskillit.core import FleetErrorCode, InfraOutcome, SessionCheckpoint, SkillResult
 from autoskillit.fleet import DispatchStatus
 from autoskillit.fleet._outcome import classify_dispatch_outcome
 from autoskillit.fleet.result_parser import L3ParseResult
@@ -335,3 +335,44 @@ class TestClassifyDispatchOutcomeParsedNone:
         status, reason = classify_dispatch_outcome(None, skill_result, sidecar_exists=False)
         assert status == DispatchStatus.FAILURE
         assert reason == FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK
+
+
+class TestCheckpointOnlyResumePolicy:
+    def test_process_killed_no_sidecar_with_checkpoint_is_resumable(self):
+        parsed, skill_result = _no_sentinel(session_id="sess-abc", lifespan_started=True)
+        skill_result = dataclasses.replace(
+            skill_result,
+            retry_reason="resume",
+            infra=InfraOutcome(exit_category="process_killed"),
+        )
+        checkpoint = SessionCheckpoint(
+            completed_items=["plan", "verify", "implement"],
+            step_name="implement",
+            progress_pct=0.375,
+            ts="2026-06-01T00:00:00Z",
+        )
+        status, reason = classify_dispatch_outcome(
+            parsed, skill_result, sidecar_exists=False, checkpoint=checkpoint
+        )
+        assert status == DispatchStatus.RESUMABLE
+        assert reason == FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK
+
+    def test_timeout_no_sidecar_with_checkpoint_is_resumable(self):
+        skill_result = dataclasses.replace(
+            _DEFAULT_SKILL_RESULT,
+            session_id="sess-abc",
+            lifespan_started=True,
+            subtype="timeout",
+            retry_reason="resume",
+            infra=InfraOutcome(exit_category="process_killed"),
+        )
+        checkpoint = SessionCheckpoint(
+            completed_items=["plan"],
+            step_name="plan",
+            progress_pct=0.125,
+            ts="2026-06-01T00:00:00Z",
+        )
+        status, reason = classify_dispatch_outcome(
+            None, skill_result, sidecar_exists=False, checkpoint=checkpoint, subtype="timeout"
+        )
+        assert status == DispatchStatus.RESUMABLE


### PR DESCRIPTION
## Summary

The fleet dispatch outcome classifier (`_outcome.py`) uses a coarse boolean `has_progress` gate — `checkpoint is not None or sidecar_exists` — to decide whether a killed dispatch is RESUMABLE. The sidecar only records completed *issues*, not recipe *steps*. For single-issue dispatches killed mid-pipeline, the sidecar has zero entries (the entry is written only after all steps finish), so `has_progress=False` and the dispatch is classified FAILURE. The session's 87.5% step completion is invisible to the classifier.

Meanwhile, step-level progress *is* tracked by the pipeline tracker (`tools_pipeline_tracker.py`) and the `pipeline_step_post_hook.py` PostToolUse hook, but this data is never read by the outcome classification path in `_api.py`. Additionally, `SkillResult` carries `WriteEvidence` with `has_progress_evidence` and `has_implementation_progress` properties — these are also never consulted by the classifier.

The architectural fix introduces a **checkpoint bridge from the pipeline tracker** to the outcome classifier, providing step-level progress evidence that makes RESUMABLE classification possible for single-issue dispatches killed at any point after the first recipe step completes.

Part B will cover: `STALE` removal from `_ABANDON_REASONS`, `classify_stale_dispatch` consistency alignment, and the `merge_sidecar_chain` call gap in `parse_and_resume`.

Closes #3585

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260601-220040-939725/.autoskillit/temp/rectify/rectify_fleet_progress_evidence_2026-06-01_220500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 111 | 25.5k | 3.5M | 129.0k | 81 | 112.5k | 21m 3s |
| review_approach* | opus[1m] | 1 | 48 | 6.1k | 439.5k | 49.2k | 21 | 32.3k | 3m 27s |
| dry_walkthrough* | opus | 2 | 92 | 14.0k | 868.8k | 60.1k | 49 | 84.3k | 10m 33s |
| implement* | opus[1m] | 2 | 116 | 14.4k | 2.2M | 74.8k | 84 | 83.4k | 8m 26s |
| audit_impl* | opus[1m] | 2 | 1.9k | 19.2k | 526.2k | 55.0k | 36 | 92.8k | 8m 0s |
| make_plan* | opus[1m] | 1 | 835 | 6.7k | 1.0M | 72.4k | 32 | 58.9k | 3m 53s |
| prepare_pr* | MiniMax-M3 | 1 | 45.7k | 2.3k | 165.0k | 47.5k | 14 | 0 | 1m 16s |
| compose_pr* | MiniMax-M3 | 1 | 37.7k | 1.3k | 148.3k | 38.5k | 11 | 0 | 57s |
| review_pr* | opus[1m] | 2 | 191 | 81.6k | 2.7M | 129.7k | 83 | 204.6k | 19m 14s |
| resolve_review* | opus[1m] | 2 | 1.2k | 21.6k | 3.8M | 81.5k | 112 | 115.6k | 19m 40s |
| resolve_pre_review_conflicts* | opus[1m] | 2 | 53 | 3.7k | 569.4k | 42.4k | 40 | 51.0k | 1m 53s |
| **Total** | | | 87.9k | 196.4k | 16.0M | 129.7k | | 835.4k | 1h 38m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 260 | 8593.4 | 320.6 | 55.2 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 16 | 237304.7 | 7225.1 | 1351.2 |
| resolve_pre_review_conflicts | 1192 | 477.7 | 42.8 | 3.1 |
| **Total** | **1468** | 10919.9 | 569.1 | 133.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 8 | 4.5k | 178.8k | 14.8M | 751.1k | 1h 25m |
| opus | 1 | 92 | 14.0k | 868.8k | 84.3k | 10m 33s |
| MiniMax-M3 | 2 | 83.4k | 3.7k | 313.2k | 0 | 2m 13s |