### PR TITLE
L3 Fleet Dispatcher reset_dispatch Instruction Path

### DIFF
--- a/src/autoskillit/cli/_prompts_campaign.py
+++ b/src/autoskillit/cli/_prompts_campaign.py
@@ -370,6 +370,7 @@ Action:
 
 This is the ONLY condition where re-dispatching the same dispatch_name is permitted.
 Stale-artifact recovery uses a NEW dispatch_name — see STALE-ARTIFACT RECOVERY section.
+
 ## STALE-ARTIFACT RECOVERY
 
 Trigger: ANY dispatch (whether classified FAILURE or RESUMABLE) fails with a reason

--- a/src/autoskillit/cli/_prompts_campaign.py
+++ b/src/autoskillit/cli/_prompts_campaign.py
@@ -224,6 +224,8 @@ This dispatch was interrupted mid-run with partial sidecar progress.
 Re-dispatch it using compute_remaining_issues(dispatch_id, original_urls, project_dir)
 to retrieve only the remaining issue URLs, then call dispatch_food_truck with{_reenter_clause}.
 Do NOT re-dispatch from the full original issue list.
+If the resume re-dispatch fails with a stale-artifact reason (in-progress label,
+claim failure), follow the STALE-ARTIFACT RECOVERY section.
 """
 
     _ing_section = ""
@@ -285,7 +287,8 @@ After startup, only these tools should be used for all campaign operations:
 - {mcp_prefix}get_pipeline_report
 - {mcp_prefix}get_token_summary
 - {mcp_prefix}get_timing_summary
-- {mcp_prefix}get_quota_events{gate_tool_line}
+- {mcp_prefix}get_quota_events
+- {mcp_prefix}reset_dispatch{gate_tool_line}
 
 Explicitly FORBIDDEN: open_kitchen, close_kitchen, run_skill, and all GitHub/CI tools.
 Use ONLY {mcp_prefix}dispatch_food_truck to dispatch — never run_skill.
@@ -348,8 +351,11 @@ On FAILURE:
   emit the %%FLEET_PROGRESS%% marker with state=failure, proceed to next dispatch.
 - If continue_on_failure={campaign_recipe.continue_on_failure} is false: halt campaign
   immediately (proceed to INTERRUPT/CLEANUP).
+- Exception: if the failure reason indicates stale artifacts (in-progress label,
+  claim failure), follow the STALE-ARTIFACT RECOVERY section instead of halting.
 
-NEVER retry the same dispatch_name on non-quota failures in v1.
+NEVER retry the same dispatch_name on non-quota failures. For stale-artifact recovery,
+always use a NEW dispatch_name (see STALE-ARTIFACT RECOVERY below).
 
 ## QUOTA RETRY
 
@@ -363,6 +369,24 @@ Action:
 3. If the retry still fails: halt campaign (proceed to INTERRUPT/CLEANUP).
 
 This is the ONLY condition where re-dispatching the same dispatch_name is permitted.
+Stale-artifact recovery uses a NEW dispatch_name — see STALE-ARTIFACT RECOVERY section.
+## STALE-ARTIFACT RECOVERY
+
+Trigger: ANY dispatch (whether classified FAILURE or RESUMABLE) fails with a reason
+mentioning "in-progress label", "could not claim", "stale artifact", or "already claimed"
+— indicating a prior failed session left unresolved artifacts (labels, PRs, branches).
+
+This section applies regardless of whether you reached it from FAILURE RECOVERY or from
+a failed RESUMABLE re-dispatch.
+
+Action:
+1. Identify the prior dispatch_id from the failure envelope (prior_dispatch_id field)
+   or from the campaign state (the dispatch that previously owned this issue).
+2. Call {mcp_prefix}reset_dispatch(dispatch_id=<prior_dispatch_id>) to clean up
+   stale artifacts (removes in-progress label, closes orphaned PR, deletes branch).
+3. Re-dispatch with a NEW dispatch_name (never reuse the original dispatch_name).
+4. If reset_dispatch fails or the re-dispatch still fails: halt campaign
+   (proceed to INTERRUPT/CLEANUP).
 {resume_section}{resumable_section}
 ## INTERRUPT/CLEANUP SEQUENCE
 

--- a/src/autoskillit/cli/_prompts_kitchen.py
+++ b/src/autoskillit/cli/_prompts_kitchen.py
@@ -113,7 +113,7 @@ def _build_fleet_dispatch_prompt(
 You are a fleet dispatcher. You coordinate recipe execution across targets \
 by dispatching food trucks.
 
-TOOL SURFACE — these 10 tools are available in this session:
+TOOL SURFACE — these 11 tools are available in this session:
 - {mcp_prefix}dispatch_food_truck     — launch a headless L2 food truck for a recipe
 - {mcp_prefix}batch_cleanup_clones    — clean up clone artifacts after all dispatches
 - {mcp_prefix}get_pipeline_report     — pipeline execution report
@@ -124,6 +124,7 @@ TOOL SURFACE — these 10 tools are available in this session:
 - {mcp_prefix}load_recipe             — load a recipe and inspect its ingredients
 - {mcp_prefix}fetch_github_issue      — retrieve issue context when dispatching issue work
 - {mcp_prefix}get_issue_title         — get the title of a GitHub issue
+- {mcp_prefix}reset_dispatch          — reset a failed dispatch and clean stale artifacts
 {_food_truck_section}{admiral_section}
 ## ROUTING AUTHORITY
 
@@ -162,8 +163,10 @@ When a dispatch_food_truck call returns with dispatch_status="resumable":
   A PreToolUse guard will block fresh dispatches on already-claimed issues.
 - If the guard blocks your call, find the prior dispatch result and extract
   the resume fields listed above.
-- If the prior session is unrecoverable, report to the human operator —
-  do not attempt to bypass by removing labels or force-retrying.
+- If the prior session is unrecoverable and stale artifacts remain (in-progress label,
+  open PR), call {mcp_prefix}reset_dispatch(dispatch_id=<prior_dispatch_id>) to clean up,
+  then re-dispatch fresh with a new dispatch_name. If reset_dispatch fails, report to the
+  human operator.
 
 ## MULTI-ISSUE DISPATCH — BEM PRE-STEP GATE — MANDATORY
 

--- a/src/autoskillit/hooks/guards/fleet_claim_guard.py
+++ b/src/autoskillit/hooks/guards/fleet_claim_guard.py
@@ -86,6 +86,8 @@ def main() -> None:
         sys.exit(0)
     issue_urls_raw = ingredients.get("issue_urls", "")
     if not issue_urls_raw:
+        issue_urls_raw = ingredients.get("issue_url", "")
+    if not issue_urls_raw:
         sys.exit(0)
 
     urls = [u.strip() for u in issue_urls_raw.split(",") if u.strip()]
@@ -101,7 +103,8 @@ def main() -> None:
                 f"You must resume the prior session — pass resume_session_id (from "
                 f"dispatched_session_id in the prior result) and prior_dispatch_id (from "
                 f"dispatch_id in the prior result) to dispatch_food_truck. If the prior "
-                f"session is unrecoverable, ask the human operator to remove the label."
+                f"session is unrecoverable, call reset_dispatch(dispatch_id="
+                f"<prior_dispatch_id>) to clean stale artifacts, then re-dispatch fresh."
             )
             sys.exit(0)
 

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -763,9 +763,16 @@ When `dispatch_food_truck` returns with `dispatch_status: "resumable"`:
    from `fleet_claim_guard`, retrieve the prior dispatch result and use its
    `dispatched_session_id` and `dispatch_id` for resume.
 
-4. **Escalate, don't retry blind.** If the prior session is unrecoverable (missing session
-   log, corrupt state), this is a **human intervention** scenario. Emit the L3 result
-   sentinel with `success=false` and `reason=resume_unrecoverable`, then halt.
+4. **Reset stale artifacts when resume is impossible.** If the prior session is
+   unrecoverable (missing session log, corrupt state) but left stale artifacts
+   (in-progress label, open PR, remote branch), call
+   `reset_dispatch(dispatch_id=<prior_dispatch_id>)` to clean up. Then re-dispatch
+   fresh with a new `dispatch_name`.
+
+5. **Escalate only after reset fails.** If `reset_dispatch` itself fails or the
+   re-dispatch after reset still fails, this is a **human intervention** scenario.
+   Emit the L3 result sentinel with `success=false` and `reason=resume_unrecoverable`,
+   then halt.
 
 ---
 

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -704,28 +704,6 @@ def test_campaign_prompt_tool_list_still_enumerates_seven_tools():
     assert "reset_dispatch" in prompt
 
 
-def test_campaign_prompt_tool_list_includes_reset_dispatch():
-    """reset_dispatch must appear in the campaign prompt tool allowlist."""
-    from unittest.mock import MagicMock
-
-    from autoskillit.cli._prompts import _build_fleet_campaign_prompt
-
-    recipe = MagicMock()
-    recipe.name = "test-campaign"
-    recipe.description = "Test"
-    recipe.dispatches = [MagicMock()]
-    recipe.continue_on_failure = False
-
-    prompt = _build_fleet_campaign_prompt(
-        campaign_recipe=recipe,
-        manifest_yaml="dispatches: []",
-        completed_dispatches="",
-        mcp_prefix="mcp__autoskillit__",
-        campaign_id="abc-123",
-    )
-    assert "reset_dispatch" in prompt
-
-
 def test_campaign_prompt_has_stale_artifact_recovery_section():
     """STALE-ARTIFACT RECOVERY must be a top-level section with reset_dispatch instruction."""
     from unittest.mock import MagicMock

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -676,8 +676,8 @@ def test_orchestrator_prompt_contains_missing_on_failure_instruction():
     assert "recipe authoring error. Stop the pipeline and report the missing route." in prompt
 
 
-def test_campaign_prompt_tool_list_still_enumerates_six_tools():
-    """The 6 operational tools must still be listed in the campaign prompt after the fix."""
+def test_campaign_prompt_tool_list_still_enumerates_seven_tools():
+    """The 7 operational tools must still be listed in the campaign prompt after the fix."""
     from unittest.mock import MagicMock
 
     from autoskillit.cli._prompts import _build_fleet_campaign_prompt
@@ -701,6 +701,65 @@ def test_campaign_prompt_tool_list_still_enumerates_six_tools():
     assert "get_token_summary" in prompt
     assert "get_timing_summary" in prompt
     assert "get_quota_events" in prompt
+    assert "reset_dispatch" in prompt
+
+
+def test_campaign_prompt_tool_list_includes_reset_dispatch():
+    """reset_dispatch must appear in the campaign prompt tool allowlist."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.cli._prompts import _build_fleet_campaign_prompt
+
+    recipe = MagicMock()
+    recipe.name = "test-campaign"
+    recipe.description = "Test"
+    recipe.dispatches = [MagicMock()]
+    recipe.continue_on_failure = False
+
+    prompt = _build_fleet_campaign_prompt(
+        campaign_recipe=recipe,
+        manifest_yaml="dispatches: []",
+        completed_dispatches="",
+        mcp_prefix="mcp__autoskillit__",
+        campaign_id="abc-123",
+    )
+    assert "reset_dispatch" in prompt
+
+
+def test_campaign_prompt_has_stale_artifact_recovery_section():
+    """STALE-ARTIFACT RECOVERY must be a top-level section with reset_dispatch instruction."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.cli._prompts import _build_fleet_campaign_prompt
+
+    recipe = MagicMock()
+    recipe.name = "test-campaign"
+    recipe.description = "Test"
+    recipe.dispatches = [MagicMock()]
+    recipe.continue_on_failure = False
+
+    prompt = _build_fleet_campaign_prompt(
+        campaign_recipe=recipe,
+        manifest_yaml="dispatches: []",
+        completed_dispatches="",
+        mcp_prefix="mcp__autoskillit__",
+        campaign_id="abc-123",
+    )
+    assert "## STALE-ARTIFACT RECOVERY" in prompt
+    stale_idx = prompt.index("## STALE-ARTIFACT RECOVERY")
+    next_section_idx = prompt.find("\n## ", stale_idx + 1)
+    stale_section = (
+        prompt[stale_idx:next_section_idx] if next_section_idx != -1 else prompt[stale_idx:]
+    )
+    assert "reset_dispatch" in stale_section
+
+
+def test_fleet_dispatch_prompt_includes_reset_dispatch():
+    """Ad-hoc fleet dispatch prompt tool surface must include reset_dispatch."""
+    from autoskillit.cli._prompts_kitchen import _build_fleet_dispatch_prompt
+
+    prompt = _build_fleet_dispatch_prompt(mcp_prefix="mcp__autoskillit__")
+    assert "reset_dispatch" in prompt
 
 
 def test_campaign_prompt_includes_gate_dispatch_handling_section():

--- a/tests/cli/test_fleet_dispatch.py
+++ b/tests/cli/test_fleet_dispatch.py
@@ -275,8 +275,8 @@ def test_build_fleet_dispatch_prompt_accepts_marketplace_prefix() -> None:
     assert MARKETPLACE_PREFIX + "dispatch_food_truck" in prompt
 
 
-def test_build_fleet_dispatch_prompt_lists_all_10_tools() -> None:
-    """Dispatch prompt must enumerate all 10 tools in the TOOL SURFACE section."""
+def test_build_fleet_dispatch_prompt_lists_all_11_tools() -> None:
+    """Dispatch prompt must enumerate all 11 tools in the TOOL SURFACE section."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_fleet_dispatch_prompt
 
@@ -300,6 +300,7 @@ def test_build_fleet_dispatch_prompt_lists_all_10_tools() -> None:
         "load_recipe",
         "fetch_github_issue",
         "get_issue_title",
+        "reset_dispatch",
     ):
         assert tool in tool_surface, (
             f"Expected tool {tool!r} in TOOL SURFACE section of dispatch prompt"

--- a/tests/cli/test_l3_orchestrator_prompt.py
+++ b/tests/cli/test_l3_orchestrator_prompt.py
@@ -356,7 +356,7 @@ class TestProgressMarkers:
 
 class TestToolSurface:
     @pytest.mark.parametrize("prefix", [DIRECT_PREFIX, MARKETPLACE_PREFIX])
-    def test_six_fleet_tools_listed(self, prefix: str) -> None:
+    def test_seven_fleet_tools_listed(self, prefix: str) -> None:
         prompt = _build(mcp_prefix=prefix)
         for tool in (
             "dispatch_food_truck",
@@ -365,6 +365,7 @@ class TestToolSurface:
             "get_token_summary",
             "get_timing_summary",
             "get_quota_events",
+            "reset_dispatch",
         ):
             assert f"{prefix}{tool}" in prompt, f"Missing tool: {prefix}{tool}"
 

--- a/tests/hooks/test_fleet_claim_guard.py
+++ b/tests/hooks/test_fleet_claim_guard.py
@@ -253,3 +253,42 @@ def test_fleet_claim_guard_registered() -> None:
     assert found_in_scripts, "guards/fleet_claim_guard.py not in dispatch_food_truck scripts"
 
     assert "fleet_claim_guard.py" in NEW_SUBDIR_BASENAMES
+
+
+def test_fleet_claim_guard_checks_singular_issue_url() -> None:
+    """T14: Guard must also check the singular 'issue_url' ingredient key."""
+    event = {
+        "tool_name": "dispatch_food_truck",
+        "tool_input": {
+            "ingredients": {
+                "issue_url": "https://github.com/org/repo/issues/42",
+            },
+        },
+    }
+    with mock.patch(
+        "autoskillit.hooks.guards.fleet_claim_guard.subprocess.run",
+        _mock_gh({"https://github.com/org/repo/issues/42": [{"name": "in-progress"}]}),
+    ):
+        output = _run_guard(event)
+    assert output
+    result = json.loads(output)
+    assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_fleet_claim_guard_deny_includes_reset_dispatch_guidance() -> None:
+    """T15: Deny message must mention reset_dispatch as a recovery option."""
+    event = {
+        "tool_name": "dispatch_food_truck",
+        "tool_input": {
+            "ingredients": {
+                "issue_urls": _ISSUE_URL,
+            },
+        },
+    }
+    with mock.patch(
+        "autoskillit.hooks.guards.fleet_claim_guard.subprocess.run",
+        _mock_gh({_ISSUE_URL: [{"name": "in-progress"}]}),
+    ):
+        output = _run_guard(event)
+    reason = json.loads(output)["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "reset_dispatch" in reason


### PR DESCRIPTION
## Summary

The L3 fleet dispatcher (both campaign and ad-hoc modes) has no instruction path to call `reset_dispatch` when a dispatch fails due to stale artifacts (in-progress labels, open PRs, remote branches) left by a prior failed session. The tool exists and is callable from fleet sessions, but the prompt allowlists omit it, failure recovery instructions don't mention it, and the `fleet_claim_guard` misses single-issue dispatches due to an ingredient name mismatch (`issue_urls` vs `issue_url`).

This plan adds `reset_dispatch` to both prompt tool allowlists, adds a stale-artifact recovery path reachable from both FAILURE and RESUMABLE dispatch flows, updates the sous-chef SKILL.md fleet dispatch resume discipline, and fixes the `fleet_claim_guard` ingredient name coverage.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260601-220920-870555/.autoskillit/temp/make-plan/l3_fleet_reset_dispatch_plan_2026-06-01_221500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

Closes #3586

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 68 | 21.1k | 1.4M | 96.1k | 57 | 148.6k | 13m 3s |
| verify* | sonnet | 1 | 78 | 9.0k | 352.8k | 52.0k | 25 | 35.5k | 4m 37s |
| implement* | MiniMax-M3 | 1 | 78.3k | 13.8k | 2.0M | 86.1k | 95 | 0 | 9m 3s |
| audit_impl* | sonnet | 1 | 46 | 8.7k | 145.5k | 39.6k | 16 | 34.3k | 4m 43s |
| prepare_pr* | MiniMax-M3 | 1 | 42.8k | 2.0k | 164.7k | 46.6k | 14 | 0 | 1m 15s |
| compose_pr* | MiniMax-M3 | 1 | 37.2k | 1.2k | 146.1k | 38.0k | 12 | 0 | 58s |
| review_pr* | sonnet | 1 | 166 | 42.4k | 1.3M | 94.2k | 61 | 78.6k | 9m 57s |
| resolve_review* | opus | 1 | 37 | 9.1k | 1.1M | 71.2k | 41 | 54.7k | 6m 29s |
| **Total** | | | 158.7k | 107.3k | 6.6M | 96.1k | | 351.6k | 50m 8s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 165 | 12361.3 | 0.0 | 83.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 23 | 49438.3 | 2378.1 | 396.0 |
| **Total** | **188** | 35259.8 | 1870.5 | 570.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 68 | 21.1k | 1.4M | 148.6k | 13m 3s |
| sonnet | 3 | 290 | 60.0k | 1.8M | 148.4k | 19m 18s |
| MiniMax-M3 | 3 | 158.3k | 17.0k | 2.4M | 0 | 11m 16s |
| opus | 1 | 37 | 9.1k | 1.1M | 54.7k | 6m 29s |