### PR TITLE
Implementation Plan: P5-A5-WP1 — Emit DeprecationWarning from Three Shim Functions in commands.py

### DIFF
--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -60,6 +61,12 @@ def build_interactive_cmd(
     tools: Sequence[str] = (),
 ) -> ClaudeInteractiveCmd:
     """Deprecated shim. Use ClaudeCodeBackend().build_interactive_cmd() directly."""
+    warnings.warn(
+        "build_interactive_cmd() is deprecated. "
+        "Use ClaudeCodeBackend().build_interactive_cmd() directly.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     spec = ClaudeCodeBackend().build_interactive_cmd(
         initial_prompt=initial_prompt,
         model=model,
@@ -82,6 +89,12 @@ def build_headless_cmd(
     base: Mapping[str, str] | None = None,
 ) -> CmdSpec:
     """Deprecated shim. Use ClaudeCodeBackend().build_headless_cmd() directly."""
+    warnings.warn(
+        "build_headless_cmd() is deprecated. "
+        "Use ClaudeCodeBackend().build_headless_cmd() directly.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     spec = ClaudeCodeBackend().build_headless_cmd(
         prompt,
         model=model,
@@ -100,6 +113,12 @@ def build_headless_resume_cmd(
     env_extras: Mapping[str, str] | None = None,
 ) -> CmdSpec:
     """Deprecated shim. Use ClaudeCodeBackend().build_resume_cmd() directly."""
+    warnings.warn(
+        "build_headless_resume_cmd() is deprecated. "
+        "Use ClaudeCodeBackend().build_resume_cmd() directly.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     spec = ClaudeCodeBackend().build_resume_cmd(
         resume_session_id=resume_session_id,
         prompt=prompt,

--- a/tests/execution/backends/test_claude_code_backend.py
+++ b/tests/execution/backends/test_claude_code_backend.py
@@ -50,7 +50,8 @@ class TestClaudeCodeBackend:
 
         backend = ClaudeCodeBackend()
         skill_cmd = "say hello"
-        direct = build_headless_cmd(skill_cmd)
+        with pytest.warns(DeprecationWarning):
+            direct = build_headless_cmd(skill_cmd)
         result = backend.build_cmd(skill_cmd, str(tmp_path))
         assert tuple(direct.cmd) == result.cmd
         assert direct.env == result.env

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -315,3 +315,29 @@ def test_system_prompt_forwarded_to_backend(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(ClaudeCodeBackend, "build_interactive_cmd", spy)
     build_interactive_cmd(system_prompt="forwarded-prompt")
     assert captured["system_prompt"] == "forwarded-prompt"
+
+
+class TestShimDeprecationWarnings:
+    def test_build_interactive_cmd_warns(self) -> None:
+        with pytest.warns(DeprecationWarning) as rec:
+            build_interactive_cmd()
+        assert any(
+            "deprecated" in str(w.message).lower() or "ClaudeCodeBackend" in str(w.message)
+            for w in rec.list
+        )
+
+    def test_build_headless_cmd_warns(self) -> None:
+        with pytest.warns(DeprecationWarning) as rec:
+            build_headless_cmd("test prompt")
+        assert any(
+            "deprecated" in str(w.message).lower() or "ClaudeCodeBackend" in str(w.message)
+            for w in rec.list
+        )
+
+    def test_build_headless_resume_cmd_warns(self) -> None:
+        with pytest.warns(DeprecationWarning) as rec:
+            build_headless_resume_cmd(resume_session_id="abc", prompt="go")
+        assert any(
+            "deprecated" in str(w.message).lower() or "ClaudeCodeBackend" in str(w.message)
+            for w in rec.list
+        )

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -321,23 +321,14 @@ class TestShimDeprecationWarnings:
     def test_build_interactive_cmd_warns(self) -> None:
         with pytest.warns(DeprecationWarning) as rec:
             build_interactive_cmd()
-        assert any(
-            "deprecated" in str(w.message).lower() or "ClaudeCodeBackend" in str(w.message)
-            for w in rec.list
-        )
+        assert "build_interactive_cmd() is deprecated" in str(rec.list[0].message)
 
     def test_build_headless_cmd_warns(self) -> None:
         with pytest.warns(DeprecationWarning) as rec:
             build_headless_cmd("test prompt")
-        assert any(
-            "deprecated" in str(w.message).lower() or "ClaudeCodeBackend" in str(w.message)
-            for w in rec.list
-        )
+        assert "build_headless_cmd() is deprecated" in str(rec.list[0].message)
 
     def test_build_headless_resume_cmd_warns(self) -> None:
         with pytest.warns(DeprecationWarning) as rec:
             build_headless_resume_cmd(resume_session_id="abc", prompt="go")
-        assert any(
-            "deprecated" in str(w.message).lower() or "ClaudeCodeBackend" in str(w.message)
-            for w in rec.list
-        )
+        assert "build_headless_resume_cmd() is deprecated" in str(rec.list[0].message)


### PR DESCRIPTION
## Summary

Add `warnings.warn(DeprecationWarning, stacklevel=2)` calls to the three shim functions in `src/autoskillit/execution/commands.py` (`build_interactive_cmd`, `build_headless_cmd`, `build_headless_resume_cmd`). Add a `TestShimDeprecationWarnings` test class in `tests/execution/test_commands.py` with one test per shim. Wrap the existing `build_headless_cmd` call in `tests/execution/backends/test_claude_code_backend.py:test_build_cmd_matches_build_headless_cmd` with `pytest.warns(DeprecationWarning)` so it doesn't fail after the warning is emitted. All re-exports, the `ClaudeInteractiveCmd` dataclass, and `ClaudeHeadlessCmd` alias are untouched.

Closes #3128

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260601-225230-067784/.autoskillit/temp/make-plan/P5-A5-WP1_emit_deprecation_warnings_plan_2026-06-01_225500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 801 | 9.8k | 1.1M | 76.5k | 43 | 60.3k | 8m 4s |
| verify* | sonnet | 1 | 68 | 8.1k | 346.8k | 64.7k | 26 | 48.1k | 2m 33s |
| implement* | MiniMax-M3 | 1 | 65.3k | 7.1k | 1.3M | 64.3k | 73 | 0 | 4m 36s |
| audit_impl* | sonnet | 1 | 1.8k | 5.7k | 142.6k | 36.3k | 14 | 26.7k | 2m 57s |
| prepare_pr* | MiniMax-M3 | 1 | 42.6k | 2.3k | 234.2k | 43.8k | 14 | 0 | 1m 25s |
| compose_pr* | MiniMax-M3 | 1 | 36.9k | 2.0k | 262.9k | 39.0k | 17 | 0 | 1m 25s |
| **Total** | | | 147.4k | 35.1k | 3.4M | 76.5k | | 135.1k | 21m 4s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 48 | 26552.4 | 0.0 | 147.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **48** | 70442.8 | 2815.1 | 730.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 801 | 9.8k | 1.1M | 60.3k | 8m 4s |
| sonnet | 2 | 1.8k | 13.8k | 489.4k | 74.8k | 5m 31s |
| MiniMax-M3 | 3 | 144.8k | 11.4k | 1.8M | 0 | 7m 28s |