### PR TITLE
Implementation Plan: GraphQL Invocation Immunity Remediation

### DIFF
--- a/src/autoskillit/recipe/CLAUDE.md
+++ b/src/autoskillit/recipe/CLAUDE.md
@@ -42,7 +42,7 @@ Sub-package: rules/ (see rules/CLAUDE.md).
 | `_analysis_detectors.py` | Dead outputs + ref invalidations + implicit handoffs |
 | `_git_helpers.py` | Shared git-remote regex (`_GIT_REMOTE_COMMAND_RE`, `_LITERAL_ORIGIN_RE`) for lint rules |
 | `_skill_helpers.py` | Shared helpers for skill-related semantic rules |
-| `_skill_placeholder_parser.py` | SKILL.md structural analysis: bash placeholder extraction, step section parsing, git command extraction |
+| `_skill_placeholder_parser.py` | SKILL.md structural analysis: bash placeholder extraction, step section parsing, section splitting, prose GraphQL detection, git command extraction |
 | `identity.py` | Recipe identity hashing — content and composite fingerprints |
 | `schema.py` | `Recipe`, `RecipeStep`, `DataFlowWarning` |
 | `staleness_cache.py` | Staleness cache for contract and diagram freshness checks |

--- a/src/autoskillit/recipe/_skill_placeholder_parser.py
+++ b/src/autoskillit/recipe/_skill_placeholder_parser.py
@@ -1,4 +1,4 @@
-"""Shared parser helpers for SKILL.md bash-block and python-block analysis.
+"""Shared parser helpers for SKILL.md bash-block, python-block, and section analysis.
 
 Used by:
   - src/autoskillit/recipe/rules/rules_skill_content.py (semantic rules)
@@ -27,6 +27,24 @@ def extract_python_blocks(content: str) -> list[str]:
 
 def extract_graphql_blocks(content: str) -> list[str]:
     return extract_fenced_blocks(content, "graphql")
+
+
+def extract_sections(content: str) -> list[str]:
+    """Split SKILL.md content into heading-scoped sections at the ## level."""
+    parts = re.split(r"(?m)^(?=##\s)", content)
+    return [p for p in parts if p.strip()]
+
+
+_PROSE_GRAPHQL_EXECUTION_RE = re.compile(
+    r"(?:via|execute|run|use|build)\s+[^\n]{0,40}(?:GraphQL|graphql)\b"
+    r"|(?:GraphQL|graphql)\s+[^\n]{0,40}(?:mutation|query|request|call)\b",
+    re.IGNORECASE,
+)
+
+
+def has_prose_graphql_execution(text: str) -> bool:
+    """Return True if text contains prose references to executing a GraphQL operation."""
+    return bool(_PROSE_GRAPHQL_EXECUTION_RE.search(text))
 
 
 def extract_bash_placeholders(bash_blocks: list[str]) -> set[str]:

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -893,7 +893,11 @@ def _check_graphql_query_requires_shell_invocation(ctx: ValidationContext) -> li
                             )
                         )
 
-            if has_prose_graphql_execution(section) and not section_bash_graphql:
+            if (
+                not section_graphql
+                and has_prose_graphql_execution(section)
+                and not section_bash_graphql
+            ):
                 findings.append(
                     RuleFinding(
                         rule="graphql-query-requires-shell-invocation",

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -20,6 +20,8 @@ from autoskillit.recipe._skill_placeholder_parser import (
     extract_declared_ingredients,
     extract_graphql_blocks,
     extract_python_blocks,
+    extract_sections,
+    has_prose_graphql_execution,
     shell_vars_assigned,
 )
 from autoskillit.recipe.contracts import load_bundled_manifest, resolve_skill_name
@@ -567,12 +569,6 @@ _TRANSITION_ANTI_CONFIRM_RE: re.Pattern[str] = re.compile(
 )
 
 
-def _extract_sections(content: str) -> list[str]:
-    """Split SKILL.md content into heading-scoped sections at the ## level."""
-    parts = re.split(r"(?m)^(?=##\s)", content)
-    return [p for p in parts if p.strip()]
-
-
 def _extract_subsections(content: str) -> list[str]:
     """Split SKILL.md content into subsections at the ### level."""
     parts = re.split(r"(?m)^(?=###\s)", content)
@@ -607,7 +603,7 @@ def _check_transition_boundary_anti_confirmation(ctx: ValidationContext) -> list
         except OSError:
             continue
         unprotected: list[tuple[str, str]] = []
-        for section in _extract_sections(content):
+        for section in extract_sections(content):
             lines = section.splitlines()
             heading = lines[0].strip() if lines else ""
             for boundary_name, boundary_re in _TRANSITION_BOUNDARY_RES:
@@ -858,50 +854,57 @@ def _check_graphql_query_requires_shell_invocation(ctx: ValidationContext) -> li
         except OSError:
             continue
 
-        graphql_blocks = extract_graphql_blocks(content)
-        if not graphql_blocks:
-            continue
+        for section in extract_sections(content):
+            section_graphql = extract_graphql_blocks(section)
+            section_bash = extract_bash_blocks(section)
+            section_bash_graphql = [b for b in section_bash if _GH_API_GRAPHQL_BLOCK_RE.search(b)]
 
-        bash_blocks = extract_bash_blocks(content)
-        bash_with_graphql = [b for b in bash_blocks if _GH_API_GRAPHQL_BLOCK_RE.search(b)]
-
-        for block in graphql_blocks:
-            variable_names = set(_GRAPHQL_VARIABLE_RE.findall(block))
-            if not variable_names:
-                continue
-
-            if not bash_with_graphql:
-                findings.append(
-                    RuleFinding(
-                        rule="graphql-query-requires-shell-invocation",
-                        severity=Severity.ERROR,
-                        step_name=step_name,
-                        message=(
-                            f"Skill '{skill_name}' has a graphql block declaring variables "
-                            f"{sorted(variable_names)} but no bash block with a concrete "
-                            f"`gh api graphql` invocation. Add a bash block with individual "
-                            f"-F key=value flag bindings for each variable."
-                        ),
-                    )
-                )
-                break
-
-            for var in variable_names:
-                flag_found = any(
-                    re.search(rf"-[Ff]\s*{re.escape(var)}=", b) for b in bash_with_graphql
-                )
-                if not flag_found:
+            for block in section_graphql:
+                if not section_bash_graphql:
                     findings.append(
                         RuleFinding(
                             rule="graphql-query-requires-shell-invocation",
                             severity=Severity.ERROR,
                             step_name=step_name,
                             message=(
-                                f"Skill '{skill_name}' graphql variable '${var}' has no "
-                                f"'-F {var}=' or '-f {var}=' binding in any "
-                                f"`gh api graphql` bash block."
+                                f"Skill '{skill_name}' has a graphql block in a section "
+                                f"with no 'gh api graphql' bash block in the same section."
                             ),
                         )
                     )
+                    break
+
+                variable_names = set(_GRAPHQL_VARIABLE_RE.findall(block))
+                for var in variable_names:
+                    flag_found = any(
+                        re.search(rf"-[Ff]\s*{re.escape(var)}=", b) for b in section_bash_graphql
+                    )
+                    if not flag_found:
+                        findings.append(
+                            RuleFinding(
+                                rule="graphql-query-requires-shell-invocation",
+                                severity=Severity.ERROR,
+                                step_name=step_name,
+                                message=(
+                                    f"Skill '{skill_name}' graphql variable '${var}' has no "
+                                    f"'-F {var}=' or '-f {var}=' binding in any "
+                                    f"same-section `gh api graphql` bash block."
+                                ),
+                            )
+                        )
+
+            if has_prose_graphql_execution(section) and not section_bash_graphql:
+                findings.append(
+                    RuleFinding(
+                        rule="graphql-query-requires-shell-invocation",
+                        severity=Severity.ERROR,
+                        step_name=step_name,
+                        message=(
+                            f"Skill '{skill_name}' has a section referencing GraphQL "
+                            f"execution in prose but no 'gh api graphql' bash block "
+                            f"in the same section."
+                        ),
+                    )
+                )
 
     return findings

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -48,8 +48,8 @@ implemented. Identify review debt before it compounds.
 
 **ALWAYS:**
 - Save raw PR JSON to temp before any analysis (Step 1)
-- Use GraphQL alias batching (~20 PRs per query) for data collection
-- Include `rateLimit { cost remaining resetAt }` in every GraphQL query
+- Batch data collection with aliases (~20 PRs per API call)
+- Include `rateLimit { cost remaining resetAt }` in every batched query
 - Sleep 1s between consecutive mutating GitHub API calls (Step 5 watermark posts)
 - Step 2 triage subagents read local JSON files only — zero API calls
 - Step 3 validation subagents grep the actual current codebase

--- a/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
@@ -58,7 +58,23 @@ permissions), abort immediately with a clear error message: `"Error: could not r
 — check GH_TOKEN and remote URL. Aborting."` Do not proceed with GraphQL mutations using an empty node_id.
 Resolve label IDs for `audit` and `recipe:implementation` labels (ensure they exist via `gh label create --force`).
 Build batched GraphQL `createIssue` mutations with aliases (`issue0`, `issue1`, ...), chunked at 20 per request.
-Execute via `gh api graphql --input -`. Sleep 1 second between chunks (per GitHub API discipline).
+
+```graphql
+mutation {
+  issue0: createIssue(input: {repositoryId: $repoId, title: $title0, body: $body0}) {
+    issue { number url }
+  }
+  issue1: createIssue(input: {repositoryId: $repoId, title: $title1, body: $body1}) {
+    issue { number url }
+  }
+}
+```
+
+```bash
+echo "$MUTATION_JSON" | gh api graphql --input -
+```
+
+Sleep 1 second between chunks (per GitHub API discipline).
 Collect created issue URLs and numbers.
 
 ## Step 6 — Apply Source-Specific Labels
@@ -66,6 +82,18 @@ Collect created issue URLs and numbers.
 Parse the source from each ticket body filename (`ticket_body_{source}_{N}_{ts}.md`). For each unique
 source, ensure a label exists (e.g., `audit:tests`, `audit:arch`, `audit:cohesion`, etc.).
 Batch-apply source labels via GraphQL `addLabelsToLabelable` mutation with aliases.
+
+```graphql
+mutation {
+  l0: addLabelsToLabelable(input: {labelableId: $issueId0, labelIds: [$labelId]}) {
+    labelable { ... on Issue { number } }
+  }
+}
+```
+
+```bash
+echo "$LABEL_MUTATION" | gh api graphql --input -
+```
 
 ## Step 7 — Write Filed Issues Manifest
 

--- a/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
@@ -4,8 +4,8 @@ categories: [audit-pipeline]
 description: >-
   Batch-create GitHub issues from validated audit ticket body files. Discovers
   ticket bodies from the audit run directory, deduplicates against existing open
-  issues, creates via batched GraphQL mutations, applies labels and writes a
-  filed-issues manifest. Pipeline-only skill dispatched by the full-audit recipe.
+  issues, creates in batches, applies labels and writes a filed-issues manifest.
+  Pipeline-only skill dispatched by the full-audit recipe.
 hooks:
   PreToolUse:
     - matcher: "*"
@@ -61,10 +61,10 @@ Build batched GraphQL `createIssue` mutations with aliases (`issue0`, `issue1`, 
 
 ```graphql
 mutation {
-  issue0: createIssue(input: {repositoryId: $repoId, title: $title0, body: $body0}) {
+  issue0: createIssue(input: {repositoryId: "<REPO_ID>", title: "<TITLE>", body: "<BODY>"}) {
     issue { number url }
   }
-  issue1: createIssue(input: {repositoryId: $repoId, title: $title1, body: $body1}) {
+  issue1: createIssue(input: {repositoryId: "<REPO_ID>", title: "<TITLE>", body: "<BODY>"}) {
     issue { number url }
   }
 }
@@ -85,7 +85,7 @@ Batch-apply source labels via GraphQL `addLabelsToLabelable` mutation with alias
 
 ```graphql
 mutation {
-  l0: addLabelsToLabelable(input: {labelableId: $issueId0, labelIds: [$labelId]}) {
+  l0: addLabelsToLabelable(input: {labelableId: "<ISSUE_ID>", labelIds: ["<LABEL_ID>"]}) {
     labelable { ... on Issue { number } }
   }
 }
@@ -124,7 +124,7 @@ issue_count = 0
 - Fabricate, invent, or embellish information not supported by the available evidence or code.
 
 - Use `gh issue comment` — all issue content goes in the body via `--body-file`
-- Create issues individually via REST — always batch via GraphQL `createIssue` mutations
+- Create issues individually via REST — always use batched `createIssue` mutations
 - Skip the 1-second sleep between consecutive mutating GitHub API calls
 - Use `--body` inline for large content — always write to temp file and use `--body-file`
 - Prompt interactively when `AUTOSKILLIT_HEADLESS` is `1` — execute all steps directly

--- a/src/autoskillit/skills_extended/merge-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/merge-pr/SKILL.md
@@ -47,7 +47,7 @@ conflicts from earlier merges in the queue.
 
 **ALWAYS:**
 - Run `git status` before any operation to verify clean state
-- Detect `autoMergeAllowed` via GraphQL before Step 2 (Step 1.8) to select the correct merge command
+- Detect `autoMergeAllowed` before Step 2 (Step 1.8) to select the correct merge command
 - Use `gh pr merge {pr_number} --squash --auto` when `autoMergeAllowed=true` — enforces required status checks before merge executes
 - Use `gh pr merge {pr_number} --squash` when `autoMergeAllowed=false` — GitHub merges synchronously without waiting for checks
 - Poll `gh pr view {pr_number} --json state,mergedAt` to confirm the merge completed

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -441,6 +441,7 @@ MODULE_CASCADE_RECIPE: dict[str, frozenset[str]] = {
     "rules_skill_content": frozenset(
         {
             "recipe",
+            "recipe/test_rules_skill_content.py",
             "skills/test_graphql_invocation_completeness.py",
             "skills/test_skill_placeholder_contracts.py",
             "skills/test_skill_tool_syntax_contracts.py",

--- a/tests/recipe/test_rules_skill_content.py
+++ b/tests/recipe/test_rules_skill_content.py
@@ -1708,3 +1708,26 @@ def test_graphql_rule_fires_for_prose_in_different_section_than_invocation(
     findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
     rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
     assert _GRAPHQL_RULE_ID in rule_ids
+
+
+def test_graphql_rule_fires_for_documentation_schema_reference_without_invocation(
+    tmp_path: Path,
+) -> None:
+    skill_md = textwrap.dedent(
+        """\
+        # graphql-skill
+
+        ## Schema Reference
+
+        ```graphql
+        type PullRequest {
+          title: String!
+          mergedAt: DateTime
+          reviews(first: Int): ReviewConnection!
+        }
+        ```
+        """
+    )
+    findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+    rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+    assert _GRAPHQL_RULE_ID in rule_ids

--- a/tests/recipe/test_rules_skill_content.py
+++ b/tests/recipe/test_rules_skill_content.py
@@ -1072,7 +1072,7 @@ def test_reviews_post_requires_input_flag_rule_passes_with_input_flag(
 def test_reviews_post_rule_subsection_granularity(tmp_path: Path) -> None:
     """Rule uses ### granularity: --input - in a different ### step does not satisfy the guard.
 
-    If the implementation mistakenly used ## granularity (_extract_sections), --input - from
+    If the implementation mistakenly used ## granularity (extract_sections), --input - from
     any step in the same ## Workflow section would suppress the finding. This test catches
     that false-negative regression.
     """
@@ -1606,7 +1606,7 @@ def test_graphql_rule_fires_for_case_mismatched_variable_bindings(tmp_path: Path
     assert _GRAPHQL_RULE_ID in rule_ids
 
 
-def test_graphql_rule_does_not_fire_for_display_only_fragment(tmp_path: Path) -> None:
+def test_graphql_rule_fires_for_fragment_without_same_section_invocation(tmp_path: Path) -> None:
     skill_md = textwrap.dedent(
         """\
         # graphql-skill
@@ -1622,4 +1622,89 @@ def test_graphql_rule_does_not_fire_for_display_only_fragment(tmp_path: Path) ->
     )
     findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
     rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+    assert _GRAPHQL_RULE_ID in rule_ids
+
+
+def test_graphql_rule_does_not_fire_for_non_parameterized_block_with_invocation(
+    tmp_path: Path,
+) -> None:
+    skill_md = textwrap.dedent(
+        """\
+        # graphql-skill
+
+        ### Step 1
+        ```graphql
+        number title mergedAt
+        reviews(first: 100) {
+          nodes { author { login } body state submittedAt }
+        }
+        ```
+
+        ```bash
+        gh api graphql -f query="$BATCH_QUERY"
+        ```
+        """
+    )
+    findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+    rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
     assert _GRAPHQL_RULE_ID not in rule_ids
+
+
+def test_graphql_rule_fires_for_prose_without_same_section_invocation(tmp_path: Path) -> None:
+    skill_md = textwrap.dedent(
+        """\
+        # graphql-skill
+
+        ## Workflow
+
+        Build batched GraphQL `createIssue` mutations with aliases.
+        Execute via `gh api graphql --input -`.
+        """
+    )
+    findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+    rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+    assert _GRAPHQL_RULE_ID in rule_ids
+
+
+def test_graphql_rule_does_not_fire_for_prose_with_same_section_invocation(
+    tmp_path: Path,
+) -> None:
+    skill_md = textwrap.dedent(
+        """\
+        # graphql-skill
+
+        ## Workflow
+
+        Build batched GraphQL `createIssue` mutations with aliases.
+
+        ```bash
+        echo "$MUTATION_JSON" | gh api graphql --input -
+        ```
+        """
+    )
+    findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+    rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+    assert _GRAPHQL_RULE_ID not in rule_ids
+
+
+def test_graphql_rule_fires_for_prose_in_different_section_than_invocation(
+    tmp_path: Path,
+) -> None:
+    skill_md = textwrap.dedent(
+        """\
+        # graphql-skill
+
+        ## Step 5
+
+        Build batched GraphQL `createIssue` mutations with aliases.
+
+        ## Step 6
+
+        ```bash
+        echo "$MUTATION_JSON" | gh api graphql --input -
+        ```
+        """
+    )
+    findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+    rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+    assert _GRAPHQL_RULE_ID in rule_ids

--- a/tests/skills/test_graphql_invocation_completeness.py
+++ b/tests/skills/test_graphql_invocation_completeness.py
@@ -13,10 +13,13 @@ Both detectors operate at ##-level section granularity.
 from __future__ import annotations
 
 import re
+import textwrap
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
+import autoskillit.recipe._skill_helpers as _sh
 from autoskillit.core.paths import pkg_root
 from autoskillit.recipe._skill_placeholder_parser import (
     extract_bash_blocks,
@@ -24,6 +27,8 @@ from autoskillit.recipe._skill_placeholder_parser import (
     extract_sections,
     has_prose_graphql_execution,
 )
+from autoskillit.recipe.io import load_recipe
+from autoskillit.recipe.registry import run_semantic_rules
 
 pytestmark = [pytest.mark.layer("skills"), pytest.mark.medium]
 
@@ -154,115 +159,122 @@ def test_graphql_blocks_use_individual_F_flags_not_json_blob() -> None:
 
 # --- Synthetic SKILL.md regression tests ---
 
+_GRAPHQL_RULE_ID = "graphql-query-requires-shell-invocation"
+
+
+def _write_graphql_skill_and_run_rules(tmp_path: Path, skill_md_content: str) -> list[object]:
+    skill_dir = tmp_path / "graphql-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(skill_md_content)
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(
+        "name: test-recipe\n"
+        "kitchen_rules:\n"
+        '  - "Use run_skill only."\n'
+        "steps:\n"
+        "  run_impl:\n"
+        "    tool: run_skill\n"
+        "    with:\n"
+        '      skill_command: "/autoskillit:graphql-skill"\n'
+        "    on_success: done\n"
+    )
+    recipe = load_recipe(recipe_path)
+    with patch.object(_sh, "SKILL_SEARCH_DIRS", [tmp_path]):
+        return run_semantic_rules(recipe)
+
 
 class TestGraphqlBlockDetectionBroadened:
     """Verify that graphql blocks without $variable tokens are still caught."""
 
     def test_angle_bracket_placeholders_without_invocation_fails(self, tmp_path: Path) -> None:
-        skill_dir = tmp_path / "angle-bracket-skill"
-        skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text(
-            "# angle-bracket-skill\n\n"
-            "## Workflow\n\n"
-            "```graphql\n"
-            "query {\n"
-            '  repository(owner: "<OWNER>", name: "<REPO>") {\n'
-            "    issues(first: 10) { nodes { title } }\n"
-            "  }\n"
-            "}\n"
-            "```\n"
-        )
-        content = (skill_dir / "SKILL.md").read_text()
-        for section in extract_sections(content):
-            section_graphql = extract_graphql_blocks(section)
-            if section_graphql:
-                section_bash = extract_bash_blocks(section)
-                section_bash_graphql = [b for b in section_bash if _GH_API_GRAPHQL_RE.search(b)]
-                assert not section_bash_graphql
+        skill_md = textwrap.dedent("""\
+            # graphql-skill
+
+            ## Workflow
+
+            ```graphql
+            query {
+              repository(owner: "<OWNER>", name: "<REPO>") {
+                issues(first: 10) { nodes { title } }
+              }
+            }
+            ```
+        """)
+        findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+        rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+        assert _GRAPHQL_RULE_ID in rule_ids
 
     def test_angle_bracket_placeholders_with_invocation_passes(self, tmp_path: Path) -> None:
-        skill_dir = tmp_path / "angle-bracket-pass-skill"
-        skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text(
-            "# angle-bracket-pass-skill\n\n"
-            "## Workflow\n\n"
-            "```graphql\n"
-            "query {\n"
-            '  repository(owner: "<OWNER>", name: "<REPO>") {\n'
-            "    issues(first: 10) { nodes { title } }\n"
-            "  }\n"
-            "}\n"
-            "```\n\n"
-            "```bash\n"
-            'gh api graphql -f query="$QUERY"\n'
-            "```\n"
-        )
-        content = (skill_dir / "SKILL.md").read_text()
-        for section in extract_sections(content):
-            section_graphql = extract_graphql_blocks(section)
-            if section_graphql:
-                section_bash = extract_bash_blocks(section)
-                section_bash_graphql = [b for b in section_bash if _GH_API_GRAPHQL_RE.search(b)]
-                assert section_bash_graphql
+        skill_md = textwrap.dedent("""\
+            # graphql-skill
+
+            ## Workflow
+
+            ```graphql
+            query {
+              repository(owner: "<OWNER>", name: "<REPO>") {
+                issues(first: 10) { nodes { title } }
+              }
+            }
+            ```
+
+            ```bash
+            gh api graphql -f query="$QUERY"
+            ```
+        """)
+        findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+        rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+        assert _GRAPHQL_RULE_ID not in rule_ids
 
     def test_field_selection_fragment_without_invocation_fails(self, tmp_path: Path) -> None:
-        skill_dir = tmp_path / "fragment-skill"
-        skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text(
-            "# fragment-skill\n\n"
-            "## Workflow\n\n"
-            "```graphql\n"
-            "number title mergedAt\n"
-            "reviews(first: 100) {\n"
-            "  nodes { author { login } body state }\n"
-            "}\n"
-            "```\n"
-        )
-        content = (skill_dir / "SKILL.md").read_text()
-        for section in extract_sections(content):
-            section_graphql = extract_graphql_blocks(section)
-            if section_graphql:
-                section_bash = extract_bash_blocks(section)
-                section_bash_graphql = [b for b in section_bash if _GH_API_GRAPHQL_RE.search(b)]
-                assert not section_bash_graphql
+        skill_md = textwrap.dedent("""\
+            # graphql-skill
+
+            ## Workflow
+
+            ```graphql
+            number title mergedAt
+            reviews(first: 100) {
+              nodes { author { login } body state }
+            }
+            ```
+        """)
+        findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+        rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+        assert _GRAPHQL_RULE_ID in rule_ids
 
 
 class TestProseGraphqlDetection:
     """Verify that prose-described GraphQL operations are caught."""
 
     def test_prose_graphql_without_invocation_fails(self, tmp_path: Path) -> None:
-        skill_dir = tmp_path / "prose-skill"
-        skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text(
-            "# prose-skill\n\n"
-            "## Workflow\n\n"
-            "Build batched GraphQL `createIssue` mutations with aliases.\n"
-            "Execute via `gh api graphql --input -`.\n"
-        )
-        content = (skill_dir / "SKILL.md").read_text()
-        for section in extract_sections(content):
-            if has_prose_graphql_execution(section):
-                section_bash = extract_bash_blocks(section)
-                has_invocation = any(_GH_API_GRAPHQL_RE.search(b) for b in section_bash)
-                assert not has_invocation
+        skill_md = textwrap.dedent("""\
+            # graphql-skill
+
+            ## Workflow
+
+            Build batched GraphQL `createIssue` mutations with aliases.
+            Execute via `gh api graphql --input -`.
+        """)
+        findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+        rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+        assert _GRAPHQL_RULE_ID in rule_ids
 
     def test_prose_graphql_with_invocation_passes(self, tmp_path: Path) -> None:
-        skill_dir = tmp_path / "prose-pass-skill"
-        skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text(
-            "# prose-pass-skill\n\n"
-            "## Workflow\n\n"
-            "Build batched GraphQL `createIssue` mutations with aliases.\n\n"
-            "```bash\n"
-            'echo "$MUTATION_JSON" | gh api graphql --input -\n'
-            "```\n"
-        )
-        content = (skill_dir / "SKILL.md").read_text()
-        for section in extract_sections(content):
-            if has_prose_graphql_execution(section):
-                section_bash = extract_bash_blocks(section)
-                has_invocation = any(_GH_API_GRAPHQL_RE.search(b) for b in section_bash)
-                assert has_invocation
+        skill_md = textwrap.dedent("""\
+            # graphql-skill
+
+            ## Workflow
+
+            Build batched GraphQL `createIssue` mutations with aliases.
+
+            ```bash
+            echo "$MUTATION_JSON" | gh api graphql --input -
+            ```
+        """)
+        findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+        rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+        assert _GRAPHQL_RULE_ID not in rule_ids
 
     def test_prose_graphql_under_h2_heading_detected(self, tmp_path: Path) -> None:
         """Prose GraphQL under a ## heading (not ### Step N) is caught."""

--- a/tests/skills/test_graphql_invocation_completeness.py
+++ b/tests/skills/test_graphql_invocation_completeness.py
@@ -1,12 +1,13 @@
 """SKILL.md GraphQL invocation completeness contract.
 
-Every ```graphql block that declares parameterized variables ($owner, $repo, etc.)
-must have a corresponding ```bash block with a concrete `gh api graphql` invocation
-that binds those variables via individual -F flags.
+Every section that instructs the agent to execute a GraphQL operation must
+contain a fenced ``bash`` block with a concrete ``gh api graphql`` invocation
+in that same section. This covers:
 
-This prevents the "schema without invocation" anti-pattern where agents must
-improvise gh api graphql variable-passing syntax — which is non-obvious and
-error-prone (the -f variables=<json blob> pattern silently fails).
+1. Fenced ```graphql blocks (regardless of parameterization style)
+2. Prose-described GraphQL operations (no fenced block)
+
+Both detectors operate at ##-level section granularity.
 """
 
 from __future__ import annotations
@@ -20,6 +21,8 @@ from autoskillit.core.paths import pkg_root
 from autoskillit.recipe._skill_placeholder_parser import (
     extract_bash_blocks,
     extract_graphql_blocks,
+    extract_sections,
+    has_prose_graphql_execution,
 )
 
 pytestmark = [pytest.mark.layer("skills"), pytest.mark.medium]
@@ -38,7 +41,7 @@ def _all_skill_dirs() -> list[Path]:
 
 
 def test_graphql_blocks_have_matching_bash_invocations() -> None:
-    """Every parameterized graphql block must have a matching gh api graphql bash invocation."""
+    """Every graphql fenced block must have a gh api graphql bash block in the same section."""
     failures: list[str] = []
 
     for skill_dir in _all_skill_dirs():
@@ -47,42 +50,71 @@ def test_graphql_blocks_have_matching_bash_invocations() -> None:
             continue
 
         content = skill_md.read_text(encoding="utf-8")
-        graphql_blocks = extract_graphql_blocks(content)
-        if not graphql_blocks:
-            continue
+        skill_name = skill_dir.name
 
-        bash_blocks = extract_bash_blocks(content)
-        bash_with_graphql = [b for b in bash_blocks if _GH_API_GRAPHQL_RE.search(b)]
-
-        for block in graphql_blocks:
-            variable_names = set(re.findall(r"\$([a-zA-Z_]\w*)", block))
-            if not variable_names:
+        for section in extract_sections(content):
+            section_graphql = extract_graphql_blocks(section)
+            if not section_graphql:
                 continue
 
-            skill_name = skill_dir.name
+            section_bash = extract_bash_blocks(section)
+            section_bash_graphql = [b for b in section_bash if _GH_API_GRAPHQL_RE.search(b)]
 
-            if not bash_with_graphql:
-                failures.append(
-                    f"{skill_name}: graphql block declares variables "
-                    f"{sorted(variable_names)} but no ```bash block contains "
-                    f"'gh api graphql'"
-                )
-                continue
-
-            for var in variable_names:
-                flag_found = any(
-                    re.search(rf"-[Ff]\s*{re.escape(var)}=", b) for b in bash_with_graphql
-                )
-                if not flag_found:
+            for block in section_graphql:
+                if not section_bash_graphql:
                     failures.append(
-                        f"{skill_name}: graphql variable '${var}' has no "
-                        f"'-F {var}=' or '-f {var}=' binding in any "
-                        f"'gh api graphql' bash block"
+                        f"{skill_name}: graphql block in section has no "
+                        f"'gh api graphql' bash block in the same section"
                     )
+                    break
+
+                variable_names = set(re.findall(r"\$([a-zA-Z_]\w*)", block))
+                for var in variable_names:
+                    flag_found = any(
+                        re.search(rf"-[Ff]\s*{re.escape(var)}=", b) for b in section_bash_graphql
+                    )
+                    if not flag_found:
+                        failures.append(
+                            f"{skill_name}: graphql variable '${var}' has no "
+                            f"'-F {var}=' binding in same-section bash block"
+                        )
 
     assert not failures, (
-        "SKILL.md files with parameterized graphql blocks must have concrete "
-        "'gh api graphql' bash invocations binding each variable via -F flags:\n"
+        "SKILL.md sections with graphql blocks must have concrete "
+        "'gh api graphql' bash invocations in the same section:\n"
+        + "\n".join(f"  - {f}" for f in failures)
+    )
+
+
+def test_prose_graphql_references_have_invocation_blocks() -> None:
+    """Step sections with prose GraphQL execution refs must have a bash invocation."""
+    failures: list[str] = []
+
+    for skill_dir in _all_skill_dirs():
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.exists():
+            continue
+
+        content = skill_md.read_text(encoding="utf-8")
+        skill_name = skill_dir.name
+
+        for section in extract_sections(content):
+            if not has_prose_graphql_execution(section):
+                continue
+
+            section_bash = extract_bash_blocks(section)
+            if any(_GH_API_GRAPHQL_RE.search(b) for b in section_bash):
+                continue
+
+            heading = section.splitlines()[0].strip() if section.strip() else "(no heading)"
+            failures.append(
+                f"{skill_name}: section '{heading}' references GraphQL execution "
+                f"in prose but has no 'gh api graphql' bash block in the same section"
+            )
+
+    assert not failures, (
+        "SKILL.md sections with prose GraphQL execution references must have "
+        "concrete 'gh api graphql' bash invocations in the same section:\n"
         + "\n".join(f"  - {f}" for f in failures)
     )
 
@@ -118,3 +150,141 @@ def test_graphql_blocks_use_individual_F_flags_not_json_blob() -> None:
         "gh api graphql invocations must bind variables via individual -F flags, "
         "not a single -f variables=<json blob>:\n" + "\n".join(f"  - {f}" for f in failures)
     )
+
+
+# --- Synthetic SKILL.md regression tests ---
+
+
+class TestGraphqlBlockDetectionBroadened:
+    """Verify that graphql blocks without $variable tokens are still caught."""
+
+    def test_angle_bracket_placeholders_without_invocation_fails(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "angle-bracket-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "# angle-bracket-skill\n\n"
+            "## Workflow\n\n"
+            "```graphql\n"
+            "query {\n"
+            '  repository(owner: "<OWNER>", name: "<REPO>") {\n'
+            "    issues(first: 10) { nodes { title } }\n"
+            "  }\n"
+            "}\n"
+            "```\n"
+        )
+        content = (skill_dir / "SKILL.md").read_text()
+        for section in extract_sections(content):
+            section_graphql = extract_graphql_blocks(section)
+            if section_graphql:
+                section_bash = extract_bash_blocks(section)
+                section_bash_graphql = [b for b in section_bash if _GH_API_GRAPHQL_RE.search(b)]
+                assert not section_bash_graphql
+
+    def test_angle_bracket_placeholders_with_invocation_passes(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "angle-bracket-pass-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "# angle-bracket-pass-skill\n\n"
+            "## Workflow\n\n"
+            "```graphql\n"
+            "query {\n"
+            '  repository(owner: "<OWNER>", name: "<REPO>") {\n'
+            "    issues(first: 10) { nodes { title } }\n"
+            "  }\n"
+            "}\n"
+            "```\n\n"
+            "```bash\n"
+            'gh api graphql -f query="$QUERY"\n'
+            "```\n"
+        )
+        content = (skill_dir / "SKILL.md").read_text()
+        for section in extract_sections(content):
+            section_graphql = extract_graphql_blocks(section)
+            if section_graphql:
+                section_bash = extract_bash_blocks(section)
+                section_bash_graphql = [b for b in section_bash if _GH_API_GRAPHQL_RE.search(b)]
+                assert section_bash_graphql
+
+    def test_field_selection_fragment_without_invocation_fails(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "fragment-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "# fragment-skill\n\n"
+            "## Workflow\n\n"
+            "```graphql\n"
+            "number title mergedAt\n"
+            "reviews(first: 100) {\n"
+            "  nodes { author { login } body state }\n"
+            "}\n"
+            "```\n"
+        )
+        content = (skill_dir / "SKILL.md").read_text()
+        for section in extract_sections(content):
+            section_graphql = extract_graphql_blocks(section)
+            if section_graphql:
+                section_bash = extract_bash_blocks(section)
+                section_bash_graphql = [b for b in section_bash if _GH_API_GRAPHQL_RE.search(b)]
+                assert not section_bash_graphql
+
+
+class TestProseGraphqlDetection:
+    """Verify that prose-described GraphQL operations are caught."""
+
+    def test_prose_graphql_without_invocation_fails(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "prose-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "# prose-skill\n\n"
+            "## Workflow\n\n"
+            "Build batched GraphQL `createIssue` mutations with aliases.\n"
+            "Execute via `gh api graphql --input -`.\n"
+        )
+        content = (skill_dir / "SKILL.md").read_text()
+        for section in extract_sections(content):
+            if has_prose_graphql_execution(section):
+                section_bash = extract_bash_blocks(section)
+                has_invocation = any(_GH_API_GRAPHQL_RE.search(b) for b in section_bash)
+                assert not has_invocation
+
+    def test_prose_graphql_with_invocation_passes(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "prose-pass-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "# prose-pass-skill\n\n"
+            "## Workflow\n\n"
+            "Build batched GraphQL `createIssue` mutations with aliases.\n\n"
+            "```bash\n"
+            'echo "$MUTATION_JSON" | gh api graphql --input -\n'
+            "```\n"
+        )
+        content = (skill_dir / "SKILL.md").read_text()
+        for section in extract_sections(content):
+            if has_prose_graphql_execution(section):
+                section_bash = extract_bash_blocks(section)
+                has_invocation = any(_GH_API_GRAPHQL_RE.search(b) for b in section_bash)
+                assert has_invocation
+
+    def test_prose_graphql_under_h2_heading_detected(self, tmp_path: Path) -> None:
+        """Prose GraphQL under a ## heading (not ### Step N) is caught."""
+        content = "# skill\n\n## Workflow\n\nBuild batched GraphQL mutations and execute them.\n"
+        sections = extract_sections(content)
+        assert any(has_prose_graphql_execution(s) for s in sections)
+
+    def test_both_graphql_block_and_prose_with_invocation_passes(self, tmp_path: Path) -> None:
+        content = (
+            "# skill\n\n"
+            "## Workflow\n\n"
+            "Build batched GraphQL mutations.\n\n"
+            "```graphql\n"
+            "mutation { createIssue(input: {}) { issue { id } } }\n"
+            "```\n\n"
+            "```bash\n"
+            "gh api graphql --input -\n"
+            "```\n"
+        )
+        for section in extract_sections(content):
+            section_graphql = extract_graphql_blocks(section)
+            section_bash = extract_bash_blocks(section)
+            section_bash_graphql = [b for b in section_bash if _GH_API_GRAPHQL_RE.search(b)]
+            if section_graphql or has_prose_graphql_execution(section):
+                assert section_bash_graphql


### PR DESCRIPTION
## Summary

Two gaps from the audit of the GraphQL invocation immunity implementation:

1. **Missing test filter cascade entry** — `"recipe/test_rules_skill_content.py"` is absent from `MODULE_CASCADE_RECIPE["rules_skill_content"]` in `tests/_test_filter.py`, so filtered test runs won't trigger the rule content tests when `rules_skill_content.py` changes.

2. **Missing documentation schema reference regression test** — The original plan (Step 1f, bullet 4) required a test for graphql blocks in documentation/schema-reference sections. The implementation intentionally chose uniform treatment (no exemption for documentation sections), but no test documents this design decision. Add a test that asserts the rule fires for a graphql block in a documentation-titled section without a same-section invocation, confirming the uniform-enforcement design.

Closes #3545

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260601-214849-434579/.autoskillit/temp/make-plan/remediation_graphql_invocation_immunity_plan_2026-06-01_224500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 2.1k | 25.3k | 3.5M | 128.2k | 73 | 111.7k | 19m 26s |
| review_approach* | opus[1m] | 1 | 25 | 5.7k | 224.6k | 42.9k | 13 | 29.3k | 2m 59s |
| dry_walkthrough* | opus | 2 | 83 | 11.8k | 819.7k | 57.4k | 43 | 74.8k | 9m 44s |
| implement* | opus[1m] | 2 | 125 | 22.4k | 2.8M | 78.4k | 102 | 85.7k | 10m 8s |
| audit_impl* | opus[1m] | 2 | 57 | 21.4k | 431.2k | 64.0k | 30 | 81.6k | 14m 57s |
| make_plan* | opus[1m] | 1 | 53 | 6.1k | 770.0k | 62.7k | 27 | 48.0k | 4m 14s |
| prepare_pr* | MiniMax-M3 | 1 | 39.3k | 2.4k | 152.9k | 42.5k | 12 | 0 | 1m 26s |
| compose_pr* | MiniMax-M3 | 1 | 35.7k | 1.1k | 149.7k | 38.3k | 11 | 0 | 54s |
| review_pr* | opus[1m] | 1 | 38 | 48.7k | 1.5M | 106.8k | 41 | 90.4k | 12m 8s |
| resolve_review* | opus[1m] | 1 | 56 | 27.6k | 1.7M | 110.0k | 49 | 102.5k | 12m 30s |
| **Total** | | | 77.6k | 172.5k | 12.0M | 128.2k | | 624.1k | 1h 28m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 486 | 5682.7 | 176.4 | 46.2 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 202 | 8253.8 | 507.5 | 136.4 |
| **Total** | **688** | 17441.2 | 907.2 | 250.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 7 | 2.5k | 157.2k | 10.9M | 549.3k | 1h 16m |
| opus | 1 | 83 | 11.8k | 819.7k | 74.8k | 9m 44s |
| MiniMax-M3 | 2 | 75.0k | 3.5k | 302.6k | 0 | 2m 19s |