### PR TITLE
Implementation Plan: P5-A4-WP1 — Make BackendCapabilities Constructible with No Arguments

### DIFF
--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -40,27 +40,27 @@ class BackendCapabilities:
     """
 
     # True when backend streams a side-channel JSONL log (Channel B)
-    channel_b_capable: bool
+    channel_b_capable: bool = field(default=False)
     # True when the subprocess needs a pseudo-TTY allocation
-    pty_required: bool
+    pty_required: bool = field(default=False)
     # True when backend supports --resume <session_id>
-    session_resume_capable: bool
+    session_resume_capable: bool = field(default=False)
     # True when backend accepts --add-dir / --plugin-dir skill injection
-    skill_injection_capable: bool
+    skill_injection_capable: bool = field(default=False)
     # Forward-declared: planned for thinking-block rendering
-    supports_thinking_blocks: bool
+    supports_thinking_blocks: bool = field(default=False)
     # True when backend stdout is Claude JSON format
-    supports_claude_format_stdout: bool
+    supports_claude_format_stdout: bool = field(default=False)
     # True when non-zero exit code definitively signals failure
-    exit_code_is_terminal: bool
+    exit_code_is_terminal: bool = field(default=False)
     # Forward-declared: planned for MCP config wiring
-    mcp_config_capable: bool
+    mcp_config_capable: bool = field(default=False)
     # True when backend can be used for food-truck (fleet) dispatches
-    food_truck_capable: bool
+    food_truck_capable: bool = field(default=False)
     # JSONL record types that signal session completion
-    completion_record_types: frozenset[str]
+    completion_record_types: frozenset[str] = field(default_factory=frozenset)
     # JSONL record types that constitute session activity
-    session_record_types: frozenset[str]
+    session_record_types: frozenset[str] = field(default_factory=frozenset)
     # True when backend supports LLM triage via claude -p
     triage_capable: bool = field(default=False)
     # Forward-declared: planned for context exhaustion handling

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -50,23 +50,22 @@ def test_backend_capabilities_slots():
 
 
 def test_backend_capabilities_all_false_empty_constructible() -> None:
-    """BackendCapabilities() with zero args yields all-False/empty defaults."""
+    """BackendCapabilities() with zero args yields the declared default for every field."""
     from autoskillit.core import BackendCapabilities
 
     caps = BackendCapabilities()
-    # 9 original bool fields
-    assert caps.channel_b_capable is False
-    assert caps.pty_required is False
-    assert caps.session_resume_capable is False
-    assert caps.skill_injection_capable is False
-    assert caps.supports_thinking_blocks is False
-    assert caps.supports_claude_format_stdout is False
-    assert caps.exit_code_is_terminal is False
-    assert caps.mcp_config_capable is False
-    assert caps.food_truck_capable is False
-    # 2 original frozenset fields
-    assert caps.completion_record_types == frozenset()
-    assert caps.session_record_types == frozenset()
+    fields = dataclasses.fields(BackendCapabilities)
+    hints = typing.get_type_hints(BackendCapabilities)
+
+    for f in fields:
+        hint = hints.get(f.name)
+        actual = getattr(caps, f.name)
+        if hint is bool:
+            assert actual is f.default, (
+                f"{f.name!r}: zero-arg yields {actual!r}, declared default is {f.default!r}"
+            )
+        elif hint == frozenset[str]:
+            assert actual == frozenset(), f"{f.name!r}: expected frozenset(), got {actual!r}"
 
 
 def test_backend_capabilities_field_count():

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -49,6 +49,26 @@ def test_backend_capabilities_slots():
     assert not hasattr(CLAUDE_CODE_CAPABILITIES, "__dict__")
 
 
+def test_backend_capabilities_all_false_empty_constructible() -> None:
+    """BackendCapabilities() with zero args yields all-False/empty defaults."""
+    from autoskillit.core import BackendCapabilities
+
+    caps = BackendCapabilities()
+    # 9 original bool fields
+    assert caps.channel_b_capable is False
+    assert caps.pty_required is False
+    assert caps.session_resume_capable is False
+    assert caps.skill_injection_capable is False
+    assert caps.supports_thinking_blocks is False
+    assert caps.supports_claude_format_stdout is False
+    assert caps.exit_code_is_terminal is False
+    assert caps.mcp_config_capable is False
+    assert caps.food_truck_capable is False
+    # 2 original frozenset fields
+    assert caps.completion_record_types == frozenset()
+    assert caps.session_record_types == frozenset()
+
+
 def test_backend_capabilities_field_count():
     """Field count by type must match the dataclass definition."""
     from autoskillit.core import BackendCapabilities

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -6,14 +6,13 @@ import json
 import pathlib
 import textwrap
 from collections.abc import Callable
-from dataclasses import replace
 from pathlib import Path
 from typing import Any
 from unittest.mock import Mock
 
 import pytest
 
-from autoskillit.core import CLAUDE_CODE_CAPABILITIES, CmdSpec
+from autoskillit.core import BackendCapabilities, CmdSpec
 from autoskillit.core.types import SubprocessResult, TerminationReason
 from autoskillit.execution.session import ClaudeSessionResult
 from autoskillit.execution.session._exit_classification import _CODEX_API_ERROR_PATTERNS
@@ -25,21 +24,9 @@ CODEX_API_ERROR_SIGNAL_STRINGS: tuple[str, ...] = tuple(
 )
 
 
-def _mock_backend(
-    *,
-    pty_required: bool = True,
-    channel_b_capable: bool = True,
-    session_resume_capable: bool = True,
-    **kw: object,
-) -> Mock:
-    """Build a mock backend with configurable capabilities."""
-    caps = replace(
-        CLAUDE_CODE_CAPABILITIES,
-        pty_required=pty_required,
-        channel_b_capable=channel_b_capable,
-        session_resume_capable=session_resume_capable,
-        **kw,
-    )
+def _mock_backend(**kw: Any) -> Mock:
+    """Build a mock backend with all-False/empty capability baseline."""
+    caps = BackendCapabilities(**kw)
     backend = Mock()
     backend.name = "claude-code"
     backend.capabilities = caps
@@ -61,6 +48,7 @@ def _mock_backend(
     backend.version.return_value = ""
     backend.list_plugins.return_value = []
     backend.validate_skill_content.return_value = []
+    backend.validate_session_layout.return_value = []
     return backend
 
 

--- a/tests/execution/test_backend_dispatch.py
+++ b/tests/execution/test_backend_dispatch.py
@@ -16,7 +16,7 @@ pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 @pytest.mark.anyio
 async def test_run_headless_core_uses_ctx_backend_for_command_construction(minimal_ctx):
-    backend = _mock_backend()
+    backend = _mock_backend(pty_required=True, channel_b_capable=True)
     minimal_ctx.backend = backend
 
     mock_runner = AsyncMock()
@@ -109,7 +109,7 @@ class TestBackendDispatchRouting:
 class TestStepBackendOverride:
     @pytest.mark.anyio
     async def test_step_backend_none_falls_back_to_ctx_backend(self, minimal_ctx):
-        backend = _mock_backend()
+        backend = _mock_backend(pty_required=True, channel_b_capable=True)
         minimal_ctx.backend = backend
         minimal_ctx.runner = AsyncMock(
             return_value=SubprocessResult(
@@ -146,7 +146,7 @@ class TestStepBackendOverride:
 
     @pytest.mark.anyio
     async def test_step_backend_override_routes_through_get_backend(self, minimal_ctx):
-        backend = _mock_backend()
+        backend = _mock_backend(pty_required=True, channel_b_capable=True)
         minimal_ctx.backend = backend
         minimal_ctx.runner = AsyncMock(
             return_value=SubprocessResult(
@@ -192,7 +192,7 @@ class TestStepBackendOverride:
 
     @pytest.mark.anyio
     async def test_step_backend_flows_to_stream_parser_and_build_result(self, minimal_ctx):
-        ctx_backend = _mock_backend()
+        ctx_backend = _mock_backend(pty_required=True, channel_b_capable=True)
         step_backend_mock = _mock_backend(
             pty_required=False, channel_b_capable=False, process_name="codex"
         )
@@ -239,7 +239,7 @@ class TestStepBackendOverride:
 
     @pytest.mark.anyio
     async def test_backend_override_unknown_name_raises_valueerror(self, minimal_ctx):
-        backend = _mock_backend()
+        backend = _mock_backend(pty_required=True, channel_b_capable=True)
         minimal_ctx.backend = backend
         minimal_ctx.runner = AsyncMock()
         from autoskillit.execution.headless import run_headless_core
@@ -344,7 +344,7 @@ class TestCodexLogDispatch:
 
         fake_runner, flush_calls = _patch_for_flush(monkeypatch, tmp_path, result)
         minimal_ctx.runner = fake_runner  # type: ignore[assignment]
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
         await _execute_claude_headless(
             CmdSpec(cmd=("codex", "--quiet", "test"), env={}),

--- a/tests/execution/test_flush_provider_integration.py
+++ b/tests/execution/test_flush_provider_integration.py
@@ -73,7 +73,7 @@ class TestProviderFieldsReachFlush:
             monkeypatch, tmp_path, _SUCCESS_RESULT, minimal_ctx
         )
         minimal_ctx.runner = fake_runner  # type: ignore[assignment]
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
         await _execute_claude_headless(
             ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
@@ -151,7 +151,7 @@ class TestProviderFieldsReachFlush:
         monkeypatch.setattr(_sl_mod, "flush_session_log", lambda **kw: flush_calls.append(kw))
 
         minimal_ctx.runner = fake_runner  # type: ignore[assignment]
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
         result = await _execute_claude_headless(
             ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
@@ -195,7 +195,7 @@ class TestProviderFieldsReachFlush:
             raise RuntimeError("disk crash")
 
         minimal_ctx.runner = raising_runner  # type: ignore[assignment]
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
         result = await _execute_claude_headless(
             ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),

--- a/tests/execution/test_headless_backend_mixing.py
+++ b/tests/execution/test_headless_backend_mixing.py
@@ -55,7 +55,7 @@ class TestBackendMixingCommandRouting:
             )
         )
 
-        claude_code_backend = _mock_backend()
+        claude_code_backend = _mock_backend(pty_required=True, channel_b_capable=True)
         claude_code_backend.name = "claude-code"
 
         with (
@@ -91,7 +91,7 @@ class TestBackendMixingEnvPolicy:
         codex_backend.name = "codex"
         minimal_ctx.backend = codex_backend
 
-        claude_code_backend = _mock_backend()
+        claude_code_backend = _mock_backend(pty_required=True, channel_b_capable=True)
         claude_code_backend.name = "claude-code"
         claude_code_backend.build_skill_session_cmd.return_value = CmdSpec(
             cmd=("claude", "--print", "test-skill"),
@@ -161,7 +161,7 @@ class TestDefaultExecutorBackendMixing:
             )
         )
 
-        claude_code_backend = _mock_backend()
+        claude_code_backend = _mock_backend(pty_required=True, channel_b_capable=True)
         claude_code_backend.name = "claude-code"
 
         with (

--- a/tests/execution/test_headless_backend_override.py
+++ b/tests/execution/test_headless_backend_override.py
@@ -52,7 +52,7 @@ class TestBackendOverrideCommandRouting:
             )
         )
 
-        claude_code_backend = _mock_backend()
+        claude_code_backend = _mock_backend(pty_required=True, channel_b_capable=True)
         claude_code_backend.name = "claude-code"
 
         with (
@@ -76,7 +76,7 @@ class TestBackendOverrideCommandRouting:
     @pytest.mark.anyio
     async def test_backend_override_none_uses_ctx_backend(self, minimal_ctx):
         """When backend_override=None, ctx.backend's build_skill_session_cmd is called."""
-        backend = _mock_backend()
+        backend = _mock_backend(pty_required=True, channel_b_capable=True)
         minimal_ctx.backend = backend
         minimal_ctx.runner = AsyncMock(
             return_value=SubprocessResult(
@@ -106,7 +106,7 @@ class TestBackendOverrideCommandRouting:
     @pytest.mark.anyio
     async def test_backend_override_codex_uses_codex_backend(self, minimal_ctx):
         """When backend_override='codex', codex mock's build_skill_session_cmd is called."""
-        claude_code_backend = _mock_backend()
+        claude_code_backend = _mock_backend(pty_required=True, channel_b_capable=True)
         claude_code_backend.name = "claude-code"
         minimal_ctx.backend = claude_code_backend
         minimal_ctx.runner = AsyncMock(
@@ -153,7 +153,7 @@ class TestBackendOverrideEnvPolicy:
         codex_backend.name = "codex"
         minimal_ctx.backend = codex_backend
 
-        claude_code_backend = _mock_backend()
+        claude_code_backend = _mock_backend(pty_required=True, channel_b_capable=True)
         claude_code_backend.name = "claude-code"
         claude_code_backend.build_skill_session_cmd.return_value = CmdSpec(
             cmd=("claude", "--print", "test-skill"),
@@ -201,7 +201,7 @@ class TestBackendOverrideEnvPolicy:
         """Codex override backend strips ANTHROPIC_API_KEY from spec.env."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
 
-        claude_code_backend = _mock_backend()
+        claude_code_backend = _mock_backend(pty_required=True, channel_b_capable=True)
         claude_code_backend.name = "claude-code"
         minimal_ctx.backend = claude_code_backend
 
@@ -257,7 +257,7 @@ class TestBackendOverrideParserSelection:
         """When backend_override is set, step_backend.stream_parser is called."""
         ctx_backend = _mock_backend(pty_required=False, channel_b_capable=False)
         ctx_backend.name = "codex"
-        step_backend = _mock_backend()
+        step_backend = _mock_backend(pty_required=True, channel_b_capable=True)
         step_backend.name = "claude-code"
         minimal_ctx.backend = ctx_backend
         minimal_ctx.runner = AsyncMock(

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -210,7 +210,7 @@ class TestRunHeadlessCoreFilesystemWrites:
         base_runner = MockSubprocessRunner()
         base_runner.set_default(_sr(0, _success_session_json("done"), ""))
         minimal_ctx.runner = _FileSideEffectRunner(base_runner, skill_temp / "output.txt")
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
         result = await run_headless_core(
             "/autoskillit:probe",
@@ -233,7 +233,7 @@ class TestRunHeadlessCoreFilesystemWrites:
         runner = MockSubprocessRunner()
         runner.set_default(_sr(0, _success_session_json("done"), ""))
         minimal_ctx.runner = runner
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
         result = await run_headless_core(
             "/autoskillit:probe",

--- a/tests/execution/test_headless_dispatch.py
+++ b/tests/execution/test_headless_dispatch.py
@@ -436,7 +436,9 @@ class TestDispatchFoodTruckGuards:
         )
         minimal_ctx.runner = runner
         minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(
+            food_truck_capable=True, pty_required=True, channel_b_capable=True
+        )
 
         executor = DefaultHeadlessExecutor(minimal_ctx)
         result = await executor.dispatch_food_truck(

--- a/tests/execution/test_headless_env_injection.py
+++ b/tests/execution/test_headless_env_injection.py
@@ -40,7 +40,7 @@ async def test_headless_command_includes_headless_env_var(minimal_ctx, tmp_path:
         )
     )
 
-    backend = _mock_backend()
+    backend = _mock_backend(pty_required=True, channel_b_capable=True)
     backend.build_skill_session_cmd.return_value = CmdSpec(
         cmd=("claude", "--print", "test"),
         env={"AUTOSKILLIT_HEADLESS": "1"},

--- a/tests/execution/test_headless_provider_fallback.py
+++ b/tests/execution/test_headless_provider_fallback.py
@@ -117,7 +117,7 @@ class TestProviderFallbackLoop:
             ctx=minimal_ctx,
         )
         minimal_ctx.runner = fake_runner
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
         result = await _execute_claude_headless(
             ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
@@ -146,7 +146,7 @@ class TestProviderFallbackLoop:
             ctx=minimal_ctx,
         )
         minimal_ctx.runner = fake_runner
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
         result = await _execute_claude_headless(
             ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
@@ -174,7 +174,7 @@ class TestProviderFallbackLoop:
             _make_queued_build_result(_STALE_RESULT),
         )
         minimal_ctx.runner = fake_runner
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
         result = await _execute_claude_headless(
             ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),
@@ -200,7 +200,7 @@ class TestProviderFallbackLoop:
             ctx=minimal_ctx,
         )
         minimal_ctx.runner = fake_runner
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
         result = await _execute_claude_headless(
             ClaudeHeadlessCmd(cmd=("echo", "test"), env={}),

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -34,7 +34,7 @@ async def test_run_headless_core_forwards_provider_extras_to_build_cmd(
 
     execute_kwargs: dict = {}
 
-    backend = _mock_backend()
+    backend = _mock_backend(pty_required=True, channel_b_capable=True)
     backend.build_skill_session_cmd.return_value = CmdSpec(
         cmd=("claude", "--print", "test"), env={}
     )
@@ -68,7 +68,7 @@ async def test_run_headless_core_defaults_provider_extras_none(
     from autoskillit.core import CmdSpec
     from autoskillit.execution.headless import run_headless_core
 
-    backend = _mock_backend()
+    backend = _mock_backend(pty_required=True, channel_b_capable=True)
     backend.build_skill_session_cmd.return_value = CmdSpec(
         cmd=("claude", "--print", "test"), env={}
     )
@@ -174,7 +174,7 @@ async def test_run_headless_core_forwards_provider_name_and_fallback_env(
 
     execute_kwargs: dict = {}
 
-    backend = _mock_backend()
+    backend = _mock_backend(pty_required=True, channel_b_capable=True)
     backend.build_skill_session_cmd.return_value = CmdSpec(
         cmd=("claude", "--print", "test"), env={}
     )
@@ -208,7 +208,7 @@ async def test_run_headless_core_bridges_profile_to_provider_when_empty(
 
     execute_kwargs: dict = {}
 
-    backend = _mock_backend()
+    backend = _mock_backend(pty_required=True, channel_b_capable=True)
     backend.build_skill_session_cmd.return_value = CmdSpec(
         cmd=("claude", "--print", "test"), env={}
     )
@@ -273,7 +273,7 @@ async def test_no_fallback_env_returns_empty_provider_used(
         return _sub_result
 
     minimal_ctx.runner = fake_runner
-    minimal_ctx.backend = _mock_backend()
+    minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
     monkeypatch.setattr(
         "autoskillit.execution.headless._headless_execute._build_skill_result",
@@ -315,7 +315,7 @@ async def test_provider_name_stamps_provider_used_on_result(
         return _sub_result
 
     minimal_ctx.runner = fake_runner
-    minimal_ctx.backend = _mock_backend()
+    minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
     monkeypatch.setattr(
         "autoskillit.execution.headless._headless_execute._build_skill_result",
@@ -458,7 +458,9 @@ async def test_dispatch_food_truck_forwards_marker_dir_and_session_id(
         lambda *a, **kw: object(),
     )
 
-    minimal_ctx.backend = _mock_backend()
+    minimal_ctx.backend = _mock_backend(
+        food_truck_capable=True, pty_required=True, channel_b_capable=True
+    )
     executor = DefaultHeadlessExecutor(minimal_ctx)
     marker = tmp_path / "markers"
     await executor.dispatch_food_truck(
@@ -529,7 +531,7 @@ async def test_execute_forwards_readonly_skill_to_build_result(
         return _sr(0, result_line)
 
     minimal_ctx.runner = fake_runner
-    minimal_ctx.backend = _mock_backend()
+    minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
     spec = ClaudeHeadlessCmd(cmd=("echo", "test"), env={})
     await _execute_claude_headless(
@@ -584,7 +586,9 @@ async def test_dispatch_food_truck_derives_marker_dir_from_cwd(
         lambda *a, **kw: object(),
     )
 
-    minimal_ctx.backend = _mock_backend()
+    minimal_ctx.backend = _mock_backend(
+        food_truck_capable=True, pty_required=True, channel_b_capable=True
+    )
     executor = DefaultHeadlessExecutor(minimal_ctx)
     await executor.dispatch_food_truck(
         "prompt",
@@ -626,7 +630,9 @@ async def test_dispatch_food_truck_marker_dir_none_when_cwd_falsy(
 
     from autoskillit.execution.headless import DefaultHeadlessExecutor
 
-    minimal_ctx.backend = _mock_backend()
+    minimal_ctx.backend = _mock_backend(
+        food_truck_capable=True, pty_required=True, channel_b_capable=True
+    )
     executor = DefaultHeadlessExecutor(minimal_ctx)
     await executor.dispatch_food_truck(
         "prompt",
@@ -655,7 +661,7 @@ async def test_execute_claude_headless_forwards_marker_dir_to_runner(
         return _sr()
 
     minimal_ctx.runner = fake_runner
-    minimal_ctx.backend = _mock_backend()
+    minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
     monkeypatch.setattr(
         "autoskillit.execution.headless._headless_execute._build_skill_result",
         lambda *a, **kw: SkillResult(
@@ -861,7 +867,7 @@ async def test_execute_claude_headless_passes_stream_parser_to_runner(
     minimal_ctx.runner = fake_runner
 
     sentinel = object()
-    backend = _mock_backend()
+    backend = _mock_backend(pty_required=True, channel_b_capable=True)
     backend.stream_parser.return_value = sentinel
     minimal_ctx.backend = backend
 
@@ -903,7 +909,7 @@ async def test_execute_claude_headless_stream_parser_receives_completion_marker(
 
     minimal_ctx.runner = fake_runner
 
-    backend = _mock_backend()
+    backend = _mock_backend(pty_required=True, channel_b_capable=True)
     minimal_ctx.backend = backend
 
     monkeypatch.setattr(
@@ -943,7 +949,7 @@ async def test_run_headless_core_forwards_marker_dir_and_caller_session_id(
     marker_dir = tmp_path / "markers"
     marker_dir.mkdir()
 
-    backend = _mock_backend()
+    backend = _mock_backend(pty_required=True, channel_b_capable=True)
     backend.build_skill_session_cmd.return_value = CmdSpec(
         cmd=("claude", "--print", "test"), env={}
     )

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -832,7 +832,7 @@ async def test_dispatch_food_truck_marker_dir_none_when_no_channel_b(
         lambda *a, **kw: object(),
     )
 
-    minimal_ctx.backend = _mock_backend(channel_b_capable=False)
+    minimal_ctx.backend = _mock_backend(food_truck_capable=True, channel_b_capable=False)
 
     from autoskillit.execution.headless import DefaultHeadlessExecutor
 

--- a/tests/execution/test_idle_output_env.py
+++ b/tests/execution/test_idle_output_env.py
@@ -46,7 +46,7 @@ class TestExecuteClaudeHeadlessIdleEnv:
         monkeypatch.setenv("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", "30")
         minimal_ctx.runner = MockSubprocessRunner()
         minimal_ctx.runner.set_default(_success_result())
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
         await run_headless_core("/investigate foo", str(tmp_path), minimal_ctx)
 
@@ -73,7 +73,7 @@ class TestExecuteClaudeHeadlessIdleEnv:
         minimal_ctx.config.run_skill.idle_output_timeout = 60
         minimal_ctx.runner = MockSubprocessRunner()
         minimal_ctx.runner.set_default(_success_result())
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
         await run_headless_core(
             "/investigate foo", str(tmp_path), minimal_ctx, idle_output_timeout=15.0
@@ -120,7 +120,7 @@ class TestExecuteClaudeHeadlessIdleEnv:
         minimal_ctx.config.run_skill.idle_output_timeout = 0  # cfg also 0
         minimal_ctx.runner = MockSubprocessRunner()
         minimal_ctx.runner.set_default(_success_result())
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
 
         await run_headless_core("/investigate foo", str(tmp_path), minimal_ctx)
 

--- a/tests/execution/test_write_evidence.py
+++ b/tests/execution/test_write_evidence.py
@@ -73,7 +73,7 @@ class TestMultiDirFsSnapshot:
             return _make_result()
 
         minimal_ctx.runner = mock_runner
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
         proj = tmp_path / "proj"
         proj.mkdir()
 
@@ -242,7 +242,7 @@ class TestSubdirSnapshot:
             return _make_result(returncode=0, stdout=_success_session_json("done"))
 
         minimal_ctx.runner = mock_runner
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
         proj = tmp_path / "proj"
         proj.mkdir()
 
@@ -270,7 +270,7 @@ class TestSubdirSnapshot:
             return _make_result(returncode=0, stdout=_success_session_json("done"))
 
         minimal_ctx.runner = mock_runner
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
         proj = tmp_path / "proj"
         proj.mkdir()
 
@@ -370,7 +370,7 @@ class TestStatSnapshot:
             return _make_result(returncode=0, stdout=_success_session_json("done"))
 
         minimal_ctx.runner = mock_runner
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
         proj = tmp_path / "proj"
         proj.mkdir()
 
@@ -419,7 +419,7 @@ class TestPlannerSkillEndToEnd:
             return _make_result(returncode=0, stdout=_success_session_json("done"))
 
         minimal_ctx.runner = mock_runner
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
         proj = tmp_path / "proj"
         proj.mkdir()
 
@@ -457,7 +457,7 @@ class TestLateCreatedDirectoryDetection:
             return _make_result(returncode=0, stdout=_success_session_json("done"))
 
         minimal_ctx.runner = mock_runner
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
         proj = tmp_path / "proj"
         proj.mkdir()
 
@@ -505,7 +505,7 @@ class TestSentinelDisambiguation:
             return _make_result(returncode=0, stdout=_success_session_json("done"))
 
         minimal_ctx.runner = mock_runner
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
         proj = tmp_path / "proj"
         proj.mkdir()
 
@@ -545,7 +545,7 @@ class TestSentinelDisambiguation:
             return _make_result(returncode=0, stdout=_success_session_json("done"))
 
         minimal_ctx.runner = mock_runner
-        minimal_ctx.backend = _mock_backend()
+        minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
         proj = tmp_path / "proj"
         proj.mkdir()
 


### PR DESCRIPTION
## Summary

Add field-level defaults (`False` for 9 bool fields, `frozenset()` for 2 frozenset fields) to the 11 original `BackendCapabilities` fields so the dataclass is constructible with zero arguments. Rewrite `_mock_backend()` in `tests/execution/conftest.py` to construct `BackendCapabilities` directly (instead of `replace(CLAUDE_CODE_CAPABILITIES, ...)`) with an all-False/empty baseline. Update bare `_mock_backend()` call sites across 11 test files to pass explicit capability kwargs where the test exercises code paths gated on `pty_required`, `channel_b_capable`, or `food_truck_capable`. Add a new constructibility test.

**Intentional semantic baseline shift:** The new `_mock_backend()` produces an all-False/empty `BackendCapabilities` by default. This intentionally differs from the old behavior where bare calls inherited Claude Code values (`session_resume_capable=True`, `completion_record_types=frozenset({"result"})`, `session_record_types=frozenset({"assistant"})`, and others). Tests that require non-default values for any capability must now pass them explicitly. No current test fails from this shift because no bare-call test exercises the affected code paths for these fields.

Closes #3127

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260601-225223-456611/.autoskillit/temp/make-plan/p5_a4_wp1_backend_capabilities_defaults_plan_2026-06-01_225500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 679 | 32.1k | 749.6k | 98.3k | 34 | 87.9k | 18m 57s |
| verify* | sonnet | 1 | 102 | 17.2k | 645.6k | 72.0k | 38 | 55.4k | 5m 59s |
| implement* | MiniMax-M3 | 1 | 111.8k | 24.3k | 3.2M | 104.2k | 177 | 0 | 16m 2s |
| fix* | sonnet | 1 | 150 | 5.3k | 813.7k | 56.8k | 46 | 40.2k | 6m 52s |
| audit_impl* | sonnet | 1 | 54 | 15.7k | 214.2k | 63.1k | 16 | 48.1k | 10m 16s |
| prepare_pr* | MiniMax-M3 | 1 | 44.4k | 2.9k | 211.2k | 48.8k | 16 | 0 | 1m 42s |
| compose_pr* | MiniMax-M3 | 1 | 36.8k | 1.3k | 147.3k | 38.3k | 12 | 0 | 54s |
| review_pr* | sonnet | 1 | 222 | 27.8k | 1.4M | 83.8k | 62 | 67.9k | 6m 40s |
| resolve_review* | sonnet | 1 | 205 | 16.7k | 1.6M | 83.9k | 64 | 67.7k | 8m 9s |
| resolve_pre_review_conflicts* | sonnet | 1 | 92 | 1.9k | 371.3k | 41.1k | 24 | 24.6k | 55s |
| **Total** | | | 194.5k | 145.2k | 9.4M | 104.2k | | 392.0k | 1h 16m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 174 | 18355.0 | 0.0 | 139.5 |
| fix | 2 | 406836.5 | 20125.0 | 2669.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 27 | 59530.0 | 2509.2 | 619.1 |
| resolve_pre_review_conflicts | 759 | 489.2 | 32.5 | 2.5 |
| **Total** | **962** | 9763.7 | 407.4 | 150.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 679 | 32.1k | 749.6k | 87.9k | 18m 57s |
| sonnet | 6 | 825 | 84.6k | 5.1M | 304.1k | 38m 53s |
| MiniMax-M3 | 3 | 193.0k | 28.5k | 3.6M | 0 | 18m 38s |