### PR TITLE
Implementation Plan: P6-A6-WP1 — Fix SessionIndexEntry.claude_code_log Annotation from str to str | None

### DIFF
--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -561,9 +561,7 @@ class SessionIndexEntry(TypedDict):
     order_id: str
     campaign_id: str
     dispatch_id: str
-    claude_code_log: (
-        str | None
-    )  # path to Claude Code session JSONL, or None for non-Claude-Code sessions
+    claude_code_log: str | None  # path to Claude Code JSONL, or None for non-Claude-Code sessions
     codex_log: str | None  # path to Codex rollout NDJSON, or None for non-Codex sessions
     skill_command: str
     success: bool

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -561,7 +561,9 @@ class SessionIndexEntry(TypedDict):
     order_id: str
     campaign_id: str
     dispatch_id: str
-    claude_code_log: str
+    claude_code_log: (
+        str | None
+    )  # path to Claude Code session JSONL, or None for non-Claude-Code sessions
     codex_log: str | None  # path to Codex rollout NDJSON, or None for non-Codex sessions
     skill_command: str
     success: bool


### PR DESCRIPTION
## Summary

Correct the `SessionIndexEntry.claude_code_log` TypedDict annotation from `str` to `str | None` so the declared type matches the values actually written to `sessions.jsonl`. Codex sessions and fallback sessions where the log path cannot be resolved write `None` for this field, but the current annotation incorrectly declares `str`. The fix is a single-line annotation change with an inline comment matching the adjacent `codex_log` field's style. No call-site modifications are needed — `src/autoskillit/server/tools/tools_github.py:438` already guards with `or ''`.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260602-005528-822023/.autoskillit/temp/make-plan/P6-A6-WP1_plan_2026-06-02_010000.md`

Closes #3136

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 665 | 3.4k | 395.0k | 46.4k | 18 | 31.2k | 2m 13s |
| verify* | sonnet | 1 | 1.1k | 6.5k | 365.2k | 39.2k | 26 | 22.7k | 2m 27s |
| implement* | MiniMax-M3 | 1 | 41.0k | 2.2k | 525.4k | 43.4k | 22 | 0 | 3m 13s |
| audit_impl* | sonnet | 1 | 44 | 3.5k | 140.1k | 34.0k | 12 | 20.7k | 2m 43s |
| prepare_pr* | MiniMax-M3 | 1 | 38.5k | 1.8k | 111.6k | 40.3k | 13 | 0 | 1m 1s |
| compose_pr* | MiniMax-M3 | 1 | 36.8k | 1.6k | 185.3k | 38.4k | 12 | 0 | 1m 13s |
| review_pr* | sonnet | 1 | 188 | 11.7k | 980.3k | 51.3k | 50 | 35.1k | 3m 14s |
| resolve_review* | sonnet | 1 | 238 | 10.1k | 1.2M | 57.9k | 61 | 42.0k | 5m 59s |
| resolve_pre_review_conflicts* | sonnet | 1 | 82 | 2.1k | 325.1k | 35.0k | 22 | 9.8k | 1m 55s |
| **Total** | | | 118.7k | 43.0k | 4.2M | 57.9k | | 161.5k | 24m 2s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 4 | 131341.2 | 0.0 | 555.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 299213.2 | 10509.5 | 2525.2 |
| resolve_pre_review_conflicts | 0 | — | — | — |
| **Total** | **8** | 528083.2 | 20183.1 | 5375.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 665 | 3.4k | 395.0k | 31.2k | 2m 13s |
| sonnet | 5 | 1.7k | 33.9k | 3.0M | 130.3k | 16m 20s |
| MiniMax-M3 | 3 | 116.4k | 5.7k | 822.2k | 0 | 5m 28s |