### PR TITLE
Implementation Plan: P5-A7-WP1 — Introduce KNOWN_BACKEND_NAMES Validation in AgentBackendConfig

### DIFF
--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -9,6 +9,7 @@ from typing import ClassVar
 
 from autoskillit.core import (
     DRY_WALKTHROUGH_VERIFIED_MARKER,
+    KNOWN_BACKEND_NAMES,
     LABEL_LIFECYCLE_REGISTRY,
     IssueLabelState,
     OutputFormat,
@@ -577,3 +578,9 @@ class AgentBackendConfig:
     def __post_init__(self) -> None:
         if not self.backend:
             raise ValueError("backend must not be empty")
+        elif self.backend not in KNOWN_BACKEND_NAMES:
+            logger.warning(
+                "unknown_backend",
+                backend=self.backend,
+                valid_names=sorted(KNOWN_BACKEND_NAMES),
+            )

--- a/tests/config/test_agent_backend_config.py
+++ b/tests/config/test_agent_backend_config.py
@@ -66,11 +66,16 @@ class TestAgentBackendConfigField:
         with structlog.testing.capture_logs() as cap_logs:
             cfg = AgentBackendConfig(backend="aider")
         assert cfg.backend == "aider"
-        warning_events = [e for e in cap_logs if e.get("log_level") == "warning"]
-        assert any(
-            e.get("event") == "unknown_backend" and e.get("backend") == "aider"
-            for e in warning_events
-        ), f"Expected unknown_backend warning for 'aider', got: {cap_logs}"
+        unknown_backend_events = [
+            e
+            for e in cap_logs
+            if e.get("log_level") == "warning"
+            and e.get("event") == "unknown_backend"
+            and e.get("backend") == "aider"
+        ]
+        assert len(unknown_backend_events) == 1, (
+            f"Expected exactly one unknown_backend warning for 'aider', got: {cap_logs}"
+        )
 
 
 class TestAgentBackendConfigLoading:
@@ -97,22 +102,14 @@ class TestAgentBackendConfigLoading:
         assert cfg.agent_backend.backend == "codex"
 
     def test_agent_backend_yaml_override(self, tmp_path, monkeypatch) -> None:
-        import structlog.testing
-
         from autoskillit.config import load_config
 
         monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
         config_dir = tmp_path / ".autoskillit"
         config_dir.mkdir()
         (config_dir / "config.yaml").write_text(yaml.dump({"agent_backend": {"backend": "aider"}}))
-        with structlog.testing.capture_logs() as cap_logs:
-            cfg = load_config(tmp_path)
+        cfg = load_config(tmp_path)
         assert cfg.agent_backend.backend == "aider"
-        warning_events = [e for e in cap_logs if e.get("log_level") == "warning"]
-        assert any(
-            e.get("event") == "unknown_backend" and e.get("backend") == "aider"
-            for e in warning_events
-        ), f"Expected unknown_backend warning for 'aider', got: {cap_logs}"
 
     def test_agent_backend_key_accepted_by_schema_validator(self, tmp_path) -> None:
         from autoskillit.config import load_config

--- a/tests/config/test_agent_backend_config.py
+++ b/tests/config/test_agent_backend_config.py
@@ -58,6 +58,20 @@ class TestAgentBackendConfigField:
         cfg = AgentBackendConfig(backend="codex")
         assert cfg.backend == "codex"
 
+    def test_agent_backend_config_warns_on_unknown_backend(self) -> None:
+        import structlog.testing
+
+        from autoskillit.config.settings import AgentBackendConfig
+
+        with structlog.testing.capture_logs() as cap_logs:
+            cfg = AgentBackendConfig(backend="aider")
+        assert cfg.backend == "aider"
+        warning_events = [e for e in cap_logs if e.get("log_level") == "warning"]
+        assert any(
+            e.get("event") == "unknown_backend" and e.get("backend") == "aider"
+            for e in warning_events
+        ), f"Expected unknown_backend warning for 'aider', got: {cap_logs}"
+
 
 class TestAgentBackendConfigLoading:
     def test_load_config_agent_backend_defaults(self, tmp_path) -> None:
@@ -83,14 +97,22 @@ class TestAgentBackendConfigLoading:
         assert cfg.agent_backend.backend == "codex"
 
     def test_agent_backend_yaml_override(self, tmp_path, monkeypatch) -> None:
+        import structlog.testing
+
         from autoskillit.config import load_config
 
         monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
         config_dir = tmp_path / ".autoskillit"
         config_dir.mkdir()
         (config_dir / "config.yaml").write_text(yaml.dump({"agent_backend": {"backend": "aider"}}))
-        cfg = load_config(tmp_path)
+        with structlog.testing.capture_logs() as cap_logs:
+            cfg = load_config(tmp_path)
         assert cfg.agent_backend.backend == "aider"
+        warning_events = [e for e in cap_logs if e.get("log_level") == "warning"]
+        assert any(
+            e.get("event") == "unknown_backend" and e.get("backend") == "aider"
+            for e in warning_events
+        ), f"Expected unknown_backend warning for 'aider', got: {cap_logs}"
 
     def test_agent_backend_key_accepted_by_schema_validator(self, tmp_path) -> None:
         from autoskillit.config import load_config


### PR DESCRIPTION
## Summary

Extend `AgentBackendConfig.__post_init__` in `config/_config_dataclasses.py` with a soft-warning branch that validates the `backend` field against the existing IL-0 constant `KNOWN_BACKEND_NAMES`. Update tests to assert the warning fires for unknown backends and does not fire for known ones.

**Prior work note:** The IL-0 constant `KNOWN_BACKEND_NAMES: frozenset[str]` already exists at `core/types/_type_constants_env.py:65`, is in `__all__` (line 41), and is re-exported via `core/__init__.pyi` (line 163). The issue originally specified `_KNOWN_BACKEND_NAMES` (underscore prefix), but the public-name variant was introduced by a prior WP and is already consumed by `workspace/skills.py` and `tests/arch/test_backend_name_sync.py`. This plan uses the existing `KNOWN_BACKEND_NAMES` directly — no rename, no duplicate constant.

Closes #3130

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260602-005516-866636/.autoskillit/temp/make-plan/P5-A7-WP1_introduce_known_backend_names_plan_2026-06-02_010000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 2.6k | 9.9k | 636.9k | 65.1k | 34 | 51.9k | 7m 26s |
| verify* | sonnet | 1 | 1.3k | 10.5k | 424.5k | 48.0k | 28 | 31.4k | 4m 40s |
| implement* | MiniMax-M3 | 1 | 50.0k | 4.8k | 530.3k | 51.2k | 36 | 0 | 5m 33s |
| audit_impl* | sonnet | 1 | 1.4k | 3.7k | 141.6k | 35.6k | 13 | 23.3k | 2m 27s |
| prepare_pr* | MiniMax-M3 | 1 | 39.1k | 1.8k | 152.6k | 42.5k | 12 | 0 | 1m 5s |
| compose_pr* | MiniMax-M3 | 1 | 37.6k | 2.1k | 224.7k | 39.2k | 15 | 0 | 1m 24s |
| review_pr* | sonnet | 3 | 520 | 41.8k | 2.8M | 60.1k | 146 | 119.8k | 18m 23s |
| resolve_review* | sonnet | 1 | 199 | 11.4k | 1.2M | 66.7k | 60 | 50.7k | 5m 39s |
| **Total** | | | 132.7k | 86.0k | 6.1M | 66.7k | | 277.0k | 46m 38s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 31 | 17107.1 | 0.0 | 154.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 25 | 48395.2 | 2027.0 | 454.8 |
| **Total** | **56** | 108584.3 | 4946.9 | 1536.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.6k | 9.9k | 636.9k | 51.9k | 7m 26s |
| sonnet | 4 | 3.4k | 67.4k | 4.5M | 225.1k | 31m 9s |
| MiniMax-M3 | 3 | 126.6k | 8.7k | 907.6k | 0 | 8m 2s |