### PR TITLE
Implementation Plan: P5-A3-WP1 — Add Backend Coherence Arch Tests

### DIFF
--- a/tests/arch/test_backend_coherence.py
+++ b/tests/arch/test_backend_coherence.py
@@ -158,3 +158,77 @@ def test_applicable_guards_uses_capability_field():
     assert 'casefold() == "codex"' not in source, (
         "skill_load_guard must not compare backend name directly"
     )
+
+
+def test_all_backends_have_name_constant():
+    """Every BACKEND_REGISTRY key must have a corresponding AGENT_BACKEND_* constant."""
+    import inspect
+
+    from autoskillit.core.types import _type_constants_env
+    from autoskillit.execution.backends import BACKEND_REGISTRY
+
+    source = inspect.getsource(_type_constants_env)
+    tree = ast.parse(source)
+    string_constants = {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+
+    for key in BACKEND_REGISTRY:
+        expected_name = f"AGENT_BACKEND_{key.upper().replace('-', '_')}"
+        assert key in string_constants, (
+            f"BACKEND_REGISTRY key {key!r} has no matching constant in "
+            f"_type_constants_env.py — add {expected_name} = {key!r}"
+        )
+
+
+def test_backend_doctor_coverage():
+    """_doctor_runtime must use capability-field dispatch, not backend-name strings."""
+    import inspect
+
+    from autoskillit.cli.doctor import _doctor_runtime
+
+    source = inspect.getsource(_doctor_runtime)
+    tree = ast.parse(source)
+    has_capability_field = any(
+        isinstance(node, ast.Attribute) and node.attr in {"version_check_command", "process_name"}
+        for node in ast.walk(tree)
+    )
+    assert has_capability_field, (
+        "Expected capability-driven dispatch (version_check_command/process_name) "
+        "in _doctor_runtime; backend-name string comparisons were replaced by P4."
+    )
+
+
+def test_all_backends_have_init_hook():
+    """cli/_init_helpers.py must import from the execution backends layer."""
+    import inspect
+
+    from autoskillit.cli import _init_helpers
+
+    source = inspect.getsource(_init_helpers)
+    tree = ast.parse(source)
+    has_execution_import = any(
+        isinstance(node, ast.ImportFrom)
+        and node.module is not None
+        and node.module.startswith("autoskillit.execution")
+        for node in ast.walk(tree)
+    )
+    assert has_execution_import, (
+        "cli/_init_helpers.py does not import from 'autoskillit.execution.backends'. "
+        "After P4-A2, _register_all must dispatch via BACKEND_REGISTRY — "
+        "add 'from autoskillit.execution.backends import BACKEND_REGISTRY' "
+        "to cli/_init_helpers.py."
+    )
+
+
+def test_known_backend_names_matches_registry():
+    """KNOWN_BACKEND_NAMES (IL-0) must equal BACKEND_REGISTRY keys (IL-1)."""
+    from autoskillit.core import KNOWN_BACKEND_NAMES
+    from autoskillit.execution.backends import BACKEND_REGISTRY
+
+    assert set(BACKEND_REGISTRY.keys()) == KNOWN_BACKEND_NAMES, (
+        "When a new backend is added to BACKEND_REGISTRY, KNOWN_BACKEND_NAMES "
+        "in core/types/_type_constants_env.py must also be updated."
+    )

--- a/tests/arch/test_backend_coherence.py
+++ b/tests/arch/test_backend_coherence.py
@@ -169,15 +169,17 @@ def test_all_backends_have_name_constant():
 
     source = inspect.getsource(_type_constants_env)
     tree = ast.parse(source)
-    string_constants = {
-        node.value
+    assignment_targets = {
+        target.id
         for node in ast.walk(tree)
-        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        if isinstance(node, (ast.Assign, ast.AnnAssign))
+        for target in (node.targets if isinstance(node, ast.Assign) else [node.target])
+        if isinstance(target, ast.Name)
     }
 
     for key in BACKEND_REGISTRY:
         expected_name = f"AGENT_BACKEND_{key.upper().replace('-', '_')}"
-        assert key in string_constants, (
+        assert expected_name in assignment_targets, (
             f"BACKEND_REGISTRY key {key!r} has no matching constant in "
             f"_type_constants_env.py — add {expected_name} = {key!r}"
         )

--- a/tests/arch/test_backend_coherence.py
+++ b/tests/arch/test_backend_coherence.py
@@ -195,7 +195,10 @@ def test_backend_doctor_coverage():
     tree = ast.parse(source)
     has_capability_field = any(
         isinstance(node, ast.Attribute) and node.attr in {"version_check_command", "process_name"}
-        for node in ast.walk(tree)
+        for func_node in ast.walk(tree)
+        if isinstance(func_node, ast.FunctionDef)
+        and any(arg.arg == "backend" for arg in func_node.args.args + func_node.args.kwonlyargs)
+        for node in ast.walk(func_node)
     )
     assert has_capability_field, (
         "Expected capability-driven dispatch (version_check_command/process_name) "

--- a/tests/arch/test_backend_coherence.py
+++ b/tests/arch/test_backend_coherence.py
@@ -221,10 +221,10 @@ def test_all_backends_have_init_hook():
         for node in ast.walk(tree)
     )
     assert has_execution_import, (
-        "cli/_init_helpers.py does not import from 'autoskillit.execution.backends'. "
-        "After P4-A2, _register_all must dispatch via BACKEND_REGISTRY — "
-        "add 'from autoskillit.execution.backends import BACKEND_REGISTRY' "
-        "to cli/_init_helpers.py."
+        "cli/_init_helpers.py does not import from 'autoskillit.execution'. "
+        "After P4-A2, _register_all must dispatch via the execution layer — "
+        "ensure an import from 'autoskillit.execution.*' is present "
+        "in cli/_init_helpers.py."
     )
 
 


### PR DESCRIPTION
## Summary

Add four architectural test functions to `tests/arch/test_backend_coherence.py` that enforce backend coherence contracts via AST analysis:

1. **test_all_backends_have_name_constant** — Verifies every `BACKEND_REGISTRY` key has a corresponding `AGENT_BACKEND_*` string constant in `_type_constants_env.py`.
2. **test_backend_doctor_coverage** — Verifies `_doctor_runtime.py` uses capability-field attribute access (`version_check_command`, `process_name`) rather than backend-name string comparisons.
3. **test_all_backends_have_init_hook** — Verifies `_init_helpers.py` imports from the execution layer (`autoskillit.execution` or `autoskillit.execution.backends`).
4. **test_known_backend_names_matches_registry** — Verifies `KNOWN_BACKEND_NAMES` (IL-0) matches `BACKEND_REGISTRY` keys (IL-1).

All tests use the established deferred-import-in-test-body pattern. No new module-level imports, no new helper functions. Single file modified: `tests/arch/test_backend_coherence.py`.

### Issue Corrections

Three technical details in the issue description do not match the current codebase:

1. **`_KNOWN_BACKEND_NAMES` vs `KNOWN_BACKEND_NAMES`**: The issue references `_KNOWN_BACKEND_NAMES` (with leading underscore), but the actual symbol is `KNOWN_BACKEND_NAMES` (no underscore) in `_type_constants_env.py:65` and re-exported from `autoskillit.core` via `__init__.pyi:163`.

2. **`ast.Constant` vs `ast.Attribute` for doctor coverage**: The issue prescribes collecting `ast.Constant` string values to find `version_check_command`/`process_name`. In `_doctor_runtime.py`, these appear as attribute accesses (`backend.capabilities.version_check_command` on line 23/27, `backend.capabilities.process_name` on line 102), not string literals. The `ast.Attribute` node pattern (checking `node.attr`) is the correct approach, consistent with existing tests in the file (`test_triage_uses_capability_field` at line 119).

3. **`autoskillit.execution.backends` vs `autoskillit.execution` import in `_init_helpers.py`**: The issue expects `_init_helpers.py` to import from `autoskillit.execution.backends`. The actual import is `from autoskillit.execution import get_backend` (line 449). The test checks `module.startswith("autoskillit.execution")` to match the actual code pattern while preserving the intent.

### Existing Test Overlap

`test_known_backend_names_matches_registry` already exists in `tests/arch/test_backend_name_sync.py:10`. The issue explicitly requests adding it to `test_backend_coherence.py` as well — this plan adds it as requested. Both tests serve different thematic groupings (name-sync vs coherence) and pytest collects them independently.

Closes #3126

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260602-063051-719051/.autoskillit/temp/make-plan/P5-A3-WP1_add_backend_coherence_arch_tests_plan_2026-06-02_063500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 158 | 354 | 2.2M | 78.8k | 44 | 188.3k | 11m 2s |
| verify* | sonnet | 1 | 76 | 4.7k | 310.4k | 42.1k | 22 | 25.6k | 2m 46s |
| implement* | MiniMax-M3 | 1 | 64.8k | 5.1k | 749.2k | 55.1k | 43 | 0 | 5m 1s |
| audit_impl* | sonnet | 1 | 1.6k | 7.8k | 140.4k | 34.2k | 13 | 28.0k | 2m 56s |
| prepare_pr* | MiniMax-M3 | 1 | 43.1k | 2.1k | 155.7k | 44.6k | 12 | 0 | 1m 10s |
| compose_pr* | MiniMax-M3 | 1 | 35.7k | 1.6k | 149.7k | 38.9k | 12 | 0 | 58s |
| review_pr* | sonnet | 2 | 314 | 26.6k | 1.6M | 57.9k | 91 | 76.7k | 7m 43s |
| resolve_review* | sonnet | 1 | 223 | 18.4k | 1.7M | 78.3k | 69 | 62.4k | 6m 59s |
| **Total** | | | 145.9k | 66.7k | 7.1M | 78.8k | | 381.0k | 38m 38s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 74 | 10124.6 | 0.0 | 68.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 23 | 72535.3 | 2714.8 | 801.6 |
| **Total** | **97** | 72757.9 | 3927.7 | 687.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 158 | 354 | 2.2M | 188.3k | 11m 2s |
| sonnet | 4 | 2.2k | 57.5k | 3.8M | 192.7k | 20m 27s |
| MiniMax-M3 | 3 | 143.5k | 8.8k | 1.1M | 0 | 7m 9s |