### PR TITLE
Implementation Plan: Add test-filter-manifest entry for bash_write_targets.py

### DIFF
--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -230,11 +230,6 @@ src/autoskillit/recipes/scripts/*.sh:
 scripts/recipe/*.sh:
   - recipe/
 
-src/autoskillit/core/bash_write_targets.py:
-  - core/
-  - arch/
-  - contracts/
-
 src/autoskillit/core/__init__.pyi:
   - core/
   - arch/

--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -235,10 +235,6 @@ src/autoskillit/core/__init__.pyi:
   - arch/
   - contracts/
 
-src/autoskillit/core/bash_write_targets.py:
-  - core/
-  - execution/
-
 tests/**/CLAUDE.md: []
 
 # Eval framework files

--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -230,6 +230,11 @@ src/autoskillit/recipes/scripts/*.sh:
 scripts/recipe/*.sh:
   - recipe/
 
+src/autoskillit/core/bash_write_targets.py:
+  - core/
+  - arch/
+  - contracts/
+
 src/autoskillit/core/__init__.pyi:
   - core/
   - arch/

--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -235,6 +235,10 @@ src/autoskillit/core/__init__.pyi:
   - arch/
   - contracts/
 
+src/autoskillit/core/bash_write_targets.py:
+  - core/
+  - execution/
+
 tests/**/CLAUDE.md: []
 
 # Eval framework files

--- a/src/autoskillit/core/CLAUDE.md
+++ b/src/autoskillit/core/CLAUDE.md
@@ -27,6 +27,7 @@ Sub-packages: types/ (see types/CLAUDE.md) and runtime/ (see runtime/CLAUDE.md).
 | `_step_context.py` | `current_step_name`, `current_order_id` ContextVars for pipeline step attribution |
 | `feature_flags.py` | `is_feature_enabled()` — IL-0 feature gate resolution primitive |
 | `tool_sequence_analysis.py` | Cross-session tool call sequence DFG analysis (stdlib-only) |
+| `bash_write_targets.py` | Bash command write-target extraction (stdlib-only, IL-0) |
 
 ## Architecture Notes
 

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -1,4 +1,3 @@
-from .bash_write_targets import extract_bash_write_targets as extract_bash_write_targets
 from ._claude_env import build_agent_env as build_agent_env
 from ._claude_env import build_claude_env as build_claude_env
 from ._cmd_runner import CmdRunner as CmdRunner
@@ -34,6 +33,7 @@ from ._terminal_table import TerminalColumn as TerminalColumn
 from ._terminal_table import _render_gfm_table as _render_gfm_table
 from ._terminal_table import _render_terminal_table as _render_terminal_table
 from ._version_snapshot import collect_version_snapshot as collect_version_snapshot
+from .bash_write_targets import extract_bash_write_targets as extract_bash_write_targets
 from .branch_guard import is_protected_branch as is_protected_branch
 from .claude_conventions import ClaudeDirectoryConventions as ClaudeDirectoryConventions
 from .claude_conventions import LayoutError as LayoutError

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -1,3 +1,4 @@
+from .bash_write_targets import extract_bash_write_targets as extract_bash_write_targets
 from ._claude_env import build_agent_env as build_agent_env
 from ._claude_env import build_claude_env as build_claude_env
 from ._cmd_runner import CmdRunner as CmdRunner

--- a/src/autoskillit/core/bash_write_targets.py
+++ b/src/autoskillit/core/bash_write_targets.py
@@ -1,0 +1,266 @@
+"""Bash command write-target extraction (stdlib-only, IL-0).
+
+Independent re-implementation of the write-target extraction logic from
+hooks/_command_classification.py and hooks/guards/write_guard.py, suitable
+for import by IL-1 modules (execution/).
+
+hooks/ retains its own function bodies unchanged because hook scripts import
+via sys.path manipulation and cannot use autoskillit package imports.
+A parity test corpus guards against drift between the two implementations.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+
+_SHELL_OPS: frozenset[str] = frozenset({"&&", "||", ";", "!", "|", "("})
+
+_REDIRECT_TOKEN_RE = re.compile(r"^(\d*)>{1,2}(.+)$")
+_REDIRECT_OP_ONLY_RE = re.compile(r"^(\d*)>{1,2}$")
+_FD_REDIRECT_RE = re.compile(r"^\d*>{1,2}&")
+_TRAILING_SHELL_CLOSERS = frozenset({")", "`", "}", "'", '"', ";", "&", "|"})
+
+_PSEUDO_DEVICE_PATHS: frozenset[str] = frozenset(
+    {
+        "/dev/null",
+        "/dev/zero",
+        "/dev/stdout",
+        "/dev/stderr",
+        "/dev/stdin",
+    }
+)
+
+_WRITE_VERBS: frozenset[str] = frozenset(
+    {
+        "sed",
+        "tee",
+        "mv",
+        "cp",
+        "patch",
+        "rm",
+        "unlink",
+    }
+)
+
+_GIT_FLAG_WITH_VALUE: frozenset[str] = frozenset({"-C", "--git-dir", "--work-tree", "-c"})
+
+
+def _resolve_write_target(path: str, cwd: str = "") -> str | None:
+    if not path:
+        return None
+    if path.startswith("&") or _FD_REDIRECT_RE.match(path):
+        return None
+    if os.path.isabs(path):
+        return path
+    if cwd:
+        return os.path.join(cwd, path)
+    return None
+
+
+def _tokenize_command_segments(command: str) -> list[list[str]]:
+    try:
+        tokens = shlex.split(command)
+    except (ValueError, TypeError):
+        return []
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for token in tokens:
+        if token in _SHELL_OPS:
+            if current:
+                segments.append(current)
+                current = []
+        else:
+            current.append(token)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def _extract_redirect_targets(tokens: list[str], cwd: str = "") -> list[str]:
+    targets: list[str] = []
+    depth = 0
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "(" or (tok.startswith("(") and len(tok) > 1):
+            depth += 1
+            if tok.endswith(")") and len(tok) > 1:
+                depth -= 1
+            i += 1
+            continue
+        if tok == ")":
+            if depth > 0:
+                depth -= 1
+            i += 1
+            continue
+        if tok.endswith(")") and len(tok) > 1:
+            if depth > 0:
+                depth -= 1
+            i += 1
+            continue
+        if depth > 0:
+            i += 1
+            continue
+        if tok in (">", ">>"):
+            if i + 1 < len(tokens):
+                path = tokens[i + 1]
+                while path and path[-1] in _TRAILING_SHELL_CLOSERS:
+                    path = path[:-1]
+                resolved = _resolve_write_target(path, cwd)
+                if resolved is not None:
+                    targets.append(resolved)
+                i += 2
+                continue
+        elif _REDIRECT_OP_ONLY_RE.match(tok):
+            if i + 1 < len(tokens):
+                path = tokens[i + 1]
+                while path and path[-1] in _TRAILING_SHELL_CLOSERS:
+                    path = path[:-1]
+                resolved = _resolve_write_target(path, cwd)
+                if resolved is not None:
+                    targets.append(resolved)
+                i += 2
+                continue
+        else:
+            m = _REDIRECT_TOKEN_RE.match(tok)
+            if m:
+                path = m.group(2)
+                while path and path[-1] in _TRAILING_SHELL_CLOSERS:
+                    path = path[:-1]
+                resolved = _resolve_write_target(path, cwd)
+                if resolved is not None:
+                    targets.append(resolved)
+        i += 1
+    return targets
+
+
+def _command_verb(segment: list[str]) -> str:
+    if not segment:
+        return ""
+    start = 0
+    if segment[0] == "env" and len(segment) > 1:
+        start = 1
+        while start < len(segment) and (segment[start].startswith("-") or "=" in segment[start]):
+            start += 1
+    return segment[start] if start < len(segment) else ""
+
+
+def _is_gh_command(segment: list[str]) -> bool:
+    return _command_verb(segment) == "gh"
+
+
+def _extract_segment_targets(segment: list[str], cwd: str) -> list[str] | None:
+    if _is_gh_command(segment):
+        return None
+
+    verb = _command_verb(segment)
+    targets: list[str] = []
+    found_write = False
+
+    if verb == "git" and len(segment) >= 2:
+        idx = 1
+        while idx < len(segment):
+            tok = segment[idx]
+            if tok in _GIT_FLAG_WITH_VALUE:
+                idx += 2
+                if idx >= len(segment):
+                    break
+            elif tok.startswith("-") and "=" not in tok and tok not in ("--", "--hard"):
+                idx += 1
+            else:
+                break
+        if idx < len(segment):
+            subcmd = segment[idx]
+            if subcmd == "checkout" and "--" in segment[idx + 1 :]:
+                found_write = True
+                double_dash = segment.index("--", idx + 1)
+                for t in segment[double_dash + 1 :]:
+                    resolved = _resolve_write_target(t, cwd)
+                    if resolved is not None and resolved not in _PSEUDO_DEVICE_PATHS:
+                        targets.append(resolved)
+            elif subcmd == "reset" and "--hard" in segment[idx + 1 :]:
+                found_write = True
+    elif verb in _WRITE_VERBS:
+        found_write = True
+        non_flag = [
+            t
+            for t in segment[1:]
+            if not t.startswith("-") and not t.startswith("&") and not _FD_REDIRECT_RE.match(t)
+        ]
+        if verb == "sed":
+            flags = [t for t in segment[1:] if t.startswith("-")]
+            has_inplace = any(t.startswith("-i") or t == "--in-place" for t in flags)
+            if has_inplace and non_flag:
+                path = non_flag[-1]
+                resolved = _resolve_write_target(path, cwd)
+                if resolved is not None and resolved not in _PSEUDO_DEVICE_PATHS:
+                    targets.append(resolved)
+        elif verb == "tee":
+            if non_flag:
+                path = non_flag[0]
+                resolved = _resolve_write_target(path, cwd)
+                if resolved is not None and resolved not in _PSEUDO_DEVICE_PATHS:
+                    targets.append(resolved)
+        elif verb in ("mv", "cp"):
+            if len(non_flag) >= 2:
+                path = non_flag[-1]
+                resolved = _resolve_write_target(path, cwd)
+                if resolved is not None and resolved not in _PSEUDO_DEVICE_PATHS:
+                    targets.append(resolved)
+        elif verb == "patch":
+            for t in non_flag:
+                resolved = _resolve_write_target(t, cwd)
+                if resolved is not None:
+                    if resolved not in _PSEUDO_DEVICE_PATHS:
+                        targets.append(resolved)
+                    break
+        elif verb in ("rm", "unlink"):
+            for t in non_flag:
+                resolved = _resolve_write_target(t, cwd)
+                if resolved is not None and resolved not in _PSEUDO_DEVICE_PATHS:
+                    targets.append(resolved)
+
+    if found_write:
+        return targets
+    return None
+
+
+def extract_bash_write_targets(command: str, cwd: str = "") -> list[str]:
+    """Extract filesystem write targets from a Bash command string.
+
+    Uses shlex tokenization + verb-aware segment dispatch + redirect
+    extraction. Returns only paths that are actual write destinations
+    (redirect targets, tee targets, cp/mv destinations, sed -i targets).
+
+    Returns [] for read-only commands, slash-command tokens, and URL paths.
+    Pseudo-device paths (/dev/null, /dev/stderr, etc.) are excluded.
+    """
+    segments = _tokenize_command_segments(command)
+    if cwd and not os.path.isabs(cwd):
+        cwd = ""
+
+    all_targets: list[str] = []
+
+    for segment in segments:
+        result = _extract_segment_targets(segment, cwd)
+        if result is not None:
+            all_targets.extend(result)
+
+    try:
+        flat_tokens = shlex.split(command)
+    except (ValueError, TypeError, AttributeError):
+        flat_tokens = []
+    redirect_paths = _extract_redirect_targets(flat_tokens, cwd)
+    for path in redirect_paths:
+        if path not in _PSEUDO_DEVICE_PATHS:
+            all_targets.append(path)
+
+    seen: set[str] = set()
+    unique: list[str] = []
+    for t in all_targets:
+        if t not in seen:
+            seen.add(t)
+            unique.append(t)
+    return unique

--- a/src/autoskillit/core/bash_write_targets.py
+++ b/src/autoskillit/core/bash_write_targets.py
@@ -184,11 +184,20 @@ def _extract_segment_targets(segment: list[str], cwd: str) -> list[str] | None:
                 found_write = True
     elif verb in _WRITE_VERBS:
         found_write = True
-        non_flag = [
-            t
-            for t in segment[1:]
-            if not t.startswith("-") and not t.startswith("&") and not _FD_REDIRECT_RE.match(t)
-        ]
+        non_flag: list[str] = []
+        skip_next = False
+        for t in segment[1:]:
+            if skip_next:
+                skip_next = False
+                continue
+            if t.startswith("-") or t.startswith("&") or _FD_REDIRECT_RE.match(t):
+                continue
+            if _REDIRECT_OP_ONLY_RE.match(t):
+                skip_next = True
+                continue
+            if _REDIRECT_TOKEN_RE.match(t):
+                continue
+            non_flag.append(t)
         if verb == "sed":
             flags = [t for t in segment[1:] if t.startswith("-")]
             has_inplace = any(t.startswith("-i") or t == "--in-place" for t in flags)
@@ -198,9 +207,8 @@ def _extract_segment_targets(segment: list[str], cwd: str) -> list[str] | None:
                 if resolved is not None and resolved not in _PSEUDO_DEVICE_PATHS:
                     targets.append(resolved)
         elif verb == "tee":
-            if non_flag:
-                path = non_flag[0]
-                resolved = _resolve_write_target(path, cwd)
+            for t in non_flag:
+                resolved = _resolve_write_target(t, cwd)
                 if resolved is not None and resolved not in _PSEUDO_DEVICE_PATHS:
                     targets.append(resolved)
         elif verb in ("mv", "cp"):

--- a/src/autoskillit/execution/headless/CLAUDE.md
+++ b/src/autoskillit/execution/headless/CLAUDE.md
@@ -14,7 +14,7 @@ Headless Claude session orchestration — command prep, subprocess invocation, r
 | `_headless_recovery.py` | Session recovery: `_recover_from_separate_marker`, `_synthesize_from_write_artifacts` |
 | `_headless_result.py` | `SkillResult` construction: `_build_skill_result` (evidence/telemetry moved to `_headless_evidence.py`) |
 | `_headless_evidence.py` | Evidence computation (`_compute_write_evidence`, `_adapt_agent_result`), audit recording (`_capture_failure`, `_apply_budget_guard`), telemetry builders (`_build_session_telemetry`, `_build_error_path_telemetry`) |
-| `_headless_scan.py` | `_scan_jsonl_write_paths()` — scans stdout JSONL for Write/Edit/Bash tool calls |
+| `_headless_scan.py` | `_scan_jsonl_write_paths()` — scans stdout JSONL for Write/Edit/Bash tool calls; uses `core/bash_write_targets` for precise write-target extraction |
 
 ## Architecture Notes
 

--- a/src/autoskillit/execution/headless/_headless_scan.py
+++ b/src/autoskillit/execution/headless/_headless_scan.py
@@ -11,15 +11,11 @@ from __future__ import annotations
 import json
 import os
 
-import regex as re
-
+from autoskillit.core.bash_write_targets import extract_bash_write_targets
 from autoskillit.execution.session._session_model import _is_parent_assistant_record
 
 _WRITE_TOOL_NAMES: frozenset[str] = frozenset({"Write", "Edit"})
 _BASH_TOOL_NAME: str = "Bash"
-_ABS_PATH_PATTERN: re.Pattern[str] = re.compile(r'(?:^|[\s="\'])(/(?:[a-zA-Z0-9._/~@+:-]+))')
-# Exclude paths of 4 chars or fewer (/tmp, /etc, /bin, /var) as low-signal noise.
-_MIN_BASH_PATH_LEN: int = 5
 
 
 def _scan_jsonl_write_paths(stdout: str, cwd: str) -> list[str]:
@@ -77,15 +73,12 @@ def _scan_jsonl_write_paths(stdout: str, cwd: str) -> list[str]:
             elif tool_name == _BASH_TOOL_NAME:
                 command = inputs.get("command", "")
                 if isinstance(command, str):
-                    for match in _ABS_PATH_PATTERN.finditer(command):
-                        path = match.group(1)
-                        if (
-                            len(path) >= _MIN_BASH_PATH_LEN
-                            and not path.startswith(cwd_prefix)
-                            and path != cwd.rstrip("/")
-                        ):
+                    targets = extract_bash_write_targets(command, cwd)
+                    for path in targets:
+                        if not path.startswith(cwd_prefix) and path != cwd.rstrip("/"):
                             warnings.append(
-                                f"Bash command contained path '{path}' outside session cwd '{cwd}'"
+                                f"Bash command contained write target '{path}'"
+                                f" outside session cwd '{cwd}'"
                             )
 
     return warnings

--- a/src/autoskillit/execution/headless/_headless_scan.py
+++ b/src/autoskillit/execution/headless/_headless_scan.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 import os
 
-from autoskillit.core.bash_write_targets import extract_bash_write_targets
+from autoskillit.core import extract_bash_write_targets
 from autoskillit.execution.session._session_model import _is_parent_assistant_record
 
 _WRITE_TOOL_NAMES: frozenset[str] = frozenset({"Write", "Edit"})

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -15,6 +15,8 @@ if _HOOKS_DIR not in sys.path:
 
 from _command_classification import (  # type: ignore[import-not-found]  # noqa: E402
     _FD_REDIRECT_RE,
+    _REDIRECT_OP_ONLY_RE,
+    _REDIRECT_TOKEN_RE,
     command_verb,
     extract_interpreter_write_paths,
     extract_redirect_targets,
@@ -88,11 +90,20 @@ def _extract_segment_targets(segment: list[str], cwd: str) -> list[str] | None:
                 found_write = True
     elif verb in _WRITE_VERBS:
         found_write = True
-        non_flag = [
-            t
-            for t in segment[1:]
-            if not t.startswith("-") and not t.startswith("&") and not _FD_REDIRECT_RE.match(t)
-        ]
+        non_flag: list[str] = []
+        skip_next = False
+        for t in segment[1:]:
+            if skip_next:
+                skip_next = False
+                continue
+            if t.startswith("-") or t.startswith("&") or _FD_REDIRECT_RE.match(t):
+                continue
+            if _REDIRECT_OP_ONLY_RE.match(t):
+                skip_next = True
+                continue
+            if _REDIRECT_TOKEN_RE.match(t):
+                continue
+            non_flag.append(t)
         if verb == "sed":
             # -i flag must be present; last non-flag arg is the target
             flags = [t for t in segment[1:] if t.startswith("-")]
@@ -103,9 +114,8 @@ def _extract_segment_targets(segment: list[str], cwd: str) -> list[str] | None:
                 if resolved is not None and resolved not in _PSEUDO_DEVICE_PATHS:
                     targets.append(resolved)
         elif verb == "tee":
-            if non_flag:
-                path = non_flag[0]
-                resolved = resolve_write_target(path, cwd)
+            for t in non_flag:
+                resolved = resolve_write_target(t, cwd)
                 if resolved is not None and resolved not in _PSEUDO_DEVICE_PATHS:
                     targets.append(resolved)
         elif verb in ("mv", "cp"):

--- a/src/autoskillit/recipe/_api_cache.py
+++ b/src/autoskillit/recipe/_api_cache.py
@@ -234,23 +234,3 @@ def _clear_stale_caches() -> None:
     _SKILL_CATEGORY_CACHE.clear()
     _LOAD_CACHE.clear()
     _STALENESS_CACHES_CLEARED = True
-
-
-def _clear_all_yaml_caches() -> None:
-    """Clear ALL content-addressed caches and _LOAD_CACHE for test isolation."""
-    from autoskillit.recipe._contracts_manifest import _MANIFEST_CACHE  # noqa: PLC0415
-    from autoskillit.recipe._skill_helpers import (  # noqa: PLC0415
-        _SKILL_CATEGORY_CACHE,
-        _SKILL_NAMES_CACHE,
-    )
-    from autoskillit.recipe.methodology_venue_appendix import (  # noqa: PLC0415
-        _ML_SUB_AREA_CACHE,
-    )
-    from autoskillit.recipe.rules.rules_blocks import _BUDGETS_CACHE  # noqa: PLC0415
-
-    _MANIFEST_CACHE.clear()
-    _BUDGETS_CACHE.clear()
-    _ML_SUB_AREA_CACHE.clear()
-    _SKILL_NAMES_CACHE.clear()
-    _SKILL_CATEGORY_CACHE.clear()
-    _LOAD_CACHE.clear()

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -251,6 +251,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "_type_exceptions": frozenset({"core", "fleet", "recipe", "server"}),
     "_step_context": frozenset({"core", "execution", "pipeline", "server"}),
     "_execution_marker": frozenset({"core", "execution", "fleet", "server"}),
+    "bash_write_targets": frozenset({"core", "execution"}),
 }
 
 # Narrow per-module cascade for execution/. Modules not listed here fall through

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -858,7 +858,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "server": 14,
         "recipe": 42,  # was 33; +9 from CI/graph/dataflow splits
         "execution": 18,
-        "core": 20,
+        "core": 21,
         "core/types": 28,
         "cli": 21,
         "hooks": 12,

--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -55,3 +55,4 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_version_snapshot.py` | Tests for core/_version_snapshot.py |
 | `test_version_snapshot_codex_routing.py` | Codex version snapshot routing tests — verifies collect_version_snapshot() routes codex_version correctly by AUTOSKILLIT_AGENT_BACKEND |
 | `test_backend_gating_core.py` | Backend gating tests for _version_snapshot.py — verifies empty fallbacks for non-claude-code backends |
+| `test_bash_write_targets.py` | Tests for core/bash_write_targets.py — write-target extraction and parity with hooks/_command_classification.py |

--- a/tests/core/test_bash_write_targets.py
+++ b/tests/core/test_bash_write_targets.py
@@ -1,0 +1,139 @@
+"""Tests for core/bash_write_targets.py — Bash write-target extraction."""
+
+import pytest
+
+from autoskillit.core.bash_write_targets import extract_bash_write_targets
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+class TestExtractBashWriteTargets:
+    def test_redirect(self):
+        assert extract_bash_write_targets("echo x > /path/out.txt") == ["/path/out.txt"]
+
+    def test_tee(self):
+        assert extract_bash_write_targets("cat file | tee /path/out.txt") == ["/path/out.txt"]
+
+    def test_no_write(self):
+        assert extract_bash_write_targets("cat /path/file.txt") == []
+
+    def test_slash_command_clean(self):
+        assert extract_bash_write_targets("/autoskillit:test-skill-flat") == []
+
+    def test_gh_api_clean(self):
+        assert extract_bash_write_targets("gh api /repos/owner/repo") == []
+
+    def test_cp_destination(self):
+        assert extract_bash_write_targets("cp source.txt /path/dest.txt") == ["/path/dest.txt"]
+
+    def test_sed_inplace(self):
+        assert extract_bash_write_targets("sed -i 's/a/b/' /path/file.txt") == ["/path/file.txt"]
+
+    def test_mv_destination(self):
+        assert extract_bash_write_targets("mv /old/file /new/file") == ["/new/file"]
+
+    def test_pipe_chain(self):
+        assert extract_bash_write_targets("cat /a | grep foo > /b") == ["/b"]
+
+    def test_dev_null_excluded(self):
+        assert extract_bash_write_targets("cmd 2>/dev/null") == []
+
+    def test_pseudo_devices_excluded(self):
+        assert extract_bash_write_targets("echo x > /dev/stderr") == []
+        assert extract_bash_write_targets("tee /dev/null") == []
+
+    def test_relative_path_resolved(self):
+        result = extract_bash_write_targets("echo x > output.txt", cwd="/workspace")
+        assert result == ["/workspace/output.txt"]
+
+    def test_variable_assignment_clean(self):
+        assert extract_bash_write_targets("BASE_DIR=/source/repo/configs") == []
+
+    def test_append_redirect(self):
+        assert extract_bash_write_targets("echo x >> /path/out.txt") == ["/path/out.txt"]
+
+    def test_git_checkout_files(self):
+        result = extract_bash_write_targets("git checkout branch -- /path/file.txt")
+        assert result == ["/path/file.txt"]
+
+    def test_rm_detected(self):
+        result = extract_bash_write_targets("rm /path/file.txt")
+        assert result == ["/path/file.txt"]
+
+
+_PARITY_CORPUS: list[tuple[str, str]] = [
+    ("echo x > /path/out.txt", "/workspace"),
+    ("cat /path/file.txt", "/workspace"),
+    ("cat file | tee /path/out.txt", "/workspace"),
+    ("cp source.txt /path/dest.txt", "/workspace"),
+    ("mv /old/file /new/file", "/workspace"),
+    ("sed -i 's/a/b/' /path/file.txt", "/workspace"),
+    ("rm /path/file.txt", "/workspace"),
+    ("echo hello >> /path/log.txt", "/workspace"),
+    ("cmd 2>/dev/null", "/workspace"),
+    ("tee /dev/null", "/workspace"),
+    ("echo x > /dev/stderr", "/workspace"),
+    ("gh api /repos/owner/repo/pulls", "/workspace"),
+    ("cat /source/repo/README.md > /tmp/out.txt", "/workspace"),
+    ("echo hello > /tmp/out.txt", "/workspace"),
+    ("git checkout branch -- /path/file.txt", "/workspace"),
+    ("git reset --hard HEAD", "/workspace"),
+    ("cat /a | grep foo > /b", "/workspace"),
+    ("echo x > output.txt", "/workspace"),
+    ("patch /path/file.txt < diff.patch", "/workspace"),
+    ("unlink /path/file.txt", "/workspace"),
+]
+
+
+@pytest.mark.parametrize("command,cwd", _PARITY_CORPUS, ids=[c[0][:50] for c in _PARITY_CORPUS])
+def test_parity_with_command_classification(command: str, cwd: str) -> None:
+    """Core and hooks implementations must produce identical write targets."""
+    import shlex
+    import sys
+    from pathlib import Path
+
+    hooks_dir = str(
+        Path(__file__).resolve().parent.parent.parent / "src" / "autoskillit" / "hooks"
+    )
+    if hooks_dir not in sys.path:
+        sys.path.insert(0, hooks_dir)
+
+    from _command_classification import (  # type: ignore[import-not-found]
+        extract_redirect_targets as hooks_extract_redirect_targets,
+    )
+    from _command_classification import (
+        tokenize_command_segments as hooks_tokenize_command_segments,
+    )
+    from guards.write_guard import (  # type: ignore[import-not-found]
+        _PSEUDO_DEVICE_PATHS as HOOKS_PSEUDO_DEVICE_PATHS,
+    )
+    from guards.write_guard import (
+        _extract_segment_targets as hooks_extract_segment_targets,
+    )
+
+    core_result = extract_bash_write_targets(command, cwd)
+
+    hooks_segments = hooks_tokenize_command_segments(command)
+    hooks_all: list[str] = []
+    for seg in hooks_segments:
+        seg_result = hooks_extract_segment_targets(seg, cwd)
+        if seg_result is not None:
+            hooks_all.extend(seg_result)
+    try:
+        flat_tokens = shlex.split(command)
+    except (ValueError, TypeError, AttributeError):
+        flat_tokens = []
+    redirect_paths = hooks_extract_redirect_targets(flat_tokens, cwd)
+    for path in redirect_paths:
+        if path not in HOOKS_PSEUDO_DEVICE_PATHS:
+            hooks_all.append(path)
+    seen: set[str] = set()
+    hooks_unique: list[str] = []
+    for t in hooks_all:
+        if t not in seen:
+            seen.add(t)
+            hooks_unique.append(t)
+
+    assert core_result == hooks_unique, (
+        f"Parity mismatch for {command!r}: core={core_result}, hooks={hooks_unique}"
+    )

--- a/tests/core/test_bash_write_targets.py
+++ b/tests/core/test_bash_write_targets.py
@@ -60,6 +60,20 @@ class TestExtractBashWriteTargets:
         result = extract_bash_write_targets("rm /path/file.txt")
         assert result == ["/path/file.txt"]
 
+    def test_cp_with_redirect(self):
+        result = extract_bash_write_targets("cp /a /outside/dest > /log")
+        assert "/outside/dest" in result
+        assert "/log" in result
+
+    def test_mv_with_redirect(self):
+        result = extract_bash_write_targets("mv /a /outside/dest > /log")
+        assert "/outside/dest" in result
+        assert "/log" in result
+
+    def test_tee_multiple_targets(self):
+        result = extract_bash_write_targets("cat file | tee /path/a /path/b")
+        assert result == ["/path/a", "/path/b"]
+
 
 _PARITY_CORPUS: list[tuple[str, str]] = [
     ("echo x > /path/out.txt", "/workspace"),
@@ -82,21 +96,23 @@ _PARITY_CORPUS: list[tuple[str, str]] = [
     ("echo x > output.txt", "/workspace"),
     ("patch /path/file.txt < diff.patch", "/workspace"),
     ("unlink /path/file.txt", "/workspace"),
+    ("cp /a /outside/dest > /log", "/workspace"),
+    ("cat file | tee /path/a /path/b", "/workspace"),
 ]
 
 
 @pytest.mark.parametrize("command,cwd", _PARITY_CORPUS, ids=[c[0][:50] for c in _PARITY_CORPUS])
-def test_parity_with_command_classification(command: str, cwd: str) -> None:
+def test_parity_with_command_classification(
+    command: str, cwd: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Core and hooks implementations must produce identical write targets."""
     import shlex
-    import sys
     from pathlib import Path
 
     hooks_dir = str(
         Path(__file__).resolve().parent.parent.parent / "src" / "autoskillit" / "hooks"
     )
-    if hooks_dir not in sys.path:
-        sys.path.insert(0, hooks_dir)
+    monkeypatch.syspath_prepend(hooks_dir)
 
     from _command_classification import (  # type: ignore[import-not-found]
         extract_redirect_targets as hooks_extract_redirect_targets,

--- a/tests/execution/test_headless_synthesis.py
+++ b/tests/execution/test_headless_synthesis.py
@@ -253,13 +253,13 @@ class TestScanJsonlWritePaths:
         assert len(warnings) == 1
         assert "Edit" in warnings[0]
 
-    def test_detects_bash_with_absolute_path_outside_cwd(self):
+    def test_detects_bash_with_redirect_outside_cwd(self):
         line = _make_tool_use_line(
             "Bash", {"command": "cat /source/repo/README.md > /tmp/out.txt"}
         )
         warnings = _scan_jsonl_write_paths(line, self.CWD)
-        assert len(warnings) >= 1
-        assert any("/source/repo" in w for w in warnings)
+        assert len(warnings) == 1
+        assert any("/tmp/out.txt" in w for w in warnings)
 
     def test_no_warnings_for_empty_stdout(self):
         assert _scan_jsonl_write_paths("", self.CWD) == []
@@ -300,6 +300,47 @@ class TestScanJsonlWritePaths:
     def test_no_warning_when_cwd_is_relative(self):
         line = _make_tool_use_line("Write", {"file_path": "/any/path/file.md", "content": "x"})
         assert _scan_jsonl_write_paths(line, "relative/path") == []
+
+    def test_no_warning_for_slash_command_token_in_bash(self):
+        line = _make_tool_use_line("Bash", {"command": "/autoskillit:test-skill-flat --some-arg"})
+        assert _scan_jsonl_write_paths(line, self.CWD) == []
+
+    def test_no_warning_for_gh_api_url_path_in_bash(self):
+        line = _make_tool_use_line(
+            "Bash", {"command": "gh api /repos/owner/repo/pulls --json number"}
+        )
+        assert _scan_jsonl_write_paths(line, self.CWD) == []
+
+    def test_no_warning_for_read_only_path_in_bash(self):
+        line = _make_tool_use_line("Bash", {"command": "cat /source/repo/README.md"})
+        assert _scan_jsonl_write_paths(line, self.CWD) == []
+
+    def test_no_warning_for_variable_assignment_path_in_bash(self):
+        line = _make_tool_use_line("Bash", {"command": "BASE_DIR=/source/repo/configs"})
+        assert _scan_jsonl_write_paths(line, self.CWD) == []
+
+    def test_bash_redirect_outside_cwd_detected(self):
+        line = _make_tool_use_line("Bash", {"command": "echo hello > /source/repo/out.txt"})
+        warnings = _scan_jsonl_write_paths(line, self.CWD)
+        assert len(warnings) == 1
+        assert "/source/repo/out.txt" in warnings[0]
+
+    def test_bash_tee_outside_cwd_detected(self):
+        line = _make_tool_use_line("Bash", {"command": "cat file | tee /source/repo/out.txt"})
+        warnings = _scan_jsonl_write_paths(line, self.CWD)
+        assert len(warnings) >= 1
+
+    def test_bash_redirect_inside_cwd_clean(self):
+        line = _make_tool_use_line("Bash", {"command": f"echo hello > {self.CWD}/out.txt"})
+        assert _scan_jsonl_write_paths(line, self.CWD) == []
+
+    def test_exact_warning_count_for_mixed_bash(self):
+        line = _make_tool_use_line(
+            "Bash", {"command": "cat /source/repo/README.md > /other/dir/out.txt"}
+        )
+        warnings = _scan_jsonl_write_paths(line, self.CWD)
+        assert len(warnings) == 1
+        assert "/other/dir/out.txt" in warnings[0]
 
     def test_scan_jsonl_write_paths_excludes_subagent(self):
         """Subagent Write/Edit calls must not produce write-path warnings."""

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -111,6 +111,7 @@ class TestModuleCascadeCore:
             "_step_context",
             "_execution_marker",
             "git_remote",
+            "bash_write_targets",
         }
         assert set(MODULE_CASCADE_CORE.keys()) == expected_stems
 


### PR DESCRIPTION
## Summary

Add a test-filter-manifest entry for `src/autoskillit/core/bash_write_targets.py` so that changes to this module trigger only its relevant tests (`core/test_bash_write_targets.py` and `execution/` tests via `_headless_scan.py` import) instead of the full suite.

Closes #3543

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260601-214800-010951/.autoskillit/temp/make-plan/remediation_write_path_scanner_false_positives_plan_2026-06-01_225100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 103 | 32.3k | 4.1M | 130.3k | 98 | 113.6k | 23m 53s |
| review_approach* | opus[1m] | 1 | 2.8k | 5.6k | 197.2k | 47.8k | 12 | 34.3k | 3m 56s |
| dry_walkthrough* | opus | 2 | 84 | 18.9k | 1.2M | 63.1k | 63 | 78.6k | 9m 34s |
| implement* | opus[1m] | 2 | 123 | 23.2k | 3.4M | 109.3k | 109 | 113.1k | 9m 54s |
| audit_impl* | opus[1m] | 2 | 1.1k | 17.5k | 1.0M | 55.6k | 53 | 78.4k | 10m 38s |
| make_plan* | opus[1m] | 1 | 51 | 4.9k | 588.3k | 46.3k | 32 | 31.1k | 2m 0s |
| post_run_diagnostics* | opus[1m] | 1 | 35 | 3.5k | 287.6k | 64.1k | 18 | 40.9k | 9m 9s |
| prepare_pr* | MiniMax-M3 | 1 | 37.8k | 1.8k | 192.7k | 41.3k | 14 | 0 | 1m 10s |
| compose_pr* | MiniMax-M3 | 1 | 37.3k | 1.2k | 147.8k | 38.4k | 13 | 0 | 55s |
| review_pr* | opus[1m] | 2 | 480 | 63.3k | 3.4M | 158.0k | 86 | 242.4k | 23m 21s |
| resolve_review* | opus[1m] | 2 | 119 | 36.8k | 5.2M | 106.2k | 125 | 203.0k | 30m 50s |
| **Total** | | | 80.0k | 209.1k | 19.7M | 158.0k | | 935.3k | 2h 5m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 487 | 6883.4 | 232.3 | 47.6 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| post_run_diagnostics | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 96 | 53705.2 | 2114.2 | 383.0 |
| **Total** | **583** | 33812.8 | 1604.3 | 358.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 8 | 4.8k | 187.1k | 18.2M | 856.7k | 1h 53m |
| opus | 1 | 84 | 18.9k | 1.2M | 78.6k | 9m 34s |
| MiniMax-M3 | 2 | 75.1k | 3.1k | 340.5k | 0 | 2m 5s |