### PR TITLE
Implementation Plan: P2-A13-WP1 — Write Contract Tests for select-vis-lenses and synthesize-vis-plan; Update test_plan_visualization_contracts.py

### DIFF
--- a/src/autoskillit/skills_extended/synthesize-vis-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/synthesize-vis-plan/SKILL.md
@@ -17,6 +17,11 @@ conflicts across their recommendations using the priority hierarchy, and writes
 three output files: a visualization plan with figure inventory, a report
 placement outline, and a Tier-C routing trace.
 
+The input lens outputs originate from three selection tiers defined by
+`select-vis-lenses`: Tier A (always-on mandatory lenses), Tier B
+(experiment-type-selected lenses), and Tier C (methodology-tradition-selected
+lens). The priority hierarchy in Step 1 maps directly to these tiers.
+
 ## When to Use
 
 - As the `synthesize` step of the vis-lens phoropter in the `research` recipe,

--- a/tests/contracts/CLAUDE.md
+++ b/tests/contracts/CLAUDE.md
@@ -47,7 +47,7 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `test_no_pagination_file_read.py` | Contract tests for no-pagination file read instruction in high-turn SKILL.md files |
 | `test_package_gateways.py` | Tests for Package Gateway API (groupC) — REQ-GWAY-001 through REQ-GWAY-008 |
 | `test_plan_experiment_contracts.py` | Contract tests for plan-experiment SKILL.md — data provenance lifecycle |
-| `test_plan_visualization_contracts.py` | Contract tests: select-vis-lenses SKILL.md experiment type vocabulary |
+| `test_plan_visualization_contracts.py` | Contract tests: select-vis-lenses Tier B experiment-type canonical names match registry |
 | `test_select_vis_lenses_contracts.py` | Contract tests: select-vis-lenses SKILL.md experiment type vocabulary and token emission |
 | `test_pr_traceability_contracts.py` | Cross-skill contract tests for requirement traceability across PR lifecycle skills |
 | `test_prepare_compose_pr_contracts.py` | Contract tests for prepare-pr and compose-pr skills |

--- a/tests/contracts/CLAUDE.md
+++ b/tests/contracts/CLAUDE.md
@@ -47,7 +47,7 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `test_no_pagination_file_read.py` | Contract tests for no-pagination file read instruction in high-turn SKILL.md files |
 | `test_package_gateways.py` | Tests for Package Gateway API (groupC) — REQ-GWAY-001 through REQ-GWAY-008 |
 | `test_plan_experiment_contracts.py` | Contract tests for plan-experiment SKILL.md — data provenance lifecycle |
-| `test_plan_visualization_contracts.py` | Contract tests: plan-visualization SKILL.md experiment type vocabulary |
+| `test_plan_visualization_contracts.py` | Contract tests: select-vis-lenses SKILL.md experiment type vocabulary |
 | `test_select_vis_lenses_contracts.py` | Contract tests: select-vis-lenses SKILL.md experiment type vocabulary and token emission |
 | `test_pr_traceability_contracts.py` | Cross-skill contract tests for requirement traceability across PR lifecycle skills |
 | `test_prepare_compose_pr_contracts.py` | Contract tests for prepare-pr and compose-pr skills |

--- a/tests/contracts/test_plan_visualization_contracts.py
+++ b/tests/contracts/test_plan_visualization_contracts.py
@@ -1,4 +1,4 @@
-"""Contract tests for plan-visualization SKILL.md — experiment type vocabulary."""
+"""Contract tests for select-vis-lenses SKILL.md — experiment type vocabulary."""
 
 import re
 from pathlib import Path
@@ -12,7 +12,7 @@ SKILL_PATH = (
     / "src"
     / "autoskillit"
     / "skills_extended"
-    / "plan-visualization"
+    / "select-vis-lenses"
     / "SKILL.md"
 )
 EXPERIMENT_TYPES_DIR = (
@@ -31,7 +31,7 @@ def _extract_lens_table_section(text: str) -> str:
         text,
         re.IGNORECASE,
     )
-    assert m, "Tier B experiment-type table not found in plan-visualization SKILL.md"
+    assert m, "Tier B experiment-type table not found in select-vis-lenses SKILL.md"
     return m.group(0).lower()
 
 

--- a/tests/contracts/test_select_vis_lenses_contracts.py
+++ b/tests/contracts/test_select_vis_lenses_contracts.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+from autoskillit.core.io import load_yaml
+
 pytestmark = [pytest.mark.small]
 
 SKILL_PATH = (
@@ -21,6 +23,13 @@ EXPERIMENT_TYPES_DIR = (
     / "autoskillit"
     / "recipes"
     / "experiment-types"
+)
+CONTRACTS_YAML = (
+    Path(__file__).resolve().parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "recipe"
+    / "skill_contracts.yaml"
 )
 
 
@@ -112,3 +121,37 @@ class TestSelectVisLensesOutputDirectory:
                 f"SKILL.md references '{{{{AUTOSKILLIT_TEMP}}}}/{ref}/' "
                 f"but should only reference select-vis-lenses/"
             )
+
+
+def test_skill_path_exists() -> None:
+    """select-vis-lenses/SKILL.md must exist at the expected path."""
+    assert SKILL_PATH.exists(), f"Expected SKILL.md at {SKILL_PATH}"
+
+
+def test_tier_b_experiment_type_table_section_present() -> None:
+    """SKILL.md must contain the Tier B experiment-type lookup table heading and rows."""
+    table_text = _extract_lens_table_section(SKILL_PATH.read_text())
+    assert len(table_text.strip()) > 0
+
+
+def test_required_output_tokens_present() -> None:
+    """SKILL.md must mention all five structured output tokens."""
+    text = SKILL_PATH.read_text()
+    for token in (
+        "selected_lenses",
+        "lens_context_paths",
+        "disambiguation_rule_applied",
+        "tier_c_lens",
+        "methodology_tradition",
+    ):
+        assert token in text, f"select-vis-lenses SKILL.md missing required output token '{token}'"
+
+
+def test_write_behavior_always_declared() -> None:
+    """skill_contracts.yaml must declare write_behavior='always' for select-vis-lenses."""
+    data = load_yaml(CONTRACTS_YAML)
+    entry = data["skills"].get("select-vis-lenses")
+    assert entry is not None, "select-vis-lenses not found in skill_contracts.yaml"
+    assert entry.get("write_behavior") == "always", (
+        f"Expected write_behavior='always', got '{entry.get('write_behavior')}'"
+    )

--- a/tests/contracts/test_select_vis_lenses_contracts.py
+++ b/tests/contracts/test_select_vis_lenses_contracts.py
@@ -131,7 +131,12 @@ def test_skill_path_exists() -> None:
 def test_tier_b_experiment_type_table_section_present() -> None:
     """SKILL.md must contain the Tier B experiment-type lookup table heading and rows."""
     table_text = _extract_lens_table_section(SKILL_PATH.read_text())
-    assert len(table_text.strip()) > 0
+    data_rows = [
+        ln
+        for ln in table_text.splitlines()
+        if ln.strip().startswith("|") and "---" not in ln and "experiment" not in ln.lower()
+    ]
+    assert len(data_rows) >= 1, "Tier B experiment-type table must contain at least one data row"
 
 
 def test_required_output_tokens_present() -> None:

--- a/tests/contracts/test_synthesize_vis_plan_contracts.py
+++ b/tests/contracts/test_synthesize_vis_plan_contracts.py
@@ -19,6 +19,13 @@ SKILL_PATH = (
     / "synthesize-vis-plan"
     / "SKILL.md"
 )
+CONTRACTS_YAML = (
+    Path(__file__).resolve().parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "recipe"
+    / "skill_contracts.yaml"
+)
 
 
 def _text() -> str:
@@ -171,20 +178,31 @@ def test_applied_union_rules_from_arguments_not_recipe() -> None:
 
 
 def test_synthesize_vis_plan_emits_visualization_plan_path_token() -> None:
-    assert "visualization_plan_path =" in _text()
+    assert re.search(r"visualization_plan_path\s*=", _text()), (
+        "synthesize-vis-plan SKILL.md must emit visualization_plan_path token"
+    )
 
 
 def test_synthesize_vis_plan_emits_report_plan_path_token() -> None:
-    assert "report_plan_path =" in _text()
+    assert re.search(r"report_plan_path\s*=", _text()), (
+        "synthesize-vis-plan SKILL.md must emit report_plan_path token"
+    )
 
 
 def test_synthesize_vis_plan_emits_visualization_plan_trace_path_token() -> None:
-    assert "visualization_plan_trace_path =" in _text()
+    assert re.search(r"visualization_plan_trace_path\s*=", _text()), (
+        "synthesize-vis-plan SKILL.md must emit visualization_plan_trace_path token"
+    )
 
 
 def test_synthesize_vis_plan_write_behavior_always() -> None:
-    """SKILL.md must document that outputs are always written."""
-    assert "always written" in _text()
+    """skill_contracts.yaml must declare write_behavior='always' for synthesize-vis-plan."""
+    data = load_yaml(CONTRACTS_YAML)
+    entry = data["skills"].get("synthesize-vis-plan")
+    assert entry is not None, "synthesize-vis-plan not found in skill_contracts.yaml"
+    assert entry.get("write_behavior") == "always", (
+        f"Expected write_behavior='always', got '{entry.get('write_behavior')}'"
+    )
 
 
 def test_synthesize_vis_plan_documents_tier_identity_rule() -> None:

--- a/tests/contracts/test_synthesize_vis_plan_contracts.py
+++ b/tests/contracts/test_synthesize_vis_plan_contracts.py
@@ -168,3 +168,28 @@ def test_applied_union_rules_from_arguments_not_recipe() -> None:
     assert "applied_union_rules" in text
     assert "select-vis-lenses" in text
     assert "not from recipe context" in text
+
+
+def test_synthesize_vis_plan_emits_visualization_plan_path_token() -> None:
+    assert "visualization_plan_path =" in _text()
+
+
+def test_synthesize_vis_plan_emits_report_plan_path_token() -> None:
+    assert "report_plan_path =" in _text()
+
+
+def test_synthesize_vis_plan_emits_visualization_plan_trace_path_token() -> None:
+    assert "visualization_plan_trace_path =" in _text()
+
+
+def test_synthesize_vis_plan_write_behavior_always() -> None:
+    """SKILL.md must document that outputs are always written."""
+    assert "always written" in _text()
+
+
+def test_synthesize_vis_plan_documents_tier_identity_rule() -> None:
+    """SKILL.md must reference all three tier identities."""
+    text = _text()
+    assert "Tier A" in text
+    assert "Tier B" in text
+    assert "Tier C" in text


### PR DESCRIPTION
## Summary

Add missing contract tests to two existing test files (`test_select_vis_lenses_contracts.py` and `test_synthesize_vis_plan_contracts.py`) and retarget `test_plan_visualization_contracts.py` from `plan-visualization` to `select-vis-lenses`. All three files already exist from prior work packages (P2-A2-WP1, P2-A10-WP1); this WP fills the remaining test gaps specified in issue #3082.

Closes #3082

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260602-071550-382515/.autoskillit/temp/make-plan/p2_a13_wp1_write_tests_contracts_plan_2026-06-02_071550.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.9k | 18.2k | 1.3M | 86.0k | 49 | 127.5k | 10m 53s |
| verify* | opus[1m] | 1 | 57 | 12.3k | 1.1M | 66.5k | 52 | 49.8k | 4m 56s |
| implement* | MiniMax-M3 | 1 | 55.1k | 5.4k | 867.4k | 60.1k | 45 | 0 | 4m 19s |
| fix* | opus[1m] | 1 | 46 | 4.5k | 807.0k | 53.9k | 36 | 37.0k | 3m 55s |
| audit_impl* | opus[1m] | 1 | 24 | 8.2k | 178.6k | 37.0k | 12 | 30.2k | 4m 47s |
| prepare_pr* | MiniMax-M3 | 1 | 43.4k | 2.7k | 201.6k | 45.4k | 14 | 0 | 1m 9s |
| compose_pr* | MiniMax-M3 | 1 | 35.7k | 1.2k | 187.7k | 38.3k | 12 | 0 | 50s |
| review_pr* | sonnet | 1 | 190 | 43.6k | 1.2M | 89.9k | 61 | 74.3k | 9m 46s |
| resolve_review* | sonnet | 1 | 199 | 13.6k | 1.4M | 71.6k | 63 | 55.6k | 5m 37s |
| dispatch:95b79f35-cfe1-4458-b517-d5b360ff89df* | sonnet | 1 | 892 | 251 | 8.3M | 88.0k | 111 | 488.7k | 1h 0m |
| **Total** | | | 137.5k | 110.0k | 15.5M | 89.9k | | 863.1k | 1h 46m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 76 | 11412.7 | 0.0 | 70.5 |
| fix | 5 | 161406.2 | 7406.6 | 909.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 37 | 37796.9 | 1502.8 | 367.5 |
| dispatch:95b79f35-cfe1-4458-b517-d5b360ff89df | 87 | 95894.1 | 5616.8 | 2.9 |
| **Total** | **205** | 75811.4 | 4210.2 | 536.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 4 | 2.0k | 43.2k | 3.4M | 244.6k | 24m 32s |
| MiniMax-M3 | 3 | 134.2k | 9.3k | 1.3M | 0 | 6m 19s |
| sonnet | 3 | 1.3k | 57.5k | 10.9M | 618.5k | 1h 15m |