### PR TITLE
Implementation Plan: P5-A6-WP1 — Append 'Adding a new backend' 7-step checklist to execution/backends/CLAUDE.md

### DIFF
--- a/src/autoskillit/execution/backends/CLAUDE.md
+++ b/src/autoskillit/execution/backends/CLAUDE.md
@@ -14,3 +14,22 @@ IL-1 backend abstraction layer — concrete `CodingAgentBackend` implementations
 | `_codex_parse.py` | `CodexStreamParser`, `CodexResultParser`, `_scan_codex_ndjson`, `_CodexParseAccumulator` |
 | `codex_scenario_player.py` | `CodexScenarioPlayer`, `make_codex_scenario_player`, `CodexStepRecord`, `CodexScenario`, `_load_manifest`, `_FakeCodexCLI`, `_write_shim_script` — scenario replay data layer for Codex backend |
 | `_cmd_builder.py` | `CmdBuilder`, `CmdOrderingError` — typed builder that enforces positional-before-variadic ordering by construction |
+
+## Adding a new backend
+
+1. **Create the backend module** — add `execution/backends/<name>.py` implementing the `CodingAgentBackend` Protocol. Include a concrete `BackendCapabilities` dataclass instance.
+
+2. **Add the name constant** — add `AGENT_BACKEND_<NAME>: str = "<name>"` to `core/types/_type_constants_env.py` and include it in `KNOWN_BACKEND_NAMES`.
+   *Enforced by `test_all_backends_have_name_constant` in `tests/arch/test_backend_coherence.py`.*
+
+3. **Register in `BACKEND_REGISTRY`** — add a `'<name>': <NameBackend>` entry to the `BACKEND_REGISTRY` dict in `execution/backends/__init__.py`.
+
+4. **Declare hook sync and MCP registration via capability fields** — populate the relevant capability fields on `BackendCapabilities` (e.g., `mcp_config_capable`) so that the `init`-time helpers in `cli/_init_helpers.py` and the `ensure_pre_launch()` protocol method discover the backend through data-driven dispatch. Do not add new conditional branches in `cli/_init_helpers.py`.
+   *Enforced by `test_all_backends_have_init_hook` in `tests/arch/test_backend_coherence.py`.*
+
+5. **Populate doctor fields** — set `version_check_command`, `process_name`, and `min_version` on `BackendCapabilities`. Do not add a new `_check_<name>_version()` function.
+   *Enforced by `test_backend_doctor_coverage` in `tests/arch/test_backend_coherence.py`.*
+
+6. **Add a `FeatureDef`** — add an entry to `FEATURE_REGISTRY` in `core/types/_type_constants_features.py` with `default_enabled=False` and `requires_backend_alignment=True`.
+
+7. **Extend test coverage** — add tests to `tests/execution/backends/test_backend_registry.py`, `tests/contracts/test_backend_compliance.py`, and `tests/contracts/test_backend_protocol.py`.

--- a/src/autoskillit/execution/backends/CLAUDE.md
+++ b/src/autoskillit/execution/backends/CLAUDE.md
@@ -25,7 +25,7 @@ IL-1 backend abstraction layer — concrete `CodingAgentBackend` implementations
 3. **Register in `BACKEND_REGISTRY`** — add a `'<name>': <NameBackend>` entry to the `BACKEND_REGISTRY` dict in `execution/backends/__init__.py`.
 
 4. **Declare hook sync and MCP registration via capability fields** — populate the relevant capability fields on `BackendCapabilities` (e.g., `mcp_config_capable`) so that the `init`-time helpers in `cli/_init_helpers.py` and the `ensure_pre_launch()` protocol method discover the backend through data-driven dispatch. Do not add new conditional branches in `cli/_init_helpers.py`.
-   *Enforced by `test_all_backends_have_init_hook` in `tests/arch/test_backend_coherence.py`.*
+   *Enforced by `test_all_backends_have_init_hook` in `tests/arch/test_backend_coherence.py` (verifies `cli/_init_helpers.py` imports from the execution layer — the connectivity prerequisite for capability-field dispatch).*
 
 5. **Populate doctor fields** — set `version_check_command`, `process_name`, and `min_version` on `BackendCapabilities`. Do not add a new `_check_<name>_version()` function.
    *Enforced by `test_backend_doctor_coverage` in `tests/arch/test_backend_coherence.py`.*


### PR DESCRIPTION
## Summary

Append a `## Adding a new backend` section to `src/autoskillit/execution/backends/CLAUDE.md` containing an ordered 7-item checklist documenting every registration step a developer must complete when adding a new backend. Each step cross-references the arch test in `test_backend_coherence.py` that enforces it (where applicable).

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260602-074154-623545/.autoskillit/temp/make-plan/P5-A6-WP1_append_adding_backend_checklist_plan_2026-06-02_074600.md`

Closes #3129

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 44 | 4.1k | 301.0k | 42.5k | 14 | 28.1k | 2m 42s |
| verify* | sonnet | 1 | 1.1k | 6.7k | 344.5k | 42.2k | 25 | 25.6k | 2m 59s |
| implement* | MiniMax-M3 | 1 | 41.3k | 4.5k | 499.2k | 46.0k | 30 | 0 | 2m 48s |
| audit_impl* | sonnet | 1 | 1.2k | 4.4k | 140.9k | 34.3k | 11 | 23.7k | 2m 36s |
| prepare_pr* | MiniMax-M3 | 1 | 38.5k | 2.0k | 155.0k | 41.7k | 13 | 0 | 50s |
| compose_pr* | MiniMax-M3 | 1 | 34.7k | 1.2k | 149.2k | 38.1k | 13 | 0 | 47s |
| review_pr* | sonnet | 2 | 290 | 27.6k | 1.4M | 54.7k | 91 | 116.3k | 7m 57s |
| resolve_review* | sonnet | 1 | 189 | 9.2k | 1.1M | 55.8k | 50 | 39.5k | 4m 29s |
| **Total** | | | 117.3k | 59.8k | 4.1M | 55.8k | | 233.2k | 25m 10s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 19 | 26273.3 | 0.0 | 235.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 534511.5 | 19750.0 | 4576.0 |
| **Total** | **21** | 195307.4 | 11105.3 | 2848.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 44 | 4.1k | 301.0k | 28.1k | 2m 42s |
| sonnet | 4 | 2.8k | 47.9k | 3.0M | 205.1k | 18m 3s |
| MiniMax-M3 | 3 | 114.5k | 7.8k | 803.4k | 0 | 4m 25s |