### PR TITLE
Health Inspector A2 — Watcher & Process Integration

### DIFF
--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -415,6 +415,7 @@ class FleetConfig:
     idle_output_timeout: float = 1800
     acquire_timeout_sec: float = 300.0
     max_issues_per_food_truck: int = 3
+    inspector_model: str = ""
 
     def validate(self, feature_enabled: bool) -> None:
         """Validate only when the feature is active."""

--- a/src/autoskillit/core/types/_type_protocols_execution.py
+++ b/src/autoskillit/core/types/_type_protocols_execution.py
@@ -71,6 +71,8 @@ class HeadlessExecutor(Protocol):
         backend_override: str | None = None,
         marker_dir: Path | None = None,
         caller_session_id: str | None = None,
+        inspector_eligible: bool = False,
+        inspector_model: str = "",
     ) -> SkillResult: ...
 
     async def dispatch_food_truck(

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -139,6 +139,8 @@ async def run_headless_core(
     backend_override: str | None = None,
     marker_dir: Path | None = None,
     caller_session_id: str | None = None,
+    inspector_eligible: bool = False,
+    inspector_model: str = "",
 ) -> SkillResult:
     """Shared headless runner used by run_skill.
 
@@ -245,6 +247,8 @@ async def run_headless_core(
             model_identity=model_identity,
             marker_dir=marker_dir,
             session_id=caller_session_id,
+            inspector_eligible=inspector_eligible,
+            inspector_model=inspector_model,
         )
 
 
@@ -290,6 +294,8 @@ class DefaultHeadlessExecutor:
         backend_override: str | None = None,
         marker_dir: Path | None = None,
         caller_session_id: str | None = None,
+        inspector_eligible: bool = False,
+        inspector_model: str = "",
     ) -> SkillResult:
         cfg = self._ctx.config.run_skill
         effective_timeout = timeout if timeout is not None else cfg.timeout
@@ -329,6 +335,8 @@ class DefaultHeadlessExecutor:
             backend_override=backend_override,
             marker_dir=marker_dir,
             caller_session_id=caller_session_id,
+            inspector_eligible=inspector_eligible,
+            inspector_model=inspector_model,
         )
 
     async def dispatch_food_truck(

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -109,6 +109,8 @@ async def _execute_claude_headless(
     session_id: str | None = None,
     step_backend: CodingAgentBackend | None = None,
     model_identity: ModelIdentity = ModelIdentity.unknown(),
+    inspector_eligible: bool = False,
+    inspector_model: str = "",
 ) -> SkillResult:
     """Shared subprocess execution for headless Claude sessions.
 
@@ -259,6 +261,7 @@ async def _execute_claude_headless(
                 stream_parser=_stream_parser,
                 completion_record_types=_step_backend.capabilities.completion_record_types,
                 session_record_types=_step_backend.capabilities.session_record_types,
+                inspector_callback=None,
             )
         except Exception as exc:
             logger.error("headless_runner_crashed", exc_info=True)

--- a/src/autoskillit/execution/process/__init__.py
+++ b/src/autoskillit/execution/process/__init__.py
@@ -218,6 +218,7 @@ async def run_managed_async(
     marker_dir: Path | None = None,
     session_id: str | None = None,
     stream_parser: StreamParser | None = None,
+    inspector_callback: InspectorCallback | None = None,
 ) -> SubprocessResult:
     """Async subprocess execution with temp file I/O and process tree cleanup.
 
@@ -386,6 +387,8 @@ async def run_managed_async(
                             marker_dir=marker_dir,
                             session_id=session_id,
                             max_suppression_seconds=max_suppression_seconds or 1800.0,
+                            inspector_callback=inspector_callback,
+                            timeout_scope_ref=timeout_scope_ref,
                         ),
                     )
                 tracing_handle = None
@@ -493,6 +496,7 @@ async def run_managed_async(
                 kill_reason=kill_reason,
                 tracked_comm=_tracked_comm,
                 orphaned_tool_result=signals.channel_b_orphaned_tool_result,
+                inspector_verdict=signals.inspector_verdict,
             )
             proc_log.debug(
                 "run_managed_async_result",
@@ -648,4 +652,5 @@ class DefaultSubprocessRunner:
             stream_parser=stream_parser,
             completion_record_types=completion_record_types,
             session_record_types=session_record_types,
+            inspector_callback=inspector_callback,
         )

--- a/src/autoskillit/execution/process/_process_race.py
+++ b/src/autoskillit/execution/process/_process_race.py
@@ -9,7 +9,13 @@ from typing import TYPE_CHECKING, assert_never
 import anyio
 import anyio.abc
 
-from autoskillit.core import ChannelBStatus, ChannelConfirmation, TerminationReason, get_logger
+from autoskillit.core import (
+    ChannelBStatus,
+    ChannelConfirmation,
+    InspectorEvidence,
+    TerminationReason,
+    get_logger,
+)
 from autoskillit.core import fast_loads as _fast_loads
 from autoskillit.execution.process._process_monitor import (
     _has_active_api_connection,
@@ -21,9 +27,25 @@ from autoskillit.execution.process._process_monitor import (
 from autoskillit.execution.session._exit_classification import is_signal_death_code
 
 if TYPE_CHECKING:
-    from autoskillit.core import InspectorVerdict, StreamParser
+    from autoskillit.core import InspectorCallback, InspectorVerdict, StreamParser
 
 logger = get_logger(__name__)
+
+INSPECTOR_MAX_SECONDS: float = 60.0
+CLEANUP_BUDGET_SECONDS: float = 15.0
+
+
+def _package_evidence(
+    stdout_path: Path,
+    idle_seconds: float,
+    execution_marker_present: bool,
+) -> InspectorEvidence:
+    return InspectorEvidence(
+        idle_seconds=idle_seconds,
+        stdout_path=str(stdout_path),
+        jsonl_lines=(),
+        execution_marker_present=execution_marker_present,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,6 +98,7 @@ class RaceAccumulator:
     channel_b_orphaned_tool_result: bool = False
     process_exited_event: anyio.Event = field(default_factory=anyio.Event)
     exit_snapshot: dict[str, object] | None = None
+    inspector_verdict: InspectorVerdict | None = None
 
     def to_race_signals(self) -> RaceSignals:
         return RaceSignals(
@@ -89,6 +112,7 @@ class RaceAccumulator:
             channel_b_orphaned_tool_result=self.channel_b_orphaned_tool_result,
             process_exited_event=self.process_exited_event,
             exit_snapshot=self.exit_snapshot,
+            inspector_verdict=self.inspector_verdict,
         )
 
 
@@ -161,6 +185,8 @@ async def _watch_stdout_idle(
     marker_dir: Path | None = None,
     session_id: str | None = None,
     max_suppression_seconds: float = 1800.0,
+    inspector_callback: InspectorCallback | None = None,
+    timeout_scope_ref: list[anyio.CancelScope | None] | None = None,
 ) -> None:
     """Kill the child if stdout stops growing for idle_output_timeout seconds.
 
@@ -223,6 +249,50 @@ async def _watch_stdout_idle(
                 "stdout idle for %ss — firing IDLE_STALL",
                 idle_output_timeout,
             )
+            if inspector_callback is not None:
+                _invoke = True
+                _budget = INSPECTOR_MAX_SECONDS
+
+                _scope = timeout_scope_ref[0] if timeout_scope_ref else None
+                if _scope is not None:
+                    _remaining = _scope.deadline - _time.monotonic()
+                    _budget = min(INSPECTOR_MAX_SECONDS, _remaining - CLEANUP_BUDGET_SECONDS)
+                    if _budget <= 0:
+                        logger.debug("inspector_skipped_insufficient_time", remaining=_remaining)
+                        _invoke = False
+                elif timeout_scope_ref is not None:
+                    logger.debug("inspector_skipped_scope_not_ready")
+                    _invoke = False
+
+                if _invoke:
+                    _marker_present = marker_dir is not None and _has_active_execution_marker(
+                        marker_dir, session_id=session_id
+                    )
+                    _evidence = _package_evidence(
+                        stdout_path,
+                        idle_seconds=_time.monotonic() - last_growth_time,
+                        execution_marker_present=_marker_present,
+                    )
+                    try:
+                        with anyio.fail_after(_budget):
+                            _verdict = await inspector_callback(_evidence)
+                    except TimeoutError:
+                        logger.warning("inspector_callback_timed_out", budget=_budget)
+                        _verdict = None
+
+                    if _verdict is not None and _verdict.action == "SPARE":
+                        last_growth_time = _time.monotonic()
+                        logger.info(
+                            "inspector_spare",
+                            reasoning=_verdict.reasoning,
+                            confidence=_verdict.confidence,
+                            elapsed=_verdict.elapsed_seconds,
+                        )
+                        continue
+
+                    if _verdict is not None:
+                        acc.inspector_verdict = _verdict
+
             acc.idle_stall = True
             trigger.set()
             return
@@ -462,7 +532,10 @@ def resolve_termination(
         else:
             termination = TerminationReason.NATURAL_EXIT
     elif signals.idle_stall:
-        termination = TerminationReason.IDLE_STALL
+        if signals.inspector_verdict is not None:
+            termination = TerminationReason.HEALTH_INSPECTOR
+        else:
+            termination = TerminationReason.IDLE_STALL
     else:
         match signals.channel_b_status:
             case ChannelBStatus.STALE | ChannelBStatus.DIR_MISSING:

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -223,6 +223,7 @@ _TOOL_PARAMS: dict[str, frozenset[str]] = {
             "max_issues_per_food_truck",
             "enable_deadline_extension",
             "default_model",
+            "inspector_model",
         }
     ),
     "configure_order": frozenset(

--- a/src/autoskillit/server/tools/tools_config.py
+++ b/src/autoskillit/server/tools/tools_config.py
@@ -85,6 +85,7 @@ def _collect_fleet_params(
     acquire_timeout_sec: float | None,
     max_issues_per_food_truck: int | None,
     enable_deadline_extension: bool | None,
+    inspector_model: str | None = None,
 ) -> dict:
     params: dict = {}
     for name, val in [
@@ -96,6 +97,7 @@ def _collect_fleet_params(
         ("acquire_timeout_sec", acquire_timeout_sec),
         ("max_issues_per_food_truck", max_issues_per_food_truck),
         ("enable_deadline_extension", enable_deadline_extension),
+        ("inspector_model", inspector_model),
     ]:
         if val is not None:
             params[name] = val
@@ -149,6 +151,7 @@ async def configure_fleet(
     acquire_timeout_sec: float | None = None,
     max_issues_per_food_truck: int | None = None,
     enable_deadline_extension: bool | None = None,
+    inspector_model: str | None = None,
     default_model: str | None = None,
 ) -> str:
     """Configure fleet dispatch parameters for this kitchen session.
@@ -186,6 +189,7 @@ async def configure_fleet(
             acquire_timeout_sec,
             max_issues_per_food_truck,
             enable_deadline_extension,
+            inspector_model,
         )
 
         core_params = {"default_model": default_model} if default_model is not None else None

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -587,6 +587,9 @@ async def run_skill(
             effective_model = model
 
             _cfg = _get_config()
+            _in_fleet_dispatch = bool(os.environ.get(DISPATCH_ID_ENV_VAR))
+            _inspector_model = _cfg.fleet.inspector_model if _in_fleet_dispatch else ""
+
             if not step_provider and step_name and tool_ctx.active_recipe_steps is not None:
                 _recipe_step_pre = tool_ctx.active_recipe_steps.get(step_name)
                 if _recipe_step_pre is not None and _recipe_step_pre.provider:
@@ -922,6 +925,8 @@ async def run_skill(
                         resume_session_id=resume_session_id,
                         marker_dir=_marker_dir,
                         caller_session_id=_orchestrator_sid,
+                        inspector_eligible=_in_fleet_dispatch and bool(_inspector_model),
+                        inspector_model=_inspector_model,
                     )
                 if skill_result.success:
                     tool_ctx.audit.record_success(skill_command)

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -16,7 +16,7 @@ NEW_HEADLESS_MODULES = [
     "_headless_execute.py",
 ]
 HEADLESS_SIZE_BUDGETS = {
-    "headless/__init__.py": 472,
+    "headless/__init__.py": 479,
     "headless/_headless_helpers.py": 220,
     "headless/_headless_execute.py": 605,
     "headless/_headless_recovery.py": 366,

--- a/tests/config/test_fleet_config.py
+++ b/tests/config/test_fleet_config.py
@@ -276,3 +276,14 @@ def test_config_resolution_fleet_enabled_via_experimental(tmp_path) -> None:
         is_feature_enabled("fleet", cfg.features, experimental_enabled=cfg.experimental_enabled)
         is True
     )
+
+
+class TestFleetConfigInspectorModel:
+    """FleetConfig.inspector_model field defaults and overrides."""
+
+    def test_inspector_model_default_empty(self) -> None:
+        assert FleetConfig().inspector_model == ""
+
+    def test_inspector_model_override(self) -> None:
+        cfg = FleetConfig(inspector_model="claude-haiku-4-5-20251001")
+        assert cfg.inspector_model == "claude-haiku-4-5-20251001"

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -390,6 +390,7 @@ class TestGroupDApiContractPreservation:
             "marker_dir",
             "session_id",
             "stream_parser",
+            "inspector_callback",
         }
         assert expected == public_params, (
             f"run_managed_async public params changed.\n"

--- a/tests/execution/test_process_idle_watchdog.py
+++ b/tests/execution/test_process_idle_watchdog.py
@@ -14,6 +14,7 @@ import pytest
 import structlog.testing
 
 from autoskillit.execution.process._process_race import (
+    CLEANUP_BUDGET_SECONDS,
     RaceAccumulator,
     _watch_stdout_idle,
 )
@@ -842,7 +843,7 @@ async def test_inspector_skipped_when_insufficient_time(tmp_path: anyio.Path) ->
     timeout_scope_ref: list[anyio.CancelScope | None] = [None]
 
     async def set_short_scope() -> None:
-        with anyio.move_on_after(0.5) as scope:
+        with anyio.move_on_after(CLEANUP_BUDGET_SECONDS * 0.03) as scope:
             timeout_scope_ref[0] = scope
             await trigger.wait()
 

--- a/tests/execution/test_process_idle_watchdog.py
+++ b/tests/execution/test_process_idle_watchdog.py
@@ -17,6 +17,7 @@ from autoskillit.execution.process._process_race import (
     RaceAccumulator,
     _watch_stdout_idle,
 )
+from tests.conftest import make_stub_inspector
 
 
 @pytest.mark.anyio
@@ -692,3 +693,221 @@ async def test_stdout_idle_NOT_fired_when_execution_marker_active(
 
 
 # test write
+
+
+@pytest.mark.anyio
+async def test_inspector_callback_kill_fires_idle_stall(tmp_path: anyio.Path) -> None:
+    """KILL verdict from inspector callback sets acc.inspector_verdict + idle_stall."""
+    stdout_file = tmp_path / "stdout.txt"
+    await anyio.Path(stdout_file).write_bytes(b"initial output\n")
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    timeout_scope_ref: list[anyio.CancelScope | None] = [None]
+
+    async def set_scope() -> None:
+        with anyio.move_on_after(30.0) as scope:
+            timeout_scope_ref[0] = scope
+            await trigger.wait()
+        if not trigger.is_set():
+            trigger.set()
+
+    with anyio.fail_after(2.0):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(set_scope)
+            await anyio.sleep(0.05)
+            tg.start_soon(
+                functools.partial(
+                    _watch_stdout_idle,
+                    stdout_file,
+                    0.2,
+                    acc,
+                    trigger,
+                    0.05,
+                    inspector_callback=make_stub_inspector("KILL"),
+                    timeout_scope_ref=timeout_scope_ref,
+                )
+            )
+            await trigger.wait()
+
+    assert acc.inspector_verdict is not None
+    assert acc.inspector_verdict.action == "KILL"
+    assert acc.idle_stall is True
+    assert trigger.is_set()
+
+
+@pytest.mark.anyio
+async def test_inspector_callback_spare_resets_timer(tmp_path: anyio.Path) -> None:
+    """SPARE verdict resets last_growth_time and continues polling without firing kill."""
+    stdout_file = tmp_path / "stdout.txt"
+    await anyio.Path(stdout_file).write_bytes(b"initial output\n")
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    timeout_scope_ref: list[anyio.CancelScope | None] = [None]
+    callback_calls: list[int] = [0]
+
+    async def killing_callback(evidence):  # type: ignore[no-untyped-def]
+        callback_calls[0] += 1
+        from autoskillit.core import InspectorVerdict
+
+        if callback_calls[0] == 1:
+            return InspectorVerdict(
+                action="SPARE", reasoning="first", confidence="high", elapsed_seconds=0.0
+            )
+        trigger.set()
+        return InspectorVerdict(
+            action="KILL", reasoning="second", confidence="high", elapsed_seconds=0.0
+        )
+
+    async def set_scope() -> None:
+        with anyio.move_on_after(30.0) as scope:
+            timeout_scope_ref[0] = scope
+            await anyio.sleep(2.0)
+        if not trigger.is_set():
+            trigger.set()
+
+    with anyio.fail_after(3.0):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(set_scope)
+            await anyio.sleep(0.05)
+            tg.start_soon(
+                functools.partial(
+                    _watch_stdout_idle,
+                    stdout_file,
+                    0.2,
+                    acc,
+                    trigger,
+                    0.05,
+                    inspector_callback=killing_callback,
+                    timeout_scope_ref=timeout_scope_ref,
+                )
+            )
+            await trigger.wait()
+
+    assert callback_calls[0] >= 2
+    assert acc.inspector_verdict is not None
+    assert acc.inspector_verdict.action == "KILL"
+
+
+@pytest.mark.anyio
+async def test_inspector_callback_none_preserves_behavior(tmp_path: anyio.Path) -> None:
+    """inspector_callback=None preserves backward-compatible IDLE_STALL behavior."""
+    stdout_file = tmp_path / "stdout.txt"
+    await anyio.Path(stdout_file).write_bytes(b"initial output\n")
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    with anyio.fail_after(2.0):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(
+                functools.partial(
+                    _watch_stdout_idle,
+                    stdout_file,
+                    0.2,
+                    acc,
+                    trigger,
+                    0.05,
+                )
+            )
+            await trigger.wait()
+
+    assert acc.inspector_verdict is None
+    assert acc.idle_stall is True
+    assert trigger.is_set()
+
+
+@pytest.mark.anyio
+async def test_inspector_skipped_when_insufficient_time(tmp_path: anyio.Path) -> None:
+    """Inspector is skipped when CancelScope has < CLEANUP_BUDGET remaining."""
+    stdout_file = tmp_path / "stdout.txt"
+    await anyio.Path(stdout_file).write_bytes(b"initial output\n")
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    callback_called: list[bool] = [False]
+
+    async def tracking_callback(evidence):  # type: ignore[no-untyped-def]
+        callback_called[0] = True
+        from autoskillit.core import InspectorVerdict
+
+        return InspectorVerdict(
+            action="KILL", reasoning="should not fire", confidence="high", elapsed_seconds=0.0
+        )
+
+    timeout_scope_ref: list[anyio.CancelScope | None] = [None]
+
+    async def set_short_scope() -> None:
+        with anyio.move_on_after(0.05) as scope:
+            timeout_scope_ref[0] = scope
+            await trigger.wait()
+        if not trigger.is_set():
+            trigger.set()
+
+    with anyio.fail_after(2.0):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(set_short_scope)
+            await anyio.sleep(0.01)
+            tg.start_soon(
+                functools.partial(
+                    _watch_stdout_idle,
+                    stdout_file,
+                    0.1,
+                    acc,
+                    trigger,
+                    0.05,
+                    inspector_callback=tracking_callback,
+                    timeout_scope_ref=timeout_scope_ref,
+                )
+            )
+            await trigger.wait()
+
+    assert callback_called[0] is False
+    assert acc.inspector_verdict is None
+    assert acc.idle_stall is True
+
+
+@pytest.mark.anyio
+async def test_inspector_skipped_when_scope_none(tmp_path: anyio.Path) -> None:
+    """Inspector is skipped when timeout_scope_ref element is None (scope not yet set)."""
+    stdout_file = tmp_path / "stdout.txt"
+    await anyio.Path(stdout_file).write_bytes(b"initial output\n")
+
+    acc = RaceAccumulator()
+    trigger = anyio.Event()
+
+    callback_called: list[bool] = [False]
+
+    async def tracking_callback(evidence):  # type: ignore[no-untyped-def]
+        callback_called[0] = True
+        from autoskillit.core import InspectorVerdict
+
+        return InspectorVerdict(
+            action="KILL", reasoning="should not fire", confidence="high", elapsed_seconds=0.0
+        )
+
+    timeout_scope_ref: list[anyio.CancelScope | None] = [None]
+
+    with anyio.fail_after(2.0):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(
+                functools.partial(
+                    _watch_stdout_idle,
+                    stdout_file,
+                    0.1,
+                    acc,
+                    trigger,
+                    0.05,
+                    inspector_callback=tracking_callback,
+                    timeout_scope_ref=timeout_scope_ref,
+                )
+            )
+            await trigger.wait()
+
+    assert callback_called[0] is False
+    assert acc.inspector_verdict is None
+    assert acc.idle_stall is True

--- a/tests/execution/test_process_idle_watchdog.py
+++ b/tests/execution/test_process_idle_watchdog.py
@@ -842,13 +842,11 @@ async def test_inspector_skipped_when_insufficient_time(tmp_path: anyio.Path) ->
     timeout_scope_ref: list[anyio.CancelScope | None] = [None]
 
     async def set_short_scope() -> None:
-        with anyio.move_on_after(0.05) as scope:
+        with anyio.move_on_after(0.5) as scope:
             timeout_scope_ref[0] = scope
             await trigger.wait()
-        if not trigger.is_set():
-            trigger.set()
 
-    with anyio.fail_after(2.0):
+    with anyio.fail_after(3.0):
         async with anyio.create_task_group() as tg:
             tg.start_soon(set_short_scope)
             await anyio.sleep(0.01)

--- a/tests/execution/test_process_race.py
+++ b/tests/execution/test_process_race.py
@@ -335,7 +335,7 @@ class TestResolveTerminationInspector:
             ),
         )
         termination, _ = resolve_termination(signals)
-        assert termination in (TerminationReason.NATURAL_EXIT, TerminationReason.SIGNAL_DEATH)
+        assert termination == TerminationReason.NATURAL_EXIT
 
 
 class TestSubprocessResultInspectorVerdict:

--- a/tests/execution/test_process_race.py
+++ b/tests/execution/test_process_race.py
@@ -11,6 +11,7 @@ import pytest
 from autoskillit.core.types import (
     ChannelBStatus,
     ChannelConfirmation,
+    InspectorVerdict,
     TerminationReason,
 )
 from autoskillit.execution.process._process_race import (
@@ -266,6 +267,95 @@ class TestInspectorVerdictField:
             channel_b_status=None,
         )
         assert rs.inspector_verdict is None
+
+    def test_to_race_signals_copies_inspector_verdict(self) -> None:
+        acc = RaceAccumulator()
+        verdict = InspectorVerdict(
+            action="KILL", reasoning="stuck", confidence="high", elapsed_seconds=5.0
+        )
+        acc.inspector_verdict = verdict
+        signals = acc.to_race_signals()
+        assert signals.inspector_verdict is verdict
+
+
+class TestRaceAccumulatorFieldCount:
+    """Sentinel test: breaks when RaceAccumulator fields change."""
+
+    def test_race_accumulator_field_count(self) -> None:
+        n = len(dataclasses.fields(RaceAccumulator))
+        assert n == 11, (
+            f"RaceAccumulator has {n} fields (expected 11). Update tests for new fields."
+        )
+
+
+class TestResolveTerminationInspector:
+    """resolve_termination produces HEALTH_INSPECTOR when inspector_verdict + idle_stall."""
+
+    def test_inspector_verdict_with_idle_stall_gives_health_inspector(self) -> None:
+        signals = RaceSignals(
+            process_exited=False,
+            process_returncode=None,
+            channel_a_confirmed=False,
+            channel_b_status=None,
+            channel_b_session_id="",
+            stdout_session_id=None,
+            idle_stall=True,
+            inspector_verdict=InspectorVerdict(
+                action="KILL", reasoning="stuck", confidence="high", elapsed_seconds=5.0
+            ),
+        )
+        termination, _ = resolve_termination(signals)
+        assert termination == TerminationReason.HEALTH_INSPECTOR
+
+    def test_idle_stall_without_verdict_gives_idle_stall(self) -> None:
+        signals = RaceSignals(
+            process_exited=False,
+            process_returncode=None,
+            channel_a_confirmed=False,
+            channel_b_status=None,
+            channel_b_session_id="",
+            stdout_session_id=None,
+            idle_stall=True,
+            inspector_verdict=None,
+        )
+        termination, _ = resolve_termination(signals)
+        assert termination == TerminationReason.IDLE_STALL
+
+    def test_process_exit_takes_priority_over_inspector(self) -> None:
+        signals = RaceSignals(
+            process_exited=True,
+            process_returncode=0,
+            channel_a_confirmed=False,
+            channel_b_status=None,
+            channel_b_session_id="",
+            stdout_session_id=None,
+            idle_stall=True,
+            inspector_verdict=InspectorVerdict(
+                action="KILL", reasoning="stuck", confidence="high", elapsed_seconds=5.0
+            ),
+        )
+        termination, _ = resolve_termination(signals)
+        assert termination in (TerminationReason.NATURAL_EXIT, TerminationReason.SIGNAL_DEATH)
+
+
+class TestSubprocessResultInspectorVerdict:
+    """SubprocessResult.inspector_verdict is populated from signals."""
+
+    def test_subprocess_result_accepts_inspector_verdict(self) -> None:
+        from autoskillit.core import SubprocessResult
+
+        verdict = InspectorVerdict(
+            action="KILL", reasoning="stuck", confidence="high", elapsed_seconds=5.0
+        )
+        result = SubprocessResult(
+            returncode=-1,
+            stdout="",
+            stderr="",
+            termination=TerminationReason.HEALTH_INSPECTOR,
+            pid=12345,
+            inspector_verdict=verdict,
+        )
+        assert result.inspector_verdict is verdict
 
 
 class TestExitSnapshot:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -97,6 +97,8 @@ class ExecutorCall:
     backend_override: str | None = None
     marker_dir: Path | None = None
     caller_session_id: str | None = None
+    inspector_eligible: bool = False
+    inspector_model: str = ""
 
 
 @dataclasses.dataclass
@@ -199,6 +201,8 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
         backend_override: str | None = None,
         marker_dir: Path | None = None,
         caller_session_id: str | None = None,
+        inspector_eligible: bool = False,
+        inspector_model: str = "",
     ) -> SkillResult:
         self.calls.append(
             ExecutorCall(
@@ -235,6 +239,8 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
                 backend_override=backend_override,
                 marker_dir=marker_dir,
                 caller_session_id=caller_session_id,
+                inspector_eligible=inspector_eligible,
+                inspector_model=inspector_model,
             )
         )
         if self._queue:

--- a/tests/server/test_tools_config.py
+++ b/tests/server/test_tools_config.py
@@ -485,3 +485,33 @@ async def test_configure_fleet_snapshot_semaphore_invariant(tmp_path, monkeypatc
             payload["config"]["fleet"]["acquire_timeout_sec"]
             == mock_ctx.config.fleet.acquire_timeout_sec
         )
+
+
+@pytest.mark.anyio
+async def test_configure_fleet_passes_inspector_model_through(tmp_path, monkeypatch) -> None:
+    """configure_fleet passes inspector_model to the session config overlay."""
+    from autoskillit.server import _state
+    from tests.server._helpers import _HOOK_CONFIG_OVERLAY_RELPATH
+
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_OVERLAY_RELPATH)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(json.dumps({}))
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.project_dir = tmp_path
+    mock_ctx.config = AutomationConfig()
+    mock_ctx.fleet_lock = FleetSemaphore(max_concurrent=3)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_state, "_ctx", mock_ctx)
+
+    from autoskillit.server.tools.tools_config import configure_fleet
+
+    result = await configure_fleet(inspector_model="claude-haiku-4-5-20251001")
+    payload = json.loads(result)
+
+    assert payload["success"] is True
+    overlay_path = tmp_path.joinpath(*_HOOK_CONFIG_OVERLAY_RELPATH)
+    overlay = json.loads(overlay_path.read_text())
+    assert overlay["fleet"]["inspector_model"] == "claude-haiku-4-5-20251001"
+    assert payload["config"]["fleet"]["inspector_model"] == "claude-haiku-4-5-20251001"

--- a/tests/server/test_tools_config.py
+++ b/tests/server/test_tools_config.py
@@ -493,7 +493,7 @@ async def test_configure_fleet_passes_inspector_model_through(tmp_path, monkeypa
     from autoskillit.server import _state
     from tests.server._helpers import _HOOK_CONFIG_OVERLAY_RELPATH
 
-    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_OVERLAY_RELPATH)
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_RELPATH)
     hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
     hook_cfg_path.write_text(json.dumps({}))
 

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -525,3 +525,49 @@ async def test_run_skill_succeeds_when_cleanup_session_raises(
 
     mock_ssm.cleanup_session.assert_called_once()
     assert result.get("success") is True
+
+
+@pytest.mark.anyio
+async def test_run_skill_passes_inspector_eligible_when_fleet_dispatch(
+    tool_ctx_kitchen_open, monkeypatch
+) -> None:
+    """When DISPATCH_ID_ENV_VAR is set and fleet has inspector_model, run_skill passes params."""
+
+    from autoskillit.core import DISPATCH_ID_ENV_VAR
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    monkeypatch.setenv(DISPATCH_ID_ENV_VAR, "test-dispatch-id-123")
+
+    from autoskillit.config import AutomationConfig
+
+    cfg = AutomationConfig()
+    cfg.fleet.inspector_model = "claude-haiku-4-5-20251001"
+    tool_ctx_kitchen_open.config = cfg
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    await run_skill("/test skill", "/tmp")
+
+    assert len(executor.calls) == 1
+    assert executor.calls[0].inspector_eligible is True
+    assert executor.calls[0].inspector_model == "claude-haiku-4-5-20251001"
+
+
+@pytest.mark.anyio
+async def test_run_skill_no_inspector_outside_dispatch(tool_ctx_kitchen_open, monkeypatch) -> None:
+    """When DISPATCH_ID_ENV_VAR is absent, inspector_eligible=False."""
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    monkeypatch.delenv("AUTOSKILLIT_DISPATCH_ID", raising=False)
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    await run_skill("/test skill", "/tmp")
+
+    assert len(executor.calls) == 1
+    assert executor.calls[0].inspector_eligible is False
+    assert executor.calls[0].inspector_model == ""


### PR DESCRIPTION
## Summary

Wire the Health Inspector types and protocols (defined in #3533) into the runtime process management layer. This involves six coordinated changes: (1) add `inspector_verdict` to `RaceAccumulator` and `to_race_signals()`, (2) modify `_watch_stdout_idle` to accept and dispatch an `InspectorCallback` with SPARE/KILL branching, (3) update `resolve_termination()` to produce `HEALTH_INSPECTOR` when an inspector verdict is present alongside `idle_stall`, (4) thread `inspector_callback` from `DefaultSubprocessRunner` through `run_managed_async` to the watcher, (5) thread `inspector_eligible`/`inspector_model` parameters from `tools_execution.py` down to `_execute_claude_headless`, and (6) add `FleetConfig.inspector_model` configuration. All call sites pass `inspector_callback=None` — the real closure is #3534's responsibility.

Closes #3574

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260602-070322-928016/.autoskillit/temp/make-plan/health_inspector_a2_watcher_process_integration_plan_2026-06-02_073000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.3k | 40.6k | 1.5M | 137.3k | 56 | 128.7k | 18m 2s |
| review_approach* | opus[1m] | 1 | 5.2k | 5.6k | 160.1k | 36.6k | 12 | 54.4k | 5m 15s |
| verify* | opus[1m] | 1 | 47 | 12.2k | 570.7k | 69.5k | 33 | 52.6k | 6m 20s |
| implement* | MiniMax-M3 | 1 | 130.7k | 22.0k | 5.3M | 116.2k | 164 | 0 | 13m 48s |
| audit_impl* | opus[1m] | 1 | 23 | 14.7k | 149.3k | 42.8k | 13 | 44.3k | 8m 28s |
| prepare_pr* | MiniMax-M3 | 1 | 48.0k | 2.7k | 270.1k | 52.1k | 18 | 0 | 1m 27s |
| compose_pr* | MiniMax-M3 | 1 | 35.7k | 1.3k | 188.8k | 38.8k | 12 | 0 | 46s |
| review_pr* | opus[1m] | 1 | 45 | 56.2k | 1.5M | 116.2k | 55 | 99.9k | 14m 3s |
| resolve_review* | opus[1m] | 1 | 47 | 14.4k | 1.2M | 76.0k | 50 | 68.4k | 7m 35s |
| **Total** | | | 221.1k | 169.7k | 10.9M | 137.3k | | 448.3k | 1h 15m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 509 | 10504.9 | 0.0 | 43.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 5 | 243267.0 | 13683.2 | 2880.0 |
| **Total** | **514** | 21185.0 | 872.2 | 330.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 6.7k | 143.7k | 5.1M | 448.3k | 59m 46s |
| MiniMax-M3 | 3 | 214.4k | 26.0k | 5.8M | 0 | 16m 0s |