### PR TITLE
Rectify: Write Guard Shell Variable Immunity

### DIFF
--- a/src/autoskillit/core/bash_write_targets.py
+++ b/src/autoskillit/core/bash_write_targets.py
@@ -21,6 +21,7 @@ _REDIRECT_TOKEN_RE = re.compile(r"^(\d*)>{1,2}(.+)$")
 _REDIRECT_OP_ONLY_RE = re.compile(r"^(\d*)>{1,2}$")
 _FD_REDIRECT_RE = re.compile(r"^\d*>{1,2}&")
 _TRAILING_SHELL_CLOSERS = frozenset({")", "`", "}", "'", '"', ";", "&", "|"})
+_SHELL_VAR_RE = re.compile(r"\$\{[A-Za-z_]|\$[A-Za-z_]")
 
 _PSEUDO_DEVICE_PATHS: frozenset[str] = frozenset(
     {
@@ -52,6 +53,10 @@ def _resolve_write_target(path: str, cwd: str = "") -> str | None:
         return None
     if path.startswith("&") or _FD_REDIRECT_RE.match(path):
         return None
+    if _SHELL_VAR_RE.search(path):
+        path = os.path.expandvars(path)
+        if _SHELL_VAR_RE.search(path):
+            return None
     if os.path.isabs(path):
         return path
     if cwd:

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -49,6 +49,7 @@ _REDIRECT_TOKEN_RE = re.compile(r"^(\d*)>{1,2}(.+)$")
 _REDIRECT_OP_ONLY_RE = re.compile(r"^(\d*)>{1,2}$")
 _FD_REDIRECT_RE = re.compile(r"^\d*>{1,2}&")
 _TRAILING_SHELL_CLOSERS = frozenset({")", "`", "}", "'", '"', ";", "&", "|"})
+_SHELL_VAR_RE = re.compile(r"\$\{[A-Za-z_]|\$[A-Za-z_]")
 
 
 def resolve_write_target(path: str, cwd: str = "") -> str | None:
@@ -56,6 +57,10 @@ def resolve_write_target(path: str, cwd: str = "") -> str | None:
         return None
     if path.startswith("&") or _FD_REDIRECT_RE.match(path):
         return None
+    if _SHELL_VAR_RE.search(path):
+        path = os.path.expandvars(path)
+        if _SHELL_VAR_RE.search(path):
+            return None
     if os.path.isabs(path):
         return path
     if cwd:

--- a/tests/core/test_bash_write_targets.py
+++ b/tests/core/test_bash_write_targets.py
@@ -74,6 +74,15 @@ class TestExtractBashWriteTargets:
         result = extract_bash_write_targets("cat file | tee /path/a /path/b")
         assert result == ["/path/a", "/path/b"]
 
+    def test_shell_variable_unknown_failopen(self):
+        result = extract_bash_write_targets("echo x > $UNKNOWN_DIR/out.txt", cwd="/workspace")
+        assert result == []
+
+    def test_shell_variable_known_expands(self, monkeypatch):
+        monkeypatch.setenv("MY_DIR", "/workspace/.autoskillit/temp")
+        result = extract_bash_write_targets("echo x > $MY_DIR/out.txt", cwd="/workspace")
+        assert result == ["/workspace/.autoskillit/temp/out.txt"]
+
 
 _PARITY_CORPUS: list[tuple[str, str]] = [
     ("echo x > /path/out.txt", "/workspace"),
@@ -98,6 +107,9 @@ _PARITY_CORPUS: list[tuple[str, str]] = [
     ("unlink /path/file.txt", "/workspace"),
     ("cp /a /outside/dest > /log", "/workspace"),
     ("cat file | tee /path/a /path/b", "/workspace"),
+    ("echo x > $MY_OUTPUT_DIR/out.txt", "/workspace"),
+    ("tee $MY_OUTPUT_DIR/out.txt", "/workspace"),
+    ("REVIEW_OUTPUT_DIR='.autoskillit/temp' && echo x > $REVIEW_OUTPUT_DIR/out.txt", "/workspace"),
 ]
 
 

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -331,6 +331,36 @@ class TestResolveWriteTarget:
 
         assert resolve_write_target(path, cwd) == expected
 
+    @pytest.mark.parametrize(
+        "env_setup, path, cwd, expected",
+        [
+            (
+                {"TEST_EXPAND_DIR": "/resolved/dir"},
+                "$TEST_EXPAND_DIR/output.txt",
+                "/workspace",
+                "/resolved/dir/output.txt",
+            ),
+            ({}, "$REVIEW_OUTPUT_DIR/file.json", "/workspace", None),
+            ({}, "${REVIEW_OUTPUT_DIR}/file.json", "/workspace", None),
+            ({}, "$NONEXISTENT_VAR/path", "/workspace", None),
+            (
+                {"TEST_EXPAND_DIR": "/resolved/dir"},
+                "$TEST_EXPAND_DIR/$NONEXISTENT/file",
+                "/workspace",
+                None,
+            ),
+            ({}, "report$2026.txt", "/workspace", "/workspace/report$2026.txt"),
+        ],
+    )
+    def test_resolve_write_target_shell_vars(self, env_setup, path, cwd, expected, monkeypatch):
+        from autoskillit.hooks._command_classification import resolve_write_target
+
+        for var in ["TEST_EXPAND_DIR", "REVIEW_OUTPUT_DIR", "NONEXISTENT_VAR", "NONEXISTENT"]:
+            monkeypatch.delenv(var, raising=False)
+        for var, val in env_setup.items():
+            monkeypatch.setenv(var, val)
+        assert resolve_write_target(path, cwd) == expected
+
 
 class TestExtractRedirectTargetsCwd:
     @pytest.mark.parametrize(

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -1068,6 +1068,7 @@ class TestWriteGuardCrossProductMatrix:
             ("/workspace/src/main.py", "/workspace/src/main.py"),
             ("src/main.py", "/workspace/src/main.py"),
             ("./src/main.py", "/workspace/./src/main.py"),
+            ("$MY_VAR/src/main.py", None),
         ],
     )
     def test_all_write_mechanisms_resolve_all_path_types(
@@ -1076,7 +1077,47 @@ class TestWriteGuardCrossProductMatrix:
         from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
 
         monkeypatch.setenv("AUTOSKILLIT_CWD", "/workspace")
+        monkeypatch.delenv("MY_VAR", raising=False)
         cmd = cmd_template.format(path=path_type)
         result = _extract_bash_write_targets(cmd)
-        assert result is not None, f"Expected write detection for: {cmd}"
-        assert expected_resolved in result, f"Expected {expected_resolved} in {result} for: {cmd}"
+        if expected_resolved is None:
+            assert result is None or result == [], f"Expected fail-open for: {cmd}, got: {result}"
+        else:
+            assert result is not None, f"Expected write detection for: {cmd}"
+            assert expected_resolved in result, (
+                f"Expected {expected_resolved} in {result} for: {cmd}"
+            )
+
+
+class TestShellVariableWriteGuardIntegration:
+    def test_redirect_with_env_var_in_environ_allowed(self, monkeypatch):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        monkeypatch.setenv("AUTOSKILLIT_CWD", "/workspace")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/workspace/.autoskillit/temp")
+        monkeypatch.setenv("MY_DIR", "/workspace/.autoskillit/temp/review-pr")
+        result = _extract_bash_write_targets('echo x > "$MY_DIR/out.txt"')
+        assert result is not None
+        assert "/workspace/.autoskillit/temp/review-pr/out.txt" in result
+
+    def test_redirect_with_unknown_var_failopen(self, monkeypatch):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        monkeypatch.setenv("AUTOSKILLIT_CWD", "/workspace")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/workspace/.autoskillit/temp")
+        monkeypatch.delenv("UNKNOWN_DIR", raising=False)
+        result = _extract_bash_write_targets('echo x > "$UNKNOWN_DIR/out.txt"')
+        assert result is None or result == []
+
+    def test_redirect_with_inline_assignment_failopen(self, monkeypatch):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        monkeypatch.setenv("AUTOSKILLIT_CWD", "/workspace")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "/workspace/.autoskillit/temp")
+        monkeypatch.delenv("REVIEW_OUTPUT_DIR", raising=False)
+        cmd = (
+            'REVIEW_OUTPUT_DIR=".autoskillit/temp/review-pr/iter_0"'
+            ' && echo x > "$REVIEW_OUTPUT_DIR/out.txt"'
+        )
+        result = _extract_bash_write_targets(cmd)
+        assert result is None or result == []


### PR DESCRIPTION
## Summary

`resolve_write_target()` treats shell variable tokens (`$VAR/file`) as literal relative paths, producing false-positive DENYs. The root cause is that the write guard pipeline has no awareness that `shlex.split()` preserves shell variables unexpanded. This same gap exists in both the hooks-side implementation (`hooks/_command_classification.py:resolve_write_target`) and the IL-0 parity twin (`core/bash_write_targets.py:_resolve_write_target`). The cross-product test matrix tests three path categories (absolute, relative, `./`-relative) but never includes a fourth: shell-variable-prefixed paths.

The architectural fix introduces shell variable awareness as a **token classification category** in `resolve_write_target()`. The approach uses a two-phase strategy:

1. **Pre-expansion detection**: A regex (`_SHELL_VAR_RE = re.compile(r'\$[{(]|\$[A-Za-z_]')`) checks the ORIGINAL path for shell-variable-like syntax before any expansion. Paths without `$`-variable syntax skip expansion entirely, preserving existing behavior for literal filenames containing `$` (e.g., `report$2026.txt`) and for plain relative/absolute paths.

2. **Expand + residue check**: Only when a variable reference is detected does `os.path.expandvars()` run. If the expanded result still contains `$`-variable syntax (checked by the same regex), the variable could not be resolved from `os.environ`, so the function returns `None` (fail-open). This correctly handles the case where an env var's VALUE itself contains a literal `$` — since the pre-expansion check already confirmed the original token had variable syntax, and the post-expansion check uses a regex (not a bare `"$" in`) to look for remaining variable references.

The broader immunity comes from:
1. Making `resolve_write_target()` a proper **token classifier** that handles all token categories (absolute, relative, fd-redirect, shell-variable) instead of assuming all non-absolute, non-fd tokens are relative paths.
2. Adding shell-variable paths as a fourth path category in the cross-product test matrix, preventing this class of gap from recurring.
3. Adding a parity test case for shell-variable tokens, ensuring the hooks and core implementations stay aligned on this behavior.
4. Using a regex-based variable-reference detector (not bare `"$" in path`) to avoid false positives on literal `$` in filenames and in expanded env var values.

Part B will cover Tier 2: inline assignment parsing (`_build_shell_env` and `_expand_shell_vars` helpers) — implement as a separate task.

Closes #3600

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260602-084258-633314/.autoskillit/temp/rectify/rectify_write_guard_shell_variable_immunity_2026-06-02_150000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 77 | 25.6k | 2.7M | 122.7k | 70 | 106.0k | 24m 52s |
| review_approach* | sonnet | 1 | 3.7k | 6.7k | 153.0k | 47.3k | 15 | 77.4k | 5m 57s |
| dry_walkthrough* | opus | 1 | 46 | 16.4k | 468.9k | 67.2k | 34 | 50.3k | 6m 42s |
| implement* | sonnet | 1 | 1.9k | 11.2k | 1.1M | 67.5k | 61 | 51.4k | 5m 12s |
| audit_impl* | sonnet | 1 | 62 | 8.4k | 209.5k | 38.3k | 21 | 31.9k | 3m 33s |
| prepare_pr* | MiniMax-M3 | 1 | 47.3k | 3.0k | 157.4k | 49.3k | 13 | 0 | 1m 7s |
| compose_pr* | MiniMax-M3 | 1 | 35.4k | 2.4k | 191.9k | 39.9k | 13 | 0 | 56s |
| review_pr* | sonnet | 1 | 116 | 38.6k | 588.9k | 53.9k | 34 | 68.1k | 8m 23s |
| **Total** | | | 88.7k | 112.3k | 5.6M | 122.7k | | 385.1k | 56m 44s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 97 | 11502.7 | 529.8 | 115.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **97** | 57523.2 | 3970.2 | 1157.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 77 | 25.6k | 2.7M | 106.0k | 24m 52s |
| sonnet | 4 | 5.8k | 64.9k | 2.1M | 228.8k | 23m 7s |
| opus | 1 | 46 | 16.4k | 468.9k | 50.3k | 6m 42s |
| MiniMax-M3 | 2 | 82.7k | 5.3k | 349.3k | 0 | 2m 2s |