### PR TITLE
Implementation Plan: P6-A5-WP1 Delete _SKILLS_SUBDIR and CODEX_SKILLS_SUBDIR Aliases

### DIFF
--- a/src/autoskillit/workspace/__init__.py
+++ b/src/autoskillit/workspace/__init__.py
@@ -38,7 +38,6 @@ from autoskillit.workspace.clone_registry import (
     register_clone as register_clone,
 )
 from autoskillit.workspace.session_skills import (
-    CODEX_SKILLS_SUBDIR,
     DefaultSessionSkillManager,
     SkillsDirectoryProvider,
     collect_closure_write_paths,
@@ -81,7 +80,6 @@ __all__ = [
     "remove_worktree_sidecar",
     "write_worktree_sidecar",
     "RUNS_DIR",
-    "CODEX_SKILLS_SUBDIR",
     "DefaultSkillResolver",
     "SkillResolver",
     "SkillsDirectoryProvider",

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -54,9 +54,6 @@ _CANDIDATE_ROOTS: list[Path] = [
 
 _FM_PATTERN = re.compile(r"^---\n(.*?)\n?---\n?(.*)", re.DOTALL)
 
-_SKILLS_SUBDIR = ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
-CODEX_SKILLS_SUBDIR = ClaudeDirectoryConventions.PLUGIN_DIR_SKILLS_SUBDIR
-
 logger = get_logger(__name__)
 
 
@@ -495,7 +492,7 @@ class DefaultSessionSkillManager:
     ) -> None:
         self._provider = provider
         self._root = ephemeral_root
-        self._skills_subdir = _SKILLS_SUBDIR
+        self._skills_subdir = ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
 
     def compute_skill_closure(self, skill_name: str) -> frozenset[str]:
         """Return the transitive activate_deps closure for ``skill_name``.
@@ -607,7 +604,7 @@ class DefaultSessionSkillManager:
         self._skills_subdir = (
             Path(backend.capabilities.skills_subdir)
             if backend is not None and backend.capabilities.skills_subdir
-            else _SKILLS_SUBDIR
+            else ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
         )
 
         session_skills_dir = self._root / session_id

--- a/tests/contracts/test_claude_code_interface_contracts.py
+++ b/tests/contracts/test_claude_code_interface_contracts.py
@@ -71,7 +71,7 @@ class TestAddDirLayoutContract:
     """Guard: init_session must write .claude/skills/<name>/SKILL.md.
 
     CRITICAL: Path components (".claude", "skills", "SKILL.md") are literal
-    strings here. Do NOT replace them with _SKILLS_SUBDIR or
+    strings here. Do NOT replace them with
     ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR — that would re-create
     the "tests mirror implementation" failure mode this guard was designed
     to prevent. If the constant drifts, TestClaudeDirectoryConventions catches
@@ -96,7 +96,7 @@ class TestAddDirLayoutContract:
         assert len(discovered) > 0, (
             "init_session must write skills to .claude/skills/<name>/SKILL.md "
             "(Claude Code --add-dir convention). "
-            "If this fails, session_skills._SKILLS_SUBDIR has regressed."
+            "If this fails, the ADD_DIR_SKILLS_SUBDIR convention has regressed."
         )
 
     def test_init_session_no_flat_skills_at_session_root(self, tmp_path: Path) -> None:
@@ -187,7 +187,7 @@ class TestCookAddDirStructure:
     to verify the output structure matches what Claude Code requires.
 
     CRITICAL: Path components are HARDCODED STRING LITERALS. Do NOT use
-    ClaudeDirectoryConventions or _SKILLS_SUBDIR here.
+    ClaudeDirectoryConventions here.
 
     This test closes the double-mock gap in test_cook_interactive.py (all tests
     mock init_session and subprocess.run together, so no test verified

--- a/tests/contracts/test_ephemeral_skill_namespace.py
+++ b/tests/contracts/test_ephemeral_skill_namespace.py
@@ -16,9 +16,8 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.core import SkillSource
+from autoskillit.core import ClaudeDirectoryConventions, SkillSource
 from autoskillit.workspace.session_skills import (
-    _SKILLS_SUBDIR,
     DefaultSessionSkillManager,
     SkillsDirectoryProvider,
 )
@@ -34,7 +33,7 @@ def test_ephemeral_skill_md_namespace_matches_session_delivery(tmp_path: Path) -
     mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
     session_path = mgr.init_session("ns-check-session", cook_session=True)
 
-    skills_base = session_path / _SKILLS_SUBDIR
+    skills_base = session_path / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
     resolver = DefaultSkillResolver()
     violations: list[str] = []
 

--- a/tests/workspace/test_constants.py
+++ b/tests/workspace/test_constants.py
@@ -16,9 +16,3 @@ def test_worktrees_dir_constant_is_exported():
     from autoskillit.workspace import WORKTREES_DIR
 
     assert WORKTREES_DIR == "worktrees"
-
-
-def test_codex_skills_subdir_constant_is_exported():
-    from autoskillit.workspace import CODEX_SKILLS_SUBDIR
-
-    assert str(CODEX_SKILLS_SUBDIR) == "skills"

--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -7,11 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from autoskillit.core import ValidatedAddDir
-from autoskillit.workspace.session_skills import (
-    _SKILLS_SUBDIR,
-    CODEX_SKILLS_SUBDIR,
-)
+from autoskillit.core import ClaudeDirectoryConventions, ValidatedAddDir
 from tests.workspace._helpers import _CODEX_CAPABILITIES
 
 pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
@@ -50,9 +46,11 @@ def codex_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 def test_codex_init_session_creates_skills_subdir(make_session_skill_manager, codex_env) -> None:
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
-    skill_files = list((session_path / CODEX_SKILLS_SUBDIR).glob("*/SKILL.md"))
+    skill_files = list(
+        (session_path / ClaudeDirectoryConventions.PLUGIN_DIR_SKILLS_SUBDIR).glob("*/SKILL.md")
+    )
     assert len(skill_files) > 0
-    assert not (session_path / _SKILLS_SUBDIR).exists()
+    assert not (session_path / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR).exists()
 
 
 def test_codex_init_session_copies_config_toml(make_session_skill_manager, codex_env) -> None:
@@ -143,9 +141,11 @@ def test_codex_init_session_returns_validated_add_dir(
 def test_claude_backend_still_uses_dot_claude_layout(make_session_skill_manager) -> None:
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True)
-    skill_files = list((session_path / _SKILLS_SUBDIR).glob("*/SKILL.md"))
+    skill_files = list(
+        (session_path / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR).glob("*/SKILL.md")
+    )
     assert len(skill_files) > 0
-    assert not (session_path / CODEX_SKILLS_SUBDIR).exists()
+    assert not (session_path / ClaudeDirectoryConventions.PLUGIN_DIR_SKILLS_SUBDIR).exists()
 
 
 def test_codex_init_session_sessions_symlink_respects_xdg(

--- a/tests/workspace/test_session_skills_namespace.py
+++ b/tests/workspace/test_session_skills_namespace.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 import pytest
 
+from autoskillit.core import ClaudeDirectoryConventions
 from autoskillit.workspace.session_skills import (
-    _SKILLS_SUBDIR,
     DefaultSessionSkillManager,
     SkillsDirectoryProvider,
     _rewrite_skill_namespace_refs,
@@ -95,7 +95,13 @@ def test_activate_with_deps_materialised_content_has_namespace_rewritten(
         config=config,
     )
 
-    mermaid_md = tmp_path / "session-ns-activate" / _SKILLS_SUBDIR / "mermaid" / "SKILL.md"
+    mermaid_md = (
+        tmp_path
+        / "session-ns-activate"
+        / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
+        / "mermaid"
+        / "SKILL.md"
+    )
     assert not mermaid_md.exists()
 
     result = mgr.activate_skill_deps("session-ns-activate", "mermaid")

--- a/tests/workspace/test_session_skills_provider.py
+++ b/tests/workspace/test_session_skills_provider.py
@@ -10,10 +10,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from autoskillit.core import ClaudeDirectoryConventions
 from autoskillit.core.io import load_yaml
 from autoskillit.workspace.session_skills import (
-    _SKILLS_SUBDIR,
-    CODEX_SKILLS_SUBDIR,
     DefaultSessionSkillManager,
     SkillsDirectoryProvider,
     resolve_ephemeral_root,
@@ -80,8 +79,8 @@ def test_provider_does_not_inject_for_cook_session() -> None:
 @pytest.mark.parametrize(
     ("backend_name", "skills_subdir"),
     [
-        pytest.param(None, _SKILLS_SUBDIR, id="claude-code"),
-        pytest.param("codex", CODEX_SKILLS_SUBDIR, id="codex"),
+        pytest.param(None, ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR, id="claude-code"),
+        pytest.param("codex", ClaudeDirectoryConventions.PLUGIN_DIR_SKILLS_SUBDIR, id="codex"),
     ],
 )
 def test_session_skill_manager_creates_ephemeral_dir(
@@ -110,14 +109,14 @@ def test_session_skill_manager_creates_ephemeral_dir(
     skill_files = list((session_path / skills_subdir).glob("*/SKILL.md"))
     assert len(skill_files) > 0
     if backend_name == "codex":
-        assert not (session_path / _SKILLS_SUBDIR).exists()
+        assert not (session_path / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR).exists()
 
 
 @pytest.mark.parametrize(
     ("backend_name", "skills_subdir"),
     [
-        pytest.param(None, _SKILLS_SUBDIR, id="claude-code"),
-        pytest.param("codex", CODEX_SKILLS_SUBDIR, id="codex"),
+        pytest.param(None, ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR, id="claude-code"),
+        pytest.param("codex", ClaudeDirectoryConventions.PLUGIN_DIR_SKILLS_SUBDIR, id="codex"),
     ],
 )
 def test_session_manager_injects_disable_for_tier2(
@@ -156,7 +155,7 @@ def test_session_manager_injects_disable_for_tier2(
     mermaid_dir = session_path / skills_subdir / "mermaid"
     assert not mermaid_dir.exists()
     if backend_name == "codex":
-        assert not (session_path / _SKILLS_SUBDIR).exists()
+        assert not (session_path / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR).exists()
 
 
 def test_session_manager_no_flag_for_cook_session(tmp_path: Path) -> None:
@@ -173,7 +172,9 @@ def test_session_manager_no_flag_for_cook_session(tmp_path: Path) -> None:
         )
     )
     session_path = mgr.init_session("cook-session-123", cook_session=True, config=config)
-    mermaid_md = session_path / _SKILLS_SUBDIR / "mermaid" / "SKILL.md"
+    mermaid_md = (
+        session_path / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR / "mermaid" / "SKILL.md"
+    )
     assert mermaid_md.exists()
 
 
@@ -197,7 +198,13 @@ def test_activate_skill_deps_removes_flag(tmp_path: Path) -> None:
     )
     result = mgr.activate_skill_deps("session-toggle", "mermaid")
     assert result is True
-    mermaid_md = tmp_path / "session-toggle" / _SKILLS_SUBDIR / "mermaid" / "SKILL.md"
+    mermaid_md = (
+        tmp_path
+        / "session-toggle"
+        / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
+        / "mermaid"
+        / "SKILL.md"
+    )
     content = mermaid_md.read_text()
     fm_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
     assert fm_match
@@ -220,7 +227,13 @@ def test_activate_with_deps_materialises_absent_skill(
         )
     )
     mgr.init_session("session-materialise", cook_session=False, config=config)
-    mermaid_md = tmp_path / "session-materialise" / _SKILLS_SUBDIR / "mermaid" / "SKILL.md"
+    mermaid_md = (
+        tmp_path
+        / "session-materialise"
+        / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
+        / "mermaid"
+        / "SKILL.md"
+    )
     assert not mermaid_md.exists()
 
     result = mgr.activate_skill_deps("session-materialise", "mermaid")
@@ -254,7 +267,13 @@ def test_activate_with_deps_already_present_removes_flag(
         config=config,
         allow_only=frozenset({"mermaid"}),
     )
-    mermaid_md = tmp_path / "session-flag-remove" / _SKILLS_SUBDIR / "mermaid" / "SKILL.md"
+    mermaid_md = (
+        tmp_path
+        / "session-flag-remove"
+        / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
+        / "mermaid"
+        / "SKILL.md"
+    )
     assert mermaid_md.exists()
 
     content = mermaid_md.read_text()
@@ -284,7 +303,7 @@ def test_init_session_gated_tier2_skill_dir_absent(tmp_path: Path) -> None:
         )
     )
     session_path = mgr.init_session("test-absent", cook_session=False, config=config)
-    skills_base = session_path / _SKILLS_SUBDIR
+    skills_base = session_path / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
     # Tier2 directory absent
     assert not (skills_base / "mermaid").exists()
     # Non-gated BUNDLED_EXTENDED skills are written (BUNDLED skills go via --plugin-dir, not here)
@@ -310,7 +329,7 @@ def test_init_session_tier2_skill_present_when_in_allow_only(tmp_path: Path) -> 
         config=config,
         allow_only=frozenset({"mermaid"}),
     )
-    skills_base = session_path / _SKILLS_SUBDIR
+    skills_base = session_path / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
     assert (skills_base / "mermaid" / "SKILL.md").exists()
     assert not (skills_base / "make-plan").exists()
 
@@ -334,7 +353,7 @@ def test_init_session_backend_none_uses_claude_skills_subdir(tmp_path: Path) -> 
     provider = SkillsDirectoryProvider()
     mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
     session_path = mgr.init_session("test-backend-none", cook_session=True)
-    skills_dir = session_path / _SKILLS_SUBDIR
+    skills_dir = session_path / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
     assert skills_dir.is_dir()
     skill_files = list(skills_dir.glob("*/SKILL.md"))
     assert len(skill_files) > 0
@@ -344,8 +363,6 @@ def test_init_session_codex_backend_uses_codex_skills_subdir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """When capabilities.skills_subdir == 'skills', skills_base resolves to skills/."""
-
-    from autoskillit.workspace.session_skills import CODEX_SKILLS_SUBDIR
 
     codex_backend = MagicMock()
     codex_backend.capabilities = _CODEX_CAPABILITIES
@@ -362,8 +379,8 @@ def test_init_session_codex_backend_uses_codex_skills_subdir(
     mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
     session_path = mgr.init_session("test-codex-backend", cook_session=True, backend=codex_backend)
 
-    codex_skills = session_path / CODEX_SKILLS_SUBDIR
-    claude_skills = session_path / _SKILLS_SUBDIR
+    codex_skills = session_path / ClaudeDirectoryConventions.PLUGIN_DIR_SKILLS_SUBDIR
+    claude_skills = session_path / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
     assert codex_skills.is_dir()
     skill_files = list(codex_skills.glob("*/SKILL.md"))
     assert len(skill_files) > 0


### PR DESCRIPTION
## Summary

Delete the `_SKILLS_SUBDIR` and `CODEX_SKILLS_SUBDIR` module-level alias constants from `session_skills.py`, remove `CODEX_SKILLS_SUBDIR` from the `workspace/__init__.py` re-export surface, and update all test files to use `ClaudeDirectoryConventions` constants directly. This removes an unnecessary indirection layer — callers should reference the canonical `ClaudeDirectoryConventions` enum members rather than module-level aliases.

Closes #3135

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260602-125957-756767/.autoskillit/temp/make-plan/p6_a5_wp1_delete_skills_subdir_aliases_plan_2026-06-02_130500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 73 | 12.9k | 1.2M | 96.1k | 50 | 79.6k | 8m 31s |
| verify* | sonnet | 1 | 60 | 5.3k | 235.5k | 43.6k | 20 | 26.9k | 3m 20s |
| implement* | MiniMax-M3 | 1 | 74.0k | 10.6k | 1.5M | 73.5k | 99 | 0 | 3m 51s |
| audit_impl* | sonnet | 1 | 44 | 9.6k | 147.3k | 40.8k | 13 | 36.6k | 5m 4s |
| prepare_pr* | MiniMax-M3 | 1 | 40.6k | 2.3k | 158.0k | 43.9k | 12 | 0 | 43s |
| compose_pr* | MiniMax-M3 | 1 | 37.0k | 1.2k | 147.0k | 38.2k | 12 | 0 | 41s |
| review_pr* | sonnet | 3 | 424 | 81.2k | 2.5M | 78.9k | 143 | 175.0k | 19m 37s |
| **Total** | | | 152.3k | 123.1k | 5.9M | 96.1k | | 318.1k | 41m 48s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 109 | 13326.1 | 0.0 | 97.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **109** | 54139.1 | 2918.4 | 1129.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 73 | 12.9k | 1.2M | 79.6k | 8m 31s |
| sonnet | 3 | 528 | 96.1k | 2.9M | 238.5k | 28m 2s |
| MiniMax-M3 | 3 | 151.7k | 14.1k | 1.8M | 0 | 5m 15s |