### PR TITLE
Implementation Plan: P6-A4-WP1 — Replace capabilities-based skills_subdir lookup with conventions-based lookup, refactor provisioning to backend.setup_session_dir delegation

### DIFF
--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re as _re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from ._type_checkpoint import SessionCheckpoint
@@ -39,6 +40,8 @@ class BackendConventions:
     backend looks for skills, and which project-local directories to scan.
     """
 
+    #: Relative path from backend session root to the skills directory.
+    skills_subdir: Path = Path("skills")
     #: Project-relative directories to scan for project-local skills.
     project_local_skill_search_dirs: tuple[str, ...] = ()
 

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -271,6 +271,7 @@ class ClaudeCodeBackend:
     @property
     def conventions(self) -> BackendConventions:
         return BackendConventions(
+            skills_subdir=ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR,
             project_local_skill_search_dirs=(
                 ".claude/skills",
                 ".autoskillit/skills",

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -338,6 +338,7 @@ class CodexBackend:
     @property
     def conventions(self) -> BackendConventions:
         return BackendConventions(
+            skills_subdir=ClaudeDirectoryConventions.PLUGIN_DIR_SKILLS_SUBDIR,
             project_local_skill_search_dirs=(".codex/skills", ".agents/skills"),
         )
 

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -26,7 +26,6 @@ from autoskillit.core import (
     SkillSource,
     ValidatedAddDir,
     atomic_write,
-    default_log_dir,
     get_logger,
     is_feature_enabled,
     pkg_root,
@@ -608,8 +607,8 @@ class DefaultSessionSkillManager:
         )
         _override_name_set: frozenset[str] = override_names(overrides)
         self._skills_subdir = (
-            Path(backend.capabilities.skills_subdir)
-            if backend is not None and backend.capabilities.skills_subdir
+            backend.conventions.skills_subdir
+            if backend is not None
             else ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
         )
 
@@ -623,52 +622,8 @@ class DefaultSessionSkillManager:
                 msg = "; ".join(pre_launch_errors)
                 raise RuntimeError(f"Pre-launch check failed: {msg}")
 
-        if backend is not None and backend.capabilities.required_session_files:
-            codex_home_source = Path.home() / ".codex"
-            if "config.toml" in backend.capabilities.required_session_files:
-                try:
-                    shutil.copy2(
-                        codex_home_source / "config.toml",
-                        session_skills_dir / "config.toml",
-                    )
-                    logger.debug("codex_config_copy", src=str(codex_home_source / "config.toml"))
-                except FileNotFoundError:
-                    logger.error(
-                        "codex_config_copy_missing",
-                        src=str(codex_home_source / "config.toml"),
-                    )
-                    raise
-        if backend is not None and backend.capabilities.session_dir_symlinks:
-            codex_home_source = Path.home() / ".codex"
-            if "auth.json" in backend.capabilities.session_dir_symlinks:
-                auth_source = codex_home_source / "auth.json"
-                auth_dest = session_skills_dir / "auth.json"
-                if auth_source.exists():
-                    try:
-                        auth_dest.symlink_to(auth_source.resolve())
-                        logger.debug(
-                            "codex_auth_symlink",
-                            src=str(auth_source),
-                            dest=str(auth_dest),
-                        )
-                    except OSError:
-                        logger.warning("codex_auth_symlink_failed", src=str(auth_source))
-                else:
-                    logger.warning("codex_auth_copy_missing", src=str(auth_source))
-            if ".env" in backend.capabilities.session_dir_symlinks:
-                env_source = codex_home_source / ".env"
-                if env_source.exists():
-                    shutil.copy2(env_source, session_skills_dir / ".env")
-                    logger.debug("codex_env_copy", src=str(env_source))
-            if "sessions" in backend.capabilities.session_dir_symlinks:
-                sessions_target = default_log_dir() / "codex-sessions"
-                sessions_target.mkdir(parents=True, exist_ok=True)
-                sessions_link = session_skills_dir / "sessions"
-                try:
-                    sessions_link.symlink_to(sessions_target)
-                    logger.debug("codex_sessions_symlink", target=str(sessions_target))
-                except OSError:
-                    logger.warning("codex_sessions_symlink_failed", target=str(sessions_target))
+        if backend is not None:
+            backend.setup_session_dir(session_skills_dir)
         format_rejected: set[str] = set()
         for skill_info in self._provider.list_skills():
             if allow_only is not None and skill_info.name not in allow_only:

--- a/tests/arch/test_backend_coherence.py
+++ b/tests/arch/test_backend_coherence.py
@@ -131,8 +131,8 @@ def test_triage_uses_capability_field():
     assert not has_string_compare, "_apply_triage_gate must not compare backend name strings"
 
 
-def test_skills_subdir_uses_capability_field():
-    """session_skills.py must read backend.capabilities.skills_subdir, not module constants."""
+def test_skills_subdir_uses_conventions_field():
+    """session_skills.py must read backend.conventions.skills_subdir, not module constants."""
     import inspect
     import textwrap
 
@@ -143,7 +143,7 @@ def test_skills_subdir_uses_capability_field():
     has_skills_subdir = any(
         isinstance(node, ast.Attribute) and node.attr == "skills_subdir" for node in ast.walk(tree)
     )
-    assert has_skills_subdir, "init_session must read .skills_subdir capability field"
+    assert has_skills_subdir, "init_session must read .skills_subdir conventions field"
 
 
 def test_applicable_guards_uses_capability_field():

--- a/tests/arch/test_capability_consumption.py
+++ b/tests/arch/test_capability_consumption.py
@@ -49,14 +49,6 @@ _FORWARD_DECLARED: dict[str, ForwardDeclaredField] = {
         rationale="Health Inspector capability gating — production consumer in #3574",
         added_date=date(2026, 6, 1),
     ),
-    "skills_subdir": ForwardDeclaredField(
-        issue=3134,
-        rationale=(
-            "read site migrated to backend.conventions.skills_subdir — "
-            "capabilities field retained on BackendCapabilities for schema consistency"
-        ),
-        added_date=date(2026, 6, 2),
-    ),
     "required_session_files": ForwardDeclaredField(
         issue=3134,
         rationale=(

--- a/tests/arch/test_capability_consumption.py
+++ b/tests/arch/test_capability_consumption.py
@@ -49,6 +49,30 @@ _FORWARD_DECLARED: dict[str, ForwardDeclaredField] = {
         rationale="Health Inspector capability gating — production consumer in #3574",
         added_date=date(2026, 6, 1),
     ),
+    "skills_subdir": ForwardDeclaredField(
+        issue=3134,
+        rationale=(
+            "read site migrated to backend.conventions.skills_subdir — "
+            "capabilities field retained on BackendCapabilities for schema consistency"
+        ),
+        added_date=date(2026, 6, 2),
+    ),
+    "required_session_files": ForwardDeclaredField(
+        issue=3134,
+        rationale=(
+            "production consumer moved to CodexBackend.setup_session_dir — "
+            "field retained for validate_session_layout"
+        ),
+        added_date=date(2026, 6, 2),
+    ),
+    "session_dir_symlinks": ForwardDeclaredField(
+        issue=3134,
+        rationale=(
+            "production consumer moved to CodexBackend.setup_session_dir — "
+            "field retained for validate_session_layout"
+        ),
+        added_date=date(2026, 6, 2),
+    ),
 }
 
 

--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -49,7 +50,7 @@ def test_codex_init_session_delegates_to_setup_session_dir(
 ) -> None:
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
-    codex_env.backend.setup_session_dir.assert_called_once_with(session_path)
+    codex_env.backend.setup_session_dir.assert_called_once_with(Path(str(session_path)))
 
 
 def test_no_backend_skips_setup_session_dir(make_session_skill_manager) -> None:

--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -1,8 +1,7 @@
-"""Tests for Codex-specific session skill layout and config file copying."""
+"""Tests for Codex-specific session skill layout delegation."""
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -16,28 +15,20 @@ pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
 def _make_codex_backend() -> MagicMock:
     b = MagicMock()
     b.capabilities = _CODEX_CAPABILITIES
+    b.conventions.skills_subdir = ClaudeDirectoryConventions.PLUGIN_DIR_SKILLS_SUBDIR
     b.ensure_pre_launch.return_value = []
     return b
 
 
 @pytest.fixture
-def codex_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """Fake ~/.codex/ home and codex backend mock."""
-    fake_home = tmp_path / "fakehome"
-    codex_dir = fake_home / ".codex"
-    codex_dir.mkdir(parents=True)
-    (codex_dir / "config.toml").write_text("[codex]\nmodel = 'o3'\n")
-
-    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
-
+def codex_env():
+    """Codex backend mock for delegation-contract tests."""
     backend = _make_codex_backend()
 
     return type(
         "CodexEnv",
         (),
         {
-            "fake_home": fake_home,
-            "codex_dir": codex_dir,
             "backend": backend,
         },
     )()
@@ -53,80 +44,18 @@ def test_codex_init_session_creates_skills_subdir(make_session_skill_manager, co
     assert not (session_path / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR).exists()
 
 
-def test_codex_init_session_copies_config_toml(make_session_skill_manager, codex_env) -> None:
-    mgr = make_session_skill_manager()
-    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
-    copied = session_path / "config.toml"
-    assert copied.exists()
-    assert copied.read_text() == "[codex]\nmodel = 'o3'\n"
-
-
-def test_codex_init_session_symlinks_auth_json(make_session_skill_manager, codex_env) -> None:
-    (codex_env.codex_dir / "auth.json").write_text('{"token": "test"}')
-    mgr = make_session_skill_manager()
-    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
-    auth = session_path / "auth.json"
-    assert auth.is_symlink()
-    assert auth.resolve() == (codex_env.codex_dir / "auth.json").resolve()
-    assert auth.read_text() == '{"token": "test"}'
-
-
-def test_codex_init_session_auth_json_symlink_target_absent(
+def test_codex_init_session_delegates_to_setup_session_dir(
     make_session_skill_manager, codex_env
 ) -> None:
     mgr = make_session_skill_manager()
     session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
-    assert not (session_path / "auth.json").exists()
-    assert not (session_path / "auth.json").is_symlink()
+    codex_env.backend.setup_session_dir.assert_called_once_with(session_path)
 
 
-def test_codex_init_session_copies_env_if_present(make_session_skill_manager, codex_env) -> None:
-    (codex_env.codex_dir / ".env").write_text("API_KEY=secret\n")
+def test_no_backend_skips_setup_session_dir(make_session_skill_manager) -> None:
     mgr = make_session_skill_manager()
-    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
-    copied = session_path / ".env"
-    assert copied.exists()
-    assert copied.read_text() == "API_KEY=secret\n"
-
-
-def test_codex_init_session_skips_env_if_absent(make_session_skill_manager, codex_env) -> None:
-    mgr = make_session_skill_manager()
-    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
-    assert not (session_path / ".env").exists()
-
-
-def test_codex_init_session_auth_json_missing_no_crash(
-    make_session_skill_manager, codex_env
-) -> None:
-    mgr = make_session_skill_manager()
-    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
-    assert not (session_path / "auth.json").exists()
-
-
-def test_codex_init_session_creates_sessions_symlink(
-    make_session_skill_manager, codex_env
-) -> None:
-    mgr = make_session_skill_manager()
-    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
-    sessions_link = session_path / "sessions"
-    assert sessions_link.is_symlink()
-    target = sessions_link.resolve()
-    assert target.is_dir()
-    assert str(target).endswith("codex-sessions")
-
-
-def test_codex_init_session_config_toml_missing_raises(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, make_session_skill_manager
-) -> None:
-    fake_home = tmp_path / "fakehome"
-    (fake_home / ".codex").mkdir(parents=True)
-    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
-
-    backend = _make_codex_backend()
-
-    mgr = make_session_skill_manager()
-    with pytest.raises(FileNotFoundError):
-        mgr.init_session("sid", cook_session=True, backend=backend)
+    result = mgr.init_session("sid", cook_session=True)
+    assert isinstance(result, ValidatedAddDir)
 
 
 def test_codex_init_session_returns_validated_add_dir(
@@ -146,20 +75,6 @@ def test_claude_backend_still_uses_dot_claude_layout(make_session_skill_manager)
     )
     assert len(skill_files) > 0
     assert not (session_path / ClaudeDirectoryConventions.PLUGIN_DIR_SKILLS_SUBDIR).exists()
-
-
-def test_codex_init_session_sessions_symlink_respects_xdg(
-    make_session_skill_manager, codex_env, monkeypatch, tmp_path
-):
-    xdg_dir = tmp_path / "custom_xdg"
-    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_dir))
-    mgr = make_session_skill_manager()
-    session_path = mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
-    sessions_link = session_path / "sessions"
-    assert sessions_link.is_symlink()
-    target = sessions_link.resolve()
-    expected = xdg_dir / "autoskillit" / "logs" / "codex-sessions"
-    assert target == expected
 
 
 def test_codex_init_session_calls_ensure_pre_launch(make_session_skill_manager, codex_env) -> None:

--- a/tests/workspace/test_session_skills_provider.py
+++ b/tests/workspace/test_session_skills_provider.py
@@ -84,22 +84,15 @@ def test_provider_does_not_inject_for_cook_session() -> None:
     ],
 )
 def test_session_skill_manager_creates_ephemeral_dir(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     make_session_skill_manager,
     backend_name: str | None,
     skills_subdir: Path,
 ) -> None:
     backend = None
     if backend_name == "codex":
-        fake_home = tmp_path / "fakehome"
-        codex_dir = fake_home / ".codex"
-        codex_dir.mkdir(parents=True)
-        (codex_dir / "config.toml").write_text("[codex]\n")
-        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
-
         backend = MagicMock()
         backend.capabilities = _CODEX_CAPABILITIES
+        backend.conventions.skills_subdir = ClaudeDirectoryConventions.PLUGIN_DIR_SKILLS_SUBDIR
         backend.ensure_pre_launch.return_value = []
 
     mgr = make_session_skill_manager()
@@ -120,8 +113,6 @@ def test_session_skill_manager_creates_ephemeral_dir(
     ],
 )
 def test_session_manager_injects_disable_for_tier2(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     make_session_skill_manager,
     backend_name: str | None,
     skills_subdir: Path,
@@ -131,14 +122,9 @@ def test_session_manager_injects_disable_for_tier2(
 
     backend = None
     if backend_name == "codex":
-        fake_home = tmp_path / "fakehome"
-        codex_dir = fake_home / ".codex"
-        codex_dir.mkdir(parents=True)
-        (codex_dir / "config.toml").write_text("[codex]\n")
-        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
-
         backend = MagicMock()
         backend.capabilities = _CODEX_CAPABILITIES
+        backend.conventions.skills_subdir = ClaudeDirectoryConventions.PLUGIN_DIR_SKILLS_SUBDIR
         backend.ensure_pre_launch.return_value = []
 
     mgr = make_session_skill_manager()
@@ -360,20 +346,14 @@ def test_init_session_backend_none_uses_claude_skills_subdir(tmp_path: Path) -> 
 
 
 def test_init_session_codex_backend_uses_codex_skills_subdir(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
 ) -> None:
-    """When capabilities.skills_subdir == 'skills', skills_base resolves to skills/."""
+    """When conventions.skills_subdir == Path('skills'), skills_base resolves to skills/."""
 
     codex_backend = MagicMock()
     codex_backend.capabilities = _CODEX_CAPABILITIES
+    codex_backend.conventions.skills_subdir = ClaudeDirectoryConventions.PLUGIN_DIR_SKILLS_SUBDIR
     codex_backend.ensure_pre_launch.return_value = []
-
-    fake_home = tmp_path / "fakehome"
-    codex_dir = fake_home / ".codex"
-    codex_dir.mkdir(parents=True)
-    (codex_dir / "config.toml").write_text("[codex]\n")
-
-    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
 
     provider = SkillsDirectoryProvider()
     mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)


### PR DESCRIPTION
## Summary

Replace the `backend.capabilities.skills_subdir` lookup in `DefaultSessionSkillManager.init_session()` with `backend.conventions.skills_subdir`, and replace the inline provisioning block (config.toml copy, auth.json symlink, .env copy, sessions symlink) with a single `backend.setup_session_dir(session_skills_dir)` delegation call. Update the `CodingAgentBackend` protocol to declare `conventions` and `setup_session_dir`. Update arch enforcement tests (`test_capability_consumption.py`, `test_backend_coherence.py`). Update all affected workspace tests: swap capabilities mocks for conventions mocks and replace artifact-asserting tests with delegation-contract tests.

Closes #3134

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260602-125954-015583/.autoskillit/temp/make-plan/p6_a4_wp1_plan_2026-06-02_130600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 138 | 33.2k | 3.7M | 120.4k | 121 | 134.6k | 18m 31s |
| verify* | sonnet | 1 | 92 | 12.8k | 492.1k | 58.0k | 32 | 41.3k | 6m 33s |
| implement* | MiniMax-M3 | 1 | 65.8k | 10.1k | 1.4M | 72.0k | 83 | 0 | 5m 33s |
| fix* | sonnet | 1 | 270 | 18.5k | 2.1M | 80.3k | 91 | 63.6k | 10m 20s |
| audit_impl* | sonnet | 1 | 76 | 18.9k | 334.5k | 61.4k | 20 | 46.4k | 8m 30s |
| prepare_pr* | MiniMax-M3 | 1 | 44.9k | 2.4k | 162.4k | 46.6k | 14 | 0 | 59s |
| compose_pr* | MiniMax-M3 | 1 | 35.4k | 1.3k | 186.1k | 38.3k | 14 | 0 | 36s |
| review_pr* | sonnet | 1 | 182 | 29.7k | 1.1M | 78.1k | 53 | 62.2k | 7m 3s |
| resolve_review* | sonnet | 1 | 149 | 10.9k | 851.5k | 61.4k | 45 | 45.3k | 5m 32s |
| resolve_pre_review_conflicts* | sonnet | 1 | 652 | 32.4k | 6.0M | 108.4k | 175 | 92.5k | 21m 1s |
| **Total** | | | 147.6k | 170.1k | 16.2M | 120.4k | | 485.9k | 1h 24m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 222 | 6379.9 | 0.0 | 45.4 |
| fix | 17 | 121169.2 | 3743.1 | 1088.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| resolve_pre_review_conflicts | 685 | 8716.9 | 135.0 | 47.2 |
| **Total** | **924** | 17577.7 | 525.9 | 184.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 138 | 33.2k | 3.7M | 134.6k | 18m 31s |
| sonnet | 6 | 1.4k | 123.1k | 10.8M | 351.3k | 59m 2s |
| MiniMax-M3 | 3 | 146.1k | 13.8k | 1.8M | 0 | 7m 8s |