### PR TITLE
Implementation Plan: BEM Group Ordering — Strengthen Instructions for Topological Correctness

### DIFF
--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -73,7 +73,7 @@ it is a positive integer ≥ 1; if a non-positive or non-integer value is provid
 with `"Error: --max-parallel must be a positive integer"`. Validate the issue count:
 - **Zero issues**: abort immediately with `"Error: build-execution-map requires at least 1 issue number"` and exit non-zero.
 - **One issue**: emit a warning and write a trivial single-group map (single issue always gets `parallel: false`).
-- **Two or more issues**: proceed to Step 0.5.
+- **Two or more issues**: proceed to Step 1.
 
 ### Step 1 — Fetch Issue Data (parallel subagents) (SINGLE MESSAGE)
 
@@ -237,12 +237,31 @@ Using the pairwise assessments from Step 2, partition issues into dispatch group
   dependency direction (the issue that others depend on goes first)
 - Groups with a single issue get `parallel: false`
 
-Merge order within parallel groups: determined by which changes are most foundational (the
-AI decides based on issue content — the issue whose changes are most likely to affect
-others merges last).
+Merge order within parallel groups: the issue whose changes are depended upon by other
+issues in the group merges first; the issue whose changes build on top of others merges
+last. When no dependency relationship exists between issues in the same parallel group,
+order by estimated impact breadth (narrower-scope changes first).
 
 The `merge_order` list is the flattened sequence of issue numbers across groups in dispatch
 order.
+
+#### Step 3a — Verify Group Ordering Invariants
+
+Before proceeding to Step 3b, work through each check below. If any check fails, re-partition
+the groups to fix the violation before continuing.
+
+1. **Dependency direction**: For every `pairwise_assessment` with `parallel_safe: false`, the
+   issue identified as the dependency is in a numerically lower-numbered group than the issue
+   that depends on it.
+2. **Transitivity**: If A must precede B (from one assessment) and B must precede C (from
+   another assessment), then `group(A) < group(B) < group(C)`.
+3. **Merge order respects dependencies**: For every `pairwise_assessment` with
+   `parallel_safe: false` where both issues are in the same parallel group, the dependency
+   issue appears earlier in the group's `merge_order` position.
+4. **No duplicate assignments**: No issue appears in more than one group.
+5. **Group count consistency**: `group_count` equals the actual number of entries in `groups[]`.
+6. **Merge order completeness**: `merge_order` contains exactly the issue numbers from all
+   `groups[]` entries, with no omissions and no extras.
 
 #### Step 3b — Deferred Issue Partitioning
 
@@ -261,7 +280,7 @@ After assembling dispatch groups, partition them based on deferral status from S
 3. Re-number groups sequentially in both `groups[]` (starting from 1) and `deferred_groups[]`
    (starting from 1, independent numbering).
 4. Compute `merge_order` from `groups[]` and `deferred_merge_order` from `deferred_groups[]`,
-   both following the same foundational-first ordering principle from Step 3.
+   both following the same dependency-first ordering rule from Step 3.
 5. Compute:
    - `deferred_count` = total issues across all `deferred_groups[]` entries
    - `dispatched_count` = `total_issues` − `deferred_count`
@@ -286,6 +305,9 @@ After groups are assembled in Step 3, enforce the `max_parallel` cap:
    - The original group's `parallel_safe` ordering is preserved — do not re-sort.
    - Sequential groups (`parallel: false`) are never split — they are passed through unchanged
      regardless of size.
+   - When splitting, apply the dependency-first ordering rule from Step 3 to decide which
+     issues land in the first sub-group vs. later sub-groups: issues that others depend on
+     go in the first sub-group.
 
 2. Renumber all groups sequentially (1, 2, 3, …) after splitting. If original Group 1
    splits into 2 sub-groups and original Group 2 remains intact, the result is:
@@ -432,10 +454,9 @@ When `--assess-review-approach` is active, each issue object gains two additiona
 }
 ```
 
-Note on `deferred_merge_order`: This field is schema-only in the current plan — no downstream
-code path reads it. It is included for structural completeness and to support future supplementary
-BEM optimization (Step 6e can reuse pre-computed ordering). When deferred issues are re-dispatched
-via Step 6e, the supplementary BEM generates its own `merge_order`, so `deferred_merge_order`
-is advisory.
+Note on `deferred_merge_order`: No downstream code path currently reads this field. It is
+included for structural completeness and to support future supplementary BEM optimization
+(Step 6e can reuse pre-computed ordering). The ordering follows the same dependency-first
+rule as `merge_order` and is equally authoritative.
 
 When the flag is inactive, these fields are omitted entirely (not set to defaults).

--- a/tests/contracts/test_execution_map_contracts.py
+++ b/tests/contracts/test_execution_map_contracts.py
@@ -403,3 +403,163 @@ def test_bem_contract_pattern_example_includes_new_tokens() -> None:
     assert "has_deferred" in example
     assert "deferred_count" in example
     assert "dispatched_count" in example
+
+
+def test_bem_has_verification_checklist_step() -> None:
+    """SKILL.md must contain a Step 3a verification checklist."""
+    text = _skill_md_text()
+    assert "Step 3a" in text, "SKILL.md must define Step 3a verification checklist"
+    lower = text.lower()
+    assert "verif" in lower, "Step 3a must be a verification step"
+
+
+def test_bem_verification_checklist_covers_dependency_direction() -> None:
+    """Step 3a must enforce that dependencies are in earlier groups."""
+    text = _skill_md_text()
+    step3a_start = text.find("Step 3a")
+    assert step3a_start != -1
+    next_heading = text.find("\n###", step3a_start + 1)
+    if next_heading == -1:
+        next_heading = text.find("\n#### Step 3b", step3a_start + 1)
+    step3a = text[step3a_start:next_heading] if next_heading != -1 else text[step3a_start:]
+    lower = step3a.lower()
+    assert "dependency" in lower, "Step 3a must check dependency direction"
+    assert (
+        "lower-numbered group" in lower or "earlier group" in lower or "numerically lower" in lower
+    ), "Step 3a must specify that dependencies go in earlier/lower-numbered groups"
+
+
+def test_bem_verification_checklist_covers_transitivity() -> None:
+    """Step 3a must enforce transitive ordering."""
+    text = _skill_md_text()
+    step3a_start = text.find("Step 3a")
+    assert step3a_start != -1
+    next_heading = text.find("\n###", step3a_start + 1)
+    if next_heading == -1:
+        next_heading = text.find("\n#### Step 3b", step3a_start + 1)
+    step3a = text[step3a_start:next_heading] if next_heading != -1 else text[step3a_start:]
+    assert "transitiv" in step3a.lower(), "Step 3a must check transitive ordering"
+
+
+def test_bem_verification_checklist_covers_no_duplicates() -> None:
+    """Step 3a must enforce no issue appears in multiple groups."""
+    text = _skill_md_text()
+    step3a_start = text.find("Step 3a")
+    assert step3a_start != -1
+    next_heading = text.find("\n###", step3a_start + 1)
+    if next_heading == -1:
+        next_heading = text.find("\n#### Step 3b", step3a_start + 1)
+    step3a = text[step3a_start:next_heading] if next_heading != -1 else text[step3a_start:]
+    lower = step3a.lower()
+    assert "more than one group" in lower or "duplicate" in lower, (
+        "Step 3a must prohibit duplicate issue assignments"
+    )
+
+
+def test_bem_merge_order_language_unambiguous() -> None:
+    """Step 3 merge-order language must not use 'most foundational...merges last' phrasing."""
+    text = _skill_md_text()
+    step3_start = text.find("### Step 3")
+    assert step3_start != -1
+    step3b_start = text.find("#### Step 3", step3_start + 10)
+    step3_section = text[step3_start:step3b_start] if step3b_start != -1 else text[step3_start:]
+    assert "most foundational" not in step3_section.lower(), (
+        "Step 3 must not use ambiguous 'most foundational' merge-order language"
+    )
+
+
+def test_bem_no_dangling_step_reference() -> None:
+    """SKILL.md must not contain a dangling 'Step 0.5' reference."""
+    text = _skill_md_text()
+    assert "Step 0.5" not in text, "SKILL.md must not reference non-existent Step 0.5"
+
+
+@pytest.fixture()
+def sample_bem_json_with_dependency_ordering() -> str:
+    return json.dumps(
+        {
+            "total_issues": 3,
+            "dispatched_count": 3,
+            "deferred_count": 0,
+            "has_deferred": False,
+            "group_count": 2,
+            "groups": [
+                {
+                    "group": 1,
+                    "parallel": False,
+                    "issues": [{"number": 100, "title": "Foundation"}],
+                },
+                {
+                    "group": 2,
+                    "parallel": True,
+                    "issues": [
+                        {"number": 101, "title": "Consumer A"},
+                        {"number": 102, "title": "Consumer B"},
+                    ],
+                },
+            ],
+            "merge_order": [100, 101, 102],
+            "pairwise_assessments": [
+                {
+                    "pair": [100, 101],
+                    "parallel_safe": False,
+                    "confidence": "high",
+                    "reasoning": "#101 depends on #100's API changes",
+                },
+                {
+                    "pair": [100, 102],
+                    "parallel_safe": False,
+                    "confidence": "high",
+                    "reasoning": "#102 depends on #100's API changes",
+                },
+                {
+                    "pair": [101, 102],
+                    "parallel_safe": True,
+                    "confidence": "high",
+                    "reasoning": "Independent consumers of #100",
+                },
+            ],
+            "deferred_groups": [],
+            "deferred_merge_order": [],
+        }
+    )
+
+
+def test_bem_merge_order_invariant_dependency_direction(
+    sample_bem_json_with_dependency_ordering: str,
+) -> None:
+    """merge_order must place dependencies before their dependents."""
+    data = json.loads(sample_bem_json_with_dependency_ordering)
+    merge_order = data["merge_order"]
+    for assessment in data["pairwise_assessments"]:
+        if not assessment["parallel_safe"]:
+            a, b = assessment["pair"]
+            a_group = next(
+                g["group"] for g in data["groups"] for i in g["issues"] if i["number"] == a
+            )
+            b_group = next(
+                g["group"] for g in data["groups"] for i in g["issues"] if i["number"] == b
+            )
+            if a_group < b_group:
+                assert merge_order.index(a) < merge_order.index(b)
+            elif b_group < a_group:
+                assert merge_order.index(b) < merge_order.index(a)
+
+
+def test_bem_deferred_merge_order_not_advisory() -> None:
+    """Schema notes must not describe deferred_merge_order as advisory."""
+    text = _skill_md_text()
+    dmo_start = text.find("deferred_merge_order")
+    assert dmo_start != -1
+    schema_notes_start = text.find("Schema notes:", dmo_start - 500)
+    if schema_notes_start == -1:
+        schema_notes_start = text.find("Note on `deferred_merge_order`")
+    assert schema_notes_start != -1
+    next_section = text.find("\n##", schema_notes_start + 1)
+    notes_section = (
+        text[schema_notes_start:next_section] if next_section != -1 else text[schema_notes_start:]
+    )
+    assert "advisory" not in notes_section.lower(), (
+        "deferred_merge_order must not be described as advisory; "
+        "it follows the same ordering rule as merge_order"
+    )


### PR DESCRIPTION
## Summary

Add a post-assembly verification checklist (Step 3a) to the BEM `build-execution-map` SKILL.md that forces the LLM to self-check dependency ordering invariants before proceeding. Fix ambiguous merge-order language, resolve the `deferred_merge_order` directive-vs-advisory inconsistency, fix the dangling "Step 0.5" reference, and add contract tests verifying the new verification checklist exists and covers key invariants.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260602-093431-655257/.autoskillit/temp/make-plan/bem_group_ordering_strengthen_instructions_plan_2026-06-02_143228.md`

Closes #3609

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 1.2k | 23.4k | 2.5M | 79.8k | 80 | 187.1k | 22m 10s |
| review_approach* | opus[1m] | 1 | 1.6k | 4.7k | 219.9k | 41.7k | 13 | 27.5k | 3m 12s |
| verify* | opus[1m] | 1 | 35 | 8.2k | 373.4k | 67.8k | 21 | 50.9k | 3m 35s |
| implement* | MiniMax-M3 | 1 | 63.7k | 7.6k | 1.8M | 69.6k | 57 | 0 | 3m 11s |
| audit_impl* | opus[1m] | 1 | 33 | 7.7k | 181.9k | 39.1k | 14 | 30.7k | 3m 18s |
| prepare_pr* | MiniMax-M3 | 1 | 41.7k | 1.7k | 119.1k | 45.1k | 11 | 0 | 39s |
| compose_pr* | MiniMax-M3 | 1 | 37.3k | 1.1k | 186.0k | 38.3k | 11 | 0 | 37s |
| review_pr* | opus[1m] | 2 | 65 | 35.9k | 1.5M | 73.7k | 59 | 103.1k | 12m 15s |
| resolve_review* | opus[1m] | 1 | 32 | 4.0k | 628.5k | 49.2k | 28 | 32.8k | 4m 35s |
| **Total** | | | 145.7k | 94.3k | 7.5M | 79.8k | | 432.2k | 53m 35s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 201 | 9139.6 | 0.0 | 37.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **201** | 37353.9 | 2150.0 | 469.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 3.0k | 83.9k | 5.4M | 432.2k | 49m 8s |
| MiniMax-M3 | 3 | 142.7k | 10.4k | 2.1M | 0 | 4m 27s |