### PR TITLE
Implementation Plan: P6-A1-WP1 — Add skills_subdir Field to BackendConventions

### DIFF
--- a/tests/core/test_backend_dataclasses.py
+++ b/tests/core/test_backend_dataclasses.py
@@ -202,20 +202,27 @@ def test_backend_module_all_exhaustive():
 def test_backend_conventions_frozen_slots_fields():
     import typing
     from dataclasses import FrozenInstanceError
+    from pathlib import Path
 
     from autoskillit.core.types._type_backend import BackendConventions
 
     assert hasattr(BackendConventions, "__slots__")
 
     inst = BackendConventions(
+        skills_subdir=Path("/claude/skills"),
         project_local_skill_search_dirs=(".claude/skills",),
     )
+    assert inst.skills_subdir == Path("/claude/skills")
     assert inst.project_local_skill_search_dirs == (".claude/skills",)
+
+    with pytest.raises(FrozenInstanceError):
+        inst.skills_subdir = Path("/other")  # type: ignore[misc]
 
     with pytest.raises(FrozenInstanceError):
         inst.project_local_skill_search_dirs = (".other/skills",)  # type: ignore[misc]
 
     hints = typing.get_type_hints(BackendConventions)
+    assert hints["skills_subdir"] is Path
     assert hints["project_local_skill_search_dirs"] == tuple[str, ...]
 
 

--- a/tests/core/test_backend_protocols.py
+++ b/tests/core/test_backend_protocols.py
@@ -101,7 +101,10 @@ def test_stub_class_satisfies_coding_agent_backend():
 
         @property
         def conventions(self) -> BackendConventions:
-            return BackendConventions(project_local_skill_search_dirs=())
+            return BackendConventions(
+                skills_subdir=Path("test/skills"),
+                project_local_skill_search_dirs=(),
+            )
 
         def build_cmd(self, skill_command: str, cwd: str) -> CmdSpec: ...
 

--- a/tests/execution/backends/test_claude_code_backend.py
+++ b/tests/execution/backends/test_claude_code_backend.py
@@ -97,6 +97,7 @@ class TestClaudeCodeBackend:
     def test_conventions_returns_backend_conventions(self) -> None:
         result = ClaudeCodeBackend().conventions
         assert isinstance(result, BackendConventions)
+        assert result.skills_subdir == Path(".claude/skills")
         assert result.project_local_skill_search_dirs == (
             ".claude/skills",
             ".autoskillit/skills",

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -1327,6 +1327,9 @@ class TestCodexBackendConventions:
     def test_agents_skills_in_project_local_dirs(self) -> None:
         assert ".agents/skills" in CodexBackend().conventions.project_local_skill_search_dirs
 
+    def test_conventions_skills_subdir(self) -> None:
+        assert CodexBackend().conventions.skills_subdir == Path("skills")
+
 
 class TestCodexBackendSetupSessionDir:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Add the `skills_subdir: Path` required field to the existing `BackendConventions` frozen dataclass in `_type_backend.py`, import `Path` from `pathlib`, and update all constructor call sites (2 production backends + 2 test files) to supply the new required argument. Extend `test_backend_conventions_frozen_slots_fields` to cover the new field's type hint, value access, and immutability.

Most deliverables from the issue (class definition, `__all__` entry, protocol members, `__init__.pyi` stub, protocol tests) were completed in prior commits on this branch. The sole remaining gap is the `skills_subdir: Path` field and its cascading constructor updates.

**Design note — `BackendConventions.skills_subdir: Path` vs `BackendCapabilities.skills_subdir: str`:** This is intentional transitional staging. `BackendCapabilities.skills_subdir: str` is the legacy field currently consumed by `session_skills.py:610-612` (which wraps it in `Path(...)` at the call site). `BackendConventions.skills_subdir: Path` is the properly typed replacement. The production consumer migration from `backend.capabilities.skills_subdir` to `backend.conventions.skills_subdir` is deferred to downstream WPs (P6-A2, P6-A3) that depend on this WP. Until then, the field is forward-declared with no production reader — this is expected and matches the phased rollout.

Closes #3131

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260602-142822-217856/.autoskillit/temp/make-plan/p6_a1_wp1_define_backendconventions_plan_2026-06-02_145600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 90 | 19.9k | 1.7M | 102.2k | 66 | 163.3k | 12m 25s |
| verify* | opus[1m] | 1 | 37 | 6.2k | 400.1k | 53.3k | 22 | 36.4k | 4m 43s |
| implement* | MiniMax-M3 | 1 | 56.0k | 7.5k | 1.2M | 61.0k | 76 | 0 | 3m 53s |
| audit_impl* | opus[1m] | 1 | 23 | 4.5k | 144.5k | 36.8k | 12 | 24.4k | 2m 10s |
| prepare_pr* | MiniMax-M3 | 1 | 43.1k | 2.5k | 160.6k | 45.1k | 13 | 0 | 52s |
| compose_pr* | MiniMax-M3 | 1 | 37.6k | 1.4k | 149.3k | 39.0k | 12 | 0 | 40s |
| review_pr* | sonnet | 2 | 292 | 52.1k | 1.6M | 72.3k | 91 | 107.0k | 12m 3s |
| resolve_review* | opus[1m] | 1 | 42 | 7.9k | 849.2k | 68.4k | 39 | 52.0k | 6m 10s |
| resolve_pre_review_conflicts* | opus[1m] | 1 | 32 | 4.5k | 677.9k | 72.1k | 34 | 55.5k | 1m 44s |
| **Total** | | | 137.3k | 106.5k | 7.0M | 102.2k | | 438.6k | 44m 42s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 22 | 56613.6 | 0.0 | 339.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| resolve_pre_review_conflicts | 222 | 3053.5 | 250.0 | 20.3 |
| **Total** | **244** | 28575.9 | 1797.7 | 436.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 5 | 224 | 42.9k | 3.8M | 331.7k | 27m 14s |
| MiniMax-M3 | 3 | 136.8k | 11.4k | 1.6M | 0 | 5m 25s |
| sonnet | 1 | 292 | 52.1k | 1.6M | 107.0k | 12m 3s |