### PR TITLE
Pipeline Health Scanner — Codex Log Format Support

### DIFF
--- a/src/autoskillit/agents/pipeline-health-scanner.md
+++ b/src/autoskillit/agents/pipeline-health-scanner.md
@@ -11,7 +11,7 @@ You are a **Pipeline Health Scanner** — an analysis agent that reads through a
 ## Your Inputs
 
 You receive:
-1. `sessions.jsonl` entries for your batch (step_name, success, subtype, duration, tokens, anomaly_count, claude_code_log path, session directory path)
+1. `sessions.jsonl` entries for your batch (step_name, success, subtype, duration, tokens, anomaly_count, claude_code_log path, codex_log path, backend, session directory path)
 2. Context about what the step is supposed to do
 
 ## Data Sources
@@ -19,9 +19,41 @@ You receive:
 For each session in your batch, you have access to:
 
 - **`summary.json`** — structured overview: `turn_tool_calls`, `success`, `subtype`, `write_call_count`, `anomaly_count`, `duration_seconds`, `silent_gap_seconds`
-- **Claude Code JSONL** (via `claude_code_log` path) — full session transcript; grep for errors, read specific turns, check tool results
+- **Claude Code JSONL** (via `claude_code_log` path) — full session transcript; grep for errors, read specific turns, check tool results. Only available for Claude Code backend sessions.
+- **Codex NDJSON** (via `codex_log` path) — Codex rollout log; see "Codex Session Logs" section below for reading strategy. Only available for Codex backend sessions.
 - **`anomalies.jsonl`** — process-level anomalies (if present)
 - **`audit_log.json`** — failure records with retry reasons (if present)
+
+### Codex Session Logs (NDJSON)
+
+When `claude_code_log` is null and `codex_log` is non-null (or `backend` is `"codex"`), the session used the Codex backend. The `codex_log` path points to a `rollout-*.jsonl` file containing NDJSON events.
+
+**Reading strategy — use grep, not Read.** Codex rollout files can be large for multi-hour sessions. Extract only the event types you need:
+
+- **Failure detection:** `grep 'turn.failed' <codex_log_path>` — each line is a JSON object with `error.message` and `error.code` (e.g. `rate_limit_exceeded`, `context_length_exceeded`)
+- **Tool call inventory:** `grep '"mcp_tool_call"' <codex_log_path>` — each `item.completed` event with `item.type: "mcp_tool_call"` has `tool_name` and `args`
+- **Shell commands:** `grep '"function_call"' <codex_log_path>` — each `item.completed` event with `item.type: "function_call"` has `name` (e.g. `"shell"`), `args`, and `output`
+- **Token usage:** `grep 'turn.completed' <codex_log_path>` — the `usage` object has `input_tokens`, `output_tokens`, `cached_input_tokens`
+- **Session identity:** `grep 'thread.started' <codex_log_path>` — contains `thread_id`
+
+**Grep false positives:** Grep matches any line containing the string, not only lines where it is the `event` field value. After grepping, validate the event type before extracting fields: pipe through `python3 -c "import sys,json; [print(l) for l in sys.stdin if json.loads(l.strip()).get('event')=='turn.failed']"` or use `jq 'select(.event == "turn.failed")'`. Apply the same pattern for other event types.
+
+**Typical event shapes (for field reference):**
+- `turn.failed`: `{"event":"turn.failed","error":{"code":"rate_limit_exceeded","message":"Rate limit exceeded"}}`
+- `turn.completed`: `{"event":"turn.completed","usage":{"input_tokens":1234,"output_tokens":456,"cached_input_tokens":0}}`
+- `thread.started`: `{"event":"thread.started","thread_id":"abc-123"}`
+- `item.completed` (tool): `{"event":"item.completed","item":{"type":"mcp_tool_call","tool_name":"Read","args":{}}}`
+
+**Multi-version note:** `args` and `output` fields on `mcp_tool_call` events may be absent in sessions from Codex versions before mid-2025 (added in Codex PR #5899). Do not crash or error if these fields are missing — treat their absence as "no argument data available".
+
+**What Codex logs CAN provide:** which tools were called (names and counts), whether turns failed, error codes and messages, token usage per turn, file changes, success/failure classification.
+
+**What Codex logs CANNOT provide:** per-turn timestamps, request IDs, conversation structure, subagent spawn records, silent gap detection. Do NOT attempt to reconstruct Claude-style turn-by-turn analysis from Codex NDJSON.
+
+**Graceful degradation:**
+- `claude_code_log` present → full analysis (existing behavior)
+- `codex_log` present, `claude_code_log` null → coarse analysis (tool counts, error detection, success/failure)
+- Both null → summary.json and anomalies.jsonl only (no transcript analysis)
 
 ## Analysis Approach
 

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -563,6 +563,7 @@ class SessionIndexEntry(TypedDict):
     dispatch_id: str
     claude_code_log: str | None  # path to Claude Code JSONL, or None for non-Claude-Code sessions
     codex_log: str | None  # path to Codex rollout NDJSON, or None for non-Codex sessions
+    backend: str  # "claude-code" or "codex" — unambiguous backend identifier
     skill_command: str
     success: bool
     subtype: str

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -303,6 +303,7 @@ async def _execute_claude_headless(
                     ),
                     max_sessions=ctx.config.linux_tracing.max_sessions,
                     model_identity=model_identity,
+                    backend=_step_backend.name,
                     telemetry=_build_error_path_telemetry(
                         ctx.github_api_log,
                         session_id="",
@@ -364,6 +365,7 @@ async def _execute_claude_headless(
                         ),
                         max_sessions=ctx.config.linux_tracing.max_sessions,
                         model_identity=model_identity,
+                        backend=_step_backend.name,
                         telemetry=_build_error_path_telemetry(
                             ctx.github_api_log,
                             session_id="",
@@ -563,6 +565,7 @@ async def _execute_claude_headless(
                 model_identity=model_identity,
                 is_resume=spec.is_resume,
                 codex_log_path=_codex_log,
+                backend=_step_backend.name,
             )
         except Exception:
             logger.debug("session_log_flush_failed", exc_info=True)

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -9,7 +9,7 @@ import traceback
 from collections.abc import Callable, Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 import anyio
 
@@ -303,7 +303,7 @@ async def _execute_claude_headless(
                     ),
                     max_sessions=ctx.config.linux_tracing.max_sessions,
                     model_identity=model_identity,
-                    backend=_step_backend.name,
+                    backend=cast(Literal["claude-code", "codex"], _step_backend.name),
                     telemetry=_build_error_path_telemetry(
                         ctx.github_api_log,
                         session_id="",
@@ -365,7 +365,7 @@ async def _execute_claude_headless(
                         ),
                         max_sessions=ctx.config.linux_tracing.max_sessions,
                         model_identity=model_identity,
-                        backend=_step_backend.name,
+                        backend=cast(Literal["claude-code", "codex"], _step_backend.name),
                         telemetry=_build_error_path_telemetry(
                             ctx.github_api_log,
                             session_id="",
@@ -565,7 +565,7 @@ async def _execute_claude_headless(
                 model_identity=model_identity,
                 is_resume=spec.is_resume,
                 codex_log_path=_codex_log,
-                backend=_step_backend.name,
+                backend=cast(Literal["claude-code", "codex"], _step_backend.name),
             )
         except Exception:
             logger.debug("session_log_flush_failed", exc_info=True)

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -13,7 +13,7 @@ import shutil
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from autoskillit.core import ProviderOutcome, RecipeIdentity, SessionTelemetry
@@ -152,7 +152,7 @@ def flush_session_log(
     max_sessions: int | None = None,
     is_resume: bool = False,
     codex_log_path: Path | None = None,
-    backend: str = "claude-code",
+    backend: Literal["claude-code", "codex"] = "claude-code",
     telemetry: SessionTelemetry,
 ) -> None:
     """Flush session diagnostics to disk.

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -152,6 +152,7 @@ def flush_session_log(
     max_sessions: int | None = None,
     is_resume: bool = False,
     codex_log_path: Path | None = None,
+    backend: str = "claude-code",
     telemetry: SessionTelemetry,
 ) -> None:
     """Flush session diagnostics to disk.
@@ -393,6 +394,7 @@ def flush_session_log(
         "tracked_comm": _effective_tracked_comm,
         "tracked_comm_drift": _tracked_comm_drift,
         "tracer_target_resolution_version": 2,
+        "backend": backend,
         "orphaned_tool_result": orphaned_tool_result,
         "last_stop_reason": last_stop_reason,
         "request_ids": _cb_request_ids,
@@ -513,6 +515,7 @@ def flush_session_log(
         "file_changes_count": file_changes_count,
         "tracked_comm": _effective_tracked_comm,
         "tracked_comm_drift": _tracked_comm_drift,
+        "backend": backend,
         "autoskillit_version": versions.get("autoskillit_version", "") if versions else "",
         "claude_code_version": versions.get("claude_code_version", "") if versions else "",
         "codex_version": versions.get("codex_version", "") if versions else "",

--- a/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
@@ -51,6 +51,16 @@ Read ~/.local/share/autoskillit/logs/sessions.jsonl and filter entries where kit
 
 Group the filtered entries by step_name. Each group represents one phase of the pipeline (e.g., plan, implement, test, merge).
 
+### Step 2b: Identify Codex sessions
+
+Some sessions may use the Codex backend instead of Claude Code. These are identifiable by:
+- `backend` field is `"codex"` in the sessions.jsonl entry
+- `codex_log` is non-null while `claude_code_log` is null
+
+When passing session entries to scanner subagents in Step 3, include the `codex_log` path and `backend` field in the JSON array. The scanner agent knows how to handle both backend types — it will use grep-based coarse analysis for Codex sessions and full JSONL analysis for Claude Code sessions.
+
+No special grouping is needed — Codex and Claude Code sessions for the same step can be in the same scanner batch.
+
 ### Step 3: Spawn scanner subagents (SINGLE MESSAGE)
 
 **Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
@@ -60,7 +70,7 @@ Do not output any prose between subagent dispatches. Immediately proceed to the 
 For each step group, spawn a scanner subagent via the Agent tool with subagent_type: "autoskillit:pipeline-health-scanner".
 
 Each scanner receives in its prompt:
-- The sessions.jsonl entries for its batch (JSON array)
+- The sessions.jsonl entries for its batch (JSON array — includes `claude_code_log`, `codex_log`, and `backend` fields)
 - The session directory paths: ~/.local/share/autoskillit/logs/sessions/<dir_name>/
 - Context about what the step does (derive from step_name)
 

--- a/tests/contracts/test_analyze_pipeline_health_contracts.py
+++ b/tests/contracts/test_analyze_pipeline_health_contracts.py
@@ -62,3 +62,12 @@ def test_analyze_pipeline_health_pattern_examples_match_delimiter():
         assert _check_expected_patterns(example, [_OUTPUT_DELIMITER]), (
             f"pattern_example must match '{_OUTPUT_DELIMITER}' after normalization: {example!r}"
         )
+
+
+def test_analyze_pipeline_health_skill_has_codex_guidance():
+    """SKILL.md must contain guidance for Codex session handling."""
+    from autoskillit.core import pkg_root
+
+    skill_path = pkg_root() / "skills_extended" / "analyze-pipeline-health" / "SKILL.md"
+    content = skill_path.read_text()
+    assert "codex_log" in content, "SKILL.md must reference codex_log for Codex session handling"

--- a/tests/core/test_session_index_schema.py
+++ b/tests/core/test_session_index_schema.py
@@ -24,6 +24,7 @@ _REQUIRED_INDEX_FIELDS = {
     "api_retry_exhausted",
     "codex_version",
     "codex_log",
+    "backend",
     "skill_command",
 }
 

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -309,7 +309,7 @@ def _subagent_assistant_ndjson(
     )
 
 
-def _flush(tmp_path: Path, **overrides) -> None:
+def _flush(tmp_path: Path, *, backend: str = "claude-code", **overrides) -> None:
     from autoskillit.core.types._type_results import ModelIdentity, ProviderOutcome
     from autoskillit.core.types._type_results_execution import (
         RecipeIdentity,
@@ -391,6 +391,7 @@ def _flush(tmp_path: Path, **overrides) -> None:
         telemetry=telemetry,
         provider_outcome=provider_outcome,
         recipe_identity=recipe_identity,
+        backend=backend,
     )
 
 

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -1781,3 +1781,26 @@ def test_model_identity_readers_agree(tmp_path, model_identity, expected_model):
 
     assert disk_model == hook_model, f"readers disagree: disk={disk_model!r}, hook={hook_model!r}"
     assert disk_model == expected_model
+
+
+class TestBackendField:
+    """backend field in sessions.jsonl and summary.json."""
+
+    def test_flush_stores_backend_in_sessions_index(self, tmp_path):
+        """flush_session_log with backend='codex' writes backend to index."""
+        _flush(tmp_path, backend="codex")
+        entry = json.loads((tmp_path / "sessions.jsonl").read_text().strip())
+        assert entry["backend"] == "codex"
+
+    def test_flush_stores_backend_in_summary(self, tmp_path):
+        """flush_session_log with backend='codex' writes backend to summary.json."""
+        _flush(tmp_path, backend="codex")
+        dirs = [d for d in (tmp_path / "sessions").iterdir() if d.is_dir()]
+        summary = json.loads((dirs[0] / "summary.json").read_text())
+        assert summary["backend"] == "codex"
+
+    def test_flush_backend_defaults_to_claude_code(self, tmp_path):
+        """When backend is not provided, defaults to 'claude-code'."""
+        _flush(tmp_path)
+        entry = json.loads((tmp_path / "sessions.jsonl").read_text().strip())
+        assert entry["backend"] == "claude-code"

--- a/tests/server/test_tools_agents.py
+++ b/tests/server/test_tools_agents.py
@@ -448,6 +448,14 @@ def test_pipeline_health_scanner_agent_exists():
     assert "scan_result:" in body, (
         "pipeline-health-scanner.md body must contain a 'scan_result:' structured completion token"
     )
+    assert "codex_log" in body, (
+        "pipeline-health-scanner.md body must contain Codex log guidance "
+        "(codex_log data source section)"
+    )
+    assert "turn.failed" in body, (
+        "pipeline-health-scanner.md body must reference turn.failed event type "
+        "(Codex error detection guidance)"
+    )
 
 
 # DIAG_C7: plan-registry-tracer maxTurns >= 80


### PR DESCRIPTION
## Summary

Extend the pipeline-health-scanner agent definition and analyze-pipeline-health skill to read and analyze Codex NDJSON rollout files (`codex_log`) when `claude_code_log` is null. Add a `backend` field to `sessions.jsonl` index entries for unambiguous backend identification. Add a synthetic Codex rollout fixture and tests validating the new content.

Closes #3498

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260602-160510-748571/.autoskillit/temp/make-plan/pipeline_health_scanner_codex_log_format_support_plan_2026-06-02_162000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 3.9k | 1.4k | 6.7M | 120.3k | 92 | 237.0k | 19m 4s |
| review_approach* | sonnet | 1 | 1.4k | 6.0k | 182.3k | 40.9k | 15 | 27.7k | 3m 18s |
| verify* | sonnet | 1 | 76 | 13.3k | 394.7k | 59.6k | 30 | 42.9k | 5m 0s |
| implement* | MiniMax-M3 | 1 | 68.0k | 10.9k | 2.3M | 75.1k | 98 | 0 | 6m 20s |
| audit_impl* | sonnet | 1 | 44 | 9.0k | 146.4k | 40.2k | 15 | 33.4k | 5m 0s |
| prepare_pr* | MiniMax-M3 | 1 | 45.1k | 2.0k | 324.6k | 46.0k | 20 | 0 | 1m 3s |
| compose_pr* | MiniMax-M3 | 1 | 34.7k | 1.2k | 186.5k | 38.1k | 12 | 0 | 38s |
| review_pr* | sonnet | 1 | 110 | 30.7k | 600.1k | 76.3k | 43 | 60.3k | 7m 10s |
| resolve_review* | opus[1m] | 1 | 49 | 11.8k | 1.7M | 66.1k | 62 | 49.4k | 8m 33s |
| resolve_pre_review_conflicts* | opus[1m] | 1 | 25 | 1.8k | 226.8k | 40.3k | 18 | 23.5k | 47s |
| **Total** | | | 153.4k | 88.2k | 12.8M | 120.3k | | 474.2k | 56m 57s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 99 | 23105.2 | 0.0 | 110.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 12 | 142614.4 | 4116.8 | 982.1 |
| resolve_pre_review_conflicts | 898 | 252.6 | 26.2 | 2.0 |
| **Total** | **1009** | 12647.2 | 470.0 | 87.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 3 | 3.9k | 15.0k | 8.6M | 309.9k | 28m 24s |
| sonnet | 4 | 1.7k | 59.1k | 1.3M | 164.4k | 20m 30s |
| MiniMax-M3 | 3 | 147.8k | 14.1k | 2.8M | 0 | 8m 2s |