### PR TITLE
Disable Codex image_generation Hosted Tool in All Spawned Sessions

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -390,6 +390,8 @@ class CodexBackend:
             CodexFlags.JSON,
             CodexFlags.SANDBOX,
             "workspace-write",
+            CodexFlags.CONFIG_OVERRIDE,
+            "features.image_generation=false",
         ]
         if model:
             cmd += [CodexFlags.MODEL, self.translate_model(model)]
@@ -527,6 +529,8 @@ class CodexBackend:
             "workspace-write",
             CodexFlags.ASK_FOR_APPROVAL_SHORT,
             "never",
+            CodexFlags.CONFIG_OVERRIDE,
+            "features.image_generation=false",
         ]
         if model:
             cmd += [CodexFlags.MODEL, self.translate_model(model)]
@@ -633,6 +637,8 @@ class CodexBackend:
             "never",
             CodexFlags.CONFIG_OVERRIDE,
             "web_search=disabled",
+            CodexFlags.CONFIG_OVERRIDE,
+            "features.image_generation=false",
         ]
         if model:
             cmd += [CodexFlags.MODEL, self.translate_model(model)]
@@ -674,6 +680,7 @@ class CodexBackend:
                 builder.mode_flag(CodexFlags.DANGEROUSLY_BYPASS)
         if model:
             builder.kv_flag(CodexFlags.MODEL, self.translate_model(model))
+        builder.kv_flag(CodexFlags.CONFIG_OVERRIDE, "features.image_generation=false")
         if system_prompt is not None and isinstance(resume_spec, NoResume):
             builder.kv_flag(CodexFlags.CONFIG_OVERRIDE, f"developer_instructions={system_prompt}")
         if initial_prompt is not None:
@@ -715,6 +722,7 @@ class CodexBackend:
         if output_format == OutputFormat.JSON:
             cmd.append(CodexFlags.JSON)
         cmd.extend([CodexFlags.SANDBOX, "read-only"])
+        cmd.extend([CodexFlags.CONFIG_OVERRIDE, "features.image_generation=false"])
         cmd.append(CodexFlags.RESUME_SUBCOMMAND)
         cmd.append(resume_session_id)
         cmd.append(prompt)

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -100,6 +100,8 @@ CODEX_ENV_DENYLIST: frozenset[str] = frozenset(
 
 CODEX_ENV_PREFIX_DENYLIST: tuple[str, ...] = ("CLAUDE_CODE_",)
 
+_IMAGE_GENERATION_DISABLED = "features.image_generation=false"
+
 
 @dataclass(frozen=True, slots=True)
 class CodexEnvPolicy:
@@ -391,7 +393,7 @@ class CodexBackend:
             CodexFlags.SANDBOX,
             "workspace-write",
             CodexFlags.CONFIG_OVERRIDE,
-            "features.image_generation=false",
+            _IMAGE_GENERATION_DISABLED,
         ]
         if model:
             cmd += [CodexFlags.MODEL, self.translate_model(model)]
@@ -530,7 +532,7 @@ class CodexBackend:
             CodexFlags.ASK_FOR_APPROVAL_SHORT,
             "never",
             CodexFlags.CONFIG_OVERRIDE,
-            "features.image_generation=false",
+            _IMAGE_GENERATION_DISABLED,
         ]
         if model:
             cmd += [CodexFlags.MODEL, self.translate_model(model)]
@@ -638,7 +640,7 @@ class CodexBackend:
             CodexFlags.CONFIG_OVERRIDE,
             "web_search=disabled",
             CodexFlags.CONFIG_OVERRIDE,
-            "features.image_generation=false",
+            _IMAGE_GENERATION_DISABLED,
         ]
         if model:
             cmd += [CodexFlags.MODEL, self.translate_model(model)]
@@ -680,7 +682,7 @@ class CodexBackend:
                 builder.mode_flag(CodexFlags.DANGEROUSLY_BYPASS)
         if model:
             builder.kv_flag(CodexFlags.MODEL, self.translate_model(model))
-        builder.kv_flag(CodexFlags.CONFIG_OVERRIDE, "features.image_generation=false")
+        builder.kv_flag(CodexFlags.CONFIG_OVERRIDE, _IMAGE_GENERATION_DISABLED)
         if system_prompt is not None and isinstance(resume_spec, NoResume):
             builder.kv_flag(CodexFlags.CONFIG_OVERRIDE, f"developer_instructions={system_prompt}")
         if initial_prompt is not None:
@@ -722,7 +724,7 @@ class CodexBackend:
         if output_format == OutputFormat.JSON:
             cmd.append(CodexFlags.JSON)
         cmd.extend([CodexFlags.SANDBOX, "read-only"])
-        cmd.extend([CodexFlags.CONFIG_OVERRIDE, "features.image_generation=false"])
+        cmd.extend([CodexFlags.CONFIG_OVERRIDE, _IMAGE_GENERATION_DISABLED])
         cmd.append(CodexFlags.RESUME_SUBCOMMAND)
         cmd.append(resume_session_id)
         cmd.append(prompt)

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -359,6 +359,8 @@ class TestCodexHeadlessCmd:
             "--json",
             "--sandbox",
             "workspace-write",
+            "-c",
+            "features.image_generation=false",
             "do stuff",
         )
 
@@ -418,6 +420,8 @@ class TestCodexResumeCmd:
             "--json",
             "--sandbox",
             "read-only",
+            "-c",
+            "features.image_generation=false",
             "resume",
             "abc123",
             "continue",
@@ -744,9 +748,11 @@ class TestCodexBuildInteractiveCmd:
 
     def test_system_prompt_with_no_resume_appends_config_override(self) -> None:
         spec = CodexBackend().build_interactive_cmd(system_prompt="foo")
-        assert CodexFlags.CONFIG_OVERRIDE in spec.cmd
-        idx = spec.cmd.index(CodexFlags.CONFIG_OVERRIDE)
-        assert spec.cmd[idx + 1] == "developer_instructions=foo"
+        overrides = [
+            spec.cmd[i + 1] for i, v in enumerate(spec.cmd[:-1]) if v == CodexFlags.CONFIG_OVERRIDE
+        ]
+        assert "developer_instructions=foo" in overrides
+        assert "features.image_generation=false" in overrides
 
     def test_system_prompt_with_named_resume_does_not_append_config_override(self) -> None:
         from autoskillit.core import NamedResume
@@ -754,7 +760,11 @@ class TestCodexBuildInteractiveCmd:
         spec = CodexBackend().build_interactive_cmd(
             resume_spec=NamedResume(session_id="s1"), system_prompt="foo"
         )
-        assert CodexFlags.CONFIG_OVERRIDE not in spec.cmd
+        overrides = [
+            spec.cmd[i + 1] for i, v in enumerate(spec.cmd[:-1]) if v == CodexFlags.CONFIG_OVERRIDE
+        ]
+        assert not any(v.startswith("developer_instructions=") for v in overrides)
+        assert "features.image_generation=false" in overrides
 
     def test_add_dirs_appends_add_dir_for_each_entry(self) -> None:
         spec = CodexBackend().build_interactive_cmd(add_dirs=["/a", "/b"])

--- a/tests/execution/backends/test_codex_interactive.py
+++ b/tests/execution/backends/test_codex_interactive.py
@@ -66,27 +66,40 @@ class TestCodexInteractiveCmdSystemPrompt:
             system_prompt="do stuff",
             resume_spec=NoResume(),
         )
-        assert CodexFlags.CONFIG_OVERRIDE in spec.cmd
-        idx = list(spec.cmd).index(CodexFlags.CONFIG_OVERRIDE)
-        assert spec.cmd[idx + 1] == "developer_instructions=do stuff"
+        overrides = [
+            spec.cmd[i + 1] for i, v in enumerate(spec.cmd[:-1]) if v == CodexFlags.CONFIG_OVERRIDE
+        ]
+        assert "developer_instructions=do stuff" in overrides
+        assert "features.image_generation=false" in overrides
 
     def test_system_prompt_with_named_resume_suppressed(self) -> None:
         spec = CodexBackend().build_interactive_cmd(
             system_prompt="do stuff",
             resume_spec=NamedResume(session_id="s1"),
         )
-        assert CodexFlags.CONFIG_OVERRIDE not in spec.cmd
+        overrides = [
+            spec.cmd[i + 1] for i, v in enumerate(spec.cmd[:-1]) if v == CodexFlags.CONFIG_OVERRIDE
+        ]
+        assert not any(v.startswith("developer_instructions=") for v in overrides)
+        assert "features.image_generation=false" in overrides
 
     def test_system_prompt_with_bare_resume_suppressed(self) -> None:
         spec = CodexBackend().build_interactive_cmd(
             system_prompt="do stuff",
             resume_spec=BareResume(),
         )
-        assert CodexFlags.CONFIG_OVERRIDE not in spec.cmd
+        overrides = [
+            spec.cmd[i + 1] for i, v in enumerate(spec.cmd[:-1]) if v == CodexFlags.CONFIG_OVERRIDE
+        ]
+        assert not any(v.startswith("developer_instructions=") for v in overrides)
+        assert "features.image_generation=false" in overrides
 
     def test_no_system_prompt_with_no_resume_excludes_config_override(self) -> None:
         spec = CodexBackend().build_interactive_cmd(resume_spec=NoResume())
-        assert CodexFlags.CONFIG_OVERRIDE not in spec.cmd
+        overrides = [
+            spec.cmd[i + 1] for i, v in enumerate(spec.cmd[:-1]) if v == CodexFlags.CONFIG_OVERRIDE
+        ]
+        assert overrides == ["features.image_generation=false"]
 
 
 class TestCodexInteractiveCmdAddDirs:

--- a/tests/execution/test_recording_sigterm.py
+++ b/tests/execution/test_recording_sigterm.py
@@ -15,7 +15,6 @@ import sys
 
 import pytest
 
-from autoskillit.core.runtime.readiness import readiness_sentinel_path
 from tests._subprocess_ready import wait_for_subprocess_ready
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
@@ -32,27 +31,37 @@ def test_sigterm_writes_scenario_json(tmp_path):
     """
     output_dir = tmp_path / "scenario"
     output_dir.mkdir()
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
 
     env = {
         **os.environ,
         "RECORD_SCENARIO": "1",
         "RECORD_SCENARIO_DIR": str(output_dir),
         "RECORD_SCENARIO_RECIPE": "test-recipe",
+        "AUTOSKILLIT_STATE_DIR": str(state_dir),
     }
     # Use sys.executable -m to ensure we run the worktree-installed version,
     # not a system-wide `autoskillit` binary that may lack the lifespan fix.
+    # cwd=tmp_path and AUTOSKILLIT_STATE_DIR isolate the subprocess's
+    # filesystem state from the project tree (e.g. any real execution
+    # markers under CWD) so the sentinel location is deterministic.
     proc = subprocess.Popen(
         [sys.executable, "-m", "autoskillit"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=env,
+        cwd=tmp_path,
     )
 
     # Wait for the filesystem sentinel — written inside the lifespan's try:
     # block AFTER the anyio signal receiver is armed. Observing the sentinel
     # guarantees SIGTERM will be caught by the event-loop-routed handler.
-    sentinel_path = readiness_sentinel_path(proc.pid)
+    # Compute the path manually from the overridden state dir rather than
+    # calling readiness_sentinel_path(), because the test process's own
+    # AUTOSKILLIT_STATE_DIR may differ from the subprocess's.
+    sentinel_path = state_dir / "kitchen_state" / f"server_ready_{proc.pid}.sentinel"
     wait_for_subprocess_ready(proc, sentinel_path, deadline_s=10.0)
 
     # SIGTERM is the exact signal Claude Code sends on /exit. Close stdin so

--- a/tests/integration/test_codex_food_truck.py
+++ b/tests/integration/test_codex_food_truck.py
@@ -45,6 +45,11 @@ class TestCodexFoodTruckCommand:
         idx = spec.cmd.index("-c")
         assert spec.cmd[idx + 1] == "web_search=disabled"
 
+    def test_image_generation_disabled_flag(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        overrides = [spec.cmd[i + 1] for i, v in enumerate(spec.cmd[:-1]) if v == "-c"]
+        assert "features.image_generation=false" in overrides
+
     def test_no_tools_flag(self) -> None:
         spec = CodexBackend().build_food_truck_cmd(**self.BASE)
         assert "--tools" not in spec.cmd


### PR DESCRIPTION
## Summary

Add `-c features.image_generation=false` to all 5 Codex command builders in `CodexBackend` to suppress the automatic `image_generation` hosted tool injection that causes HTTP 400 errors from the OpenAI Responses API. Update 8 test assertions across 2 backend test files that relied on `CONFIG_OVERRIDE` presence/absence semantics that change when every builder always includes `-c`. Add a new test in the integration food truck test file to verify the new flag. Fix the `test_sigterm_writes_scenario_json` test isolation by setting `cwd=tmp_path` and `AUTOSKILLIT_STATE_DIR` on the spawned subprocess.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260602-174226-242749/.autoskillit/temp/make-plan/disable_codex_image_generation_plan_2026-06-02_175000.md`

Closes #3634

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 88 | 12.7k | 1.7M | 93.7k | 62 | 77.1k | 8m 37s |
| verify* | sonnet | 1 | 76 | 6.9k | 333.1k | 46.2k | 23 | 29.8k | 2m 38s |
| implement* | MiniMax-M3 | 1 | 67.7k | 9.8k | 1.2M | 73.4k | 69 | 0 | 4m 15s |
| audit_impl* | sonnet | 1 | 52 | 9.5k | 177.0k | 38.5k | 16 | 31.8k | 4m 3s |
| prepare_pr* | MiniMax-M3 | 1 | 42.4k | 1.7k | 160.7k | 45.6k | 11 | 0 | 50s |
| compose_pr* | MiniMax-M3 | 1 | 35.6k | 1.4k | 186.1k | 38.3k | 13 | 0 | 46s |
| review_pr* | sonnet | 1 | 148 | 34.4k | 891.8k | 80.8k | 44 | 64.7k | 7m 16s |
| resolve_review* | sonnet | 1 | 203 | 11.0k | 1.4M | 72.6k | 64 | 56.4k | 7m 23s |
| **Total** | | | 146.4k | 87.3k | 6.1M | 93.7k | | 259.9k | 35m 51s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 69 | 18023.2 | 0.0 | 141.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 12 | 120488.7 | 4701.9 | 918.9 |
| **Total** | **81** | 75587.5 | 3208.4 | 1078.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 88 | 12.7k | 1.7M | 77.1k | 8m 37s |
| sonnet | 4 | 479 | 61.8k | 2.8M | 182.7k | 21m 22s |
| MiniMax-M3 | 3 | 145.8k | 12.8k | 1.6M | 0 | 5m 50s |