### PR TITLE
Add experiment-type skills and remediate Part A audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a two-tier
 orchestrator. Bundled recipes turn GitHub issues into merged PRs by chaining
 plan, dry-walkthrough, worktree, test, and PR-review skills against 48 MCP
-tools and 139 bundled skills.
+tools and 140 bundled skills.
 
 https://github.com/user-attachments/assets/bcd910c8-7269-46d6-a496-53b2cb24d212
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a two-tier
 orchestrator. Bundled recipes turn GitHub issues into merged PRs by chaining
 plan, dry-walkthrough, worktree, test, and PR-review skills against 48 MCP
-tools and 138 bundled skills.
+tools and 139 bundled skills.
 
 https://github.com/user-attachments/assets/bcd910c8-7269-46d6-a496-53b2cb24d212
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a
 multi-level orchestrator. The bundled recipes implement issue → plan → worktree
-→ tests → PR → merge pipelines using 58 MCP tools and 139 bundled skills.
+→ tests → PR → merge pipelines using 58 MCP tools and 140 bundled skills.
 
 ## Start here
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a
 multi-level orchestrator. The bundled recipes implement issue → plan → worktree
-→ tests → PR → merge pipelines using 58 MCP tools and 138 bundled skills.
+→ tests → PR → merge pipelines using 58 MCP tools and 139 bundled skills.
 
 ## Start here
 

--- a/docs/developer/end-turn-hazards.md
+++ b/docs/developer/end-turn-hazards.md
@@ -190,7 +190,7 @@ two detectors on every SKILL.md in the project:
 | `_check_loop_boundary()` | "For each" loops with tool invocations but no anti-prose guard |
 
 These run as part of `test_no_text_then_tool_in_any_step`, a parametrized
-test that scans all 139 bundled skills. Any new skill with an unguarded
+test that scans all 140 bundled skills. Any new skill with an unguarded
 loop fails CI automatically.
 
 ## If This Gets Fixed Upstream

--- a/docs/developer/end-turn-hazards.md
+++ b/docs/developer/end-turn-hazards.md
@@ -190,7 +190,7 @@ two detectors on every SKILL.md in the project:
 | `_check_loop_boundary()` | "For each" loops with tool invocations but no anti-prose guard |
 
 These run as part of `test_no_text_then_tool_in_any_step`, a parametrized
-test that scans all 138 bundled skills. Any new skill with an unguarded
+test that scans all 139 bundled skills. Any new skill with an unguarded
 loop fails CI automatically.
 
 ## If This Gets Fixed Upstream

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -4,7 +4,7 @@ How AutoSkillit runs a recipe end to end: orchestrator, kitchen gating, clone an
 
 ## Overview
 
-AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 58 MCP tools and 138 bundled skills, organized into a gated visibility system.
+AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 58 MCP tools and 139 bundled skills, organized into a gated visibility system.
 
 ## Core Concepts
 

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -4,7 +4,7 @@ How AutoSkillit runs a recipe end to end: orchestrator, kitchen gating, clone an
 
 ## Overview
 
-AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 58 MCP tools and 139 bundled skills, organized into a gated visibility system.
+AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 58 MCP tools and 140 bundled skills, organized into a gated visibility system.
 
 ## Core Concepts
 

--- a/docs/skills/catalog.md
+++ b/docs/skills/catalog.md
@@ -1,7 +1,7 @@
 # Skill catalog
 
-The complete list of bundled skills (138 total: 3 in `src/autoskillit/skills/`,
-135 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
+The complete list of bundled skills (139 total: 3 in `src/autoskillit/skills/`,
+136 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
 you need an exhaustive listing; this catalog groups by purpose.
 
 ## Tier 1 — free range (3)
@@ -139,8 +139,8 @@ symptom, and the audit suite is updated so the same class of bug cannot
 recur. Commit messages prefix with `Rectify:` for traceability; the count of
 `Rectify:` commits is reported in `docs/developer/contributing.md`.
 
-## Total: 138
+## Total: 139
 
-3 (Tier 1) + 135 (`skills_extended/`) = 138 bundled skills. The total is
+3 (Tier 1) + 136 (`skills_extended/`) = 139 bundled skills. The total is
 verified by `tests/docs/test_doc_counts.py` against a filesystem walk so any
 addition or removal is caught immediately.

--- a/docs/skills/catalog.md
+++ b/docs/skills/catalog.md
@@ -1,7 +1,7 @@
 # Skill catalog
 
-The complete list of bundled skills (139 total: 3 in `src/autoskillit/skills/`,
-136 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
+The complete list of bundled skills (140 total: 3 in `src/autoskillit/skills/`,
+137 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
 you need an exhaustive listing; this catalog groups by purpose.
 
 ## Tier 1 — free range (3)
@@ -139,8 +139,8 @@ symptom, and the audit suite is updated so the same class of bug cannot
 recur. Commit messages prefix with `Rectify:` for traceability; the count of
 `Rectify:` commits is reported in `docs/developer/contributing.md`.
 
-## Total: 139
+## Total: 140
 
-3 (Tier 1) + 136 (`skills_extended/`) = 139 bundled skills. The total is
+3 (Tier 1) + 137 (`skills_extended/`) = 140 bundled skills. The total is
 verified by `tests/docs/test_doc_counts.py` against a filesystem walk so any
 addition or removal is caught immediately.

--- a/docs/skills/visibility.md
+++ b/docs/skills/visibility.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-AutoSkillit's 139 bundled skills are organized into three tiers that control when and where
+AutoSkillit's 140 bundled skills are organized into three tiers that control when and where
 they appear as slash commands. The tier system is orthogonal to subset categories — you can
 disable a subset across all tiers simultaneously, or reclassify individual skills between
 tiers. See [Subset Categories](subsets.md) for subset configuration.

--- a/docs/skills/visibility.md
+++ b/docs/skills/visibility.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-AutoSkillit's 138 bundled skills are organized into three tiers that control when and where
+AutoSkillit's 139 bundled skills are organized into three tiers that control when and where
 they appear as slash commands. The tier system is orthogonal to subset categories — you can
 disable a subset across all tiers simultaneously, or reclassify individual skills between
 tiers. See [Subset Categories](subsets.md) for subset configuration.

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -293,6 +293,8 @@ skills:
     - resolve-claims-review
     - build-execution-map
     - promote-to-main
+    - classify-experiment-type
+    - apply-review-dimensions
 
 workspace:
   worktree_root: null   # null = auto-resolve to ../worktrees/ relative to project root

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2402,6 +2402,7 @@ skills:
       type: string
     expected_output_patterns:
     - "experiment_type[ \\t]*=[ \\t]*\\S+"
+    - "dimension_weights[ \\t]*=[ \\t]*[a-z_]+:[HMLS](,[a-z_]+:[HMLS])*"
     - "is_silent_type[ \\t]*=[ \\t]*(true|false)"
     - "dimensions_manifest_path[ \\t]*=[ \\t]*/.+"
     - "selected_lenses[ \\t]*=[ \\t]*([^\\n]*|none)"

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2376,6 +2376,68 @@ skills:
     - "## Findings\n### confirmed_bug\n...\n---pipeline-health-result---\n%%ORDER_UP%%"
     - "Analysis complete.\n\n---\npipeline-health-result---\n%%ORDER_UP%%"
     read_only: true
+  classify-experiment-type:
+    inputs:
+    - name: experiment_plan_path
+      type: file_path
+      required: true
+    - name: scope_report_path
+      type: file_path
+      required: false
+    outputs:
+    - name: experiment_type
+      type: string
+    - name: dimension_weights
+      type: string
+    - name: is_silent_type
+      type: string
+      allowed_values: ['true', 'false']
+    - name: classification_timestamp
+      type: string
+    - name: dimensions_manifest_path
+      type: file_path
+    - name: selected_lenses
+      type: string
+    - name: lens_context_paths
+      type: string
+    expected_output_patterns:
+    - "experiment_type[ \\t]*=[ \\t]*\\S+"
+    - "is_silent_type[ \\t]*=[ \\t]*(true|false)"
+    - "dimensions_manifest_path[ \\t]*=[ \\t]*/.+"
+    - "selected_lenses[ \\t]*=[ \\t]*([^\\n]*|none)"
+    - "lens_context_paths[ \\t]*=[ \\t]*([^\\n]*|none)"
+    pattern_examples:
+    - "experiment_type = benchmark\ndimension_weights = causal_structure:H,variance_protocol:M,statistical_corrections:M,ecological_validity:M,measurement_alignment:H,resource_proportionality:M,data_acquisition:H,agent_implementability:M,scope_alignment:M\nis_silent_type = false\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /abs/cwd/.autoskillit/temp/classify-experiment-type/dimensions_manifest_benchmark_2026-06-02_183000.json\nselected_lenses = causal_structure,variance_protocol,statistical_corrections,ecological_validity,measurement_alignment,resource_proportionality,data_acquisition,agent_implementability,scope_alignment\nlens_context_paths = /abs/cwd/.autoskillit/temp/classify-experiment-type/lens_ctx_causal_structure_benchmark_2026-06-02_183000.md,/abs/cwd/.autoskillit/temp/classify-experiment-type/lens_ctx_variance_protocol_benchmark_2026-06-02_183000.md\n%%ORDER_UP%%"
+    - "experiment_type = qualitative_interpretive\ndimension_weights = causal_structure:S,variance_protocol:S,statistical_corrections:S,ecological_validity:S,measurement_alignment:S,resource_proportionality:S,data_acquisition:L,agent_implementability:L,scope_alignment:S\nis_silent_type = true\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /abs/cwd/.autoskillit/temp/classify-experiment-type/dimensions_manifest_qualitative_2026-06-02_183000.json\nselected_lenses = \nlens_context_paths = \n%%ORDER_UP%%"
+    write_behavior: always
+  apply-review-dimensions:
+    inputs:
+    - name: dimensions_manifest_path
+      type: file_path
+      required: true
+    - name: scope_report_path
+      type: file_path
+      required: true
+    - name: experiment_plan_path
+      type: file_path
+      required: true
+    - name: experiment_type
+      type: string
+      required: true
+    - name: classification_timestamp
+      type: string
+      required: true
+    outputs:
+    - name: findings_manifest_path
+      type: file_path
+    - name: evaluation_dashboard_path
+      type: file_path
+    expected_output_patterns:
+    - "findings_manifest_path[ \\t]*=[ \\t]*/.+"
+    - "evaluation_dashboard_path[ \\t]*=[ \\t]*/.+"
+    pattern_examples:
+    - "findings_manifest_path = /abs/cwd/.autoskillit/temp/apply-review-dimensions/findings_manifest_2026-06-02_183000.json\nevaluation_dashboard_path = /abs/cwd/.autoskillit/temp/apply-review-dimensions/evaluation_dashboard_2026-06-02_183000.md\n%%ORDER_UP%%"
+    write_behavior: always
 callable_contracts:
   autoskillit.smoke_utils.check_loop_iteration:
     inputs:

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2410,6 +2410,34 @@ skills:
     - "experiment_type = benchmark\ndimension_weights = causal_structure:H,variance_protocol:M,statistical_corrections:M,ecological_validity:M,measurement_alignment:H,resource_proportionality:M,data_acquisition:H,agent_implementability:M,scope_alignment:M\nis_silent_type = false\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /abs/cwd/.autoskillit/temp/classify-experiment-type/dimensions_manifest_benchmark_2026-06-02_183000.json\nselected_lenses = causal_structure,variance_protocol,statistical_corrections,ecological_validity,measurement_alignment,resource_proportionality,data_acquisition,agent_implementability,scope_alignment\nlens_context_paths = /abs/cwd/.autoskillit/temp/classify-experiment-type/lens_ctx_causal_structure_benchmark_2026-06-02_183000.md,/abs/cwd/.autoskillit/temp/classify-experiment-type/lens_ctx_variance_protocol_benchmark_2026-06-02_183000.md\n%%ORDER_UP%%"
     - "experiment_type = exploratory\ndimension_weights = causal_structure:S,variance_protocol:S,statistical_corrections:S,ecological_validity:S,measurement_alignment:S,resource_proportionality:S,data_acquisition:L,agent_implementability:L,scope_alignment:S\nis_silent_type = true\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /abs/cwd/.autoskillit/temp/classify-experiment-type/dimensions_manifest_exploratory_2026-06-02_183000.json\nselected_lenses = \nlens_context_paths = \n%%ORDER_UP%%"
     write_behavior: always
+  apply-review-dimensions:
+    inputs:
+    - name: dimensions_manifest_path
+      type: file_path
+      required: true
+    - name: scope_report_path
+      type: file_path
+      required: false
+    - name: experiment_plan_path
+      type: file_path
+      required: true
+    - name: experiment_type
+      type: string
+      required: true
+    - name: classification_timestamp
+      type: string
+      required: true
+    outputs:
+    - name: findings_manifest_path
+      type: file_path
+    - name: evaluation_dashboard_path
+      type: file_path
+    expected_output_patterns:
+    - "findings_manifest_path[ \\t]*=[ \\t]*/.+"
+    - "evaluation_dashboard_path[ \\t]*=[ \\t]*/.+"
+    pattern_examples:
+    - "findings_manifest_path = /abs/cwd/.autoskillit/temp/apply-review-dimensions/findings_manifest_benchmark_2026-06-02_183000.json\nevaluation_dashboard_path = /abs/cwd/.autoskillit/temp/apply-review-dimensions/evaluation_dashboard_benchmark_2026-06-02_183000.md\n%%ORDER_UP%%"
+    write_behavior: always
 callable_contracts:
   autoskillit.smoke_utils.check_loop_iteration:
     inputs:

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2408,35 +2408,7 @@ skills:
     - "lens_context_paths[ \\t]*=[ \\t]*([^\\n]*|none)"
     pattern_examples:
     - "experiment_type = benchmark\ndimension_weights = causal_structure:H,variance_protocol:M,statistical_corrections:M,ecological_validity:M,measurement_alignment:H,resource_proportionality:M,data_acquisition:H,agent_implementability:M,scope_alignment:M\nis_silent_type = false\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /abs/cwd/.autoskillit/temp/classify-experiment-type/dimensions_manifest_benchmark_2026-06-02_183000.json\nselected_lenses = causal_structure,variance_protocol,statistical_corrections,ecological_validity,measurement_alignment,resource_proportionality,data_acquisition,agent_implementability,scope_alignment\nlens_context_paths = /abs/cwd/.autoskillit/temp/classify-experiment-type/lens_ctx_causal_structure_benchmark_2026-06-02_183000.md,/abs/cwd/.autoskillit/temp/classify-experiment-type/lens_ctx_variance_protocol_benchmark_2026-06-02_183000.md\n%%ORDER_UP%%"
-    - "experiment_type = qualitative_interpretive\ndimension_weights = causal_structure:S,variance_protocol:S,statistical_corrections:S,ecological_validity:S,measurement_alignment:S,resource_proportionality:S,data_acquisition:L,agent_implementability:L,scope_alignment:S\nis_silent_type = true\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /abs/cwd/.autoskillit/temp/classify-experiment-type/dimensions_manifest_qualitative_2026-06-02_183000.json\nselected_lenses = \nlens_context_paths = \n%%ORDER_UP%%"
-    write_behavior: always
-  apply-review-dimensions:
-    inputs:
-    - name: dimensions_manifest_path
-      type: file_path
-      required: true
-    - name: scope_report_path
-      type: file_path
-      required: true
-    - name: experiment_plan_path
-      type: file_path
-      required: true
-    - name: experiment_type
-      type: string
-      required: true
-    - name: classification_timestamp
-      type: string
-      required: true
-    outputs:
-    - name: findings_manifest_path
-      type: file_path
-    - name: evaluation_dashboard_path
-      type: file_path
-    expected_output_patterns:
-    - "findings_manifest_path[ \\t]*=[ \\t]*/.+"
-    - "evaluation_dashboard_path[ \\t]*=[ \\t]*/.+"
-    pattern_examples:
-    - "findings_manifest_path = /abs/cwd/.autoskillit/temp/apply-review-dimensions/findings_manifest_2026-06-02_183000.json\nevaluation_dashboard_path = /abs/cwd/.autoskillit/temp/apply-review-dimensions/evaluation_dashboard_2026-06-02_183000.md\n%%ORDER_UP%%"
+    - "experiment_type = exploratory\ndimension_weights = causal_structure:S,variance_protocol:S,statistical_corrections:S,ecological_validity:S,measurement_alignment:S,resource_proportionality:S,data_acquisition:L,agent_implementability:L,scope_alignment:S\nis_silent_type = true\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /abs/cwd/.autoskillit/temp/classify-experiment-type/dimensions_manifest_exploratory_2026-06-02_183000.json\nselected_lenses = \nlens_context_paths = \n%%ORDER_UP%%"
     write_behavior: always
 callable_contracts:
   autoskillit.smoke_utils.check_loop_iteration:

--- a/src/autoskillit/skills_extended/apply-review-dimensions/SKILL.md
+++ b/src/autoskillit/skills_extended/apply-review-dimensions/SKILL.md
@@ -278,8 +278,8 @@ NOTE: NO `verdict` field in this YAML block — verdict is computed by
 ### Step 8: Emit Structured Output Tokens
 
 ```
-findings_manifest_path = /absolute/path/to/.autoskillit/temp/apply-review-dimensions/findings_manifest_{slug}_{YYYY-MM-DD_HHMMSS}.json
-evaluation_dashboard_path = /absolute/path/to/.autoskillit/temp/apply-review-dimensions/evaluation_dashboard_{slug}_{YYYY-MM-DD_HHMMSS}.md
+findings_manifest_path = {{AUTOSKILLIT_TEMP}}/apply-review-dimensions/findings_manifest_{slug}_{YYYY-MM-DD_HHMMSS}.json
+evaluation_dashboard_path = {{AUTOSKILLIT_TEMP}}/apply-review-dimensions/evaluation_dashboard_{slug}_{YYYY-MM-DD_HHMMSS}.md
 ```
 
 > **IMPORTANT:** Emit the structured output tokens as **literal plain text with no
@@ -291,6 +291,11 @@ evaluation_dashboard_path = /absolute/path/to/.autoskillit/temp/apply-review-dim
 No `verdict` token. No `revision_guidance` token.
 
 ## Output
+
+Output tokens (relative to the current working directory):
+
+- `findings_manifest_path` — `{{AUTOSKILLIT_TEMP}}/apply-review-dimensions/findings_manifest_{slug}_{YYYY-MM-DD_HHMMSS}.json`
+- `evaluation_dashboard_path` — `{{AUTOSKILLIT_TEMP}}/apply-review-dimensions/evaluation_dashboard_{slug}_{YYYY-MM-DD_HHMMSS}.md`
 
 ```
 {{AUTOSKILLIT_TEMP}}/apply-review-dimensions/

--- a/src/autoskillit/skills_extended/apply-review-dimensions/SKILL.md
+++ b/src/autoskillit/skills_extended/apply-review-dimensions/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: apply-review-dimensions
+categories: [research]
+backend_requirements: [claude-code]
+description: Evaluate experiment design across weighted dimensions using multi-level subagent analysis with adversarial red-team, producing a findings manifest and evaluation dashboard.
+hooks:
+  PreToolUse:
+    - matcher: "*"
+      hooks:
+        - type: command
+          command: "echo '[SKILL: apply-review-dimensions] Evaluating review dimensions...'"
+          once: true
+---
+
+# Apply Review Dimensions Skill
+
+Evaluate an experiment plan across its classified dimension weight matrix using a
+multi-level subagent hierarchy (L1 fail-fast → L2 + red-team → L3 → L4) with
+three-layer silencing. Produces a findings manifest and evaluation dashboard. Does
+NOT emit a verdict — verdict computation is the responsibility of a downstream
+synthesis step.
+
+## When to Use
+
+Invoked as the apply step of the review-design phoropter module, after
+`classify-experiment-type` and before the downstream verdict synthesis step. NOT
+invoked standalone — the recipe step named `apply` with
+`phoropter_family: review-design` calls this skill.
+
+## Arguments
+
+`/autoskillit:apply-review-dimensions {dimensions_manifest_path} {scope_report_path} {experiment_plan_path} {experiment_type} {classification_timestamp}`
+
+- **dimensions_manifest_path** — Absolute path to the JSON file emitted by the
+  classify step's `select_review_dimensions` run_python callable. Contains
+  `{dimension: weight}` pairs plus a `secondary_modifiers` list.
+- **scope_report_path** — Absolute path to the scope report. Forwarded via recipe
+  context variable `${{ context.scope_report }}` threaded through as a direct
+  `with: args:` positional argument. This is the mechanism P3-A3/P3-A4 must use
+  when wiring the apply step in recipe YAML. NOT captured from
+  classify-experiment-type output.
+- **experiment_plan_path** — Absolute path to the experiment plan file.
+- **experiment_type** — Snake-case experiment type name from classification.
+- **classification_timestamp** — ISO 8601 UTC timestamp from classification.
+
+## Critical Constraints
+
+**NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+- Emit verdict (verdict is computed by `aggregate_review_verdict` in the synthesize step)
+- Spawn background subagents (`run_in_background: true` is prohibited)
+- Write outside `{{AUTOSKILLIT_TEMP}}/apply-review-dimensions/`
+- Proceed past L1 when any STRUCTURAL critical finding is present
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
+
+**ALWAYS:**
+- Use `Agent(model="sonnet")` for all subagents
+- Write `findings_manifest` and `evaluation_dashboard` before emitting tokens
+- Emit both output tokens as absolute paths
+- Write output to `{{AUTOSKILLIT_TEMP}}/apply-review-dimensions/`
+- Issue all subagent calls in a single message to maximize parallel execution
+
+## Workflow
+
+### Step 0: Setup
+
+1. Create `{{AUTOSKILLIT_TEMP}}/apply-review-dimensions/` if absent.
+2. Load dimensions_manifest JSON from `dimensions_manifest_path`.
+3. **Empty / all-silent detection:** If all dimension weights are `S` (SILENT) or
+   the dimension list is empty:
+   - Write an empty `findings_manifest` JSON (empty array) to
+     `{{AUTOSKILLIT_TEMP}}/apply-review-dimensions/findings_manifest_{slug}_{YYYY-MM-DD_HHMMSS}.json`
+   - Write a "Scope Advisory" `evaluation_dashboard` to
+     `{{AUTOSKILLIT_TEMP}}/apply-review-dimensions/evaluation_dashboard_{slug}_{YYYY-MM-DD_HHMMSS}.md`
+   - Emit output tokens and return without spawning any subagents.
+
+### Step 1: L1 Fail-Fast Gate (Level 1)
+
+Two parallel subagents, each weight is H (highest priority — L1 is the gate that
+halts on STRUCTURAL criticals):
+
+- `estimand_clarity` — "Can the claim be written as a formal contrast (A vs B on
+  Y in Z)?"
+- `hypothesis_falsifiability` — "What result would cause the author to conclude
+  H0?"
+
+Severity calibration from the experiment_type registry's `l1_severity` dict.
+
+Each subagent returns findings in JSON structure.
+
+**ADDRESSABLE vs STRUCTURAL classification:**
+- **ADDRESSABLE** — Concrete methodological flaw with a mechanical fix. The
+  research question remains answerable after revision.
+- **STRUCTURAL** — Research question is not answerable with this experimental
+  design regardless of revision.
+
+**Classification scope limitation:** Only `hypothesis_falsifiability` findings
+are eligible for ADDRESSABLE. `estimand_clarity` findings default to STRUCTURAL.
+
+**Gate logic:**
+- Any STRUCTURAL critical → halt L2-L4. Write findings with what's available and
+  proceed directly to Step 6.
+- All criticals ADDRESSABLE → tag as `"priority": "REQUIRED"` and continue to
+  Step 2.
+
+### Step 2: L2 + Red-Team (Level 2, concurrent)
+
+Launch all L2 subagents AND the red-team agent in the same parallel message.
+
+**L2 subagents** (weights from matrix):
+- `baseline_fairness` — "Are all compared systems given symmetric resources and
+  tuning effort?"
+- `causal_structure` — Only spawn when weight >= L. "Can cause/effect be
+  isolated?"
+- `unit_interference` — "Can treatments spill over between experimental units?"
+- `scope_alignment` — Only spawn when (a) `scope_report_path` provided AND (b)
+  weight >= L. "Does the plan address the proposed investigation directions?"
+
+**`scope_alignment` evaluation procedure:**
+
+1. **Direction extraction:** Read "Proposed Investigation Directions" from the
+   scope report. Enumerate as D1, D2, D3...
+   - Empty section guard: If absent or no enumerable directions, emit an Info
+     finding and return.
+2. **Coverage mapping:** For each direction, check if the plan addresses it via
+   hypothesis, arm, or measurement.
+3. **Coverage ratio:** `covered_count / total_directions`
+4. **Narrowing detection:** If `total_directions >= 3` and `covered_count == 1`,
+   flag as unjustified narrowing unless explicit exclusion rationale exists.
+5. **Justification check:** Directions with explicit rationale for deferral are
+   "justified-excluded."
+
+Findings rules for `scope_alignment`:
+- Critical (weight=H): coverage < 50% AND no justification
+- Warning: coverage < 50% with partial justification, OR narrows to 1 from >= 3
+- Info: coverage >= 50% but some uncovered lack justification
+
+**Red-team agent** (concurrent with L2):
+- Five universal challenges: Goodhart exploitation, data leakage, asymmetric
+  tuning, survivorship bias, evaluation collision
+- Type-specific focus: from registry's `red_team_focus.specific` field
+- ALL findings: `"requires_decision": true`, `"dimension": "red_team"`
+
+### Step 3: L3 (Level 3, after L2, no wait for red-team)
+
+Three parallel subagents, each receiving the full plan + experiment_type + L1+L2
+findings summary:
+
+- `error_budget` — "Is power analysis present? Are error rates acknowledged?"
+- `statistical_corrections` — "Are multiple comparisons corrections
+  pre-specified?"
+- `variance_protocol` — "Are seeds fixed? Is run-to-run variance addressed?"
+
+NOTE: absent seeds IS a valid finding at H-weight — do not suppress via foothold
+validation. This is the explicit exception to the foothold validation rule.
+
+### Step 4: L4 (Level 4, spawn only weight >= L)
+
+Up to six subagents:
+
+- `benchmark_representativeness` — "Does this generalize beyond the specific
+  test bed?"
+- `ecological_validity` — "Do test conditions match deployment context?"
+- `measurement_alignment` — "Do metrics actually measure what the question
+  claims?"
+- `reproducibility_spec` — "Could an independent party reproduce this?"
+- `data_acquisition` — Full acquisition checklist: hypothesis coverage, external
+  source readiness, gitignored path handling, dependency ordering, directive
+  compliance, template syntax validation. STOP-eligible if: hypothesis has no
+  data source, directive-specified data has no acquisition step, unresolved
+  template placeholders, wet_lab sources present.
+- `agent_implementability` — Step atomicity, file path resolvability, performance
+  feasibility, verification criteria completeness, dependency ordering, absence
+  of human-only actions, artifact continuity. REVISE-eligible only.
+
+### Three-Layer Silencing Rules
+
+1. **Static SILENT from matrix:** S-weight dimensions are not spawned and not
+   mentioned in the output.
+2. **Foothold validation:** Before spawning M/L dimensions, check the plan has
+   relevant content. If absent: M → L, L → S. Exception: `variance_protocol`
+   absent seeds is a valid H-weight finding (do not suppress).
+3. **Finding-count suppression:** L-weight zero findings → omit entirely. H/M
+   zero findings → emit "No issues identified."
+4. **Scope-report absent:** `scope_alignment` is treated SILENT regardless of
+   weight when `scope_report_path` is absent.
+
+### Step 5: Wait for Red-Team
+
+After L3 and L4 complete, wait for the red-team agent if it is still running.
+Merge all red-team findings into the finding pool with
+`requires_decision: true` preserved.
+
+### Step 6: Write Findings Manifest
+
+Write
+`{{AUTOSKILLIT_TEMP}}/apply-review-dimensions/findings_manifest_{slug}_{YYYY-MM-DD_HHMMSS}.json`.
+
+**Explicit JSON schema (machine contract):**
+
+```json
+{
+  "findings": [
+    {
+      "dimension": "estimand_clarity",
+      "level": 1,
+      "severity": "critical",
+      "finding": "description of gap",
+      "addressable": true,
+      "requires_decision": false,
+      "priority": "REQUIRED",
+      "fixability": "ADDRESSABLE",
+      "message": "human-readable finding message"
+    }
+  ],
+  "red_team_findings": [
+    {
+      "dimension": "red_team",
+      "level": 2,
+      "severity": "warning",
+      "finding": "adversarial concern",
+      "addressable": false,
+      "requires_decision": true,
+      "priority": "ADVISORY",
+      "fixability": null,
+      "message": "human-readable red-team finding"
+    }
+  ]
+}
+```
+
+The required fields for every finding are: `dimension`, `level`, `severity`,
+`finding`, `addressable`, `requires_decision`, `priority`, `fixability`,
+`message`. The top-level object has a `findings` array and a `red_team_findings`
+sub-array.
+
+### Step 7: Write Evaluation Dashboard
+
+Write
+`{{AUTOSKILLIT_TEMP}}/apply-review-dimensions/evaluation_dashboard_{slug}_{YYYY-MM-DD_HHMMSS}.md`
+always (full-analysis path or STRUCTURAL halt path).
+
+**Full-analysis path contents:**
+- Dimension scorecard table: dimension → weight → findings count → severity
+  summary
+- Adversarial findings section (red-team findings, each `requires_decision: true`)
+- **Cannot Assess** section (minimum 2 entries)
+- Mechanizable check log
+- Machine-readable YAML summary block
+
+**STRUCTURAL halt path contents** (when only L1 data is available):
+- Dimension scorecard showing only L1 dimensions (`estimand_clarity`,
+  `hypothesis_falsifiability`)
+- Adversarial findings section: "N/A — halted before red-team launch"
+- Cannot Assess section: minimum 2 entries (dimensions that would have been
+  evaluated had L1 passed)
+- Mechanizable check log: fixed items only
+- Machine-readable YAML summary block with `active_dimensions: 2`,
+  `red_team_count: 0`
+
+**Machine-readable YAML summary block:**
+
+```yaml
+# --- apply-review-dimensions machine summary ---
+experiment_type: {type}
+critical_count: {n}
+warning_count: {n}
+blocking_count: {n}
+required_count: {n}
+advisory_count: {n}
+red_team_count: {n}
+active_dimensions: {n}
+```
+
+NOTE: NO `verdict` field in this YAML block — verdict is computed by
+`aggregate_review_verdict` in the downstream synthesis step.
+
+### Step 8: Emit Structured Output Tokens
+
+```
+findings_manifest_path = /absolute/path/to/.autoskillit/temp/apply-review-dimensions/findings_manifest_{slug}_{YYYY-MM-DD_HHMMSS}.json
+evaluation_dashboard_path = /absolute/path/to/.autoskillit/temp/apply-review-dimensions/evaluation_dashboard_{slug}_{YYYY-MM-DD_HHMMSS}.md
+```
+
+> **IMPORTANT:** Emit the structured output tokens as **literal plain text with no
+> markdown formatting on the token names**. Do not wrap token names in `**bold**`,
+> `*italic*`, or any other markdown. Do not wrap the output block in a code fence.
+> The adjudicator performs a regex match on the exact token name — decorators and
+> code fences cause match failure.
+
+No `verdict` token. No `revision_guidance` token.
+
+## Output
+
+```
+{{AUTOSKILLIT_TEMP}}/apply-review-dimensions/
+├── findings_manifest_{slug}_{YYYY-MM-DD_HHMMSS}.json   (always)
+└── evaluation_dashboard_{slug}_{YYYY-MM-DD_HHMMSS}.md  (always)
+```
+
+## Related Skills
+
+- `/autoskillit:classify-experiment-type` — produces `dimensions_manifest_path`
+  input
+- Downstream synthesis step — consumes `findings_manifest_path` to compute
+  verdict (verdict computation lives in the synthesis step, not in this skill)
+- `/autoskillit:plan-experiment` — produces `experiment_plan_path`
+- `/autoskillit:scope` — produces `scope_report_path`

--- a/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
+++ b/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
@@ -63,11 +63,14 @@ python -c "from autoskillit.core import pkg_root; print(pkg_root() / 'recipes' /
 
 (b) Glob `*.yaml` in that directory. Parse each file extracting: `name`,
 `classification_triggers`, `dimension_weights`, `applicable_lenses`, `red_team_focus`,
-`l1_severity`, `dimension_weight_rationale`.
+`l1_severity`, `dimension_weight_rationale`. If a file is malformed or unreadable, log a
+warning and skip it — do not abort registry loading.
 
 (c) Check `.autoskillit/experiment-types/` in the current working directory for user
 overrides. A user-defined type with the same `name` replaces the bundled entry entirely
-(no field merging).
+(no field merging). Validate that each user-defined entry contains all required fields
+(`name`, `classification_triggers`, `dimension_weights`); if any required field is missing,
+log a warning and skip the entry rather than silently accepting a partial spec.
 
 (d) Build registry mapping `type_name → spec`. The set of valid `experiment_type` values
 is the set of keys in the registry.
@@ -124,7 +127,7 @@ returned by the triage subagent. This matches how the Python `is_silent_type(spe
 function in `experiment_type_registry.py` operates — it reads
 `spec.dimension_weights.values()` from the registry entry directly.
 
-Apply the `is_silent_type` rule: **>=6 of 8 `dimension_weights` == S** →
+Apply the `is_silent_type` rule: **>=6 of 9 `dimension_weights` == S** →
 `is_silent_type=true`.
 
 Reference: `docs/research/silent-type-convention.md`.

--- a/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
+++ b/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
@@ -110,7 +110,7 @@ One subagent receives full plan plus parsed fields. Returns:
 (bundled sorted alphabetically, then user-defined sorted alphabetically). First type whose
 `classification_triggers` match the plan is selected. No match → default to `exploratory`.
 
-**Secondary modifiers** (additive, increase dimension weights):
+**Secondary modifiers** (additive, increase — never decrease — dimension weights):
 - `+causal`: mechanism claim in non-causal type → `causal_structure` weight +1 tier
 - `+high_cost`: resources > 4 GPU-hours → `resource_proportionality` L→M
 - `+deployment`: motivation references production/users → `ecological_validity` floor = M

--- a/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
+++ b/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: classify-experiment-type
+categories: [research]
+backend_requirements: [claude-code]
+description: Classify an experiment plan into a type, build the dimension weight matrix, and emit dialing interface tokens for the apply-review-dimensions step.
+hooks:
+  PreToolUse:
+    - matcher: "*"
+      hooks:
+        - type: command
+          command: "echo '[SKILL: classify-experiment-type] Classifying experiment type...'"
+          once: true
+---
+
+# Classify Experiment Type Skill
+
+Classify an experiment plan into its experiment type, build the dimension weight matrix
+with secondary modifier adjustments, detect silent types, and emit structured interface
+tokens consumed by `apply-review-dimensions`. This skill is the "dial" step of the
+review-design phoropter module — it determines which dimensions and at what weight will
+be evaluated.
+
+## When to Use
+
+Invoked as the dial step of the review-design phoropter module, after `plan_experiment`
+and before `apply-review-dimensions`. NOT invoked standalone — the recipe step named
+`dial` with `phoropter_family: review-design` calls this skill.
+
+## Arguments
+
+`/autoskillit:classify-experiment-type {experiment_plan_path} [{scope_report_path}]`
+
+- **experiment_plan_path** — Absolute path to the experiment plan. Scan tokens after the
+  skill name for the first path-like token (starts with `/`, `./`, or `.autoskillit/`).
+- **scope_report_path** (optional) — Absolute path to the scope report. Second path-like
+  token if present. Forwarded downstream to apply-review-dimensions via recipe context.
+
+## Critical Constraints
+
+**NEVER:**
+- Fabricate, invent, or embellish information not supported by the available evidence or code.
+- Modify files outside `{{AUTOSKILLIT_TEMP}}/classify-experiment-type/`
+- Emit verdict (verdict is not an output of this skill)
+- Spawn subagents in the background (`run_in_background: true` is prohibited)
+- Issue subagent Task calls sequentially — ALL must be in a single parallel message
+
+**ALWAYS:**
+- Use `Agent(model="sonnet")` for the triage subagent
+- Emit `is_silent_type=true|false`
+- Emit `dimensions_manifest_path` as an absolute path
+- Write output to `{{AUTOSKILLIT_TEMP}}/classify-experiment-type/`
+
+## Workflow
+
+### Step 0: Registry Loading
+
+(a) Locate bundled types directory:
+
+```
+python -c "from autoskillit.core import pkg_root; print(pkg_root() / 'recipes' / 'experiment-types')"
+```
+
+(b) Glob `*.yaml` in that directory. Parse each file extracting: `name`,
+`classification_triggers`, `dimension_weights`, `applicable_lenses`, `red_team_focus`,
+`l1_severity`, `dimension_weight_rationale`.
+
+(c) Check `.autoskillit/experiment-types/` in the current working directory for user
+overrides. A user-defined type with the same `name` replaces the bundled entry entirely
+(no field merging).
+
+(d) Build registry mapping `type_name → spec`. The set of valid `experiment_type` values
+is the set of keys in the registry.
+
+### Step 1: Plan Frontmatter Parsing
+
+Two-level backward-compatible fallback:
+
+- **Level 1 (frontmatter)**: Read YAML between `---` delimiters directly (zero LLM
+  tokens). Record `source: frontmatter` for each extracted field. If YAML is malformed,
+  treat all fields as missing → fall through to Level 2.
+- **Level 2 (LLM extraction)**: For each missing field, launch a targeted extraction
+  subagent against the corresponding prose section. All extractions are independent and
+  run in parallel. Record `source: extracted`.
+
+Fields and prose-target mapping:
+
+| Missing Field | Prose Target | Extraction Prompt |
+|---|---|---|
+| experiment_type | Full plan | "Classify using the loaded registry types: {', '.join(registry.keys())}" |
+| hypothesis_h0/h1 | ## Hypothesis | "Extract the null/alternative hypothesis" |
+| estimand | ## Hypothesis + ## Independent Variables | "Extract: treatment, outcome, population, contrast" |
+| metrics | ## Dependent Variables table | "Extract each row as structured object" |
+| baselines | ## Independent Variables | "Extract comparators: name, version, tuning" |
+| statistical_plan | ## Analysis Plan | "Extract: test, alpha, power, correction, sample size" |
+| success_criteria | ## Success Criteria | "Extract three criteria" |
+
+### Step 2: Triage Subagent Dispatch
+
+One subagent receives full plan plus parsed fields. Returns:
+- `experiment_type`: one of the type names in the loaded registry
+- `dimension_weights`: the complete weight matrix (H/M/L/S per dimension)
+- `secondary_modifiers`: list of active modifiers with effects
+
+**Schema validation:** If returned `experiment_type` is not in the registry, default to
+`exploratory` and log a warning.
+
+**Classification rules (first-match):** Iterate types in registry insertion order
+(bundled sorted alphabetically, then user-defined sorted alphabetically). First type whose
+`classification_triggers` match the plan is selected. No match → default to `exploratory`.
+
+**Secondary modifiers** (additive, increase dimension weights):
+- `+causal`: mechanism claim in non-causal type → `causal_structure` weight +1 tier
+- `+high_cost`: resources > 4 GPU-hours → `resource_proportionality` L→M
+- `+deployment`: motivation references production/users → `ecological_validity` floor = M
+- `+multi_metric`: ≥3 DVs → `statistical_corrections` weight +1 tier
+
+### Step 3: Silent-Type Detection
+
+After classification, evaluate silent-type status against the **BASE registry entry's
+`dimension_weights`** (the spec loaded in Step 0), NOT the modifier-adjusted weights
+returned by the triage subagent. This matches how the Python `is_silent_type(spec)`
+function in `experiment_type_registry.py` operates — it reads
+`spec.dimension_weights.values()` from the registry entry directly.
+
+Apply the `is_silent_type` rule: **>=6 of 8 `dimension_weights` == S** →
+`is_silent_type=true`.
+
+Reference: `docs/research/silent-type-convention.md`.
+
+**When `is_silent_type=true`:**
+
+1. Write `dimensions_manifest` JSON to
+   `{{AUTOSKILLIT_TEMP}}/classify-experiment-type/dimensions_manifest_{slug}_{YYYY-MM-DD_HHMMSS}.json`
+   with all-S weights from the base spec plus `secondary_modifiers: []`. This file MUST
+   exist at a valid path — `dimensions_manifest_path` always points to a real file, even
+   on the silent path.
+2. Set `selected_lenses = ''` (empty string)
+3. Set `lens_context_paths = ''` (empty string)
+4. Emit auto-GO advisory note in structured output
+5. Proceed to Step 5 (all output tokens are emitted, including `dimensions_manifest_path`
+   pointing to the written file)
+
+**When `is_silent_type=false`:** Proceed to Step 4.
+
+### Step 4: Dimensions Manifest Construction
+
+1. Build `{dimension: weight}` dict from the dimension_weights matrix (applying
+   secondary modifier adjustments).
+2. Write JSON to
+   `{{AUTOSKILLIT_TEMP}}/classify-experiment-type/dimensions_manifest_{slug}_{YYYY-MM-DD_HHMMSS}.json`
+   with schema:
+
+   ```json
+   {
+     "dimensions": {"causal_structure": "H", "variance_protocol": "M", ...},
+     "secondary_modifiers": ["+causal", "+multi_metric"]
+   }
+   ```
+
+3. For each non-SILENT dimension (weight != S), write a lens context file at
+   `{{AUTOSKILLIT_TEMP}}/classify-experiment-type/lens_ctx_{dimension}_{slug}_{YYYY-MM-DD_HHMMSS}.md`
+   containing: experiment_type, weight, and relevant plan excerpts for that dimension.
+4. `selected_lenses` = comma-separated non-SILENT dimension names.
+5. `lens_context_paths` = comma-separated absolute paths to per-dimension context files.
+
+### Step 5: Emit Structured Output Tokens
+
+```
+experiment_type = {experiment_type}
+dimension_weights = {inline summary, e.g., causal_structure:H,variance_protocol:M,...}
+is_silent_type = true|false
+classification_timestamp = {ISO 8601 UTC}
+dimensions_manifest_path = /absolute/path/to/dimensions_manifest_{slug}_{timestamp}.json
+selected_lenses = {comma-separated non-SILENT dimension names}
+lens_context_paths = {comma-separated absolute paths}
+```
+
+Do NOT emit `verdict`. When `is_silent_type=true`, prepend advisory:
+`auto-GO: silent type detected — recipe may route around apply-review-dimensions`.
+
+> **IMPORTANT:** Emit the structured output tokens as **literal plain text with no
+> markdown formatting on the token names**. Do not wrap token names in `**bold**`,
+> `*italic*`, or any other markdown. Do not wrap the output block in a code fence.
+> The adjudicator performs a regex match on the exact token name — decorators and
+> code fences cause match failure.
+
+## Output
+
+```
+{{AUTOSKILLIT_TEMP}}/classify-experiment-type/
+├── dimensions_manifest_{slug}_{YYYY-MM-DD_HHMMSS}.json
+├── lens_ctx_{dimension1}_{slug}_{YYYY-MM-DD_HHMMSS}.md
+├── lens_ctx_{dimension2}_{slug}_{YYYY-MM-DD_HHMMSS}.md
+└── ...
+```
+
+## Related Skills
+
+- `/autoskillit:review-design` — monolith this skill is extracted from
+- `/autoskillit:apply-review-dimensions` — consumes this skill's output
+  (`dimensions_manifest_path`, `selected_lenses`, `lens_context_paths`)
+- `/autoskillit:plan-experiment` — produces the plan this skill classifies

--- a/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
+++ b/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
@@ -49,6 +49,7 @@ and before `apply-review-dimensions`. NOT invoked standalone — the recipe step
 - Emit `is_silent_type=true|false`
 - Emit `dimensions_manifest_path` as an absolute path
 - Write output to `{{AUTOSKILLIT_TEMP}}/classify-experiment-type/`
+- Issue all subagent calls in a single message to maximize parallel execution
 
 ## Workflow
 
@@ -79,8 +80,9 @@ Two-level backward-compatible fallback:
   tokens). Record `source: frontmatter` for each extracted field. If YAML is malformed,
   treat all fields as missing → fall through to Level 2.
 - **Level 2 (LLM extraction)**: For each missing field, launch a targeted extraction
-  subagent against the corresponding prose section. All extractions are independent and
-  run in parallel. Record `source: extracted`.
+  subagent against the corresponding prose section. All extractions are independent —
+  launch all extraction subagents in a single message so they run in parallel. Record
+  `source: extracted`.
 
 Fields and prose-target mapping:
 

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -247,7 +247,7 @@ analyze-pipeline-health, analyze-prs, arch-lens-c4-container, arch-lens-concurre
 arch-lens-development, arch-lens-error-resilience, arch-lens-module-dependency, arch-lens-operational,
 arch-lens-process-flow, arch-lens-repository-access, arch-lens-scenarios, arch-lens-security, arch-lens-state-lifecycle,
 audit-arch, audit-bugs, audit-claims, audit-cohesion, audit-defense-standards, audit-docs, audit-friction, audit-impl, audit-review-decisions, audit-tests,
-build-execution-map, bundle-local-report, close-kitchen, collapse-issues, compose-pr, compose-research-pr, design-guards, diagnose-ci, download-data, dry-walkthrough, elaborate-phase,
+build-execution-map, bundle-local-report, classify-experiment-type, close-kitchen, collapse-issues, compose-pr, compose-research-pr, design-guards, diagnose-ci, download-data, dry-walkthrough, elaborate-phase,
 enrich-issues, exp-lens-benchmark-representativeness, exp-lens-causal-assumptions, exp-lens-comparator-construction,
 exp-lens-error-budget, exp-lens-estimand-clarity, exp-lens-exploratory-confirmatory, exp-lens-fair-comparison,
 exp-lens-governance-risk, exp-lens-iterative-learning, exp-lens-measurement-validity, exp-lens-pipeline-integrity,

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -243,7 +243,7 @@ Available tools for use in `tool:` fields:
 
 These skills ship with the autoskillit plugin and are invoked as `/autoskillit:<name>`:
 
-analyze-pipeline-health, analyze-prs, arch-lens-c4-container, arch-lens-concurrency, arch-lens-data-lineage, arch-lens-deployment,
+analyze-pipeline-health, analyze-prs, apply-review-dimensions, arch-lens-c4-container, arch-lens-concurrency, arch-lens-data-lineage, arch-lens-deployment,
 arch-lens-development, arch-lens-error-resilience, arch-lens-module-dependency, arch-lens-operational,
 arch-lens-process-flow, arch-lens-repository-access, arch-lens-scenarios, arch-lens-security, arch-lens-state-lifecycle,
 audit-arch, audit-bugs, audit-claims, audit-cohesion, audit-defense-standards, audit-docs, audit-friction, audit-impl, audit-review-decisions, audit-tests,

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -313,9 +313,9 @@ def test_docs_state_39_kitchen_tools(doc_path: Path) -> None:
     _assert_doc_states_number(doc_path, "kitchen tools", 39)
 
 
-def test_skill_visibility_states_139_skills() -> None:
-    # 139 total = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 136 extended.
-    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 139)
+def test_skill_visibility_states_140_skills() -> None:
+    # 140 total = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 137 extended.
+    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 140)
 
 
 def test_safety_hooks_states_24_hooks() -> None:

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -313,9 +313,9 @@ def test_docs_state_39_kitchen_tools(doc_path: Path) -> None:
     _assert_doc_states_number(doc_path, "kitchen tools", 39)
 
 
-def test_skill_visibility_states_138_skills() -> None:
-    # 138 total = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 135 extended.
-    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 138)
+def test_skill_visibility_states_139_skills() -> None:
+    # 139 total = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 136 extended.
+    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 139)
 
 
 def test_safety_hooks_states_24_hooks() -> None:

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -592,6 +592,9 @@ class TestOutputPathTokensDerivedFromContracts:
             "download_report",
             # classify-experiment-type output (phoropter dial step)
             "dimensions_manifest_path",
+            # apply-review-dimensions output (phoropter apply step)
+            "findings_manifest_path",
+            "evaluation_dashboard_path",
         }
     )
 

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -590,6 +590,8 @@ class TestOutputPathTokensDerivedFromContracts:
             # run-experiment group manifest output (multi-group awareness)
             "group_manifest",
             "download_report",
+            # classify-experiment-type output (phoropter dial step)
+            "dimensions_manifest_path",
         }
     )
 

--- a/tests/recipe/test_contract_strength.py
+++ b/tests/recipe/test_contract_strength.py
@@ -14,6 +14,8 @@ _KNOWN_UNGAPPED_WRITE_ALWAYS = frozenset(
     {
         "audit-tests",
         "build-execution-map",
+        "classify-experiment-type",
+        "apply-review-dimensions",
         "compose-research-pr",
         "design-guards",
         "diagnose-ci",

--- a/tests/recipe/test_contract_strength.py
+++ b/tests/recipe/test_contract_strength.py
@@ -15,7 +15,6 @@ _KNOWN_UNGAPPED_WRITE_ALWAYS = frozenset(
         "audit-tests",
         "build-execution-map",
         "classify-experiment-type",
-        "apply-review-dimensions",
         "compose-research-pr",
         "design-guards",
         "diagnose-ci",

--- a/tests/recipe/test_contract_strength.py
+++ b/tests/recipe/test_contract_strength.py
@@ -12,6 +12,7 @@ pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 _KNOWN_UNGAPPED_WRITE_ALWAYS = frozenset(
     {
+        "apply-review-dimensions",
         "audit-tests",
         "build-execution-map",
         "classify-experiment-type",

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -748,6 +748,7 @@ def test_write_behavior_defaults_to_none() -> None:
 
 
 ALWAYS_WRITE_SKILLS = {
+    "apply-review-dimensions",
     "audit-tests",
     "build-execution-map",
     "classify-experiment-type",

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -751,7 +751,6 @@ ALWAYS_WRITE_SKILLS = {
     "audit-tests",
     "build-execution-map",
     "classify-experiment-type",
-    "apply-review-dimensions",
     "compose-research-pr",
     "design-guards",
     "diagnose-ci",

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -750,6 +750,8 @@ def test_write_behavior_defaults_to_none() -> None:
 ALWAYS_WRITE_SKILLS = {
     "audit-tests",
     "build-execution-map",
+    "classify-experiment-type",
+    "apply-review-dimensions",
     "compose-research-pr",
     "design-guards",
     "diagnose-ci",

--- a/tests/skills/test_skill_output_compliance.py
+++ b/tests/skills/test_skill_output_compliance.py
@@ -279,6 +279,8 @@ def test_output_path_tokens_synchronized() -> None:
             "group_manifest",
             "download_report",
             "selected_directions",
+            # classify-experiment-type output (phoropter dial step)
+            "dimensions_manifest_path",
         }
     )
 

--- a/tests/skills/test_skill_output_compliance.py
+++ b/tests/skills/test_skill_output_compliance.py
@@ -281,6 +281,9 @@ def test_output_path_tokens_synchronized() -> None:
             "selected_directions",
             # classify-experiment-type output (phoropter dial step)
             "dimensions_manifest_path",
+            # apply-review-dimensions output (phoropter apply step)
+            "findings_manifest_path",
+            "evaluation_dashboard_path",
         }
     )
 

--- a/tests/skills_extended/CLAUDE.md
+++ b/tests/skills_extended/CLAUDE.md
@@ -9,3 +9,4 @@ Extended (Tier 2/3) skill tests.
 | `__init__.py` | empty |
 | `test_bundle_local_report.py` | Tests for the bundle-local-report skill renderer |
 | `test_classify_experiment_type_skill.py` | Structural SKILL.md tests for the classify-experiment-type skill |
+| `test_apply_review_dimensions_skill.py` | Structural SKILL.md tests for the apply-review-dimensions skill |

--- a/tests/skills_extended/CLAUDE.md
+++ b/tests/skills_extended/CLAUDE.md
@@ -8,3 +8,4 @@ Extended (Tier 2/3) skill tests.
 |------|---------|
 | `__init__.py` | empty |
 | `test_bundle_local_report.py` | Tests for the bundle-local-report skill renderer |
+| `test_classify_experiment_type_skill.py` | Structural SKILL.md tests for the classify-experiment-type skill |

--- a/tests/skills_extended/test_apply_review_dimensions_skill.py
+++ b/tests/skills_extended/test_apply_review_dimensions_skill.py
@@ -1,11 +1,4 @@
-"""Tests for the apply-review-dimensions skill SKILL.md specification.
-
-These are stateless read-only tests that verify structural validity of the
-SKILL.md file: directory exists, frontmatter parses, required sections are
-present, no verdict token is emitted in the output section, the findings
-manifest JSON schema is documented, and the three-layer silencing rules are
-documented (including the variance_protocol foothold-validation exception).
-"""
+"""Tests for the apply-review-dimensions skill SKILL.md specification."""
 
 from __future__ import annotations
 
@@ -42,6 +35,7 @@ def test_skill_sections() -> None:
     """All required H2 sections are present in the SKILL.md body."""
     content = _SKILL_MD.read_text(encoding="utf-8")
     required = [
+        "## When to Use",
         "## Arguments",
         "## Critical Constraints",
         "## Workflow",

--- a/tests/skills_extended/test_apply_review_dimensions_skill.py
+++ b/tests/skills_extended/test_apply_review_dimensions_skill.py
@@ -1,0 +1,101 @@
+"""Tests for the apply-review-dimensions skill SKILL.md specification.
+
+These are stateless read-only tests that verify structural validity of the
+SKILL.md file: directory exists, frontmatter parses, required sections are
+present, no verdict token is emitted in the output section, the findings
+manifest JSON schema is documented, and the three-layer silencing rules are
+documented (including the variance_protocol foothold-validation exception).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import pkg_root
+from autoskillit.core.io import load_yaml
+
+pytestmark = [pytest.mark.medium]
+
+_SKILL_DIR = pkg_root() / "skills_extended" / "apply-review-dimensions"
+_SKILL_MD = _SKILL_DIR / "SKILL.md"
+
+
+def test_skill_directory_exists() -> None:
+    """Skill directory exists and SKILL.md is present."""
+    assert _SKILL_DIR.is_dir(), f"Skill directory missing: {_SKILL_DIR}"
+    assert _SKILL_MD.is_file(), f"SKILL.md missing: {_SKILL_MD}"
+
+
+def test_skill_frontmatter() -> None:
+    """SKILL.md frontmatter is valid YAML and contains required fields."""
+    content = _SKILL_MD.read_text(encoding="utf-8")
+    parts = content.split("---", 2)
+    assert len(parts) >= 3, "SKILL.md missing YAML frontmatter delimiters"
+    fm = load_yaml(parts[1])
+    assert isinstance(fm, dict), "SKILL.md frontmatter is not a YAML mapping"
+    assert fm["name"] == "apply-review-dimensions"
+    assert fm["categories"] == ["research"]
+    assert fm["backend_requirements"] == ["claude-code"]
+
+
+def test_skill_sections() -> None:
+    """All required H2 sections are present in the SKILL.md body."""
+    content = _SKILL_MD.read_text(encoding="utf-8")
+    required = [
+        "## Arguments",
+        "## Critical Constraints",
+        "## Workflow",
+        "## Output",
+        "## Related Skills",
+    ]
+    for section in required:
+        assert section in content, f"SKILL.md missing required section: {section!r}"
+
+
+def test_no_verdict_token() -> None:
+    """The Output section must not emit a 'verdict' token.
+
+    apply-review-dimensions is the apply step — verdict is computed by the
+    downstream synthesis step (aggregate_review_verdict), not this skill.
+    """
+    content = _SKILL_MD.read_text(encoding="utf-8")
+    assert "## Output" in content, "SKILL.md missing ## Output section"
+    after_output = content.split("## Output", 1)[1]
+    related = after_output.split("## Related Skills", 1)
+    output_section = related[0] if len(related) > 1 else after_output
+    assert "findings_manifest_path" in output_section
+    assert "evaluation_dashboard_path" in output_section
+    assert "verdict =" not in output_section, (
+        "Output section must not contain a 'verdict =' token; verdict belongs downstream"
+    )
+    assert "verdict=" not in output_section, (
+        "Output section must not contain a 'verdict=' token; verdict belongs downstream"
+    )
+
+
+def test_findings_manifest_schema_documented() -> None:
+    """Findings manifest JSON schema is documented with all required fields."""
+    content = _SKILL_MD.read_text(encoding="utf-8")
+    required_fields = [
+        "dimension",
+        "level",
+        "severity",
+        "finding",
+        "addressable",
+        "requires_decision",
+        "priority",
+        "fixability",
+        "message",
+    ]
+    for field in required_fields:
+        assert field in content, f"Missing schema field: {field}"
+    assert "red_team_findings" in content
+
+
+def test_silencing_rules_documented() -> None:
+    """Three-layer silencing rules are documented with variance_protocol exception."""
+    content = _SKILL_MD.read_text(encoding="utf-8")
+    assert "Static SILENT" in content or "static SILENT" in content
+    assert "Foothold validation" in content or "foothold validation" in content
+    assert "Finding-count suppression" in content or "finding-count suppression" in content
+    assert "variance_protocol" in content  # exception to foothold validation

--- a/tests/skills_extended/test_classify_experiment_type_skill.py
+++ b/tests/skills_extended/test_classify_experiment_type_skill.py
@@ -1,0 +1,94 @@
+"""Tests for the classify-experiment-type skill SKILL.md specification.
+
+These are stateless read-only tests that verify structural validity of the
+SKILL.md file: directory exists, frontmatter parses, required sections are
+present, silent-type rule is documented correctly, and verdict is not in
+the output tokens.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import pkg_root
+from autoskillit.core.io import load_yaml
+
+pytestmark = [pytest.mark.medium]
+
+_SKILL_DIR = pkg_root() / "skills_extended" / "classify-experiment-type"
+_SKILL_MD = _SKILL_DIR / "SKILL.md"
+
+
+def test_skill_directory_exists() -> None:
+    """Skill directory exists and SKILL.md is present."""
+    assert _SKILL_DIR.is_dir(), f"Skill directory missing: {_SKILL_DIR}"
+    assert _SKILL_MD.is_file(), f"SKILL.md missing: {_SKILL_MD}"
+
+
+def test_skill_frontmatter() -> None:
+    """SKILL.md frontmatter is valid YAML and contains required fields."""
+    content = _SKILL_MD.read_text(encoding="utf-8")
+    parts = content.split("---", 2)
+    assert len(parts) >= 3, "SKILL.md missing YAML frontmatter delimiters"
+    fm = load_yaml(parts[1])
+    assert isinstance(fm, dict), "SKILL.md frontmatter is not a YAML mapping"
+    assert fm["name"] == "classify-experiment-type"
+    assert fm["categories"] == ["research"]
+    assert fm["backend_requirements"] == ["claude-code"]
+
+
+def test_skill_sections() -> None:
+    """All required H2 sections are present in the SKILL.md body."""
+    content = _SKILL_MD.read_text(encoding="utf-8")
+    required = [
+        "## When to Use",
+        "## Arguments",
+        "## Critical Constraints",
+        "## Workflow",
+        "## Output",
+        "## Related Skills",
+    ]
+    for section in required:
+        assert section in content, f"SKILL.md missing required section: {section!r}"
+
+
+def test_no_verdict_token() -> None:
+    """The Output section must not emit a 'verdict' token.
+
+    classify-experiment-type is the dial step — verdict belongs to
+    apply-review-dimensions / review-design, not this skill.
+    """
+    content = _SKILL_MD.read_text(encoding="utf-8")
+    assert "## Output" in content, "SKILL.md missing ## Output section"
+    after_output = content.split("## Output", 1)[1]
+    # Look at content between ## Output and the next H2 (Related Skills).
+    related = after_output.split("## Related Skills", 1)
+    output_section = related[0] if len(related) > 1 else after_output
+    assert "verdict =" not in output_section, (
+        "Output section must not contain a 'verdict =' token; verdict belongs downstream"
+    )
+    assert "verdict=" not in output_section, (
+        "Output section must not contain a 'verdict=' token; verdict belongs downstream"
+    )
+
+
+def test_silent_type_rule_documented() -> None:
+    """Silent-type detection rule references '>=6 of 8' and the shared convention doc.
+
+    Also confirms the rule explicitly operates on the BASE registry entry's
+    dimension_weights — not on modifier-adjusted weights from triage.
+    """
+    content = _SKILL_MD.read_text(encoding="utf-8")
+    threshold_present = ">=6 of 8" in content or "≥6 of 8" in content or ">= 6" in content
+    assert threshold_present, "Silent-type rule '>=6 of 8' not documented in SKILL.md"
+    assert "is_silent_type" in content, "Token 'is_silent_type' not referenced in SKILL.md"
+    assert "docs/research/silent-type-convention.md" in content, (
+        "Reference to docs/research/silent-type-convention.md missing from SKILL.md"
+    )
+    # Confirm the rule operates on the BASE registry entry, not modifier-adjusted weights.
+    assert "BASE registry entry" in content, (
+        "Silent-type check must explicitly reference the BASE registry entry's dimension_weights"
+    )
+    assert "modifier-adjusted" in content, (
+        "SKILL.md must clarify that silent-type check does NOT use modifier-adjusted weights"
+    )

--- a/tests/skills_extended/test_classify_experiment_type_skill.py
+++ b/tests/skills_extended/test_classify_experiment_type_skill.py
@@ -73,14 +73,10 @@ def test_no_verdict_token() -> None:
 
 
 def test_silent_type_rule_documented() -> None:
-    """Silent-type detection rule references '>=6 of 8' and the shared convention doc.
-
-    Also confirms the rule explicitly operates on the BASE registry entry's
-    dimension_weights — not on modifier-adjusted weights from triage.
-    """
+    """Silent-type detection rule references '>=6 of 9' and the shared convention doc."""
     content = _SKILL_MD.read_text(encoding="utf-8")
-    threshold_present = ">=6 of 8" in content or "≥6 of 8" in content or ">= 6" in content
-    assert threshold_present, "Silent-type rule '>=6 of 8' not documented in SKILL.md"
+    threshold_present = ">=6 of 9" in content or "≥6 of 9" in content
+    assert threshold_present, "Silent-type rule '>=6 of 9' not documented in SKILL.md"
     assert "is_silent_type" in content, "Token 'is_silent_type' not referenced in SKILL.md"
     assert "docs/research/silent-type-convention.md" in content, (
         "Reference to docs/research/silent-type-convention.md missing from SKILL.md"

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -616,6 +616,7 @@ RESEARCH_SKILL_NAMES = {
     "audit-claims",
     "resolve-claims-review",
     "classify-experiment-type",
+    "apply-review-dimensions",
 }
 
 

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -615,6 +615,7 @@ RESEARCH_SKILL_NAMES = {
     "troubleshoot-experiment",
     "audit-claims",
     "resolve-claims-review",
+    "classify-experiment-type",
 }
 
 

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -615,7 +615,6 @@ RESEARCH_SKILL_NAMES = {
     "troubleshoot-experiment",
     "audit-claims",
     "resolve-claims-review",
-    "apply-review-dimensions",
     "classify-experiment-type",
 }
 

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -615,6 +615,7 @@ RESEARCH_SKILL_NAMES = {
     "troubleshoot-experiment",
     "audit-claims",
     "resolve-claims-review",
+    "apply-review-dimensions",
     "classify-experiment-type",
 }
 


### PR DESCRIPTION
## Summary

Splits the monolithic `review-design` skill into two phoropter-style skills — `classify-experiment-type` (phoropter dial phase, emitting `dimensions_manifest_path`) and `apply-review-dimensions` (dimension evaluation phase, consuming the manifest and emitting `findings_manifest_path` + `evaluation_dashboard_path` without a verdict). Also remediates two audit findings from the Part A implementation (missing "never decrease" qualifier on secondary modifiers; over-permissive `RESEARCH_SKILL_NAMES` set in `tests/workspace/test_skills.py`).

<details>
<summary>Individual Group Plans</summary>

### Plan A — Create classify-experiment-type/SKILL.md (PART A)

Create `src/autoskillit/skills_extended/classify-experiment-type/SKILL.md` — the phoropter dial phase skill that extracts Steps 0–1 plus silent-type detection from the review-design monolith. This skill classifies an experiment plan into a type, builds the dimension weight matrix, detects silent types, and emits dialing interface tokens (`dimensions_manifest_path`, `selected_lenses`, `lens_context_paths`) consumed by apply-review-dimensions.

Part B covers `apply-review-dimensions/SKILL.md` (separate task).

### Plan B — Create apply-review-dimensions/SKILL.md (PART B)

Create `src/autoskillit/skills_extended/apply-review-dimensions/SKILL.md` — the dimension evaluation skill that consumes `dimensions_manifest_path` from the classify step and runs L1–L4 + red-team analysis, producing `findings_manifest_path` and `evaluation_dashboard_path` without emitting a verdict.

Part A covers `classify-experiment-type/SKILL.md` (separate task).

### Plan C — Remediate classify-experiment-type Part A audit findings

Fix two audit findings from the classify-experiment-type Part A implementation:

1. Add the "never decrease" qualifier to the secondary modifiers documentation in `classify-experiment-type/SKILL.md` line 113.
2. Remove `"apply-review-dimensions"` from `RESEARCH_SKILL_NAMES` in `tests/workspace/test_skills.py` — the plan explicitly prohibited adding it in Part A.

</details>

Closes #3091

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/impl-20260602-174558-699372/.autoskillit/temp/make-plan/create_classify_and_apply_review_skills_plan_2026-06-02_175300_part_a.md`
- `/home/talon/projects/autoskillit-runs/impl-20260602-174558-699372/.autoskillit/temp/make-plan/create_classify_and_apply_review_skills_plan_2026-06-02_175300_part_b.md`
- `/home/talon/projects/autoskillit-runs/impl-20260602-174558-699372/.autoskillit/temp/make-plan/create_classify_and_apply_review_skills_remediation_plan_2026-06-02_193600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 153 | 33.9k | 3.5M | 117.9k | 94 | 149.5k | 18m 26s |
| verify* | sonnet | 3 | 525 | 30.9k | 1.7M | 74.1k | 103 | 149.6k | 13m 3s |
| implement* | MiniMax-M3 | 3 | 195.1k | 40.5k | 8.1M | 103.4k | 280 | 0 | 24m 45s |
| fix* | sonnet | 3 | 706 | 48.6k | 6.6M | 114.8k | 250 | 201.0k | 26m 53s |
| audit_impl* | sonnet | 2 | 1.0k | 17.7k | 707.3k | 55.2k | 41 | 65.5k | 13m 7s |
| prepare_pr* | MiniMax-M3 | 1 | 53.7k | 3.2k | 223.6k | 57.6k | 15 | 0 | 1m 26s |
| compose_pr* | MiniMax-M3 | 1 | 36.2k | 1.8k | 267.0k | 39.5k | 16 | 0 | 59s |
| review_pr* | sonnet | 1 | 126 | 39.9k | 921.4k | 105.9k | 45 | 91.2k | 11m 2s |
| resolve_review* | sonnet | 1 | 325 | 30.6k | 3.0M | 99.1k | 99 | 83.2k | 16m 52s |
| **Total** | | | 287.9k | 246.9k | 25.0M | 117.9k | | 740.1k | 2h 6m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 838 | 9683.4 | 0.0 | 48.3 |
| fix | 81 | 81019.1 | 2481.7 | 600.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 31 | 96589.8 | 2684.6 | 986.7 |
| **Total** | **950** | 26276.7 | 779.0 | 259.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 153 | 33.9k | 3.5M | 149.5k | 18m 26s |
| sonnet | 5 | 2.7k | 167.6k | 12.8M | 590.6k | 1h 21m |
| MiniMax-M3 | 3 | 285.0k | 45.5k | 8.6M | 0 | 27m 11s |