### PR TITLE
Add review callables; gate estimand_clarity stop on fixability

### DIFF
--- a/src/autoskillit/smoke_utils/CLAUDE.md
+++ b/src/autoskillit/smoke_utils/CLAUDE.md
@@ -6,10 +6,10 @@ Utility callables for smoke-test pipeline `run_python` steps (decomposed from mo
 
 | File | Purpose |
 |------|---------|
-| `__init__.py` | Re-export facade — 21 public names via `__all__` |
+| `__init__.py` | Re-export facade — 25 public names via `__all__` |
 | `_helpers.py` | Shared JSON loading helpers (`_load_json`, `try_load_json`) |
 | `_merge_gate_diagnosis.py` | Merge gate test failure diagnosis file writer |
-| `_review.py` | PR diff annotation, review loop guards, diff context enrichment |
+| `_review.py` | PR diff annotation, review loop guards, diff context enrichment, dimension selection, verdict aggregation |
 | `_eval.py` | Eval manifest parsing, context building, scorecard compilation |
 | `_telemetry.py` | PR token summary patching, `_PR_SECTION_RE` |
 | `_git.py` | Git/merge-queue helpers, domain partitions, zero-change detection |

--- a/src/autoskillit/smoke_utils/__init__.py
+++ b/src/autoskillit/smoke_utils/__init__.py
@@ -22,6 +22,7 @@ from autoskillit.smoke_utils._helpers import try_load_json
 from autoskillit.smoke_utils._merge_gate_diagnosis import diagnose_merge_gate
 from autoskillit.smoke_utils._review import (
     LOCAL_ROUND_EXEMPT_VERDICTS,
+    aggregate_review_verdict,
     annotate_pr_diff,
     check_loop_iteration,
     check_loop_with_progress,
@@ -29,11 +30,13 @@ from autoskillit.smoke_utils._review import (
     enrich_diff_context,
     init_counter,
     pre_iteration_cleanup,
+    select_review_dimensions,
 )
 from autoskillit.smoke_utils._telemetry import consolidate_health_reports, patch_pr_token_summary
 
 __all__ = [
     "LOCAL_ROUND_EXEMPT_VERDICTS",
+    "aggregate_review_verdict",
     "annotate_pr_diff",
     "build_agent_eval_context",
     "build_eval_context",
@@ -55,5 +58,6 @@ __all__ = [
     "parse_eval_manifests",
     "patch_pr_token_summary",
     "pre_iteration_cleanup",
+    "select_review_dimensions",
     "try_load_json",
 ]

--- a/src/autoskillit/smoke_utils/_review.py
+++ b/src/autoskillit/smoke_utils/_review.py
@@ -498,9 +498,7 @@ def aggregate_review_verdict(
     structural_stop_triggers = [
         f
         for f in l1_criticals
-        if f.get("fixability") == "STRUCTURAL"
-        or f.get("fixability") is None
-        or f.get("dimension") == "estimand_clarity"
+        if f.get("fixability") == "STRUCTURAL" or f.get("fixability") is None
     ]
     rt_stop = [f for f in critical_findings if f.get("dimension") == "red_team"]
     stop_triggers = structural_stop_triggers + rt_stop

--- a/src/autoskillit/smoke_utils/_review.py
+++ b/src/autoskillit/smoke_utils/_review.py
@@ -472,9 +472,7 @@ def aggregate_review_verdict(
 
     rt_cap = rt_max_severity.strip() if rt_max_severity.strip() else "critical"
     if not rt_max_severity.strip() and experiment_type.strip():
-        from autoskillit.recipe.experiment_type_registry import (  # noqa: PLC0415
-            get_experiment_type_by_name,
-        )
+        from autoskillit.recipe import get_experiment_type_by_name  # noqa: PLC0415
 
         spec = get_experiment_type_by_name(experiment_type.strip())
         if spec is not None:

--- a/src/autoskillit/smoke_utils/_review.py
+++ b/src/autoskillit/smoke_utils/_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC
 from pathlib import Path
 
 from autoskillit.core import get_logger
@@ -136,6 +137,8 @@ LOCAL_ROUND_EXEMPT_VERDICTS: frozenset[str] = frozenset(
         "approved_with_comments",
     }
 )
+
+SEVERITY_RANK: dict[str, int] = {"info": 0, "warning": 1, "critical": 2}
 
 
 def check_review_loop(
@@ -354,3 +357,232 @@ def pre_iteration_cleanup(
         removed += 1
 
     return {"cleaned": "true", "removed_count": str(removed)}
+
+
+def select_review_dimensions(
+    experiment_type: str = "",
+    dimension_weights_json: str = "",
+    secondary_modifiers_json: str = "",
+    output_dir: str = "",
+) -> dict[str, str]:
+    """Transform dimension weights and modifiers into the dialing contract format.
+
+    Called by run_python from review-design recipe steps. Parses dimension
+    weights, applies secondary modifiers, filters silent (S) dimensions,
+    sorts by tier, and writes a dimensions manifest.
+    """
+    from autoskillit.core import atomic_write  # noqa: PLC0415
+
+    _EMPTY = {"selected_lenses": "", "lens_context_paths": "", "dimensions_manifest_path": ""}
+
+    weights_str = dimension_weights_json.strip()
+    if not weights_str:
+        return _EMPTY
+
+    weights: dict[str, str] = json.loads(weights_str)
+    if not weights:
+        return _EMPTY
+
+    modifiers_str = secondary_modifiers_json.strip()
+    modifiers: list[str] = json.loads(modifiers_str) if modifiers_str else []
+
+    tier_order = ["H", "M", "L", "S"]
+
+    def _upgrade_one_tier(current: str) -> str:
+        idx = tier_order.index(current)
+        return tier_order[max(0, idx - 1)]
+
+    for mod in modifiers:
+        if mod == "+causal" and "causal_structure" in weights:
+            weights["causal_structure"] = _upgrade_one_tier(weights["causal_structure"])
+        elif mod == "+high_cost" and "resource_proportionality" in weights:
+            if weights["resource_proportionality"] == "L":
+                weights["resource_proportionality"] = "M"
+        elif mod == "+deployment" and "ecological_validity" in weights:
+            if tier_order.index(weights["ecological_validity"]) > tier_order.index("M"):
+                weights["ecological_validity"] = "M"
+        elif mod == "+multi_metric" and "statistical_corrections" in weights:
+            weights["statistical_corrections"] = _upgrade_one_tier(
+                weights["statistical_corrections"]
+            )
+
+    active = {dim: w for dim, w in weights.items() if w != "S"}
+    if not active:
+        return _EMPTY
+
+    out = Path(output_dir)
+    if not out.is_absolute():
+        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
+
+    tier_rank = {"H": 0, "M": 1, "L": 2}
+    sorted_dims = sorted(active.items(), key=lambda x: tier_rank.get(x[1], 3))
+
+    selected_lenses = ",".join(d for d, _ in sorted_dims)
+    lens_context_paths = ",".join("" for _ in sorted_dims)
+
+    out.mkdir(parents=True, exist_ok=True)
+    manifest_path = out / "dimensions_manifest.json"
+    manifest_data = dict(sorted_dims)
+    atomic_write(manifest_path, json.dumps(manifest_data))
+
+    return {
+        "selected_lenses": selected_lenses,
+        "lens_context_paths": lens_context_paths,
+        "dimensions_manifest_path": str(manifest_path),
+    }
+
+
+def aggregate_review_verdict(
+    findings_manifest_path: str = "",
+    dimensions_manifest_path: str = "",
+    experiment_type: str = "",
+    rt_max_severity: str = "",
+    output_dir: str = "",
+) -> dict[str, str]:
+    """Compute GO/REVISE/STOP verdict from review findings and dimension weights.
+
+    Called by run_python from the review-design verdict step. Applies red-team
+    severity caps, computes proportional warning thresholds, identifies
+    structural stop triggers, and writes evaluation artifacts.
+    """
+    from datetime import datetime  # noqa: PLC0415
+
+    from autoskillit.core import atomic_write  # noqa: PLC0415
+
+    if not findings_manifest_path.strip():
+        return {"error": "findings_manifest_path is empty"}
+
+    findings_path = Path(findings_manifest_path.strip())
+    if not findings_path.exists():
+        return {"error": f"findings manifest not found: {findings_manifest_path}"}
+
+    out = Path(output_dir)
+    if not out.is_absolute():
+        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
+
+    findings: list[dict[str, str | None]] = json.loads(findings_path.read_text())
+
+    active_dimensions = 0
+    dim_data: dict[str, str] = {}
+    if dimensions_manifest_path.strip():
+        dim_path = Path(dimensions_manifest_path.strip())
+        if dim_path.exists():
+            dim_data = json.loads(dim_path.read_text())
+            active_dimensions = sum(1 for w in dim_data.values() if w != "S")
+
+    rt_cap = rt_max_severity.strip() if rt_max_severity.strip() else "critical"
+    if not rt_max_severity.strip() and experiment_type.strip():
+        from autoskillit.recipe.experiment_type_registry import (  # noqa: PLC0415
+            get_experiment_type_by_name,
+        )
+
+        spec = get_experiment_type_by_name(experiment_type.strip())
+        if spec is not None:
+            rt_cap = spec.red_team_focus.get("severity_cap", "critical")
+
+    for f in findings:
+        if f.get("dimension") == "red_team":
+            f_sev = f.get("severity", "info")
+            if SEVERITY_RANK.get(str(f_sev), 0) > SEVERITY_RANK.get(rt_cap, 2):
+                f["severity"] = rt_cap
+
+    warning_threshold = active_dimensions * 5
+
+    critical_findings = [f for f in findings if f.get("severity") == "critical"]
+    warning_findings = [f for f in findings if f.get("severity") == "warning"]
+    info_findings = [f for f in findings if f.get("severity") == "info"]
+
+    l1_criticals = [
+        f
+        for f in critical_findings
+        if f.get("dimension") in {"estimand_clarity", "hypothesis_falsifiability"}
+    ]
+    structural_stop_triggers = [
+        f
+        for f in l1_criticals
+        if f.get("fixability") == "STRUCTURAL"
+        or f.get("fixability") is None
+        or f.get("dimension") == "estimand_clarity"
+    ]
+    rt_stop = [f for f in critical_findings if f.get("dimension") == "red_team"]
+    stop_triggers = structural_stop_triggers + rt_stop
+
+    if stop_triggers:
+        verdict = "STOP"
+    elif critical_findings or (
+        active_dimensions > 0 and len(warning_findings) >= warning_threshold
+    ):
+        verdict = "REVISE"
+    else:
+        verdict = "GO"
+
+    out.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%d_%H%M%S")
+
+    scorecard_rows = []
+    for dim, weight in dim_data.items():
+        c = sum(
+            1 for f in findings if f.get("dimension") == dim and f.get("severity") == "critical"
+        )
+        w = sum(
+            1 for f in findings if f.get("dimension") == dim and f.get("severity") == "warning"
+        )
+        i = sum(1 for f in findings if f.get("dimension") == dim and f.get("severity") == "info")
+        scorecard_rows.append(f"| {dim} | {weight} | {c} | {w} | {i} |")
+
+    dashboard_lines = [
+        "# Evaluation Dashboard\n",
+        f"## Verdict: {verdict}\n",
+        "## Dimension Scorecard\n",
+        "| Dimension | Weight | Critical | Warning | Info |",
+        "|-----------|--------|----------|---------|------|",
+        *scorecard_rows,
+        "",
+        "## Finding Summary\n",
+        f"- **Critical:** {len(critical_findings)}",
+        f"- **Warning:** {len(warning_findings)}",
+        f"- **Info:** {len(info_findings)}",
+        f"- **Stop triggers:** {len(stop_triggers)}",
+        "",
+        "## Summary\n",
+        "```yaml",
+        f"verdict: {verdict}",
+        f"total_findings: {len(findings)}",
+        f"critical_count: {len(critical_findings)}",
+        f"warning_count: {len(warning_findings)}",
+        f"info_count: {len(info_findings)}",
+        f"active_dimensions: {active_dimensions}",
+        f"warning_threshold: {warning_threshold}",
+        f"stop_triggers: {len(stop_triggers)}",
+        "```",
+    ]
+    dashboard_path = out / f"evaluation_dashboard_{timestamp}.md"
+    atomic_write(dashboard_path, "\n".join(dashboard_lines))
+
+    result: dict[str, str] = {
+        "verdict": verdict,
+        "evaluation_dashboard_path": str(dashboard_path),
+    }
+
+    if verdict == "REVISE":
+        required = [
+            f"- **[{f.get('dimension', '?')}]** {f.get('message', f.get('finding', ''))}"
+            for f in critical_findings
+        ]
+        recommended = [
+            f"- **[{f.get('dimension', '?')}]** {f.get('message', f.get('finding', ''))}"
+            for f in warning_findings
+        ]
+        guidance_lines = [
+            "# Revision Guidance\n",
+            "## Required Revisions (Critical)\n",
+            *(required if required else ["- (none)"]),
+            "",
+            "## Recommended Revisions (Warning)\n",
+            *(recommended if recommended else ["- (none)"]),
+        ]
+        guidance_path = out / f"revision_guidance_{timestamp}.md"
+        atomic_write(guidance_path, "\n".join(guidance_lines))
+        result["revision_guidance_path"] = str(guidance_path)
+
+    return result

--- a/src/autoskillit/smoke_utils/_review.py
+++ b/src/autoskillit/smoke_utils/_review.py
@@ -139,6 +139,8 @@ LOCAL_ROUND_EXEMPT_VERDICTS: frozenset[str] = frozenset(
 )
 
 SEVERITY_RANK: dict[str, int] = {"info": 0, "warning": 1, "critical": 2}
+TIER_RANK: dict[str, int] = {"H": 0, "M": 1, "L": 2}
+_STRUCTURAL_FIXABILITY_VALUES: frozenset[str | None] = frozenset({"STRUCTURAL", None})
 
 
 def check_review_loop(
@@ -375,20 +377,32 @@ def select_review_dimensions(
 
     _EMPTY = {"selected_lenses": "", "lens_context_paths": "", "dimensions_manifest_path": ""}
 
+    out = Path(output_dir)
+    if not out.is_absolute():
+        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
+
     weights_str = dimension_weights_json.strip()
     if not weights_str:
         return _EMPTY
 
-    weights: dict[str, str] = json.loads(weights_str)
+    try:
+        weights: dict[str, str] = json.loads(weights_str)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in dimension_weights_json: {exc}") from exc
     if not weights:
         return _EMPTY
 
     modifiers_str = secondary_modifiers_json.strip()
-    modifiers: list[str] = json.loads(modifiers_str) if modifiers_str else []
+    try:
+        modifiers: list[str] = json.loads(modifiers_str) if modifiers_str else []
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in secondary_modifiers_json: {exc}") from exc
 
     tier_order = ["H", "M", "L", "S"]
 
     def _upgrade_one_tier(current: str) -> str:
+        if current not in tier_order:
+            raise ValueError(f"unknown tier {current!r}; expected one of {tier_order}")
         idx = tier_order.index(current)
         return tier_order[max(0, idx - 1)]
 
@@ -410,12 +424,7 @@ def select_review_dimensions(
     if not active:
         return _EMPTY
 
-    out = Path(output_dir)
-    if not out.is_absolute():
-        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
-
-    tier_rank = {"H": 0, "M": 1, "L": 2}
-    sorted_dims = sorted(active.items(), key=lambda x: tier_rank.get(x[1], 3))
+    sorted_dims = sorted(active.items(), key=lambda x: TIER_RANK.get(x[1], 3))
 
     selected_lenses = ",".join(d for d, _ in sorted_dims)
     lens_context_paths = ",".join("" for _ in sorted_dims)
@@ -452,22 +461,28 @@ def aggregate_review_verdict(
     if not findings_manifest_path.strip():
         return {"error": "findings_manifest_path is empty"}
 
-    findings_path = Path(findings_manifest_path.strip())
-    if not findings_path.exists():
-        return {"error": f"findings manifest not found: {findings_manifest_path}"}
-
     out = Path(output_dir)
     if not out.is_absolute():
         raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
 
-    findings: list[dict[str, str | None]] = json.loads(findings_path.read_text())
+    findings_path = Path(findings_manifest_path.strip())
+    if not findings_path.exists():
+        return {"error": f"findings manifest not found: {findings_manifest_path}"}
+
+    try:
+        findings: list[dict[str, str | None]] = json.loads(findings_path.read_text())
+    except json.JSONDecodeError as exc:
+        return {"error": f"corrupt findings manifest: {exc}"}
 
     active_dimensions = 0
     dim_data: dict[str, str] = {}
     if dimensions_manifest_path.strip():
         dim_path = Path(dimensions_manifest_path.strip())
         if dim_path.exists():
-            dim_data = json.loads(dim_path.read_text())
+            try:
+                dim_data = json.loads(dim_path.read_text())
+            except json.JSONDecodeError as exc:
+                return {"error": f"corrupt dimensions manifest: {exc}"}
             active_dimensions = sum(1 for w in dim_data.values() if w != "S")
 
     rt_cap = rt_max_severity.strip() if rt_max_severity.strip() else "critical"
@@ -496,9 +511,7 @@ def aggregate_review_verdict(
         if f.get("dimension") in {"estimand_clarity", "hypothesis_falsifiability"}
     ]
     structural_stop_triggers = [
-        f
-        for f in l1_criticals
-        if f.get("fixability") == "STRUCTURAL" or f.get("fixability") is None
+        f for f in l1_criticals if f.get("fixability") in _STRUCTURAL_FIXABILITY_VALUES
     ]
     rt_stop = [f for f in critical_findings if f.get("dimension") == "red_team"]
     stop_triggers = structural_stop_triggers + rt_stop

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -514,6 +514,7 @@ MODULE_CASCADE_RECIPE: dict[str, frozenset[str]] = {
             "skills/test_review_design_contracts.py",
             "integration",
             "cli",
+            "smoke_utils",
         }
     ),
     "registry": frozenset(
@@ -781,6 +782,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "skills/test_vis_lens_methodology_norms.py",
             "skills/test_audit_impl_diff_discipline.py",
             "skills/test_skill_variable_threading.py",
+            "smoke_utils",
         }
     ),
     "migration": frozenset(

--- a/tests/arch/test_run_python_path_resolution.py
+++ b/tests/arch/test_run_python_path_resolution.py
@@ -42,6 +42,16 @@ _EXPLICITLY_EXCLUDED: dict[str, str] = {
         "patch_pr_token_summary receives log_dir as an absolute path from the "
         "caller context; never passed as a relative string to run_python steps"
     ),
+    "findings_manifest_path": (
+        "input file path produced by an upstream run_python callable; "
+        "always absolute (returned by select_review_dimensions or written by "
+        "apply-review-dimensions skill); never a relative path at the call site"
+    ),
+    "dimensions_manifest_path": (
+        "input file path produced by select_review_dimensions; "
+        "always absolute (dimensions_manifest_path return value); "
+        "never a relative path at the run_python call site"
+    ),
 }
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -148,11 +148,12 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/cli/update/_update_checks.py", 77),
     # _update_checks_fetch.py — fetch cache (extracted from _update_checks.py)
     ("src/autoskillit/cli/update/_update_checks_fetch.py", 58),
-    # smoke_utils/_review.py — ranges, valid lines, diff metrics, enriched handoff
-    ("src/autoskillit/smoke_utils/_review.py", 100),
+    # smoke_utils/_review.py — ranges, valid lines, diff metrics, enriched handoff, manifest
     ("src/autoskillit/smoke_utils/_review.py", 101),
-    ("src/autoskillit/smoke_utils/_review.py", 119),
-    ("src/autoskillit/smoke_utils/_review.py", 310),
+    ("src/autoskillit/smoke_utils/_review.py", 102),
+    ("src/autoskillit/smoke_utils/_review.py", 120),
+    ("src/autoskillit/smoke_utils/_review.py", 313),
+    ("src/autoskillit/smoke_utils/_review.py", 426),
     # smoke_utils/_git.py — partitions, merge queue data
     # Line 110 is a list-payload write site (dual membership: also in list_sites
     # in test_allowlist_includes_list_payloads_as_documented). The AST scanner catches
@@ -234,7 +235,7 @@ class TestSchemaVersionConvention:
         """List-payload sites are included since the AST scanner can't distinguish return types."""
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
-            ("src/autoskillit/smoke_utils/_review.py", 100),
+            ("src/autoskillit/smoke_utils/_review.py", 101),
             ("src/autoskillit/smoke_utils/_git.py", 110),
         ]
         for site in list_sites:

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -152,8 +152,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils/_review.py", 101),
     ("src/autoskillit/smoke_utils/_review.py", 102),
     ("src/autoskillit/smoke_utils/_review.py", 120),
-    ("src/autoskillit/smoke_utils/_review.py", 313),
-    ("src/autoskillit/smoke_utils/_review.py", 426),
+    ("src/autoskillit/smoke_utils/_review.py", 315),
+    ("src/autoskillit/smoke_utils/_review.py", 435),
     # smoke_utils/_git.py — partitions, merge queue data
     # Line 110 is a list-payload write site (dual membership: also in list_sites
     # in test_allowlist_includes_list_payloads_as_documented). The AST scanner catches

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -2780,6 +2780,7 @@ def test_aggregate_review_verdict_missing_file_returns_error(tmp_path: Path) -> 
 
     result = aggregate_review_verdict(
         findings_manifest_path=str(tmp_path / "nonexistent.json"),
+        output_dir=str(tmp_path / "out"),
     )
     assert "error" in result
 

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -2365,10 +2365,11 @@ def test_diagnose_merge_gate_rejects_empty_output_dir() -> None:
 
 
 def test_smoke_utils_all_exports_complete() -> None:
-    """smoke_utils.__all__ must list all 23 public names."""
+    """smoke_utils.__all__ must list all 25 public names."""
     import autoskillit.smoke_utils as su
 
     expected = {
+        "aggregate_review_verdict",
         "annotate_pr_diff",
         "build_agent_eval_context",
         "build_eval_context",
@@ -2391,6 +2392,7 @@ def test_smoke_utils_all_exports_complete() -> None:
         "parse_eval_manifests",
         "patch_pr_token_summary",
         "pre_iteration_cleanup",
+        "select_review_dimensions",
         "try_load_json",
     }
     assert set(su.__all__) == expected
@@ -2399,6 +2401,7 @@ def test_smoke_utils_all_exports_complete() -> None:
 @pytest.mark.parametrize(
     "name",
     [
+        "aggregate_review_verdict",
         "annotate_pr_diff",
         "build_agent_eval_context",
         "build_eval_context",
@@ -2420,6 +2423,7 @@ def test_smoke_utils_all_exports_complete() -> None:
         "parse_eval_manifests",
         "patch_pr_token_summary",
         "pre_iteration_cleanup",
+        "select_review_dimensions",
         "try_load_json",
     ],
 )
@@ -2541,6 +2545,244 @@ def test_pre_iteration_cleanup_noop_when_dir_empty(tmp_path: Path) -> None:
     result = pre_iteration_cleanup(output_dir=str(out))
     assert result["cleaned"] == "true"
     assert result["removed_count"] == "0"
+
+
+# ---------------------------------------------------------------------------
+# T_SRD1–T_SRD5: select_review_dimensions callable
+# ---------------------------------------------------------------------------
+
+
+def test_select_review_dimensions_happy_path(tmp_path: Path) -> None:
+    """select_review_dimensions sorts by tier and excludes S dimensions."""
+    from autoskillit.smoke_utils import select_review_dimensions
+
+    weights = {
+        "causal_structure": "H",
+        "variance_protocol": "M",
+        "ecological_validity": "L",
+        "data_acquisition": "S",
+    }
+    result = select_review_dimensions(
+        dimension_weights_json=json.dumps(weights),
+        output_dir=str(tmp_path),
+    )
+    lenses = result["selected_lenses"].split(",")
+    assert lenses == ["causal_structure", "variance_protocol", "ecological_validity"]
+    assert "data_acquisition" not in result["selected_lenses"]
+    ctx_parts = result["lens_context_paths"].split(",")
+    assert len(ctx_parts) == len(lenses)
+    assert all(p == "" for p in ctx_parts)
+    manifest = json.loads(Path(result["dimensions_manifest_path"]).read_text())
+    assert "data_acquisition" not in manifest
+    assert list(manifest.keys()) == [
+        "causal_structure",
+        "variance_protocol",
+        "ecological_validity",
+    ]
+
+
+def test_select_review_dimensions_all_s_returns_empty(tmp_path: Path) -> None:
+    """All-S weights returns empty outputs and writes no file."""
+    from autoskillit.smoke_utils import select_review_dimensions
+
+    weights = {"causal_structure": "S", "variance_protocol": "S"}
+    result = select_review_dimensions(
+        dimension_weights_json=json.dumps(weights),
+        output_dir=str(tmp_path),
+    )
+    assert result["selected_lenses"] == ""
+    assert result["lens_context_paths"] == ""
+    assert result["dimensions_manifest_path"] == ""
+    assert not list(tmp_path.iterdir())
+
+
+def test_select_review_dimensions_causal_modifier_upgrades(tmp_path: Path) -> None:
+    """+causal modifier upgrades causal_structure one tier."""
+    from autoskillit.smoke_utils import select_review_dimensions
+
+    weights = {"causal_structure": "L", "variance_protocol": "M"}
+    result = select_review_dimensions(
+        dimension_weights_json=json.dumps(weights),
+        secondary_modifiers_json=json.dumps(["+causal"]),
+        output_dir=str(tmp_path),
+    )
+    manifest = json.loads(Path(result["dimensions_manifest_path"]).read_text())
+    assert manifest["causal_structure"] == "M"
+    lenses = result["selected_lenses"].split(",")
+    assert set(lenses) == {"causal_structure", "variance_protocol"}
+
+
+def test_select_review_dimensions_empty_weights_returns_empty(tmp_path: Path) -> None:
+    """Empty dimension_weights_json returns empty outputs without filesystem writes."""
+    from autoskillit.smoke_utils import select_review_dimensions
+
+    result = select_review_dimensions(
+        dimension_weights_json="",
+        output_dir=str(tmp_path),
+    )
+    assert result == {
+        "selected_lenses": "",
+        "lens_context_paths": "",
+        "dimensions_manifest_path": "",
+    }
+    assert not list(tmp_path.iterdir())
+
+
+def test_select_review_dimensions_creates_output_dir(tmp_path: Path) -> None:
+    """Missing output_dir is created by the function."""
+    from autoskillit.smoke_utils import select_review_dimensions
+
+    out = tmp_path / "nested" / "output"
+    assert not out.exists()
+    weights = {"scope_alignment": "H"}
+    result = select_review_dimensions(
+        dimension_weights_json=json.dumps(weights),
+        output_dir=str(out),
+    )
+    assert out.exists()
+    assert Path(result["dimensions_manifest_path"]).exists()
+
+
+# ---------------------------------------------------------------------------
+# T_ARV1–T_ARV7: aggregate_review_verdict callable
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_review_verdict_go(tmp_path: Path) -> None:
+    """GO verdict when no criticals and warnings below threshold."""
+    from autoskillit.smoke_utils import aggregate_review_verdict
+
+    findings = [
+        {"dimension": "scope_alignment", "severity": "info", "message": "ok"},
+        {"dimension": "variance_protocol", "severity": "warning", "message": "minor"},
+    ]
+    (tmp_path / "findings.json").write_text(json.dumps(findings))
+    dims = {"scope_alignment": "H", "variance_protocol": "M"}
+    (tmp_path / "dims.json").write_text(json.dumps(dims))
+
+    result = aggregate_review_verdict(
+        findings_manifest_path=str(tmp_path / "findings.json"),
+        dimensions_manifest_path=str(tmp_path / "dims.json"),
+        output_dir=str(tmp_path / "out"),
+    )
+    assert result["verdict"] == "GO"
+    assert "evaluation_dashboard_path" in result
+    assert Path(result["evaluation_dashboard_path"]).exists()
+    assert "revision_guidance_path" not in result
+
+
+def test_aggregate_review_verdict_revise(tmp_path: Path) -> None:
+    """REVISE verdict when non-stop-trigger critical is present."""
+    from autoskillit.smoke_utils import aggregate_review_verdict
+
+    findings = [
+        {
+            "dimension": "scope_alignment",
+            "severity": "critical",
+            "message": "gap",
+            "fixability": "ADDRESSABLE",
+        },
+    ]
+    (tmp_path / "findings.json").write_text(json.dumps(findings))
+
+    result = aggregate_review_verdict(
+        findings_manifest_path=str(tmp_path / "findings.json"),
+        output_dir=str(tmp_path / "out"),
+    )
+    assert result["verdict"] == "REVISE"
+    assert "revision_guidance_path" in result
+    assert Path(result["revision_guidance_path"]).exists()
+    assert Path(result["evaluation_dashboard_path"]).exists()
+
+
+def test_aggregate_review_verdict_stop_structural_l1(tmp_path: Path) -> None:
+    """STOP verdict on estimand_clarity critical (always structural)."""
+    from autoskillit.smoke_utils import aggregate_review_verdict
+
+    findings = [
+        {
+            "dimension": "estimand_clarity",
+            "severity": "critical",
+            "message": "ambiguous",
+            "fixability": None,
+        },
+    ]
+    (tmp_path / "findings.json").write_text(json.dumps(findings))
+
+    result = aggregate_review_verdict(
+        findings_manifest_path=str(tmp_path / "findings.json"),
+        output_dir=str(tmp_path / "out"),
+    )
+    assert result["verdict"] == "STOP"
+    assert "revision_guidance_path" not in result
+
+
+def test_aggregate_review_verdict_rt_cap_downgrades(tmp_path: Path) -> None:
+    """rt_max_severity='warning' downgrades red_team critical to warning."""
+    from autoskillit.smoke_utils import aggregate_review_verdict
+
+    findings = [
+        {"dimension": "red_team", "severity": "critical", "message": "adversarial"},
+    ]
+    (tmp_path / "findings.json").write_text(json.dumps(findings))
+    dims = {"scope_alignment": "H"}
+    (tmp_path / "dims.json").write_text(json.dumps(dims))
+
+    result = aggregate_review_verdict(
+        findings_manifest_path=str(tmp_path / "findings.json"),
+        dimensions_manifest_path=str(tmp_path / "dims.json"),
+        rt_max_severity="warning",
+        output_dir=str(tmp_path / "out"),
+    )
+    assert result["verdict"] == "GO"
+
+
+def test_aggregate_review_verdict_empty_path_returns_error() -> None:
+    """Empty findings_manifest_path returns error key."""
+    from autoskillit.smoke_utils import aggregate_review_verdict
+
+    result = aggregate_review_verdict(findings_manifest_path="")
+    assert "error" in result
+
+
+def test_aggregate_review_verdict_missing_file_returns_error(tmp_path: Path) -> None:
+    """Non-existent findings_manifest_path returns error key."""
+    from autoskillit.smoke_utils import aggregate_review_verdict
+
+    result = aggregate_review_verdict(
+        findings_manifest_path=str(tmp_path / "nonexistent.json"),
+    )
+    assert "error" in result
+
+
+def test_aggregate_review_verdict_warning_threshold_proportional(tmp_path: Path) -> None:
+    """warning_threshold = active_dimensions * 5: 10 warnings -> REVISE, 9 -> GO."""
+    from autoskillit.smoke_utils import aggregate_review_verdict
+
+    dims = {"dim_a": "H", "dim_b": "M"}  # 2 active -> threshold=10
+    (tmp_path / "dims.json").write_text(json.dumps(dims))
+
+    findings_10 = [
+        {"dimension": "dim_a", "severity": "warning", "message": f"w{i}"} for i in range(10)
+    ]
+    (tmp_path / "f10.json").write_text(json.dumps(findings_10))
+    r10 = aggregate_review_verdict(
+        findings_manifest_path=str(tmp_path / "f10.json"),
+        dimensions_manifest_path=str(tmp_path / "dims.json"),
+        output_dir=str(tmp_path / "out10"),
+    )
+    assert r10["verdict"] == "REVISE"
+
+    findings_9 = [
+        {"dimension": "dim_a", "severity": "warning", "message": f"w{i}"} for i in range(9)
+    ]
+    (tmp_path / "f9.json").write_text(json.dumps(findings_9))
+    r9 = aggregate_review_verdict(
+        findings_manifest_path=str(tmp_path / "f9.json"),
+        dimensions_manifest_path=str(tmp_path / "dims.json"),
+        output_dir=str(tmp_path / "out9"),
+    )
+    assert r9["verdict"] == "GO"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -2696,7 +2696,7 @@ def test_aggregate_review_verdict_revise(tmp_path: Path) -> None:
 
 
 def test_aggregate_review_verdict_stop_structural_l1(tmp_path: Path) -> None:
-    """STOP verdict on estimand_clarity critical (always structural)."""
+    """STOP verdict on estimand_clarity critical with fixability=None."""
     from autoskillit.smoke_utils import aggregate_review_verdict
 
     findings = [
@@ -2715,6 +2715,30 @@ def test_aggregate_review_verdict_stop_structural_l1(tmp_path: Path) -> None:
     )
     assert result["verdict"] == "STOP"
     assert "revision_guidance_path" not in result
+
+
+def test_aggregate_review_verdict_estimand_clarity_addressable_is_revise(tmp_path: Path) -> None:
+    """estimand_clarity critical with fixability=ADDRESSABLE → REVISE, not STOP."""
+    from autoskillit.smoke_utils import aggregate_review_verdict
+
+    findings = [
+        {
+            "dimension": "estimand_clarity",
+            "severity": "critical",
+            "message": "ambiguous but addressable",
+            "fixability": "ADDRESSABLE",
+        },
+    ]
+    (tmp_path / "findings.json").write_text(json.dumps(findings))
+
+    result = aggregate_review_verdict(
+        findings_manifest_path=str(tmp_path / "findings.json"),
+        output_dir=str(tmp_path / "out"),
+    )
+    assert result["verdict"] == "REVISE"
+    assert "revision_guidance_path" in result
+    assert Path(result["revision_guidance_path"]).exists()
+    assert Path(result["evaluation_dashboard_path"]).exists()
 
 
 def test_aggregate_review_verdict_rt_cap_downgrades(tmp_path: Path) -> None:

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -2715,6 +2715,8 @@ def test_aggregate_review_verdict_stop_structural_l1(tmp_path: Path) -> None:
     )
     assert result["verdict"] == "STOP"
     assert "revision_guidance_path" not in result
+    assert "evaluation_dashboard_path" in result
+    assert Path(result["evaluation_dashboard_path"]).exists()
 
 
 def test_aggregate_review_verdict_estimand_clarity_addressable_is_revise(tmp_path: Path) -> None:
@@ -2759,6 +2761,9 @@ def test_aggregate_review_verdict_rt_cap_downgrades(tmp_path: Path) -> None:
         output_dir=str(tmp_path / "out"),
     )
     assert result["verdict"] == "GO"
+    dashboard = Path(result["evaluation_dashboard_path"]).read_text()
+    assert "warning_count: 1" in dashboard
+    assert "critical_count: 0" in dashboard
 
 
 def test_aggregate_review_verdict_empty_path_returns_error() -> None:


### PR DESCRIPTION
## Summary

Add two new smoke_utils callables (`select_review_dimensions` and `aggregate_review_verdict`) that power the review pipeline's dimension selection and verdict aggregation stages, and fix a bug in `aggregate_review_verdict` where `estimand_clarity` critical findings were unconditionally treated as stop triggers regardless of their `fixability` value. The fix brings `estimand_clarity` in line with `hypothesis_falsifiability`: stop only when `fixability == "STRUCTURAL"` or `fixability is None`, and include a regression test for the `fixability="ADDRESSABLE"` case.

<details>
<summary>Individual Group Plans</summary>

### Group 1: Add select_review_dimensions() and aggregate_review_verdict()

Add two new callables to `src/autoskillit/smoke_utils/_review.py`:

1. **`select_review_dimensions()`** — Transforms classify-experiment-type output (dimension weights + modifiers) into the dialing contract format: `selected_lenses`, `lens_context_paths`, and `dimensions_manifest_path`. Applies four modifier rules, filters silent (S) dimensions, sorts by tier, and writes a manifest file.

2. **`aggregate_review_verdict()`** — Consumes a findings manifest and dimensions manifest to produce a GO/REVISE/STOP verdict. Applies red-team severity caps, computes proportional warning thresholds, identifies structural stop triggers, and writes evaluation dashboard and revision guidance artifacts.

Both follow the established smoke_utils callable pattern: `str`-only parameters with empty-string defaults, `dict[str, str]` return, lazy autoskillit imports inside the function body, absoluteness guard on `output_dir`.

### Group 2: Remediate estimand_clarity unconditional stop trigger

Fix a bug in `aggregate_review_verdict()` where `estimand_clarity` criticals are unconditionally treated as stop triggers regardless of their `fixability` value. The plan specification requires both `estimand_clarity` and `hypothesis_falsifiability` to follow the same rule: stop only when `fixability == "STRUCTURAL"` or `fixability is None`. Add a regression test for the `fixability="ADDRESSABLE"` case.

</details>

Closes #3092

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/impl-20260602-205550-796917/.autoskillit/temp/make-plan/add_select_review_dimensions_plan_2026-06-02_211000.md`
- `/home/talon/projects/autoskillit-runs/impl-20260602-205550-796917/.autoskillit/temp/make-plan/remediate_estimand_clarity_stop_trigger_plan_2026-06-02_220500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 3.7k | 51.1k | 1.6M | 128.6k | 62 | 162.1k | 24m 26s |
| verify* | sonnet | 2 | 144 | 14.6k | 629.5k | 55.1k | 49 | 62.7k | 7m 50s |
| implement* | MiniMax-M3 | 2 | 122.9k | 20.5k | 4.4M | 81.4k | 158 | 0 | 14m 38s |
| fix* | sonnet | 1 | 270 | 15.4k | 2.0M | 78.3k | 92 | 89.8k | 7m 19s |
| audit_impl* | sonnet | 2 | 104 | 23.2k | 419.0k | 65.3k | 31 | 72.3k | 11m 40s |
| prepare_pr* | MiniMax-M3 | 1 | 40.8k | 3.1k | 287.5k | 45.0k | 21 | 0 | 1m 43s |
| compose_pr* | MiniMax-M3 | 1 | 37.3k | 1.7k | 186.3k | 38.8k | 12 | 0 | 51s |
| review_pr* | sonnet | 1 | 140 | 46.5k | 993.8k | 101.4k | 46 | 86.0k | 11m 46s |
| resolve_review* | sonnet | 1 | 367 | 25.0k | 3.0M | 91.7k | 106 | 75.8k | 10m 53s |
| **Total** | | | 205.7k | 201.0k | 13.4M | 128.6k | | 548.6k | 1h 31m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 524 | 8336.6 | 0.0 | 39.0 |
| fix | 17 | 115651.5 | 5281.8 | 903.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 57 | 52205.4 | 1329.5 | 438.1 |
| **Total** | **598** | 22443.3 | 917.4 | 336.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 3.7k | 51.1k | 1.6M | 162.1k | 24m 26s |
| sonnet | 5 | 1.0k | 124.6k | 7.0M | 386.5k | 49m 30s |
| MiniMax-M3 | 3 | 201.0k | 25.3k | 4.8M | 0 | 17m 12s |