### PR TITLE
Rectify: Unify work_dir into Signature-Aware Sentinel Stripping

### DIFF
--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -240,7 +240,7 @@ DATA_MANIFEST_SOURCE_TYPES: frozenset[str] = frozenset(
     }
 )
 
-RUN_PYTHON_SENTINEL_KEYS: frozenset[str] = frozenset({"callable", "timeout"})
+RUN_PYTHON_SENTINEL_KEYS: frozenset[str] = frozenset({"callable", "timeout", "work_dir"})
 
 SCOPE_DIRECTION_SOURCE_TYPES: frozenset[str] = frozenset(
     {

--- a/src/autoskillit/recipe/rules/dataflow/rules_dataflow_callable.py
+++ b/src/autoskillit/recipe/rules/dataflow/rules_dataflow_callable.py
@@ -93,7 +93,7 @@ def _check_callable_signature_mismatch(ctx: ValidationContext) -> list[RuleFindi
         if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
             continue
         valid_params = set(sig.parameters.keys())
-        tool_level_params = RUN_PYTHON_SENTINEL_KEYS | {"args", "work_dir"}
+        tool_level_params = RUN_PYTHON_SENTINEL_KEYS | {"args"}
         provided_args = _get_provided_args(step.with_args) - tool_level_params
         invalid = provided_args - valid_params
         for arg_name in sorted(invalid):

--- a/src/autoskillit/server/tools/CLAUDE.md
+++ b/src/autoskillit/server/tools/CLAUDE.md
@@ -18,7 +18,7 @@ MCP `@mcp.tool()` handlers registered on import (20 tool modules).
 | `tools_ci_merge_queue.py` | `toggle_auto_merge`, `enqueue_pr`, `wait_for_merge_queue` |
 | `tools_clone.py` | `clone_repo`, `remove_clone`, `push_to_remote`, `register_clone_status`, `batch_cleanup_clones`, `bootstrap_clone` |
 | `_claim_helpers.py` | `ClaimDecision`, `_try_claim_with_liveness`, `_get_campaign_state_paths` — shared claiming logic for `claim_issue` and `claim_and_resolve_issue` |
-| `_execution_helpers.py` | `_import_and_call`, `_coerce_scalar`, `maybe_promote_work_dir`, `strip_work_dir_from_args`, `validate_path_arg_anchoring`, `resolve_relative_path_args` — execution helpers for `run_python` (no MCP tools) |
+| `_execution_helpers.py` | `_import_and_call`, `_coerce_scalar`, `maybe_promote_work_dir`, `validate_path_arg_anchoring`, `resolve_relative_path_args` — execution helpers for `run_python` (no MCP tools) |
 | `tools_execution.py` | `run_cmd`, `run_python`, `run_skill` |
 | `tools_fleet_dispatch.py` | `dispatch_food_truck`, `record_gate_dispatch` |
 | `tools_fleet_reset.py` | `reset_dispatch` (full dispatch artifact cleanup) |

--- a/src/autoskillit/server/tools/_execution_helpers.py
+++ b/src/autoskillit/server/tools/_execution_helpers.py
@@ -59,17 +59,6 @@ def maybe_promote_work_dir(args: dict[str, object] | None, work_dir: str) -> str
     return work_dir
 
 
-def strip_work_dir_from_args(args: dict[str, object] | None) -> dict[str, object] | None:
-    """Return a new args dict without the work_dir key, if present.
-
-    Returns the input unchanged when args is None. Preserves input args when
-    work_dir is not a key (no copy needed).
-    """
-    if args is None or "work_dir" not in args:
-        return args
-    return {k: v for k, v in args.items() if k != "work_dir"}
-
-
 def _coerce_scalar(val: object, annotation: object) -> object:
     """Coerce val to match the annotated type.
 

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -57,7 +57,6 @@ from autoskillit.server.tools._execution_helpers import (
     _import_and_call,
     maybe_promote_work_dir,
     resolve_relative_path_args,
-    strip_work_dir_from_args,
     validate_path_arg_anchoring,
 )
 
@@ -350,7 +349,6 @@ async def run_python(
                     work_dir=promoted,
                 )
                 work_dir = promoted
-                args = strip_work_dir_from_args(args)
             if work_dir and not Path(work_dir).is_absolute():
                 return json.dumps(
                     {

--- a/tests/arch/test_run_python_path_resolution.py
+++ b/tests/arch/test_run_python_path_resolution.py
@@ -168,7 +168,7 @@ def test_sentinel_covers_work_dir_for_rpc_merge_callables() -> None:
 
     from autoskillit.core import RUN_PYTHON_SENTINEL_KEYS
 
-    mod = importlib.import_module("autoskillit.execution.merge_queue._cmd_rpc_merge")
+    mod = importlib.import_module("autoskillit.recipe._cmd_rpc_merge")
     callables_with_work_dir = []
     for name in dir(mod):
         obj = getattr(mod, name)

--- a/tests/arch/test_run_python_path_resolution.py
+++ b/tests/arch/test_run_python_path_resolution.py
@@ -129,8 +129,11 @@ def test_sentinel_keys_do_not_collide_with_callable_params() -> None:
                 if p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
             }
             overlap = RUN_PYTHON_SENTINEL_KEYS & explicit_params
+            nested_args = with_args.get("args", {})
             for key in sorted(overlap):
                 if sig.parameters[key].default is inspect.Parameter.empty:
+                    if isinstance(nested_args, dict) and key in nested_args:
+                        continue
                     unsafe_collisions.append(
                         f"{yaml_file.name}:{step_name} → {callable_path} declares "
                         f"'{key}' as required (no default) — recipe must pass it via args:"
@@ -153,8 +156,32 @@ def test_sentinel_keys_subset_of_tool_params() -> None:
         f"Sentinel keys {RUN_PYTHON_SENTINEL_KEYS - tool_params} are not in _TOOL_PARAMS"
     )
     non_sentinel_tool_params = tool_params - RUN_PYTHON_SENTINEL_KEYS - {"args"}
-    assert non_sentinel_tool_params == {"work_dir"}, (
+    assert non_sentinel_tool_params == set(), (
         f"Unexpected non-sentinel tool params: {non_sentinel_tool_params}"
+    )
+
+
+def test_sentinel_covers_work_dir_for_rpc_merge_callables() -> None:
+    """work_dir in sentinel set ensures introspection guard preserves it for _cmd_rpc_merge."""
+    import importlib
+    import inspect
+
+    from autoskillit.core import RUN_PYTHON_SENTINEL_KEYS
+
+    mod = importlib.import_module("autoskillit.execution.merge_queue._cmd_rpc_merge")
+    callables_with_work_dir = []
+    for name in dir(mod):
+        obj = getattr(mod, name)
+        if not callable(obj) or name.startswith("_"):
+            continue
+        sig = inspect.signature(obj)
+        if "work_dir" in sig.parameters:
+            callables_with_work_dir.append(name)
+
+    assert callables_with_work_dir, "_cmd_rpc_merge should have callables that accept work_dir"
+    assert "work_dir" in RUN_PYTHON_SENTINEL_KEYS, (
+        "work_dir must be in RUN_PYTHON_SENTINEL_KEYS so the introspection guard "
+        "preserves it for callables that declare it"
     )
 
 

--- a/tests/server/test_run_python_work_dir_promotion.py
+++ b/tests/server/test_run_python_work_dir_promotion.py
@@ -78,35 +78,44 @@ async def test_run_python_auto_promotes_work_dir_from_args(tool_ctx_kitchen_open
     assert expected.exists()
 
 
-# T2b: work_dir is removed from args after promotion (does not leak to callable)
+# T2b: work_dir is stripped by sentinel introspection for callables that don't accept it
 @pytest.mark.anyio
 async def test_run_python_strips_work_dir_from_args_after_promotion(
-    tool_ctx_kitchen_open, tmp_path, monkeypatch
+    tool_ctx_kitchen_open, tmp_path
 ):
-    captured_args: dict = {}
-
-    async def fake_import_and_call(dotted_path, args=None, timeout=30):
-        captured_args.update(args or {})
-        return {"success": True, "result": "ok"}
-
-    monkeypatch.setattr(
-        "autoskillit.server.tools.tools_execution._import_and_call",
-        fake_import_and_call,
-    )
     result_json = await run_python(
-        callable="some.module.func",
+        callable="tests.server._type_coercion_fixtures._typed_callable",
         args={
-            "output_dir": str(tmp_path / "output"),  # absolute — no relative-path conflict
+            "name": "test",
+            "count": "1",
             "work_dir": str(tmp_path),
         },
         work_dir="",
     )
     result = json.loads(result_json)
     assert result["success"] is True
-    assert "work_dir" not in captured_args, (
-        "work_dir must be removed from args after promotion to prevent leaking "
-        "to the callable via _import_and_call"
+    assert result["result"] == {"name": "test", "count": 1, "ratio": 1.0}
+
+
+# T2b2: work_dir is preserved for callables that accept it
+@pytest.mark.anyio
+async def test_run_python_preserves_work_dir_for_callable_that_accepts_it(
+    tool_ctx_kitchen_open, tmp_path
+):
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    result_json = await run_python(
+        callable="tests.server._type_coercion_fixtures._work_dir_param",
+        args={
+            "base_branch": "main",
+            "work_dir": str(work_dir),
+        },
+        work_dir="",
     )
+    result = json.loads(result_json)
+    assert result["success"] is True
+    assert result["result"]["work_dir"] == str(work_dir)
+    assert result["result"]["base_branch"] == "main"
 
 
 # T2c: run_python surfaces diagnostic when work_dir is misplaced AND path-like arg is relative


### PR DESCRIPTION
## Summary

The `run_python` execution pipeline has two independent parameter-stripping mechanisms: (1) `RUN_PYTHON_SENTINEL_KEYS` processed by `_import_and_call` with full signature introspection, and (2) `strip_work_dir_from_args` processed upstream with zero signature awareness. This architectural split means `work_dir` is the only tool-level parameter that is stripped unconditionally regardless of whether the callable legitimately accepts it — causing `TypeError` on 86% of `review_path_rebase` sessions. The fix unifies `work_dir` into the existing signature-aware sentinel system, eliminating the entire class of tool-level/callable-level parameter collision bugs.

Test T2b (`test_run_python_strips_work_dir_from_args_after_promotion`) encodes a wrong universal invariant. It monkeypatches `_import_and_call` with a fake that captures `args`, then asserts `"work_dir" not in captured_args`. This test explicitly assumes that `work_dir` must NEVER reach any callable — but that assumption is wrong for callables like `review_path_rebase` that declare `work_dir` as a required parameter. No end-to-end test exists for the path: `run_python(callable_with_work_dir_param, args={"work_dir": ...}, work_dir="")`.

The fix: add `"work_dir"` to `RUN_PYTHON_SENTINEL_KEYS`, remove the unconditional `strip_work_dir_from_args` mechanism, delete the function, and update related tests and documentation. The signature-aware introspection guard in `_import_and_call` will then handle `work_dir` correctly — stripping it when the callable doesn't accept it, preserving it when the callable does.

Closes #3641

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260602-213054-790477/.autoskillit/temp/rectify/rectify_work_dir_sentinel_unification_2026-06-02_213054.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 4.2k | 16.7k | 1.2M | 105.8k | 43 | 144.6k | 13m 6s |
| review_approach* | opus[1m] | 1 | 24 | 5.2k | 176.3k | 40.6k | 11 | 26.9k | 3m 31s |
| dry_walkthrough* | opus | 1 | 50 | 25.0k | 966.2k | 98.4k | 37 | 81.6k | 10m 58s |
| implement* | opus[1m] | 1 | 60 | 9.1k | 1.1M | 58.2k | 58 | 41.5k | 4m 54s |
| audit_impl* | opus[1m] | 1 | 33 | 11.0k | 179.0k | 38.8k | 15 | 34.8k | 4m 50s |
| prepare_pr* | MiniMax-M3 | 1 | 43.1k | 1.7k | 115.8k | 44.1k | 13 | 0 | 43s |
| compose_pr* | MiniMax-M3 | 1 | 35.4k | 2.2k | 192.9k | 39.8k | 14 | 0 | 56s |
| review_pr* | opus[1m] | 3 | 104 | 67.3k | 1.5M | 79.9k | 105 | 184.1k | 16m 49s |
| **Total** | | | 83.0k | 138.3k | 5.5M | 105.8k | | 513.5k | 55m 51s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 91 | 11913.2 | 456.0 | 100.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **91** | 60062.5 | 5642.6 | 1519.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 5 | 4.5k | 109.3k | 4.2M | 431.9k | 43m 12s |
| opus | 1 | 50 | 25.0k | 966.2k | 81.6k | 10m 58s |
| MiniMax-M3 | 2 | 78.5k | 3.9k | 308.7k | 0 | 1m 39s |