### PR TITLE
Generate Codex Agent Definitions from Bundled Agent Sources

### DIFF
--- a/src/autoskillit/execution/backends/CLAUDE.md
+++ b/src/autoskillit/execution/backends/CLAUDE.md
@@ -9,7 +9,7 @@ IL-1 backend abstraction layer — concrete `CodingAgentBackend` implementations
 | `__init__.py` | `BACKEND_REGISTRY`, `get_backend()` factory, re-exports |
 | `claude.py` | `ClaudeCodeBackend` (incl. `validate_session_layout`), `ClaudeEnvPolicy`, `ClaudeSessionLocator`, `ClaudeStreamParser`, `ClaudeResultParser` (prompt utilities moved to `_claude_prompt.py`) |
 | `_claude_prompt.py` | Prompt injection utilities, session constants (`_ensure_skill_prefix`, `_inject_completion_directive`, `_compose_resume_prompt`, etc.), shared by claude + codex + commands |
-| `codex.py` | `CodexFlags`, `CodexBackend` (incl. `validate_session_layout`), `CodexEnvPolicy`, `CodexSessionLocator` (parse/config moved to `_codex_parse.py` / `_codex_config.py`) |
+| `codex.py` | `CodexFlags`, `CodexBackend` (incl. `validate_session_layout`, `setup_session_dir` agent TOML generation via `_generate_agent_tomls`), `CodexEnvPolicy`, `CodexSessionLocator` (parse/config moved to `_codex_parse.py` / `_codex_config.py`) |
 | `_codex_config.py` | TOML serialization with `[[key]]` array-of-tables support, MCP registration (`ensure_codex_mcp_registered`, `_serialize_toml`) |
 | `_codex_parse.py` | `CodexStreamParser`, `CodexResultParser`, `_scan_codex_ndjson`, `_CodexParseAccumulator` |
 | `codex_scenario_player.py` | `CodexScenarioPlayer`, `make_codex_scenario_player`, `CodexStepRecord`, `CodexScenario`, `_load_manifest`, `_FakeCodexCLI`, `_write_shim_script` — scenario replay data layer for Codex backend |

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -21,6 +21,7 @@ from autoskillit.core import (
     AUTOSKILLIT_PRIVATE_ENV_VARS,
     CAMPAIGN_ID_ENV_VAR,
     CODEX_INTERACTIVE_REQUIRED_ENV,
+    CODEX_MODEL_ALIASES,
     FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
     KITCHEN_SESSION_ID_ENV_VAR,
     MCP_CLIENT_BACKEND_ENV_VAR,
@@ -45,6 +46,8 @@ from autoskillit.core import (
     default_log_dir,
     extract_skill_name,
     get_logger,
+    load_yaml,
+    pkg_root,
 )
 from autoskillit.execution.backends._claude_prompt import (
     _HEADLESS_EXCLUSIVE_VARS,
@@ -58,7 +61,10 @@ from autoskillit.execution.backends._claude_prompt import (
     _inject_narration_suppression,
 )
 from autoskillit.execution.backends._cmd_builder import CmdBuilder
-from autoskillit.execution.backends._codex_config import ensure_codex_mcp_registered
+from autoskillit.execution.backends._codex_config import (
+    _format_toml_value,
+    ensure_codex_mcp_registered,
+)
 from autoskillit.execution.backends._codex_parse import CodexResultParser, CodexStreamParser
 
 __all__ = [
@@ -297,6 +303,47 @@ def _validate_codex_config() -> list[str]:
     return []
 
 
+def _generate_agent_tomls(session_dir: Path) -> int:
+    agents_src = pkg_root() / "agents"
+    out_dir = session_dir / "agents"
+    out_dir.mkdir(exist_ok=True)
+    count = 0
+    for md_path in sorted(agents_src.glob("*.md")):
+        if md_path.name == "CLAUDE.md":
+            continue
+        content = md_path.read_text(encoding="utf-8")
+        if not content.startswith("---"):
+            logger.warning("agent_toml_skip_no_frontmatter", path=str(md_path))
+            continue
+        parts = content.split("---", 2)
+        if len(parts) < 3:
+            logger.warning("agent_toml_skip_no_frontmatter", path=str(md_path))
+            continue
+        meta = load_yaml(parts[1])
+        body = parts[2].strip()
+        if not body:
+            logger.warning("agent_toml_skip_empty_body", path=str(md_path))
+            continue
+        if "'''" in body:
+            logger.warning("agent_toml_skip_triple_quote", path=str(md_path))
+            continue
+        name = meta["name"]
+        desc = meta["description"]
+        lines = [
+            f"name = {_format_toml_value(name)}",
+            f"description = {_format_toml_value(desc)}",
+            'sandbox_mode = "workspace-write"',
+        ]
+        model_key = meta.get("model")
+        if model_key and model_key in CODEX_MODEL_ALIASES:
+            lines.append(f"model = {_format_toml_value(CODEX_MODEL_ALIASES[model_key])}")
+        lines.append(f"developer_instructions = '''\n{body}\n'''")
+        (out_dir / f"{name}.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        count += 1
+    logger.debug("codex_agents_generated", count=count, dest=str(out_dir))
+    return count
+
+
 @dataclass(frozen=True, slots=True)
 class CodexBackend:
     @property
@@ -368,7 +415,6 @@ class CodexBackend:
 
     def translate_model(self, model: str) -> str:
         from autoskillit.core import (
-            CODEX_MODEL_ALIASES,
             strip_context_window_suffix,
         )
 
@@ -809,6 +855,11 @@ class CodexBackend:
             logger.warning(
                 "codex_sessions_symlink_failed", target=str(sessions_target), exc_info=True
             )
+
+        try:
+            _generate_agent_tomls(session_dir)
+        except Exception:
+            logger.warning("codex_agent_toml_generation_failed", exc_info=True)
 
     def validate_skill_content(self, content: str) -> list[str]:
         return []

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -321,6 +321,9 @@ def _generate_agent_tomls(session_dir: Path) -> int:
             logger.warning("agent_toml_skip_no_frontmatter", path=str(md_path))
             continue
         meta = load_yaml(parts[1])
+        if not isinstance(meta, dict):
+            logger.warning("agent_toml_skip_invalid_frontmatter", path=str(md_path))
+            continue
         body = parts[2].strip()
         if not body:
             logger.warning("agent_toml_skip_empty_body", path=str(md_path))

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -43,6 +43,7 @@ from autoskillit.core import (
     SessionCheckpoint,
     SkillSessionConfig,
     ValidatedAddDir,
+    atomic_write,
     default_log_dir,
     extract_skill_name,
     get_logger,
@@ -338,7 +339,7 @@ def _generate_agent_tomls(session_dir: Path) -> int:
         if model_key and model_key in CODEX_MODEL_ALIASES:
             lines.append(f"model = {_format_toml_value(CODEX_MODEL_ALIASES[model_key])}")
         lines.append(f"developer_instructions = '''\n{body}\n'''")
-        (out_dir / f"{name}.toml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        atomic_write(out_dir / f"{name}.toml", "\n".join(lines) + "\n")
         count += 1
     logger.debug("codex_agents_generated", count=count, dest=str(out_dir))
     return count

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -11,6 +11,7 @@ import structlog.testing
 from autoskillit.core import (
     AGENT_BACKEND_CODEX,
     CAMPAIGN_ID_ENV_VAR,
+    CODEX_MODEL_ALIASES,
     KITCHEN_SESSION_ID_ENV_VAR,
     MCP_CLIENT_BACKEND_ENV_VAR,
     SESSION_TYPE_ORCHESTRATOR,
@@ -28,6 +29,7 @@ from autoskillit.core import (
     SkillSessionConfig,
     StreamParser,
     ValidatedAddDir,
+    pkg_root,
 )
 from autoskillit.execution.backends.codex import (
     CODEX_ENV_PREFIX_DENYLIST,
@@ -1415,3 +1417,57 @@ class TestCodexBackendSetupSessionDir:
         CodexBackend().setup_session_dir(self.session_dir)
         # Verify sessions is still a directory (symlink failed silently)
         assert not (self.session_dir / "sessions").is_symlink()
+
+    def test_setup_session_dir_creates_agents_directory(self) -> None:
+        self._write_all_source_files()
+        CodexBackend().setup_session_dir(self.session_dir)
+        assert (self.session_dir / "agents").is_dir()
+
+    def test_agent_toml_count_matches_md_sources(self) -> None:
+        self._write_all_source_files()
+        CodexBackend().setup_session_dir(self.session_dir)
+        toml_files = list((self.session_dir / "agents").glob("*.toml"))
+        md_count = len([p for p in (pkg_root() / "agents").glob("*.md") if p.name != "CLAUDE.md"])
+        assert len(toml_files) == md_count
+
+    def test_agent_toml_required_fields_present_and_nonempty(self) -> None:
+        import tomllib
+
+        self._write_all_source_files()
+        CodexBackend().setup_session_dir(self.session_dir)
+        for toml_path in sorted((self.session_dir / "agents").glob("*.toml")):
+            data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+            assert data["name"], f"{toml_path.name}: name empty"
+            assert data["description"], f"{toml_path.name}: description empty"
+            assert data["developer_instructions"], (
+                f"{toml_path.name}: developer_instructions empty"
+            )
+            assert data["sandbox_mode"] == "workspace-write", (
+                f"{toml_path.name}: wrong sandbox_mode"
+            )
+
+    def test_agent_toml_model_alias_mapped(self) -> None:
+        import tomllib
+
+        self._write_all_source_files()
+        CodexBackend().setup_session_dir(self.session_dir)
+        wp_toml = self.session_dir / "agents" / "wp-elaborator.toml"
+        data = tomllib.loads(wp_toml.read_text(encoding="utf-8"))
+        assert data["model"] == CODEX_MODEL_ALIASES["sonnet"]
+
+    def test_no_claude_md_toml_generated(self) -> None:
+        self._write_all_source_files()
+        CodexBackend().setup_session_dir(self.session_dir)
+        assert not (self.session_dir / "agents" / "CLAUDE.toml").exists()
+
+    def test_developer_instructions_preserves_markdown_structure(self) -> None:
+        import tomllib
+
+        self._write_all_source_files()
+        CodexBackend().setup_session_dir(self.session_dir)
+        wp_toml = self.session_dir / "agents" / "wp-elaborator.toml"
+        data = tomllib.loads(wp_toml.read_text(encoding="utf-8"))
+        body = data["developer_instructions"]
+        assert "# wp-elaborator" in body
+        assert "## Tool Constraints" in body
+        assert "```json" in body

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -1427,8 +1427,20 @@ class TestCodexBackendSetupSessionDir:
         self._write_all_source_files()
         CodexBackend().setup_session_dir(self.session_dir)
         toml_files = list((self.session_dir / "agents").glob("*.toml"))
-        md_count = len([p for p in (pkg_root() / "agents").glob("*.md") if p.name != "CLAUDE.md"])
-        assert len(toml_files) == md_count
+        expected = 0
+        for md_path in (pkg_root() / "agents").glob("*.md"):
+            if md_path.name == "CLAUDE.md":
+                continue
+            text = md_path.read_text(encoding="utf-8")
+            if not text.startswith("---"):
+                continue
+            parts = text.split("---", 2)
+            if len(parts) < 3 or not parts[2].strip() or "'''" in parts[2]:
+                continue
+            expected += 1
+        assert len(toml_files) == expected, (
+            f"TOML count {len(toml_files)} != valid source count {expected}"
+        )
 
     def test_agent_toml_required_fields_present_and_nonempty(self) -> None:
         import tomllib


### PR DESCRIPTION
## Summary

Add agent TOML generation to `CodexBackend.setup_session_dir()`. For each of the 11 bundled agent `.md` files in `src/autoskillit/agents/`, parse YAML frontmatter and markdown body, map fields to Codex's TOML format, and write the result to `<session_dir>/agents/<name>.toml`. Codex discovers these automatically since `CODEX_HOME` is already set to the session directory.

The conversion function lives in `codex.py` as a module-level helper `_generate_agent_tomls()`, using `_format_toml_value` from `_codex_config.py` for short string fields and TOML multiline literal strings (`'''...'''`) for `developer_instructions` (the markdown body, which can be 200+ lines).

## Requirements

- REQ-AGENT-001: `setup_session_dir()` must generate `.toml` files in `<session_dir>/agents/` for each `.md` file in `src/autoskillit/agents/` (excluding `CLAUDE.md`)
- REQ-AGENT-002: The canonical source remains `*.md` — no TOML files committed to the repo, no file duplication
- REQ-AGENT-003: Use `CODEX_MODEL_ALIASES` for model name translation
- REQ-AGENT-004: Parse YAML frontmatter AND markdown body from `*.md` files. Note: the existing `_read_skill_frontmatter` in `workspace/skills.py:32-48` drops the markdown body (only returns `parts[1]`). The implementation must extract BOTH the frontmatter dict AND `parts[2]` (the body) to populate `developer_instructions`. Failing to extract the body would produce empty system prompts — a silent data loss bug.
- REQ-AGENT-005: Generated TOML must include `name`, `description`, `developer_instructions` (required), and `model` (optional, when alias available)
- REQ-AGENT-006: `sandbox_mode = "workspace-write"` for all agents (all 11 include `Bash` in their tool set; the "read-only" branch is unreachable given current agents)
- REQ-AGENT-007: Document capability loss for agents with tools that have no Codex equivalent: `pipeline-health-scanner` uses `Agent` tool (nested sub-subagent spawning — Codex equivalent is `spawn_agent` but may not work in headless sessions per #15250); `plan-registry-tracer` uses `LSP` tool (no Codex equivalent — reduced to grep-only analysis)
- REQ-TEST-001: Test that `setup_session_dir()` creates an `agents/` directory with the expected TOML files
- REQ-TEST-002: Test round-trip: parse a known `.md` agent definition, generate TOML, verify `name`, `description`, and `developer_instructions` are present and non-empty

Closes #3646

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260602-232308-966509/.autoskillit/temp/make-plan/generate_codex_agent_definitions_plan_2026-06-02_232308.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 68 | 24.7k | 1.5M | 97.4k | 52 | 85.4k | 16m 20s |
| review_approach* | opus[1m] | 1 | 38 | 5.8k | 422.7k | 50.6k | 23 | 36.2k | 3m 8s |
| verify* | opus[1m] | 1 | 53 | 9.2k | 983.9k | 75.3k | 46 | 58.4k | 6m 53s |
| implement* | MiniMax-M3 | 1 | 65.2k | 7.4k | 1.1M | 63.7k | 55 | 0 | 4m 46s |
| audit_impl* | opus[1m] | 1 | 24 | 10.3k | 181.0k | 39.0k | 12 | 34.5k | 5m 26s |
| prepare_pr* | MiniMax-M3 | 1 | 41.6k | 2.4k | 203.2k | 45.6k | 15 | 0 | 1m 6s |
| compose_pr* | MiniMax-M3 | 1 | 36.2k | 1.8k | 152.3k | 39.6k | 11 | 0 | 58s |
| review_pr* | opus[1m] | 1 | 31 | 18.8k | 636.4k | 64.1k | 26 | 48.7k | 5m 32s |
| resolve_review* | opus[1m] | 1 | 49 | 6.7k | 1.4M | 76.3k | 45 | 59.7k | 4m 7s |
| **Total** | | | 143.3k | 87.1k | 6.7M | 97.4k | | 322.9k | 48m 20s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 113 | 10078.8 | 0.0 | 65.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 19 | 74816.7 | 3139.9 | 354.0 |
| **Total** | **132** | 50466.3 | 2446.3 | 659.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 263 | 75.5k | 5.2M | 322.9k | 41m 29s |
| MiniMax-M3 | 3 | 143.0k | 11.5k | 1.5M | 0 | 6m 50s |