### PR TITLE
Decompose review_design into Phoropter Steps in research.yaml

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -332,8 +332,14 @@ def _generate_agent_tomls(session_dir: Path) -> int:
         if "'''" in body:
             logger.warning("agent_toml_skip_triple_quote", path=str(md_path))
             continue
-        name = meta["name"]
-        desc = meta["description"]
+        name = meta.get("name")
+        if not name:
+            logger.warning("agent_toml_skip_missing_name", path=str(md_path))
+            continue
+        desc = meta.get("description")
+        if not desc:
+            logger.warning("agent_toml_skip_missing_description", path=str(md_path))
+            continue
         lines = [
             f"name = {_format_toml_value(name)}",
             f"description = {_format_toml_value(desc)}",

--- a/src/autoskillit/recipe/rules/rules_phoropter_adjacency.py
+++ b/src/autoskillit/recipe/rules/rules_phoropter_adjacency.py
@@ -34,6 +34,8 @@ def _check_phoropter_phase_order(ctx: ValidationContext) -> list[RuleFinding]:
             continue
         if family in errored_families:
             continue
+        if step.action == "route":
+            continue
 
         expected_phase = expected_next.get(family, "dial")
         if step_name != expected_phase:
@@ -76,6 +78,8 @@ def _check_phoropter_interleaving(ctx: ValidationContext) -> list[RuleFinding]:
     for step_name, step in ctx.recipe.steps.items():
         family = step.phoropter_family
         if family is not None:
+            if step.action == "route":
+                continue
             in_progress[family] = step_name
             if step_name in _PHOROPTER_PHASES:
                 idx = _PHOROPTER_PHASES.index(step_name)

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -599,7 +599,7 @@ skills:
     expected_output_patterns:
     - "triage_report[ \\t]*=[ \\t]*(\\S[^\\n]*|none)"
     pattern_examples:
-    - "triage_report = .autoskillit/temp/triage-issues/triage_report_20260310_120000.md\n%%ORDER_UP%%"
+    - "triage_report = /tmp/triage_report_20260310_120000.md\n%%ORDER_UP%%"
 
   review-pr:
     inputs:
@@ -2408,8 +2408,8 @@ skills:
     - "selected_lenses[ \\t]*=[ \\t]*([^\\n]*|none)"
     - "lens_context_paths[ \\t]*=[ \\t]*([^\\n]*|none)"
     pattern_examples:
-    - "experiment_type = benchmark\ndimension_weights = causal_structure:H,variance_protocol:M,statistical_corrections:M,ecological_validity:M,measurement_alignment:H,resource_proportionality:M,data_acquisition:H,agent_implementability:M,scope_alignment:M\nis_silent_type = false\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /abs/cwd/.autoskillit/temp/classify-experiment-type/dimensions_manifest_benchmark_2026-06-02_183000.json\nselected_lenses = causal_structure,variance_protocol,statistical_corrections,ecological_validity,measurement_alignment,resource_proportionality,data_acquisition,agent_implementability,scope_alignment\nlens_context_paths = /abs/cwd/.autoskillit/temp/classify-experiment-type/lens_ctx_causal_structure_benchmark_2026-06-02_183000.md,/abs/cwd/.autoskillit/temp/classify-experiment-type/lens_ctx_variance_protocol_benchmark_2026-06-02_183000.md\n%%ORDER_UP%%"
-    - "experiment_type = exploratory\ndimension_weights = causal_structure:S,variance_protocol:S,statistical_corrections:S,ecological_validity:S,measurement_alignment:S,resource_proportionality:S,data_acquisition:L,agent_implementability:L,scope_alignment:S\nis_silent_type = true\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /abs/cwd/.autoskillit/temp/classify-experiment-type/dimensions_manifest_exploratory_2026-06-02_183000.json\nselected_lenses = \nlens_context_paths = \n%%ORDER_UP%%"
+    - "experiment_type = benchmark\ndimension_weights = causal_structure:H,variance_protocol:M,statistical_corrections:M,ecological_validity:M,measurement_alignment:H,resource_proportionality:M,data_acquisition:H,agent_implementability:M,scope_alignment:M\nis_silent_type = false\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /tmp/classify-experiment-type/dimensions_manifest_benchmark_2026-06-02_183000.json\nselected_lenses = causal_structure,variance_protocol,statistical_corrections,ecological_validity,measurement_alignment,resource_proportionality,data_acquisition,agent_implementability,scope_alignment\nlens_context_paths = /tmp/classify-experiment-type/lens_ctx_causal_structure_benchmark_2026-06-02_183000.md,/tmp/classify-experiment-type/lens_ctx_variance_protocol_benchmark_2026-06-02_183000.md\n%%ORDER_UP%%"
+    - "experiment_type = exploratory\ndimension_weights = causal_structure:S,variance_protocol:S,statistical_corrections:S,ecological_validity:S,measurement_alignment:S,resource_proportionality:S,data_acquisition:L,agent_implementability:L,scope_alignment:S\nis_silent_type = true\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /tmp/classify-experiment-type/dimensions_manifest_exploratory_2026-06-02_183000.json\nselected_lenses = \nlens_context_paths = \n%%ORDER_UP%%"
     write_behavior: always
   apply-review-dimensions:
     inputs:
@@ -2437,7 +2437,7 @@ skills:
     - "findings_manifest_path[ \\t]*=[ \\t]*/.+"
     - "evaluation_dashboard_path[ \\t]*=[ \\t]*/.+"
     pattern_examples:
-    - "findings_manifest_path = /abs/cwd/.autoskillit/temp/apply-review-dimensions/findings_manifest_benchmark_2026-06-02_183000.json\nevaluation_dashboard_path = /abs/cwd/.autoskillit/temp/apply-review-dimensions/evaluation_dashboard_benchmark_2026-06-02_183000.md\n%%ORDER_UP%%"
+    - "findings_manifest_path = /tmp/apply-review-dimensions/findings_manifest_benchmark_2026-06-02_183000.json\nevaluation_dashboard_path = /tmp/apply-review-dimensions/evaluation_dashboard_benchmark_2026-06-02_183000.md\n%%ORDER_UP%%"
     write_behavior: always
 callable_contracts:
   autoskillit.smoke_utils.check_loop_iteration:

--- a/src/autoskillit/recipes/diagrams/research.md
+++ b/src/autoskillit/recipes/diagrams/research.md
@@ -1,18 +1,38 @@
-<!-- autoskillit-recipe-hash: sha256:88d0f9f65b2b9fc09968435229d21f6264c19a9b986d74a771f9fe4826d88085 -->
+<!-- autoskillit-recipe-hash: sha256:1d5fac42c5bb63012f0407cb60737d61eca2eb680d3e461a56f588852875fabb -->
 <!-- autoskillit-diagram-format: v7 -->
 
 ## research
 
 scope
 |
+select_directions
+|
 plan_experiment
 |
-review_design
-|   +-- [dial] (optional)
-|   |    +-- [apply] (phoropter: vis-lens)
-|   |    |    +-- [synthesize] (phoropter: vis-lens)
-|   +-- [resolve_design_review] (on STOP verdict)
-|   x fail [-> escalate_stop]
+dial (phoropter: review-design)
+|    +-- [silent_type_gate] (route — is_silent_type)
+|    |    +-- [synthesize] (phoropter: review-design, when is_silent_type)
+|    |    |
+|    |    [apply] (phoropter: review-design, default after gate)
+|    |    |    +-- [synthesize] (phoropter: review-design)
+|    |    |    |
+|    |    |    [revise_design] (on REVISE verdict)
+|    |    |
+|    |    [synthesize] (phoropter: review-design)
+|    |    |    +-- [vis_dial] (on GO verdict)
+|    |    |    +-- [revise_design] (on REVISE verdict)
+|    |    |    +-- [resolve_design_review] (on STOP verdict)
+|    |    |    x fail [-> create_worktree]
+|    |    |
+|    |    x fail [-> create_worktree]
+|    |
+|    x fail [-> create_worktree]
+|
+vis_dial
+|
+vis_apply
+|
+vis_synthesize
 |
 stage_data
 |

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -118,37 +118,99 @@
       "capture": {
         "experiment_plan": "${{ result.experiment_plan }}"
       },
-      "on_success": "review_design",
+      "on_success": "dial",
       "on_failure": "escalate_stop"
     },
-    "review_design": {
+    "dial": {
       "tool": "run_skill",
       "model": "",
+      "phoropter_family": "review-design",
       "with": {
-        "skill_command": "/autoskillit:review-design ${{ context.experiment_plan }} ${{ context.scope_report }}",
+        "skill_command": "/autoskillit:classify-experiment-type ${{ context.experiment_plan }} ${{ context.scope_report }}",
         "cwd": "${{ inputs.source_dir }}",
-        "step_name": "review_design",
-        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-design"
+        "step_name": "dial",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/classify-experiment-type"
       },
       "capture": {
-        "verdict": "${{ result.verdict }}",
         "experiment_type": "${{ result.experiment_type }}",
-        "evaluation_dashboard": "${{ result.evaluation_dashboard }}",
-        "revision_guidance": "${{ result.revision_guidance }}",
-        "classification_timestamp": "${{ result.classification_timestamp }}"
+        "dimensions_manifest": "${{ result.dimensions_manifest_path }}",
+        "classification_timestamp": "${{ result.classification_timestamp }}",
+        "is_silent_type": "${{ result.is_silent_type }}"
       },
       "pass_through": [
-        "experiment_type"
+        "experiment_type",
+        "classification_timestamp",
+        "is_silent_type"
       ],
       "skip_when_false": "inputs.review_design",
       "retries": 2,
       "on_exhausted": "create_worktree",
       "on_context_limit": "create_worktree",
       "on_failure": "create_worktree",
+      "on_success": "silent_type_gate"
+    },
+    "silent_type_gate": {
+      "action": "route",
+      "phoropter_family": "review-design",
+      "on_result": [
+        {
+          "when": "${{ context.is_silent_type }} == true",
+          "route": "synthesize"
+        },
+        {
+          "when": "${{ context.is_silent_type }} == false",
+          "route": "apply"
+        }
+      ]
+    },
+    "apply": {
+      "tool": "run_skill",
+      "model": "",
+      "phoropter_family": "review-design",
+      "with": {
+        "skill_command": "/autoskillit:apply-review-dimensions ${{ context.dimensions_manifest }} ${{ context.scope_report }} ${{ context.experiment_plan }} ${{ context.experiment_type }} ${{ context.classification_timestamp }}",
+        "cwd": "${{ inputs.source_dir }}",
+        "step_name": "apply",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/apply-review-dimensions"
+      },
+      "capture": {
+        "findings_manifest_path": "${{ result.findings_manifest_path }}",
+        "evaluation_dashboard": "${{ result.evaluation_dashboard_path }}"
+      },
+      "on_failure": "create_worktree",
+      "on_exhausted": "create_worktree",
+      "on_context_limit": "create_worktree",
+      "on_result": [
+        {
+          "when": "${{ result.verdict }} == REVISE",
+          "route": "revise_design"
+        },
+        {
+          "route": "synthesize"
+        }
+      ]
+    },
+    "synthesize": {
+      "tool": "run_python",
+      "phoropter_family": "review-design",
+      "with": {
+        "callable": "autoskillit.smoke_utils.aggregate_review_verdict",
+        "findings_manifest_path": "${{ context.findings_manifest_path }}",
+        "dimensions_manifest_path": "${{ context.dimensions_manifest }}",
+        "experiment_type": "${{ context.experiment_type }}",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/aggregate-review-verdict",
+        "work_dir": "${{ inputs.source_dir }}"
+      },
+      "capture": {
+        "verdict": "${{ result.verdict }}",
+        "revision_guidance": "${{ result.revision_guidance_path }}",
+        "evaluation_dashboard": "${{ result.evaluation_dashboard_path }}"
+      },
+      "on_failure": "create_worktree",
       "on_result": [
         {
           "when": "${{ result.verdict }} == GO",
-          "route": "dial"
+          "route": "vis_dial"
         },
         {
           "when": "${{ result.verdict }} == REVISE",
@@ -163,14 +225,13 @@
         }
       ]
     },
-    "dial": {
+    "vis_dial": {
       "tool": "run_skill",
       "model": "",
-      "phoropter_family": "vis-lens",
       "with": {
         "skill_command": "/autoskillit:select-vis-lenses ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}",
         "cwd": "${{ inputs.source_dir }}",
-        "step_name": "dial",
+        "step_name": "vis_dial",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/select-vis-lenses"
       },
       "capture": {
@@ -180,35 +241,33 @@
         "tier_c_lens": "${{ result.tier_c_lens }}",
         "methodology_tradition": "${{ result.methodology_tradition }}"
       },
-      "on_success": "apply",
+      "on_success": "vis_apply",
       "on_failure": "escalate_stop"
     },
-    "apply": {
+    "vis_apply": {
       "tool": "run_skill",
       "model": "",
-      "phoropter_family": "vis-lens",
       "with": {
         "skill_command": "/autoskillit:vis-lens-{slug} {context_path}",
         "cwd": "${{ inputs.source_dir }}",
-        "step_name": "apply",
+        "step_name": "vis_apply",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/run-vis-lenses"
       },
       "capture_list": {
         "vis_lens_output_paths": "${{ result.diagram_path }}"
       },
       "retries": 0,
-      "on_success": "synthesize",
+      "on_success": "vis_synthesize",
       "on_failure": "escalate_stop",
       "note": "LENS ITERATION: context.selected_lenses contains comma-separated vis-lens slugs (e.g. \"always-on,chart-select\"). context.lens_context_paths contains the corresponding comma-separated context file paths (same order as slugs). For each lens slug, run:\n  /autoskillit:vis-lens-{slug} {matching_context_path}\nRun all selected lenses in parallel (all run_skill calls in a single message). Accumulate each diagram_path value into context.vis_lens_output_paths via capture_list. If a lens fails, continue with remaining lenses.\n"
     },
-    "synthesize": {
+    "vis_synthesize": {
       "tool": "run_skill",
       "model": "",
-      "phoropter_family": "vis-lens",
       "with": {
         "skill_command": "/autoskillit:synthesize-vis-plan ${{ inputs.source_dir }} ${{ context.experiment_plan }} {{AUTOSKILLIT_TEMP}}/run-vis-lenses --tier-c-lens=${{ context.tier_c_lens }} --methodology-tradition=${{ context.methodology_tradition }} --disambiguation-rule-applied=${{ context.disambiguation_rule_applied }}",
         "cwd": "${{ inputs.source_dir }}",
-        "step_name": "synthesize",
+        "step_name": "vis_synthesize",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/synthesize-vis-plan"
       },
       "capture": {
@@ -243,14 +302,14 @@
           "route": "create_worktree"
         },
         {
-          "route": "plan_experiment"
+          "route": "apply"
         }
       ],
       "on_failure": "create_worktree",
       "optional_context_refs": [
         "design_review_count"
       ],
-      "note": "Iteration guard for the review_design → revise_design → plan_experiment cycle. Caps design revision loops at 3 iterations. On exhaustion, proceeds to create_worktree with the best available design.\n"
+      "note": "Iteration guard for the dial → apply → synthesize REVISE → revise_design → check_design_review_loop → apply cycle. Re-entry skips re-dialing since experiment_type is stable across revision cycles. Caps design revision loops at 3 iterations. On exhaustion, proceeds to create_worktree with the best available design.\n"
     },
     "resolve_design_review": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -151,7 +151,6 @@
     },
     "silent_type_gate": {
       "action": "route",
-      "phoropter_family": "review-design",
       "on_result": [
         {
           "when": "${{ context.is_silent_type }} == true",

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -151,6 +151,7 @@
     },
     "silent_type_gate": {
       "action": "route",
+      "phoropter_family": "review-design",
       "on_result": [
         {
           "when": "${{ context.is_silent_type }} == true",

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -133,7 +133,7 @@
       },
       "capture": {
         "experiment_type": "${{ result.experiment_type }}",
-        "dimensions_manifest": "${{ result.dimensions_manifest_path }}",
+        "dimensions_manifest_path": "${{ result.dimensions_manifest_path }}",
         "classification_timestamp": "${{ result.classification_timestamp }}",
         "is_silent_type": "${{ result.is_silent_type }}"
       },
@@ -168,7 +168,7 @@
       "model": "",
       "phoropter_family": "review-design",
       "with": {
-        "skill_command": "/autoskillit:apply-review-dimensions ${{ context.dimensions_manifest }} ${{ context.scope_report }} ${{ context.experiment_plan }} ${{ context.experiment_type }} ${{ context.classification_timestamp }}",
+        "skill_command": "/autoskillit:apply-review-dimensions ${{ context.dimensions_manifest_path }} ${{ context.scope_report }} ${{ context.experiment_plan }} ${{ context.experiment_type }} ${{ context.classification_timestamp }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "apply",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/apply-review-dimensions"
@@ -196,7 +196,7 @@
       "with": {
         "callable": "autoskillit.smoke_utils.aggregate_review_verdict",
         "findings_manifest_path": "${{ context.findings_manifest_path }}",
-        "dimensions_manifest_path": "${{ context.dimensions_manifest }}",
+        "dimensions_manifest_path": "${{ context.dimensions_manifest_path }}",
         "experiment_type": "${{ context.experiment_type }}",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/aggregate-review-verdict",
         "work_dir": "${{ inputs.source_dir }}"

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -177,7 +177,6 @@ steps:
 
   silent_type_gate:
     action: route
-    phoropter_family: review-design
     on_result:
     - when: "${{ context.is_silent_type }} == true"
       route: synthesize

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -150,46 +150,91 @@ steps:
     optional_context_refs: [revision_guidance, selected_directions]
     capture:
       experiment_plan: "${{ result.experiment_plan }}"
-    on_success: review_design
+    on_success: dial
     on_failure: escalate_stop
 
-  review_design:
+  dial:
     tool: run_skill
     model: ""
+    phoropter_family: review-design
     with:
-      skill_command: "/autoskillit:review-design ${{ context.experiment_plan }} ${{ context.scope_report }}"
+      skill_command: "/autoskillit:classify-experiment-type ${{ context.experiment_plan }} ${{ context.scope_report }}"
       cwd: "${{ inputs.source_dir }}"
-      step_name: review_design
-      output_dir: "{{AUTOSKILLIT_TEMP}}/review-design"
+      step_name: dial
+      output_dir: "{{AUTOSKILLIT_TEMP}}/classify-experiment-type"
     capture:
-      verdict: "${{ result.verdict }}"
       experiment_type: "${{ result.experiment_type }}"
-      evaluation_dashboard: "${{ result.evaluation_dashboard }}"
-      revision_guidance: "${{ result.revision_guidance }}"
+      dimensions_manifest: "${{ result.dimensions_manifest_path }}"
       classification_timestamp: "${{ result.classification_timestamp }}"
-    pass_through: [experiment_type]
+      is_silent_type: "${{ result.is_silent_type }}"
+    pass_through: [experiment_type, classification_timestamp, is_silent_type]
     skip_when_false: inputs.review_design
     retries: 2
     on_exhausted: create_worktree
     on_context_limit: create_worktree
     on_failure: create_worktree
+    on_success: silent_type_gate
+
+  silent_type_gate:
+    action: route
+    phoropter_family: review-design
+    on_result:
+    - when: "${{ context.is_silent_type }} == true"
+      route: synthesize
+    - when: "${{ context.is_silent_type }} == false"
+      route: apply
+
+  apply:
+    tool: run_skill
+    model: ""
+    phoropter_family: review-design
+    with:
+      skill_command: "/autoskillit:apply-review-dimensions ${{ context.dimensions_manifest }} ${{ context.scope_report }} ${{ context.experiment_plan }} ${{ context.experiment_type }} ${{ context.classification_timestamp }}"
+      cwd: "${{ inputs.source_dir }}"
+      step_name: apply
+      output_dir: "{{AUTOSKILLIT_TEMP}}/apply-review-dimensions"
+    capture:
+      findings_manifest_path: "${{ result.findings_manifest_path }}"
+      evaluation_dashboard: "${{ result.evaluation_dashboard_path }}"
+    on_failure: create_worktree
+    on_exhausted: create_worktree
+    on_context_limit: create_worktree
+    on_result:
+    - when: "${{ result.verdict }} == REVISE"
+      route: revise_design
+    - route: synthesize
+
+  synthesize:
+    tool: run_python
+    phoropter_family: review-design
+    with:
+      callable: "autoskillit.smoke_utils.aggregate_review_verdict"
+      findings_manifest_path: "${{ context.findings_manifest_path }}"
+      dimensions_manifest_path: "${{ context.dimensions_manifest }}"
+      experiment_type: "${{ context.experiment_type }}"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/aggregate-review-verdict"
+      work_dir: "${{ inputs.source_dir }}"
+    capture:
+      verdict: "${{ result.verdict }}"
+      revision_guidance: "${{ result.revision_guidance_path }}"
+      evaluation_dashboard: "${{ result.evaluation_dashboard_path }}"
+    on_failure: create_worktree
     on_result:
     - when: "${{ result.verdict }} == GO"
-      route: dial
+      route: vis_dial
     - when: "${{ result.verdict }} == REVISE"
       route: revise_design
     - when: "${{ result.verdict }} == STOP"
       route: resolve_design_review
     - route: create_worktree
 
-  dial:
+  vis_dial:
     tool: run_skill
     model: ""
-    phoropter_family: vis-lens
     with:
       skill_command: "/autoskillit:select-vis-lenses ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}"
       cwd: "${{ inputs.source_dir }}"
-      step_name: dial
+      step_name: vis_dial
       output_dir: "{{AUTOSKILLIT_TEMP}}/select-vis-lenses"
     capture:
       selected_lenses: "${{ result.selected_lenses }}"
@@ -197,22 +242,21 @@ steps:
       disambiguation_rule_applied: "${{ result.disambiguation_rule_applied }}"
       tier_c_lens: "${{ result.tier_c_lens }}"
       methodology_tradition: "${{ result.methodology_tradition }}"
-    on_success: apply
+    on_success: vis_apply
     on_failure: escalate_stop
 
-  apply:
+  vis_apply:
     tool: run_skill
     model: ""
-    phoropter_family: vis-lens
     with:
       skill_command: "/autoskillit:vis-lens-{slug} {context_path}"
       cwd: "${{ inputs.source_dir }}"
-      step_name: apply
+      step_name: vis_apply
       output_dir: "{{AUTOSKILLIT_TEMP}}/run-vis-lenses"
     capture_list:
       vis_lens_output_paths: "${{ result.diagram_path }}"
     retries: 0
-    on_success: synthesize
+    on_success: vis_synthesize
     on_failure: escalate_stop
     note: >
       LENS ITERATION: context.selected_lenses contains comma-separated vis-lens
@@ -224,14 +268,13 @@ steps:
       Accumulate each diagram_path value into context.vis_lens_output_paths via
       capture_list. If a lens fails, continue with remaining lenses.
 
-  synthesize:
+  vis_synthesize:
     tool: run_skill
     model: ""
-    phoropter_family: vis-lens
     with:
       skill_command: "/autoskillit:synthesize-vis-plan ${{ inputs.source_dir }} ${{ context.experiment_plan }} {{AUTOSKILLIT_TEMP}}/run-vis-lenses --tier-c-lens=${{ context.tier_c_lens }} --methodology-tradition=${{ context.methodology_tradition }} --disambiguation-rule-applied=${{ context.disambiguation_rule_applied }}"
       cwd: "${{ inputs.source_dir }}"
-      step_name: synthesize
+      step_name: vis_synthesize
       output_dir: "{{AUTOSKILLIT_TEMP}}/synthesize-vis-plan"
     capture:
       visualization_plan_path: "${{ result.visualization_plan_path }}"
@@ -256,14 +299,16 @@ steps:
     on_result:
     - when: "${{ result.max_exceeded }} == true"
       route: create_worktree
-    - route: plan_experiment
+    - route: apply
     on_failure: create_worktree
     optional_context_refs:
     - design_review_count
     note: >
-      Iteration guard for the review_design → revise_design → plan_experiment cycle.
-      Caps design revision loops at 3 iterations. On exhaustion, proceeds to
-      create_worktree with the best available design.
+      Iteration guard for the dial → apply → synthesize REVISE → revise_design →
+      check_design_review_loop → apply cycle. Re-entry skips re-dialing since
+      experiment_type is stable across revision cycles. Caps design revision
+      loops at 3 iterations. On exhaustion, proceeds to create_worktree with
+      the best available design.
 
   resolve_design_review:
     tool: run_skill

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -177,6 +177,7 @@ steps:
 
   silent_type_gate:
     action: route
+    phoropter_family: review-design
     on_result:
     - when: "${{ context.is_silent_type }} == true"
       route: synthesize

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -164,7 +164,7 @@ steps:
       output_dir: "{{AUTOSKILLIT_TEMP}}/classify-experiment-type"
     capture:
       experiment_type: "${{ result.experiment_type }}"
-      dimensions_manifest: "${{ result.dimensions_manifest_path }}"
+      dimensions_manifest_path: "${{ result.dimensions_manifest_path }}"
       classification_timestamp: "${{ result.classification_timestamp }}"
       is_silent_type: "${{ result.is_silent_type }}"
     pass_through: [experiment_type, classification_timestamp, is_silent_type]
@@ -189,7 +189,7 @@ steps:
     model: ""
     phoropter_family: review-design
     with:
-      skill_command: "/autoskillit:apply-review-dimensions ${{ context.dimensions_manifest }} ${{ context.scope_report }} ${{ context.experiment_plan }} ${{ context.experiment_type }} ${{ context.classification_timestamp }}"
+      skill_command: "/autoskillit:apply-review-dimensions ${{ context.dimensions_manifest_path }} ${{ context.scope_report }} ${{ context.experiment_plan }} ${{ context.experiment_type }} ${{ context.classification_timestamp }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: apply
       output_dir: "{{AUTOSKILLIT_TEMP}}/apply-review-dimensions"
@@ -210,7 +210,7 @@ steps:
     with:
       callable: "autoskillit.smoke_utils.aggregate_review_verdict"
       findings_manifest_path: "${{ context.findings_manifest_path }}"
-      dimensions_manifest_path: "${{ context.dimensions_manifest }}"
+      dimensions_manifest_path: "${{ context.dimensions_manifest_path }}"
       experiment_type: "${{ context.experiment_type }}"
       output_dir: "{{AUTOSKILLIT_TEMP}}/aggregate-review-verdict"
       work_dir: "${{ inputs.source_dir }}"

--- a/src/autoskillit/skills_extended/apply-review-dimensions/SKILL.md
+++ b/src/autoskillit/skills_extended/apply-review-dimensions/SKILL.md
@@ -311,3 +311,12 @@ Output tokens (relative to the current working directory):
   verdict (verdict computation lives in the synthesis step, not in this skill)
 - `/autoskillit:plan-experiment` — produces `experiment_plan_path`
 - `/autoskillit:scope` — produces `scope_report_path`
+
+## Context Limit Behavior
+
+When context is exhausted mid-execution, the `findings_manifest_path` and
+`evaluation_dashboard_path` in `{{AUTOSKILLIT_TEMP}}/apply-review-dimensions/`
+may be partially written but missing the deeper L3/L4 review findings. The
+recipe's `on_context_limit` route triggers `create_worktree`, preserving
+whatever findings were captured so the downstream synthesis step can still
+compute a verdict from the available evidence.

--- a/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
+++ b/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
@@ -205,3 +205,12 @@ Do NOT emit `verdict`. When `is_silent_type=true`, prepend advisory:
 - `/autoskillit:apply-review-dimensions` — consumes this skill's output
   (`dimensions_manifest_path`, `selected_lenses`, `lens_context_paths`)
 - `/autoskillit:plan-experiment` — produces the plan this skill classifies
+
+## Context Limit Behavior
+
+When context is exhausted mid-execution, the `dimensions_manifest_path` and
+lens context files in `{{AUTOSKILLIT_TEMP}}/classify-experiment-type/` may
+be partially written but the experiment_type classification may be incomplete.
+The recipe's `on_context_limit` route triggers `create_worktree`, preserving
+whatever was written so the next pipeline stage can attempt recovery or
+fall through to the unblocked execution path.

--- a/src/autoskillit/smoke_utils/_review.py
+++ b/src/autoskillit/smoke_utils/_review.py
@@ -458,21 +458,20 @@ def aggregate_review_verdict(
 
     from autoskillit.core import atomic_write  # noqa: PLC0415
 
-    if not findings_manifest_path.strip():
-        return {"error": "findings_manifest_path is empty"}
-
     out = Path(output_dir)
     if not out.is_absolute():
         raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
 
-    findings_path = Path(findings_manifest_path.strip())
-    if not findings_path.exists():
-        return {"error": f"findings manifest not found: {findings_manifest_path}"}
-
-    try:
-        findings: list[dict[str, str | None]] = json.loads(findings_path.read_text())
-    except json.JSONDecodeError as exc:
-        return {"error": f"corrupt findings manifest: {exc}"}
+    if findings_manifest_path.strip():
+        findings_path = Path(findings_manifest_path.strip())
+        if not findings_path.exists():
+            return {"error": f"findings manifest not found: {findings_manifest_path}"}
+        try:
+            findings: list[dict[str, str | None]] = json.loads(findings_path.read_text())
+        except json.JSONDecodeError as exc:
+            return {"error": f"corrupt findings manifest: {exc}"}
+    else:
+        findings = []
 
     active_dimensions = 0
     dim_data: dict[str, str] = {}

--- a/tests/contracts/test_callable_skill_parity.py
+++ b/tests/contracts/test_callable_skill_parity.py
@@ -89,6 +89,8 @@ def test_recipe_skills_have_contract_tests() -> None:
         "compose-research-pr",
         "audit-claims",
         "bundle-local-report",
+        "classify-experiment-type",
+        "apply-review-dimensions",
     }
     failures: list[str] = []
     for recipe_name, skill_name in _skill_based_steps():

--- a/tests/recipe/test_audit_trail_recipe_contracts.py
+++ b/tests/recipe/test_audit_trail_recipe_contracts.py
@@ -21,7 +21,7 @@ def test_dial_captures_disambiguation_fields():
 
 
 def test_dial_captures_classification_timestamp():
-    """dial step captures classification_timestamp."""
+    """review-design dial step captures classification_timestamp (not vis_dial)."""
     recipe = load_yaml(RECIPE_PATH)
     rd_step = recipe["steps"]["dial"]
     captures = rd_step.get("capture", {})

--- a/tests/recipe/test_audit_trail_recipe_contracts.py
+++ b/tests/recipe/test_audit_trail_recipe_contracts.py
@@ -12,18 +12,18 @@ RECIPE_PATH = Path("src/autoskillit/recipes/research.yaml")
 
 
 def test_dial_captures_disambiguation_fields():
-    """dial step captures disambiguation_rule_applied and tier_c_lens."""
+    """vis_dial step captures disambiguation_rule_applied and tier_c_lens."""
     recipe = load_yaml(RECIPE_PATH)
-    dial_step = recipe["steps"]["dial"]
+    dial_step = recipe["steps"]["vis_dial"]
     captures = dial_step.get("capture", {})
     assert "disambiguation_rule_applied" in captures
     assert "tier_c_lens" in captures
 
 
-def test_review_design_captures_classification_timestamp():
-    """review_design step captures classification_timestamp."""
+def test_dial_captures_classification_timestamp():
+    """dial step captures classification_timestamp."""
     recipe = load_yaml(RECIPE_PATH)
-    rd_step = recipe["steps"]["review_design"]
+    rd_step = recipe["steps"]["dial"]
     captures = rd_step.get("capture", {})
     assert "classification_timestamp" in captures
 

--- a/tests/recipe/test_bundled_recipes_research.py
+++ b/tests/recipe/test_bundled_recipes_research.py
@@ -66,35 +66,39 @@ class TestResearchRecipeStructure:
         assert "review_design" in recipe.ingredients
         assert recipe.ingredients["review_design"].default == "true"
 
-    def test_research_has_review_design_step(self, recipe) -> None:
-        assert "review_design" in recipe.steps
+    def test_research_has_dial_step(self, recipe) -> None:
+        assert "dial" in recipe.steps
+        assert recipe.steps["dial"].phoropter_family == "review-design"
 
-    def test_review_design_step_skip_when_false(self, recipe) -> None:
-        step = recipe.steps["review_design"]
+    def test_dial_step_skip_when_false(self, recipe) -> None:
+        step = recipe.steps["dial"]
         assert step.skip_when_false == "inputs.review_design"
 
-    def test_review_design_step_retries_and_exhausted(self, recipe) -> None:
-        step = recipe.steps["review_design"]
+    def test_dial_step_retries_and_exhausted(self, recipe) -> None:
+        step = recipe.steps["dial"]
         assert step.retries == 2
         assert step.on_exhausted == "create_worktree"
 
-    def test_review_design_receives_scope_report(self, recipe) -> None:
-        """review_design step must pass scope_report as a second argument."""
-        step = recipe.steps["review_design"]
+    def test_dial_receives_scope_report(self, recipe) -> None:
+        """dial step must pass scope_report as a second argument."""
+        step = recipe.steps["dial"]
         cmd = step.with_args["skill_command"]
         assert "${{ context.scope_report }}" in cmd
 
-    def test_plan_experiment_routes_to_review_design(self, recipe) -> None:
+    def test_plan_experiment_routes_to_dial(self, recipe) -> None:
         step = recipe.steps["plan_experiment"]
-        assert step.on_success == "review_design"
+        assert step.on_success == "dial"
 
-    def test_review_design_on_result_routing(self, recipe) -> None:
-        """review_design STOP verdict routes to resolve_design_review (not design_rejected)."""
-        step = recipe.steps["review_design"]
+    def test_synthesize_on_result_routing(self, recipe) -> None:
+        """synthesize routes GO/REVISE/STOP verdicts in research.yaml.
+
+        The review-design synthesize step is the source of the final verdict.
+        """
+        step = recipe.steps["synthesize"]
         assert step.on_result is not None
         go_cond = next((c for c in step.on_result.conditions if c.when and "GO" in c.when), None)
         assert go_cond is not None, "Missing GO route"
-        assert go_cond.route == "dial"
+        assert go_cond.route == "vis_dial"
         revise_cond = next(
             (c for c in step.on_result.conditions if c.when and "REVISE" in c.when), None
         )
@@ -304,6 +308,15 @@ class TestResearchRecipeStructure:
     def test_research_recipe_validates_cleanly_with_new_steps(self, recipe) -> None:
         errors = validate_recipe_structure(recipe)
         assert errors == [], f"Validation errors: {errors}"
+
+    def test_check_design_review_loop_routes_to_apply(self, recipe) -> None:
+        step = recipe.steps["check_design_review_loop"]
+        fallback = next(
+            (c for c in step.on_result.conditions if not c.when or "max_exceeded" not in c.when),
+            None,
+        )
+        assert fallback is not None
+        assert fallback.route == "apply"
 
     # --- Archival phase tests ---
 

--- a/tests/recipe/test_bundled_recipes_research.py
+++ b/tests/recipe/test_bundled_recipes_research.py
@@ -312,7 +312,7 @@ class TestResearchRecipeStructure:
     def test_check_design_review_loop_routes_to_apply(self, recipe) -> None:
         step = recipe.steps["check_design_review_loop"]
         fallback = next(
-            (c for c in step.on_result.conditions if not c.when or "max_exceeded" not in c.when),
+            (c for c in step.on_result.conditions if c.when is None),
             None,
         )
         assert fallback is not None

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -1018,7 +1018,8 @@ def test_research_recipe_card_contains_research_skills() -> None:
     expected_subset = {
         "scope",
         "plan-experiment",
-        "review-design",
+        "classify-experiment-type",
+        "apply-review-dimensions",
         "run-experiment",
         "generate-report",
         "resolve-failures",

--- a/tests/recipe/test_plan_visualization_step.py
+++ b/tests/recipe/test_plan_visualization_step.py
@@ -17,84 +17,85 @@ def recipe():
     return load_recipe(RESEARCH_RECIPE_PATH)
 
 
-def test_dial_step_exists(recipe) -> None:
-    assert "dial" in recipe.steps
+def test_vis_dial_step_exists(recipe) -> None:
+    assert "vis_dial" in recipe.steps
 
 
-def test_apply_step_exists(recipe) -> None:
-    assert "apply" in recipe.steps
+def test_vis_apply_step_exists(recipe) -> None:
+    assert "vis_apply" in recipe.steps
 
 
-def test_synthesize_step_exists(recipe) -> None:
-    assert "synthesize" in recipe.steps
+def test_vis_synthesize_step_exists(recipe) -> None:
+    assert "vis_synthesize" in recipe.steps
 
 
-def test_dial_phoropter_family(recipe) -> None:
-    assert recipe.steps["dial"].phoropter_family == "vis-lens"
+def test_vis_dial_phoropter_family(recipe) -> None:
+    """vis-lens steps no longer carry phoropter_family after rename."""
+    assert recipe.steps["vis_dial"].phoropter_family is None
 
 
-def test_apply_phoropter_family(recipe) -> None:
-    assert recipe.steps["apply"].phoropter_family == "vis-lens"
+def test_vis_apply_phoropter_family(recipe) -> None:
+    assert recipe.steps["vis_apply"].phoropter_family is None
 
 
-def test_synthesize_phoropter_family(recipe) -> None:
-    assert recipe.steps["synthesize"].phoropter_family == "vis-lens"
+def test_vis_synthesize_phoropter_family(recipe) -> None:
+    assert recipe.steps["vis_synthesize"].phoropter_family is None
 
 
-def test_dial_captures_disambiguation_fields(recipe) -> None:
-    capture = recipe.steps["dial"].capture
+def test_vis_dial_captures_disambiguation_fields(recipe) -> None:
+    capture = recipe.steps["vis_dial"].capture
     assert "disambiguation_rule_applied" in capture
     assert "tier_c_lens" in capture
     assert "methodology_tradition" in capture
 
 
-def test_dial_captures_lens_selection(recipe) -> None:
-    """dial must also capture selected_lenses and lens_context_paths for the apply step."""
-    capture = recipe.steps["dial"].capture
+def test_vis_dial_captures_lens_selection(recipe) -> None:
+    """vis_dial must also capture selected_lenses and lens_context_paths for the apply step."""
+    capture = recipe.steps["vis_dial"].capture
     assert "selected_lenses" in capture
     assert "lens_context_paths" in capture
 
 
-def test_apply_uses_capture_list(recipe) -> None:
-    step = recipe.steps["apply"]
+def test_vis_apply_uses_capture_list(recipe) -> None:
+    step = recipe.steps["vis_apply"]
     assert step.capture_list is not None
     assert len(step.capture_list) > 0
 
 
-def test_apply_retries_zero(recipe) -> None:
+def test_vis_apply_retries_zero(recipe) -> None:
     """capture_list requires retries: 0."""
-    assert recipe.steps["apply"].retries == 0
+    assert recipe.steps["vis_apply"].retries == 0
 
 
-def test_synthesize_captures_paths(recipe) -> None:
-    capture = recipe.steps["synthesize"].capture
+def test_vis_synthesize_captures_paths(recipe) -> None:
+    capture = recipe.steps["vis_synthesize"].capture
     assert "visualization_plan_path" in capture
     assert "report_plan_path" in capture
     assert "visualization_plan_trace_path" in capture
 
 
-def test_dial_on_success_apply(recipe) -> None:
-    assert recipe.steps["dial"].on_success == "apply"
+def test_vis_dial_on_success_vis_apply(recipe) -> None:
+    assert recipe.steps["vis_dial"].on_success == "vis_apply"
 
 
-def test_apply_on_success_synthesize(recipe) -> None:
-    assert recipe.steps["apply"].on_success == "synthesize"
+def test_vis_apply_on_success_vis_synthesize(recipe) -> None:
+    assert recipe.steps["vis_apply"].on_success == "vis_synthesize"
 
 
-def test_synthesize_on_success_create_worktree(recipe) -> None:
-    assert recipe.steps["synthesize"].on_success == "create_worktree"
+def test_vis_synthesize_on_success_create_worktree(recipe) -> None:
+    assert recipe.steps["vis_synthesize"].on_success == "create_worktree"
 
 
-def test_synthesize_on_failure_escalate_stop(recipe) -> None:
-    assert recipe.steps["synthesize"].on_failure == "escalate_stop"
+def test_vis_synthesize_on_failure_escalate_stop(recipe) -> None:
+    assert recipe.steps["vis_synthesize"].on_failure == "escalate_stop"
 
 
-def test_review_design_go_routes_to_dial(recipe) -> None:
-    """review_design GO verdict must route to dial."""
-    step = recipe.steps["review_design"]
+def test_synthesize_go_routes_to_vis_dial(recipe) -> None:
+    """synthesize GO verdict must route to vis_dial."""
+    step = recipe.steps["synthesize"]
     go_condition = next((c for c in step.on_result.conditions if c.when and "GO" in c.when), None)
-    assert go_condition is not None, "Missing GO route in review_design"
-    assert go_condition.route == "dial"
+    assert go_condition is not None, "Missing GO route in synthesize"
+    assert go_condition.route == "vis_dial"
 
 
 def test_create_worktree_copies_viz_plan(recipe) -> None:

--- a/tests/recipe/test_research_smoke_fixtures.py
+++ b/tests/recipe/test_research_smoke_fixtures.py
@@ -101,7 +101,7 @@ def test_both_fixtures_nonempty_and_distinct():
 
 
 def test_dial_captures_methodology_tradition(research_recipe):
-    assert "methodology_tradition" in research_recipe.steps["dial"].capture
+    assert "methodology_tradition" in research_recipe.steps["vis_dial"].capture
 
 
 def test_generate_report_receives_experiment_type_arg(research_recipe):

--- a/tests/recipe/test_rules_phoropter_adjacency.py
+++ b/tests/recipe/test_rules_phoropter_adjacency.py
@@ -245,3 +245,42 @@ def test_minimal_recipe_no_phoropter_findings():
     phoropter_rules = {"phoropter-phase-order", "phoropter-step-interleaving"}
     findings = [f for f in run_semantic_rules(recipe) if f.rule in phoropter_rules]
     assert not findings
+
+
+# --- route-action transparency tests ---
+
+
+def test_route_action_between_phases_is_transparent():
+    """A route-action step between dial and apply within the same phoropter family
+    must NOT produce a phase-order finding — it is transparent to phase tracking."""
+    import autoskillit.recipe  # noqa: F401
+
+    recipe = _make_recipe(
+        {
+            "dial": RecipeStep(tool="run_skill", phoropter_family="test-fam"),
+            "gate": RecipeStep(action="route", phoropter_family="test-fam"),
+            "apply": RecipeStep(tool="run_skill", phoropter_family="test-fam"),
+            "synthesize": RecipeStep(tool="run_skill", phoropter_family="test-fam"),
+            "done": RecipeStep(action="stop"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-phase-order"]
+    assert len(findings) == 0
+
+
+def test_route_action_does_not_trigger_interleaving():
+    """The phoropter-step-interleaving rule must NOT produce a false positive
+    when a route-action step is inserted between dial and apply within the same family."""
+    import autoskillit.recipe  # noqa: F401
+
+    recipe = _make_recipe(
+        {
+            "dial": RecipeStep(tool="run_skill", phoropter_family="test-fam"),
+            "gate": RecipeStep(action="route", phoropter_family="test-fam"),
+            "apply": RecipeStep(tool="run_skill", phoropter_family="test-fam"),
+            "synthesize": RecipeStep(tool="run_skill", phoropter_family="test-fam"),
+            "done": RecipeStep(action="stop"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-step-interleaving"]
+    assert len(findings) == 0

--- a/tests/recipe/test_rules_verdict.py
+++ b/tests/recipe/test_rules_verdict.py
@@ -145,20 +145,17 @@ def test_unrouted_verdict_value_severity_is_error() -> None:
         )
 
 
-def test_unrouted_verdict_passes_for_review_design_in_research_recipe() -> None:
-    """The unrouted-verdict-value rule must not fire for review-design in research.yaml.
-
-    All three verdict values (GO, REVISE, STOP) have explicit on_result conditions.
-    This test ensures the rule exercises review-design, not just review-pr.
+def test_unrouted_verdict_passes_for_synthesize_in_research_recipe() -> None:
+    """The unrouted-verdict-value rule must not fire for the review-design synthesize step
+    in research.yaml. All three verdict values (GO, REVISE, STOP) plus a fallback have
+    explicit on_result conditions.
     """
     recipe = load_recipe(builtin_recipes_dir() / "research.yaml")
     findings = run_semantic_rules(recipe)
     unrouted = [
-        f
-        for f in findings
-        if f.rule == "unrouted-verdict-value" and f.step_name == "review_design"
+        f for f in findings if f.rule == "unrouted-verdict-value" and f.step_name == "synthesize"
     ]
-    assert not unrouted, f"unrouted-verdict-value fired for review_design step: {unrouted}"
+    assert not unrouted, f"unrouted-verdict-value fired for synthesize step: {unrouted}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -2766,12 +2766,16 @@ def test_aggregate_review_verdict_rt_cap_downgrades(tmp_path: Path) -> None:
     assert "critical_count: 0" in dashboard
 
 
-def test_aggregate_review_verdict_empty_path_returns_error() -> None:
-    """Empty findings_manifest_path returns error key."""
+def test_aggregate_review_verdict_empty_path_returns_go(tmp_path: Path) -> None:
+    """Empty findings_manifest_path (silent type path) returns GO with no findings."""
     from autoskillit.smoke_utils import aggregate_review_verdict
 
-    result = aggregate_review_verdict(findings_manifest_path="")
-    assert "error" in result
+    result = aggregate_review_verdict(
+        findings_manifest_path="",
+        output_dir=str(tmp_path / "out"),
+    )
+    assert result.get("verdict") == "GO"
+    assert "error" not in result
 
 
 def test_aggregate_review_verdict_missing_file_returns_error(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Replace the monolithic `review_design` step in `research.yaml` with a review-design phoropter triple (`dial` → `silent_type_gate` → `apply` → `synthesize`) that uses the `classify-experiment-type` and `apply-review-dimensions` skills plus the `aggregate_review_verdict` callable. Rename the existing vis-lens phoropter steps (`dial`/`apply`/`synthesize` → `vis_dial`/`vis_apply`/`vis_synthesize`) to resolve YAML key conflicts, update the `check_design_review_loop` re-entry to `apply`, update both phoropter adjacency rules to allow route-action steps within a family sequence, and retarget all affected tests.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260602-230135-543205/.autoskillit/temp/make-plan/apply_same_decomposition_to_research_yaml_plan_2026-06-02_231500.md`

Closes #3094

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 12 | 8.4k | 459.5k | 159.8k | 70 | 19.3k | 32m 8s |
| verify* | sonnet | 1 | 76 | 14.4k | 439.4k | 73.3k | 28 | 56.6k | 5m 51s |
| implement* | MiniMax-M3 | 1 | 193.0k | 44.8k | 14.4M | 175.9k | 281 | 0 | 41m 33s |
| retry_worktree* | sonnet | 1 | 148 | 5.3k | 1.2M | 96.4k | 52 | 173.4k | 4m 31s |
| audit_impl* | sonnet | 1 | 3.1k | 11.0k | 146.7k | 41.0k | 13 | 34.2k | 6m 14s |
| prepare_pr* | MiniMax-M3 | 1 | 45.0k | 1.8k | 212.7k | 47.6k | 15 | 0 | 55s |
| compose_pr* | MiniMax-M3 | 1 | 34.9k | 1.1k | 149.3k | 38.2k | 12 | 0 | 46s |
| review_pr* | sonnet | 3 | 538 | 110.5k | 4.7M | 136.0k | 174 | 293.5k | 30m 16s |
| resolve_review* | sonnet | 3 | 1.6k | 67.5k | 8.3M | 105.1k | 285 | 211.6k | 35m 9s |
| **Total** | | | 278.4k | 264.8k | 29.9M | 175.9k | | 788.7k | 2h 37m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 453 | 31771.9 | 0.0 | 98.9 |
| retry_worktree | 453 | 2583.4 | 382.8 | 11.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 59 | 140661.0 | 3586.7 | 1144.7 |
| **Total** | **965** | 31035.5 | 817.3 | 274.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 12 | 8.4k | 459.5k | 19.3k | 32m 8s |
| sonnet | 5 | 5.5k | 208.7k | 14.7M | 769.3k | 1h 22m |
| MiniMax-M3 | 3 | 272.9k | 47.7k | 14.8M | 0 | 43m 14s |