### PR TITLE
Rectify: Backend Requirements Annotation Over-Classification

### DIFF
--- a/.autoskillit/test-source-map.json
+++ b/.autoskillit/test-source-map.json
@@ -1502,7 +1502,10 @@
     "tests/arch/test_mcp_env_forward_coverage.py",
     "tests/arch/test_pty_coherence.py",
     "tests/arch/test_run_python_path_resolution.py",
+    "tests/arch/test_backend_annotation_context_awareness.py",
+    "tests/arch/test_skill_backend_annotation_accuracy.py",
     "tests/arch/test_skill_backend_annotations.py",
+    "tests/arch/test_skill_capability_registry.py",
     "tests/arch/test_skill_registries.py",
     "tests/arch/test_write_restriction_coverage.py",
     "tests/cli/test_cli_hooks.py",
@@ -1980,7 +1983,10 @@
     "tests/arch/test_pty_coherence.py",
     "tests/arch/test_regex_import.py",
     "tests/arch/test_session_type_exhaustive.py",
+    "tests/arch/test_backend_annotation_context_awareness.py",
+    "tests/arch/test_skill_backend_annotation_accuracy.py",
     "tests/arch/test_skill_backend_annotations.py",
+    "tests/arch/test_skill_capability_registry.py",
     "tests/cli/test_cli_hooks.py",
     "tests/cli/test_cli_prompts.py",
     "tests/cli/test_cli_serve_logging.py",
@@ -2653,6 +2659,11 @@
   ],
   "src/autoskillit/core/types/_type_constants_features.py": [
     "tests/core/test_label_lifecycle.py"
+  ],
+  "src/autoskillit/core/types/_type_constants_registries.py": [
+    "tests/arch/test_skill_backend_annotation_accuracy.py",
+    "tests/arch/test_skill_backend_annotations.py",
+    "tests/arch/test_skill_capability_registry.py"
   ],
   "src/autoskillit/core/types/_type_dispatch_identity.py": [
     "tests/core/types/test_dispatch_identity.py",
@@ -14775,7 +14786,10 @@
   ],
   "src/autoskillit/workspace/skills.py": [
     "tests/arch/test_protocol_names.py",
+    "tests/arch/test_backend_annotation_context_awareness.py",
+    "tests/arch/test_skill_backend_annotation_accuracy.py",
     "tests/arch/test_skill_backend_annotations.py",
+    "tests/arch/test_skill_capability_registry.py",
     "tests/cli/test_cli_serve_logging.py",
     "tests/cli/test_cook_env_scrub.py",
     "tests/cli/test_cook_features.py",

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -195,6 +195,7 @@ from .types import SESSION_TYPE_FLEET as SESSION_TYPE_FLEET
 from .types import SESSION_TYPE_ORCHESTRATOR as SESSION_TYPE_ORCHESTRATOR
 from .types import SESSION_TYPE_SKILL as SESSION_TYPE_SKILL
 from .types import SKILL_ACTIVATE_DEPS_REQUIRED as SKILL_ACTIVATE_DEPS_REQUIRED
+from .types import SKILL_CAPABILITY_REGISTRY as SKILL_CAPABILITY_REGISTRY
 from .types import SKILL_COMMAND_DISPLAY_MAX as SKILL_COMMAND_DISPLAY_MAX
 from .types import SKILL_COMMAND_PREFIX as SKILL_COMMAND_PREFIX
 from .types import SKILL_FILE_ADVISORY_MAP as SKILL_FILE_ADVISORY_MAP
@@ -305,6 +306,7 @@ from .types import SessionSkillManager as SessionSkillManager
 from .types import SessionTelemetry as SessionTelemetry
 from .types import SessionType as SessionType
 from .types import Severity as Severity
+from .types import SkillCapabilityDef as SkillCapabilityDef
 from .types import SkillFamilyDef as SkillFamilyDef
 from .types import SkillLister as SkillLister
 from .types import SkillResolver as SkillResolver

--- a/src/autoskillit/core/types/_type_constants_registries.py
+++ b/src/autoskillit/core/types/_type_constants_registries.py
@@ -1,12 +1,14 @@
 """Tool registries, pack registries, tool-to-tag mappings, visibility tags.
 
-Zero autoskillit imports.
+Zero autoskillit imports — except sibling _type_constants_env for backend name constants.
 """
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from dataclasses import dataclass
+from typing import Literal, NamedTuple
 
+from ._type_constants_env import AGENT_BACKEND_CLAUDE_CODE
 from ._type_enums import FleetErrorCode
 
 __all__ = [
@@ -31,6 +33,8 @@ __all__ = [
     "CORE_PACKS",
     "TOOL_SUBSET_TAGS",
     "ALL_VISIBILITY_TAGS",
+    "SkillCapabilityDef",
+    "SKILL_CAPABILITY_REGISTRY",
 ]
 
 # Native Claude Code tools that pipeline orchestrators must NEVER use directly.
@@ -290,3 +294,51 @@ if not _non_category_tool_tags <= ALL_VISIBILITY_TAGS:
         f"ALL_VISIBILITY_TAGS is missing non-category tags found in TOOL_SUBSET_TAGS: "
         f"{sorted(_missing)}. Add the missing tags to ALL_VISIBILITY_TAGS."
     )
+
+
+@dataclass(frozen=True, slots=True)
+class SkillCapabilityDef:
+    """A capability that a skill may require from its execution backend."""
+
+    description: str
+    required_backends: frozenset[str]
+    codex_status: Literal["works-as-is", "degraded", "fix-required", "not-applicable"]
+
+
+SKILL_CAPABILITY_REGISTRY: dict[str, SkillCapabilityDef] = {
+    "agent_subagent": SkillCapabilityDef(
+        description="Agent(subagent_type=...) tool — delegates to specialized subagent",
+        required_backends=frozenset({AGENT_BACKEND_CLAUDE_CODE}),
+        codex_status="fix-required",
+    ),
+    "agent_model": SkillCapabilityDef(
+        description="Agent(model=...) tool — spawns model-specific subagent",
+        required_backends=frozenset({AGENT_BACKEND_CLAUDE_CODE}),
+        codex_status="fix-required",
+    ),
+    "open_kitchen": SkillCapabilityDef(
+        description="open_kitchen / close_kitchen lifecycle tools",
+        required_backends=frozenset({AGENT_BACKEND_CLAUDE_CODE}),
+        codex_status="not-applicable",
+    ),
+    "run_skill": SkillCapabilityDef(
+        description="run_skill MCP tool call (headless session dispatch)",
+        required_backends=frozenset({AGENT_BACKEND_CLAUDE_CODE}),
+        codex_status="not-applicable",
+    ),
+    "test_check": SkillCapabilityDef(
+        description="test_check MCP tool (headless test runner)",
+        required_backends=frozenset({AGENT_BACKEND_CLAUDE_CODE}),
+        codex_status="not-applicable",
+    ),
+    "claude_dir": SkillCapabilityDef(
+        description="Reads/writes .claude/ directory structure",
+        required_backends=frozenset(),
+        codex_status="works-as-is",
+    ),
+    "cross_skill_ref": SkillCapabilityDef(
+        description="Cross-skill /autoskillit: invocation via Skill tool",
+        required_backends=frozenset({AGENT_BACKEND_CLAUDE_CODE}),
+        codex_status="fix-required",
+    ),
+}

--- a/src/autoskillit/skills/close-kitchen/SKILL.md
+++ b/src/autoskillit/skills/close-kitchen/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: close-kitchen
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref, open_kitchen]
 description: Close the AutoSkillit kitchen — hides kitchen MCP tools for this session.
 disable-model-invocation: true
 ---

--- a/src/autoskillit/skills/open-kitchen/SKILL.md
+++ b/src/autoskillit/skills/open-kitchen/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: open-kitchen
 backend_requirements: [claude-code]
+uses_capabilities: [open_kitchen]
 description: Open the AutoSkillit kitchen — reveals all kitchen MCP tools for this session. Human-only entry point.
 disable-model-invocation: true
 ---

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sous-chef
 backend_requirements: [claude-code]
-uses_capabilities: [cross_skill_ref, open_kitchen, run_skill]
+uses_capabilities: [cross_skill_ref, open_kitchen, run_skill, test_check]
 description: Internal bootstrap document injected by open_kitchen into every orchestrator session.
 ---
 <!-- Internal bootstrap document — not a user-invocable skill.

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: sous-chef
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref, open_kitchen, run_skill]
 description: Internal bootstrap document injected by open_kitchen into every orchestrator session.
 ---
 <!-- Internal bootstrap document — not a user-invocable skill.

--- a/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: analyze-pipeline-health
+backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref, run_skill]
 categories: [diagnostics]
 description: Analyze pipeline session logs for anomalies and regressions. Spawns parallel Haiku scanner subagents per step group, each investigating its batch of sessions and reporting findings with evidence.
 hooks:

--- a/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: analyze-pipeline-health
 categories: [diagnostics]
-backend_requirements: [claude-code]
 description: Analyze pipeline session logs for anomalies and regressions. Spawns parallel Haiku scanner subagents per step group, each investigating its batch of sessions and reporting findings with evidence.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/analyze-prs/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-prs/SKILL.md
@@ -2,6 +2,7 @@
 name: analyze-prs
 categories: [github]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: Analyze all open PRs targeting a base branch — determine merge order, identify file overlaps, and tag each PR as simple or needs_check for complexity. Use at the start of a PR consolidation workflow.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/apply-review-dimensions/SKILL.md
+++ b/src/autoskillit/skills_extended/apply-review-dimensions/SKILL.md
@@ -2,6 +2,7 @@
 name: apply-review-dimensions
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: Evaluate experiment design across weighted dimensions using multi-level subagent analysis with adversarial red-team, producing a findings manifest and evaluation dashboard.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
@@ -2,6 +2,7 @@
 name: arch-lens-c4-container
 categories: [arch-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-c4-container/"]
 description: Create C4 Container architecture diagram showing static structure, building blocks, and technology choices. Anatomical lens answering "How is it built?"

--- a/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
@@ -2,6 +2,7 @@
 name: arch-lens-concurrency
 categories: [arch-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-concurrency/"]
 description: Create Concurrency architecture diagram showing parallel execution patterns, thread pools, synchronization, and barriers. Physiological lens answering "How does parallelism work?"

--- a/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
@@ -2,6 +2,7 @@
 name: arch-lens-data-lineage
 categories: [arch-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-data-lineage/"]
 description: Create Data Lineage architecture diagram showing information flow, transformations, and storage destinations. Data-centric lens answering "Where is the data?"

--- a/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
@@ -2,6 +2,7 @@
 name: arch-lens-deployment
 categories: [arch-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-deployment/"]
 description: Create Deployment/Physical architecture diagram showing infrastructure topology, process boundaries, and network communication. Physical lens answering "Where does it run?"

--- a/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
@@ -2,6 +2,7 @@
 name: arch-lens-development
 categories: [arch-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-development/"]
 description: Create Development architecture diagram showing project structure, build tools, and quality gates. Development lens answering "How is it built and tested?"

--- a/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
@@ -2,6 +2,7 @@
 name: arch-lens-error-resilience
 categories: [arch-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-error-resilience/"]
 description: Create Error/Resilience architecture diagram showing failure handling, recovery mechanisms, and circuit breakers. Diagnostic lens answering "How are failures handled?"

--- a/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
@@ -2,6 +2,7 @@
 name: arch-lens-module-dependency
 categories: [arch-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-module-dependency/"]
 description: Create Module Dependency architecture diagram showing package coupling, layering, and fan-in/fan-out. Structural lens answering "How are modules coupled?"

--- a/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
@@ -2,6 +2,7 @@
 name: arch-lens-operational
 categories: [arch-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-operational/"]
 description: Create Operational architecture diagram showing CLI workflows, configuration, and observability. Administration lens answering "How is it run and monitored?"

--- a/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
@@ -2,6 +2,7 @@
 name: arch-lens-process-flow
 categories: [arch-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-process-flow/"]
 description: Create Process/Execution Flow architecture diagram showing runtime behavior, state transitions, and decision points. Physiological lens answering "How does it behave?"

--- a/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
@@ -2,6 +2,7 @@
 name: arch-lens-repository-access
 categories: [arch-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-repository-access/"]
 description: Create Repository/Data Access architecture diagram showing the repository pattern, entity relationships, and data access patterns. Data-centric lens answering "How is data accessed?"

--- a/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
@@ -2,6 +2,7 @@
 name: arch-lens-scenarios
 categories: [arch-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-scenarios/"]
 description: Create Scenarios architecture diagram showing end-to-end user journeys and component cooperation validation. Validation lens answering "Do the components work together?"

--- a/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
@@ -2,6 +2,7 @@
 name: arch-lens-security
 categories: [arch-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-security/"]
 description: Create Security architecture diagram showing trust boundaries, validation layers, and process isolation. Security lens answering "Where are the trust boundaries?"

--- a/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
@@ -2,6 +2,7 @@
 name: arch-lens-state-lifecycle
 categories: [arch-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-state-lifecycle/"]
 description: Create State Lifecycle architecture diagram showing field contracts, validation gates, and resume safety. Contract overlay lens answering "How is state corruption prevented?"

--- a/src/autoskillit/skills_extended/audit-bugs/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-bugs/SKILL.md
@@ -2,6 +2,7 @@
 name: audit-bugs
 categories: [audit]
 backend_requirements: [claude-code]
+uses_capabilities: [claude_dir, cross_skill_ref]
 description: Analyze historical bug patterns by mining Claude Code project logs for /autoskillit:investigate skill invocations since a specified date. Identifies recurring root causes, architectural gaps, and proactive detection strategies. Use when user says "audit bugs", "bug patterns", "analyze investigations", or "bug audit".
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/audit-claims/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-claims/SKILL.md
@@ -2,6 +2,7 @@
 name: audit-claims
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: >
   Parallel subagent-driven claim extraction and citation integrity audit for
   research PRs. Extracts claims by section, matches against available evidence,

--- a/src/autoskillit/skills_extended/audit-cohesion/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-cohesion/SKILL.md
@@ -2,6 +2,7 @@
 name: audit-cohesion
 categories: [audit]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 description: Audit codebase for internal cohesion - how well components fit together and maintain consistent patterns. Distinct from audit-arch (which checks rule violations); this checks integration fitness and convergence. Use when user says "audit cohesion", "check cohesion", "cohesion audit", or "alignment check".
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/audit-defense-standards/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-defense-standards/SKILL.md
@@ -2,6 +2,7 @@
 name: audit-defense-standards
 categories: [audit]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 description: Audit the codebase against defense standards derived from historical bug patterns. Standards accumulate over time as new patterns are discovered via audit-bugs and design-guards. Use when user says "audit defenses", "audit defense standards", "check defenses", or "defense audit".
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/audit-docs/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-docs/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: audit-docs
 categories: [audit]
-backend_requirements: [claude-code]
 description: >
   Audit documentation for drift, staleness, and inconsistency against the actual
   codebase. Use when user says "audit docs", "check documentation", "docs audit",

--- a/src/autoskillit/skills_extended/audit-friction/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-friction/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: audit-friction
 categories: [audit]
-backend_requirements: [claude-code]
+uses_capabilities: [claude_dir]
 description: Scan Claude Code project logs for friction patterns — repeated failures, approach loops, tool errors, misunderstanding cycles, and stuck workflows. Categorizes and counts friction events to surface what causes the most resistance. Use when user says "audit friction", "find friction", "friction audit", or "what keeps going wrong".
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/audit-impl/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-impl/SKILL.md
@@ -2,6 +2,7 @@
 name: audit-impl
 categories: [audit]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, agent_subagent, cross_skill_ref]
 description: Audit a completed implementation against its originating plan(s). Returns GO (merge approved) or NO GO (generates remediation file for retry). Final gate before merge in any implementation pipeline.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -2,6 +2,7 @@
 name: audit-review-decisions
 categories: [audit]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: >
   Audit merged PR review threads for agreed-but-deferred suggestions (design decisions,
   future work, out-of-scope items) that were never implemented. Mines REVIEW-FLAG markers

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -2,7 +2,7 @@
 name: audit-review-decisions
 categories: [audit]
 backend_requirements: [claude-code]
-uses_capabilities: [agent_model]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: >
   Audit merged PR review threads for agreed-but-deferred suggestions (design decisions,
   future work, out-of-scope items) that were never implemented. Mines REVIEW-FLAG markers

--- a/src/autoskillit/skills_extended/audit-tests/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-tests/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: audit-tests
 categories: [audit]
-backend_requirements: [claude-code]
 description: Audit the test suite for useless tests, consolidation opportunities, over-mocking, weak assertions, placement/organization issues, xdist safety violations, test path filter integrity, and other test quality issues. Use when user says "audit tests", "audit test suite", "review tests", or "test quality check". Generates an improvement plan in {{AUTOSKILLIT_TEMP}}/ with explanations for each proposed change.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -2,6 +2,7 @@
 name: build-execution-map
 categories: [github]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: Analyze issue dependencies and produce a dispatch execution map for parallel orchestration
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
+++ b/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
@@ -2,6 +2,7 @@
 name: classify-experiment-type
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: Classify an experiment plan into a type, build the dimension weight matrix, and emit dialing interface tokens for the apply-review-dimensions step.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/collapse-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/collapse-issues/SKILL.md
@@ -2,6 +2,7 @@
 name: collapse-issues
 categories: [github]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 description: >
   Identify clusters of related triaged GitHub issues sharing the same recipe route
   and collapse them into a single combined issue with full content from all originals.

--- a/src/autoskillit/skills_extended/compose-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-pr/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: compose-pr
+backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 categories: [github]
 description: Composition executor for pull requests. ALWAYS invoke this skill when instructed to compose a PR. Do not read prep files or create PRs directly — use this skill first to load the composition workflow.
 hooks:

--- a/src/autoskillit/skills_extended/compose-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: compose-pr
 categories: [github]
-backend_requirements: [claude-code]
 description: Composition executor for pull requests. ALWAYS invoke this skill when instructed to compose a PR. Do not read prep files or create PRs directly — use this skill first to load the composition workflow.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/compose-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-research-pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: compose-research-pr
 categories: [research]
-backend_requirements: [claude-code]
 description: >
   Reads a PR prep file and validated experiment diagrams, composes the PR body,
   and creates the GitHub PR. Part 3 of 3 in the decomposed research-PR flow.

--- a/src/autoskillit/skills_extended/design-guards/SKILL.md
+++ b/src/autoskillit/skills_extended/design-guards/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: design-guards
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 description: Investigate a bug pattern audit report and design architectural guards (tests, contracts, structural changes) that provide immunity to each identified pattern. Use when user says "design guards", "design defenses", or wants architectural solutions for bug patterns.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/diagnose-ci/SKILL.md
+++ b/src/autoskillit/skills_extended/diagnose-ci/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: diagnose-ci
 categories: [ci]
-backend_requirements: [claude-code]
 description: Diagnostic executor for CI failures. ALWAYS invoke this skill when instructed to diagnose CI failures. Do not fetch CI logs directly — use this skill first to load the diagnosis workflow.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/download-data/SKILL.md
+++ b/src/autoskillit/skills_extended/download-data/SKILL.md
@@ -2,6 +2,7 @@
 name: download-data
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: >
   Download external and gitignored datasets declared in the experiment plan's
   data_manifest. Executes acquisition commands sequentially into pre-created

--- a/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
+++ b/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dry-walkthrough
 backend_requirements: [claude-code]
-uses_capabilities: [agent_model]
+uses_capabilities: [agent_model, test_check]
 description: Plan validation executor. ALWAYS invoke this skill when instructed to validate or dry-walkthrough a plan. Do not read the plan or trace changes directly — use this skill first to load the validation workflow.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
+++ b/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dry-walkthrough
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: Plan validation executor. ALWAYS invoke this skill when instructed to validate or dry-walkthrough a plan. Do not read the plan or trace changes directly — use this skill first to load the validation workflow.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/elaborate-phase/SKILL.md
+++ b/src/autoskillit/skills_extended/elaborate-phase/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: elaborate-phase
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [dry-walkthrough]
 description: Elaborate a migration plan phase into a complete self-contained implementation plan. Use when user says "elaborate phase", "elaborate phase N", or "phase elaboration". Assesses codebase, writes detailed phase plan, then validates with dry walkthrough.
 hooks:

--- a/src/autoskillit/skills_extended/enrich-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/enrich-issues/SKILL.md
@@ -2,7 +2,7 @@
 name: enrich-issues
 categories: [github]
 backend_requirements: [claude-code]
-uses_capabilities: [agent_model, cross_skill_ref]
+uses_capabilities: [agent_model, cross_skill_ref, open_kitchen]
 description: >
   Backfill structured requirements on existing GitHub issues triaged with
   recipe:implementation labels. Scans candidates, skips already-enriched issues,

--- a/src/autoskillit/skills_extended/enrich-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/enrich-issues/SKILL.md
@@ -2,6 +2,7 @@
 name: enrich-issues
 categories: [github]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: >
   Backfill structured requirements on existing GitHub issues triaged with
   recipe:implementation labels. Scans candidates, skips already-enriched issues,

--- a/src/autoskillit/skills_extended/exp-lens-benchmark-representativeness/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-benchmark-representativeness/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-benchmark-representativeness
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Benchmark Representativeness experimental design diagram showing coverage matrix, generalization gaps, and untested regions. Generalizability lens answering "Does this generalize beyond the test bed?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-causal-assumptions/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-causal-assumptions/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-causal-assumptions
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Causal Assumptions experimental design diagram showing confounders, mediators, colliders, and identification strategy. Causal-structural lens answering "What causal assumptions support this design?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-comparator-construction/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-comparator-construction/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-comparator-construction
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Comparator Construction experimental design analysis assessing whether baselines and controls are fair and relevant. Counterfactual lens answering "Is the comparator fair and relevant?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-error-budget/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-error-budget/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-error-budget
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Analyze statistical error budget showing Type I/II errors, power, minimum detectable effect, multiplicity corrections, and sequential monitoring. Statistical lens answering "Are error risks sized and controlled?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-estimand-clarity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-estimand-clarity/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-estimand-clarity
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Estimand Clarity experimental design analysis decomposing the implicit estimand from code vs. explicit claims from prose. Evidential lens answering "What exactly is the claim?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-exploratory-confirmatory/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-exploratory-confirmatory/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-exploratory-confirmatory
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Assess whether analytic decisions were pre-specified or post-hoc and whether exploratory/confirmatory norms are aligned. Boundary lens answering "Is this discovery or test, and are norms aligned?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-fair-comparison/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-fair-comparison/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-fair-comparison
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create a comparison fairness matrix assessing whether alternatives are evaluated under symmetric constraints. Fairness lens answering "Are alternatives compared under symmetric constraints?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-governance-risk/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-governance-risk/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-governance-risk
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create a risk register and stakeholder impact assessment for experiments with deployment implications. Governance lens answering "What risks arise from acting on this result?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-iterative-learning/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-iterative-learning/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-iterative-learning
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Iterative Learning experimental design diagram showing factor space exploration, adaptive allocation, and next-experiment recommendations. Decision-Theoretic lens answering "How does this maximize learning per cost?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-measurement-validity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-measurement-validity/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-measurement-validity
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Analyze measurement validity for experimental design — auditing metric-construct alignment, proxy validity, reliability, sensitivity, and consequential validity. Argumentative lens answering "Do measurements justify the interpretation?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-pipeline-integrity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-pipeline-integrity/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-pipeline-integrity
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Pipeline Integrity experimental design diagram showing data splits, leakage points, preprocessing order, and label contamination. Integrity lens answering "Could data handling create optimistic bias?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-randomization-blocking/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-randomization-blocking/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-randomization-blocking
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Randomization & Blocking experimental design diagram showing assignment mechanisms, blocking factors, and comparability sources. Design-Structural lens answering "Where does comparability come from?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-reproducibility-artifacts/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-reproducibility-artifacts/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-reproducibility-artifacts
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Reproducibility Artifacts experimental design diagram showing run instructions, environment capture, data availability, determinism controls, and audit trail. Transparency lens answering "Could an independent party reproduce this?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-sensitivity-robustness/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-sensitivity-robustness/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-sensitivity-robustness
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Sensitivity & Robustness experimental design analysis identifying load-bearing analytic choices and untested perturbations. Robustness lens answering "Which assumptions are load-bearing?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-severity-testing/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-severity-testing/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-severity-testing
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Analyze severity of experimental tests — adversarial cases, negative controls, falsification tests, easy-pass detection, and confirmatory theater. Falsificationist lens answering "Would this design have caught the error?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-unit-interference/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-unit-interference/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-unit-interference
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Unit Interference experimental design diagram showing unit hierarchy, cluster structure, shared resources, and SUTVA violation pathways. Causal-Structural lens answering "What is the unit, and can treatments spill over?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-validity-threats/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-validity-threats/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-validity-threats
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create a validity threat matrix identifying alternative explanations and design mitigations. Adversarial lens answering "What alternative explanations survive?"
 hooks:

--- a/src/autoskillit/skills_extended/exp-lens-variance-stability/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-variance-stability/SKILL.md
@@ -2,6 +2,7 @@
 name: exp-lens-variance-stability
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create a variance analysis profile assessing whether signals exceed noise and whether results are stable across random seeds. Stability lens answering "Is the signal larger than the noise?"
 hooks:

--- a/src/autoskillit/skills_extended/generate-report/SKILL.md
+++ b/src/autoskillit/skills_extended/generate-report/SKILL.md
@@ -2,6 +2,7 @@
 name: generate-report
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: Synthesize experiment results into a structured research report in the research/ folder. Supports --inconclusive flag.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/implement-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-experiment/SKILL.md
@@ -2,7 +2,7 @@
 name: implement-experiment
 categories: [research]
 backend_requirements: [claude-code]
-uses_capabilities: [agent_model]
+uses_capabilities: [agent_model, test_check]
 description: Deploy experiment artifacts in an isolated git worktree following an approved experiment plan, with per-phase commits.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/implement-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-experiment/SKILL.md
@@ -2,6 +2,7 @@
 name: implement-experiment
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: Deploy experiment artifacts in an isolated git worktree following an approved experiment plan, with per-phase commits.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: implement-worktree-no-merge
 backend_requirements: [claude-code]
-uses_capabilities: [agent_model, cross_skill_ref]
+uses_capabilities: [agent_model, cross_skill_ref, run_skill]
 activate_deps: [write-recipe]
 description: Implementation executor. ALWAYS invoke this skill when instructed to implement a plan in a worktree. Do not read the plan or edit files directly — use this skill first to load the full implementation workflow.
 hooks:

--- a/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: implement-worktree-no-merge
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 activate_deps: [write-recipe]
 description: Implementation executor. ALWAYS invoke this skill when instructed to implement a plan in a worktree. Do not read the plan or edit files directly — use this skill first to load the full implementation workflow.
 hooks:

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: implement-worktree
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 activate_deps: [write-recipe]
 description: Worktree implementation executor. ALWAYS invoke this skill when instructed to implement a plan in a worktree with testing and merging. Do not read the plan or edit files directly — use this skill first to load the full implementation workflow.
 hooks:

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: implement-worktree
 backend_requirements: [claude-code]
-uses_capabilities: [agent_model, cross_skill_ref]
+uses_capabilities: [agent_model, cross_skill_ref, test_check]
 activate_deps: [write-recipe]
 description: Worktree implementation executor. ALWAYS invoke this skill when instructed to implement a plan in a worktree with testing and merging. Do not read the plan or edit files directly — use this skill first to load the full implementation workflow.
 hooks:

--- a/src/autoskillit/skills_extended/investigate/SKILL.md
+++ b/src/autoskillit/skills_extended/investigate/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: investigate
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, claude_dir, cross_skill_ref]
 description: Deep investigation of errors, bugs, or codebase questions without making any code changes. Use when user mentions investigate, understand, explore, analyze, or pastes error tracebacks. Spawns parallel subagents for comprehensive exploration.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/issue-splitter/SKILL.md
+++ b/src/autoskillit/skills_extended/issue-splitter/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: issue-splitter
 categories: [github]
-backend_requirements: [claude-code]
 description: >
   Analyze a GitHub issue for mixed concerns and split it into focused sub-issues
   with proper cross-references. Integrates into triage-issues as a pre-classification step.

--- a/src/autoskillit/skills_extended/make-arch-diag/SKILL.md
+++ b/src/autoskillit/skills_extended/make-arch-diag/SKILL.md
@@ -2,6 +2,7 @@
 name: make-arch-diag
 categories: [arch-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [arch-lens]
 description: Generate architecture diagram for a specific component or system. Prompts user to select which area to document, then creates comprehensive mermaid diagrams.
 hooks:

--- a/src/autoskillit/skills_extended/make-experiment-diag/SKILL.md
+++ b/src/autoskillit/skills_extended/make-experiment-diag/SKILL.md
@@ -2,6 +2,7 @@
 name: make-experiment-diag
 categories: [exp-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [exp-lens]
 description: Interactive selection of experimental design lens for visualizing experiment methodology. Routes to the appropriate exp-lens-* skill.
 hooks:

--- a/src/autoskillit/skills_extended/make-groups/SKILL.md
+++ b/src/autoskillit/skills_extended/make-groups/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: make-groups
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: Break a large plan, architecture proposal, or feature document into sequenced implementation groups for the make-plan pipeline. Use when user says "make groups", "group requirements", "sequence groups", or wants to decompose a large document into ordered implementation units.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: make-plan
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, agent_subagent, cross_skill_ref]
 activate_deps: [arch-lens, write-recipe]
 description: Planning executor. ALWAYS invoke this skill when instructed to create, devise, or write an implementation plan. Do not explore the codebase or draft a plan directly — use this skill first to load the planning workflow.
 hooks:

--- a/src/autoskillit/skills_extended/merge-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/merge-pr/SKILL.md
@@ -2,6 +2,7 @@
 name: merge-pr
 categories: [github]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 description: Merge a single PR into the integration branch. For simple PRs, uses gh pr merge --squash --auto to enforce GitHub's required status checks. For needs_check PRs, re-assesses complexity and returns needs_plan=true with a conflict report when conflicts are detected. Use inside the merge-prs loop.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/migrate-recipes/SKILL.md
+++ b/src/autoskillit/skills_extended/migrate-recipes/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: migrate-recipes
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [write-recipe]
 description: Apply versioned migration notes to an AutoSkillit recipe. Use when user confirms migration, called by agent or autoskillit migrate CLI, or invoked directly.
 hooks:

--- a/src/autoskillit/skills_extended/migrate-recipes/SKILL.md
+++ b/src/autoskillit/skills_extended/migrate-recipes/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: migrate-recipes
 backend_requirements: [claude-code]
-uses_capabilities: [cross_skill_ref]
+uses_capabilities: [cross_skill_ref, run_skill]
 activate_deps: [write-recipe]
 description: Apply versioned migration notes to an AutoSkillit recipe. Use when user confirms migration, called by agent or autoskillit migrate CLI, or invoked directly.
 hooks:

--- a/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: open-integration-pr
 categories: [github]
 backend_requirements: [claude-code]
-uses_capabilities: [agent_model, cross_skill_ref]
+uses_capabilities: [agent_model, cross_skill_ref, run_skill]
 activate_deps: [arch-lens]
 description: >
   Create an integration PR for the merge-prs. Reads pr_order_file JSON, generates

--- a/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
@@ -2,6 +2,7 @@
 name: open-integration-pr
 categories: [github]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 activate_deps: [arch-lens]
 description: >
   Create an integration PR for the merge-prs. Reads pr_order_file JSON, generates

--- a/src/autoskillit/skills_extended/pipeline-summary/SKILL.md
+++ b/src/autoskillit/skills_extended/pipeline-summary/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pipeline-summary
 categories: [github]
-backend_requirements: [claude-code]
 description: Create a GitHub issue and PR summarizing pipeline bugs and fixes. Use when a pipeline run completes with accumulated bug fixes on a feature branch.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -2,6 +2,7 @@
 name: plan-experiment
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: Convert a scope report into a structured experiment plan with hypothesis, variables, phases, and success criteria.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -2,7 +2,7 @@
 name: plan-experiment
 categories: [research]
 backend_requirements: [claude-code]
-uses_capabilities: [agent_model, cross_skill_ref]
+uses_capabilities: [agent_model, cross_skill_ref, test_check]
 description: Convert a scope report into a structured experiment plan with hypothesis, variables, phases, and success criteria.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/plan-visualization/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-visualization/SKILL.md
@@ -2,6 +2,7 @@
 name: plan-visualization
 categories: [research, vis-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: >
   Orchestrates 2–4 vis-lens skills in parallel to produce a figure inventory
   (visualization-plan.md) and a report-placement outline (report-plan.md).

--- a/src/autoskillit/skills_extended/planner-assess-review-approach/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-assess-review-approach/SKILL.md
@@ -2,6 +2,7 @@
 name: planner-assess-review-approach
 categories: [planner]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: >
   Assess each work package for review-approach benefit before implementation.
   Writes review_approach_assessment.json; does NOT invoke review-approach.

--- a/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: planner-elaborate-assignments
+backend_requirements: [claude-code]
+uses_capabilities: [run_skill]
 categories: [planner]
 description: >
   Elaborate all assignments for a target phase via parallel L0 subagents.

--- a/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: planner-elaborate-assignments
 categories: [planner]
-backend_requirements: [claude-code]
 description: >
   Elaborate all assignments for a target phase via parallel L0 subagents.
   One invocation per phase; spawns one L0 per assignment concurrently. (Pass 2 loop body)

--- a/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: planner-elaborate-wps
 categories: [planner]
-backend_requirements: [claude-code]
 description: >
   Elaborate all work packages for a target phase via parallel L0 subagents.
   One invocation per phase; spawns one L0 per WP concurrently. (Pass 3 loop body)

--- a/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: planner-elaborate-wps
+backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref, run_skill]
 categories: [planner]
 description: >
   Elaborate all work packages for a target phase via parallel L0 subagents.

--- a/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
@@ -2,6 +2,7 @@
 name: planner-validate-task-alignment
 categories: [planner]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: Validate that plan phases and WPs align with the stated task
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/prepare-issue/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-issue/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: prepare-issue
 categories: [github]
-backend_requirements: [claude-code]
 description: >
   Create a single GitHub issue and immediately triage it — dedup check,
   classification (recipe:implementation or recipe:remediation), mixed-concern

--- a/src/autoskillit/skills_extended/prepare-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-pr/SKILL.md
@@ -2,6 +2,7 @@
 name: prepare-pr
 categories: [github]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: Preparation executor for pull-request metadata. ALWAYS invoke this skill when instructed to prepare PR metadata. Do not read plans or classify files directly — use this skill first to load the preparation workflow.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/prepare-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-research-pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: prepare-research-pr
 categories: [research]
-backend_requirements: [claude-code]
 description: >
   Reads a research report and experiment plan, synthesizes a recommendation,
   selects 1-2 exp-lens lenses, writes a context file per lens, and writes a

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: process-issues
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref, run_skill]
 description: Execute recipe sessions batch-by-batch for triaged GitHub issues. Reads the triage-issues output manifest, processes each batch sequentially, and launches the appropriate recipe for each issue. Use when user says "process issues", "run issues", or "execute pipeline for issues".
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/promote-to-main/SKILL.md
+++ b/src/autoskillit/skills_extended/promote-to-main/SKILL.md
@@ -2,6 +2,7 @@
 name: promote-to-main
 categories: [github]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: >
   Promote integration to main with comprehensive changelog and PR creation. Use when
   user says "promote to main", "open promotion PR", "integration to main", or

--- a/src/autoskillit/skills_extended/rectify/SKILL.md
+++ b/src/autoskillit/skills_extended/rectify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: rectify
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, agent_subagent, cross_skill_ref]
 activate_deps: [arch-lens]
 description: Deep investigation of test gaps and architectural weaknesses following an investigation, then devise a plan for architectural immunity rather than direct fixes. Use when user says "rectify", "rectify this", or wants to address root architectural causes after an investigation.
 hooks:

--- a/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
@@ -2,6 +2,7 @@
 name: resolve-claims-review
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: >
   Fetch claim findings from audit-claims, run citation-aware intent validation
   (ACCEPT/REJECT/DISCUSS), apply targeted citation fixes, escalate findings

--- a/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
@@ -2,6 +2,7 @@
 name: resolve-design-review
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: >
   Triage STOP verdict findings from review-design, classifying each as
   ADDRESSABLE/STRUCTURAL/DISCUSS using parallel subagents. If any are ADDRESSABLE

--- a/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
@@ -2,7 +2,7 @@
 name: resolve-design-review
 categories: [research]
 backend_requirements: [claude-code]
-uses_capabilities: [agent_model]
+uses_capabilities: [agent_model, run_skill]
 description: >
   Triage STOP verdict findings from review-design, classifying each as
   ADDRESSABLE/STRUCTURAL/DISCUSS using parallel subagents. If any are ADDRESSABLE

--- a/src/autoskillit/skills_extended/resolve-failures/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-failures/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: resolve-failures
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref, test_check]
 description: Failure resolution executor. ALWAYS invoke this skill when instructed to fix test failures in a worktree. Do not read test output or edit code directly — use this skill first to load the failure resolution workflow.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/resolve-failures/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-failures/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: resolve-failures
 backend_requirements: [claude-code]
-uses_capabilities: [cross_skill_ref, test_check]
+uses_capabilities: [cross_skill_ref, run_skill, test_check]
 description: Failure resolution executor. ALWAYS invoke this skill when instructed to fix test failures in a worktree. Do not read test output or edit code directly — use this skill first to load the failure resolution workflow.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
@@ -2,6 +2,7 @@
 name: resolve-research-review
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: >
   Fetch PR review comments from review-research-pr, run research-aware intent
   validation (ACCEPT/REJECT/DISCUSS), apply targeted fixes, escalate unrerunnable

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -2,7 +2,7 @@
 name: resolve-review
 categories: [github]
 backend_requirements: [claude-code]
-uses_capabilities: [agent_model]
+uses_capabilities: [agent_model, cross_skill_ref, run_skill, test_check]
 description: Fetch PR review comments, run intent validation (ACCEPT/REJECT/DISCUSS) before applying fixes, and post inline replies. MCP-only — used exclusively by recipe orchestration via run_skill after review_pr reports changes_requested or needs_human verdict.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -2,6 +2,7 @@
 name: resolve-review
 categories: [github]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: Fetch PR review comments, run intent validation (ACCEPT/REJECT/DISCUSS) before applying fixes, and post inline replies. MCP-only — used exclusively by recipe orchestration via run_skill after review_pr reports changes_requested or needs_human verdict.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/retry-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/retry-worktree/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: retry-worktree
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: Worktree retry executor. ALWAYS invoke this skill when instructed to continue or retry an implementation in an existing worktree. Do not resume editing files directly — use this skill first to load the retry workflow.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/review-approach/SKILL.md
+++ b/src/autoskillit/skills_extended/review-approach/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: review-approach
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: Research modern solutions and approaches for issues or features proposed in a report or plan. Use when user says "review approach", "review approaches", "research solutions", or wants external validation of a proposed direction.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/review-design/SKILL.md
+++ b/src/autoskillit/skills_extended/review-design/SKILL.md
@@ -2,6 +2,7 @@
 name: review-design
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: Validate an experiment plan before execution using triage-first, fail-fast dimensional analysis with an adversarial red-team. Emits verdict (GO/REVISE/STOP), experiment_type, evaluation_dashboard, and revision_guidance.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: review-pr
 categories: [github]
 backend_requirements: [claude-code]
-uses_capabilities: [agent_model]
+uses_capabilities: [agent_model, cross_skill_ref, run_skill]
 description: Automated diff-scoped PR code review using parallel audit subagents. Posts inline GitHub review comments and submits a summary verdict. Use after a PR is opened to gate CI on review approval.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -2,6 +2,7 @@
 name: review-pr
 categories: [github]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: Automated diff-scoped PR code review using parallel audit subagents. Posts inline GitHub review comments and submits a summary verdict. Use after a PR is opened to gate CI on review approval.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/review-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-research-pr/SKILL.md
@@ -2,6 +2,7 @@
 name: review-research-pr
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: Automated diff-scoped research PR review using parallel audit subagents aligned to research quality dimensions. Posts inline GitHub review comments and submits a summary verdict. Use after a research PR is opened to gate on review approval.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/review-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-research-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: review-research-pr
 categories: [research]
 backend_requirements: [claude-code]
-uses_capabilities: [agent_model]
+uses_capabilities: [agent_model, run_skill]
 description: Automated diff-scoped research PR review using parallel audit subagents aligned to research quality dimensions. Posts inline GitHub review comments and submits a summary verdict. Use after a research PR is opened to gate on review approval.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/run-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/run-experiment/SKILL.md
@@ -2,6 +2,7 @@
 name: run-experiment
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: Execute a designed experiment in a worktree and collect structured results. Supports --adjust retry mode.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/scope/SKILL.md
+++ b/src/autoskillit/skills_extended/scope/SKILL.md
@@ -2,6 +2,7 @@
 name: scope
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: Survey codebase and web sources to build a known/unknown matrix for a research question. Phase 1 of the research recipe.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/select-directions/SKILL.md
+++ b/src/autoskillit/skills_extended/select-directions/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: select-directions
 categories: [research]
-backend_requirements: [claude-code]
 description: >
   Direction-selection gate: parse scope directions manifest, present for
   selection (human or agent), enforce breadth, output filtered directions.

--- a/src/autoskillit/skills_extended/select-directions/SKILL.md
+++ b/src/autoskillit/skills_extended/select-directions/SKILL.md
@@ -1,5 +1,7 @@
 ---
 name: select-directions
+backend_requirements: [claude-code]
+uses_capabilities: [run_skill]
 categories: [research]
 description: >
   Direction-selection gate: parse scope directions manifest, present for

--- a/src/autoskillit/skills_extended/select-vis-lenses/SKILL.md
+++ b/src/autoskillit/skills_extended/select-vis-lenses/SKILL.md
@@ -2,6 +2,7 @@
 name: select-vis-lenses
 categories: [research, vis-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 phoropter_family: vis-lens
 description: >
   Dial step of the vis-lens phoropter: parses experiment plan fields, applies

--- a/src/autoskillit/skills_extended/setup-environment/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-environment/SKILL.md
@@ -2,6 +2,7 @@
 name: setup-environment
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: >
   Pre-flight environment gate for the research recipe. Reads the experiment
   plan, detects the required environment type, builds a Docker image or creates

--- a/src/autoskillit/skills_extended/setup-project/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-project/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: setup-project
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, claude_dir, cross_skill_ref]
 activate_deps: [write-recipe]
 description: Explore a target project and generate tailored recipes and config through an interactive workflow. Use when user wants to onboard a new project to AutoSkillit, says "setup project", or wants a starting point config.
 hooks:

--- a/src/autoskillit/skills_extended/setup-project/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-project/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: setup-project
 backend_requirements: [claude-code]
-uses_capabilities: [agent_model, claude_dir, cross_skill_ref]
+uses_capabilities: [agent_model, claude_dir, cross_skill_ref, test_check]
 activate_deps: [write-recipe]
 description: Explore a target project and generate tailored recipes and config through an interactive workflow. Use when user wants to onboard a new project to AutoSkillit, says "setup project", or wants a starting point config.
 hooks:

--- a/src/autoskillit/skills_extended/smoke-task/SKILL.md
+++ b/src/autoskillit/skills_extended/smoke-task/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: smoke-task
-backend_requirements: [claude-code]
 description: Execute an arbitrary prose task as a headless Claude session. For smoke-test pipeline use only.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/stage-data/SKILL.md
+++ b/src/autoskillit/skills_extended/stage-data/SKILL.md
@@ -2,6 +2,7 @@
 name: stage-data
 categories: [research]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model]
 description: >
   Pre-flight resource gate for the research recipe. Reads the experiment plan's
   data_manifest, checks disk space and network connectivity for external/gitignored

--- a/src/autoskillit/skills_extended/synthesize-vis-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/synthesize-vis-plan/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: synthesize-vis-plan
 categories: [research, vis-lens]
-backend_requirements: [claude-code]
 description: >
   Synthesize step of the vis-lens phoropter: reads captured yaml:figure-spec
   blocks from lens output files, resolves inter-lens conflicts via the

--- a/src/autoskillit/skills_extended/triage-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/triage-issues/SKILL.md
@@ -2,6 +2,7 @@
 name: triage-issues
 categories: [github]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: Analyze open GitHub issues and produce a sequenced implementation plan — grouping issues into parallel batches, ordering those batches, and tagging each issue with its recipe route. Use when user says "triage issues", "prioritize issues", or "plan issue order".
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
@@ -2,7 +2,6 @@
 name: troubleshoot-experiment
 description: Read session logs and process traces for a failed research pipeline step, classify failure, and emit is_fixable signal.
 categories: [research]
-backend_requirements: [claude-code]
 hooks:
   PreToolUse:
     - matcher: "*"

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -2,6 +2,7 @@
 name: validate-audit
 categories: [audit]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: Validate audit findings from audit-arch, audit-tests, audit-cohesion, audit-feature-gates, audit-docs, or audit-review-decisions against actual code, git history, and design intent using 9–10 parallel subagents. Removes contested findings, documents exceptions, adjusts severities. Use when user says "validate audit", "validate findings", "validate report", or "check audit results".
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/validate-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-review-decisions/SKILL.md
@@ -2,6 +2,7 @@
 name: validate-review-decisions
 categories: [audit]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: >-
   Validate review-decisions audit findings with mandatory intent analysis
   and seven evidence-gathering rules. Adds docstring-as-contract recognition,

--- a/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
@@ -2,6 +2,7 @@
 name: validate-test-audit
 categories: [audit]
 backend_requirements: [claude-code]
+uses_capabilities: [agent_model, cross_skill_ref]
 description: >-
   Validate test audit findings with test-domain semantic rules and intent
   analysis. Adds import-path-as-contract recognition, precondition-as-assertion

--- a/src/autoskillit/skills_extended/vis-lens-always-on/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-always-on/SKILL.md
@@ -2,6 +2,7 @@
 name: vis-lens-always-on
 categories: [vis-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Always-On visualization triage report running three sequential analysis passes (anti-pattern, accessibility, annotation completeness) and emitting a combined PASS|WARN_N|FAIL_N verdict. Composite lens answering \"What are the blocking visualization issues?\""
 hooks:

--- a/src/autoskillit/skills_extended/vis-lens-antipattern/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-antipattern/SKILL.md
@@ -2,6 +2,7 @@
 name: vis-lens-antipattern
 categories: [vis-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Anti-Pattern Detection visualization audit showing severity-tiered catalog of visualization anti-patterns present in or planned for the experiment. Diagnostic lens answering \"Which visualization anti-patterns are present?\""
 hooks:

--- a/src/autoskillit/skills_extended/vis-lens-caption-annot/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-caption-annot/SKILL.md
@@ -2,6 +2,7 @@
 name: vis-lens-caption-annot
 categories: [vis-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Annotative Caption visualization planning spec showing declarative titles, axis labels with units, error definition in legend, baseline references, sample sizes, and venue-specific caption format. Annotative lens answering \"Are figure captions and axis labels fully self-contained?\""
 hooks:

--- a/src/autoskillit/skills_extended/vis-lens-chart-select/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-chart-select/SKILL.md
@@ -2,6 +2,7 @@
 name: vis-lens-chart-select
 categories: [vis-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Chart Type Selection visualization planning spec showing encoding channel assignments, Cleveland-McGill perceptual hierarchy, and data-type→chart-type matrix. Typological lens answering \"Which chart type is perceptually optimal for this data?\""
 hooks:

--- a/src/autoskillit/skills_extended/vis-lens-color-access/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-color-access/SKILL.md
@@ -2,6 +2,7 @@
 name: vis-lens-color-access
 categories: [vis-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Chromatic Accessibility visualization planning spec showing colorblind safety (Okabe-Ito, Paul Tol palettes), perceptual uniformity checks (viridis/cividis pass; jet/rainbow fail), non-color redundant encoding (shape + line-style), and text size minimums. Chromatic lens answering \"Is the color encoding accessible and perceptually uniform?\""
 hooks:

--- a/src/autoskillit/skills_extended/vis-lens-figure-table/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-figure-table/SKILL.md
@@ -2,6 +2,7 @@
 name: vis-lens-figure-table
 categories: [vis-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Decisional Layout visualization planning spec showing figure-vs-table selection heuristics: tables win for exact values, ≤5 items, leaderboards, and ablation matrices; figures win for trends, distributions, and spatial patterns; borderline cases recommend both. Decisional lens answering \"Should this result be a figure or a table?\""
 hooks:

--- a/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
@@ -2,6 +2,7 @@
 name: vis-lens-methodology-norms
 categories: [vis-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Methodology Norms visualization planning spec showing ML sub-area mandatory figures, community conventions, and coverage gaps. Methodology-Normative lens answering \"Which domain-specific figures are expected by reviewers?\""
 hooks:

--- a/src/autoskillit/skills_extended/vis-lens-multi-compare/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-multi-compare/SKILL.md
@@ -2,6 +2,7 @@
 name: vis-lens-multi-compare
 categories: [vis-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Compositional Layout visualization planning spec showing small-multiples vs overlay decisions, faceting strategy (row/col), shared-axis alignment, grouped vs stacked bars, factorial interaction plots, and panel reading order. Compositional lens answering \"Which layout best reveals the comparison structure?\""
 hooks:

--- a/src/autoskillit/skills_extended/vis-lens-reproducibility/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-reproducibility/SKILL.md
@@ -2,6 +2,7 @@
 name: vis-lens-reproducibility
 categories: [vis-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Replicative Reproducibility visualization planning spec showing data availability, preprocessing parameter disclosure (bin widths, smoothing windows), plotting library/version, random seeds, and code reference per figure. Replicative lens answering \"Can the figures be reproduced from the data and code?\""
 hooks:

--- a/src/autoskillit/skills_extended/vis-lens-story-arc/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-story-arc/SKILL.md
@@ -2,6 +2,7 @@
 name: vis-lens-story-arc
 categories: [vis-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Narrative Story Arc visualization planning spec showing visual consistency across the report (same color = same model everywhere), logical figure progression, redundant figure detection, and narrative dependency between figures. Narrative lens answering \"Do the figures tell a coherent story across the report?\""
 hooks:

--- a/src/autoskillit/skills_extended/vis-lens-temporal/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-temporal/SKILL.md
@@ -2,6 +2,7 @@
 name: vis-lens-temporal
 categories: [vis-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Temporal Dynamics visualization planning spec showing axis scaling (linear vs log), smoothing disclosure, epoch/step alignment, run aggregation (mean + variance bands), early-stopping markers, and wall-clock vs step-count x-axis. Temporal lens answering \"Are training dynamics shown clearly and honestly?\""
 hooks:

--- a/src/autoskillit/skills_extended/vis-lens-uncertainty/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-uncertainty/SKILL.md
@@ -2,6 +2,7 @@
 name: vis-lens-uncertainty
 categories: [vis-lens]
 backend_requirements: [claude-code]
+uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Uncertainty Representation visualization planning spec showing error bar definitions, distribution-aware alternatives, and multi-seed variance protocols. Statistical lens answering \"How is uncertainty honestly represented?\""
 hooks:

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: write-recipe
 backend_requirements: [claude-code]
+uses_capabilities: [claude_dir, cross_skill_ref]
 description: Generate YAML recipes for .autoskillit/recipes/. Use when user says "make script skill", "generate script", "script a workflow", "write a script", "create a script", "new recipe", "write a pipeline", or when loaded by other skills for script formatting.
 hooks:
   PreToolUse:
@@ -83,6 +84,7 @@ Every generated script MUST follow the workflow YAML schema:
 ```yaml
 name: {script-name}
 backend_requirements: [claude-code]
+uses_capabilities: [claude_dir, cross_skill_ref]
 autoskillit_version: "{version}"  # from kitchen_status.package_version
 description: {One line description.}
 summary: {Concise pipeline chain, e.g. "plan > verify > implement > test > merge"}
@@ -298,6 +300,7 @@ This is the reference format. All generated scripts should match this style:
 ```yaml
 name: implementation
 backend_requirements: [claude-code]
+uses_capabilities: [claude_dir, cross_skill_ref]
 description: Plan, verify, implement, test, and merge a task.
 summary: make-plan > dry-walk > implement > test > merge
 
@@ -391,6 +394,7 @@ A condensed bugfix loop showing retry, classify, and routing patterns:
 ```yaml
 name: example-loop
 backend_requirements: [claude-code]
+uses_capabilities: [claude_dir, cross_skill_ref]
 description: Test, fix, and merge with automatic retry.
 summary: test > investigate > plan > implement > verify > merge
 

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: write-recipe
 backend_requirements: [claude-code]
-uses_capabilities: [claude_dir, cross_skill_ref]
+uses_capabilities: [claude_dir, cross_skill_ref, run_skill, test_check]
 description: Generate YAML recipes for .autoskillit/recipes/. Use when user says "make script skill", "generate script", "script a workflow", "write a script", "create a script", "new recipe", "write a pipeline", or when loaded by other skills for script formatting.
 hooks:
   PreToolUse:
@@ -84,7 +84,7 @@ Every generated script MUST follow the workflow YAML schema:
 ```yaml
 name: {script-name}
 backend_requirements: [claude-code]
-uses_capabilities: [claude_dir, cross_skill_ref]
+uses_capabilities: [claude_dir, cross_skill_ref, run_skill, test_check]
 autoskillit_version: "{version}"  # from kitchen_status.package_version
 description: {One line description.}
 summary: {Concise pipeline chain, e.g. "plan > verify > implement > test > merge"}
@@ -300,7 +300,7 @@ This is the reference format. All generated scripts should match this style:
 ```yaml
 name: implementation
 backend_requirements: [claude-code]
-uses_capabilities: [claude_dir, cross_skill_ref]
+uses_capabilities: [claude_dir, cross_skill_ref, run_skill, test_check]
 description: Plan, verify, implement, test, and merge a task.
 summary: make-plan > dry-walk > implement > test > merge
 
@@ -394,7 +394,7 @@ A condensed bugfix loop showing retry, classify, and routing patterns:
 ```yaml
 name: example-loop
 backend_requirements: [claude-code]
-uses_capabilities: [claude_dir, cross_skill_ref]
+uses_capabilities: [claude_dir, cross_skill_ref, run_skill, test_check]
 description: Test, fix, and merge with automatic retry.
 summary: test > investigate > plan > implement > verify > merge
 

--- a/src/autoskillit/workspace/skills.py
+++ b/src/autoskillit/workspace/skills.py
@@ -10,6 +10,7 @@ from autoskillit.core import (
     ALL_PROJECT_LOCAL_SKILL_SEARCH_DIRS,
     KNOWN_BACKEND_NAMES,
     RETIRED_SKILL_NAMES,
+    SKILL_CAPABILITY_REGISTRY,
     SkillSource,
     YAMLError,
     get_logger,
@@ -27,6 +28,7 @@ class SkillInfo:
     path: Path
     categories: frozenset[str] = frozenset()
     backend_requirements: frozenset[str] = frozenset()
+    uses_capabilities: frozenset[str] = frozenset()
 
 
 def _read_skill_frontmatter(path: Path) -> dict[str, Any]:
@@ -146,12 +148,36 @@ def _skill_info_from_frontmatter(name: str, source: SkillSource, skill_path: Pat
             valid=sorted(KNOWN_BACKEND_NAMES),
         )
         backend_requirements = backend_requirements - invalid
+
+    caps_raw = data.get("uses_capabilities", [])
+    if caps_raw and not isinstance(caps_raw, list):
+        logger.warning(
+            "uses_capabilities_not_a_list",
+            value=caps_raw,
+            skill=name,
+            hint="use bracket syntax: uses_capabilities: [agent_subagent]",
+        )
+        caps_raw = [caps_raw]
+    uses_capabilities = (
+        frozenset(str(c) for c in caps_raw) if isinstance(caps_raw, list) else frozenset()
+    )
+    unknown_caps = uses_capabilities - frozenset(SKILL_CAPABILITY_REGISTRY)
+    if unknown_caps:
+        logger.warning(
+            "unrecognized_uses_capabilities",
+            invalid=sorted(unknown_caps),
+            skill=name,
+            valid=sorted(SKILL_CAPABILITY_REGISTRY),
+        )
+        uses_capabilities = uses_capabilities - unknown_caps
+
     return SkillInfo(
         name=name,
         source=source,
         path=skill_path,
         categories=categories,
         backend_requirements=backend_requirements,
+        uses_capabilities=uses_capabilities,
     )
 
 

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -97,7 +97,10 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_subagent_filter_guard.py` | AST guard: all assistant-record NDJSON processing sites must use _is_parent_assistant_record or _is_parent_assistant predicate |
 | `test_enqueue_ready_type_enforcement.py` | AST guard: mutation methods (_enqueue_direct, _enable_auto_merge_direct) must accept EnqueueReady, not str |
 | `test_origin_isolation_contract.py` | AST + shell lint guard: no hardcoded "origin" in git remote operations outside allowlist; shell scripts must try upstream before origin |
-| `test_skill_backend_annotations.py` | Architectural invariant: skills using Claude-Code-only features must declare backend_requirements: [claude-code] |
+| `test_backend_annotation_context_awareness.py` | Context-aware pattern detection: distinguishes self-referential autoskillit: documentation from genuine cross-skill dependencies |
+| `test_skill_backend_annotation_accuracy.py` | Reverse-direction annotation validation: skills with backend_requirements: [claude-code] must have genuine Claude-Code-only dependency |
+| `test_skill_backend_annotations.py` | Bidirectional annotation enforcement: forward (pattern → uses_capabilities), reverse (annotation → justified), co-requirement, and derivation checks |
+| `test_skill_capability_registry.py` | Capability registry consistency: every SKILL_CAPABILITY_REGISTRY key consumed, backend_requirements derivable from uses_capabilities, no unknown capabilities declared |
 | `test_write_guard_resolution.py` | Arch test: extract_redirect_targets must use resolve_write_target, not inline startswith |
 | `test_codex_timeout_coherence.py` | Cross-system timeout hierarchy: Codex MCP tool_timeout_sec must exceed max session duration |
 | `test_skill_search_dir_symmetry.py` | Suppression-delivery symmetry invariants for project-local skill search dirs |

--- a/tests/arch/_helpers.py
+++ b/tests/arch/_helpers.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import ast
+import re as _stdlib_re
+from collections.abc import Iterator
 from pathlib import Path
 
 from tests.arch._rules import (
@@ -448,3 +450,29 @@ def _runtime_import_froms(path: Path) -> list[ast.ImportFrom]:
 
     _walk(tree.body)
     return result
+
+
+# ── Section C: Skill frontmatter and iteration helpers ───────────────────────
+
+_FM_SPLIT = _stdlib_re.compile(r"^---\n(.*?)\n?---\n?(.*)", _stdlib_re.DOTALL)
+
+
+def _strip_frontmatter(content: str) -> str:
+    m = _FM_SPLIT.match(content)
+    return m.group(2) if m else content
+
+
+def _iter_skill_dirs() -> Iterator[tuple[str, Path]]:
+    from autoskillit.core import paths
+
+    pkg = paths.pkg_root()
+    for skill_dir in (pkg / "skills", pkg / "skills_extended"):
+        if not skill_dir.is_dir():
+            continue
+        for entry in sorted(skill_dir.iterdir()):
+            if not entry.is_dir():
+                continue
+            skill_md = entry / "SKILL.md"
+            if not skill_md.is_file():
+                continue
+            yield entry.name, skill_md

--- a/tests/arch/test_backend_annotation_context_awareness.py
+++ b/tests/arch/test_backend_annotation_context_awareness.py
@@ -2,18 +2,11 @@
 
 from __future__ import annotations
 
-import re
-
 import pytest
 
+from tests.arch._helpers import _strip_frontmatter
+
 pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
-
-_FM_SPLIT = re.compile(r"^---\n(.*?)\n?---\n?(.*)", re.DOTALL)
-
-
-def _strip_frontmatter(content: str) -> str:
-    m = _FM_SPLIT.match(content)
-    return m.group(2) if m else content
 
 
 def _is_self_referential_only(body: str, skill_name: str) -> bool:

--- a/tests/arch/test_backend_annotation_context_awareness.py
+++ b/tests/arch/test_backend_annotation_context_awareness.py
@@ -28,7 +28,6 @@ def _is_self_referential_only(body: str, skill_name: str) -> bool:
     return True
 
 
-@pytest.mark.xfail(reason="context-aware detection not yet applied — rectify plan in progress")
 def test_self_referential_autoskillit_not_classified_as_dependency():
     from autoskillit.core import paths
     from autoskillit.workspace.skills import _read_skill_frontmatter
@@ -74,7 +73,6 @@ def test_self_referential_autoskillit_not_classified_as_dependency():
     )
 
 
-@pytest.mark.xfail(reason="context-aware detection not yet applied — rectify plan in progress")
 def test_documentation_mentions_distinguished_from_usage():
     from autoskillit.core import paths
     from autoskillit.workspace.skills import _read_skill_frontmatter

--- a/tests/arch/test_backend_annotation_context_awareness.py
+++ b/tests/arch/test_backend_annotation_context_awareness.py
@@ -1,0 +1,114 @@
+"""Context-aware pattern detection distinguishes documentation from usage."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+_FM_SPLIT = re.compile(r"^---\n(.*?)\n?---\n?(.*)", re.DOTALL)
+
+
+def _strip_frontmatter(content: str) -> str:
+    m = _FM_SPLIT.match(content)
+    return m.group(2) if m else content
+
+
+def _is_self_referential_only(body: str, skill_name: str) -> bool:
+    for line in body.splitlines():
+        stripped = line.strip()
+        if "autoskillit:" not in stripped:
+            continue
+        if stripped.startswith("#") or stripped.startswith("|"):
+            continue
+        if f"autoskillit:{skill_name}" not in stripped:
+            return False
+    return True
+
+
+@pytest.mark.xfail(reason="context-aware detection not yet applied — rectify plan in progress")
+def test_self_referential_autoskillit_not_classified_as_dependency():
+    from autoskillit.core import paths
+    from autoskillit.workspace.skills import _read_skill_frontmatter
+
+    pkg = paths.pkg_root()
+    false_positives: list[str] = []
+
+    for skill_dir in (pkg / "skills", pkg / "skills_extended"):
+        if not skill_dir.is_dir():
+            continue
+        for entry in sorted(skill_dir.iterdir()):
+            if not entry.is_dir():
+                continue
+            skill_md = entry / "SKILL.md"
+            if not skill_md.is_file():
+                continue
+            content = skill_md.read_text(encoding="utf-8")
+            body = _strip_frontmatter(content)
+            if "autoskillit:" not in body:
+                continue
+            if not _is_self_referential_only(body, entry.name):
+                continue
+            has_other_patterns = any(
+                pat in body
+                for pat in (
+                    "Agent(model=",
+                    "Agent(subagent_type=",
+                    "open_kitchen",
+                    "close_kitchen",
+                    "run_skill",
+                    "test_check",
+                )
+            )
+            if has_other_patterns:
+                continue
+            fm = _read_skill_frontmatter(skill_md)
+            if "claude-code" in fm.get("backend_requirements", []):
+                false_positives.append(entry.name)
+
+    assert not false_positives, (
+        f"{len(false_positives)} skill(s) annotated as claude-code due to self-referential "
+        f"autoskillit: only:\n" + "\n".join(f"  {s}" for s in false_positives)
+    )
+
+
+@pytest.mark.xfail(reason="context-aware detection not yet applied — rectify plan in progress")
+def test_documentation_mentions_distinguished_from_usage():
+    from autoskillit.core import paths
+    from autoskillit.workspace.skills import _read_skill_frontmatter
+
+    pkg = paths.pkg_root()
+    false_positives: list[str] = []
+
+    for skill_dir in (pkg / "skills", pkg / "skills_extended"):
+        if not skill_dir.is_dir():
+            continue
+        for entry in sorted(skill_dir.iterdir()):
+            if not entry.is_dir():
+                continue
+            skill_md = entry / "SKILL.md"
+            if not skill_md.is_file():
+                continue
+            content = skill_md.read_text(encoding="utf-8")
+            body = _strip_frontmatter(content)
+            mentions_agent_in_docs = False
+            prescribes_agent_call = False
+            for line in body.splitlines():
+                stripped = line.strip()
+                if "Agent(model=" in stripped or "Agent(subagent_type=" in stripped:
+                    if stripped.startswith("|") or stripped.startswith("-"):
+                        mentions_agent_in_docs = True
+                    else:
+                        prescribes_agent_call = True
+
+            if mentions_agent_in_docs and not prescribes_agent_call:
+                fm = _read_skill_frontmatter(skill_md)
+                if "claude-code" in fm.get("backend_requirements", []):
+                    false_positives.append(entry.name)
+
+    assert not false_positives, (
+        f"{len(false_positives)} skill(s) annotated as claude-code due to Agent( mentions "
+        f"in documentation only:\n" + "\n".join(f"  {s}" for s in false_positives)
+    )

--- a/tests/arch/test_backend_annotation_context_awareness.py
+++ b/tests/arch/test_backend_annotation_context_awareness.py
@@ -96,7 +96,7 @@ def test_documentation_mentions_distinguished_from_usage():
             for line in body.splitlines():
                 stripped = line.strip()
                 if "Agent(model=" in stripped or "Agent(subagent_type=" in stripped:
-                    if stripped.startswith("|") or stripped.startswith("-"):
+                    if stripped.startswith("|"):
                         mentions_agent_in_docs = True
                     else:
                         prescribes_agent_call = True

--- a/tests/arch/test_skill_backend_annotation_accuracy.py
+++ b/tests/arch/test_skill_backend_annotation_accuracy.py
@@ -46,7 +46,6 @@ def _has_genuine_claude_code_dependency(body: str, skill_name: str) -> bool:
     return False
 
 
-@pytest.mark.xfail(reason="over-broad annotations — rectify plan in progress")
 def test_annotated_skills_have_justified_annotation():
     pkg = paths.pkg_root()
     over_annotated: list[str] = []

--- a/tests/arch/test_skill_backend_annotation_accuracy.py
+++ b/tests/arch/test_skill_backend_annotation_accuracy.py
@@ -34,8 +34,8 @@ def _has_genuine_claude_code_dependency(body: str, skill_name: str) -> bool:
         if "autoskillit:" in stripped:
             if f"autoskillit:{skill_name}" in stripped:
                 continue
-            cap = SKILL_CAPABILITY_REGISTRY.get("cross_skill_ref")
-            if cap and cap.required_backends:
+            cap = SKILL_CAPABILITY_REGISTRY["cross_skill_ref"]
+            if cap.required_backends:
                 return True
     return False
 

--- a/tests/arch/test_skill_backend_annotation_accuracy.py
+++ b/tests/arch/test_skill_backend_annotation_accuracy.py
@@ -1,0 +1,75 @@
+"""Reverse-direction annotation validation: annotated skills must justify their annotation."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from autoskillit.core import paths
+from autoskillit.core.types._type_constants_registries import SKILL_CAPABILITY_REGISTRY
+from autoskillit.workspace.skills import _read_skill_frontmatter
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+_GENUINE_CLAUDE_CODE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"Agent\(\s*subagent_type\s*="),
+    re.compile(r"Agent\(\s*model\s*="),
+    re.compile(r"\bopen_kitchen\b"),
+    re.compile(r"\bclose_kitchen\b"),
+    re.compile(r"\brun_skill\b"),
+    re.compile(r"\btest_check\b"),
+)
+
+_FM_SPLIT = re.compile(r"^---\n(.*?)\n?---\n?(.*)", re.DOTALL)
+
+
+def _strip_frontmatter(content: str) -> str:
+    m = _FM_SPLIT.match(content)
+    return m.group(2) if m else content
+
+
+def _has_genuine_claude_code_dependency(body: str, skill_name: str) -> bool:
+    for pat in _GENUINE_CLAUDE_CODE_PATTERNS:
+        if pat.search(body):
+            return True
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped.startswith("|"):
+            continue
+        if "autoskillit:" in stripped:
+            if f"autoskillit:{skill_name}" in stripped:
+                continue
+            cap = SKILL_CAPABILITY_REGISTRY.get("cross_skill_ref")
+            if cap and cap.required_backends:
+                return True
+    return False
+
+
+@pytest.mark.xfail(reason="over-broad annotations — rectify plan in progress")
+def test_annotated_skills_have_justified_annotation():
+    pkg = paths.pkg_root()
+    over_annotated: list[str] = []
+
+    for skill_dir in (pkg / "skills", pkg / "skills_extended"):
+        if not skill_dir.is_dir():
+            continue
+        for entry in sorted(skill_dir.iterdir()):
+            if not entry.is_dir():
+                continue
+            skill_md = entry / "SKILL.md"
+            if not skill_md.is_file():
+                continue
+            fm = _read_skill_frontmatter(skill_md)
+            reqs = fm.get("backend_requirements", [])
+            if "claude-code" not in reqs:
+                continue
+            content = skill_md.read_text(encoding="utf-8")
+            body = _strip_frontmatter(content)
+            if not _has_genuine_claude_code_dependency(body, entry.name):
+                over_annotated.append(entry.name)
+
+    assert not over_annotated, (
+        f"{len(over_annotated)} skill(s) have backend_requirements: [claude-code] "
+        f"without genuine justification:\n" + "\n".join(f"  {s}" for s in over_annotated)
+    )

--- a/tests/arch/test_skill_backend_annotation_accuracy.py
+++ b/tests/arch/test_skill_backend_annotation_accuracy.py
@@ -9,6 +9,7 @@ import pytest
 from autoskillit.core import paths
 from autoskillit.core.types._type_constants_registries import SKILL_CAPABILITY_REGISTRY
 from autoskillit.workspace.skills import _read_skill_frontmatter
+from tests.arch._helpers import _strip_frontmatter
 
 pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 
@@ -20,13 +21,6 @@ _GENUINE_CLAUDE_CODE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\brun_skill\b"),
     re.compile(r"\btest_check\b"),
 )
-
-_FM_SPLIT = re.compile(r"^---\n(.*?)\n?---\n?(.*)", re.DOTALL)
-
-
-def _strip_frontmatter(content: str) -> str:
-    m = _FM_SPLIT.match(content)
-    return m.group(2) if m else content
 
 
 def _has_genuine_claude_code_dependency(body: str, skill_name: str) -> bool:

--- a/tests/arch/test_skill_backend_annotations.py
+++ b/tests/arch/test_skill_backend_annotations.py
@@ -1,31 +1,60 @@
-"""Ensure all skills using Claude-Code-only features declare backend_requirements."""
+"""Bidirectional backend annotation enforcement with capability-aware detection.
+
+Forward: skill content using a capability → uses_capabilities must declare it.
+Reverse: backend_requirements present → at least one capability justifies it.
+Co-requirement: backend_requirements non-empty → uses_capabilities must also exist.
+Derivation: backend_requirements == union of required_backends from uses_capabilities.
+"""
 
 from __future__ import annotations
+
+import re
 
 import pytest
 
 from autoskillit.core import paths
+from autoskillit.core.types._type_constants_registries import SKILL_CAPABILITY_REGISTRY
 from autoskillit.workspace.skills import _read_skill_frontmatter
 
 pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 
-_CLAUDE_CODE_ONLY_PATTERNS: tuple[str, ...] = (
-    "Agent(model=",
-    "Agent(subagent_type=",
-    "open_kitchen",
-    "close_kitchen",
-    "run_skill",
-    "test_check",
-    "autoskillit:",
-    ".claude/",
-)
+_FM_SPLIT = re.compile(r"^---\n(.*?)\n?---\n?(.*)", re.DOTALL)
+
+_CAPABILITY_PATTERNS: dict[str, list[re.Pattern[str]]] = {
+    "agent_subagent": [re.compile(r"Agent\(\s*subagent_type\s*=")],
+    "agent_model": [re.compile(r"Agent\(\s*model\s*=")],
+    "open_kitchen": [re.compile(r"\bopen_kitchen\b"), re.compile(r"\bclose_kitchen\b")],
+    "run_skill": [re.compile(r"\brun_skill\b")],
+    "test_check": [re.compile(r"\btest_check\b")],
+    "claude_dir": [re.compile(r"\.claude/")],
+}
 
 
-def test_claude_code_skills_have_backend_requirements():
-    """Skills using Claude-Code-only features must declare backend_requirements: [claude-code]."""
+def _strip_frontmatter(content: str) -> str:
+    m = _FM_SPLIT.match(content)
+    return m.group(2) if m else content
+
+
+def _detect_capabilities(body: str, skill_name: str) -> set[str]:
+    detected: set[str] = set()
+    for cap_name, patterns in _CAPABILITY_PATTERNS.items():
+        for pat in patterns:
+            if pat.search(body):
+                detected.add(cap_name)
+                break
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "autoskillit:" in stripped:
+            if f"autoskillit:{skill_name}" not in stripped:
+                detected.add("cross_skill_ref")
+                break
+    return detected
+
+
+def _iter_skills():
     pkg = paths.pkg_root()
-    violations: list[str] = []
-
     for skill_dir in (pkg / "skills", pkg / "skills_extended"):
         if not skill_dir.is_dir():
             continue
@@ -35,18 +64,88 @@ def test_claude_code_skills_have_backend_requirements():
             skill_md = entry / "SKILL.md"
             if not skill_md.is_file():
                 continue
-            content = skill_md.read_text(encoding="utf-8")
-            uses_claude_code_feature = any(
-                pattern in content for pattern in _CLAUDE_CODE_ONLY_PATTERNS
-            )
-            if not uses_claude_code_feature:
-                continue
-            fm = _read_skill_frontmatter(skill_md)
-            reqs = fm.get("backend_requirements", [])
-            if "claude-code" not in reqs:
-                violations.append(entry.name)
+            yield entry.name, skill_md
 
+
+def test_forward_check_capabilities_declared():
+    """Skills using a capability must declare it in uses_capabilities."""
+    violations: list[str] = []
+    for name, skill_md in _iter_skills():
+        content = skill_md.read_text(encoding="utf-8")
+        body = _strip_frontmatter(content)
+        detected = _detect_capabilities(body, name)
+        if not detected:
+            continue
+        fm = _read_skill_frontmatter(skill_md)
+        declared = set(fm.get("uses_capabilities", []))
+        missing = detected - declared
+        if missing:
+            violations.append(f"{name}: detected={sorted(detected)}, missing={sorted(missing)}")
     assert not violations, (
-        f"{len(violations)} skill(s) use Claude-Code-only features but lack "
-        f"backend_requirements: [claude-code]:\n" + "\n".join(f"  {v}" for v in violations)
+        f"{len(violations)} skill(s) use capabilities but don't declare them:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )
+
+
+def test_reverse_check_annotation_justified():
+    """Skills with backend_requirements must have at least one capability justifying it."""
+    violations: list[str] = []
+    for name, skill_md in _iter_skills():
+        fm = _read_skill_frontmatter(skill_md)
+        backend_reqs = set(fm.get("backend_requirements", []))
+        if not backend_reqs:
+            continue
+        uses_caps = list(fm.get("uses_capabilities", []))
+        if not uses_caps:
+            violations.append(f"{name}: has backend_requirements but no uses_capabilities")
+            continue
+        derived: set[str] = set()
+        for cap_name in uses_caps:
+            cap_def = SKILL_CAPABILITY_REGISTRY.get(cap_name)
+            if cap_def:
+                derived |= cap_def.required_backends
+        for req in backend_reqs:
+            if req not in derived:
+                violations.append(
+                    f"{name}: backend_requirements includes '{req}' "
+                    f"but no declared capability requires it"
+                )
+    assert not violations, (
+        f"{len(violations)} annotation(s) not justified by capabilities:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )
+
+
+def test_co_requirement_backend_requires_capabilities():
+    """Non-empty backend_requirements → uses_capabilities must also be declared."""
+    violations: list[str] = []
+    for name, skill_md in _iter_skills():
+        fm = _read_skill_frontmatter(skill_md)
+        if fm.get("backend_requirements") and not fm.get("uses_capabilities"):
+            violations.append(name)
+    assert not violations, (
+        f"{len(violations)} skill(s) have backend_requirements without uses_capabilities:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )
+
+
+def test_derivation_backend_requirements_match_capabilities():
+    """backend_requirements must equal the union of required_backends from uses_capabilities."""
+    violations: list[str] = []
+    for name, skill_md in _iter_skills():
+        fm = _read_skill_frontmatter(skill_md)
+        uses_caps = list(fm.get("uses_capabilities", []))
+        if not uses_caps:
+            continue
+        derived: set[str] = set()
+        for cap_name in uses_caps:
+            cap_def = SKILL_CAPABILITY_REGISTRY.get(cap_name)
+            if cap_def:
+                derived |= cap_def.required_backends
+        declared = set(fm.get("backend_requirements", []))
+        if derived != declared:
+            violations.append(f"{name}: derived={sorted(derived)}, declared={sorted(declared)}")
+    assert not violations, (
+        f"{len(violations)} skill(s) have mismatched backend_requirements vs capabilities:\n"
+        + "\n".join(f"  {v}" for v in violations)
     )

--- a/tests/arch/test_skill_backend_annotations.py
+++ b/tests/arch/test_skill_backend_annotations.py
@@ -12,13 +12,11 @@ import re
 
 import pytest
 
-from autoskillit.core import paths
 from autoskillit.core.types._type_constants_registries import SKILL_CAPABILITY_REGISTRY
 from autoskillit.workspace.skills import _read_skill_frontmatter
+from tests.arch._helpers import _iter_skill_dirs, _strip_frontmatter
 
 pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
-
-_FM_SPLIT = re.compile(r"^---\n(.*?)\n?---\n?(.*)", re.DOTALL)
 
 _CAPABILITY_PATTERNS: dict[str, list[re.Pattern[str]]] = {
     "agent_subagent": [re.compile(r"Agent\(\s*subagent_type\s*=")],
@@ -28,11 +26,6 @@ _CAPABILITY_PATTERNS: dict[str, list[re.Pattern[str]]] = {
     "test_check": [re.compile(r"\btest_check\b")],
     "claude_dir": [re.compile(r"\.claude/")],
 }
-
-
-def _strip_frontmatter(content: str) -> str:
-    m = _FM_SPLIT.match(content)
-    return m.group(2) if m else content
 
 
 def _detect_capabilities(body: str, skill_name: str) -> set[str]:
@@ -53,24 +46,10 @@ def _detect_capabilities(body: str, skill_name: str) -> set[str]:
     return detected
 
 
-def _iter_skills():
-    pkg = paths.pkg_root()
-    for skill_dir in (pkg / "skills", pkg / "skills_extended"):
-        if not skill_dir.is_dir():
-            continue
-        for entry in sorted(skill_dir.iterdir()):
-            if not entry.is_dir():
-                continue
-            skill_md = entry / "SKILL.md"
-            if not skill_md.is_file():
-                continue
-            yield entry.name, skill_md
-
-
 def test_forward_check_capabilities_declared():
     """Skills using a capability must declare it in uses_capabilities."""
     violations: list[str] = []
-    for name, skill_md in _iter_skills():
+    for name, skill_md in _iter_skill_dirs():
         content = skill_md.read_text(encoding="utf-8")
         body = _strip_frontmatter(content)
         detected = _detect_capabilities(body, name)
@@ -90,7 +69,7 @@ def test_forward_check_capabilities_declared():
 def test_reverse_check_annotation_justified():
     """Skills with backend_requirements must have at least one capability justifying it."""
     violations: list[str] = []
-    for name, skill_md in _iter_skills():
+    for name, skill_md in _iter_skill_dirs():
         fm = _read_skill_frontmatter(skill_md)
         backend_reqs = set(fm.get("backend_requirements", []))
         if not backend_reqs:
@@ -119,7 +98,7 @@ def test_reverse_check_annotation_justified():
 def test_co_requirement_backend_requires_capabilities():
     """Non-empty backend_requirements → uses_capabilities must also be declared."""
     violations: list[str] = []
-    for name, skill_md in _iter_skills():
+    for name, skill_md in _iter_skill_dirs():
         fm = _read_skill_frontmatter(skill_md)
         if fm.get("backend_requirements") and not fm.get("uses_capabilities"):
             violations.append(name)
@@ -132,7 +111,7 @@ def test_co_requirement_backend_requires_capabilities():
 def test_derivation_backend_requirements_match_capabilities():
     """backend_requirements must equal the union of required_backends from uses_capabilities."""
     violations: list[str] = []
-    for name, skill_md in _iter_skills():
+    for name, skill_md in _iter_skill_dirs():
         fm = _read_skill_frontmatter(skill_md)
         uses_caps = list(fm.get("uses_capabilities", []))
         if not uses_caps:

--- a/tests/arch/test_skill_backend_annotations.py
+++ b/tests/arch/test_skill_backend_annotations.py
@@ -46,6 +46,17 @@ def _detect_capabilities(body: str, skill_name: str) -> set[str]:
     return detected
 
 
+_INLINE_DETECTED_CAPS = {"cross_skill_ref"}
+
+_pattern_keys = set(_CAPABILITY_PATTERNS) | _INLINE_DETECTED_CAPS
+_registry_keys = set(SKILL_CAPABILITY_REGISTRY)
+assert _pattern_keys == _registry_keys, (
+    f"_CAPABILITY_PATTERNS + inline caps must match registry. "
+    f"Missing: {_registry_keys - _pattern_keys}, "
+    f"Extra: {_pattern_keys - _registry_keys}"
+)
+
+
 def test_forward_check_capabilities_declared():
     """Skills using a capability must declare it in uses_capabilities."""
     violations: list[str] = []

--- a/tests/arch/test_skill_capability_registry.py
+++ b/tests/arch/test_skill_capability_registry.py
@@ -28,7 +28,6 @@ def _all_skill_frontmatter() -> list[tuple[str, dict]]:
     return results
 
 
-@pytest.mark.xfail(reason="registry not yet consumed — rectify plan in progress")
 def test_all_capability_keys_are_consumed():
     all_fm = _all_skill_frontmatter()
     used_caps: set[str] = set()
@@ -41,7 +40,6 @@ def test_all_capability_keys_are_consumed():
     )
 
 
-@pytest.mark.xfail(reason="co-requirement not yet enforced — rectify plan in progress")
 def test_backend_requirements_derivable_from_capabilities():
     all_fm = _all_skill_frontmatter()
     violations: list[str] = []
@@ -68,7 +66,6 @@ def test_backend_requirements_derivable_from_capabilities():
     )
 
 
-@pytest.mark.xfail(reason="uses_capabilities not yet declared — rectify plan in progress")
 def test_no_unknown_capability_declared():
     all_fm = _all_skill_frontmatter()
     violations: list[str] = []

--- a/tests/arch/test_skill_capability_registry.py
+++ b/tests/arch/test_skill_capability_registry.py
@@ -4,28 +4,15 @@ from __future__ import annotations
 
 import pytest
 
-from autoskillit.core import paths
 from autoskillit.core.types._type_constants_registries import SKILL_CAPABILITY_REGISTRY
 from autoskillit.workspace.skills import _read_skill_frontmatter
+from tests.arch._helpers import _iter_skill_dirs
 
 pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 
 
 def _all_skill_frontmatter() -> list[tuple[str, dict]]:
-    pkg = paths.pkg_root()
-    results: list[tuple[str, dict]] = []
-    for skill_dir in (pkg / "skills", pkg / "skills_extended"):
-        if not skill_dir.is_dir():
-            continue
-        for entry in sorted(skill_dir.iterdir()):
-            if not entry.is_dir():
-                continue
-            skill_md = entry / "SKILL.md"
-            if not skill_md.is_file():
-                continue
-            fm = _read_skill_frontmatter(skill_md)
-            results.append((entry.name, fm))
-    return results
+    return [(name, _read_skill_frontmatter(skill_md)) for name, skill_md in _iter_skill_dirs()]
 
 
 def test_all_capability_keys_are_consumed():

--- a/tests/arch/test_skill_capability_registry.py
+++ b/tests/arch/test_skill_capability_registry.py
@@ -1,0 +1,81 @@
+"""Capability registry consistency: every capability is consumed and derivable."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import paths
+from autoskillit.core.types._type_constants_registries import SKILL_CAPABILITY_REGISTRY
+from autoskillit.workspace.skills import _read_skill_frontmatter
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+def _all_skill_frontmatter() -> list[tuple[str, dict]]:
+    pkg = paths.pkg_root()
+    results: list[tuple[str, dict]] = []
+    for skill_dir in (pkg / "skills", pkg / "skills_extended"):
+        if not skill_dir.is_dir():
+            continue
+        for entry in sorted(skill_dir.iterdir()):
+            if not entry.is_dir():
+                continue
+            skill_md = entry / "SKILL.md"
+            if not skill_md.is_file():
+                continue
+            fm = _read_skill_frontmatter(skill_md)
+            results.append((entry.name, fm))
+    return results
+
+
+@pytest.mark.xfail(reason="registry not yet consumed — rectify plan in progress")
+def test_all_capability_keys_are_consumed():
+    all_fm = _all_skill_frontmatter()
+    used_caps: set[str] = set()
+    for _name, fm in all_fm:
+        for cap in fm.get("uses_capabilities", []):
+            used_caps.add(cap)
+    unused = set(SKILL_CAPABILITY_REGISTRY) - used_caps
+    assert not unused, (
+        f"Capability keys not referenced by any SKILL.md uses_capabilities: {sorted(unused)}"
+    )
+
+
+@pytest.mark.xfail(reason="co-requirement not yet enforced — rectify plan in progress")
+def test_backend_requirements_derivable_from_capabilities():
+    all_fm = _all_skill_frontmatter()
+    violations: list[str] = []
+    for name, fm in all_fm:
+        backend_reqs = frozenset(fm.get("backend_requirements", []))
+        uses_caps = list(fm.get("uses_capabilities", []))
+        if backend_reqs and not uses_caps:
+            violations.append(f"{name}: has backend_requirements but no uses_capabilities")
+            continue
+        if not uses_caps:
+            continue
+        derived: set[str] = set()
+        for cap_name in uses_caps:
+            cap_def = SKILL_CAPABILITY_REGISTRY.get(cap_name)
+            if cap_def:
+                derived |= cap_def.required_backends
+        if frozenset(derived) != backend_reqs:
+            violations.append(
+                f"{name}: derived={sorted(derived)}, declared={sorted(backend_reqs)}"
+            )
+    assert not violations, (
+        f"{len(violations)} skill(s) have inconsistent backend_requirements vs "
+        f"uses_capabilities:\n" + "\n".join(f"  {v}" for v in violations)
+    )
+
+
+@pytest.mark.xfail(reason="uses_capabilities not yet declared — rectify plan in progress")
+def test_no_unknown_capability_declared():
+    all_fm = _all_skill_frontmatter()
+    violations: list[str] = []
+    for name, fm in all_fm:
+        for cap in fm.get("uses_capabilities", []):
+            if cap not in SKILL_CAPABILITY_REGISTRY:
+                violations.append(f"{name}: unknown capability '{cap}'")
+    assert not violations, "Unknown capabilities declared in SKILL.md files:\n" + "\n".join(
+        f"  {v}" for v in violations
+    )

--- a/tests/arch/test_subpackage_structure.py
+++ b/tests/arch/test_subpackage_structure.py
@@ -57,8 +57,8 @@ class TestCoreSubpackages:
         assert len(combined) == len(remaining) + len(env) + len(features) + len(registries), (
             "Duplicate symbols across split modules"
         )
-        assert len(combined) == 86, (
-            f"Expected 86 symbols total, got {len(combined)} "
+        assert len(combined) == 88, (
+            f"Expected 88 symbols total, got {len(combined)} "
             f"(remaining={len(remaining)}, env={len(env)}, "
             f"features={len(features)}, registries={len(registries)})"
         )

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -157,10 +157,10 @@ class TestChannelBDrainWait:
         Sequence (fast poll params):
           t=0.00s  subprocess starts
           t=0.10s  script writes %%ORDER_UP%% to session JSONL (Channel B target)
-          t=0.11s  Phase 1 poll fires → session file found
-          t=0.16s  Phase 2 poll fires → marker detected → Channel B fires → drain starts
+          t~0.15s  Phase 1 poll fires → session file found
+          t~0.20s  Phase 2 poll fires → marker detected → Channel B fires → drain starts
           t=0.25s  script writes type=result to stdout (0.15s after JSONL write)
-          t=0.30s  heartbeat fires → Channel A confirms → drain completes
+          t~0.30s  heartbeat fires → Channel A confirms → drain completes
           t~0.30s  process killed with confirmed stdout
 
         timeout=300s: guards against the outer wall-clock expiring under xdist -n 4 load.
@@ -181,10 +181,10 @@ class TestChannelBDrainWait:
             completion_marker="%%ORDER_UP%%",
             completion_drain_timeout=5.0,
             _phase1_timeout=400,
-            _phase1_poll=0.01,
+            _phase1_poll=0.05,
             _phase2_poll=0.05,
             _heartbeat_poll=0.05,
-            _session_id_timeout=0.01,
+            _session_id_timeout=2.0,
         )
 
         assert result.termination == TerminationReason.COMPLETED

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -35,7 +35,9 @@ CHANNEL_B_THEN_A_CONFIRM_SCRIPT = textwrap.dedent("""\
         f.flush()
     # Delay must exceed session_id_timeout + Phase 1 poll so Phase 2 initializes
     # scan_pos from discovery boundary before the marker arrives.
-    time.sleep(1.0)
+    # 3s margin handles xdist -n 4 event-loop saturation on WSL2 where coroutine
+    # scheduling jitter can delay Phase 1 discovery by >1s.
+    time.sleep(3.0)
     with open(jsonl_path, "a") as f:
         record = {"type": "assistant", "message": {"role": "assistant",
                   "content": "%%ORDER_UP%%"}}
@@ -156,12 +158,18 @@ class TestChannelBDrainWait:
 
         Sequence (fast poll params):
           t=0.00s  subprocess starts
-          t=0.10s  script writes %%ORDER_UP%% to session JSONL (Channel B target)
-          t~0.15s  Phase 1 poll fires → session file found
-          t~0.20s  Phase 2 poll fires → marker detected → Channel B fires → drain starts
-          t=0.25s  script writes type=result to stdout (0.15s after JSONL write)
-          t~0.30s  heartbeat fires → Channel A confirms → drain completes
-          t~0.30s  process killed with confirmed stdout
+          t=0.10s  script creates session JSONL with initial content
+          t~0.11s  Phase 1 poll discovers file, Phase 2 initializes scan_pos
+          t=3.10s  script writes %%ORDER_UP%% to session JSONL (Channel B target)
+          t~3.15s  Phase 2 detects marker → Channel B fires → drain starts
+          t=3.25s  script writes type=result to stdout (0.15s after JSONL write)
+          t~3.30s  heartbeat fires → Channel A confirms → drain completes
+          t~3.30s  process killed with confirmed stdout
+
+        The 3.0s gap between file creation and marker write ensures Phase 1 discovers
+        the JSONL file and Phase 2 initializes scan_pos BEFORE the marker arrives —
+        preventing a race where Phase 2 sets scan_pos past the marker under xdist -n 4
+        event-loop saturation on WSL2.
 
         timeout=300s: guards against the outer wall-clock expiring under xdist -n 4 load.
         _phase1_timeout=400: must exceed outer timeout (300s) so that Phase 1 never fires
@@ -181,10 +189,10 @@ class TestChannelBDrainWait:
             completion_marker="%%ORDER_UP%%",
             completion_drain_timeout=5.0,
             _phase1_timeout=400,
-            _phase1_poll=0.05,
+            _phase1_poll=0.01,
             _phase2_poll=0.05,
             _heartbeat_poll=0.05,
-            _session_id_timeout=2.0,
+            _session_id_timeout=0.01,
         )
 
         assert result.termination == TerminationReason.COMPLETED


### PR DESCRIPTION
## Summary

The `backend_requirements: [claude-code]` annotation system uses a flat substring scanner (`_CLAUDE_CODE_ONLY_PATTERNS`) in an arch test to enforce that skills declare backend requirements. This scanner matches documentation prose, self-referential invocation syntax, and patterns with Codex equivalents identically to genuinely Claude-Code-only tool calls — producing ~63 false-positive annotations. These annotations flow into three downstream gates that silently exclude skills from Codex sessions, making ~63 skills unreachable on Codex despite having no genuine Claude-Code-only dependency.

The architectural weakness is **unidirectional enforcement without accuracy validation**: the arch test checks "pattern present → annotation required" but never checks "annotation present → annotation justified." Combined with a flat pattern list that has no context awareness, equivalence mapping, or granularity beyond binary yes/no, this creates a system where over-broad classification compounds silently through the runtime.

The solution replaces inference-based annotation enforcement with **declaration-based capability requirements** — a `SKILL_CAPABILITY_REGISTRY` that models per-capability backend compatibility, combined with a bidirectional arch test that validates both directions and context-aware pattern detection that distinguishes documentation from usage.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260602-232333-025600/.autoskillit/temp/rectify/rectify_backend_requirements_annotations_2026-06-02_233500.md`

Closes #3647

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 72 | 26.0k | 2.3M | 135.6k | 65 | 118.9k | 27m 26s |
| review_approach* | opus[1m] | 1 | 34 | 5.6k | 232.8k | 45.3k | 16 | 31.5k | 3m 24s |
| dry_walkthrough* | opus | 1 | 561 | 14.5k | 1.0M | 65.1k | 40 | 48.2k | 8m 14s |
| implement* | opus[1m] | 1 | 129 | 48.5k | 8.1M | 135.6k | 149 | 118.8k | 28m 59s |
| audit_impl* | opus[1m] | 1 | 40 | 10.3k | 536.5k | 55.3k | 42 | 38.8k | 7m 25s |
| prepare_pr* | MiniMax-M3 | 1 | 50.1k | 4.8k | 177.3k | 55.0k | 12 | 0 | 1m 31s |
| compose_pr* | MiniMax-M3 | 1 | 39.1k | 1.7k | 196.7k | 41.6k | 13 | 0 | 1m 2s |
| review_pr* | opus[1m] | 1 | 32 | 31.5k | 1.1M | 144.0k | 34 | 127.8k | 9m 35s |
| resolve_review* | opus[1m] | 1 | 64 | 18.2k | 2.7M | 89.8k | 70 | 74.0k | 10m 59s |
| resolve_pre_review_conflicts* | opus[1m] | 1 | 42 | 5.4k | 1.1M | 56.9k | 44 | 40.0k | 2m 22s |
| **Total** | | | 90.2k | 166.5k | 17.5M | 144.0k | | 598.0k | 1h 41m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 648 | 12550.0 | 183.4 | 74.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 106 | 25453.5 | 698.4 | 171.5 |
| resolve_pre_review_conflicts | 664 | 1692.6 | 60.2 | 8.1 |
| **Total** | **1418** | 12348.0 | 421.7 | 117.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 7 | 413 | 145.4k | 16.1M | 549.8k | 1h 30m |
| opus | 1 | 561 | 14.5k | 1.0M | 48.2k | 8m 14s |
| MiniMax-M3 | 2 | 89.2k | 6.5k | 374.0k | 0 | 2m 34s |