### PR TITLE
Implementation Plan: Decompose review_design Step in research-design.yaml

### DIFF
--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -385,6 +385,7 @@ _PARSE_STEP_HANDLED_FIELDS: frozenset[str] = frozenset(
         "block",  # Named block anchor; maps to step's block: key in YAML
         "pass_through",  # Captured outputs used for informational propagation only
         "phoropter_family",
+        "skip_when_true",
     }
 )
 if _PARSE_STEP_HANDLED_FIELDS != frozenset(RecipeStep.__dataclass_fields__):
@@ -671,6 +672,7 @@ def _parse_step(data: dict[str, Any]) -> RecipeStep:
         block=data.get("block"),
         pass_through=_ensure_list(data.get("pass_through", [])),
         phoropter_family=data.get("phoropter_family"),
+        skip_when_true=data.get("skip_when_true"),
     )
 
 

--- a/src/autoskillit/recipe/rules/rules_phoropter_adjacency.py
+++ b/src/autoskillit/recipe/rules/rules_phoropter_adjacency.py
@@ -1,9 +1,10 @@
 """Semantic validation rules enforcing phoropter step adjacency (dial→apply→synthesize).
 
-Naming constraint: phoropter-family steps must use the exact phase literals
-("dial", "apply", "synthesize") as their step keys.  The phase-order rule
-compares step_name directly against _PHOROPTER_PHASES, so a step keyed
-"vis-lens-dial" with phoropter_family set will always fail validation.
+Phase-order constraint: canonical phoropter phases ("dial", "apply", "synthesize")
+must appear in the declared order within each family.  Steps with phoropter_family
+set but a non-canonical step key (e.g., "select_review_dimensions") are transparent
+to phase ordering — they are allowed between canonical phases without advancing the
+phase counter.  Route-action steps are also transparent.
 """
 
 from __future__ import annotations
@@ -35,6 +36,8 @@ def _check_phoropter_phase_order(ctx: ValidationContext) -> list[RuleFinding]:
         if family in errored_families:
             continue
         if step.action == "route":
+            continue
+        if step_name not in _PHOROPTER_PHASES:
             continue
 
         expected_phase = expected_next.get(family, "dial")

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -143,6 +143,7 @@ class RecipeStep:
         default_factory=list
     )  # Captured output names used for informational propagation, not flow control
     phoropter_family: str | None = None
+    skip_when_true: str | None = None
 
     def __post_init__(self) -> None:
         self.capture = _coerce_capture_dict(self.capture)

--- a/src/autoskillit/recipes/research-design.json
+++ b/src/autoskillit/recipes/research-design.json
@@ -92,36 +92,95 @@
       "capture": {
         "experiment_plan": "${{ result.experiment_plan }}"
       },
-      "on_success": "review_design",
+      "on_success": "dial",
       "on_failure": "escalate_stop"
     },
-    "review_design": {
+    "dial": {
       "tool": "run_skill",
       "model": "",
+      "phoropter_family": "review-design",
       "with": {
-        "skill_command": "/autoskillit:review-design ${{ context.experiment_plan }} ${{ context.scope_report }}",
+        "skill_command": "/autoskillit:classify-experiment-type ${{ context.experiment_plan }} ${{ context.scope_report }}",
         "cwd": "${{ inputs.source_dir }}",
-        "step_name": "review_design",
-        "output_dir": "{{AUTOSKILLIT_TEMP}}/review-design"
+        "step_name": "dial",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/classify-experiment-type"
+      },
+      "capture": {
+        "experiment_type": "${{ result.experiment_type }}",
+        "is_silent_type": "${{ result.is_silent_type }}",
+        "classification_timestamp": "${{ result.classification_timestamp }}"
+      },
+      "pass_through": [
+        "experiment_type",
+        "is_silent_type",
+        "classification_timestamp"
+      ],
+      "skip_when_false": "inputs.review_design",
+      "on_context_limit": "synthesize",
+      "on_success": "select_review_dimensions",
+      "on_failure": "escalate_stop"
+    },
+    "select_review_dimensions": {
+      "tool": "run_python",
+      "phoropter_family": "review-design",
+      "with": {
+        "callable": "autoskillit.smoke_utils.select_review_dimensions",
+        "experiment_type": "${{ context.experiment_type }}",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/select-review-dimensions",
+        "work_dir": "${{ inputs.source_dir }}"
+      },
+      "capture": {
+        "selected_lenses": "${{ result.selected_lenses }}",
+        "dimensions_manifest_path": "${{ result.dimensions_manifest_path }}"
+      },
+      "on_success": "apply",
+      "on_failure": "escalate_stop"
+    },
+    "apply": {
+      "tool": "run_skill",
+      "model": "",
+      "phoropter_family": "review-design",
+      "with": {
+        "skill_command": "/autoskillit:apply-review-dimensions ${{ context.experiment_plan }} ${{ context.scope_report }} ${{ context.dimensions_manifest_path }}",
+        "cwd": "${{ inputs.source_dir }}",
+        "step_name": "apply",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/apply-review-dimensions"
+      },
+      "capture": {
+        "findings_manifest_path": "${{ result.findings_manifest_path }}",
+        "evaluation_dashboard": "${{ result.evaluation_dashboard_path }}"
+      },
+      "optional_context_refs": [
+        "is_silent_type",
+        "classification_timestamp"
+      ],
+      "skip_when_true": "context.is_silent_type",
+      "retries": 2,
+      "on_exhausted": "synthesize",
+      "on_context_limit": "synthesize",
+      "on_failure": "synthesize",
+      "on_success": "synthesize"
+    },
+    "synthesize": {
+      "tool": "run_python",
+      "phoropter_family": "review-design",
+      "with": {
+        "callable": "autoskillit.smoke_utils.aggregate_review_verdict",
+        "findings_manifest_path": "${{ context.findings_manifest_path }}",
+        "dimensions_manifest_path": "${{ context.dimensions_manifest_path }}",
+        "experiment_type": "${{ context.experiment_type }}",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/aggregate-review-verdict",
+        "work_dir": "${{ inputs.source_dir }}"
       },
       "capture": {
         "verdict": "${{ result.verdict }}",
-        "experiment_type": "${{ result.experiment_type }}",
-        "evaluation_dashboard": "${{ result.evaluation_dashboard }}",
-        "revision_guidance": "${{ result.revision_guidance }}"
+        "revision_guidance": "${{ result.revision_guidance_path }}"
       },
-      "pass_through": [
-        "experiment_type"
-      ],
-      "skip_when_false": "inputs.review_design",
-      "retries": 2,
-      "on_exhausted": "dial",
-      "on_context_limit": "dial",
-      "on_failure": "dial",
+      "on_failure": "vis_dial",
       "on_result": [
         {
           "when": "${{ result.verdict }} == GO",
-          "route": "dial"
+          "route": "vis_dial"
         },
         {
           "when": "${{ result.verdict }} == REVISE",
@@ -132,35 +191,33 @@
           "route": "resolve_design_review"
         },
         {
-          "route": "dial"
+          "route": "vis_dial"
         }
       ]
     },
-    "dial": {
+    "vis_dial": {
       "tool": "run_skill",
       "model": "",
-      "phoropter_family": "vis-lens",
       "with": {
         "skill_command": "/autoskillit:select-vis-lenses ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}",
         "cwd": "${{ inputs.source_dir }}",
-        "step_name": "dial",
+        "step_name": "vis_dial",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/dial"
       },
       "capture": {
         "selected_lenses": "${{ result.selected_lenses }}",
         "lens_context_paths": "${{ result.lens_context_paths }}"
       },
-      "on_success": "apply",
+      "on_success": "vis_apply",
       "on_failure": "escalate_stop"
     },
-    "apply": {
+    "vis_apply": {
       "tool": "run_skill",
       "model": "",
-      "phoropter_family": "vis-lens",
       "with": {
         "skill_command": "/autoskillit:vis-lens-{slug} {context_path} ${{ context.experiment_plan }}",
         "cwd": "${{ inputs.source_dir }}",
-        "step_name": "apply",
+        "step_name": "vis_apply",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/apply"
       },
       "capture_list": {
@@ -171,17 +228,16 @@
         "lens_context_paths"
       ],
       "retries": 0,
-      "on_success": "synthesize",
-      "on_failure": "synthesize"
+      "on_success": "vis_synthesize",
+      "on_failure": "vis_synthesize"
     },
-    "synthesize": {
+    "vis_synthesize": {
       "tool": "run_skill",
       "model": "",
-      "phoropter_family": "vis-lens",
       "with": {
         "skill_command": "/autoskillit:synthesize-vis-plan ${{ inputs.source_dir }} ${{ context.experiment_plan }} {{AUTOSKILLIT_TEMP}}/apply",
         "cwd": "${{ inputs.source_dir }}",
-        "step_name": "synthesize",
+        "step_name": "vis_synthesize",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/synthesize"
       },
       "capture": {
@@ -213,17 +269,17 @@
       "on_result": [
         {
           "when": "${{ result.max_exceeded }} == true",
-          "route": "dial"
+          "route": "vis_dial"
         },
         {
-          "route": "plan_experiment"
+          "route": "apply"
         }
       ],
-      "on_failure": "dial",
+      "on_failure": "vis_dial",
       "optional_context_refs": [
         "design_review_count"
       ],
-      "note": "Iteration guard for the review_design → revise_design → plan_experiment cycle. Caps design revision loops at 3 iterations. Both REVISE and STOP→resolve→revised paths flow through revise_design and hit this guard. On exhaustion, proceeds to dial with the best available design.\n"
+      "note": "Iteration guard for the apply → revise_design → apply cycle. Caps design revision loops at 3 iterations. Both REVISE and STOP→resolve→revised paths flow through revise_design and hit this guard. On exhaustion, proceeds to vis_dial with the best available design.\n"
     },
     "resolve_design_review": {
       "tool": "run_skill",
@@ -237,7 +293,8 @@
       "optional_context_refs": [
         "evaluation_dashboard",
         "experiment_plan",
-        "revision_guidance"
+        "revision_guidance",
+        "findings_manifest_path"
       ],
       "capture": {
         "revision_guidance": "${{ result.revision_guidance }}"
@@ -258,11 +315,11 @@
           "route": "design_rejected"
         }
       ],
-      "note": "Triages STOP-verdict findings from review_design. ADDRESSABLE/DISCUSS findings generate revision_guidance and loop back. Only all-STRUCTURAL findings halt at design_rejected.\n"
+      "note": "Triages STOP-verdict findings from the review-design phoropter's synthesize step. ADDRESSABLE/DISCUSS findings generate revision_guidance and loop back. Only all-STRUCTURAL findings halt at design_rejected.\n"
     },
     "design_rejected": {
       "action": "stop",
-      "message": "Research pipeline halted: experiment design rejected (verdict=STOP, resolution=failed). All stop-trigger findings are structural — revision cannot address the identified flaws. Check {{AUTOSKILLIT_TEMP}}/resolve-design-review/ for the triage report and {{AUTOSKILLIT_TEMP}}/review-design/ for the evaluation dashboard. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"experiment design rejected\"}\n"
+      "message": "Research pipeline halted: experiment design rejected (verdict=STOP, resolution=failed). All stop-trigger findings are structural — revision cannot address the identified flaws. Check {{AUTOSKILLIT_TEMP}}/resolve-design-review/ for the triage report and {{AUTOSKILLIT_TEMP}}/apply-review-dimensions/ for the evaluation dashboard. Emit the L3 result sentinel JSON block now with success=false. Example sentinel: {\"success\": false, \"reason\": \"experiment design rejected\"}\n"
     },
     "create_worktree": {
       "tool": "run_cmd",

--- a/src/autoskillit/recipes/research-design.yaml
+++ b/src/autoskillit/recipes/research-design.yaml
@@ -94,76 +94,121 @@ steps:
     optional_context_refs: [revision_guidance, selected_directions]
     capture:
       experiment_plan: "${{ result.experiment_plan }}"
-    on_success: review_design
+    on_success: dial
     on_failure: escalate_stop
-
-  review_design:
-    tool: run_skill
-    model: ""
-    with:
-      skill_command: "/autoskillit:review-design ${{ context.experiment_plan }} ${{ context.scope_report }}"
-      cwd: "${{ inputs.source_dir }}"
-      step_name: review_design
-      output_dir: "{{AUTOSKILLIT_TEMP}}/review-design"
-    capture:
-      verdict: "${{ result.verdict }}"
-      experiment_type: "${{ result.experiment_type }}"
-      evaluation_dashboard: "${{ result.evaluation_dashboard }}"
-      revision_guidance: "${{ result.revision_guidance }}"
-    pass_through: [experiment_type]
-    skip_when_false: inputs.review_design
-    retries: 2
-    on_exhausted: dial
-    on_context_limit: dial
-    on_failure: dial
-    on_result:
-    - when: "${{ result.verdict }} == GO"
-      route: dial
-    - when: "${{ result.verdict }} == REVISE"
-      route: revise_design
-    - when: "${{ result.verdict }} == STOP"
-      route: resolve_design_review
-    - route: dial
 
   dial:
     tool: run_skill
     model: ""
-    phoropter_family: vis-lens
+    phoropter_family: review-design
     with:
-      skill_command: "/autoskillit:select-vis-lenses ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}"
+      skill_command: "/autoskillit:classify-experiment-type ${{ context.experiment_plan }} ${{ context.scope_report }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: dial
-      output_dir: "{{AUTOSKILLIT_TEMP}}/dial"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/classify-experiment-type"
+    capture:
+      experiment_type: "${{ result.experiment_type }}"
+      is_silent_type: "${{ result.is_silent_type }}"
+      classification_timestamp: "${{ result.classification_timestamp }}"
+    pass_through: [experiment_type, is_silent_type, classification_timestamp]
+    skip_when_false: inputs.review_design
+    on_context_limit: synthesize
+    on_success: select_review_dimensions
+    on_failure: escalate_stop
+
+  select_review_dimensions:
+    tool: run_python
+    phoropter_family: review-design
+    with:
+      callable: "autoskillit.smoke_utils.select_review_dimensions"
+      experiment_type: "${{ context.experiment_type }}"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/select-review-dimensions"
+      work_dir: "${{ inputs.source_dir }}"
     capture:
       selected_lenses: "${{ result.selected_lenses }}"
-      lens_context_paths: "${{ result.lens_context_paths }}"
+      dimensions_manifest_path: "${{ result.dimensions_manifest_path }}"
     on_success: apply
     on_failure: escalate_stop
 
   apply:
     tool: run_skill
     model: ""
-    phoropter_family: vis-lens
+    phoropter_family: review-design
+    with:
+      skill_command: "/autoskillit:apply-review-dimensions ${{ context.experiment_plan }} ${{ context.scope_report }} ${{ context.dimensions_manifest_path }}"
+      cwd: "${{ inputs.source_dir }}"
+      step_name: apply
+      output_dir: "{{AUTOSKILLIT_TEMP}}/apply-review-dimensions"
+    capture:
+      findings_manifest_path: "${{ result.findings_manifest_path }}"
+      evaluation_dashboard: "${{ result.evaluation_dashboard_path }}"
+    optional_context_refs: [is_silent_type, classification_timestamp]
+    skip_when_true: context.is_silent_type
+    retries: 2
+    on_exhausted: synthesize
+    on_context_limit: synthesize
+    on_failure: synthesize
+    on_success: synthesize
+
+  synthesize:
+    tool: run_python
+    phoropter_family: review-design
+    with:
+      callable: "autoskillit.smoke_utils.aggregate_review_verdict"
+      findings_manifest_path: "${{ context.findings_manifest_path }}"
+      dimensions_manifest_path: "${{ context.dimensions_manifest_path }}"
+      experiment_type: "${{ context.experiment_type }}"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/aggregate-review-verdict"
+      work_dir: "${{ inputs.source_dir }}"
+    capture:
+      verdict: "${{ result.verdict }}"
+      revision_guidance: "${{ result.revision_guidance_path }}"
+    on_failure: vis_dial
+    on_result:
+    - when: "${{ result.verdict }} == GO"
+      route: vis_dial
+    - when: "${{ result.verdict }} == REVISE"
+      route: revise_design
+    - when: "${{ result.verdict }} == STOP"
+      route: resolve_design_review
+    - route: vis_dial
+
+  vis_dial:
+    tool: run_skill
+    model: ""
+    with:
+      skill_command: "/autoskillit:select-vis-lenses ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}"
+      cwd: "${{ inputs.source_dir }}"
+      step_name: vis_dial
+      output_dir: "{{AUTOSKILLIT_TEMP}}/dial"
+    capture:
+      selected_lenses: "${{ result.selected_lenses }}"
+      lens_context_paths: "${{ result.lens_context_paths }}"
+    on_success: vis_apply
+    on_failure: escalate_stop
+
+  vis_apply:
+    tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:vis-lens-{slug} {context_path} ${{ context.experiment_plan }}"
       cwd: "${{ inputs.source_dir }}"
-      step_name: apply
+      step_name: vis_apply
       output_dir: "{{AUTOSKILLIT_TEMP}}/apply"
     capture_list:
       all_figure_spec_paths: "${{ result.figure_spec_path }}"
     optional_context_refs: [selected_lenses, lens_context_paths]
     retries: 0
-    on_success: synthesize
-    on_failure: synthesize
+    on_success: vis_synthesize
+    on_failure: vis_synthesize
 
-  synthesize:
+  vis_synthesize:
     tool: run_skill
     model: ""
-    phoropter_family: vis-lens
     with:
       skill_command: "/autoskillit:synthesize-vis-plan ${{ inputs.source_dir }} ${{ context.experiment_plan }} {{AUTOSKILLIT_TEMP}}/apply"
       cwd: "${{ inputs.source_dir }}"
-      step_name: synthesize
+      step_name: vis_synthesize
       output_dir: "{{AUTOSKILLIT_TEMP}}/synthesize"
     capture:
       visualization_plan_path: "${{ result.visualization_plan_path }}"
@@ -187,16 +232,16 @@ steps:
       design_review_count: "${{ result.next_iteration }}"
     on_result:
     - when: "${{ result.max_exceeded }} == true"
-      route: dial
-    - route: plan_experiment
-    on_failure: dial
+      route: vis_dial
+    - route: apply
+    on_failure: vis_dial
     optional_context_refs:
     - design_review_count
     note: >
-      Iteration guard for the review_design → revise_design → plan_experiment cycle.
+      Iteration guard for the apply → revise_design → apply cycle.
       Caps design revision loops at 3 iterations. Both REVISE and
       STOP→resolve→revised paths flow through revise_design and hit this guard.
-      On exhaustion, proceeds to dial with the best available design.
+      On exhaustion, proceeds to vis_dial with the best available design.
 
   resolve_design_review:
     tool: run_skill
@@ -206,7 +251,7 @@ steps:
       cwd: "${{ inputs.source_dir }}"
       step_name: resolve_design_review
       output_dir: "{{AUTOSKILLIT_TEMP}}/resolve-design-review"
-    optional_context_refs: [evaluation_dashboard, experiment_plan, revision_guidance]
+    optional_context_refs: [evaluation_dashboard, experiment_plan, revision_guidance, findings_manifest_path]
     capture:
       revision_guidance: "${{ result.revision_guidance }}"
     retries: 1
@@ -219,9 +264,9 @@ steps:
       route: design_rejected
     - route: design_rejected
     note: >
-      Triages STOP-verdict findings from review_design. ADDRESSABLE/DISCUSS findings
-      generate revision_guidance and loop back. Only all-STRUCTURAL findings halt at
-      design_rejected.
+      Triages STOP-verdict findings from the review-design phoropter's synthesize step.
+      ADDRESSABLE/DISCUSS findings generate revision_guidance and loop back.
+      Only all-STRUCTURAL findings halt at design_rejected.
 
   design_rejected:
     action: stop
@@ -229,7 +274,7 @@ steps:
       Research pipeline halted: experiment design rejected (verdict=STOP, resolution=failed).
       All stop-trigger findings are structural — revision cannot address the identified flaws.
       Check {{AUTOSKILLIT_TEMP}}/resolve-design-review/ for the triage report and
-      {{AUTOSKILLIT_TEMP}}/review-design/ for the evaluation dashboard.
+      {{AUTOSKILLIT_TEMP}}/apply-review-dimensions/ for the evaluation dashboard.
       Emit the L3 result sentinel JSON block now with success=false.
       Example sentinel: {"success": false, "reason": "experiment design rejected"}
 

--- a/tests/recipe/test_bundled_recipes_research_design.py
+++ b/tests/recipe/test_bundled_recipes_research_design.py
@@ -58,17 +58,20 @@ class TestResearchDesignRecipeStructure:
         assert recipe.ingredients["issue_url"].required is False
 
     def test_step_count(self, recipe) -> None:
-        assert len(recipe.steps) == 14
+        assert len(recipe.steps) == 17
 
     def test_step_names(self, recipe) -> None:
         expected = {
             "scope",
             "select_directions",
             "plan_experiment",
-            "review_design",
             "dial",
+            "select_review_dimensions",
             "apply",
             "synthesize",
+            "vis_dial",
+            "vis_apply",
+            "vis_synthesize",
             "create_worktree",
             "revise_design",
             "check_design_review_loop",
@@ -92,7 +95,7 @@ class TestResearchDesignRecipeStructure:
 
     def test_plan_experiment_routing(self, recipe) -> None:
         step = recipe.steps["plan_experiment"]
-        assert step.on_success == "review_design"
+        assert step.on_success == "dial"
         assert step.on_failure == "escalate_stop"
 
     def test_plan_experiment_captures_experiment_plan(self, recipe) -> None:
@@ -103,30 +106,71 @@ class TestResearchDesignRecipeStructure:
         for field in ("revision_guidance", "selected_directions"):
             assert field in refs, f"plan_experiment optional_context_refs must include: {field}"
 
-    def test_review_design_skip_when_false(self, recipe) -> None:
-        assert recipe.steps["review_design"].skip_when_false == "inputs.review_design"
+    def test_dial_phoropter_family(self, recipe) -> None:
+        assert recipe.steps["dial"].phoropter_family == "review-design"
 
-    def test_review_design_retries(self, recipe) -> None:
-        assert recipe.steps["review_design"].retries == 2
+    def test_dial_skip_behavior(self, recipe) -> None:
+        assert recipe.steps["dial"].skip_when_false == "inputs.review_design"
 
-    def test_review_design_on_exhausted(self, recipe) -> None:
-        assert recipe.steps["review_design"].on_exhausted == "dial"
+    def test_dial_on_success(self, recipe) -> None:
+        assert recipe.steps["dial"].on_success == "select_review_dimensions"
 
-    def test_review_design_on_context_limit(self, recipe) -> None:
-        assert recipe.steps["review_design"].on_context_limit == "dial"
+    def test_dial_on_failure(self, recipe) -> None:
+        assert recipe.steps["dial"].on_failure == "escalate_stop"
 
-    def test_review_design_on_failure(self, recipe) -> None:
-        assert recipe.steps["review_design"].on_failure == "dial"
+    def test_dial_captures(self, recipe) -> None:
+        capture = recipe.steps["dial"].capture
+        for key in ("experiment_type", "is_silent_type", "classification_timestamp"):
+            assert key in capture, f"Missing capture key: {key}"
 
-    def test_review_design_on_result_go(self, recipe) -> None:
-        step = recipe.steps["review_design"]
+    def test_select_review_dimensions_phoropter_family(self, recipe) -> None:
+        assert recipe.steps["select_review_dimensions"].phoropter_family == "review-design"
+
+    def test_select_review_dimensions_captures(self, recipe) -> None:
+        capture = recipe.steps["select_review_dimensions"].capture
+        for key in ("selected_lenses", "dimensions_manifest_path"):
+            assert key in capture, f"Missing capture key: {key}"
+
+    def test_apply_phoropter_family(self, recipe) -> None:
+        assert recipe.steps["apply"].phoropter_family == "review-design"
+
+    def test_apply_skip_when_true(self, recipe) -> None:
+        assert recipe.steps["apply"].skip_when_true == "context.is_silent_type"
+
+    def test_apply_retries(self, recipe) -> None:
+        assert recipe.steps["apply"].retries == 2
+
+    def test_apply_on_exhausted(self, recipe) -> None:
+        assert recipe.steps["apply"].on_exhausted == "synthesize"
+
+    def test_apply_on_context_limit(self, recipe) -> None:
+        assert recipe.steps["apply"].on_context_limit == "synthesize"
+
+    def test_apply_on_failure(self, recipe) -> None:
+        assert recipe.steps["apply"].on_failure == "synthesize"
+
+    def test_apply_receives_scope_report(self, recipe) -> None:
+        step = recipe.steps["apply"]
+        cmd = step.with_args["skill_command"]
+        assert "${{ context.scope_report }}" in cmd
+
+    def test_apply_captures(self, recipe) -> None:
+        capture = recipe.steps["apply"].capture
+        for key in ("findings_manifest_path", "evaluation_dashboard"):
+            assert key in capture, f"Missing capture key: {key}"
+
+    def test_synthesize_phoropter_family(self, recipe) -> None:
+        assert recipe.steps["synthesize"].phoropter_family == "review-design"
+
+    def test_synthesize_on_result_go(self, recipe) -> None:
+        step = recipe.steps["synthesize"]
         assert step.on_result is not None
         go_cond = next((c for c in step.on_result.conditions if c.when and "GO" in c.when), None)
         assert go_cond is not None, "Missing GO route"
-        assert go_cond.route == "dial"
+        assert go_cond.route == "vis_dial"
 
-    def test_review_design_on_result_revise(self, recipe) -> None:
-        step = recipe.steps["review_design"]
+    def test_synthesize_on_result_revise(self, recipe) -> None:
+        step = recipe.steps["synthesize"]
         assert step.on_result is not None
         revise_cond = next(
             (c for c in step.on_result.conditions if c.when and "REVISE" in c.when), None
@@ -134,8 +178,8 @@ class TestResearchDesignRecipeStructure:
         assert revise_cond is not None, "Missing REVISE route"
         assert revise_cond.route == "revise_design"
 
-    def test_review_design_on_result_stop(self, recipe) -> None:
-        step = recipe.steps["review_design"]
+    def test_synthesize_on_result_stop(self, recipe) -> None:
+        step = recipe.steps["synthesize"]
         assert step.on_result is not None
         stop_cond = next(
             (c for c in step.on_result.conditions if c.when and "STOP" in c.when), None
@@ -143,70 +187,71 @@ class TestResearchDesignRecipeStructure:
         assert stop_cond is not None, "Missing STOP route"
         assert stop_cond.route == "resolve_design_review"
 
-    def test_review_design_on_result_fallback(self, recipe) -> None:
-        step = recipe.steps["review_design"]
+    def test_synthesize_on_result_fallback(self, recipe) -> None:
+        step = recipe.steps["synthesize"]
         assert step.on_result is not None
         fallback = next((c for c in step.on_result.conditions if c.when is None), None)
         assert fallback is not None, "Missing fallback route"
-        assert fallback.route == "dial"
+        assert fallback.route == "vis_dial"
 
-    def test_review_design_no_on_success(self, recipe) -> None:
-        assert recipe.steps["review_design"].on_success is None
-
-    def test_review_design_captures(self, recipe) -> None:
-        capture = recipe.steps["review_design"].capture
-        for key in ("verdict", "experiment_type", "evaluation_dashboard", "revision_guidance"):
-            assert key in capture, f"Missing capture key: {key}"
-
-    def test_review_design_receives_scope_report(self, recipe) -> None:
-        """review_design step must pass scope_report as a second argument."""
-        step = recipe.steps["review_design"]
-        cmd = step.with_args["skill_command"]
-        assert "${{ context.scope_report }}" in cmd
-
-    def test_dial_phoropter_family(self, recipe) -> None:
-        assert recipe.steps["dial"].phoropter_family == "vis-lens"
-
-    def test_dial_on_success(self, recipe) -> None:
-        assert recipe.steps["dial"].on_success == "apply"
-
-    def test_dial_on_failure(self, recipe) -> None:
-        assert recipe.steps["dial"].on_failure == "escalate_stop"
-
-    def test_dial_captures(self, recipe) -> None:
-        capture = recipe.steps["dial"].capture
-        assert "selected_lenses" in capture
-        assert "lens_context_paths" in capture
-
-    def test_apply_phoropter_family(self, recipe) -> None:
-        assert recipe.steps["apply"].phoropter_family == "vis-lens"
-
-    def test_apply_capture_list(self, recipe) -> None:
-        assert "all_figure_spec_paths" in recipe.steps["apply"].capture_list
-
-    def test_apply_retries_zero(self, recipe) -> None:
-        assert recipe.steps["apply"].retries == 0
-
-    def test_apply_on_success(self, recipe) -> None:
-        assert recipe.steps["apply"].on_success == "synthesize"
-
-    def test_apply_on_failure(self, recipe) -> None:
-        assert recipe.steps["apply"].on_failure == "synthesize"
-
-    def test_synthesize_phoropter_family(self, recipe) -> None:
-        assert recipe.steps["synthesize"].phoropter_family == "vis-lens"
-
-    def test_synthesize_on_success(self, recipe) -> None:
-        assert recipe.steps["synthesize"].on_success == "create_worktree"
-
-    def test_synthesize_on_failure(self, recipe) -> None:
-        assert recipe.steps["synthesize"].on_failure == "escalate_stop"
+    def test_synthesize_no_on_success(self, recipe) -> None:
+        assert recipe.steps["synthesize"].on_success is None
 
     def test_synthesize_captures(self, recipe) -> None:
         capture = recipe.steps["synthesize"].capture
+        for key in ("verdict", "revision_guidance"):
+            assert key in capture, f"Missing capture key: {key}"
+
+    def test_vis_dial_phoropter_family(self, recipe) -> None:
+        assert recipe.steps["vis_dial"].phoropter_family is None
+
+    def test_vis_dial_on_success(self, recipe) -> None:
+        assert recipe.steps["vis_dial"].on_success == "vis_apply"
+
+    def test_vis_dial_on_failure(self, recipe) -> None:
+        assert recipe.steps["vis_dial"].on_failure == "escalate_stop"
+
+    def test_vis_dial_captures(self, recipe) -> None:
+        capture = recipe.steps["vis_dial"].capture
+        assert "selected_lenses" in capture
+        assert "lens_context_paths" in capture
+
+    def test_vis_apply_phoropter_family(self, recipe) -> None:
+        assert recipe.steps["vis_apply"].phoropter_family is None
+
+    def test_vis_apply_capture_list(self, recipe) -> None:
+        assert "all_figure_spec_paths" in recipe.steps["vis_apply"].capture_list
+
+    def test_vis_apply_retries_zero(self, recipe) -> None:
+        assert recipe.steps["vis_apply"].retries == 0
+
+    def test_vis_apply_on_success(self, recipe) -> None:
+        assert recipe.steps["vis_apply"].on_success == "vis_synthesize"
+
+    def test_vis_apply_on_failure(self, recipe) -> None:
+        assert recipe.steps["vis_apply"].on_failure == "vis_synthesize"
+
+    def test_vis_synthesize_phoropter_family(self, recipe) -> None:
+        assert recipe.steps["vis_synthesize"].phoropter_family is None
+
+    def test_vis_synthesize_on_success(self, recipe) -> None:
+        assert recipe.steps["vis_synthesize"].on_success == "create_worktree"
+
+    def test_vis_synthesize_on_failure(self, recipe) -> None:
+        assert recipe.steps["vis_synthesize"].on_failure == "escalate_stop"
+
+    def test_vis_synthesize_captures(self, recipe) -> None:
+        capture = recipe.steps["vis_synthesize"].capture
         assert "visualization_plan_path" in capture
         assert "report_plan_path" in capture
         assert "visualization_plan_trace_path" in capture
+
+    def test_check_design_review_loop_non_exhausted_routes_to_apply(self, recipe) -> None:
+        step = recipe.steps["check_design_review_loop"]
+        assert step.on_result is not None
+        default = next((c for c in step.on_result.conditions if c.when is None), None)
+        assert default is not None
+        assert default.route == "apply"
 
     def test_no_plan_visualization_step(self, recipe) -> None:
         assert "plan_visualization" not in recipe.steps

--- a/tests/recipe/test_rules_phoropter_adjacency.py
+++ b/tests/recipe/test_rules_phoropter_adjacency.py
@@ -284,3 +284,22 @@ def test_route_action_does_not_trigger_interleaving():
     )
     findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-step-interleaving"]
     assert len(findings) == 0
+
+
+def test_non_canonical_phase_between_canonical_phases_is_transparent():
+    """A run_python step with phoropter_family set but a non-canonical step key between
+    dial and apply must NOT produce a phase-order or interleaving finding."""
+    import autoskillit.recipe  # noqa: F401
+
+    recipe = _make_recipe(
+        {
+            "dial": RecipeStep(tool="run_skill", phoropter_family="test-fam"),
+            "select_review_dimensions": RecipeStep(tool="run_python", phoropter_family="test-fam"),
+            "apply": RecipeStep(tool="run_skill", phoropter_family="test-fam"),
+            "synthesize": RecipeStep(tool="run_skill", phoropter_family="test-fam"),
+            "done": RecipeStep(action="stop"),
+        }
+    )
+    phoropter_rules = {"phoropter-phase-order", "phoropter-step-interleaving"}
+    findings = [f for f in run_semantic_rules(recipe) if f.rule in phoropter_rules]
+    assert len(findings) == 0

--- a/tests/recipe/test_schema.py
+++ b/tests/recipe/test_schema.py
@@ -241,6 +241,30 @@ def test_skip_when_false_field_is_parsed_from_yaml() -> None:
     assert step.skip_when_false == "inputs.open_pr"
 
 
+def test_phoropter_family_and_skip_when_true_fields_default_to_none() -> None:
+    """RecipeStep must have phoropter_family and skip_when_true fields defaulting to None."""
+    from autoskillit.recipe.schema import RecipeStep
+
+    step = RecipeStep(tool="run_skill")
+    assert step.phoropter_family is None
+    assert step.skip_when_true is None
+
+
+def test_phoropter_family_and_skip_when_true_parsed_from_yaml() -> None:
+    """phoropter_family and skip_when_true must be deserialized from YAML recipe data."""
+    from autoskillit.recipe.io import _parse_step
+
+    raw = {
+        "tool": "run_skill",
+        "phoropter_family": "review-design",
+        "skip_when_true": "context.is_silent_type",
+        "on_success": "next_step",
+    }
+    step = _parse_step(raw)
+    assert step.phoropter_family == "review-design"
+    assert step.skip_when_true == "context.is_silent_type"
+
+
 # ---------------------------------------------------------------------------
 # RECIPE-8: constant step type
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Decompose the monolithic `review_design` step in `research-design.yaml` into four phoropter steps (`dial`, `select_review_dimensions`, `apply`, `synthesize`) with `phoropter_family: review-design`. This requires:

1. Adding a `skip_when_true` field to `RecipeStep` (declaration-only LLM-directed annotation, not server-side pruned)
2. Updating `rules_phoropter_adjacency.py` to treat non-canonical phase names as transparent within a phoropter family
3. Renaming existing vis-lens steps to `vis_dial`/`vis_apply`/`vis_synthesize` (removing their `phoropter_family` to match the research.yaml precedent)
4. Inserting the four new review-design phoropter steps with full routing
5. Regenerating contracts
6. Rewriting all tests

The decomposition follows the precedent set by commit `250385aa` (#3653) which performed the analogous decomposition in `research.yaml`, but uses `select_review_dimensions` (a `run_python` step) and `skip_when_true` on the `apply` step instead of a `silent_type_gate` route action.

**Design note on `skip_when_true`:** This field is an LLM-directed runtime annotation — the sous-chef orchestrator reads it at runtime and skips the step accordingly. It is NOT evaluated by the server-side `_prune_skipped_steps` engine (which only handles `skip_when_false` with `inputs.*` refs). The `context.is_silent_type` value is a runtime capture from the `dial` step, not an ingredient, so server-side evaluation is architecturally impossible. This follows the same pattern as `skip_when_false` with non-ingredient refs, which are served as-is to the LLM without server-side evaluation.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260603-024813-749071/.autoskillit/temp/make-plan/p3_a3_wp1_decompose_review_design_plan_2026-06-03_030600.md`

Closes #3093

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 1.5k | 103.8k | 5.7M | 162.7k | 122 | 301.1k | 47m 45s |
| post_run_diagnostics* | sonnet | 1 | 102 | 21.6k | 660.4k | 82.7k | 32 | 67.8k | 17m 1s |
| dispatch:e08b00aa-a9a7-45fa-bb96-d73116c8f85c* | sonnet | 1 | 90 | 4.1k | 676.1k | 70.2k | 23 | 48.6k | 42m 17s |
| review_approach* | sonnet | 1 | 8.1k | 7.1k | 208.8k | 54.6k | 16 | 42.1k | 7m 53s |
| verify* | sonnet | 1 | 715 | 12.6k | 612.8k | 64.9k | 32 | 48.2k | 4m 37s |
| implement* | MiniMax-M3 | 1 | 124.7k | 25.5k | 5.4M | 128.4k | 151 | 0 | 12m 27s |
| audit_impl* | sonnet | 1 | 54 | 7.2k | 175.3k | 36.4k | 17 | 30.9k | 4m 7s |
| prepare_pr* | MiniMax-M3 | 1 | 52.8k | 3.3k | 215.3k | 55.7k | 16 | 0 | 1m 20s |
| compose_pr* | MiniMax-M3 | 1 | 35.6k | 1.3k | 149.1k | 38.6k | 11 | 0 | 48s |
| **Total** | | | 223.6k | 186.5k | 13.8M | 162.7k | | 538.7k | 2h 18m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| post_run_diagnostics | 0 | — | — | — |
| dispatch:e08b00aa-a9a7-45fa-bb96-d73116c8f85c | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 462 | 11703.4 | 0.0 | 55.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **462** | 29780.7 | 1166.0 | 403.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.5k | 103.8k | 5.7M | 301.1k | 47m 45s |
| sonnet | 5 | 9.0k | 52.5k | 2.3M | 237.6k | 1h 15m |
| MiniMax-M3 | 3 | 213.1k | 30.2k | 5.8M | 0 | 14m 35s |