### PR TITLE
Implementation Plan: Update Recipe Infrastructure (config, skill_contracts.yaml) — P3-A5-WP1

### DIFF
--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -286,6 +286,8 @@ skills:
     - prepare-research-pr
     - compose-research-pr
     - review-design
+    - classify-experiment-type
+    - apply-review-dimensions
     - resolve-design-review
     - resolve-research-review
     - troubleshoot-experiment
@@ -293,8 +295,6 @@ skills:
     - resolve-claims-review
     - build-execution-map
     - promote-to-main
-    - classify-experiment-type
-    - apply-review-dimensions
 
 workspace:
   worktree_root: null   # null = auto-resolve to ../worktrees/ relative to project root

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1747,7 +1747,6 @@ skills:
       type: file_path
     expected_output_patterns:
     - "findings_manifest_path[ \\t]*=[ \\t]*/.+"
-    - "(?:evaluation_dashboard_path[ \\t]*=[ \\t]*/.+|findings_manifest_path[ \\t]*=[ \\t]*/.+)"
     pattern_examples:
     - "findings_manifest_path = /tmp/apply-review-dimensions/findings_manifest_benchmark_2026-06-02_183000.json\nevaluation_dashboard_path = /tmp/apply-review-dimensions/evaluation_dashboard_benchmark_2026-06-02_183000.md\n%%ORDER_UP%%"
     - "findings_manifest_path = /tmp/apply-review-dimensions/findings_manifest_causal_inference_2026-06-02_183000.json\n%%ORDER_UP%%"

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1684,6 +1684,76 @@ skills:
     - "verdict = GO\nexperiment_type = exploratory\nevaluation_dashboard = /tmp/eval.md\n%%ORDER_UP%%"
     write_behavior: always
 
+  classify-experiment-type:
+    inputs:
+    - name: experiment_plan_path
+      type: file_path
+      required: true
+    - name: scope_report_path
+      type: file_path
+      required: false
+    outputs:
+    - name: experiment_type
+      type: string
+      allowed_values: [benchmark, configuration_study, causal_inference, robustness_audit, exploratory]
+    - name: dimension_weights
+      type: string
+    - name: is_silent_type
+      type: string
+      allowed_values: ['true', 'false']
+    - name: classification_timestamp
+      type: string
+    - name: dimensions_manifest_path
+      type: file_path
+    - name: selected_lenses
+      type: string
+    - name: lens_context_paths
+      type: string
+    expected_output_patterns:
+    - "experiment_type[ \\t]*=[ \\t]*\\S+"
+    - "dimension_weights[ \\t]*=[ \\t]*[a-z_]+:[HMLS](,[a-z_]+:[HMLS])*"
+    - "is_silent_type[ \\t]*=[ \\t]*(true|false)"
+    - "dimensions_manifest_path[ \\t]*=[ \\t]*/.+"
+    - "selected_lenses[ \\t]*=[ \\t]*([^\\n]*|none)"
+    - "lens_context_paths[ \\t]*=[ \\t]*([^\\n]*|none)"
+    pattern_examples:
+    - "experiment_type = benchmark\ndimension_weights = causal_structure:H,variance_protocol:M,statistical_corrections:M,ecological_validity:M,measurement_alignment:H,resource_proportionality:M,data_acquisition:H,agent_implementability:M,scope_alignment:M\nis_silent_type = false\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /tmp/classify-experiment-type/dimensions_manifest_benchmark_2026-06-02_183000.json\nselected_lenses = causal_structure,variance_protocol,statistical_corrections,ecological_validity,measurement_alignment,resource_proportionality,data_acquisition,agent_implementability,scope_alignment\nlens_context_paths = /tmp/classify-experiment-type/lens_ctx_causal_structure_benchmark_2026-06-02_183000.md,/tmp/classify-experiment-type/lens_ctx_variance_protocol_benchmark_2026-06-02_183000.md\n%%ORDER_UP%%"
+    - "experiment_type = exploratory\ndimension_weights = causal_structure:S,variance_protocol:S,statistical_corrections:S,ecological_validity:S,measurement_alignment:S,resource_proportionality:S,data_acquisition:L,agent_implementability:L,scope_alignment:S\nis_silent_type = true\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /tmp/classify-experiment-type/dimensions_manifest_exploratory_2026-06-02_183000.json\nselected_lenses = \nlens_context_paths = \n%%ORDER_UP%%"
+    - "experiment_type = configuration_study\ndimension_weights = causal_structure:M,variance_protocol:H,statistical_corrections:M,ecological_validity:M,measurement_alignment:M,resource_proportionality:H,data_acquisition:M,agent_implementability:H,scope_alignment:M\nis_silent_type = false\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /tmp/classify-experiment-type/dimensions_manifest_configuration_study_2026-06-02_183000.json\nselected_lenses = causal_structure,variance_protocol,statistical_corrections,ecological_validity,measurement_alignment,resource_proportionality,data_acquisition,agent_implementability,scope_alignment\nlens_context_paths = /tmp/classify-experiment-type/lens_ctx_variance_protocol_configuration_study_2026-06-02_183000.md\n%%ORDER_UP%%"
+    - "experiment_type = causal_inference\ndimension_weights = causal_structure:H,variance_protocol:H,statistical_corrections:H,ecological_validity:M,measurement_alignment:H,resource_proportionality:M,data_acquisition:H,agent_implementability:M,scope_alignment:M\nis_silent_type = false\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /tmp/classify-experiment-type/dimensions_manifest_causal_inference_2026-06-02_183000.json\nselected_lenses = causal_structure,variance_protocol,statistical_corrections,ecological_validity,measurement_alignment,resource_proportionality,data_acquisition,agent_implementability,scope_alignment\nlens_context_paths = /tmp/classify-experiment-type/lens_ctx_causal_structure_causal_inference_2026-06-02_183000.md\n%%ORDER_UP%%"
+    - "experiment_type = robustness_audit\ndimension_weights = causal_structure:M,variance_protocol:H,statistical_corrections:H,ecological_validity:H,measurement_alignment:M,resource_proportionality:M,data_acquisition:M,agent_implementability:M,scope_alignment:H\nis_silent_type = false\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /tmp/classify-experiment-type/dimensions_manifest_robustness_audit_2026-06-02_183000.json\nselected_lenses = causal_structure,variance_protocol,statistical_corrections,ecological_validity,measurement_alignment,resource_proportionality,data_acquisition,agent_implementability,scope_alignment\nlens_context_paths = /tmp/classify-experiment-type/lens_ctx_variance_protocol_robustness_audit_2026-06-02_183000.md\n%%ORDER_UP%%"
+    write_behavior: always
+  apply-review-dimensions:
+    inputs:
+    - name: dimensions_manifest_path
+      type: file_path
+      required: true
+    - name: scope_report_path
+      type: file_path
+      required: false
+    - name: experiment_plan_path
+      type: file_path
+      required: true
+    - name: experiment_type
+      type: string
+      required: true
+    - name: classification_timestamp
+      type: string
+      required: true
+    outputs:
+    - name: findings_manifest_path
+      type: file_path
+    - name: evaluation_dashboard_path
+      type: file_path
+    expected_output_patterns:
+    - "findings_manifest_path[ \\t]*=[ \\t]*/.+"
+    - "(?:evaluation_dashboard_path[ \\t]*=[ \\t]*/.+|findings_manifest_path[ \\t]*=[ \\t]*/.+)"
+    pattern_examples:
+    - "findings_manifest_path = /tmp/apply-review-dimensions/findings_manifest_benchmark_2026-06-02_183000.json\nevaluation_dashboard_path = /tmp/apply-review-dimensions/evaluation_dashboard_benchmark_2026-06-02_183000.md\n%%ORDER_UP%%"
+    - "findings_manifest_path = /tmp/apply-review-dimensions/findings_manifest_causal_inference_2026-06-02_183000.json\n%%ORDER_UP%%"
+    - "findings_manifest_path = /tmp/apply-review-dimensions/findings_manifest_exploratory_2026-06-02_183000.json\n%%ORDER_UP%%"
+    write_behavior: always
+
   review-research-pr:
     inputs:
     - name: worktree_path
@@ -2376,69 +2446,6 @@ skills:
     - "## Findings\n### confirmed_bug\n...\n---pipeline-health-result---\n%%ORDER_UP%%"
     - "Analysis complete.\n\n---\npipeline-health-result---\n%%ORDER_UP%%"
     read_only: true
-  classify-experiment-type:
-    inputs:
-    - name: experiment_plan_path
-      type: file_path
-      required: true
-    - name: scope_report_path
-      type: file_path
-      required: false
-    outputs:
-    - name: experiment_type
-      type: string
-    - name: dimension_weights
-      type: string
-    - name: is_silent_type
-      type: string
-      allowed_values: ['true', 'false']
-    - name: classification_timestamp
-      type: string
-    - name: dimensions_manifest_path
-      type: file_path
-    - name: selected_lenses
-      type: string
-    - name: lens_context_paths
-      type: string
-    expected_output_patterns:
-    - "experiment_type[ \\t]*=[ \\t]*\\S+"
-    - "dimension_weights[ \\t]*=[ \\t]*[a-z_]+:[HMLS](,[a-z_]+:[HMLS])*"
-    - "is_silent_type[ \\t]*=[ \\t]*(true|false)"
-    - "dimensions_manifest_path[ \\t]*=[ \\t]*/.+"
-    - "selected_lenses[ \\t]*=[ \\t]*([^\\n]*|none)"
-    - "lens_context_paths[ \\t]*=[ \\t]*([^\\n]*|none)"
-    pattern_examples:
-    - "experiment_type = benchmark\ndimension_weights = causal_structure:H,variance_protocol:M,statistical_corrections:M,ecological_validity:M,measurement_alignment:H,resource_proportionality:M,data_acquisition:H,agent_implementability:M,scope_alignment:M\nis_silent_type = false\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /tmp/classify-experiment-type/dimensions_manifest_benchmark_2026-06-02_183000.json\nselected_lenses = causal_structure,variance_protocol,statistical_corrections,ecological_validity,measurement_alignment,resource_proportionality,data_acquisition,agent_implementability,scope_alignment\nlens_context_paths = /tmp/classify-experiment-type/lens_ctx_causal_structure_benchmark_2026-06-02_183000.md,/tmp/classify-experiment-type/lens_ctx_variance_protocol_benchmark_2026-06-02_183000.md\n%%ORDER_UP%%"
-    - "experiment_type = exploratory\ndimension_weights = causal_structure:S,variance_protocol:S,statistical_corrections:S,ecological_validity:S,measurement_alignment:S,resource_proportionality:S,data_acquisition:L,agent_implementability:L,scope_alignment:S\nis_silent_type = true\nclassification_timestamp = 2026-06-02T18:30:00Z\ndimensions_manifest_path = /tmp/classify-experiment-type/dimensions_manifest_exploratory_2026-06-02_183000.json\nselected_lenses = \nlens_context_paths = \n%%ORDER_UP%%"
-    write_behavior: always
-  apply-review-dimensions:
-    inputs:
-    - name: dimensions_manifest_path
-      type: file_path
-      required: true
-    - name: scope_report_path
-      type: file_path
-      required: false
-    - name: experiment_plan_path
-      type: file_path
-      required: true
-    - name: experiment_type
-      type: string
-      required: true
-    - name: classification_timestamp
-      type: string
-      required: true
-    outputs:
-    - name: findings_manifest_path
-      type: file_path
-    - name: evaluation_dashboard_path
-      type: file_path
-    expected_output_patterns:
-    - "findings_manifest_path[ \\t]*=[ \\t]*/.+"
-    - "evaluation_dashboard_path[ \\t]*=[ \\t]*/.+"
-    pattern_examples:
-    - "findings_manifest_path = /tmp/apply-review-dimensions/findings_manifest_benchmark_2026-06-02_183000.json\nevaluation_dashboard_path = /tmp/apply-review-dimensions/evaluation_dashboard_benchmark_2026-06-02_183000.md\n%%ORDER_UP%%"
-    write_behavior: always
 callable_contracts:
   autoskillit.smoke_utils.check_loop_iteration:
     inputs:

--- a/tests/contracts/test_skill_contracts.py
+++ b/tests/contracts/test_skill_contracts.py
@@ -131,22 +131,66 @@ def test_skill_contracts_pattern_examples_use_valid_experiment_types() -> None:
         )
 
 
-def test_review_design_experiment_type_output_has_allowed_values() -> None:
-    """review-design contract must declare allowed_values for experiment_type output.
-
-    Without this constraint, invalid values (e.g. 'controlled') can propagate
-    silently through capture and downstream recipe steps.
-    """
+@pytest.mark.parametrize(
+    "skill_name",
+    ["review-design", "classify-experiment-type"],
+)
+def test_experiment_type_output_has_allowed_values(skill_name: str) -> None:
+    """Skills that emit experiment_type must declare allowed_values matching
+    VALID_EXPERIMENT_TYPES — the canonical set shared across the phoropter pipeline."""
     contracts = load_yaml(_CONTRACTS_YAML)
-    review_design = contracts["skills"]["review-design"]
-    outputs = {o["name"]: o for o in review_design["outputs"]}
+    skill = contracts["skills"][skill_name]
+    outputs = {o["name"]: o for o in skill["outputs"]}
     et_output = outputs.get("experiment_type")
-    assert et_output is not None, "review-design must declare experiment_type output"
+    assert et_output is not None, f"{skill_name} must declare experiment_type output"
     assert "allowed_values" in et_output, (
-        "experiment_type output must have allowed_values constraint. "
+        f"{skill_name}: experiment_type output must have allowed_values constraint. "
         "Without it, invalid values propagate silently."
     )
     assert set(et_output["allowed_values"]) == VALID_EXPERIMENT_TYPES
+
+
+def test_classify_and_apply_in_tier3_between_review_and_resolve() -> None:
+    """classify-experiment-type and apply-review-dimensions must be positioned
+    between review-design and resolve-design-review in defaults.yaml tier3."""
+    defaults = load_yaml(_CONTRACTS_YAML.parent.parent / "config" / "defaults.yaml")
+    tier3 = defaults["skills"]["tier3"]
+    rd_idx = tier3.index("review-design")
+    rdr_idx = tier3.index("resolve-design-review")
+    cet_idx = tier3.index("classify-experiment-type")
+    ard_idx = tier3.index("apply-review-dimensions")
+    assert rd_idx < cet_idx < rdr_idx, (
+        f"classify-experiment-type (idx={cet_idx}) must be between "
+        f"review-design (idx={rd_idx}) and resolve-design-review (idx={rdr_idx})"
+    )
+    assert rd_idx < ard_idx < rdr_idx, (
+        f"apply-review-dimensions (idx={ard_idx}) must be between "
+        f"review-design (idx={rd_idx}) and resolve-design-review (idx={rdr_idx})"
+    )
+
+
+def test_classify_experiment_type_pattern_examples_cover_all_types(
+    skills: dict[str, Any],
+) -> None:
+    """classify-experiment-type pattern_examples must cover all 5 experiment types."""
+    examples = skills["classify-experiment-type"].get("pattern_examples", [])
+    example_text = "\n".join(examples)
+    for et in sorted(VALID_EXPERIMENT_TYPES):
+        assert f"experiment_type = {et}" in example_text, (
+            f"Missing pattern_example for experiment_type={et}"
+        )
+
+
+def test_apply_review_dimensions_pattern_examples_minimum_count(
+    skills: dict[str, Any],
+) -> None:
+    """apply-review-dimensions must have >=3 pattern_examples covering normal,
+    edge case (no evaluation_dashboard), and silent-type short-circuit."""
+    examples = skills["apply-review-dimensions"].get("pattern_examples", [])
+    assert len(examples) >= 3, (
+        f"apply-review-dimensions has {len(examples)} pattern_examples, need >=3: "
+        "normal run, edge case (findings only), silent-type short-circuit"
+    )
 
 
 def test_review_design_has_scope_report_input(skills: dict[str, Any]) -> None:

--- a/tests/contracts/test_skill_contracts.py
+++ b/tests/contracts/test_skill_contracts.py
@@ -167,6 +167,11 @@ def test_classify_and_apply_in_tier3_between_review_and_resolve() -> None:
         f"apply-review-dimensions (idx={ard_idx}) must be between "
         f"review-design (idx={rd_idx}) and resolve-design-review (idx={rdr_idx})"
     )
+    assert cet_idx < ard_idx, (
+        f"classify-experiment-type (idx={cet_idx}) must precede "
+        f"apply-review-dimensions (idx={ard_idx}) — classify emits experiment_type "
+        "which apply-review-dimensions consumes"
+    )
 
 
 def test_classify_experiment_type_pattern_examples_cover_all_types(


### PR DESCRIPTION
## Summary

Both `classify-experiment-type` and `apply-review-dimensions` already exist in `defaults.yaml` tier3 and `skill_contracts.yaml`, but have gaps against the acceptance criteria:

1. **defaults.yaml positioning**: Both skills are appended at the END of tier3 (lines 296–297), not between `review-design` and `resolve-design-review` as required.
2. **classify-experiment-type contract**: Missing `allowed_values` on the `experiment_type` output; only 2 of 5 experiment types covered in `pattern_examples`.
3. **apply-review-dimensions contract**: `evaluation_dashboard_path` pattern is unconditionally required (blocking edge-case examples); only 1 pattern_example (need 3).
4. **Contract entry ordering**: Both entries are at the end of the `skills:` section, not adjacent to `review-design`.

**Input name discrepancy note:** The issue specifies `experiment_plan`/`scope_report`/`dimensions_manifest` but the actual SKILL.md implementations use `experiment_plan_path`/`scope_report_path`/`dimensions_manifest_path`. The current contracts correctly match the SKILL.md token names — no rename needed.

Closes #3095

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260603-043114-576601/.autoskillit/temp/make-plan/update_recipe_infrastructure_plan_2026-06-03_043600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 719 | 32.0k | 1.4M | 96.5k | 59 | 103.4k | 23m 13s |
| verify* | sonnet | 1 | 84 | 12.5k | 475.3k | 68.6k | 30 | 52.0k | 4m 25s |
| implement* | MiniMax-M3 | 1 | 76.4k | 17.8k | 2.3M | 75.7k | 88 | 0 | 8m 52s |
| audit_impl* | sonnet | 1 | 494 | 10.7k | 217.1k | 40.8k | 18 | 36.6k | 4m 40s |
| prepare_pr* | MiniMax-M3 | 1 | 41.6k | 2.9k | 119.3k | 46.2k | 13 | 0 | 1m 0s |
| compose_pr* | MiniMax-M3 | 1 | 38.1k | 2.0k | 230.5k | 40.6k | 14 | 0 | 53s |
| review_pr* | sonnet | 2 | 272 | 33.9k | 1.4M | 63.3k | 74 | 91.2k | 8m 38s |
| resolve_review* | sonnet | 1 | 197 | 7.7k | 1.3M | 63.7k | 59 | 47.5k | 4m 56s |
| **Total** | | | 157.8k | 119.6k | 7.5M | 96.5k | | 330.6k | 56m 41s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 201 | 11620.4 | 0.0 | 88.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 208499.8 | 7915.2 | 1289.8 |
| **Total** | **207** | 36141.2 | 1597.0 | 578.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 719 | 32.0k | 1.4M | 103.4k | 23m 13s |
| sonnet | 4 | 1.0k | 64.9k | 3.4M | 227.2k | 22m 41s |
| MiniMax-M3 | 3 | 156.1k | 22.7k | 2.7M | 0 | 10m 46s |