### PR TITLE
Rectify: Backend Override Not Threaded to init_session

### DIFF
--- a/src/autoskillit/server/_misc.py
+++ b/src/autoskillit/server/_misc.py
@@ -41,6 +41,9 @@ from autoskillit.execution import (
     fetch_repo_merge_state as fetch_repo_merge_state,
 )
 from autoskillit.execution import (
+    get_backend as get_backend,
+)
+from autoskillit.execution import (
     invalidate_cache as invalidate_cache,
 )
 from autoskillit.execution import (

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -20,6 +20,8 @@ from autoskillit.core import (
     DISPATCH_ID_ENV_VAR,
     SKILL_COMMAND_DISPLAY_MAX,
     WORKTREE_SKILLS,
+    ClaudeDirectoryConventions,
+    CodingAgentBackend,
     SkillResult,
     ValidatedAddDir,
     WriteBehaviorSpec,
@@ -49,6 +51,9 @@ from autoskillit.server._misc import (
     _hook_config_overlay_path,
     _pipeline_tracker_path,
     resolve_closure_write_dirs,
+)
+from autoskillit.server._misc import (
+    get_backend as _get_backend,
 )
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._subprocess import _run_subprocess
@@ -666,6 +671,12 @@ async def run_skill(
                 else None
             )
 
+            _effective_backend_obj: CodingAgentBackend | None = (
+                _get_backend(backend_override)
+                if backend_override is not None and tool_ctx.backend is not None
+                else tool_ctx.backend
+            )
+
             if backend_override:
                 logger.info(
                     "backend_override_activated",
@@ -690,7 +701,9 @@ async def run_skill(
 
             # Backend compatibility gate — fires before both replay and live session paths.
             if _skill_info and tool_ctx.backend is not None:
-                _effective_backend = backend_override or tool_ctx.backend.name
+                _effective_backend = (
+                    _effective_backend_obj.name if _effective_backend_obj is not None else ""
+                )
                 if _is_backend_incompatible(_skill_info, _effective_backend):
                     return SkillResult.crashed(
                         exception=RuntimeError(
@@ -805,7 +818,7 @@ async def run_skill(
                     recipe_packs=tool_ctx.active_recipe_packs,
                     recipe_features=tool_ctx.active_recipe_features,
                     allow_only=allow_only,
-                    backend=tool_ctx.backend,
+                    backend=_effective_backend_obj,
                 )
                 skill_add_dirs.append(session_root)
 
@@ -816,12 +829,13 @@ async def run_skill(
                         and tool_ctx.skill_resolver.resolve(target_name) is not None
                     )
                     if _is_known_skill:
+                        _skills_subdir = (
+                            _effective_backend_obj.conventions.skills_subdir
+                            if _effective_backend_obj is not None
+                            else ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
+                        )
                         _skill_md = (
-                            Path(session_root.path)
-                            / ".claude"
-                            / "skills"
-                            / target_name
-                            / "SKILL.md"
+                            Path(session_root.path) / _skills_subdir / target_name / "SKILL.md"
                         )
                         if not _skill_md.exists():
                             logger.error(

--- a/tests/server/test_tools_execution_backend_mixing.py
+++ b/tests/server/test_tools_execution_backend_mixing.py
@@ -307,3 +307,130 @@ async def test_backend_override_emits_structured_log_provider_profile(
     log = override_logs[0]
     assert log["reason"] == "provider_profile"
     assert log["original_backend"] == "codex"
+
+
+@pytest.mark.anyio
+async def test_backend_override_threads_effective_backend_to_init_session(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    """When backend_override is set, init_session receives the overridden backend
+    (ClaudeCodeBackend), not the orchestrator backend (Codex)."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import ValidatedAddDir
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    fake_backend = MagicMock(spec=CodingAgentBackend)
+    fake_backend.name = "codex"
+    fake_backend.capabilities.anthropic_provider_capable = False
+    tool_ctx_kitchen_open.backend = fake_backend
+
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    skill_md = session_dir / ".claude" / "skills" / "test-skill" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True)
+    skill_md.write_text("name: test-skill\n")
+
+    fake_validated = ValidatedAddDir(path=str(session_dir))
+    mock_ssm = MagicMock()
+    mock_ssm.init_session.return_value = fake_validated
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+
+    mock_skill_info = MagicMock()
+    mock_skill_info.backend_requirements = frozenset({"claude-code"})
+    mock_resolver = MagicMock()
+    mock_resolver.resolve.return_value = mock_skill_info
+    tool_ctx_kitchen_open.skill_resolver = mock_resolver
+
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a, **kw: ("default", {}),
+    )
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution.resolve_target_skill",
+        lambda cmd, resolver: ("/autoskillit:test-skill", "test-skill"),
+    )
+
+    await run_skill("/autoskillit:test-skill", str(tmp_path))
+
+    mock_ssm.init_session.assert_called_once()
+    init_backend = mock_ssm.init_session.call_args.kwargs.get("backend")
+    assert init_backend is not fake_backend, (
+        "init_session must NOT receive the orchestrator backend"
+    )
+    assert init_backend.name == "claude-code"
+
+
+@pytest.mark.anyio
+async def test_backend_override_skill_md_uses_effective_conventions(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    """SKILL.md path uses the effective backend's conventions.skills_subdir,
+    not a hardcoded '.claude/skills'."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import ValidatedAddDir
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    fake_backend = MagicMock(spec=CodingAgentBackend)
+    fake_backend.name = "codex"
+    fake_backend.capabilities.anthropic_provider_capable = False
+    tool_ctx_kitchen_open.backend = fake_backend
+
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    skill_md = session_dir / ".claude" / "skills" / "test-skill" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True)
+    skill_md.write_text("name: test-skill\n")
+
+    fake_validated = ValidatedAddDir(path=str(session_dir))
+    mock_ssm = MagicMock()
+    mock_ssm.init_session.return_value = fake_validated
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+
+    mock_skill_info = MagicMock()
+    mock_skill_info.backend_requirements = frozenset({"claude-code"})
+    mock_resolver = MagicMock()
+    mock_resolver.resolve.return_value = mock_skill_info
+    tool_ctx_kitchen_open.skill_resolver = mock_resolver
+
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a, **kw: ("default", {}),
+    )
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution.resolve_target_skill",
+        lambda cmd, resolver: ("/autoskillit:test-skill", "test-skill"),
+    )
+
+    result_json = await run_skill("/autoskillit:test-skill", str(tmp_path))
+    assert "SKILL.md not found" not in str(result_json), (
+        "SKILL.md at .claude/skills/ should be found when effective backend is claude-code"
+    )
+
+    session_dir_codex = tmp_path / "session_codex"
+    session_dir_codex.mkdir()
+    codex_skill_md = session_dir_codex / "skills" / "test-skill" / "SKILL.md"
+    codex_skill_md.parent.mkdir(parents=True)
+    codex_skill_md.write_text("name: test-skill\n")
+
+    fake_validated_codex = ValidatedAddDir(path=str(session_dir_codex))
+    mock_ssm.reset_mock()
+    mock_ssm.init_session.return_value = fake_validated_codex
+
+    result_json2 = await run_skill("/autoskillit:test-skill", str(tmp_path))
+    assert "SKILL.md not found" in str(result_json2), (
+        "SKILL.md at codex 'skills/' should NOT be found when effective backend is claude-code"
+    )

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -321,6 +321,59 @@ async def test_run_skill_passes_backend_to_init_session(
     assert mock_ssm.init_session.call_args.kwargs.get("backend") is fake_backend
 
 
+@pytest.mark.anyio
+async def test_run_skill_passes_effective_backend_to_init_session_when_override(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    """When backend_override is triggered, init_session receives the overridden
+    backend object, not tool_ctx.backend."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import ValidatedAddDir
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    skill_md = session_dir / ".claude" / "skills" / "test-skill" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True)
+    skill_md.write_text("name: test-skill\n")
+
+    fake_validated = ValidatedAddDir(path=str(session_dir))
+    mock_ssm = MagicMock()
+    mock_ssm.init_session.return_value = fake_validated
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+
+    fake_backend = MagicMock(spec=CodingAgentBackend)
+    fake_backend.name = "codex"
+    fake_backend.capabilities.anthropic_provider_capable = False
+    tool_ctx_kitchen_open.backend = fake_backend
+
+    mock_skill_info = MagicMock()
+    mock_skill_info.backend_requirements = frozenset({"claude-code"})
+    mock_resolver = MagicMock()
+    mock_resolver.resolve.return_value = mock_skill_info
+    tool_ctx_kitchen_open.skill_resolver = mock_resolver
+
+    tool_ctx_kitchen_open.executor = InMemoryHeadlessExecutor()
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a, **kw: ("default", {}),
+    )
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution.resolve_target_skill",
+        lambda cmd, resolver: ("/autoskillit:test-skill", "test-skill"),
+    )
+
+    await run_skill("/autoskillit:test-skill", str(tmp_path))
+
+    mock_ssm.init_session.assert_called_once()
+    init_backend = mock_ssm.init_session.call_args.kwargs.get("backend")
+    assert init_backend is not fake_backend
+    assert init_backend.name == "claude-code"
+
+
 class TestOutputDirParameter:
     """output_dir parameter plumbing from run_skill to executor."""
 


### PR DESCRIPTION
## Summary

`run_skill` computes `backend_override="claude-code"` for skills requiring Claude Code but passes the unmodified `tool_ctx.backend` (e.g., Codex) to `init_session` at line 800 of `tools_execution.py`. The provisioning layer then rejects the skill via `_should_inject_skill` backend filtering, causing a `RuntimeError` → `SkillResult.crashed()` for 123 non-diagnostic pipeline steps across 13 recipes.

The architectural weakness is that `backend_override` lives as a loose `str | None` variable, while the downstream consumer (`init_session`) expects a `CodingAgentBackend` object — with no structural enforcement that the two agree. The execution layer (`run_headless_core`) already has the correct pattern: it materializes `step_backend = get_backend(backend_override)` immediately after receiving the override string and uses it uniformly. The server layer lacks this materialization step.

Part A resolves the core bug: materializing an effective backend object and threading it to both `init_session` and the `_skill_md` path check, plus tests that make the gap impossible to regress. Part B will cover the dead `SkillSessionConfig.backend_override` field cleanup and broader test infrastructure hardening for the mock-isolation pattern.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260603-080343-599506/.autoskillit/temp/rectify/rectify_backend_override_init_session_2026-06-03_083000.md`

Closes #3657

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 70 | 22.6k | 2.2M | 110.7k | 69 | 152.1k | 20m 9s |
| review_approach* | opus[1m] | 1 | 48 | 6.2k | 422.3k | 47.1k | 20 | 30.1k | 4m 47s |
| dry_walkthrough* | opus | 1 | 53 | 11.5k | 825.5k | 58.7k | 30 | 41.8k | 7m 29s |
| implement* | opus[1m] | 1 | 113 | 11.3k | 1.7M | 72.2k | 68 | 56.8k | 4m 17s |
| audit_impl* | opus[1m] | 1 | 33 | 9.4k | 178.5k | 39.3k | 16 | 32.6k | 5m 10s |
| prepare_pr* | MiniMax-M3 | 1 | 42.6k | 2.1k | 119.1k | 45.7k | 11 | 0 | 43s |
| compose_pr* | MiniMax-M3 | 1 | 35.2k | 1.2k | 150.9k | 38.6k | 12 | 0 | 56s |
| review_pr* | opus[1m] | 1 | 42 | 33.4k | 809.7k | 84.3k | 35 | 68.3k | 8m 38s |
| resolve_review* | opus[1m] | 1 | 74 | 8.6k | 1.8M | 73.7k | 54 | 57.2k | 4m 48s |
| **Total** | | | 78.2k | 106.3k | 8.3M | 110.7k | | 438.9k | 57m 0s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 211 | 8283.8 | 269.3 | 53.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **211** | 39170.9 | 2080.1 | 503.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 380 | 91.5k | 7.2M | 397.1k | 47m 52s |
| opus | 1 | 53 | 11.5k | 825.5k | 41.8k | 7m 29s |
| MiniMax-M3 | 2 | 77.8k | 3.3k | 269.9k | 0 | 1m 39s |