### PR TITLE
Rectify: Context Window Suffix Stripped Before Reaching Claude Code CLI

### DIFF
--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -118,6 +118,9 @@ class BackendCapabilities:
     plugin_install_capable: bool = field(default=False)
     # True when backend supports Health Inspector LLM-callback idle detection
     inspector_capable: bool = field(default=False)
+    # True when backend CLI natively understands context-window suffixes like [1m]
+    # and translate_model must preserve them in the --model flag value
+    supports_context_window_suffix: bool = field(default=False)
 
 
 ALL_PROJECT_LOCAL_SKILL_SEARCH_DIRS: tuple[str, ...] = (
@@ -177,6 +180,7 @@ CLAUDE_CODE_CAPABILITIES: BackendCapabilities = BackendCapabilities(
     anthropic_provider_capable=True,
     plugin_install_capable=True,
     inspector_capable=True,
+    supports_context_window_suffix=True,
 )
 
 

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -312,7 +312,11 @@ class ClaudeCodeBackend:
         )
 
         base = strip_context_window_suffix(model)
-        return CLAUDE_MODEL_ALIASES.get(base, base)
+        resolved = CLAUDE_MODEL_ALIASES.get(base, base)
+        if self.capabilities.supports_context_window_suffix:
+            suffix = model[len(base) :]
+            return resolved + suffix
+        return resolved
 
     def version_cmd(self) -> tuple[str, ...]:
         return ("claude", "--version")

--- a/tests/contracts/CLAUDE.md
+++ b/tests/contracts/CLAUDE.md
@@ -91,6 +91,7 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `test_download_data_contracts.py` | Contract tests for download-data SKILL.md — external dataset acquisition step |
 | `test_source_attribution_contracts.py` | Cross-skill contract: source-attribution prohibition in dual-source skills |
 | `test_project_local_skill_delivery_contract.py` | Symmetric delivery contract tests for project-local skill overrides |
+| `test_translate_model_suffix_contract.py` | Contract: translate_model suffix preservation tied to backend capability flag |
 
 ## Architecture Notes
 

--- a/tests/contracts/test_translate_model_suffix_contract.py
+++ b/tests/contracts/test_translate_model_suffix_contract.py
@@ -1,0 +1,45 @@
+"""Contract: translate_model suffix preservation tied to backend capability."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.execution.backends import BACKEND_REGISTRY
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
+
+pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
+
+_SUFFIX_MODEL = "opus[1m]"
+
+
+class TestSuffixCapabilityContract:
+    def test_claude_code_has_suffix_capability(self) -> None:
+        assert ClaudeCodeBackend().capabilities.supports_context_window_suffix is True
+
+    @pytest.mark.parametrize("name", sorted(BACKEND_REGISTRY))
+    def test_translate_model_suffix_consistent_with_capability(self, name: str) -> None:
+        backend = BACKEND_REGISTRY[name]()
+        result = backend.translate_model(_SUFFIX_MODEL)
+        if backend.capabilities.supports_context_window_suffix:
+            assert "[1m]" in result, (
+                f"{name}: suffix must be preserved when supports_context_window_suffix=True"
+            )
+        else:
+            assert "[1m]" not in result, (
+                f"{name}: suffix must be stripped when supports_context_window_suffix=False"
+            )
+
+    def test_at_least_one_backend_supports_suffix(self) -> None:
+        count = sum(
+            1
+            for cls in BACKEND_REGISTRY.values()
+            if cls().capabilities.supports_context_window_suffix
+        )
+        assert count >= 1
+
+
+class TestBuildHeadlessCmdSuffixContract:
+    def test_build_headless_cmd_preserves_suffix(self) -> None:
+        spec = ClaudeCodeBackend().build_headless_cmd("test", model=_SUFFIX_MODEL)
+        model_idx = list(spec.cmd).index("--model")
+        assert "[1m]" in spec.cmd[model_idx + 1]

--- a/tests/contracts/test_translate_model_suffix_contract.py
+++ b/tests/contracts/test_translate_model_suffix_contract.py
@@ -36,10 +36,3 @@ class TestSuffixCapabilityContract:
             if cls().capabilities.supports_context_window_suffix
         )
         assert count >= 1
-
-
-class TestBuildHeadlessCmdSuffixContract:
-    def test_build_headless_cmd_preserves_suffix(self) -> None:
-        spec = ClaudeCodeBackend().build_headless_cmd("test", model=_SUFFIX_MODEL)
-        model_idx = list(spec.cmd).index("--model")
-        assert "[1m]" in spec.cmd[model_idx + 1]

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -97,6 +97,7 @@ def test_backend_capabilities_field_count():
         "anthropic_provider_capable",
         "plugin_install_capable",
         "inspector_capable",
+        "supports_context_window_suffix",
     }
     assert frozenset_fields == {
         "completion_record_types",
@@ -146,6 +147,7 @@ def test_backend_capabilities_field_names_locked():
         "anthropic_provider_capable",
         "plugin_install_capable",
         "inspector_capable",
+        "supports_context_window_suffix",
     }
     actual = {f.name for f in dataclasses.fields(BackendCapabilities)}
     assert actual == expected
@@ -185,6 +187,7 @@ def test_claude_code_capabilities_field_values():
     assert CLAUDE_CODE_CAPABILITIES.anthropic_provider_capable is True
     assert CLAUDE_CODE_CAPABILITIES.plugin_install_capable is True
     assert CLAUDE_CODE_CAPABILITIES.inspector_capable is True
+    assert CLAUDE_CODE_CAPABILITIES.supports_context_window_suffix is True
 
 
 def test_backend_capabilities_frozenset_defaults():

--- a/tests/execution/backends/test_model_translation.py
+++ b/tests/execution/backends/test_model_translation.py
@@ -36,8 +36,8 @@ class TestClaudeTranslateModel:
     def test_identity(self) -> None:
         assert ClaudeCodeBackend().translate_model("sonnet") == "sonnet"
 
-    def test_strips_context_suffix(self) -> None:
-        assert ClaudeCodeBackend().translate_model("opus[1m]") == "opus"
+    def test_preserves_context_suffix(self) -> None:
+        assert ClaudeCodeBackend().translate_model("opus[1m]") == "opus[1m]"
 
     def test_unknown_passthrough(self) -> None:
         assert ClaudeCodeBackend().translate_model("custom-model-xyz") == "custom-model-xyz"
@@ -46,7 +46,7 @@ class TestClaudeTranslateModel:
         assert ClaudeCodeBackend().translate_model("haiku") == "haiku"
 
     def test_suffix_case_insensitive(self) -> None:
-        assert ClaudeCodeBackend().translate_model("opus[1M]") == "opus"
+        assert ClaudeCodeBackend().translate_model("opus[1M]") == "opus[1M]"
 
 
 class TestCodexBuildCmdTranslatesModel:
@@ -81,23 +81,23 @@ class TestCodexBuildCmdTranslatesModel:
 
 
 class TestClaudeBuildCmdTranslatesModel:
-    def test_build_headless_cmd_strips_suffix(self) -> None:
+    def test_build_headless_cmd_preserves_suffix(self) -> None:
         spec = ClaudeCodeBackend().build_headless_cmd("test prompt", model="opus[1m]")
         model_idx = list(spec.cmd).index("--model")
-        assert spec.cmd[model_idx + 1] == "opus"
+        assert spec.cmd[model_idx + 1] == "opus[1m]"
 
-    def test_build_interactive_cmd_strips_suffix(self) -> None:
+    def test_build_interactive_cmd_preserves_suffix(self) -> None:
         spec = ClaudeCodeBackend().build_interactive_cmd(model="sonnet[1m]")
         model_idx = list(spec.cmd).index("--model")
-        assert spec.cmd[model_idx + 1] == "sonnet"
+        assert spec.cmd[model_idx + 1] == "sonnet[1m]"
 
-    def test_build_skill_session_cmd_strips_suffix(self) -> None:
+    def test_build_skill_session_cmd_preserves_suffix(self) -> None:
         config = SkillSessionConfig(model="sonnet[1m]", completion_marker="%%DONE%%")
         spec = ClaudeCodeBackend().build_skill_session_cmd("/test", "/repo", config)
         model_idx = list(spec.cmd).index("--model")
-        assert spec.cmd[model_idx + 1] == "sonnet"
+        assert spec.cmd[model_idx + 1] == "sonnet[1m]"
 
-    def test_build_food_truck_cmd_strips_suffix(self) -> None:
+    def test_build_food_truck_cmd_preserves_suffix(self) -> None:
         from autoskillit.core import DirectInstall
 
         spec = ClaudeCodeBackend().build_food_truck_cmd(
@@ -108,4 +108,4 @@ class TestClaudeBuildCmdTranslatesModel:
             model="opus[1m]",
         )
         model_idx = list(spec.cmd).index("--model")
-        assert spec.cmd[model_idx + 1] == "opus"
+        assert spec.cmd[model_idx + 1] == "opus[1m]"


### PR DESCRIPTION
## Summary

`ClaudeCodeBackend.translate_model()` unconditionally calls `strip_context_window_suffix()`, discarding the `[1m]` context-window qualifier before the model string reaches the Claude Code CLI. The CLI natively understands `opus[1m]` and would activate 1M-token context, but receives bare `opus` and defaults to 200K. The architectural weakness is that `translate_model()` uses a shared stripping function across backends without regard for whether each backend's CLI supports the suffix. The fix introduces a `BackendCapabilities` field (`supports_context_window_suffix`) that governs suffix preservation, following the codebase's established capability-flag dispatch pattern. A contract test then structurally enforces that any backend claiming this capability actually preserves the suffix in its `translate_model` output.

Closes #3662

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260603-090706-825917/.autoskillit/temp/rectify/rectify_context_window_suffix_2026-06-03_150000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 90 | 22.4k | 3.0M | 117.2k | 74 | 106.2k | 22m 30s |
| review_approach* | opus[1m] | 1 | 24 | 4.4k | 173.7k | 37.7k | 11 | 23.3k | 2m 20s |
| dry_walkthrough* | opus | 1 | 27 | 5.0k | 354.7k | 49.8k | 20 | 32.9k | 3m 13s |
| implement* | opus[1m] | 1 | 63 | 8.8k | 1.5M | 77.1k | 54 | 60.4k | 4m 20s |
| audit_impl* | opus[1m] | 1 | 707 | 10.2k | 198.6k | 39.2k | 17 | 48.6k | 3m 25s |
| prepare_pr* | MiniMax-M3 | 1 | 43.0k | 1.5k | 155.3k | 44.5k | 11 | 0 | 45s |
| compose_pr* | MiniMax-M3 | 1 | 36.0k | 1.2k | 150.1k | 38.6k | 12 | 0 | 41s |
| review_pr* | opus[1m] | 1 | 30 | 20.0k | 545.5k | 64.4k | 32 | 47.7k | 4m 30s |
| resolve_review* | opus[1m] | 1 | 53 | 5.0k | 932.7k | 64.1k | 37 | 47.6k | 8m 6s |
| **Total** | | | 80.0k | 78.6k | 7.1M | 117.2k | | 366.7k | 49m 53s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 81 | 18941.9 | 745.4 | 108.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 7 | 133248.3 | 6806.1 | 718.1 |
| **Total** | **88** | 80441.0 | 4167.3 | 892.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 967 | 70.8k | 6.4M | 333.8k | 45m 14s |
| opus | 1 | 27 | 5.0k | 354.7k | 32.9k | 3m 13s |
| MiniMax-M3 | 2 | 79.0k | 2.7k | 305.5k | 0 | 1m 25s |