### PR TITLE
Add Arch Constraint Catalog Reference to dry-walkthrough + /tmp NEVER to analyze-pipeline-health

### DIFF
--- a/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
@@ -31,6 +31,7 @@ Coordinator skill that reads session logs from a pipeline run, groups them by st
 - Fabricate, embellish, or invent findings not supported by evidence in session data
 - Modify any source code files
 - Create issues or PRs (findings are reported to the calling session only)
+- Write to `/tmp`, `/var/tmp`, or any system scratch directory — all intermediate and scratch files belong in `{{AUTOSKILLIT_TEMP}}/analyze-pipeline-health/`
 - Run subagents in the background (run_in_background: true is prohibited)
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 
@@ -43,6 +44,16 @@ Coordinator skill that reads session logs from a pipeline run, groups them by st
 - Issue all Task calls in a single message to maximize parallelism
 
 ## Workflow
+
+### Step 0: Resolve output directory
+
+Resolve the scratch directory for any intermediate files produced during analysis:
+
+1. Use `{{AUTOSKILLIT_TEMP}}/analyze-pipeline-health/` as the scratch directory
+2. Create the directory if it does not exist (use Bash: `mkdir -p`)
+3. All intermediate files (partial scanner results, working notes) go here — never in `/tmp` or `/var/tmp`
+
+Note: The final JSON report (Step 5) writes to the diagnostics log directory (`health-reports/`), not to this scratch directory.
 
 ### Step 1: Read sessions.jsonl
 

--- a/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
+++ b/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
@@ -147,11 +147,14 @@ PROJECT RULES CHECKLIST:
 [ ] Uses existing utilities (not reinventing) unless refactoring is part of plan or provides major improvement
 [ ] Test command uses the project's configured `test_check.commands` (list of commands, if set) or `test_check.command` (from `.autoskillit/config.yaml`, default: `task test-check`) — no unconfigured direct test runner invocations (pytest, python -m pytest, etc.)
 [ ] Worktree setup uses `worktree_setup.command` or `task install-worktree` — no hardcoded `uv venv`, `pip install`, or direct package manager invocations
+[ ] Code samples comply with the Architectural Constraint Catalog in resolve-review/SKILL.md — read the catalog table (44 constraints enforced by pytest, not pre-commit) and verify no plan code sample violates a listed constraint (e.g., .write_text() instead of _atomic_write(), bare `import re` instead of `import regex as re`)
 ```
 
 **Test command enforcement:** Scan the entire plan for any test invocation. Read the project's configured test commands from `.autoskillit/config.yaml`: check `test_check.commands` first (list of ordered commands, if set); fall back to `test_check.command` (single command, default: `task test-check`). If the plan contains `pytest`, `python -m pytest`, `make test`, or any other unconfigured test runner invocation, replace it with the config-driven command(s).
 
 **Worktree setup enforcement:** Scan the plan for any worktree environment setup. The plan should reference the project's configured `worktree_setup.command` or `task install-worktree`. If the plan contains hardcoded `uv venv`, `uv pip install`, `pip install -e`, `npm install` (as worktree setup, not as a configured command), flag it and replace with the config-driven approach.
+
+**Architectural constraint enforcement:** Read the Architectural Constraint Catalog table in `resolve-review/SKILL.md` (under the heading "Architectural Constraint Catalog — consult before classifying ACCEPT"). For each code sample or code block in the plan, verify it does not violate any cataloged constraint. If a violation is found, flag it with the constraint name and enforcing test file, and note the required alternative (e.g., "Plan line 260 uses `.write_text()` — REQ-AST-002 requires `_atomic_write()`").
 
 ### Step 4.5: Historical Regression Check
 

--- a/tests/contracts/CLAUDE.md
+++ b/tests/contracts/CLAUDE.md
@@ -88,6 +88,7 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `test_review_pr_severity_calibration.py` | Contract test: review-pr SKILL.md must contain severity calibration examples and grouping rule |
 | `test_no_interpreter_writes_in_skills.py` | Contract: no SKILL.md may prescribe interpreter-mediated file writes (python3 -c / heredoc with write APIs) |
 | `test_dry_walkthrough_transformation_extent.py` | Contract test: dry-walkthrough SKILL.md Step 2 must check transformation extent/scope |
+| `test_dry_walkthrough_arch_catalog_reference.py` | Contract test: dry-walkthrough SKILL.md Step 4 must reference the Architectural Constraint Catalog |
 | `test_download_data_contracts.py` | Contract tests for download-data SKILL.md — external dataset acquisition step |
 | `test_source_attribution_contracts.py` | Cross-skill contract: source-attribution prohibition in dual-source skills |
 | `test_project_local_skill_delivery_contract.py` | Symmetric delivery contract tests for project-local skill overrides |

--- a/tests/contracts/test_analyze_pipeline_health_contracts.py
+++ b/tests/contracts/test_analyze_pipeline_health_contracts.py
@@ -79,7 +79,8 @@ def test_analyze_pipeline_health_never_prohibits_tmp():
 
     skill_path = pkg_root() / "skills_extended" / "analyze-pipeline-health" / "SKILL.md"
     content = skill_path.read_text()
-    assert "/tmp" in content and "/var/tmp" in content, (
+    never_block = content.split("**NEVER:**", 1)[1] if "**NEVER:**" in content else ""
+    assert "/tmp" in never_block and "/var/tmp" in never_block, (
         "analyze-pipeline-health/SKILL.md NEVER block must explicitly prohibit "
         "/tmp and /var/tmp writes"
     )

--- a/tests/contracts/test_analyze_pipeline_health_contracts.py
+++ b/tests/contracts/test_analyze_pipeline_health_contracts.py
@@ -71,3 +71,30 @@ def test_analyze_pipeline_health_skill_has_codex_guidance():
     skill_path = pkg_root() / "skills_extended" / "analyze-pipeline-health" / "SKILL.md"
     content = skill_path.read_text()
     assert "codex_log" in content, "SKILL.md must reference codex_log for Codex session handling"
+
+
+def test_analyze_pipeline_health_never_prohibits_tmp():
+    """NEVER block must prohibit /tmp and /var/tmp writes."""
+    from autoskillit.core import pkg_root
+
+    skill_path = pkg_root() / "skills_extended" / "analyze-pipeline-health" / "SKILL.md"
+    content = skill_path.read_text()
+    assert "/tmp" in content and "/var/tmp" in content, (
+        "analyze-pipeline-health/SKILL.md NEVER block must explicitly prohibit "
+        "/tmp and /var/tmp writes"
+    )
+
+
+def test_analyze_pipeline_health_has_output_dir_resolution():
+    """SKILL.md must have a Step 0 resolving {{AUTOSKILLIT_TEMP}}/analyze-pipeline-health/."""
+    from autoskillit.core import pkg_root
+
+    skill_path = pkg_root() / "skills_extended" / "analyze-pipeline-health" / "SKILL.md"
+    content = skill_path.read_text()
+    assert "{{AUTOSKILLIT_TEMP}}/analyze-pipeline-health/" in content, (
+        "analyze-pipeline-health/SKILL.md must resolve "
+        "{{AUTOSKILLIT_TEMP}}/analyze-pipeline-health/ as the scratch directory"
+    )
+    assert "Step 0" in content, (
+        "analyze-pipeline-health/SKILL.md must have a Step 0 for output-dir resolution"
+    )

--- a/tests/contracts/test_dry_walkthrough_arch_catalog_reference.py
+++ b/tests/contracts/test_dry_walkthrough_arch_catalog_reference.py
@@ -18,9 +18,7 @@ def _read_skill_md() -> str:
 def test_step4_references_arch_constraint_catalog():
     """Step 4 PROJECT RULES CHECKLIST must reference the Architectural Constraint Catalog."""
     content = _read_skill_md()
-    assert "Architectural Constraint Catalog" in content or (
-        "resolve-review" in content and "constraint" in content.lower()
-    ), (
+    assert "Architectural Constraint Catalog" in content, (
         "dry-walkthrough/SKILL.md Step 4 must reference the Architectural "
         "Constraint Catalog in resolve-review/SKILL.md to catch architectural "
         "constraint violations in plan code samples"

--- a/tests/contracts/test_dry_walkthrough_arch_catalog_reference.py
+++ b/tests/contracts/test_dry_walkthrough_arch_catalog_reference.py
@@ -1,0 +1,27 @@
+"""Contract test: dry-walkthrough Step 4 references the Arch Constraint Catalog."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
+
+_SKILL_PATH = "skills_extended/dry-walkthrough/SKILL.md"
+
+
+def _read_skill_md() -> str:
+    from autoskillit.core import pkg_root
+
+    return (pkg_root() / _SKILL_PATH).read_text()
+
+
+def test_step4_references_arch_constraint_catalog():
+    """Step 4 PROJECT RULES CHECKLIST must reference the Architectural Constraint Catalog."""
+    content = _read_skill_md()
+    assert "Architectural Constraint Catalog" in content or (
+        "resolve-review" in content and "constraint" in content.lower()
+    ), (
+        "dry-walkthrough/SKILL.md Step 4 must reference the Architectural "
+        "Constraint Catalog in resolve-review/SKILL.md to catch architectural "
+        "constraint violations in plan code samples"
+    )


### PR DESCRIPTION
## Summary

Two SKILL.md instruction changes to close gaps identified by pipeline health report (issue #3646, kitchen `a348614c`):

1. **dry-walkthrough/SKILL.md** — Add a checklist item to Step 4 ("Validate Against Project Rules") directing subagents to cross-reference the Architectural Constraint Catalog in `resolve-review/SKILL.md` (lines 452-505) when validating code samples in plans. This catches the entire class of architectural constraint violations (44 entries including `REQ-AST-002` atomic writes) rather than adding fragile single-rule checks.

2. **analyze-pipeline-health/SKILL.md** — Add a NEVER constraint prohibiting `/tmp`/`/var/tmp` writes and a Step 0 output-dir resolution using `{{AUTOSKILLIT_TEMP}}/analyze-pipeline-health/` for intermediate scratch files. Follows `resolve-review/SKILL.md`'s explicit pattern since this skill is the highest-volume `/tmp` offender (48 of 99 sessions).

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260603-095505-612785/.autoskillit/temp/make-plan/add-arch-constraint-catalog-reference-to-dry-walkthrough-tmp-constraint-to-aph_plan_2026-06-03_100000.md`

Closes #3659

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.2k | 13.2k | 1.7M | 94.7k | 64 | 95.6k | 14m 20s |
| verify* | sonnet | 1 | 84 | 6.6k | 354.7k | 45.7k | 28 | 45.9k | 3m 34s |
| implement* | MiniMax-M3 | 1 | 2.5M | 9.8k | 1.0M | 52.0k | 99 | 0 | 6m 48s |
| audit_impl* | sonnet | 1 | 54 | 6.1k | 177.8k | 37.3k | 18 | 26.8k | 3m 0s |
| prepare_pr* | MiniMax-M3 | 1 | 179.3k | 1.6k | 0 | 0 | 13 | 0 | 40s |
| compose_pr* | MiniMax-M3 | 1 | 204.8k | 1.2k | 0 | 0 | 13 | 0 | 45s |
| review_pr* | sonnet | 3 | 480 | 104.0k | 3.0M | 92.5k | 147 | 239.7k | 24m 50s |
| resolve_review* | sonnet | 3 | 839 | 35.8k | 5.4M | 82.3k | 225 | 153.6k | 21m 32s |
| **Total** | | | 2.9M | 178.2k | 11.6M | 94.7k | | 561.5k | 1h 15m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 69 | 15145.2 | 0.0 | 142.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 7 | 766673.1 | 21945.0 | 5113.3 |
| **Total** | **76** | 153261.7 | 7388.6 | 2344.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.2k | 13.2k | 1.7M | 95.6k | 14m 20s |
| sonnet | 4 | 1.5k | 152.4k | 8.9M | 465.9k | 52m 58s |
| MiniMax-M3 | 3 | 2.9M | 12.6k | 1.0M | 0 | 8m 13s |