### PR TITLE
Rectify: SKILL.md Pseudocode Sync Enforcement

### DIFF
--- a/src/autoskillit/agents/plan-registry-tracer.md
+++ b/src/autoskillit/agents/plan-registry-tracer.md
@@ -132,12 +132,13 @@ For EACH file found in Steps 2–4 (tree-sitter, LSP, grep), determine if it is:
 - A **derived artifact** (generated file, compiled output, cache)
 - A **re-export** (`__init__.py`, `__all__`, `.pyi` stub)
 - A **test fixture** or factory
+- A **pseudocode documentation** file (SKILL.md with ```python blocks that reference symbols the plan modifies)
 - A **documentation file** (markdown, docstring, comment)
 - **None of the above** (regular code usage — still needs updating if renamed)
 
 ### Step 6 — Check Plan Coverage
 
-For EACH file classified as a registry, type definition, config, derived artifact, or re-export:
+For EACH file classified as a registry, type definition, config, derived artifact, re-export, or pseudocode documentation:
 - Does the plan explicitly update this file?
 - If not, is the update implied by another step in the plan?
 - If neither, this is a **finding**
@@ -182,7 +183,7 @@ This check is the primary defense against the "two-family" planning failure, whe
 
 Write this table for EACH symbol before forming any conclusion:
 
-| Symbol | File Found | Reference Type (registry/type/config/artifact/re-export/test/doc/code) | Updated by Plan? |
+| Symbol | File Found | Reference Type (registry/type/config/artifact/re-export/pseudo-doc/test/doc/code) | Updated by Plan? |
 |--------|-----------|-----------------------------------------------------------------------|-----------------|
 | ... | ... | ... | ... |
 

--- a/src/autoskillit/agents/plan-registry-tracer.md
+++ b/src/autoskillit/agents/plan-registry-tracer.md
@@ -183,7 +183,7 @@ This check is the primary defense against the "two-family" planning failure, whe
 
 Write this table for EACH symbol before forming any conclusion:
 
-| Symbol | File Found | Reference Type (registry/type/config/artifact/re-export/pseudo-doc/test/doc/code) | Updated by Plan? |
+| Symbol | File Found | Reference Type (registry/type/config/artifact/re-export/pseudocode-doc/test/doc/code) | Updated by Plan? |
 |--------|-----------|-----------------------------------------------------------------------|-----------------|
 | ... | ... | ... | ... |
 

--- a/src/autoskillit/agents/plan-registry-tracer.md
+++ b/src/autoskillit/agents/plan-registry-tracer.md
@@ -132,13 +132,13 @@ For EACH file found in Steps 2–4 (tree-sitter, LSP, grep), determine if it is:
 - A **derived artifact** (generated file, compiled output, cache)
 - A **re-export** (`__init__.py`, `__all__`, `.pyi` stub)
 - A **test fixture** or factory
-- A **pseudocode documentation** file (SKILL.md with ```python blocks that reference symbols the plan modifies)
+- A **pseudocode-doc** file (SKILL.md with ```python blocks that reference symbols the plan modifies)
 - A **documentation file** (markdown, docstring, comment)
 - **None of the above** (regular code usage — still needs updating if renamed)
 
 ### Step 6 — Check Plan Coverage
 
-For EACH file classified as a registry, type definition, config, derived artifact, re-export, or pseudocode documentation:
+For EACH file classified as a registry, type definition, config, derived artifact, re-export, or pseudocode-doc:
 - Does the plan explicitly update this file?
 - If not, is the update implied by another step in the plan?
 - If neither, this is a **finding**

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -143,6 +143,9 @@ from autoskillit.recipe.rules import rules_packs as _rules_packs  # noqa: E402 F
 from autoskillit.recipe.rules import (  # noqa: E402 F401
     rules_phoropter_adjacency as _rules_phoropter_adjacency,  # noqa: F401
 )
+from autoskillit.recipe.rules import (
+    rules_pseudocode_sync as _rules_pseudocode_sync,  # noqa: E402 F401
+)
 from autoskillit.recipe.rules import rules_reachability as _rules_reachability  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_recipe as _rules_recipe  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_remediation as _rules_remediation  # noqa: E402 F401

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -143,8 +143,8 @@ from autoskillit.recipe.rules import rules_packs as _rules_packs  # noqa: E402 F
 from autoskillit.recipe.rules import (  # noqa: E402 F401
     rules_phoropter_adjacency as _rules_phoropter_adjacency,  # noqa: F401
 )
-from autoskillit.recipe.rules import (
-    rules_pseudocode_sync as _rules_pseudocode_sync,  # noqa: E402 F401
+from autoskillit.recipe.rules import (  # noqa: E402 F401
+    rules_pseudocode_sync as _rules_pseudocode_sync,  # noqa: F401
 )
 from autoskillit.recipe.rules import rules_reachability as _rules_reachability  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_recipe as _rules_recipe  # noqa: E402 F401

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -1,6 +1,6 @@
 # rules/
 
-Semantic validation rule modules for recipe analysis (44 flat rule files + 4 subdirectories).
+Semantic validation rule modules for recipe analysis (45 flat rule files + 4 subdirectories).
 
 ## Subdirectories
 

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -1,6 +1,6 @@
 # rules/
 
-Semantic validation rule modules for recipe analysis (37 flat rule files + 4 subdirectories).
+Semantic validation rule modules for recipe analysis (44 flat rule files + 4 subdirectories).
 
 ## Subdirectories
 
@@ -41,6 +41,7 @@ See each subdirectory's CLAUDE.md for details.
 | `rules_optional_capture.py` | Optional capture guard enforcement |
 | `rules_packs.py` | Pack validation (names must exist in `PACK_REGISTRY`) |
 | `rules_phoropter_adjacency.py` | Phoropter phase-order and step-interleaving adjacency rules |
+| `rules_pseudocode_sync.py` | SKILL.md pseudocode constant-reference divergence from run_python callables |
 | `rules_reachability.py` | Symbolic BFS reachability; capture-inversion detection |
 | `rules_audit_impl_topology.py` | audit-impl-diff-topology-mismatch semantic rule |
 | `rules_remediation.py` | audit-impl remediation_path capture routing rules |

--- a/src/autoskillit/recipe/rules/rules_pseudocode_sync.py
+++ b/src/autoskillit/recipe/rules/rules_pseudocode_sync.py
@@ -1,0 +1,161 @@
+"""Semantic rule: pseudocode-callable-divergence
+
+Fires when a run_python callable in autoskillit.smoke_utils is paired (via
+phoropter_family) with a run_skill step whose SKILL.md python pseudocode inlines
+frozenset constant members without referencing the constant by name. Divergence
+risk: if the constant is updated the pseudocode silently becomes stale.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from autoskillit.core import Severity
+from autoskillit.recipe._skill_helpers import _resolve_skill_md
+from autoskillit.recipe._skill_placeholder_parser import extract_python_blocks
+from autoskillit.recipe.contracts import resolve_skill_name
+from autoskillit.recipe.registry import RuleFinding, semantic_rule
+
+if TYPE_CHECKING:
+    from autoskillit.recipe._analysis import ValidationContext
+
+
+def _get_package_source_dir(callable_path: str) -> Path | None:
+    """Resolve the source directory for the callable's package."""
+    parts = callable_path.split(".")
+    for n in range(len(parts), 1, -1):
+        pkg = ".".join(parts[:n])
+        try:
+            spec = importlib.util.find_spec(pkg)
+        except (ModuleNotFoundError, ValueError):
+            continue
+        if spec is None or not spec.origin:
+            continue
+        origin = Path(spec.origin)
+        if origin.name == "__init__.py":
+            return origin.parent
+        return origin.parent
+    return None
+
+
+def _find_frozenset_constants(source_dir: Path) -> dict[str, frozenset[str | None]]:
+    """Find module-level frozenset constants in all Python source files under source_dir."""
+    constants: dict[str, frozenset[str | None]] = {}
+    for py_file in sorted(source_dir.rglob("*.py")):
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        for node in ast.iter_child_nodes(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            for target in node.targets:
+                if not isinstance(target, ast.Name):
+                    continue
+                val = node.value
+                if not (
+                    isinstance(val, ast.Call)
+                    and isinstance(val.func, ast.Name)
+                    and val.func.id == "frozenset"
+                    and val.args
+                ):
+                    continue
+                inner = val.args[0]
+                if not isinstance(inner, (ast.Set, ast.List)):
+                    continue
+                members: set[str | None] = set()
+                valid = True
+                for elt in inner.elts:
+                    if isinstance(elt, ast.Constant) and isinstance(elt.value, (str, type(None))):
+                        members.add(elt.value)
+                    else:
+                        valid = False
+                        break
+                if valid:
+                    constants[target.id] = frozenset(members)
+    return constants
+
+
+def _member_inlined_in_block(member: str | None, block: str) -> bool:
+    """Return True if member appears as a literal in the block without being named by constant."""
+    if member is None:
+        return "None" in block
+    return f'"{member}"' in block or f"'{member}'" in block
+
+
+@semantic_rule(
+    name="pseudocode-callable-divergence",
+    description=(
+        "A run_python callable defines frozenset/set constants whose members are "
+        "inlined in the corresponding SKILL.md pseudocode without referencing the "
+        "constant by name — divergence risk if the constant is updated."
+    ),
+    severity=Severity.WARNING,
+)
+def _check_pseudocode_callable_divergence(ctx: ValidationContext) -> list[RuleFinding]:
+    """Fire WARNING when SKILL.md pseudocode inlines frozenset constant members by value."""
+    findings: list[RuleFinding] = []
+
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_python":
+            continue
+        callable_path = str(step.with_args.get("callable", ""))
+        if not callable_path.startswith("autoskillit.smoke_utils"):
+            continue
+        family = step.phoropter_family
+        if not family:
+            continue
+
+        source_dir = _get_package_source_dir(callable_path)
+        if source_dir is None:
+            continue
+        constants = _find_frozenset_constants(source_dir)
+        if not constants:
+            continue
+
+        for _, other_step in ctx.recipe.steps.items():
+            if other_step.tool != "run_skill":
+                continue
+            if other_step.phoropter_family != family:
+                continue
+            skill_cmd = other_step.with_args.get("skill_command", "")
+            if not skill_cmd:
+                continue
+            skill_name = resolve_skill_name(skill_cmd)
+            if skill_name is None:
+                continue
+            skill_md_path = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
+            if skill_md_path is None:
+                continue
+            try:
+                skill_content = skill_md_path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            python_blocks = extract_python_blocks(skill_content)
+            if not python_blocks:
+                continue
+
+            all_blocks = "\n".join(python_blocks)
+
+            for const_name, members in constants.items():
+                if const_name in all_blocks:
+                    continue
+                # Check if ALL members are inlined as literals without the constant name
+                if all(_member_inlined_in_block(m, all_blocks) for m in members):
+                    findings.append(
+                        RuleFinding(
+                            rule="pseudocode-callable-divergence",
+                            severity=Severity.WARNING,
+                            step_name=step_name,
+                            message=(
+                                f"step '{step_name}': SKILL.md for '{skill_name}' inlines "
+                                f"all members of {const_name!r} as literals without "
+                                f"referencing the constant by name. If {const_name!r} is "
+                                f"updated, the pseudocode will silently diverge."
+                            ),
+                        )
+                    )
+    return findings

--- a/src/autoskillit/recipe/rules/rules_pseudocode_sync.py
+++ b/src/autoskillit/recipe/rules/rules_pseudocode_sync.py
@@ -13,7 +13,7 @@ import importlib.util
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from autoskillit.core import Severity
+from autoskillit.core import Severity, get_logger
 from autoskillit.recipe._skill_helpers import _resolve_skill_md
 from autoskillit.recipe._skill_placeholder_parser import extract_python_blocks
 from autoskillit.recipe.contracts import resolve_skill_name
@@ -21,6 +21,8 @@ from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 if TYPE_CHECKING:
     from autoskillit.recipe._analysis import ValidationContext
+
+logger = get_logger(__name__)
 
 
 def _get_package_source_dir(callable_path: str) -> Path | None:
@@ -48,33 +50,39 @@ def _find_frozenset_constants(source_dir: Path) -> dict[str, frozenset[str | Non
         try:
             tree = ast.parse(py_file.read_text(encoding="utf-8"))
         except Exception:
+            logger.warning("Failed to parse %s", py_file, exc_info=True)
             continue
         for node in ast.iter_child_nodes(tree):
-            if not isinstance(node, ast.Assign):
-                continue
-            for target in node.targets:
-                if not isinstance(target, ast.Name):
-                    continue
+            targets: list[ast.Name] = []
+            val: ast.expr | None = None
+            if isinstance(node, ast.Assign):
+                targets = [t for t in node.targets if isinstance(t, ast.Name)]
                 val = node.value
-                if not (
-                    isinstance(val, ast.Call)
-                    and isinstance(val.func, ast.Name)
-                    and val.func.id == "frozenset"
-                    and val.args
-                ):
-                    continue
-                inner = val.args[0]
-                if not isinstance(inner, (ast.Set, ast.List)):
-                    continue
-                members: set[str | None] = set()
-                valid = True
-                for elt in inner.elts:
-                    if isinstance(elt, ast.Constant) and isinstance(elt.value, (str, type(None))):
-                        members.add(elt.value)
-                    else:
-                        valid = False
-                        break
-                if valid:
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                targets = [node.target]
+                val = node.value
+            if not targets or val is None:
+                continue
+            if not (
+                isinstance(val, ast.Call)
+                and isinstance(val.func, ast.Name)
+                and val.func.id == "frozenset"
+                and val.args
+            ):
+                continue
+            inner = val.args[0]
+            if not isinstance(inner, (ast.Set, ast.List)):
+                continue
+            members: set[str | None] = set()
+            valid = True
+            for elt in inner.elts:
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, (str, type(None))):
+                    members.add(elt.value)
+                else:
+                    valid = False
+                    break
+            if valid:
+                for target in targets:
                     constants[target.id] = frozenset(members)
     return constants
 

--- a/src/autoskillit/recipe/rules/rules_pseudocode_sync.py
+++ b/src/autoskillit/recipe/rules/rules_pseudocode_sync.py
@@ -36,8 +36,6 @@ def _get_package_source_dir(callable_path: str) -> Path | None:
         if spec is None or not spec.origin:
             continue
         origin = Path(spec.origin)
-        if origin.name == "__init__.py":
-            return origin.parent
         return origin.parent
     return None
 
@@ -137,6 +135,7 @@ def _check_pseudocode_callable_divergence(ctx: ValidationContext) -> list[RuleFi
             try:
                 skill_content = skill_md_path.read_text(encoding="utf-8")
             except OSError:
+                logger.warning("Failed to read %s", skill_md_path, exc_info=True)
                 continue
             python_blocks = extract_python_blocks(skill_content)
             if not python_blocks:

--- a/src/autoskillit/recipe/rules/rules_pseudocode_sync.py
+++ b/src/autoskillit/recipe/rules/rules_pseudocode_sync.py
@@ -26,7 +26,6 @@ logger = get_logger(__name__)
 
 
 def _get_package_source_dir(callable_path: str) -> Path | None:
-    """Resolve the source directory for the callable's package."""
     parts = callable_path.split(".")
     for n in range(len(parts), 1, -1):
         pkg = ".".join(parts[:n])
@@ -44,7 +43,6 @@ def _get_package_source_dir(callable_path: str) -> Path | None:
 
 
 def _find_frozenset_constants(source_dir: Path) -> dict[str, frozenset[str | None]]:
-    """Find module-level frozenset constants in all Python source files under source_dir."""
     constants: dict[str, frozenset[str | None]] = {}
     for py_file in sorted(source_dir.rglob("*.py")):
         try:
@@ -88,7 +86,6 @@ def _find_frozenset_constants(source_dir: Path) -> dict[str, frozenset[str | Non
 
 
 def _member_inlined_in_block(member: str | None, block: str) -> bool:
-    """Return True if member appears as a literal in the block without being named by constant."""
     if member is None:
         return "None" in block
     return f'"{member}"' in block or f"'{member}'" in block
@@ -104,7 +101,6 @@ def _member_inlined_in_block(member: str | None, block: str) -> bool:
     severity=Severity.WARNING,
 )
 def _check_pseudocode_callable_divergence(ctx: ValidationContext) -> list[RuleFinding]:
-    """Fire WARNING when SKILL.md pseudocode inlines frozenset constant members by value."""
     findings: list[RuleFinding] = []
 
     for step_name, step in ctx.recipe.steps.items():
@@ -152,7 +148,7 @@ def _check_pseudocode_callable_divergence(ctx: ValidationContext) -> list[RuleFi
                 if const_name in all_blocks:
                     continue
                 # Check if ALL members are inlined as literals without the constant name
-                if all(_member_inlined_in_block(m, all_blocks) for m in members):
+                if members and all(_member_inlined_in_block(m, all_blocks) for m in members):
                     findings.append(
                         RuleFinding(
                             rule="pseudocode-callable-divergence",

--- a/src/autoskillit/skills_extended/review-design/SKILL.md
+++ b/src/autoskillit/skills_extended/review-design/SKILL.md
@@ -568,14 +568,15 @@ One synthesis pass (no subagent — orchestrator synthesizes directly):
    for f in l1_criticals:
        if f.fixability == "ADDRESSABLE":
            f.priority = "REQUIRED"
-   # Scope guard: estimand_clarity always STRUCTURAL; None fixability defaults to STRUCTURAL
+   # Scope guard: only STRUCTURAL/None fixability triggers STOP (see _STRUCTURAL_FIXABILITY_VALUES)
    structural_stop_triggers = [
        f for f in l1_criticals
-       if f.fixability == "STRUCTURAL" or f.fixability is None or f.dimension == "estimand_clarity"
+       if f.fixability in _STRUCTURAL_FIXABILITY_VALUES  # {"STRUCTURAL", None}
    ]
 
-   # Red-team STOP path: adversarial critical findings after full analysis (L2-L4)
-   # These fire only when the L1 gate passed AND the severity cap still allows critical.
+   # Red-team STOP path: red_team has no fixability concept — dimension-only match is
+   # intentional here (unlike L1 criticals which gate on fixability via
+   # _STRUCTURAL_FIXABILITY_VALUES). The severity cap is applied upstream.
    stop_triggers = structural_stop_triggers + [f for f in critical_findings if f.dimension == "red_team"]
 
    if stop_triggers:

--- a/tests/arch/test_pyright_suppression_allowlist.py
+++ b/tests/arch/test_pyright_suppression_allowlist.py
@@ -20,7 +20,7 @@ _PYRIGHT_RE = re.compile(r"#\s*pyright:\s*ignore|#.*--\s*pyright:\s*ignore")
 PRODUCTION_ALLOWLIST: dict[tuple[str, int], str] = {
     (
         "recipe/__init__.py",
-        242,
+        245,
     ): "lazy-registry: method added by _register_rule_module() side effects",
     ("recipe/_api.py", 273): "global-mutated variable set by _finalize_registry()",
 }

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -864,7 +864,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "hooks": 13,
         "pipeline": 12,
         "fleet": 22,  # REQ-CNST-003-E9: _dispatch_reaper.py; +_sidecar_synthesis.py; +_reset.py
-        "recipe/rules": 44,  # +2: failure_verdict_bypass, stop_sentinel_direction
+        "recipe/rules": 45,  # +3: failure_verdict_bypass, stop_sentinel_direction, pseudocode_sync
         "server/tools": 25,  # _auto_overrides.py + _cancellation_shield.py + tools_fleet_reset.py
         "hooks/guards": 31,  # +fleet_claim_guard, +reset_resume_gate
     }

--- a/tests/contracts/test_review_design_contracts.py
+++ b/tests/contracts/test_review_design_contracts.py
@@ -112,3 +112,35 @@ def test_review_design_input_gating(skill_text: str) -> None:
         "review-design/SKILL.md must reference the review_design ingredient "
         "as its input gating mechanism"
     )
+
+
+# ── structural_stop_triggers pseudocode sync ────────────────────────────────
+
+
+def test_verdict_pseudocode_no_dimension_only_stop_trigger(skill_text: str) -> None:
+    """structural_stop_triggers must not use dimension-only matching to bypass fixability."""
+    step7_text = skill_text_between("### Step 7", "### Step 8", skill_text)
+    match = re.search(
+        r"structural_stop_triggers\s*=\s*\[(.+?)\n\s*\]",
+        step7_text,
+        re.DOTALL,
+    )
+    assert match, "Step 7 must contain structural_stop_triggers list comprehension"
+    comprehension_body = match.group(1)
+    assert "f.dimension ==" not in comprehension_body, (
+        "structural_stop_triggers must not use dimension-only matching — "
+        "use fixability-based gating via _STRUCTURAL_FIXABILITY_VALUES"
+    )
+    assert 'f.get("dimension")' not in comprehension_body, (
+        "structural_stop_triggers must not use dimension-only matching — "
+        "use fixability-based gating via _STRUCTURAL_FIXABILITY_VALUES"
+    )
+
+
+def test_verdict_pseudocode_structural_fixability_constant_reference(skill_text: str) -> None:
+    """Step 7 pseudocode must reference _STRUCTURAL_FIXABILITY_VALUES by name."""
+    step7_text = skill_text_between("### Step 7", "### Step 8", skill_text)
+    assert "_STRUCTURAL_FIXABILITY_VALUES" in step7_text, (
+        "Step 7 pseudocode must reference _STRUCTURAL_FIXABILITY_VALUES by name — "
+        "do not inline the fixability values as separate OR clauses"
+    )

--- a/tests/contracts/test_review_design_contracts.py
+++ b/tests/contracts/test_review_design_contracts.py
@@ -5,20 +5,14 @@ on_context_limit, and retained Critical Constraints.
 from __future__ import annotations
 
 import re
-from pathlib import Path
 
 import pytest
 
+from autoskillit.core import pkg_root
+
 pytestmark = [pytest.mark.layer("contracts"), pytest.mark.medium]
 
-SKILL_MD = (
-    Path(__file__).resolve().parents[2]
-    / "src"
-    / "autoskillit"
-    / "skills_extended"
-    / "review-design"
-    / "SKILL.md"
-)
+SKILL_MD = pkg_root() / "skills_extended" / "review-design" / "SKILL.md"
 
 
 @pytest.fixture(scope="module")

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -78,6 +78,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_planner_contracts.py` | Contract-level tests for write_behavior + output_dir coherence in planner.yaml |
 | `test_planner_recipe.py` | Tests for the planner recipe structure |
 | `test_promote_to_main_wrapper.py` | Tests for the promote-to-main wrapper recipe |
+| `test_pseudocode_sync_rule.py` | Tests for the pseudocode-callable-divergence semantic rule |
 | `test_recipe_ci_applicable_routing.py` | Structural tests for ci_applicable routing guards across all wait_for_ci chains |
 | `test_recipe_ci_contracts.py` | Cross-recipe ci_event/branch coherence and remote_url structural tests |
 | `test_recipe_ci_watch_event.py` | Tests for CI watch event in recipe steps |

--- a/tests/recipe/test_pseudocode_sync_rule.py
+++ b/tests/recipe/test_pseudocode_sync_rule.py
@@ -1,0 +1,183 @@
+"""Tests for the pseudocode-callable-divergence semantic rule."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import autoskillit.recipe._skill_helpers as _sh
+from autoskillit.recipe.io import load_recipe
+from autoskillit.recipe.registry import run_semantic_rules
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+_RECIPE_WITH_REVIEW_FAMILY = textwrap.dedent(
+    """\
+    name: test-recipe
+    kitchen_rules:
+      - "Use run_skill and run_python."
+    steps:
+      run_verdict:
+        tool: run_python
+        phoropter_family: review-design
+        with:
+          callable: "autoskillit.smoke_utils.aggregate_review_verdict"
+        on_success: done
+      run_review:
+        tool: run_skill
+        phoropter_family: review-design
+        with:
+          skill_command: "/autoskillit:review-design"
+        on_success: done
+    """
+)
+
+_RECIPE_NON_SMOKE_UTILS = textwrap.dedent(
+    """\
+    name: test-recipe
+    kitchen_rules:
+      - "Use run_skill and run_python."
+    steps:
+      run_verdict:
+        tool: run_python
+        phoropter_family: review-design
+        with:
+          callable: "some_other_package.utils.do_thing"
+        on_success: done
+      run_review:
+        tool: run_skill
+        phoropter_family: review-design
+        with:
+          skill_command: "/autoskillit:review-design"
+        on_success: done
+    """
+)
+
+# SKILL.md with inlined frozenset members — rule must fire
+_SKILL_MD_INLINED = textwrap.dedent(
+    """\
+    # review-design
+    ## Arguments
+    None.
+
+    ### Step 7
+    ```python
+    structural_stop_triggers = [
+        f for f in l1_criticals
+        if f.fixability == "STRUCTURAL" or f.fixability is None
+    ]
+    ```
+
+    ### Step 8
+    Write output.
+    """
+)
+
+# SKILL.md with constant referenced by name — rule must NOT fire
+_SKILL_MD_BY_NAME = textwrap.dedent(
+    """\
+    # review-design
+    ## Arguments
+    None.
+
+    ### Step 7
+    ```python
+    structural_stop_triggers = [
+        f for f in l1_criticals
+        if f.fixability in _STRUCTURAL_FIXABILITY_VALUES  # {"STRUCTURAL", None}
+    ]
+    ```
+
+    ### Step 8
+    Write output.
+    """
+)
+
+# SKILL.md with no python blocks — rule must NOT fire
+_SKILL_MD_NO_PYTHON = textwrap.dedent(
+    """\
+    # review-design
+    ## Arguments
+    None.
+
+    ### Step 7
+    Only prose here, no python blocks.
+
+    ### Step 8
+    Write output.
+    """
+)
+
+
+def _write_skill(tmp_path: Path, content: str) -> None:
+    skill_dir = tmp_path / "review-design"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(content)
+
+
+def test_rule_fires_for_inlined_constant_members(tmp_path: Path) -> None:
+    """Rule emits WARNING when SKILL.md inlines frozenset members without naming the constant."""
+    _write_skill(tmp_path, _SKILL_MD_INLINED)
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_RECIPE_WITH_REVIEW_FAMILY)
+    recipe = load_recipe(recipe_path)
+
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr(_sh, "SKILL_SEARCH_DIRS", [tmp_path])
+        findings = run_semantic_rules(recipe)
+
+    matching = [f for f in findings if f.rule == "pseudocode-callable-divergence"]
+    assert matching, (
+        "Expected pseudocode-callable-divergence finding when constant members are inlined"
+    )
+    assert all(f.severity.name == "WARNING" for f in matching)
+
+
+def test_rule_silent_when_constant_referenced_by_name(tmp_path: Path) -> None:
+    """Rule emits no finding when SKILL.md references the constant by name."""
+    _write_skill(tmp_path, _SKILL_MD_BY_NAME)
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_RECIPE_WITH_REVIEW_FAMILY)
+    recipe = load_recipe(recipe_path)
+
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr(_sh, "SKILL_SEARCH_DIRS", [tmp_path])
+        findings = run_semantic_rules(recipe)
+
+    matching = [f for f in findings if f.rule == "pseudocode-callable-divergence"]
+    assert not matching, (
+        "Expected no pseudocode-callable-divergence finding when constant is named; "
+        f"got: {matching}"
+    )
+
+
+def test_rule_silent_for_non_smoke_utils_callable(tmp_path: Path) -> None:
+    """Rule does not fire for callables outside autoskillit.smoke_utils."""
+    _write_skill(tmp_path, _SKILL_MD_INLINED)
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_RECIPE_NON_SMOKE_UTILS)
+    recipe = load_recipe(recipe_path)
+
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr(_sh, "SKILL_SEARCH_DIRS", [tmp_path])
+        findings = run_semantic_rules(recipe)
+
+    matching = [f for f in findings if f.rule == "pseudocode-callable-divergence"]
+    assert not matching, "Rule must not fire for callables outside autoskillit.smoke_utils"
+
+
+def test_rule_silent_when_no_python_blocks(tmp_path: Path) -> None:
+    """Rule does not fire for run_skill steps whose SKILL.md has no python pseudocode blocks."""
+    _write_skill(tmp_path, _SKILL_MD_NO_PYTHON)
+    recipe_path = tmp_path / "recipe.yaml"
+    recipe_path.write_text(_RECIPE_WITH_REVIEW_FAMILY)
+    recipe = load_recipe(recipe_path)
+
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr(_sh, "SKILL_SEARCH_DIRS", [tmp_path])
+        findings = run_semantic_rules(recipe)
+
+    matching = [f for f in findings if f.rule == "pseudocode-callable-divergence"]
+    assert not matching, "Rule must not fire when SKILL.md has no python pseudocode blocks"

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -2746,9 +2746,13 @@ def test_aggregate_review_verdict_estimand_clarity_addressable_is_revise(tmp_pat
 
 def test_structural_fixability_values_matches_skill_md_pseudocode() -> None:
     """_STRUCTURAL_FIXABILITY_VALUES must be referenced by name in SKILL.md pseudocode."""
-    skill_md = Path("src/autoskillit/skills_extended/review-design/SKILL.md").read_text()
-    step7_start = skill_md.index("### Step 7")
-    step7_end = skill_md.index("### Step 8")
+    from autoskillit.core import pkg_root
+
+    skill_md = (pkg_root() / "skills_extended" / "review-design" / "SKILL.md").read_text()
+    step7_start = skill_md.find("### Step 7")
+    assert step7_start != -1, "SKILL.md must contain '### Step 7' heading"
+    step7_end = skill_md.find("### Step 8")
+    assert step7_end != -1, "SKILL.md must contain '### Step 8' heading"
     step7_text = skill_md[step7_start:step7_end]
 
     match = re.search(

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -2745,9 +2745,7 @@ def test_aggregate_review_verdict_estimand_clarity_addressable_is_revise(tmp_pat
 
 
 def test_structural_fixability_values_matches_skill_md_pseudocode() -> None:
-    """_STRUCTURAL_FIXABILITY_VALUES members must be referenced in SKILL.md pseudocode by name."""
-    from autoskillit.smoke_utils._review import _STRUCTURAL_FIXABILITY_VALUES
-
+    """_STRUCTURAL_FIXABILITY_VALUES must be referenced by name in SKILL.md pseudocode."""
     skill_md = Path("src/autoskillit/skills_extended/review-design/SKILL.md").read_text()
     step7_start = skill_md.index("### Step 7")
     step7_end = skill_md.index("### Step 8")
@@ -2761,14 +2759,10 @@ def test_structural_fixability_values_matches_skill_md_pseudocode() -> None:
     assert match, "Step 7 must contain structural_stop_triggers list comprehension"
     comprehension_body = match.group(1)
 
-    for member in _STRUCTURAL_FIXABILITY_VALUES:
-        member_str = repr(member) if member is not None else "None"
-        assert member_str in comprehension_body or (
-            member is None and "None" in comprehension_body
-        ), (
-            f"SKILL.md pseudocode must reference fixability member {member_str} "
-            f"from _STRUCTURAL_FIXABILITY_VALUES"
-        )
+    assert "_STRUCTURAL_FIXABILITY_VALUES" in comprehension_body, (
+        "structural_stop_triggers must reference _STRUCTURAL_FIXABILITY_VALUES by name — "
+        "do not inline the fixability values as separate OR clauses"
+    )
 
     assert "f.dimension ==" not in comprehension_body, (
         "structural_stop_triggers must not use dimension-only matching — "

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -2741,6 +2742,42 @@ def test_aggregate_review_verdict_estimand_clarity_addressable_is_revise(tmp_pat
     assert "revision_guidance_path" in result
     assert Path(result["revision_guidance_path"]).exists()
     assert Path(result["evaluation_dashboard_path"]).exists()
+
+
+def test_structural_fixability_values_matches_skill_md_pseudocode() -> None:
+    """_STRUCTURAL_FIXABILITY_VALUES members must be referenced in SKILL.md pseudocode by name."""
+    from autoskillit.smoke_utils._review import _STRUCTURAL_FIXABILITY_VALUES
+
+    skill_md = Path("src/autoskillit/skills_extended/review-design/SKILL.md").read_text()
+    step7_start = skill_md.index("### Step 7")
+    step7_end = skill_md.index("### Step 8")
+    step7_text = skill_md[step7_start:step7_end]
+
+    match = re.search(
+        r"structural_stop_triggers\s*=\s*\[(.+?)\n\s*\]",
+        step7_text,
+        re.DOTALL,
+    )
+    assert match, "Step 7 must contain structural_stop_triggers list comprehension"
+    comprehension_body = match.group(1)
+
+    for member in _STRUCTURAL_FIXABILITY_VALUES:
+        member_str = repr(member) if member is not None else "None"
+        assert member_str in comprehension_body or (
+            member is None and "None" in comprehension_body
+        ), (
+            f"SKILL.md pseudocode must reference fixability member {member_str} "
+            f"from _STRUCTURAL_FIXABILITY_VALUES"
+        )
+
+    assert "f.dimension ==" not in comprehension_body, (
+        "structural_stop_triggers must not use dimension-only matching — "
+        "this was the original bug (issue #3092)"
+    )
+    assert 'f.get("dimension")' not in comprehension_body, (
+        "structural_stop_triggers must not use f.get('dimension') matching — "
+        "use fixability-based gating only"
+    )
 
 
 def test_aggregate_review_verdict_rt_cap_downgrades(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

SKILL.md files contain pseudocode that agents use as source-of-truth when implementing features. When `_review.py` was fixed to remove an over-broad `or f.dimension == "estimand_clarity"` clause from `structural_stop_triggers`, the corresponding pseudocode in `review-design/SKILL.md` was not updated. No mechanism — tests, semantic rules, pre-commit hooks, or adversarial plan review — detects divergence between SKILL.md pseudocode and its Python implementation. The adversarial Registry Tracer explicitly classifies SKILL.md as "doc" and excludes it from mandatory sync checks (Step 6 only covers registries, type definitions, configs, derived artifacts, re-exports).

This plan provides architectural immunity through three layers:
1. **Contract tests** that anchor SKILL.md pseudocode to Python constants and catch dimension-only bypass patterns
2. **A semantic rule** that fires at recipe validation time when pseudocode inline-duplicates callable constants without referencing them by name
3. **Registry Tracer expansion** that promotes pseudocode-bearing SKILL.md files to mandatory sync targets during adversarial plan review

Closes #3649

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260603-111415-412689/.autoskillit/temp/rectify/rectify_skillmd_pseudocode_sync_2026-06-03_181833.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 2.6k | 18.9k | 876.0k | 89.1k | 37 | 115.7k | 18m 33s |
| review_approach* | sonnet | 1 | 52 | 6.2k | 194.6k | 45.8k | 15 | 33.0k | 5m 59s |
| dry_walkthrough* | opus | 1 | 53 | 11.1k | 902.2k | 66.8k | 36 | 50.0k | 5m 50s |
| implement* | sonnet | 1 | 368 | 28.9k | 3.1M | 98.0k | 110 | 82.0k | 10m 19s |
| audit_impl* | sonnet | 1 | 70 | 11.0k | 258.0k | 46.5k | 19 | 40.0k | 5m 19s |
| prepare_pr* | MiniMax-M3 | 1 | 208.0k | 2.0k | 0 | 0 | 17 | 0 | 55s |
| compose_pr* | MiniMax-M3 | 1 | 184.3k | 1.2k | 0 | 0 | 12 | 0 | 37s |
| review_pr* | sonnet | 2 | 258 | 81.4k | 1.9M | 107.3k | 83 | 176.1k | 22m 15s |
| resolve_review* | opus | 2 | 102 | 34.3k | 3.7M | 100.5k | 115 | 157.5k | 20m 22s |
| resolve_pre_review_conflicts* | opus | 1 | 40 | 6.0k | 1.1M | 69.3k | 47 | 52.3k | 2m 44s |
| **Total** | | | 395.9k | 201.0k | 12.0M | 107.3k | | 706.7k | 1h 32m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 434 | 7045.6 | 189.0 | 66.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 43 | 86874.3 | 3663.8 | 797.7 |
| resolve_pre_review_conflicts | 876 | 1311.9 | 59.8 | 6.8 |
| **Total** | **1353** | 8895.2 | 522.3 | 148.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.6k | 18.9k | 876.0k | 115.7k | 18m 33s |
| sonnet | 4 | 748 | 127.5k | 5.4M | 331.2k | 43m 54s |
| opus | 3 | 195 | 51.4k | 5.8M | 259.9k | 28m 58s |
| MiniMax-M3 | 2 | 392.4k | 3.2k | 0 | 0 | 1m 32s |