### PR TITLE
Rectify: Provider-Gated Output Format Prompt Reinforcement

### DIFF
--- a/src/autoskillit/execution/backends/_claude_prompt.py
+++ b/src/autoskillit/execution/backends/_claude_prompt.py
@@ -192,9 +192,10 @@ def _inject_output_format_reinforcement(prompt: str, *, profile_name: str = "") 
     directive = (
         "\n\nOUTPUT FORMAT DIRECTIVE: All structured output tokens (key = value lines, "
         "completion markers, delimiter tokens) MUST be emitted as plain text with NO "
-        "markdown formatting. Do NOT wrap token names in **bold**, *italic*, or `backticks`. "
-        "Do NOT wrap output blocks in code fences. Correct: plan_path = /path/file.md  "
-        "Incorrect: **plan_path** = /path/file.md"
+        "markdown formatting. Do NOT wrap token names in bold, italic, or backticks. "
+        "Do NOT wrap output blocks in code fences. "
+        "Correct: plan_path = /path/file.md  "
+        "Incorrect: wrapping plan_path in asterisks or backticks"
     )
     return prompt + directive
 

--- a/src/autoskillit/execution/backends/_claude_prompt.py
+++ b/src/autoskillit/execution/backends/_claude_prompt.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import os
 from collections.abc import Mapping
+from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Any
+from typing import Any, NamedTuple
 
 from autoskillit.core import (
     ClaudeFlags,
@@ -182,6 +183,60 @@ def _inject_completion_reminder(prompt: str, marker: str) -> str:
     if not marker:
         return prompt
     return f"{prompt}\nRemember: end your final response with {marker}"
+
+
+def _inject_output_format_reinforcement(prompt: str, *, profile_name: str = "") -> str:
+    """Append plain-text output format reinforcement for non-Anthropic providers."""
+    if not profile_name:
+        return prompt
+    directive = (
+        "\n\nOUTPUT FORMAT DIRECTIVE: All structured output tokens (key = value lines, "
+        "completion markers, delimiter tokens) MUST be emitted as plain text with NO "
+        "markdown formatting. Do NOT wrap token names in **bold**, *italic*, or `backticks`. "
+        "Do NOT wrap output blocks in code fences. Correct: plan_path = /path/file.md  "
+        "Incorrect: **plan_path** = /path/file.md"
+    )
+    return prompt + directive
+
+
+@dataclass(frozen=True, slots=True)
+class PromptBuildContext:
+    """Context bag passed through the injection chain."""
+
+    completion_marker: str = ""
+    cwd: str = ""
+    temp_dir_relpath: str | None = None
+    has_skill_prefix: bool = False
+    profile_name: str = ""
+
+
+class InjectorDef(NamedTuple):
+    """Static definition of a registered prompt injector."""
+
+    name: str
+
+
+PROMPT_INJECTOR_CHAIN: tuple[InjectorDef, ...] = (
+    InjectorDef("completion-directive"),
+    InjectorDef("cwd-anchor"),
+    InjectorDef("narration-suppression"),
+    InjectorDef("output-format-reinforcement"),
+    InjectorDef("completion-reminder"),
+)
+
+
+def apply_prompt_injector_chain(prompt: str, ctx: PromptBuildContext) -> str:
+    """Apply all registered prompt injectors in declared order.
+
+    Dispatches to each injector's function using the function's own established
+    parameter interface. The existing _inject_* signatures are preserved unchanged.
+    """
+    prompt = _inject_completion_directive(prompt, ctx.completion_marker)
+    prompt = _inject_cwd_anchor(prompt, ctx.cwd, temp_dir_relpath=ctx.temp_dir_relpath)
+    prompt = _inject_narration_suppression(prompt, has_skill_prefix=ctx.has_skill_prefix)
+    prompt = _inject_output_format_reinforcement(prompt, profile_name=ctx.profile_name)
+    prompt = _inject_completion_reminder(prompt, ctx.completion_marker)
+    return prompt
 
 
 def _compose_resume_prompt(

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -55,14 +55,12 @@ from autoskillit.execution.backends._claude_prompt import (
     _INTERACTIVE_ENV_EXCLUSIONS,
     _MAX_MCP_OUTPUT_TOKENS_VALUE,
     _SESSION_BASELINE_ENV,
+    PromptBuildContext,
     _apply_output_format,
     _compose_resume_prompt,
     _ensure_skill_prefix,
     _extract_write_artifacts,
-    _inject_completion_directive,
-    _inject_completion_reminder,
-    _inject_cwd_anchor,
-    _inject_narration_suppression,
+    apply_prompt_injector_chain,
 )
 from autoskillit.execution.backends._cmd_builder import CmdBuilder
 from autoskillit.execution.process import _marker_is_standalone
@@ -564,16 +562,15 @@ class ClaudeCodeBackend:
                 skill_command, provider_profile=profile_name or ""
             )
 
-        prompt = _inject_completion_reminder(
-            _inject_narration_suppression(
-                _inject_cwd_anchor(
-                    _inject_completion_directive(effective_prompt, completion_marker),
-                    cwd,
-                    temp_dir_relpath=temp_dir_relpath,
-                ),
+        prompt = apply_prompt_injector_chain(
+            effective_prompt,
+            PromptBuildContext(
+                completion_marker=completion_marker,
+                cwd=cwd,
+                temp_dir_relpath=temp_dir_relpath,
                 has_skill_prefix=_has_prefix,
+                profile_name=profile_name,
             ),
-            completion_marker,
         )
         extras: dict[str, str] = {
             "AUTOSKILLIT_HEADLESS": "1",
@@ -666,15 +663,15 @@ class ClaudeCodeBackend:
         else:
             effective_prompt = orchestrator_prompt
 
-        prompt = _inject_completion_reminder(
-            _inject_narration_suppression(
-                _inject_cwd_anchor(
-                    _inject_completion_directive(effective_prompt, completion_marker),
-                    cwd,
-                    temp_dir_relpath=temp_dir_relpath,
-                )
+        prompt = apply_prompt_injector_chain(
+            effective_prompt,
+            PromptBuildContext(
+                completion_marker=completion_marker,
+                cwd=cwd,
+                temp_dir_relpath=temp_dir_relpath,
+                has_skill_prefix=False,
+                profile_name="",
             ),
-            completion_marker,
         )
 
         extras: dict[str, str] = {

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -55,12 +55,10 @@ from autoskillit.execution.backends._claude_prompt import (
     _HEADLESS_EXCLUSIVE_VARS,
     _MAX_MCP_OUTPUT_TOKENS_VALUE,
     _SESSION_BASELINE_ENV,
+    PromptBuildContext,
     _compose_resume_prompt,
     _ensure_skill_prefix,
-    _inject_completion_directive,
-    _inject_completion_reminder,
-    _inject_cwd_anchor,
-    _inject_narration_suppression,
+    apply_prompt_injector_chain,
 )
 from autoskillit.execution.backends._cmd_builder import CmdBuilder
 from autoskillit.execution.backends._codex_config import (
@@ -520,16 +518,15 @@ class CodexBackend:
                 skill_command, provider_profile=profile_name or ""
             )
 
-        prompt = _inject_completion_reminder(
-            _inject_narration_suppression(
-                _inject_cwd_anchor(
-                    _inject_completion_directive(effective_prompt, completion_marker),
-                    cwd,
-                    temp_dir_relpath=temp_dir_relpath,
-                ),
+        prompt = apply_prompt_injector_chain(
+            effective_prompt,
+            PromptBuildContext(
+                completion_marker=completion_marker,
+                cwd=cwd,
+                temp_dir_relpath=temp_dir_relpath,
                 has_skill_prefix=_has_prefix,
+                profile_name=profile_name,
             ),
-            completion_marker,
         )
 
         extras: dict[str, str] = {
@@ -637,15 +634,15 @@ class CodexBackend:
         else:
             effective_prompt = orchestrator_prompt
 
-        prompt = _inject_completion_reminder(
-            _inject_narration_suppression(
-                _inject_cwd_anchor(
-                    _inject_completion_directive(effective_prompt, completion_marker),
-                    cwd,
-                    temp_dir_relpath=temp_dir_relpath,
-                )
+        prompt = apply_prompt_injector_chain(
+            effective_prompt,
+            PromptBuildContext(
+                completion_marker=completion_marker,
+                cwd=cwd,
+                temp_dir_relpath=temp_dir_relpath,
+                has_skill_prefix=False,
+                profile_name="",
             ),
-            completion_marker,
         )
 
         extras: dict[str, str] = {

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -7,6 +7,7 @@ from autoskillit.execution.backends._claude_prompt import (
     _HEADLESS_EXCLUSIVE_VARS,  # noqa: F401 — re-export for downstream consumers
     _MAX_MCP_OUTPUT_TOKENS_VALUE,  # noqa: F401 — re-export for downstream consumers
     _SESSION_BASELINE_ENV,  # noqa: F401 — re-export for downstream consumers
+    PromptBuildContext,  # noqa: F401 — re-export for downstream consumers
     _apply_output_format,  # noqa: F401 — re-export for downstream consumers
     _build_resume_context,  # noqa: F401 — re-export for downstream consumers
     _compose_resume_prompt,  # noqa: F401 — re-export for downstream consumers
@@ -15,6 +16,8 @@ from autoskillit.execution.backends._claude_prompt import (
     _inject_completion_reminder,  # noqa: F401 — re-export for downstream consumers
     _inject_cwd_anchor,  # noqa: F401 — re-export for downstream consumers
     _inject_narration_suppression,  # noqa: F401 — re-export for downstream consumers
+    _inject_output_format_reinforcement,  # noqa: F401 — re-export for downstream consumers
+    apply_prompt_injector_chain,  # noqa: F401 — re-export for downstream consumers
 )
 
 ClaudeHeadlessCmd = CmdSpec

--- a/src/autoskillit/execution/headless/_headless_path_tokens.py
+++ b/src/autoskillit/execution/headless/_headless_path_tokens.py
@@ -7,6 +7,7 @@ import os
 import regex as re
 
 from autoskillit.core import get_logger, load_yaml, pkg_root
+from autoskillit.execution.session._session_content import _normalize_model_output
 
 logger = get_logger(__name__)
 
@@ -17,7 +18,8 @@ def _extract_worktree_path(assistant_messages: list[str]) -> str | None:
     """Return the last absolute path emitted as worktree_path=<value>."""
     last: str | None = None
     for msg in assistant_messages:
-        m = _WORKTREE_PATH_PATTERN.search(msg)
+        normalized = _normalize_model_output(msg)
+        m = _WORKTREE_PATH_PATTERN.search(normalized)
         if m:
             candidate = m.group(1).strip()
             if os.path.isabs(candidate):
@@ -140,7 +142,8 @@ def _extract_output_paths(assistant_messages: list[str]) -> dict[str, str]:
         logger.debug("_extract_output_paths called with empty assistant_messages")
     paths: dict[str, str] = {}
     for msg in assistant_messages:
-        for m in _OUTPUT_PATH_PATTERN.finditer(msg):
+        normalized = _normalize_model_output(msg)
+        for m in _OUTPUT_PATH_PATTERN.finditer(normalized):
             token, value = m.group(1), m.group(2).strip()
             if os.path.isabs(value):
                 paths[token] = value

--- a/tests/execution/test_commands_skill_session.py
+++ b/tests/execution/test_commands_skill_session.py
@@ -83,10 +83,22 @@ class TestBuildSkillSessionCmdSharedBehavior:
         assert spec.env["AUTOSKILLIT_APPLICABLE_GUARDS"] == expected
 
 
+def _skill_session_impl_src(backend_cls: type) -> str:
+    """Get the source of the skill session implementation method.
+
+    ClaudeCodeBackend delegates through _build_skill_session_cmd_impl;
+    CodexBackend implements directly in build_skill_session_cmd.
+    """
+    impl = getattr(backend_cls, "_build_skill_session_cmd_impl", None)
+    if impl is None:
+        impl = backend_cls.build_skill_session_cmd
+    return inspect.getsource(impl)
+
+
 class TestPromptInjectorChainBackendConsistency:
     @pytest.mark.parametrize("backend_cls", [ClaudeCodeBackend, CodexBackend])
     def test_all_backends_use_prompt_injector_chain(self, backend_cls) -> None:
-        src = inspect.getsource(backend_cls._build_skill_session_cmd_impl)
+        src = _skill_session_impl_src(backend_cls)
         assert "apply_prompt_injector_chain" in src
         assert "_inject_completion_reminder(_inject_narration" not in src
 

--- a/tests/execution/test_commands_skill_session.py
+++ b/tests/execution/test_commands_skill_session.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
 from autoskillit.execution.backends import CodexBackend
@@ -79,3 +81,17 @@ class TestBuildSkillSessionCmdSharedBehavior:
             "/autoskillit:investigate", "/repo", completion_marker="DONE"
         )
         assert spec.env["AUTOSKILLIT_APPLICABLE_GUARDS"] == expected
+
+
+class TestPromptInjectorChainBackendConsistency:
+    @pytest.mark.parametrize("backend_cls", [ClaudeCodeBackend, CodexBackend])
+    def test_all_backends_use_prompt_injector_chain(self, backend_cls) -> None:
+        src = inspect.getsource(backend_cls._build_skill_session_cmd_impl)
+        assert "apply_prompt_injector_chain" in src
+        assert "_inject_completion_reminder(_inject_narration" not in src
+
+    @pytest.mark.parametrize("backend_cls", [ClaudeCodeBackend, CodexBackend])
+    def test_orchestrator_paths_use_prompt_injector_chain(self, backend_cls) -> None:
+        src = inspect.getsource(backend_cls.build_food_truck_cmd)
+        assert "apply_prompt_injector_chain" in src
+        assert "_inject_completion_reminder(_inject_narration" not in src

--- a/tests/execution/test_commands_skill_session.py
+++ b/tests/execution/test_commands_skill_session.py
@@ -100,10 +100,8 @@ class TestPromptInjectorChainBackendConsistency:
     def test_all_backends_use_prompt_injector_chain(self, backend_cls) -> None:
         src = _skill_session_impl_src(backend_cls)
         assert "apply_prompt_injector_chain" in src
-        assert "_inject_completion_reminder(_inject_narration" not in src
 
     @pytest.mark.parametrize("backend_cls", [ClaudeCodeBackend, CodexBackend])
     def test_orchestrator_paths_use_prompt_injector_chain(self, backend_cls) -> None:
         src = inspect.getsource(backend_cls.build_food_truck_cmd)
         assert "apply_prompt_injector_chain" in src
-        assert "_inject_completion_reminder(_inject_narration" not in src

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -2774,3 +2774,62 @@ class TestInjectNarrationSuppression:
         result = _inject_narration_suppression("cmd", has_skill_prefix=True)
         assert "EFFICIENCY DIRECTIVE" in result
         assert "between tool calls" in result
+
+
+class TestInjectCompletionReminder:
+    def test_with_marker(self):
+        from autoskillit.execution.commands import _inject_completion_reminder
+
+        result = _inject_completion_reminder("prompt", "%%DONE%%")
+        assert "%%DONE%%" in result
+        assert result.endswith("%%DONE%%")
+
+    def test_empty_marker_noop(self):
+        from autoskillit.execution.commands import _inject_completion_reminder
+
+        result = _inject_completion_reminder("prompt", "")
+        assert result == "prompt"
+
+    def test_idempotent(self):
+        from autoskillit.execution.commands import _inject_completion_reminder
+
+        once = _inject_completion_reminder("prompt", "%%DONE%%")
+        twice = _inject_completion_reminder(once, "%%DONE%%")
+        assert twice.count("%%DONE%%") == 2
+
+
+def test_prompt_injector_registry_completeness():
+    from autoskillit.execution.backends._claude_prompt import PROMPT_INJECTOR_CHAIN
+
+    names = [entry.name for entry in PROMPT_INJECTOR_CHAIN]
+    assert "completion-directive" in names
+    assert "cwd-anchor" in names
+    assert "narration-suppression" in names
+    assert "output-format-reinforcement" in names
+    assert "completion-reminder" in names
+    assert names[-1] == "completion-reminder"
+
+
+def test_prompt_injector_registry_ordering():
+    from autoskillit.execution.backends._claude_prompt import PROMPT_INJECTOR_CHAIN
+
+    names = [entry.name for entry in PROMPT_INJECTOR_CHAIN]
+    assert names[0] == "completion-directive"
+    assert names[-1] == "completion-reminder"
+
+
+def test_inject_output_format_reinforcement_non_anthropic():
+    from autoskillit.execution.backends._claude_prompt import _inject_output_format_reinforcement
+
+    result = _inject_output_format_reinforcement("base prompt", profile_name="minimax")
+    lower = result.lower()
+    assert "plain text" in lower or "no markdown" in lower
+    directive_part = result.split("OUTPUT FORMAT")[1]
+    assert "**" not in directive_part
+
+
+def test_inject_output_format_reinforcement_anthropic_noop():
+    from autoskillit.execution.backends._claude_prompt import _inject_output_format_reinforcement
+
+    result = _inject_output_format_reinforcement("base prompt", profile_name="")
+    assert result == "base prompt"

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -2799,7 +2799,7 @@ class TestInjectCompletionReminder:
         result = _inject_completion_reminder("prompt", "")
         assert result == "prompt"
 
-    def test_idempotent(self):
+    def test_always_appends(self):
         from autoskillit.execution.commands import _inject_completion_reminder
 
         once = _inject_completion_reminder("prompt", "%%DONE%%")
@@ -2807,23 +2807,13 @@ class TestInjectCompletionReminder:
         assert twice.count("%%DONE%%") == 2
 
 
-def test_inject_completion_reminder_with_marker():
-    from autoskillit.execution.commands import _inject_completion_reminder
+def test_prompt_injector_registry():
+    import inspect
 
-    result = _inject_completion_reminder("prompt", "%%DONE%%")
-    assert "%%DONE%%" in result
-    assert result.endswith("%%DONE%%")
-
-
-def test_inject_completion_reminder_empty_marker():
-    from autoskillit.execution.commands import _inject_completion_reminder
-
-    result = _inject_completion_reminder("prompt", "")
-    assert result == "prompt"
-
-
-def test_prompt_injector_registry_completeness():
-    from autoskillit.execution.backends._claude_prompt import PROMPT_INJECTOR_CHAIN
+    from autoskillit.execution.backends._claude_prompt import (
+        PROMPT_INJECTOR_CHAIN,
+        apply_prompt_injector_chain,
+    )
 
     names = [entry.name for entry in PROMPT_INJECTOR_CHAIN]
     assert "completion-directive" in names
@@ -2831,15 +2821,14 @@ def test_prompt_injector_registry_completeness():
     assert "narration-suppression" in names
     assert "output-format-reinforcement" in names
     assert "completion-reminder" in names
-    assert names[-1] == "completion-reminder"
-
-
-def test_prompt_injector_registry_ordering():
-    from autoskillit.execution.backends._claude_prompt import PROMPT_INJECTOR_CHAIN
-
-    names = [entry.name for entry in PROMPT_INJECTOR_CHAIN]
     assert names[0] == "completion-directive"
     assert names[-1] == "completion-reminder"
+    source = inspect.getsource(apply_prompt_injector_chain)
+    for entry in PROMPT_INJECTOR_CHAIN:
+        func_name = f"_inject_{entry.name.replace('-', '_')}"
+        assert func_name in source, (
+            f"Chain entry '{entry.name}' missing dispatch call to {func_name}"
+        )
 
 
 def test_inject_output_format_reinforcement_non_anthropic():

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -1460,14 +1460,23 @@ class TestExtractWorktreePath:
         assert result == "/abs/worktrees/impl-first"
 
     @pytest.mark.parametrize(
+        "token,expected",
+        [
+            ("**worktree_path:** /path/to/wt", "/path/to/wt"),
+            ("`worktree_path` = /path/to/wt", "/path/to/wt"),
+        ],
+        ids=["markdown-bold", "backtick-wrapped"],
+    )
+    def test_extract_worktree_path_normalized_variants(self, token: str, expected: str):
+        assert _extract_worktree_path([token]) == expected
+
+    @pytest.mark.parametrize(
         "token",
         [
-            "**worktree_path:** /path/to/wt",
             "worktree_path: /path/to/wt",
             "WORKTREE_PATH = /path/to/wt",
-            "`worktree_path` = /path/to/wt",
         ],
-        ids=["markdown-bold", "colon-separator", "uppercase", "backtick-wrapped"],
+        ids=["colon-separator", "uppercase"],
     )
     def test_extract_worktree_path_format_variants_return_none(self, token: str):
         assert _extract_worktree_path([token]) is None

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -2807,6 +2807,21 @@ class TestInjectCompletionReminder:
         assert twice.count("%%DONE%%") == 2
 
 
+def test_inject_completion_reminder_with_marker():
+    from autoskillit.execution.commands import _inject_completion_reminder
+
+    result = _inject_completion_reminder("prompt", "%%DONE%%")
+    assert "%%DONE%%" in result
+    assert result.endswith("%%DONE%%")
+
+
+def test_inject_completion_reminder_empty_marker():
+    from autoskillit.execution.commands import _inject_completion_reminder
+
+    result = _inject_completion_reminder("prompt", "")
+    assert result == "prompt"
+
+
 def test_prompt_injector_registry_completeness():
     from autoskillit.execution.backends._claude_prompt import PROMPT_INJECTOR_CHAIN
 

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -2837,7 +2837,8 @@ def test_inject_output_format_reinforcement_non_anthropic():
     result = _inject_output_format_reinforcement("base prompt", profile_name="minimax")
     lower = result.lower()
     assert "plain text" in lower or "no markdown" in lower
-    directive_part = result.split("OUTPUT FORMAT")[1]
+    assert "OUTPUT FORMAT" in result, "Expected 'OUTPUT FORMAT' in injected directive"
+    directive_part = result.partition("OUTPUT FORMAT")[2]
     assert "**" not in directive_part
 
 

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -2103,3 +2103,23 @@ class TestWorktreePathPropagationWithEmptyMessages:
     def test_extract_output_paths_with_empty_messages_returns_empty(self):
         """_extract_output_paths([]) returns {} (documents the contract)."""
         assert _extract_output_paths([]) == {}
+
+
+class TestExtractPathTokensWithMarkdownDecorators:
+    def test_extract_worktree_path_with_markdown_bold(self):
+        msgs = ["**worktree_path** = /tmp/wt-abc"]
+        assert _extract_worktree_path(msgs) == "/tmp/wt-abc"
+
+    def test_extract_worktree_path_with_backticks(self):
+        msgs = ["`worktree_path` = /tmp/wt-abc"]
+        assert _extract_worktree_path(msgs) == "/tmp/wt-abc"
+
+    def test_extract_output_paths_with_markdown_decorators(self):
+        from autoskillit.execution.headless._headless_path_tokens import _OUTPUT_PATH_TOKENS
+
+        if not _OUTPUT_PATH_TOKENS:
+            pytest.skip("_OUTPUT_PATH_TOKENS is empty (contracts YAML not available)")
+        token = next(iter(sorted(_OUTPUT_PATH_TOKENS)))
+        msgs = [f"**{token}** = /tmp/plan.md"]
+        paths = _extract_output_paths(msgs)
+        assert paths.get(token) == "/tmp/plan.md"


### PR DESCRIPTION
## Summary

MiniMax-M3 substitutes markdown formatting (bold, italic, backticks) where the pipeline requires plain-text structured tokens (`plan_path = ...`, `worktree_path = ...`, `%%ORDER_UP%%`). The root cause is twofold:

1. **No output format reinforcement injection**: The prompt injection chain (`_inject_completion_directive` → `_inject_cwd_anchor` → `_inject_narration_suppression` → `_inject_completion_reminder`) has no function to enforce plain-text structured output tokens. Format instructions in SKILL.md files sit mid-document where they compete for model attention.

2. **Path token extractors skip normalization**: `_extract_worktree_path()` and `_extract_output_paths()` in `_headless_path_tokens.py` search raw `assistant_messages` without running through `_normalize_model_output()`. This means markdown-decorated tokens like `**worktree_path** = /path` silently fail to match even though `_check_expected_patterns()` in the same pipeline normalizes first.

The architectural weakness is that the injection chain is a manually-composed nested function call duplicated across four call sites in two backends, with no structural mechanism to ensure completeness or consistency. Adding a new concern requires modifying all four sites manually — the current bug exists because that didn't happen.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260603-111210-003506/.autoskillit/temp/rectify/rectify_provider_gated_output_format_prompt_reinforcement_2026-06-03_111210.md`

Closes #3660

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 2.8k | 23.7k | 1.7M | 114.3k | 55 | 151.7k | 14m 40s |
| review_approach* | sonnet | 1 | 52 | 7.2k | 201.2k | 48.8k | 16 | 36.4k | 4m 56s |
| dry_walkthrough* | opus | 2 | 587 | 14.8k | 1.2M | 70.0k | 71 | 85.0k | 8m 51s |
| implement* | sonnet | 2 | 10.9k | 30.1k | 5.1M | 107.7k | 186 | 110.7k | 11m 19s |
| audit_impl* | sonnet | 2 | 172 | 20.5k | 686.1k | 57.2k | 44 | 65.7k | 9m 35s |
| make_plan* | sonnet | 1 | 111 | 6.0k | 529.7k | 53.2k | 29 | 38.3k | 2m 52s |
| prepare_pr* | MiniMax-M3 | 1 | 200.7k | 2.5k | 0 | 0 | 12 | 0 | 50s |
| compose_pr* | MiniMax-M3 | 1 | 224.5k | 1.3k | 0 | 0 | 12 | 0 | 40s |
| review_pr* | sonnet | 3 | 528 | 121.6k | 4.0M | 124.9k | 156 | 330.2k | 31m 53s |
| resolve_review* | opus | 3 | 149 | 54.8k | 4.4M | 95.1k | 153 | 213.8k | 38m 33s |
| **Total** | | | 440.5k | 282.5k | 17.8M | 124.9k | | 1.0M | 2h 4m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 263 | 19421.5 | 420.8 | 114.4 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 42 | 105698.1 | 5089.7 | 1305.8 |
| **Total** | **305** | 58436.3 | 3382.5 | 926.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.8k | 23.7k | 1.7M | 151.7k | 14m 40s |
| sonnet | 5 | 11.7k | 185.4k | 10.5M | 581.2k | 1h 0m |
| opus | 2 | 736 | 69.6k | 5.6M | 298.7k | 47m 24s |
| MiniMax-M3 | 2 | 425.3k | 3.8k | 0 | 0 | 1m 30s |