### PR TITLE
Implementation Plan: Rewrite bundled recipe test assertions — P3-A7-WP1

### DIFF
--- a/tests/recipe/test_rules_skill_routing.py
+++ b/tests/recipe/test_rules_skill_routing.py
@@ -138,26 +138,26 @@ def test_skill_result_routing_gap_does_not_fire_for_terminal_catchall() -> None:
 def test_pass_through_capture_skips_routing_gap() -> None:
     """A pass_through-annotated capture should not trigger routing gap."""
     steps = {
-        "review": RecipeStep(
+        "classify": RecipeStep(
             tool="run_skill",
-            with_args={"skill_command": "/autoskillit:review-design plan.md scope.md"},
+            with_args={"skill_command": "/autoskillit:classify-experiment-type plan.md scope.md"},
             capture={
                 "experiment_type": "${{ result.experiment_type }}",
-                "verdict": "${{ result.verdict }}",
+                "is_silent_type": "${{ result.is_silent_type }}",
             },
             pass_through=["experiment_type"],
             on_result=StepResultRoute(
                 conditions=[
-                    StepResultCondition(route="next", when="${{ result.verdict }} == GO"),
-                    StepResultCondition(route="revise", when="${{ result.verdict }} == REVISE"),
-                    StepResultCondition(route="stopped", when="${{ result.verdict }} == STOP"),
+                    StepResultCondition(route="next", when="${{ result.is_silent_type }} == true"),
+                    StepResultCondition(
+                        route="revise", when="${{ result.is_silent_type }} == false"
+                    ),
                     StepResultCondition(route="next"),
                 ]
             ),
         ),
         "next": RecipeStep(tool="run_cmd", with_args={"cmd": "echo next"}),
         "revise": RecipeStep(tool="run_cmd", with_args={"cmd": "echo revise"}),
-        "stopped": RecipeStep(action="stop", message="stopped"),
     }
     recipe = _make_recipe(steps)
     findings = run_semantic_rules(recipe)
@@ -168,25 +168,25 @@ def test_pass_through_capture_skips_routing_gap() -> None:
 def test_routing_gap_still_fires_without_pass_through() -> None:
     """Without pass_through, unrouted allowed_values should still fire."""
     steps = {
-        "review": RecipeStep(
+        "classify": RecipeStep(
             tool="run_skill",
-            with_args={"skill_command": "/autoskillit:review-design plan.md scope.md"},
+            with_args={"skill_command": "/autoskillit:classify-experiment-type plan.md scope.md"},
             capture={
                 "experiment_type": "${{ result.experiment_type }}",
-                "verdict": "${{ result.verdict }}",
+                "is_silent_type": "${{ result.is_silent_type }}",
             },
             on_result=StepResultRoute(
                 conditions=[
-                    StepResultCondition(route="next", when="${{ result.verdict }} == GO"),
-                    StepResultCondition(route="revise", when="${{ result.verdict }} == REVISE"),
-                    StepResultCondition(route="stopped", when="${{ result.verdict }} == STOP"),
+                    StepResultCondition(route="next", when="${{ result.is_silent_type }} == true"),
+                    StepResultCondition(
+                        route="revise", when="${{ result.is_silent_type }} == false"
+                    ),
                     StepResultCondition(route="next"),
                 ]
             ),
         ),
         "next": RecipeStep(tool="run_cmd", with_args={"cmd": "echo next"}),
         "revise": RecipeStep(tool="run_cmd", with_args={"cmd": "echo revise"}),
-        "stopped": RecipeStep(action="stop", message="stopped"),
     }
     recipe = _make_recipe(steps)
     findings = run_semantic_rules(recipe)
@@ -198,14 +198,14 @@ def test_routing_gap_still_fires_without_pass_through() -> None:
 def test_pass_through_validity_fires_on_uncaptured_output() -> None:
     """pass_through referencing an output that is not captured should warn."""
     steps = {
-        "review": RecipeStep(
+        "classify": RecipeStep(
             tool="run_skill",
-            with_args={"skill_command": "/autoskillit:review-design plan.md scope.md"},
-            capture={"verdict": "${{ result.verdict }}"},
+            with_args={"skill_command": "/autoskillit:classify-experiment-type plan.md scope.md"},
+            capture={"is_silent_type": "${{ result.is_silent_type }}"},
             pass_through=["experiment_type"],
             on_result=StepResultRoute(
                 conditions=[
-                    StepResultCondition(route="next", when="${{ result.verdict }} == GO"),
+                    StepResultCondition(route="next", when="${{ result.is_silent_type }} == true"),
                     StepResultCondition(route="next"),
                 ]
             ),
@@ -222,17 +222,17 @@ def test_pass_through_validity_fires_on_uncaptured_output() -> None:
 def test_pass_through_validity_fires_on_routing_output() -> None:
     """pass_through referencing an output used in when clause should warn."""
     steps = {
-        "review": RecipeStep(
+        "classify": RecipeStep(
             tool="run_skill",
-            with_args={"skill_command": "/autoskillit:review-design plan.md scope.md"},
+            with_args={"skill_command": "/autoskillit:classify-experiment-type plan.md scope.md"},
             capture={
                 "experiment_type": "${{ result.experiment_type }}",
-                "verdict": "${{ result.verdict }}",
+                "is_silent_type": "${{ result.is_silent_type }}",
             },
-            pass_through=["experiment_type", "verdict"],
+            pass_through=["experiment_type", "is_silent_type"],
             on_result=StepResultRoute(
                 conditions=[
-                    StepResultCondition(route="next", when="${{ result.verdict }} == GO"),
+                    StepResultCondition(route="next", when="${{ result.is_silent_type }} == true"),
                     StepResultCondition(route="next"),
                 ]
             ),
@@ -245,7 +245,7 @@ def test_pass_through_validity_fires_on_routing_output() -> None:
     assert len(validity_findings) >= 1, (
         "pass-through-validity must warn when output controls routing"
     )
-    assert any("verdict" in f.message for f in validity_findings)
+    assert any("is_silent_type" in f.message for f in validity_findings)
     assert not any("experiment_type" in f.message for f in validity_findings), (
         "experiment_type is not used in when clause and should not be flagged"
     )


### PR DESCRIPTION
## Summary

Replace all four `/autoskillit:review-design` skill_command references in `tests/recipe/test_rules_skill_routing.py` with `/autoskillit:classify-experiment-type`. Since `classify-experiment-type` has no `verdict` output, substitute `is_silent_type` (allowed_values: `['true', 'false']`) as the routing-controlling output in all four tests. The test intent — exercising `skill-result-routing-gap` and `pass-through-validity` rules against outputs with `allowed_values` — is preserved exactly.

Closes #3099

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260603-121931-119644/.autoskillit/temp/make-plan/rewrite_bundled_recipe_test_assertions_plan_2026-06-03_122600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 56 | 12.5k | 556.6k | 67.3k | 23 | 59.6k | 5m 24s |
| verify* | sonnet | 1 | 52 | 4.9k | 194.5k | 44.9k | 17 | 28.3k | 3m 2s |
| implement* | MiniMax-M3 | 1 | 1.2M | 6.5k | 0 | 0 | 56 | 0 | 3m 0s |
| audit_impl* | sonnet | 1 | 44 | 6.0k | 142.7k | 36.3k | 12 | 26.7k | 3m 14s |
| prepare_pr* | MiniMax-M3 | 1 | 235.3k | 1.8k | 0 | 0 | 11 | 0 | 48s |
| compose_pr* | MiniMax-M3 | 1 | 185.7k | 1.7k | 0 | 0 | 12 | 0 | 41s |
| review_pr* | sonnet | 3 | 358 | 34.2k | 1.8M | 53.4k | 104 | 109.1k | 9m 48s |
| **Total** | | | 1.6M | 67.7k | 2.7M | 67.3k | | 223.7k | 26m 0s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 48 | 0.0 | 0.0 | 135.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **48** | 55274.1 | 4661.4 | 1409.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 56 | 12.5k | 556.6k | 59.6k | 5m 24s |
| sonnet | 3 | 454 | 45.1k | 2.1M | 164.1k | 16m 6s |
| MiniMax-M3 | 3 | 1.6M | 10.0k | 0 | 0 | 4m 30s |