### PR TITLE
Rectify: Heredoc Body Content Causes shlex.split False Positives Across All Guard Scripts

### DIFF
--- a/src/autoskillit/core/bash_write_targets.py
+++ b/src/autoskillit/core/bash_write_targets.py
@@ -18,7 +18,7 @@ import shlex
 _SHELL_OPS: frozenset[str] = frozenset({"&&", "||", ";", "!", "|", "("})
 
 _HEREDOC_BODY_RE = re.compile(
-    r"(<<-?\s*['\"]?(\w+)['\"]?[^\n]*)\n.*?\n\t*(\2)\b",
+    r"(<<-?\s*['\"]?(\w+)['\"]?[^\n]*)\n.*?\n\t*(\2)(?=[ \t]*(?:\n|$))",
     re.DOTALL,
 )
 

--- a/src/autoskillit/core/bash_write_targets.py
+++ b/src/autoskillit/core/bash_write_targets.py
@@ -17,6 +17,11 @@ import shlex
 
 _SHELL_OPS: frozenset[str] = frozenset({"&&", "||", ";", "!", "|", "("})
 
+_HEREDOC_BODY_RE = re.compile(
+    r"(<<-?\s*['\"]?(\w+)['\"]?[^\n]*)\n.*?\n\t*(\2)\b",
+    re.DOTALL,
+)
+
 _REDIRECT_TOKEN_RE = re.compile(r"^(\d*)>{1,2}(.+)$")
 _REDIRECT_OP_ONLY_RE = re.compile(r"^(\d*)>{1,2}$")
 _FD_REDIRECT_RE = re.compile(r"^\d*>{1,2}&")
@@ -64,9 +69,13 @@ def _resolve_write_target(path: str, cwd: str = "") -> str | None:
     return None
 
 
+def _strip_heredoc_bodies(command: str) -> str:
+    return _HEREDOC_BODY_RE.sub(r"\1\n\3", command)
+
+
 def _tokenize_command_segments(command: str) -> list[list[str]]:
     try:
-        tokens = shlex.split(command)
+        tokens = shlex.split(_strip_heredoc_bodies(command))
     except (ValueError, TypeError):
         return []
     segments: list[list[str]] = []
@@ -262,7 +271,7 @@ def extract_bash_write_targets(command: str, cwd: str = "") -> list[str]:
             all_targets.extend(result)
 
     try:
-        flat_tokens = shlex.split(command)
+        flat_tokens = shlex.split(_strip_heredoc_bodies(command))
     except (ValueError, TypeError, AttributeError):
         flat_tokens = []
     redirect_paths = _extract_redirect_targets(flat_tokens, cwd)

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -52,7 +52,7 @@ _TRAILING_SHELL_CLOSERS = frozenset({")", "`", "}", "'", '"', ";", "&", "|"})
 _SHELL_VAR_RE = re.compile(r"\$\{[A-Za-z_]|\$[A-Za-z_]")
 
 _HEREDOC_BODY_RE = re.compile(
-    r"(<<-?\s*['\"]?(\w+)['\"]?[^\n]*)\n.*?\n\t*(\2)\b",
+    r"(<<-?\s*['\"]?(\w+)['\"]?[^\n]*)\n.*?\n\t*(\2)(?=[ \t]*(?:\n|$))",
     re.DOTALL,
 )
 

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -51,6 +51,20 @@ _FD_REDIRECT_RE = re.compile(r"^\d*>{1,2}&")
 _TRAILING_SHELL_CLOSERS = frozenset({")", "`", "}", "'", '"', ";", "&", "|"})
 _SHELL_VAR_RE = re.compile(r"\$\{[A-Za-z_]|\$[A-Za-z_]")
 
+_HEREDOC_BODY_RE = re.compile(
+    r"(<<-?\s*['\"]?(\w+)['\"]?[^\n]*)\n.*?\n\t*(\2)\b",
+    re.DOTALL,
+)
+
+
+def strip_heredoc_bodies(command: str) -> str:
+    """Strip heredoc body content, preserving the opening line and terminator.
+
+    The opening line (containing << and any real redirects) is kept intact.
+    Only the body lines between the opening and terminator are removed.
+    """
+    return _HEREDOC_BODY_RE.sub(r"\1\n\3", command)
+
 
 def resolve_write_target(path: str, cwd: str = "") -> str | None:
     if not path:
@@ -75,7 +89,7 @@ def tokenize_command_segments(command: str) -> list[list[str]]:
     Returns [] on shlex parse error (unclosed quotes).
     """
     try:
-        tokens = shlex.split(command)
+        tokens = shlex.split(strip_heredoc_bodies(command))
     except (ValueError, TypeError):
         return []
     segments: list[list[str]] = []

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -22,6 +22,7 @@ from _command_classification import (  # type: ignore[import-not-found]  # noqa:
     extract_redirect_targets,
     is_gh_command,
     resolve_write_target,
+    strip_heredoc_bodies,
     tokenize_command_segments,
 )
 
@@ -163,7 +164,7 @@ def _extract_bash_write_targets(command: str) -> list[str] | None:
             all_targets.extend(result)
 
     try:
-        flat_tokens = shlex.split(command)
+        flat_tokens = shlex.split(strip_heredoc_bodies(command))
     except (ValueError, TypeError, AttributeError):
         flat_tokens = []
     redirect_paths = extract_redirect_targets(flat_tokens, cwd)

--- a/tests/arch/test_regex_guards.py
+++ b/tests/arch/test_regex_guards.py
@@ -290,7 +290,7 @@ def test_write_guard_tests_cover_deny_and_allow_paths() -> None:
         for node in ast.walk(tree)
         if isinstance(node, ast.FunctionDef) and node.name.startswith("test_")
     }
-    deny_indicators = {"denied", "blocked", "deny"}
+    deny_indicators = {"denied", "blocked", "deny", "rejected"}
     allow_indicators = {"allowed", "not_blocked", "false_positive", "readonly", "approved"}
     missing = []
     for family in REQUIRED_BIDIRECTIONAL_FAMILIES:

--- a/tests/arch/test_regex_guards.py
+++ b/tests/arch/test_regex_guards.py
@@ -266,10 +266,45 @@ def test_command_classification_exports_tokenization() -> None:
         "command_verb",
         "is_gh_command",
         "extract_redirect_targets",
+        "strip_heredoc_bodies",
     ):
         assert f"def {name}" in source, (
             f"_command_classification.py must define {name}() for structural command parsing"
         )
+
+
+REQUIRED_BIDIRECTIONAL_FAMILIES = {
+    "heredoc",
+    "redirect",
+    "fd_redirect",
+    "subshell",
+}
+
+
+def test_write_guard_tests_cover_deny_and_allow_paths() -> None:
+    """Critical command families must have both deny-path and allow-path test coverage."""
+    test_path = pathlib.Path(__file__).parent.parent / "hooks" / "test_write_guard.py"
+    tree = ast.parse(test_path.read_text())
+    test_names = {
+        node.name.lower()
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("test_")
+    }
+    deny_indicators = {"denied", "blocked", "deny"}
+    allow_indicators = {"allowed", "not_blocked", "false_positive", "readonly", "approved"}
+    missing = []
+    for family in REQUIRED_BIDIRECTIONAL_FAMILIES:
+        family_tests = {n for n in test_names if family in n}
+        has_deny = any(any(d in n for d in deny_indicators) for n in family_tests)
+        has_allow = any(any(a in n for a in allow_indicators) for n in family_tests)
+        if not has_deny:
+            missing.append(f"{family}: missing deny-path test")
+        if not has_allow:
+            missing.append(f"{family}: missing allow-path test")
+    assert not missing, (
+        f"test_write_guard.py missing bidirectional coverage: {missing}. "
+        f"Critical families need both deny and allow tests."
+    )
 
 
 def test_redirect_extraction_uses_tokenization() -> None:

--- a/tests/core/test_bash_write_targets.py
+++ b/tests/core/test_bash_write_targets.py
@@ -110,6 +110,10 @@ _PARITY_CORPUS: list[tuple[str, str]] = [
     ("echo x > $MY_OUTPUT_DIR/out.txt", "/workspace"),
     ("tee $MY_OUTPUT_DIR/out.txt", "/workspace"),
     ("REVIEW_OUTPUT_DIR='.autoskillit/temp' && echo x > $REVIEW_OUTPUT_DIR/out.txt", "/workspace"),
+    # Heredoc with > comparison in body — must NOT produce false write targets
+    ("python3 - <<'EOF'\nif x > 3:\n    pass\nEOF", "/workspace"),
+    # Heredoc with real redirect on opening line — must produce write target
+    ("cat <<'EOF' > /workspace/out.txt\nbody content\nEOF", "/workspace"),
 ]
 
 
@@ -130,6 +134,9 @@ def test_parity_with_command_classification(
         extract_redirect_targets as hooks_extract_redirect_targets,
     )
     from _command_classification import (
+        strip_heredoc_bodies as hooks_strip_heredoc_bodies,
+    )
+    from _command_classification import (
         tokenize_command_segments as hooks_tokenize_command_segments,
     )
     from guards.write_guard import (  # type: ignore[import-not-found]
@@ -148,7 +155,7 @@ def test_parity_with_command_classification(
         if seg_result is not None:
             hooks_all.extend(seg_result)
     try:
-        flat_tokens = shlex.split(command)
+        flat_tokens = shlex.split(hooks_strip_heredoc_bodies(command))
     except (ValueError, TypeError, AttributeError):
         flat_tokens = []
     redirect_paths = hooks_extract_redirect_targets(flat_tokens, cwd)
@@ -165,3 +172,28 @@ def test_parity_with_command_classification(
     assert core_result == hooks_unique, (
         f"Parity mismatch for {command!r}: core={core_result}, hooks={hooks_unique}"
     )
+
+
+def test_strip_heredoc_bodies_parity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """IL-0 and hooks implementations of strip_heredoc_bodies must agree."""
+    from pathlib import Path
+
+    hooks_dir = str(
+        Path(__file__).resolve().parent.parent.parent / "src" / "autoskillit" / "hooks"
+    )
+    monkeypatch.syspath_prepend(hooks_dir)
+
+    from _command_classification import (  # type: ignore[import-not-found]
+        strip_heredoc_bodies as hooks_strip_heredoc_bodies,
+    )
+
+    from autoskillit.core.bash_write_targets import _strip_heredoc_bodies as core_strip
+
+    cases = [
+        "python3 - <<'EOF'\nif x > 3:\n    pass\nEOF",
+        "cat <<EOF > /real/file.txt\nbody\nEOF",
+        "echo hello > /dev/null",
+        "cat <<-DELIM\n\tbody\n\tDELIM",
+    ]
+    for cmd in cases:
+        assert core_strip(cmd) == hooks_strip_heredoc_bodies(cmd), f"Parity mismatch for: {cmd!r}"

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -406,3 +406,42 @@ class TestExtractRedirectTargetsCwd:
         from autoskillit.hooks._command_classification import extract_redirect_targets
 
         assert extract_redirect_targets(tokens, cwd) == expected
+
+
+@pytest.mark.parametrize(
+    "command,expected_stripped",
+    [
+        (
+            "python3 - <<'EOF'\nif x > 3:\n    pass\nEOF",
+            "python3 - <<'EOF'\nEOF",
+        ),
+        (
+            "cat <<EOF\nbody > content\nEOF",
+            "cat <<EOF\nEOF",
+        ),
+        (
+            "cat <<-DELIM\n\tbody\nDELIM",
+            "cat <<-DELIM\nDELIM",
+        ),
+        (
+            "cat <<-DELIM\n\tbody\n\tDELIM",
+            "cat <<-DELIM\nDELIM",
+        ),
+        (
+            "cat <<'EOF' > /real/file.txt\nbody content\nEOF",
+            "cat <<'EOF' > /real/file.txt\nEOF",
+        ),
+        (
+            "echo hello > /dev/null",
+            "echo hello > /dev/null",
+        ),
+        (
+            "cat <<'A'\nbody1\nA\ncat <<'B'\nbody2\nB",
+            "cat <<'A'\nA\ncat <<'B'\nB",
+        ),
+    ],
+)
+def test_strip_heredoc_bodies(command: str, expected_stripped: str) -> None:
+    from autoskillit.hooks._command_classification import strip_heredoc_bodies
+
+    assert strip_heredoc_bodies(command) == expected_stripped

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -550,6 +550,28 @@ class TestWriteGuardInterpreterBypass:
         parsed = json.loads(result)
         assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
 
+    def test_python3_heredoc_readonly_comparison_allowed(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", self.PREFIX)
+        cmd = (
+            "python3 - <<'EOF'\n"
+            "if severity_rank[f['severity']] > severity_rank[deduped[key]['severity']]:\n"
+            "    deduped[key] = f\n"
+            "EOF"
+        )
+        event = _build_bash_event(cmd)
+        result = _run_hook(event)
+        assert result == ""  # empty = approve
+
+    def test_heredoc_with_real_redirect_on_opening_line_denied(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", self.PREFIX)
+        cmd = "cat <<'EOF' > /outside/prefix/output.txt\nsome content\nEOF"
+        event = _build_bash_event(cmd)
+        result = _run_hook(event)
+        parsed = json.loads(result)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+
     def test_python3_append_mode_denied(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", self.PREFIX)
         event = _build_bash_event("python3 -c \"open('/clone/src/f.py','a').write('x')\"")


### PR DESCRIPTION
## Summary

`shlex.split` does not understand heredoc syntax. Every guard script that calls `shlex.split(command)` on a raw command string containing a heredoc flattens the heredoc body into the shell token stream. When heredoc body content contains tokens that resemble shell operators (`>`, `>>`, `pytest`, `git commit --amend`, etc.), downstream classification logic misinterprets them.

The immediate manifestation is `write_guard.py` treating `>` comparison operators in heredoc bodies as redirect operators, producing false denies. But the vulnerability is systemic: 10 `shlex.split` call sites across 7 guard files plus 1 IL-0 parity module all lack heredoc awareness. The fix is a single shared pre-processing function that strips heredoc bodies before tokenization, applied at the shared entry points in both `_command_classification.py` and `core/bash_write_targets.py`.

Closes #3648

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260603-132907-999457/.autoskillit/temp/rectify/rectify_heredoc_false_positive_shlex_split_2026-06-03_132907.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 71 | 17.1k | 1.8M | 99.0k | 54 | 82.1k | 25m 2s |
| review_approach* | sonnet | 1 | 9.8k | 8.9k | 194.8k | 51.6k | 16 | 39.8k | 6m 53s |
| dry_walkthrough* | opus | 1 | 58 | 17.6k | 2.2M | 124.7k | 53 | 107.7k | 7m 4s |
| implement* | sonnet | 1 | 266 | 17.4k | 2.1M | 83.6k | 82 | 67.1k | 5m 45s |
| audit_impl* | sonnet | 1 | 62 | 9.8k | 211.4k | 40.4k | 20 | 35.2k | 5m 8s |
| prepare_pr* | MiniMax-M3 | 1 | 208.6k | 2.0k | 0 | 0 | 16 | 0 | 47s |
| compose_pr* | MiniMax-M3 | 1 | 260.9k | 1.5k | 0 | 0 | 16 | 0 | 56s |
| review_pr* | sonnet | 1 | 118 | 41.1k | 774.5k | 90.3k | 43 | 74.9k | 11m 44s |
| resolve_review* | opus | 1 | 45 | 18.7k | 1.1M | 80.0k | 42 | 82.6k | 12m 38s |
| **Total** | | | 479.9k | 134.1k | 8.4M | 124.7k | | 489.4k | 1h 15m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 162 | 12719.4 | 414.1 | 107.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 190393.8 | 13769.5 | 3113.3 |
| **Total** | **168** | 49802.0 | 2913.1 | 798.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 71 | 17.1k | 1.8M | 82.1k | 25m 2s |
| sonnet | 4 | 10.2k | 77.2k | 3.2M | 216.9k | 29m 32s |
| opus | 2 | 103 | 36.3k | 3.3M | 190.3k | 19m 43s |
| MiniMax-M3 | 2 | 469.5k | 3.5k | 0 | 0 | 1m 42s |