### PR TITLE
Rectify: Extend Path Token Extraction Normalization and Add `branch_name` Field

### DIFF
--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -312,6 +312,7 @@ class SkillResult:
     stderr: str
     token_usage: dict[str, Any] | None = None
     worktree_path: str | None = None
+    branch_name: str | None = None
     cli_subtype: str = field(default="")
     write_path_warnings: list[str] = field(default_factory=list)
     evidence: WriteEvidence = field(default_factory=WriteEvidence.none_observed)
@@ -371,6 +372,8 @@ class SkillResult:
         }
         if self.worktree_path is not None:
             data["worktree_path"] = self.worktree_path
+        if self.branch_name is not None:
+            data["branch_name"] = self.branch_name
         data["order_id"] = self.order_id
         return json.dumps(data, default=lambda o: o.value if isinstance(o, Enum) else str(o))
 

--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -169,20 +169,46 @@ def _parse_worktree_list(stdout: str) -> list[str]:
     return paths
 
 
+def _parse_worktree_branches(stdout: str) -> dict[str, str]:
+    """Parse ``git worktree list --porcelain`` output into a path→branch-name mapping.
+
+    Strips the ``refs/heads/`` prefix so callers receive the short branch name.
+    Skips the first entry (main worktree). Entries with detached HEAD have no branch
+    line and are omitted from the result.
+    """
+    branches: dict[str, str] = {}
+    current_path: str | None = None
+    first = True
+    for line in stdout.splitlines():
+        if line.startswith("worktree "):
+            if first:
+                first = False
+                current_path = None
+                continue
+            current_path = line.split(" ", 1)[1].strip()
+        elif line.startswith("branch ") and current_path is not None:
+            ref = line.split(" ", 1)[1].strip()
+            name = ref.removeprefix("refs/heads/")
+            branches[current_path] = name
+    return branches
+
+
 async def _detect_new_worktrees(
     pre_worktree_set: frozenset[str],
     cwd: str,
     runner: SubprocessRunner,
-) -> list[str]:
+) -> tuple[list[str], dict[str, str]]:
     result = await runner(
         ["git", "worktree", "list", "--porcelain"],
         cwd=Path(cwd),
         timeout=_GIT_TIMEOUT,
     )
     if result.returncode != 0:
-        return []
+        return [], {}
     current = _parse_worktree_list(result.stdout)
-    return [p for p in current if p not in pre_worktree_set]
+    branches = _parse_worktree_branches(result.stdout)
+    new_paths = [p for p in current if p not in pre_worktree_set]
+    return new_paths, {p: branches[p] for p in new_paths if p in branches}
 
 
 def _recover_worktree_path(new_worktrees: list[str]) -> str | None:
@@ -190,6 +216,15 @@ def _recover_worktree_path(new_worktrees: list[str]) -> str | None:
         validated = validate_worktree_path(path, verify_git=True)
         if validated is not None:
             return validated.path
+    return None
+
+
+def _recover_branch_name(new_worktrees: list[str], branch_map: dict[str, str]) -> str | None:
+    """Return the branch name for the first valid new worktree path."""
+    for path in new_worktrees:
+        validated = validate_worktree_path(path, verify_git=True)
+        if validated is not None and validated.path in branch_map:
+            return branch_map[validated.path]
     return None
 
 
@@ -639,7 +674,9 @@ async def check_and_revert_clone_contamination(
         and is_worktree_skill(skill_command)
         and snapshot.worktree_set is not None
     ):
-        new_worktrees = await _detect_new_worktrees(snapshot.worktree_set, cwd, runner)
+        new_worktrees, wt_branch_map = await _detect_new_worktrees(
+            snapshot.worktree_set, cwd, runner
+        )
         if new_worktrees:
             recovered = _recover_worktree_path(new_worktrees)
             if recovered:
@@ -648,7 +685,12 @@ async def check_and_revert_clone_contamination(
                     recovered_path=recovered,
                     extraction_status="failed",
                 )
-                skill_result = dataclasses.replace(skill_result, worktree_path=recovered)
+                recovered_branch = _recover_branch_name(new_worktrees, wt_branch_map)
+                skill_result = dataclasses.replace(
+                    skill_result,
+                    worktree_path=recovered,
+                    branch_name=recovered_branch or skill_result.branch_name,
+                )
 
     if not policy.should_fire(skill_result.success):
         return skill_result, False

--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -183,7 +183,6 @@ def _parse_worktree_branches(stdout: str) -> dict[str, str]:
         if line.startswith("worktree "):
             if first:
                 first = False
-                current_path = None
                 continue
             current_path = line.split(" ", 1)[1].strip()
         elif line.startswith("branch ") and current_path is not None:

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -57,14 +57,18 @@ from autoskillit.execution.headless._headless_helpers import (
     resolve_model_identity,
 )
 from autoskillit.execution.headless._headless_path_tokens import (  # noqa: F401
+    _BRANCH_NAME_PATTERN,
     _INTENTIONALLY_EXCLUDED_PATH_TOKENS,
     _OUTPUT_PATH_PATTERN,
     _OUTPUT_PATH_TOKENS,
     _RECOVERABLE_PATH_TOKENS,
     _WORKTREE_PATH_PATTERN,
+    NormalizedMessages,
     _build_path_token_set,
+    _extract_branch_name,
     _extract_output_paths,
     _extract_worktree_path,
+    _normalize_messages,
     _validate_output_paths,
 )
 from autoskillit.execution.headless._headless_recovery import (

--- a/src/autoskillit/execution/headless/_headless_path_tokens.py
+++ b/src/autoskillit/execution/headless/_headless_path_tokens.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from typing import NewType
 
 import regex as re
 
@@ -11,18 +12,37 @@ from autoskillit.execution.session._session_content import _normalize_model_outp
 
 logger = get_logger(__name__)
 
+NormalizedMessages = NewType("NormalizedMessages", list[str])
+
+
+def _normalize_messages(assistant_messages: list[str]) -> NormalizedMessages:
+    return NormalizedMessages([_normalize_model_output(msg) for msg in assistant_messages])
+
+
 _WORKTREE_PATH_PATTERN: re.Pattern[str] = re.compile(r"^worktree_path\s*=\s*(.+)$", re.MULTILINE)
+_BRANCH_NAME_PATTERN: re.Pattern[str] = re.compile(r"^branch_name\s*=\s*(.+)$", re.MULTILINE)
 
 
-def _extract_worktree_path(assistant_messages: list[str]) -> str | None:
+def _extract_worktree_path(assistant_messages: NormalizedMessages) -> str | None:
     """Return the last absolute path emitted as worktree_path=<value>."""
     last: str | None = None
     for msg in assistant_messages:
-        normalized = _normalize_model_output(msg)
-        m = _WORKTREE_PATH_PATTERN.search(normalized)
+        m = _WORKTREE_PATH_PATTERN.search(msg)
         if m:
             candidate = m.group(1).strip()
             if os.path.isabs(candidate):
+                last = candidate
+    return last
+
+
+def _extract_branch_name(assistant_messages: NormalizedMessages) -> str | None:
+    """Return the last branch_name token value emitted."""
+    last: str | None = None
+    for msg in assistant_messages:
+        m = _BRANCH_NAME_PATTERN.search(msg)
+        if m:
+            candidate = m.group(1).strip()
+            if candidate:
                 last = candidate
     return last
 
@@ -136,14 +156,13 @@ _OUTPUT_PATH_PATTERN: re.Pattern[str] = (
 )
 
 
-def _extract_output_paths(assistant_messages: list[str]) -> dict[str, str]:
+def _extract_output_paths(assistant_messages: NormalizedMessages) -> dict[str, str]:
     """Extract structured output path tokens from session output."""
     if not assistant_messages:
         logger.debug("_extract_output_paths called with empty assistant_messages")
     paths: dict[str, str] = {}
     for msg in assistant_messages:
-        normalized = _normalize_model_output(msg)
-        for m in _OUTPUT_PATH_PATTERN.finditer(normalized):
+        for m in _OUTPUT_PATH_PATTERN.finditer(msg):
             token, value = m.group(1), m.group(2).strip()
             if os.path.isabs(value):
                 paths[token] = value

--- a/src/autoskillit/execution/headless/_headless_recovery.py
+++ b/src/autoskillit/execution/headless/_headless_recovery.py
@@ -17,6 +17,7 @@ from autoskillit.execution.session import (
     ClaudeSessionResult,
     _check_expected_patterns,
 )
+from autoskillit.execution.session._session_content import _normalize_model_output
 
 if TYPE_CHECKING:
     from autoskillit.core import (
@@ -143,7 +144,7 @@ def _synthesize_from_write_artifacts(
         if not token_name:
             continue
         # Skip if the pattern is already satisfied in the current result.
-        if re.search(pattern, session.result):
+        if re.search(pattern, _normalize_model_output(session.result)):
             continue
         # Collect ALL absolute Write/Edit paths; use the LAST one (final deliverable).
         # Multi-artifact skills write intermediate files first, final deliverable last.
@@ -188,7 +189,7 @@ def _extract_missing_token_hints(
         if not token_name:
             continue
         # Skip if already satisfied
-        if re.search(pattern, session.output):
+        if re.search(pattern, _normalize_model_output(session.output)):
             continue
         # Collect absolute Write/Edit paths; use the LAST one (final deliverable).
         # tool_uses and token_usage live in .raw (not promoted to typed attrs) because

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -34,8 +34,10 @@ from autoskillit.execution.headless._headless_evidence import (
     _stdout_mentions_write_tools,
 )
 from autoskillit.execution.headless._headless_path_tokens import (
+    _extract_branch_name,
     _extract_output_paths,
     _extract_worktree_path,
+    _normalize_messages,
     _validate_output_paths,
 )
 from autoskillit.execution.headless._headless_recovery import (
@@ -660,7 +662,8 @@ def _build_skill_result(
     if completion_marker:
         result_text = result_text.replace(completion_marker, "").strip()
 
-    extracted_worktree_path = _extract_worktree_path(session.assistant_messages)
+    normalized_msgs = _normalize_messages(session.assistant_messages)
+    extracted_worktree_path = _extract_worktree_path(normalized_msgs)
     validated_wt = (
         validate_worktree_path(extracted_worktree_path) if extracted_worktree_path else None
     )
@@ -671,13 +674,14 @@ def _build_skill_result(
             reason="path does not exist on disk",
         )
     effective_worktree_path = validated_wt.path if validated_wt else None
+    extracted_branch_name = _extract_branch_name(normalized_msgs)
 
     # Path contamination detection
     path_contamination: str | None = None
     if not cwd:
         logger.debug("path_contamination_check_skipped", reason="cwd not provided")
     else:
-        extracted_paths = _extract_output_paths(session.assistant_messages)
+        extracted_paths = _extract_output_paths(normalized_msgs)
         path_contamination = _validate_output_paths(extracted_paths, cwd)
         if path_contamination:
             logger.warning("path_contamination_detected", detail=path_contamination, cwd=cwd)
@@ -705,6 +709,7 @@ def _build_skill_result(
         stderr=_truncate(result.stderr),
         token_usage=session.token_usage,
         worktree_path=effective_worktree_path,
+        branch_name=extracted_branch_name,
         cli_subtype=session.subtype,
         write_path_warnings=write_path_warnings,
         evidence=evidence,

--- a/src/autoskillit/execution/session/_session_content.py
+++ b/src/autoskillit/execution/session/_session_content.py
@@ -18,6 +18,10 @@ from autoskillit.execution.session._session_model import (
 
 logger = get_logger(__name__)
 
+# Code-fence opener: ```[optional-lang]\n → strip (Stage 0)
+_CODE_FENCE_OPEN_RE: re.Pattern[str] = re.compile(r"^```[a-zA-Z]*\n", re.MULTILINE)
+# Code-fence closer: standalone ``` line → strip (Stage 0)
+_CODE_FENCE_CLOSE_RE: re.Pattern[str] = re.compile(r"^```\s*$", re.MULTILINE)
 # Bold + equals: **key** = value → key = value
 _MARKDOWN_BOLD_EQUALS_RE: re.Pattern[str] = re.compile(
     r"\*\*{1,2}(\w[\w_-]*)\*{1,2}(\s*=)", re.MULTILINE
@@ -37,6 +41,8 @@ _MARKDOWN_ITALIC_COLON_RE: re.Pattern[str] = re.compile(
 )
 # Backtick: `key` = value → key = value
 _MARKDOWN_BACKTICK_RE: re.Pattern[str] = re.compile(r"`(\w[\w_-]*)`(\s*=)", re.MULTILINE)
+# Backtick-wrapped value: key = `value` → key = value (Stage 2.5)
+_BACKTICK_VALUE_RE: re.Pattern[str] = re.compile(r"^(\w[\w_-]*\s*=\s*)`([^`]+)`", re.MULTILINE)
 # HR-split delimiter: ---\n[/]name--- → ---[/]name--- (open and close delimiter variants)
 _HR_SPLIT_DELIMITER_RE: re.Pattern[str] = re.compile(r"---\n+(/?\w[\w:.-]*---)")
 # Bold-wrapped delimiter: **---[/]name---** or *---[/]name---* → ---[/]name---
@@ -59,7 +65,8 @@ def _collapse_hr_split_delimiters(text: str) -> str:
 def _normalize_model_output(text: str) -> str:
     """Normalize model output formatting variations that interfere with pattern matching.
 
-    Applies three sequential normalization stages:
+    Stage 0 — Code-fence strip: removes triple-backtick fences (with optional language
+    tag) so token lines inside fenced blocks are visible to downstream regex searches.
 
     Stage 1 — HR-split collapse: rejoins ``---\\n[/]name---`` into ``---[/]name---``
     when the model emits a markdown horizontal rule immediately before a delimiter
@@ -69,16 +76,23 @@ def _normalize_model_output(text: str) -> str:
     from ``key = value`` structured output token names so ``**plan_path** = /path``
     is treated identically to ``plan_path = /path``.
 
+    Stage 2.5 — Backtick-wrapped value strip: removes backtick wrapping from token
+    values so ``worktree_path = `/tmp/wt``` is treated identically to
+    ``worktree_path = /tmp/wt``.
+
     Stage 3 — Delimiter decorator strip: removes bold and backtick wrapping from
     ``---X---`` delimiter tokens so ``**---pipeline-health-result---**`` is treated
     identically to ``---pipeline-health-result---``.
     """
+    text = _CODE_FENCE_OPEN_RE.sub("", text)
+    text = _CODE_FENCE_CLOSE_RE.sub("", text)
     text = _collapse_hr_split_delimiters(text)
     text = _MARKDOWN_BOLD_EQUALS_RE.sub(lambda m: m.group(1).lower() + m.group(2), text)
     text = _MARKDOWN_BOLD_COLON_RE.sub(lambda m: m.group(1).lower() + " = ", text)
     text = _MARKDOWN_ITALIC_EQUALS_RE.sub(lambda m: m.group(1).lower() + m.group(2), text)
     text = _MARKDOWN_ITALIC_COLON_RE.sub(lambda m: m.group(1).lower() + " = ", text)
     text = _MARKDOWN_BACKTICK_RE.sub(lambda m: m.group(1).lower() + m.group(2), text)
+    text = _BACKTICK_VALUE_RE.sub(lambda m: m.group(1) + m.group(2), text)
     text = _DELIMITER_BOLD_RE.sub(r"\1", text)
     text = _DELIMITER_BACKTICK_RE.sub(r"\1", text)
     return text

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -16,11 +16,11 @@ NEW_HEADLESS_MODULES = [
     "_headless_execute.py",
 ]
 HEADLESS_SIZE_BUDGETS = {
-    "headless/__init__.py": 479,
+    "headless/__init__.py": 490,
     "headless/_headless_helpers.py": 220,
     "headless/_headless_execute.py": 605,
-    "headless/_headless_recovery.py": 366,
-    "headless/_headless_path_tokens.py": 175,
+    "headless/_headless_recovery.py": 370,
+    "headless/_headless_path_tokens.py": 190,
     "headless/_headless_result.py": 865,
 }
 
@@ -98,7 +98,7 @@ NEW_MQ_MODULES = ["_merge_queue_classifier.py", "_merge_queue_repo_state.py"]
 SESSION_SIZE_BUDGETS = {
     "session/__init__.py": 66,  # was 420; facade is ~40 lines after P2
     "session/_session_model.py": 520,
-    "session/_session_content.py": 230,
+    "session/_session_content.py": 245,
 }
 NEW_SESSION_FSM_MODULES = ["_retry_fsm.py", "_session_outcome.py"]
 SESSION_FSM_SIZE_BUDGETS = {

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -49,6 +49,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_headless_env_scrub.py` | Launch-site env-scrub contract test for run_headless_core |
 | `test_headless_ordering.py` | AST-based structural test for post-session operation ordering in headless.py |
 | `test_headless_path_validation.py` | Tests for headless.py: _build_skill_result, path validation, synthesis, and contract gates |
+| `test_headless_recovery.py` | Tests for _headless_recovery.py skip-check normalization — verifies decorated tokens prevent duplicate synthesis and redundant nudge hints |
 | `test_headless_provider_fallback.py` | Tests for the provider fallback loop in _execute_claude_headless — STALE and BUDGET_EXHAUSTED trigger provider switch |
 | `test_headless_provider_forwarding.py` | Tests verifying provider_extras and profile_name forwarding through the headless call chain |
 | `test_false_success_integration.py` | Integration tests for completion_required guard against false success via marker_absent_contract_met bypass |

--- a/tests/execution/test_clone_guard.py
+++ b/tests/execution/test_clone_guard.py
@@ -16,6 +16,8 @@ from autoskillit.core.types import (
 from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.clone_guard import (
     CloneSnapshot,
+    _parse_worktree_branches,
+    _recover_branch_name,
     build_clone_guard_policy,
     check_and_revert_clone_contamination,
     derive_exclude_prefix,
@@ -1140,3 +1142,108 @@ def test_validate_worktree_path_verify_git_rejects_non_worktree_dir(tmp_path):
 
     assert validate_worktree_path(regular_dir) is not None
     assert validate_worktree_path(regular_dir, verify_git=True) is None
+
+
+# ---------------------------------------------------------------------------
+# Branch name recovery from git worktree list --porcelain
+# ---------------------------------------------------------------------------
+
+
+def test_parse_worktree_branches_extracts_short_name(tmp_path):
+    """_parse_worktree_branches strips refs/heads/ and maps path → branch name."""
+    wt_dir = tmp_path / "worktrees" / "impl-feature"
+    porcelain = (
+        f"worktree {tmp_path}\n"
+        "HEAD abc123\n"
+        "branch refs/heads/main\n"
+        "\n"
+        f"worktree {wt_dir}\n"
+        "HEAD def456\n"
+        "branch refs/heads/impl-feature\n"
+    )
+    branches = _parse_worktree_branches(porcelain)
+    assert branches == {str(wt_dir): "impl-feature"}
+
+
+def test_parse_worktree_branches_skips_main_worktree(tmp_path):
+    """The first (main) worktree entry is not included in the result."""
+    porcelain = f"worktree {tmp_path}\nHEAD abc123\nbranch refs/heads/main\n"
+    branches = _parse_worktree_branches(porcelain)
+    assert branches == {}
+
+
+def test_parse_worktree_branches_omits_detached_head(tmp_path):
+    """Detached HEAD worktrees have no branch line and are absent from result."""
+    wt_dir = tmp_path / "worktrees" / "impl-detached"
+    porcelain = (
+        f"worktree {tmp_path}\n"
+        "HEAD abc123\n"
+        "branch refs/heads/main\n"
+        "\n"
+        f"worktree {wt_dir}\n"
+        "HEAD def456\n"
+        "detached\n"
+    )
+    branches = _parse_worktree_branches(porcelain)
+    assert str(wt_dir) not in branches
+
+
+def test_recover_branch_name_returns_branch_for_valid_worktree(tmp_path):
+    """_recover_branch_name returns the branch for the first valid new worktree."""
+    wt_dir = tmp_path / "worktrees" / "impl-feature"
+    wt_dir.mkdir(parents=True)
+    (wt_dir / ".git").write_text("gitdir: /tmp/fake/.git/worktrees/impl-feature\n")
+
+    branch_map = {str(wt_dir): "impl-feature"}
+    result = _recover_branch_name([str(wt_dir)], branch_map)
+    assert result == "impl-feature"
+
+
+def test_recover_branch_name_returns_none_when_no_branch_in_map(tmp_path):
+    """_recover_branch_name returns None when the worktree path is not in branch_map."""
+    wt_dir = tmp_path / "worktrees" / "impl-no-branch"
+    wt_dir.mkdir(parents=True)
+    (wt_dir / ".git").write_text("gitdir: /tmp/fake/.git/worktrees/impl-no-branch\n")
+
+    result = _recover_branch_name([str(wt_dir)], {})
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_guard_recovers_branch_name_alongside_worktree_path(tmp_path):
+    """When worktree_path is None and a new worktree is detected, branch_name is also recovered."""
+    runner = MockSubprocessRunner()
+    wt_dir = tmp_path / "worktrees" / "impl-feature"
+    wt_dir.mkdir(parents=True)
+    (wt_dir / ".git").write_text("gitdir: /tmp/fake/.git/worktrees/impl-feature\n")
+
+    porcelain_post = (
+        f"worktree {tmp_path}\n"
+        "HEAD abc123\n"
+        "branch refs/heads/main\n"
+        "\n"
+        f"worktree {wt_dir}\n"
+        "HEAD def456\n"
+        "branch refs/heads/impl-feature\n"
+    )
+    snapshot = CloneSnapshot(head_sha="abc123", worktree_set=frozenset())
+    skill_result = _make_skill_result(success=False, worktree_path=None)
+    runner.push(_git_result(stdout=porcelain_post))
+
+    result, reverted = await check_and_revert_clone_contamination(
+        snapshot,
+        skill_result,
+        str(tmp_path),
+        runner,
+        None,
+        skill_command="/autoskillit:implement-worktree-no-merge plan.md",
+        policy=build_clone_guard_policy(
+            readonly_skill=False,
+            has_write_scope=False,
+            is_clone_commit=False,
+            is_worktree=True,
+        ),
+    )
+    assert not reverted
+    assert result.worktree_path == str(wt_dir)
+    assert result.branch_name == "impl-feature"

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -17,8 +17,10 @@ from autoskillit.core.types import (
 from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.commands import _ensure_skill_prefix
 from autoskillit.execution.headless import (
+    NormalizedMessages,
     _build_skill_result,
     _extract_worktree_path,
+    _normalize_messages,
 )
 from tests.conftest import _make_result, _make_timeout_result
 from tests.execution.conftest import _mock_backend, _sr, _success_session_json
@@ -1403,59 +1405,67 @@ class TestExtractWorktreePath:
     def test_extracts_path_from_single_message(self):
         """Finds worktree_path= token in a single assistant message."""
         msg = "Worktree created.\nworktree_path=/path/to/wt\nbranch_name=impl"
-        assert _extract_worktree_path([msg]) == "/path/to/wt"
+        assert _extract_worktree_path(NormalizedMessages([msg])) == "/path/to/wt"
 
     def test_returns_last_occurrence_across_messages(self):
         """When multiple messages contain the token, last match wins."""
-        msgs = [
-            "worktree_path=/first/path",
-            "worktree_path=/second/path",
-        ]
+        msgs = NormalizedMessages(
+            [
+                "worktree_path=/first/path",
+                "worktree_path=/second/path",
+            ]
+        )
         assert _extract_worktree_path(msgs) == "/second/path"
 
     def test_returns_none_when_no_token(self):
         """Returns None when no worktree_path= token is present."""
-        assert _extract_worktree_path(["No token here."]) is None
+        assert _extract_worktree_path(NormalizedMessages(["No token here."])) is None
 
     def test_returns_none_for_empty_messages(self):
         """Returns None for empty message list."""
-        assert _extract_worktree_path([]) is None
+        assert _extract_worktree_path(NormalizedMessages([])) is None
 
     def test_strips_trailing_whitespace(self):
         """Extracted value has trailing whitespace stripped."""
         msg = "worktree_path=/some/path   \n"
-        assert _extract_worktree_path([msg]) == "/some/path"
+        assert _extract_worktree_path(NormalizedMessages([msg])) == "/some/path"
 
     def test_extract_worktree_path_with_spaces_around_equals(self):
         """Regex handles 'worktree_path = /path' format (spaces around =)."""
         msg = "Worktree created.\nworktree_path = /path/to/wt\nbranch_name = impl"
-        result = _extract_worktree_path([msg])
+        result = _extract_worktree_path(NormalizedMessages([msg]))
         assert result == "/path/to/wt"
 
     def test_extract_worktree_path_mixed_spacing(self):
         """Regex handles mixed spacing: 'worktree_path= /path' and 'worktree_path =/path'."""
         for token in ["worktree_path= /path/to/wt", "worktree_path =/path/to/wt"]:
             msg = f"Done.\n{token}\nbranch_name=impl"
-            result = _extract_worktree_path([msg])
+            result = _extract_worktree_path(NormalizedMessages([msg]))
             assert result == "/path/to/wt"
 
     def test_relative_path_with_dotdot_is_discarded(self) -> None:
         """Relative worktree_path tokens (../...) are silently discarded; returns None."""
-        result = _extract_worktree_path(["worktree_path = ../worktrees/impl-fix-20260307"])
+        result = _extract_worktree_path(
+            NormalizedMessages(["worktree_path = ../worktrees/impl-fix-20260307"])
+        )
         assert result is None
 
     def test_relative_path_without_slash_prefix_is_discarded(self) -> None:
         """Any non-absolute form is silently discarded."""
-        result = _extract_worktree_path(["worktree_path = worktrees/impl-fix-20260307"])
+        result = _extract_worktree_path(
+            NormalizedMessages(["worktree_path = worktrees/impl-fix-20260307"])
+        )
         assert result is None
 
     def test_absolute_wins_over_subsequent_relative(self) -> None:
         """If an absolute token appears before a relative one, the absolute path is returned."""
         result = _extract_worktree_path(
-            [
-                "worktree_path = /abs/worktrees/impl-first",
-                "worktree_path = ../worktrees/impl-second",
-            ]
+            NormalizedMessages(
+                [
+                    "worktree_path = /abs/worktrees/impl-first",
+                    "worktree_path = ../worktrees/impl-second",
+                ]
+            )
         )
         assert result == "/abs/worktrees/impl-first"
 
@@ -1468,7 +1478,7 @@ class TestExtractWorktreePath:
         ids=["markdown-bold", "backtick-wrapped"],
     )
     def test_extract_worktree_path_normalized_variants(self, token: str, expected: str):
-        assert _extract_worktree_path([token]) == expected
+        assert _extract_worktree_path(_normalize_messages([token])) == expected
 
     @pytest.mark.parametrize(
         "token",
@@ -1479,7 +1489,7 @@ class TestExtractWorktreePath:
         ids=["colon-separator", "uppercase"],
     )
     def test_extract_worktree_path_format_variants_return_none(self, token: str):
-        assert _extract_worktree_path([token]) is None
+        assert _extract_worktree_path(NormalizedMessages([token])) is None
 
 
 class TestBuildSkillResultWorktreePath:
@@ -1617,6 +1627,102 @@ class TestWorktreePathOnContextExhaustion:
         assert sr.success is False
         assert data["needs_retry"] is True
         assert data["worktree_path"] == path
+
+
+class TestBuildSkillResultBranchName:
+    """_build_skill_result extracts branch_name and to_json() serializes it."""
+
+    def test_extracts_branch_name_on_context_exhaustion(self, tmp_path):
+        wt = tmp_path / "impl-fix-20260307"
+        wt.mkdir()
+        assistant = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": (f"worktree_path={wt}\nbranch_name=impl-fix-20260307\n"),
+                },
+            }
+        )
+        result = json.dumps(
+            {
+                "type": "result",
+                "subtype": "error_during_execution",
+                "is_error": True,
+                "result": "prompt is too long",
+                "session_id": "s1",
+                "errors": ["prompt is too long"],
+            }
+        )
+        sub = SubprocessResult(
+            returncode=-1,
+            stdout=f"{assistant}\n{result}\n",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=1234,
+            channel_confirmation=ChannelConfirmation.UNMONITORED,
+        )
+        sr = _build_skill_result(sub, "", "/test", None, backend=ClaudeCodeBackend())
+        assert sr.branch_name == "impl-fix-20260307"
+
+    def test_branch_name_none_when_absent(self):
+        sub = SubprocessResult(
+            returncode=-1,
+            stdout=_context_exhausted_session_json(),
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=1234,
+            channel_confirmation=ChannelConfirmation.UNMONITORED,
+        )
+        sr = _build_skill_result(sub, "", "/test", None, backend=ClaudeCodeBackend())
+        assert sr.branch_name is None
+
+    def test_branch_name_serialized_in_to_json(self, tmp_path):
+        wt = tmp_path / "impl-fix-branch"
+        wt.mkdir()
+        assistant = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": f"worktree_path={wt}\nbranch_name=my-branch\n",
+                },
+            }
+        )
+        result_rec = json.dumps(
+            {
+                "type": "result",
+                "subtype": "error_during_execution",
+                "is_error": True,
+                "result": "prompt is too long",
+                "session_id": "s1",
+                "errors": ["prompt is too long"],
+            }
+        )
+        sub = SubprocessResult(
+            returncode=-1,
+            stdout=f"{assistant}\n{result_rec}\n",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=1234,
+            channel_confirmation=ChannelConfirmation.UNMONITORED,
+        )
+        sr = _build_skill_result(sub, "", "/test", None, backend=ClaudeCodeBackend())
+        data = json.loads(sr.to_json())
+        assert data.get("branch_name") == "my-branch"
+
+    def test_branch_name_absent_from_to_json_when_none(self):
+        sub = SubprocessResult(
+            returncode=-1,
+            stdout=_context_exhausted_session_json(),
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=1234,
+            channel_confirmation=ChannelConfirmation.UNMONITORED,
+        )
+        sr = _build_skill_result(sub, "", "/test", None, backend=ClaudeCodeBackend())
+        data = json.loads(sr.to_json())
+        assert "branch_name" not in data
 
 
 def test_relative_worktree_path_causes_adjudicated_failure() -> None:

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -17,8 +17,10 @@ from autoskillit.execution.headless import (
     _extract_missing_token_hints,
 )
 from autoskillit.execution.headless._headless_path_tokens import (
+    NormalizedMessages,
     _extract_output_paths,
     _extract_worktree_path,
+    _normalize_messages,
 )
 from autoskillit.execution.session import ClaudeSessionResult
 from autoskillit.pipeline.audit import DefaultAuditLog, FailureRecord
@@ -2097,22 +2099,24 @@ class TestWorktreePathPropagationWithEmptyMessages:
         Directory existence validation is handled by validate_worktree_path in
         _build_skill_result, not by _extract_worktree_path.
         """
-        result = _extract_worktree_path(["worktree_path = /nonexistent/path/xyz"])
+        result = _extract_worktree_path(
+            NormalizedMessages(["worktree_path = /nonexistent/path/xyz"])
+        )
         assert result == "/nonexistent/path/xyz"
 
     def test_extract_output_paths_with_empty_messages_returns_empty(self):
         """_extract_output_paths([]) returns {} (documents the contract)."""
-        assert _extract_output_paths([]) == {}
+        assert _extract_output_paths(NormalizedMessages([])) == {}
 
 
 class TestExtractPathTokensWithMarkdownDecorators:
     def test_extract_worktree_path_with_markdown_bold(self):
         msgs = ["**worktree_path** = /tmp/wt-abc"]
-        assert _extract_worktree_path(msgs) == "/tmp/wt-abc"
+        assert _extract_worktree_path(_normalize_messages(msgs)) == "/tmp/wt-abc"
 
     def test_extract_worktree_path_with_backticks(self):
         msgs = ["`worktree_path` = /tmp/wt-abc"]
-        assert _extract_worktree_path(msgs) == "/tmp/wt-abc"
+        assert _extract_worktree_path(_normalize_messages(msgs)) == "/tmp/wt-abc"
 
     def test_extract_output_paths_with_markdown_decorators(self):
         from autoskillit.execution.headless._headless_path_tokens import _OUTPUT_PATH_TOKENS
@@ -2121,5 +2125,85 @@ class TestExtractPathTokensWithMarkdownDecorators:
             pytest.skip("_OUTPUT_PATH_TOKENS is empty (contracts YAML not available)")
         token = next(iter(sorted(_OUTPUT_PATH_TOKENS)))
         msgs = [f"**{token}** = /tmp/plan.md"]
-        paths = _extract_output_paths(msgs)
+        paths = _extract_output_paths(_normalize_messages(msgs))
         assert paths.get(token) == "/tmp/plan.md"
+
+
+class TestNormalizeMessagesIntegration:
+    """Integration tests: _normalize_messages gateway + extraction for variants not in
+    TestExtractPathTokensWithMarkdownDecorators (italic, code-fence, backtick-value)."""
+
+    def test_worktree_path_italic_equals(self):
+        msgs = ["*worktree_path* = /tmp/wt-italic"]
+        assert _extract_worktree_path(_normalize_messages(msgs)) == "/tmp/wt-italic"
+
+    def test_worktree_path_code_fenced(self):
+        msgs = ["```\nworktree_path = /tmp/wt-fenced\n```"]
+        assert _extract_worktree_path(_normalize_messages(msgs)) == "/tmp/wt-fenced"
+
+    def test_worktree_path_backtick_value(self):
+        msgs = ["worktree_path = `/tmp/wt-btval`"]
+        assert _extract_worktree_path(_normalize_messages(msgs)) == "/tmp/wt-btval"
+
+    def test_output_path_italic_equals(self):
+        from autoskillit.execution.headless._headless_path_tokens import _OUTPUT_PATH_TOKENS
+
+        if not _OUTPUT_PATH_TOKENS:
+            pytest.skip("_OUTPUT_PATH_TOKENS is empty (contracts YAML not available)")
+        token = next(iter(sorted(_OUTPUT_PATH_TOKENS)))
+        msgs = [f"*{token}* = /tmp/plan.md"]
+        paths = _extract_output_paths(_normalize_messages(msgs))
+        assert paths.get(token) == "/tmp/plan.md"
+
+    def test_output_path_code_fenced(self):
+        from autoskillit.execution.headless._headless_path_tokens import _OUTPUT_PATH_TOKENS
+
+        if not _OUTPUT_PATH_TOKENS:
+            pytest.skip("_OUTPUT_PATH_TOKENS is empty (contracts YAML not available)")
+        token = next(iter(sorted(_OUTPUT_PATH_TOKENS)))
+        msgs = [f"```\n{token} = /tmp/plan-fenced.md\n```"]
+        paths = _extract_output_paths(_normalize_messages(msgs))
+        assert paths.get(token) == "/tmp/plan-fenced.md"
+
+
+class TestExtractBranchName:
+    """Tests for _extract_branch_name and SkillResult.branch_name integration."""
+
+    def test_extracts_plain_branch_name(self):
+        from autoskillit.execution.headless._headless_path_tokens import _extract_branch_name
+
+        msgs = NormalizedMessages(["branch_name = feature/my-branch"])
+        assert _extract_branch_name(msgs) == "feature/my-branch"
+
+    def test_last_emission_wins(self):
+        from autoskillit.execution.headless._headless_path_tokens import _extract_branch_name
+
+        msgs = NormalizedMessages(
+            [
+                "branch_name = first-branch",
+                "branch_name = second-branch",
+            ]
+        )
+        assert _extract_branch_name(msgs) == "second-branch"
+
+    def test_returns_none_when_absent(self):
+        from autoskillit.execution.headless._headless_path_tokens import _extract_branch_name
+
+        assert _extract_branch_name(NormalizedMessages(["no token here"])) is None
+
+    def test_decorated_variants_extract_after_normalization(self):
+        from autoskillit.execution.headless._headless_path_tokens import _extract_branch_name
+
+        for raw in [
+            "**branch_name** = bold-branch",
+            "`branch_name` = backtick-branch",
+            "*branch_name* = italic-branch",
+        ]:
+            result = _extract_branch_name(_normalize_messages([raw]))
+            assert result is not None, f"Expected extraction from: {raw!r}"
+
+    def test_code_fenced_branch_name_extracts(self):
+        from autoskillit.execution.headless._headless_path_tokens import _extract_branch_name
+
+        msgs = ["```\nbranch_name = fenced-branch\n```"]
+        assert _extract_branch_name(_normalize_messages(msgs)) == "fenced-branch"

--- a/tests/execution/test_headless_recovery.py
+++ b/tests/execution/test_headless_recovery.py
@@ -1,0 +1,113 @@
+"""Tests for _headless_recovery.py skip-check normalization correctness."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from autoskillit.execution.backends.claude import ClaudeResultParser
+from autoskillit.execution.headless import (
+    _extract_missing_token_hints,
+    _synthesize_from_write_artifacts,
+)
+from autoskillit.execution.session import ClaudeSessionResult
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+def _make_session(result: str, file_path: str = "/tmp/out.md") -> ClaudeSessionResult:
+    return ClaudeSessionResult(
+        subtype="success",
+        is_error=False,
+        result=result,
+        session_id="test-session",
+        tool_uses=[{"name": "Write", "id": "t0", "file_path": file_path}],
+    )
+
+
+def _ndjson(result_text: str, file_path: str = "/tmp/out.md") -> str:
+    content = [
+        {"type": "tool_use", "name": "Write", "id": "t0", "input": {"file_path": file_path}}
+    ]
+    records = [
+        json.dumps({"type": "assistant", "message": {"content": content}}),
+        json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": result_text,
+                "session_id": "test-session",
+            }
+        ),
+    ]
+    return "\n".join(records)
+
+
+class TestSynthesizeFromWriteArtifactsSkipsDecoratedToken:
+    def test_plain_token_skips_synthesis(self):
+        session = _make_session("plan_path = /tmp/out.md\n%%ORDER_UP%%")
+        result = _synthesize_from_write_artifacts(
+            session, [r"plan_path\s*=\s*/.+"], write_call_count=1
+        )
+        assert result is None
+
+    def test_bold_decorated_token_skips_synthesis(self):
+        session = _make_session("**plan_path** = /tmp/out.md\n%%ORDER_UP%%")
+        result = _synthesize_from_write_artifacts(
+            session, [r"plan_path\s*=\s*/.+"], write_call_count=1
+        )
+        assert result is None
+
+    def test_backtick_key_decorated_token_skips_synthesis(self):
+        session = _make_session("`plan_path` = /tmp/out.md\n%%ORDER_UP%%")
+        result = _synthesize_from_write_artifacts(
+            session, [r"plan_path\s*=\s*/.+"], write_call_count=1
+        )
+        assert result is None
+
+    def test_code_fenced_token_skips_synthesis(self):
+        session = _make_session("```\nplan_path = /tmp/out.md\n```\n%%ORDER_UP%%")
+        result = _synthesize_from_write_artifacts(
+            session, [r"plan_path\s*=\s*/.+"], write_call_count=1
+        )
+        assert result is None
+
+    def test_absent_token_still_synthesizes(self):
+        session = _make_session("plan summary\n%%ORDER_UP%%")
+        result = _synthesize_from_write_artifacts(
+            session, [r"plan_path\s*=\s*/.+"], write_call_count=1
+        )
+        assert result is not None
+        assert "plan_path = /tmp/out.md" in result.result
+
+
+class TestExtractMissingTokenHintsSkipsDecoratedToken:
+    def test_bold_decorated_token_produces_no_hint(self):
+        stdout = _ndjson("**plan_path** = /tmp/out.md\n%%ORDER_UP%%")
+        hints = _extract_missing_token_hints(
+            stdout, [r"plan_path\s*=\s*/.+"], ClaudeResultParser(), frozenset({"Write", "Edit"})
+        )
+        assert hints == []
+
+    def test_backtick_key_decorated_token_produces_no_hint(self):
+        stdout = _ndjson("`plan_path` = /tmp/out.md\n%%ORDER_UP%%")
+        hints = _extract_missing_token_hints(
+            stdout, [r"plan_path\s*=\s*/.+"], ClaudeResultParser(), frozenset({"Write", "Edit"})
+        )
+        assert hints == []
+
+    def test_code_fenced_token_produces_no_hint(self):
+        stdout = _ndjson("```\nplan_path = /tmp/out.md\n```\n%%ORDER_UP%%")
+        hints = _extract_missing_token_hints(
+            stdout, [r"plan_path\s*=\s*/.+"], ClaudeResultParser(), frozenset({"Write", "Edit"})
+        )
+        assert hints == []
+
+    def test_absent_token_still_produces_hint(self):
+        stdout = _ndjson("plan summary\n%%ORDER_UP%%")
+        hints = _extract_missing_token_hints(
+            stdout, [r"plan_path\s*=\s*/.+"], ClaudeResultParser(), frozenset({"Write", "Edit"})
+        )
+        assert hints == [("plan_path", "/tmp/out.md")]

--- a/tests/execution/test_headless_synthesis.py
+++ b/tests/execution/test_headless_synthesis.py
@@ -11,7 +11,11 @@ from autoskillit.core.types import (
     TerminationReason,
 )
 from autoskillit.execution.backends.claude import ClaudeCodeBackend
-from autoskillit.execution.headless import _build_skill_result, _scan_jsonl_write_paths
+from autoskillit.execution.headless import (
+    NormalizedMessages,
+    _build_skill_result,
+    _scan_jsonl_write_paths,
+)
 from tests.execution.conftest import _make_tool_use_line, _sr, _success_session_json
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
@@ -21,7 +25,7 @@ class TestExtractOutputPaths:
     def test_extracts_single_path(self):
         from autoskillit.execution.headless import _extract_output_paths
 
-        msgs = ["plan_path = /correct/path/.autoskillit/temp/make-plan/foo.md"]
+        msgs = NormalizedMessages(["plan_path = /correct/path/.autoskillit/temp/make-plan/foo.md"])
         result = _extract_output_paths(msgs)
         assert result == {"plan_path": "/correct/path/.autoskillit/temp/make-plan/foo.md"}
 
@@ -33,7 +37,7 @@ class TestExtractOutputPaths:
             "summary_path = /clone/.autoskillit/temp/report/summary.md\n"
             "investigation_path = /clone/.autoskillit/temp/investigate/inv.md"
         )
-        result = _extract_output_paths([msg])
+        result = _extract_output_paths(NormalizedMessages([msg]))
         assert result == {
             "plan_path": "/clone/.autoskillit/temp/make-plan/plan.md",
             "summary_path": "/clone/.autoskillit/temp/report/summary.md",
@@ -43,22 +47,26 @@ class TestExtractOutputPaths:
     def test_returns_empty_when_no_tokens(self):
         from autoskillit.execution.headless import _extract_output_paths
 
-        result = _extract_output_paths(["no tokens here", "just regular text"])
+        result = _extract_output_paths(NormalizedMessages(["no tokens here", "just regular text"]))
         assert result == {}
 
     def test_ignores_non_absolute_paths(self):
         from autoskillit.execution.headless import _extract_output_paths
 
-        result = _extract_output_paths(["plan_path = .autoskillit/temp/make-plan/foo.md"])
+        result = _extract_output_paths(
+            NormalizedMessages(["plan_path = .autoskillit/temp/make-plan/foo.md"])
+        )
         assert result == {}
 
     def test_extracts_from_multiple_messages(self):
         from autoskillit.execution.headless import _extract_output_paths
 
-        msgs = [
-            "plan_path = /first/path",
-            "investigation_path = /second/path",
-        ]
+        msgs = NormalizedMessages(
+            [
+                "plan_path = /first/path",
+                "investigation_path = /second/path",
+            ]
+        )
         result = _extract_output_paths(msgs)
         assert result == {
             "plan_path": "/first/path",
@@ -68,10 +76,12 @@ class TestExtractOutputPaths:
     def test_last_occurrence_wins(self):
         from autoskillit.execution.headless import _extract_output_paths
 
-        msgs = [
-            "plan_path = /first/path",
-            "plan_path = /second/path",
-        ]
+        msgs = NormalizedMessages(
+            [
+                "plan_path = /first/path",
+                "plan_path = /second/path",
+            ]
+        )
         result = _extract_output_paths(msgs)
         assert result == {"plan_path": "/second/path"}
 

--- a/tests/execution/test_session_content.py
+++ b/tests/execution/test_session_content.py
@@ -270,3 +270,32 @@ class TestEvaluateContentState:
             _PREP_PATTERNS,
         )
         assert state == ContentState.CONTRACT_VIOLATION
+
+
+class TestNormalizeModelOutputCodeFence:
+    """Tests for Stage 0 (code-fence stripping) and Stage 2.5 (backtick value strip)."""
+
+    def test_code_fence_stripped_token_visible(self) -> None:
+        raw = "```\nworktree_path = /tmp/wt\n```"
+        result = _normalize_model_output(raw)
+        assert "worktree_path = /tmp/wt" in result
+
+    def test_code_fence_with_language_tag_stripped(self) -> None:
+        raw = "```markdown\nworktree_path = /tmp/wt\n```"
+        result = _normalize_model_output(raw)
+        assert "worktree_path = /tmp/wt" in result
+
+    def test_code_fence_preserves_non_token_content(self) -> None:
+        raw = "```\nsome content\nworktree_path = /tmp/wt\nmore content\n```"
+        result = _normalize_model_output(raw)
+        assert "some content" in result
+        assert "worktree_path = /tmp/wt" in result
+        assert "more content" in result
+
+    def test_backtick_wrapped_value_stripped(self) -> None:
+        result = _normalize_model_output("worktree_path = `/tmp/wt-val`")
+        assert "worktree_path = /tmp/wt-val" in result
+
+    def test_backtick_value_not_applied_to_key(self) -> None:
+        result = _normalize_model_output("`worktree_path` = /tmp/wt")
+        assert "worktree_path = /tmp/wt" in result


### PR DESCRIPTION
## Summary

The model output processing pipeline has a structural divergence: the normalization layer (`_normalize_model_output` in `_session_content.py`) is applied before pattern-matching for success adjudication, but is **never** applied before token value extraction (`_extract_worktree_path`, `_extract_output_paths` in `_headless_path_tokens.py`) or before skip-checks in the recovery module (`_synthesize_from_write_artifacts`, `_extract_missing_token_hints` in `_headless_recovery.py`). This creates an asymmetry where a session can be declared "successful" (normalization made patterns match) while extracted token values return `None`/empty (raw regex finds nothing).

Additionally, `branch_name` is used as a string token but has no typed `SkillResult` field, no infrastructure recovery path, and is excluded from path-token validation.

The architectural fix introduces a `NormalizedMessages` newtype that makes it **structurally impossible** to pass raw model output to extraction functions, plus adds code-fence stripping to the normalization pipeline, and promotes `branch_name` to a first-class `SkillResult` field with git-level recovery.

Closes #3658

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260603-132821-292185/.autoskillit/temp/rectify/rectify_extend_path_token_extraction_normalization_and_add_branch_name_2026-06-03_133057.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 74 | 19.6k | 2.1M | 99.9k | 67 | 83.8k | 17m 34s |
| review_approach* | sonnet | 1 | 3.0k | 7.6k | 198.0k | 49.1k | 16 | 36.9k | 5m 2s |
| dry_walkthrough* | opus | 1 | 59 | 18.4k | 1.3M | 75.5k | 47 | 58.6k | 9m 4s |
| implement* | sonnet | 1 | 784 | 58.4k | 10.2M | 162.0k | 233 | 145.8k | 16m 21s |
| audit_impl* | sonnet | 1 | 2.0k | 21.3k | 468.6k | 79.0k | 35 | 64.4k | 12m 49s |
| prepare_pr* | MiniMax-M3 | 1 | 211.8k | 2.2k | 0 | 0 | 15 | 0 | 41s |
| compose_pr* | MiniMax-M3 | 1 | 226.0k | 1.8k | 0 | 0 | 15 | 0 | 46s |
| review_pr* | sonnet | 1 | 182 | 46.6k | 1.4M | 117.6k | 56 | 119.6k | 11m 49s |
| resolve_review* | opus | 1 | 44 | 10.4k | 850.1k | 60.1k | 42 | 87.4k | 9m 40s |
| **Total** | | | 443.9k | 186.4k | 16.5M | 162.0k | | 596.5k | 1h 23m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 903 | 11325.5 | 161.4 | 64.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 1 | 850120.0 | 87373.0 | 10413.0 |
| **Total** | **904** | 18305.7 | 659.9 | 206.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 74 | 19.6k | 2.1M | 83.8k | 17m 34s |
| sonnet | 4 | 6.0k | 134.0k | 12.3M | 366.7k | 46m 3s |
| opus | 2 | 103 | 28.8k | 2.2M | 146.0k | 18m 44s |
| MiniMax-M3 | 2 | 437.8k | 4.0k | 0 | 0 | 1m 27s |