### PR TITLE
[FIX] Skill Capability Registry Derived-Field Immunity

### DIFF
--- a/src/autoskillit/core/types/_type_constants_registries.py
+++ b/src/autoskillit/core/types/_type_constants_registries.py
@@ -301,44 +301,51 @@ class SkillCapabilityDef:
     """A capability that a skill may require from its execution backend."""
 
     description: str
-    required_backends: frozenset[str]
     codex_status: Literal["works-as-is", "degraded", "fix-required", "not-applicable"]
+
+    @property
+    def required_backends(self) -> frozenset[str]:
+        if self.codex_status == "not-applicable":
+            return frozenset({AGENT_BACKEND_CLAUDE_CODE})
+        return frozenset()
 
 
 SKILL_CAPABILITY_REGISTRY: dict[str, SkillCapabilityDef] = {
     "agent_subagent": SkillCapabilityDef(
         description="Agent(subagent_type=...) tool — delegates to specialized subagent",
-        required_backends=frozenset({AGENT_BACKEND_CLAUDE_CODE}),
         codex_status="fix-required",
     ),
     "agent_model": SkillCapabilityDef(
         description="Agent(model=...) tool — spawns model-specific subagent",
-        required_backends=frozenset({AGENT_BACKEND_CLAUDE_CODE}),
         codex_status="fix-required",
     ),
     "open_kitchen": SkillCapabilityDef(
         description="open_kitchen / close_kitchen lifecycle tools",
-        required_backends=frozenset({AGENT_BACKEND_CLAUDE_CODE}),
         codex_status="not-applicable",
     ),
     "run_skill": SkillCapabilityDef(
         description="run_skill MCP tool call (headless session dispatch)",
-        required_backends=frozenset({AGENT_BACKEND_CLAUDE_CODE}),
         codex_status="not-applicable",
     ),
     "test_check": SkillCapabilityDef(
         description="test_check MCP tool (headless test runner)",
-        required_backends=frozenset({AGENT_BACKEND_CLAUDE_CODE}),
         codex_status="not-applicable",
     ),
     "claude_dir": SkillCapabilityDef(
         description="Reads/writes .claude/ directory structure",
-        required_backends=frozenset(),
         codex_status="works-as-is",
     ),
     "cross_skill_ref": SkillCapabilityDef(
         description="Cross-skill /autoskillit: invocation via Skill tool",
-        required_backends=frozenset({AGENT_BACKEND_CLAUDE_CODE}),
         codex_status="fix-required",
     ),
 }
+
+_VALID_CODEX_STATUSES = {"works-as-is", "degraded", "fix-required", "not-applicable"}
+for _cap_name, _cap_def in SKILL_CAPABILITY_REGISTRY.items():
+    if _cap_def.codex_status not in _VALID_CODEX_STATUSES:
+        raise RuntimeError(
+            f"SKILL_CAPABILITY_REGISTRY[{_cap_name!r}].codex_status="
+            f"{_cap_def.codex_status!r} is not valid. "
+            f"Must be one of {sorted(_VALID_CODEX_STATUSES)}."
+        )

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -659,16 +659,8 @@ async def run_skill(
                 and tool_ctx.backend is not None
                 and not tool_ctx.backend.capabilities.anthropic_provider_capable
             )
-            _skill_requires_claude = (
-                _skill_info is not None
-                and "claude-code" in _skill_info.backend_requirements
-                and tool_ctx.backend is not None
-                and tool_ctx.backend.name != AGENT_BACKEND_CLAUDE_CODE
-            )
             backend_override: str | None = (
-                AGENT_BACKEND_CLAUDE_CODE
-                if (_provider_override or _skill_requires_claude)
-                else None
+                AGENT_BACKEND_CLAUDE_CODE if _provider_override else None
             )
 
             _effective_backend_obj: CodingAgentBackend | None = (
@@ -680,7 +672,7 @@ async def run_skill(
             if backend_override:
                 logger.info(
                     "backend_override_activated",
-                    reason="skill_requirement" if _skill_requires_claude else "provider_profile",
+                    reason="provider_profile",
                     skill=skill_command,
                     original_backend=tool_ctx.backend.name if tool_ctx.backend else "none",
                     target_backend=backend_override,

--- a/src/autoskillit/skills/close-kitchen/SKILL.md
+++ b/src/autoskillit/skills/close-kitchen/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: close-kitchen
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref, open_kitchen]
 description: Close the AutoSkillit kitchen — hides kitchen MCP tools for this session.
 disable-model-invocation: true

--- a/src/autoskillit/skills/open-kitchen/SKILL.md
+++ b/src/autoskillit/skills/open-kitchen/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: open-kitchen
-backend_requirements: [claude-code]
 uses_capabilities: [open_kitchen]
 description: Open the AutoSkillit kitchen — reveals all kitchen MCP tools for this session. Human-only entry point.
 disable-model-invocation: true

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: sous-chef
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref, open_kitchen, run_skill, test_check]
 description: Internal bootstrap document injected by open_kitchen into every orchestrator session.
 ---

--- a/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-pipeline-health/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: analyze-pipeline-health
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref, run_skill]
 categories: [diagnostics]
 description: Analyze pipeline session logs for anomalies and regressions. Spawns parallel Haiku scanner subagents per step group, each investigating its batch of sessions and reporting findings with evidence.

--- a/src/autoskillit/skills_extended/analyze-prs/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-prs/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: analyze-prs
 categories: [github]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref]
 description: Analyze all open PRs targeting a base branch — determine merge order, identify file overlaps, and tag each PR as simple or needs_check for complexity. Use at the start of a PR consolidation workflow.
 hooks:

--- a/src/autoskillit/skills_extended/apply-review-dimensions/SKILL.md
+++ b/src/autoskillit/skills_extended/apply-review-dimensions/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: apply-review-dimensions
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref]
 description: Evaluate experiment design across weighted dimensions using multi-level subagent analysis with adversarial red-team, producing a findings manifest and evaluation dashboard.
 hooks:

--- a/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: arch-lens-c4-container
 categories: [arch-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-c4-container/"]

--- a/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: arch-lens-concurrency
 categories: [arch-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-concurrency/"]

--- a/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: arch-lens-data-lineage
 categories: [arch-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-data-lineage/"]

--- a/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: arch-lens-deployment
 categories: [arch-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-deployment/"]

--- a/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: arch-lens-development
 categories: [arch-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-development/"]

--- a/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: arch-lens-error-resilience
 categories: [arch-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-error-resilience/"]

--- a/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: arch-lens-module-dependency
 categories: [arch-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-module-dependency/"]

--- a/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: arch-lens-operational
 categories: [arch-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-operational/"]

--- a/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: arch-lens-process-flow
 categories: [arch-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-process-flow/"]

--- a/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: arch-lens-repository-access
 categories: [arch-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-repository-access/"]

--- a/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: arch-lens-scenarios
 categories: [arch-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-scenarios/"]

--- a/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: arch-lens-security
 categories: [arch-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-security/"]

--- a/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: arch-lens-state-lifecycle
 categories: [arch-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 write_paths: ["{{AUTOSKILLIT_TEMP}}/arch-lens-state-lifecycle/"]

--- a/src/autoskillit/skills_extended/audit-bugs/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-bugs/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: audit-bugs
 categories: [audit]
-backend_requirements: [claude-code]
 uses_capabilities: [claude_dir, cross_skill_ref]
 description: Analyze historical bug patterns by mining Claude Code project logs for /autoskillit:investigate skill invocations since a specified date. Identifies recurring root causes, architectural gaps, and proactive detection strategies. Use when user says "audit bugs", "bug patterns", "analyze investigations", or "bug audit".
 hooks:

--- a/src/autoskillit/skills_extended/audit-claims/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-claims/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: audit-claims
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model]
 description: >
   Parallel subagent-driven claim extraction and citation integrity audit for

--- a/src/autoskillit/skills_extended/audit-cohesion/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-cohesion/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: audit-cohesion
 categories: [audit]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 description: Audit codebase for internal cohesion - how well components fit together and maintain consistent patterns. Distinct from audit-arch (which checks rule violations); this checks integration fitness and convergence. Use when user says "audit cohesion", "check cohesion", "cohesion audit", or "alignment check".
 hooks:

--- a/src/autoskillit/skills_extended/audit-defense-standards/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-defense-standards/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: audit-defense-standards
 categories: [audit]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 description: Audit the codebase against defense standards derived from historical bug patterns. Standards accumulate over time as new patterns are discovered via audit-bugs and design-guards. Use when user says "audit defenses", "audit defense standards", "check defenses", or "defense audit".
 hooks:

--- a/src/autoskillit/skills_extended/audit-impl/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-impl/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: audit-impl
 categories: [audit]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, agent_subagent, cross_skill_ref]
 description: Audit a completed implementation against its originating plan(s). Returns GO (merge approved) or NO GO (generates remediation file for retry). Final gate before merge in any implementation pipeline.
 hooks:

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: audit-review-decisions
 categories: [audit]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref]
 description: >
   Audit merged PR review threads for agreed-but-deferred suggestions (design decisions,

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: build-execution-map
 categories: [github]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model]
 description: Analyze issue dependencies and produce a dispatch execution map for parallel orchestration
 hooks:

--- a/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
+++ b/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: classify-experiment-type
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref]
 description: Classify an experiment plan into a type, build the dimension weight matrix, and emit dialing interface tokens for the apply-review-dimensions step.
 hooks:

--- a/src/autoskillit/skills_extended/collapse-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/collapse-issues/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: collapse-issues
 categories: [github]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 description: >
   Identify clusters of related triaged GitHub issues sharing the same recipe route

--- a/src/autoskillit/skills_extended/compose-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-pr/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: compose-pr
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 categories: [github]
 description: Composition executor for pull requests. ALWAYS invoke this skill when instructed to compose a PR. Do not read prep files or create PRs directly — use this skill first to load the composition workflow.

--- a/src/autoskillit/skills_extended/design-guards/SKILL.md
+++ b/src/autoskillit/skills_extended/design-guards/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: design-guards
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 description: Investigate a bug pattern audit report and design architectural guards (tests, contracts, structural changes) that provide immunity to each identified pattern. Use when user says "design guards", "design defenses", or wants architectural solutions for bug patterns.
 hooks:

--- a/src/autoskillit/skills_extended/download-data/SKILL.md
+++ b/src/autoskillit/skills_extended/download-data/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: download-data
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model]
 description: >
   Download external and gitignored datasets declared in the experiment plan's

--- a/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
+++ b/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: dry-walkthrough
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, test_check]
 description: Plan validation executor. ALWAYS invoke this skill when instructed to validate or dry-walkthrough a plan. Do not read the plan or trace changes directly — use this skill first to load the validation workflow.
 hooks:

--- a/src/autoskillit/skills_extended/elaborate-phase/SKILL.md
+++ b/src/autoskillit/skills_extended/elaborate-phase/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: elaborate-phase
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [dry-walkthrough]
 description: Elaborate a migration plan phase into a complete self-contained implementation plan. Use when user says "elaborate phase", "elaborate phase N", or "phase elaboration". Assesses codebase, writes detailed phase plan, then validates with dry walkthrough.

--- a/src/autoskillit/skills_extended/enrich-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/enrich-issues/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: enrich-issues
 categories: [github]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref, open_kitchen]
 description: >
   Backfill structured requirements on existing GitHub issues triaged with

--- a/src/autoskillit/skills_extended/exp-lens-benchmark-representativeness/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-benchmark-representativeness/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-benchmark-representativeness
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Benchmark Representativeness experimental design diagram showing coverage matrix, generalization gaps, and untested regions. Generalizability lens answering "Does this generalize beyond the test bed?"

--- a/src/autoskillit/skills_extended/exp-lens-causal-assumptions/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-causal-assumptions/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-causal-assumptions
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Causal Assumptions experimental design diagram showing confounders, mediators, colliders, and identification strategy. Causal-structural lens answering "What causal assumptions support this design?"

--- a/src/autoskillit/skills_extended/exp-lens-comparator-construction/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-comparator-construction/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-comparator-construction
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Comparator Construction experimental design analysis assessing whether baselines and controls are fair and relevant. Counterfactual lens answering "Is the comparator fair and relevant?"

--- a/src/autoskillit/skills_extended/exp-lens-error-budget/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-error-budget/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-error-budget
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Analyze statistical error budget showing Type I/II errors, power, minimum detectable effect, multiplicity corrections, and sequential monitoring. Statistical lens answering "Are error risks sized and controlled?"

--- a/src/autoskillit/skills_extended/exp-lens-estimand-clarity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-estimand-clarity/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-estimand-clarity
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Estimand Clarity experimental design analysis decomposing the implicit estimand from code vs. explicit claims from prose. Evidential lens answering "What exactly is the claim?"

--- a/src/autoskillit/skills_extended/exp-lens-exploratory-confirmatory/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-exploratory-confirmatory/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-exploratory-confirmatory
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Assess whether analytic decisions were pre-specified or post-hoc and whether exploratory/confirmatory norms are aligned. Boundary lens answering "Is this discovery or test, and are norms aligned?"

--- a/src/autoskillit/skills_extended/exp-lens-fair-comparison/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-fair-comparison/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-fair-comparison
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create a comparison fairness matrix assessing whether alternatives are evaluated under symmetric constraints. Fairness lens answering "Are alternatives compared under symmetric constraints?"

--- a/src/autoskillit/skills_extended/exp-lens-governance-risk/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-governance-risk/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-governance-risk
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create a risk register and stakeholder impact assessment for experiments with deployment implications. Governance lens answering "What risks arise from acting on this result?"

--- a/src/autoskillit/skills_extended/exp-lens-iterative-learning/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-iterative-learning/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-iterative-learning
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Iterative Learning experimental design diagram showing factor space exploration, adaptive allocation, and next-experiment recommendations. Decision-Theoretic lens answering "How does this maximize learning per cost?"

--- a/src/autoskillit/skills_extended/exp-lens-measurement-validity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-measurement-validity/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-measurement-validity
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Analyze measurement validity for experimental design — auditing metric-construct alignment, proxy validity, reliability, sensitivity, and consequential validity. Argumentative lens answering "Do measurements justify the interpretation?"

--- a/src/autoskillit/skills_extended/exp-lens-pipeline-integrity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-pipeline-integrity/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-pipeline-integrity
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Pipeline Integrity experimental design diagram showing data splits, leakage points, preprocessing order, and label contamination. Integrity lens answering "Could data handling create optimistic bias?"

--- a/src/autoskillit/skills_extended/exp-lens-randomization-blocking/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-randomization-blocking/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-randomization-blocking
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Randomization & Blocking experimental design diagram showing assignment mechanisms, blocking factors, and comparability sources. Design-Structural lens answering "Where does comparability come from?"

--- a/src/autoskillit/skills_extended/exp-lens-reproducibility-artifacts/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-reproducibility-artifacts/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-reproducibility-artifacts
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Reproducibility Artifacts experimental design diagram showing run instructions, environment capture, data availability, determinism controls, and audit trail. Transparency lens answering "Could an independent party reproduce this?"

--- a/src/autoskillit/skills_extended/exp-lens-sensitivity-robustness/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-sensitivity-robustness/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-sensitivity-robustness
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Sensitivity & Robustness experimental design analysis identifying load-bearing analytic choices and untested perturbations. Robustness lens answering "Which assumptions are load-bearing?"

--- a/src/autoskillit/skills_extended/exp-lens-severity-testing/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-severity-testing/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-severity-testing
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Analyze severity of experimental tests — adversarial cases, negative controls, falsification tests, easy-pass detection, and confirmatory theater. Falsificationist lens answering "Would this design have caught the error?"

--- a/src/autoskillit/skills_extended/exp-lens-unit-interference/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-unit-interference/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-unit-interference
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create Unit Interference experimental design diagram showing unit hierarchy, cluster structure, shared resources, and SUTVA violation pathways. Causal-Structural lens answering "What is the unit, and can treatments spill over?"

--- a/src/autoskillit/skills_extended/exp-lens-validity-threats/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-validity-threats/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-validity-threats
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create a validity threat matrix identifying alternative explanations and design mitigations. Adversarial lens answering "What alternative explanations survive?"

--- a/src/autoskillit/skills_extended/exp-lens-variance-stability/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-variance-stability/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: exp-lens-variance-stability
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: Create a variance analysis profile assessing whether signals exceed noise and whether results are stable across random seeds. Stability lens answering "Is the signal larger than the noise?"

--- a/src/autoskillit/skills_extended/generate-report/SKILL.md
+++ b/src/autoskillit/skills_extended/generate-report/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: generate-report
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref]
 description: Synthesize experiment results into a structured research report in the research/ folder. Supports --inconclusive flag.
 hooks:

--- a/src/autoskillit/skills_extended/implement-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-experiment/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: implement-experiment
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, test_check]
 description: Deploy experiment artifacts in an isolated git worktree following an approved experiment plan, with per-phase commits.
 hooks:

--- a/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: implement-worktree-no-merge
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref, run_skill]
 activate_deps: [write-recipe]
 description: Implementation executor. ALWAYS invoke this skill when instructed to implement a plan in a worktree. Do not read the plan or edit files directly — use this skill first to load the full implementation workflow.

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: implement-worktree
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref, test_check]
 activate_deps: [write-recipe]
 description: Worktree implementation executor. ALWAYS invoke this skill when instructed to implement a plan in a worktree with testing and merging. Do not read the plan or edit files directly — use this skill first to load the full implementation workflow.

--- a/src/autoskillit/skills_extended/investigate/SKILL.md
+++ b/src/autoskillit/skills_extended/investigate/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: investigate
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, claude_dir, cross_skill_ref]
 description: Deep investigation of errors, bugs, or codebase questions without making any code changes. Use when user mentions investigate, understand, explore, analyze, or pastes error tracebacks. Spawns parallel subagents for comprehensive exploration.
 hooks:

--- a/src/autoskillit/skills_extended/make-arch-diag/SKILL.md
+++ b/src/autoskillit/skills_extended/make-arch-diag/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: make-arch-diag
 categories: [arch-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [arch-lens]
 description: Generate architecture diagram for a specific component or system. Prompts user to select which area to document, then creates comprehensive mermaid diagrams.

--- a/src/autoskillit/skills_extended/make-experiment-diag/SKILL.md
+++ b/src/autoskillit/skills_extended/make-experiment-diag/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: make-experiment-diag
 categories: [exp-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [exp-lens]
 description: Interactive selection of experimental design lens for visualizing experiment methodology. Routes to the appropriate exp-lens-* skill.

--- a/src/autoskillit/skills_extended/make-groups/SKILL.md
+++ b/src/autoskillit/skills_extended/make-groups/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: make-groups
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref]
 description: Break a large plan, architecture proposal, or feature document into sequenced implementation groups for the make-plan pipeline. Use when user says "make groups", "group requirements", "sequence groups", or wants to decompose a large document into ordered implementation units.
 hooks:

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: make-plan
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, agent_subagent, cross_skill_ref]
 activate_deps: [arch-lens, write-recipe]
 description: Planning executor. ALWAYS invoke this skill when instructed to create, devise, or write an implementation plan. Do not explore the codebase or draft a plan directly — use this skill first to load the planning workflow.

--- a/src/autoskillit/skills_extended/merge-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/merge-pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: merge-pr
 categories: [github]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 description: Merge a single PR into the integration branch. For simple PRs, uses gh pr merge --squash --auto to enforce GitHub's required status checks. For needs_check PRs, re-assesses complexity and returns needs_plan=true with a conflict report when conflicts are detected. Use inside the merge-prs loop.
 hooks:

--- a/src/autoskillit/skills_extended/migrate-recipes/SKILL.md
+++ b/src/autoskillit/skills_extended/migrate-recipes/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: migrate-recipes
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref, run_skill]
 activate_deps: [write-recipe]
 description: Apply versioned migration notes to an AutoSkillit recipe. Use when user confirms migration, called by agent or autoskillit migrate CLI, or invoked directly.

--- a/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: open-integration-pr
 categories: [github]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref, run_skill]
 activate_deps: [arch-lens]
 description: >

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: plan-experiment
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref, test_check]
 description: Convert a scope report into a structured experiment plan with hypothesis, variables, phases, and success criteria.
 hooks:

--- a/src/autoskillit/skills_extended/plan-visualization/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-visualization/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: plan-visualization
 categories: [research, vis-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref]
 description: >
   Orchestrates 2–4 vis-lens skills in parallel to produce a figure inventory

--- a/src/autoskillit/skills_extended/planner-assess-review-approach/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-assess-review-approach/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: planner-assess-review-approach
 categories: [planner]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model]
 description: >
   Assess each work package for review-approach benefit before implementation.

--- a/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: planner-elaborate-assignments
-backend_requirements: [claude-code]
 uses_capabilities: [run_skill]
 categories: [planner]
 description: >

--- a/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: planner-elaborate-wps
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref, run_skill]
 categories: [planner]
 description: >

--- a/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: planner-validate-task-alignment
 categories: [planner]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model]
 description: Validate that plan phases and WPs align with the stated task
 hooks:

--- a/src/autoskillit/skills_extended/prepare-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: prepare-pr
 categories: [github]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model]
 description: Preparation executor for pull-request metadata. ALWAYS invoke this skill when instructed to prepare PR metadata. Do not read plans or classify files directly — use this skill first to load the preparation workflow.
 hooks:

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: process-issues
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref, run_skill]
 description: Execute recipe sessions batch-by-batch for triaged GitHub issues. Reads the triage-issues output manifest, processes each batch sequentially, and launches the appropriate recipe for each issue. Use when user says "process issues", "run issues", or "execute pipeline for issues".
 hooks:

--- a/src/autoskillit/skills_extended/promote-to-main/SKILL.md
+++ b/src/autoskillit/skills_extended/promote-to-main/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: promote-to-main
 categories: [github]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref]
 description: >
   Promote integration to main with comprehensive changelog and PR creation. Use when

--- a/src/autoskillit/skills_extended/rectify/SKILL.md
+++ b/src/autoskillit/skills_extended/rectify/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: rectify
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, agent_subagent, cross_skill_ref]
 activate_deps: [arch-lens]
 description: Deep investigation of test gaps and architectural weaknesses following an investigation, then devise a plan for architectural immunity rather than direct fixes. Use when user says "rectify", "rectify this", or wants to address root architectural causes after an investigation.

--- a/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: resolve-claims-review
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model]
 description: >
   Fetch claim findings from audit-claims, run citation-aware intent validation

--- a/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: resolve-design-review
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, run_skill]
 description: >
   Triage STOP verdict findings from review-design, classifying each as

--- a/src/autoskillit/skills_extended/resolve-failures/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-failures/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: resolve-failures
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref, run_skill, test_check]
 description: Failure resolution executor. ALWAYS invoke this skill when instructed to fix test failures in a worktree. Do not read test output or edit code directly — use this skill first to load the failure resolution workflow.
 hooks:

--- a/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: resolve-research-review
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model]
 description: >
   Fetch PR review comments from review-research-pr, run research-aware intent

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: resolve-review
 categories: [github]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref, run_skill, test_check]
 description: Fetch PR review comments, run intent validation (ACCEPT/REJECT/DISCUSS) before applying fixes, and post inline replies. MCP-only — used exclusively by recipe orchestration via run_skill after review_pr reports changes_requested or needs_human verdict.
 hooks:

--- a/src/autoskillit/skills_extended/retry-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/retry-worktree/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: retry-worktree
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref]
 description: Worktree retry executor. ALWAYS invoke this skill when instructed to continue or retry an implementation in an existing worktree. Do not resume editing files directly — use this skill first to load the retry workflow.
 hooks:

--- a/src/autoskillit/skills_extended/review-approach/SKILL.md
+++ b/src/autoskillit/skills_extended/review-approach/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: review-approach
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model]
 description: Research modern solutions and approaches for issues or features proposed in a report or plan. Use when user says "review approach", "review approaches", "research solutions", or wants external validation of a proposed direction.
 hooks:

--- a/src/autoskillit/skills_extended/review-design/SKILL.md
+++ b/src/autoskillit/skills_extended/review-design/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: review-design
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref]
 description: Validate an experiment plan before execution using triage-first, fail-fast dimensional analysis with an adversarial red-team. Emits verdict (GO/REVISE/STOP), experiment_type, evaluation_dashboard, and revision_guidance.
 hooks:

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: review-pr
 categories: [github]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref, run_skill]
 description: Automated diff-scoped PR code review using parallel audit subagents. Posts inline GitHub review comments and submits a summary verdict. Use after a PR is opened to gate CI on review approval.
 hooks:

--- a/src/autoskillit/skills_extended/review-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-research-pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: review-research-pr
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, run_skill]
 description: Automated diff-scoped research PR review using parallel audit subagents aligned to research quality dimensions. Posts inline GitHub review comments and submits a summary verdict. Use after a research PR is opened to gate on review approval.
 hooks:

--- a/src/autoskillit/skills_extended/run-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/run-experiment/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: run-experiment
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref]
 description: Execute a designed experiment in a worktree and collect structured results. Supports --adjust retry mode.
 hooks:

--- a/src/autoskillit/skills_extended/scope/SKILL.md
+++ b/src/autoskillit/skills_extended/scope/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: scope
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model]
 description: Survey codebase and web sources to build a known/unknown matrix for a research question. Phase 1 of the research recipe.
 hooks:

--- a/src/autoskillit/skills_extended/select-directions/SKILL.md
+++ b/src/autoskillit/skills_extended/select-directions/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: select-directions
-backend_requirements: [claude-code]
 uses_capabilities: [run_skill]
 categories: [research]
 description: >

--- a/src/autoskillit/skills_extended/select-vis-lenses/SKILL.md
+++ b/src/autoskillit/skills_extended/select-vis-lenses/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: select-vis-lenses
 categories: [research, vis-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model]
 phoropter_family: vis-lens
 description: >

--- a/src/autoskillit/skills_extended/setup-environment/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-environment/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: setup-environment
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model]
 description: >
   Pre-flight environment gate for the research recipe. Reads the experiment

--- a/src/autoskillit/skills_extended/setup-project/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-project/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: setup-project
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, claude_dir, cross_skill_ref, test_check]
 activate_deps: [write-recipe]
 description: Explore a target project and generate tailored recipes and config through an interactive workflow. Use when user wants to onboard a new project to AutoSkillit, says "setup project", or wants a starting point config.

--- a/src/autoskillit/skills_extended/stage-data/SKILL.md
+++ b/src/autoskillit/skills_extended/stage-data/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: stage-data
 categories: [research]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model]
 description: >
   Pre-flight resource gate for the research recipe. Reads the experiment plan's

--- a/src/autoskillit/skills_extended/triage-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/triage-issues/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: triage-issues
 categories: [github]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref]
 description: Analyze open GitHub issues and produce a sequenced implementation plan — grouping issues into parallel batches, ordering those batches, and tagging each issue with its recipe route. Use when user says "triage issues", "prioritize issues", or "plan issue order".
 hooks:

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: validate-audit
 categories: [audit]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref]
 description: Validate audit findings from audit-arch, audit-tests, audit-cohesion, audit-feature-gates, audit-docs, or audit-review-decisions against actual code, git history, and design intent using 9–10 parallel subagents. Removes contested findings, documents exceptions, adjusts severities. Use when user says "validate audit", "validate findings", "validate report", or "check audit results".
 hooks:

--- a/src/autoskillit/skills_extended/validate-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-review-decisions/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: validate-review-decisions
 categories: [audit]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref]
 description: >-
   Validate review-decisions audit findings with mandatory intent analysis

--- a/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: validate-test-audit
 categories: [audit]
-backend_requirements: [claude-code]
 uses_capabilities: [agent_model, cross_skill_ref]
 description: >-
   Validate test audit findings with test-domain semantic rules and intent

--- a/src/autoskillit/skills_extended/vis-lens-always-on/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-always-on/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: vis-lens-always-on
 categories: [vis-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Always-On visualization triage report running three sequential analysis passes (anti-pattern, accessibility, annotation completeness) and emitting a combined PASS|WARN_N|FAIL_N verdict. Composite lens answering \"What are the blocking visualization issues?\""

--- a/src/autoskillit/skills_extended/vis-lens-antipattern/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-antipattern/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: vis-lens-antipattern
 categories: [vis-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Anti-Pattern Detection visualization audit showing severity-tiered catalog of visualization anti-patterns present in or planned for the experiment. Diagnostic lens answering \"Which visualization anti-patterns are present?\""

--- a/src/autoskillit/skills_extended/vis-lens-caption-annot/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-caption-annot/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: vis-lens-caption-annot
 categories: [vis-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Annotative Caption visualization planning spec showing declarative titles, axis labels with units, error definition in legend, baseline references, sample sizes, and venue-specific caption format. Annotative lens answering \"Are figure captions and axis labels fully self-contained?\""

--- a/src/autoskillit/skills_extended/vis-lens-chart-select/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-chart-select/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: vis-lens-chart-select
 categories: [vis-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Chart Type Selection visualization planning spec showing encoding channel assignments, Cleveland-McGill perceptual hierarchy, and data-type→chart-type matrix. Typological lens answering \"Which chart type is perceptually optimal for this data?\""

--- a/src/autoskillit/skills_extended/vis-lens-color-access/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-color-access/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: vis-lens-color-access
 categories: [vis-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Chromatic Accessibility visualization planning spec showing colorblind safety (Okabe-Ito, Paul Tol palettes), perceptual uniformity checks (viridis/cividis pass; jet/rainbow fail), non-color redundant encoding (shape + line-style), and text size minimums. Chromatic lens answering \"Is the color encoding accessible and perceptually uniform?\""

--- a/src/autoskillit/skills_extended/vis-lens-figure-table/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-figure-table/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: vis-lens-figure-table
 categories: [vis-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Decisional Layout visualization planning spec showing figure-vs-table selection heuristics: tables win for exact values, ≤5 items, leaderboards, and ablation matrices; figures win for trends, distributions, and spatial patterns; borderline cases recommend both. Decisional lens answering \"Should this result be a figure or a table?\""

--- a/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: vis-lens-methodology-norms
 categories: [vis-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Methodology Norms visualization planning spec showing ML sub-area mandatory figures, community conventions, and coverage gaps. Methodology-Normative lens answering \"Which domain-specific figures are expected by reviewers?\""

--- a/src/autoskillit/skills_extended/vis-lens-multi-compare/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-multi-compare/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: vis-lens-multi-compare
 categories: [vis-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Compositional Layout visualization planning spec showing small-multiples vs overlay decisions, faceting strategy (row/col), shared-axis alignment, grouped vs stacked bars, factorial interaction plots, and panel reading order. Compositional lens answering \"Which layout best reveals the comparison structure?\""

--- a/src/autoskillit/skills_extended/vis-lens-reproducibility/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-reproducibility/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: vis-lens-reproducibility
 categories: [vis-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Replicative Reproducibility visualization planning spec showing data availability, preprocessing parameter disclosure (bin widths, smoothing windows), plotting library/version, random seeds, and code reference per figure. Replicative lens answering \"Can the figures be reproduced from the data and code?\""

--- a/src/autoskillit/skills_extended/vis-lens-story-arc/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-story-arc/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: vis-lens-story-arc
 categories: [vis-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Narrative Story Arc visualization planning spec showing visual consistency across the report (same color = same model everywhere), logical figure progression, redundant figure detection, and narrative dependency between figures. Narrative lens answering \"Do the figures tell a coherent story across the report?\""

--- a/src/autoskillit/skills_extended/vis-lens-temporal/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-temporal/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: vis-lens-temporal
 categories: [vis-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Temporal Dynamics visualization planning spec showing axis scaling (linear vs log), smoothing disclosure, epoch/step alignment, run aggregation (mean + variance bands), early-stopping markers, and wall-clock vs step-count x-axis. Temporal lens answering \"Are training dynamics shown clearly and honestly?\""

--- a/src/autoskillit/skills_extended/vis-lens-uncertainty/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-uncertainty/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: vis-lens-uncertainty
 categories: [vis-lens]
-backend_requirements: [claude-code]
 uses_capabilities: [cross_skill_ref]
 activate_deps: [mermaid]
 description: "Create Uncertainty Representation visualization planning spec showing error bar definitions, distribution-aware alternatives, and multi-seed variance protocols. Statistical lens answering \"How is uncertainty honestly represented?\""

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -82,7 +82,6 @@ Every generated script MUST follow the workflow YAML schema:
 
 ```yaml
 name: {script-name}
-backend_requirements: [claude-code]
 uses_capabilities: [claude_dir, cross_skill_ref, run_skill, test_check]
 autoskillit_version: "{version}"  # from kitchen_status.package_version
 description: {One line description.}
@@ -298,7 +297,6 @@ This is the reference format. All generated scripts should match this style:
 
 ```yaml
 name: implementation
-backend_requirements: [claude-code]
 uses_capabilities: [claude_dir, cross_skill_ref, run_skill, test_check]
 description: Plan, verify, implement, test, and merge a task.
 summary: make-plan > dry-walk > implement > test > merge
@@ -392,7 +390,6 @@ A condensed bugfix loop showing retry, classify, and routing patterns:
 
 ```yaml
 name: example-loop
-backend_requirements: [claude-code]
 uses_capabilities: [claude_dir, cross_skill_ref, run_skill, test_check]
 description: Test, fix, and merge with automatic retry.
 summary: test > investigate > plan > implement > verify > merge

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: write-recipe
-backend_requirements: [claude-code]
 uses_capabilities: [claude_dir, cross_skill_ref, run_skill, test_check]
 description: Generate YAML recipes for .autoskillit/recipes/. Use when user says "make script skill", "generate script", "script a workflow", "write a script", "create a script", "new recipe", "write a pipeline", or when loaded by other skills for script formatting.
 hooks:

--- a/src/autoskillit/workspace/skills.py
+++ b/src/autoskillit/workspace/skills.py
@@ -8,7 +8,6 @@ from typing import Any, NamedTuple
 
 from autoskillit.core import (
     ALL_PROJECT_LOCAL_SKILL_SEARCH_DIRS,
-    KNOWN_BACKEND_NAMES,
     RETIRED_SKILL_NAMES,
     SKILL_CAPABILITY_REGISTRY,
     SkillSource,
@@ -125,30 +124,6 @@ def _skill_info_from_frontmatter(name: str, source: SkillSource, skill_path: Pat
         if isinstance(categories_raw, list)
         else frozenset()
     )
-    backend_reqs_raw = data.get("backend_requirements", [])
-    if backend_reqs_raw and not isinstance(backend_reqs_raw, list):
-        logger.warning(
-            "backend_requirements_not_a_list",
-            value=backend_reqs_raw,
-            skill=name,
-            hint="use bracket syntax: backend_requirements: [claude-code]",
-        )
-        backend_reqs_raw = [backend_reqs_raw]
-    backend_requirements = (
-        frozenset(str(r) for r in backend_reqs_raw)
-        if isinstance(backend_reqs_raw, list)
-        else frozenset()
-    )
-    invalid = backend_requirements - KNOWN_BACKEND_NAMES
-    if invalid:
-        logger.warning(
-            "unrecognized_backend_requirements",
-            invalid=sorted(invalid),
-            skill=name,
-            valid=sorted(KNOWN_BACKEND_NAMES),
-        )
-        backend_requirements = backend_requirements - invalid
-
     caps_raw = data.get("uses_capabilities", [])
     if caps_raw and not isinstance(caps_raw, list):
         logger.warning(
@@ -170,6 +145,14 @@ def _skill_info_from_frontmatter(name: str, source: SkillSource, skill_path: Pat
             valid=sorted(SKILL_CAPABILITY_REGISTRY),
         )
         uses_capabilities = uses_capabilities - unknown_caps
+
+    backend_requirements: frozenset[str] = (
+        frozenset().union(
+            *(SKILL_CAPABILITY_REGISTRY[c].required_backends for c in uses_capabilities)
+        )
+        if uses_capabilities
+        else frozenset()
+    )
 
     return SkillInfo(
         name=name,

--- a/tests/arch/test_no_backend_name_bypass.py
+++ b/tests/arch/test_no_backend_name_bypass.py
@@ -20,7 +20,6 @@ _EXEMPT_FILES: frozenset[str] = frozenset(
         "server/_session_type.py",  # Codex pre-reveal — env var dispatch, no capabilities
         "cli/session/_session_launch.py",  # Feature-gate backend-alignment fallback
         "recipe/rules/rules_backend_compat.py",  # Backend compatibility semantic rule
-        "server/tools/tools_execution.py",  # Skill-requirement: backend_requirements membership
     }
 )
 

--- a/tests/arch/test_skill_backend_annotation_accuracy.py
+++ b/tests/arch/test_skill_backend_annotation_accuracy.py
@@ -16,10 +16,6 @@ pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 _GENUINE_CLAUDE_CODE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"Agent\(\s*subagent_type\s*="),
     re.compile(r"Agent\(\s*model\s*="),
-    re.compile(r"\bopen_kitchen\b"),
-    re.compile(r"\bclose_kitchen\b"),
-    re.compile(r"\brun_skill\b"),
-    re.compile(r"\btest_check\b"),
 )
 
 

--- a/tests/arch/test_skill_backend_annotations.py
+++ b/tests/arch/test_skill_backend_annotations.py
@@ -120,24 +120,16 @@ def test_co_requirement_backend_requires_capabilities():
 
 
 def test_derivation_backend_requirements_match_capabilities():
-    """backend_requirements must equal the union of required_backends from uses_capabilities."""
+    """backend_requirements must NOT be declared in SKILL.md — derivation is runtime-only."""
     violations: list[str] = []
     for name, skill_md in _iter_skill_dirs():
         fm = _read_skill_frontmatter(skill_md)
-        uses_caps = list(fm.get("uses_capabilities", []))
-        if not uses_caps:
-            continue
-        derived: set[str] = set()
-        for cap_name in uses_caps:
-            cap_def = SKILL_CAPABILITY_REGISTRY.get(cap_name)
-            if cap_def:
-                derived |= cap_def.required_backends
-        declared = set(fm.get("backend_requirements", []))
-        if derived != declared:
-            violations.append(f"{name}: derived={sorted(derived)}, declared={sorted(declared)}")
+        declared = fm.get("backend_requirements", [])
+        if declared:
+            violations.append(f"{name}: has backend_requirements={declared} in frontmatter")
     assert not violations, (
-        f"{len(violations)} skill(s) have mismatched backend_requirements vs capabilities:\n"
-        + "\n".join(f"  {v}" for v in violations)
+        f"{len(violations)} skill(s) still have backend_requirements in SKILL.md frontmatter "
+        f"(should be derived at runtime):\n" + "\n".join(f"  {v}" for v in violations)
     )
 
 

--- a/tests/arch/test_skill_backend_annotations.py
+++ b/tests/arch/test_skill_backend_annotations.py
@@ -139,3 +139,14 @@ def test_derivation_backend_requirements_match_capabilities():
         f"{len(violations)} skill(s) have mismatched backend_requirements vs capabilities:\n"
         + "\n".join(f"  {v}" for v in violations)
     )
+
+
+def test_no_skill_has_backend_requirements():
+    violations = []
+    for name, skill_md in _iter_skill_dirs():
+        fm = _read_skill_frontmatter(skill_md)
+        if fm.get("backend_requirements"):
+            violations.append(f"{name}: {fm.get('backend_requirements')}")
+    assert not violations, "No skill should have backend_requirements:\n" + "\n".join(
+        f"  {v}" for v in violations
+    )

--- a/tests/arch/test_skill_backend_annotations.py
+++ b/tests/arch/test_skill_backend_annotations.py
@@ -131,14 +131,3 @@ def test_derivation_backend_requirements_match_capabilities():
         f"{len(violations)} skill(s) still have backend_requirements in SKILL.md frontmatter "
         f"(should be derived at runtime):\n" + "\n".join(f"  {v}" for v in violations)
     )
-
-
-def test_no_skill_has_backend_requirements():
-    violations = []
-    for name, skill_md in _iter_skill_dirs():
-        fm = _read_skill_frontmatter(skill_md)
-        if fm.get("backend_requirements"):
-            violations.append(f"{name}: {fm.get('backend_requirements')}")
-    assert not violations, "No skill should have backend_requirements:\n" + "\n".join(
-        f"  {v}" for v in violations
-    )

--- a/tests/arch/test_skill_capability_registry.py
+++ b/tests/arch/test_skill_capability_registry.py
@@ -28,24 +28,27 @@ def test_all_capability_keys_are_consumed():
 
 
 def test_backend_requirements_derivable_from_capabilities():
-    all_fm = _all_skill_frontmatter()
+    from autoskillit.workspace.skills import DefaultSkillResolver
+
+    resolver = DefaultSkillResolver()
     violations: list[str] = []
-    for name, fm in all_fm:
-        backend_reqs = frozenset(fm.get("backend_requirements", []))
-        uses_caps = list(fm.get("uses_capabilities", []))
-        if backend_reqs and not uses_caps:
-            violations.append(f"{name}: has backend_requirements but no uses_capabilities")
-            continue
+    for skill_info in resolver.list_all():
+        uses_caps = list(skill_info.uses_capabilities)
         if not uses_caps:
+            if skill_info.backend_requirements:
+                violations.append(
+                    f"{skill_info.name}: has backend_requirements but no uses_capabilities"
+                )
             continue
         derived: set[str] = set()
         for cap_name in uses_caps:
             cap_def = SKILL_CAPABILITY_REGISTRY.get(cap_name)
             if cap_def:
                 derived |= cap_def.required_backends
-        if frozenset(derived) != backend_reqs:
+        if frozenset(derived) != skill_info.backend_requirements:
             violations.append(
-                f"{name}: derived={sorted(derived)}, declared={sorted(backend_reqs)}"
+                f"{skill_info.name}: derived={sorted(derived)}, "
+                f"actual={sorted(skill_info.backend_requirements)}"
             )
     assert not violations, (
         f"{len(violations)} skill(s) have inconsistent backend_requirements vs "
@@ -82,14 +85,20 @@ def test_codex_status_consistent_with_required_backends():
 _MCP_TOOL_CAPABILITIES = {"run_skill", "test_check", "open_kitchen"}
 
 
-def test_mcp_tools_are_backend_agnostic():
+def test_mcp_tools_require_claude_code():
+    from autoskillit.core.types._type_constants_env import AGENT_BACKEND_CLAUDE_CODE
+
     violations = []
     for cap_name in _MCP_TOOL_CAPABILITIES:
         cap = SKILL_CAPABILITY_REGISTRY.get(cap_name)
-        if cap and cap.required_backends:
-            violations.append(f"{cap_name}: required_backends={cap.required_backends!r}")
-    assert not violations, "MCP tools must have empty required_backends:\n" + "\n".join(
-        f"  {v}" for v in violations
+        if cap and cap.required_backends != frozenset({AGENT_BACKEND_CLAUDE_CODE}):
+            violations.append(
+                f"{cap_name}: expected required_backends=frozenset({{'claude-code'}}), "
+                f"got {cap.required_backends!r}"
+            )
+    assert not violations, (
+        "MCP tools must derive required_backends from codex_status='not-applicable':\n"
+        + "\n".join(f"  {v}" for v in violations)
     )
 
 

--- a/tests/arch/test_skill_capability_registry.py
+++ b/tests/arch/test_skill_capability_registry.py
@@ -73,12 +73,18 @@ def test_codex_status_consistent_with_required_backends():
 
     violations = []
     for key, cap in SKILL_CAPABILITY_REGISTRY.items():
-        if cap.codex_status != "not-applicable" and cap.required_backends == frozenset(
-            {AGENT_BACKEND_CLAUDE_CODE}
-        ):
-            violations.append(
-                f"{key}: codex_status={cap.codex_status!r} contradicts required_backends"
-            )
+        if cap.codex_status == "not-applicable":
+            if cap.required_backends != frozenset({AGENT_BACKEND_CLAUDE_CODE}):
+                violations.append(
+                    f"{key}: codex_status='not-applicable' but "
+                    f"required_backends={cap.required_backends!r} (expected {{claude-code}})"
+                )
+        else:
+            if cap.required_backends != frozenset():
+                violations.append(
+                    f"{key}: codex_status={cap.codex_status!r} but "
+                    f"required_backends={cap.required_backends!r} (expected empty)"
+                )
     assert not violations, "\n".join(f"  {v}" for v in violations)
 
 

--- a/tests/arch/test_skill_capability_registry.py
+++ b/tests/arch/test_skill_capability_registry.py
@@ -63,3 +63,37 @@ def test_no_unknown_capability_declared():
     assert not violations, "Unknown capabilities declared in SKILL.md files:\n" + "\n".join(
         f"  {v}" for v in violations
     )
+
+
+def test_codex_status_consistent_with_required_backends():
+    from autoskillit.core.types._type_constants_env import AGENT_BACKEND_CLAUDE_CODE
+
+    violations = []
+    for key, cap in SKILL_CAPABILITY_REGISTRY.items():
+        if cap.codex_status != "not-applicable" and cap.required_backends == frozenset(
+            {AGENT_BACKEND_CLAUDE_CODE}
+        ):
+            violations.append(
+                f"{key}: codex_status={cap.codex_status!r} contradicts required_backends"
+            )
+    assert not violations, "\n".join(f"  {v}" for v in violations)
+
+
+_MCP_TOOL_CAPABILITIES = {"run_skill", "test_check", "open_kitchen"}
+
+
+def test_mcp_tools_are_backend_agnostic():
+    violations = []
+    for cap_name in _MCP_TOOL_CAPABILITIES:
+        cap = SKILL_CAPABILITY_REGISTRY.get(cap_name)
+        if cap and cap.required_backends:
+            violations.append(f"{cap_name}: required_backends={cap.required_backends!r}")
+    assert not violations, "MCP tools must have empty required_backends:\n" + "\n".join(
+        f"  {v}" for v in violations
+    )
+
+
+def test_required_backends_is_derived_property():
+    from autoskillit.core.types._type_constants_registries import SkillCapabilityDef
+
+    assert "required_backends" not in SkillCapabilityDef.__dataclass_fields__

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -323,7 +323,9 @@ class TestCodexInitFlow:
         )
 
     @pytest.fixture(autouse=True)
-    def _codex_backend_config(self, tmp_path: Path) -> None:
+    def _codex_backend_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
+        monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND__BACKEND", raising=False)
         cfg_dir = tmp_path / ".autoskillit"
         cfg_dir.mkdir(parents=True, exist_ok=True)
         (cfg_dir / "config.yaml").write_text(

--- a/tests/cli/test_init_helpers.py
+++ b/tests/cli/test_init_helpers.py
@@ -422,6 +422,7 @@ class TestRegisterAllBackendBranching:
         from autoskillit.cli._init_helpers import _register_all
 
         monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
+        monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND__BACKEND", raising=False)
         self._write_config(tmp_path, "codex")
 
         monkeypatch.setattr(_hooks_mod, "sweep_all_scopes_for_orphans", lambda p: None)

--- a/tests/config/test_agent_backend_config.py
+++ b/tests/config/test_agent_backend_config.py
@@ -105,6 +105,7 @@ class TestAgentBackendConfigLoading:
         from autoskillit.config import load_config
 
         monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND", raising=False)
+        monkeypatch.delenv("AUTOSKILLIT_AGENT_BACKEND__BACKEND", raising=False)
         config_dir = tmp_path / ".autoskillit"
         config_dir.mkdir()
         (config_dir / "config.yaml").write_text(yaml.dump({"agent_backend": {"backend": "aider"}}))

--- a/tests/server/test_tools_execution_backend_mixing.py
+++ b/tests/server/test_tools_execution_backend_mixing.py
@@ -106,11 +106,12 @@ async def test_anthropic_capable_backend_profile_without_base_url_no_override(
 
 
 @pytest.mark.anyio
-async def test_skill_backend_requirement_derives_override(
+async def test_skill_backend_requirement_triggers_incompatibility_gate(
     tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
     """Skill with backend_requirements=[claude-code] on a non-claude backend
-    -> backend_override='claude-code'."""
+    -> _is_backend_incompatible gate rejects the call (no silent override)."""
+    import json
     from unittest.mock import MagicMock
 
     from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
@@ -142,18 +143,10 @@ async def test_skill_backend_requirement_derives_override(
         lambda cmd, resolver: ("/autoskillit:test-skill", "test-skill"),
     )
 
-    captured: dict = {}
-    original_run = executor.run
-
-    async def spy_run(*args, **kwargs):
-        captured.update(kwargs)
-        return await original_run(*args, **kwargs)
-
-    monkeypatch.setattr(executor, "run", spy_run)
-
-    await run_skill("/autoskillit:probe", str(tmp_path))
-
-    assert captured.get("backend_override") == "claude-code"
+    result = await run_skill("/autoskillit:probe", str(tmp_path))
+    data = json.loads(result)
+    assert data.get("status") == "crashed"
+    assert "requires backend" in data.get("error", "")
 
 
 @pytest.mark.anyio
@@ -207,10 +200,10 @@ async def test_skill_without_backend_requirement_no_override(
 
 
 @pytest.mark.anyio
-async def test_backend_override_emits_structured_log_skill_requirement(
+async def test_backend_incompatibility_does_not_emit_override_log(
     tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
-    """Skill-requirement override fires -> logger.info with reason='skill_requirement'."""
+    """Skill-requirement incompatibility crashes (no override log emitted)."""
     from unittest.mock import MagicMock
 
     import structlog
@@ -250,11 +243,7 @@ async def test_backend_override_emits_structured_log_skill_requirement(
     override_logs = [
         entry for entry in log_list if entry.get("event") == "backend_override_activated"
     ]
-    assert len(override_logs) == 1
-    log = override_logs[0]
-    assert log["reason"] == "skill_requirement"
-    assert log["original_backend"] == "codex"
-    assert log["target_backend"] == "claude-code"
+    assert len(override_logs) == 0
 
 
 @pytest.mark.anyio
@@ -312,11 +301,57 @@ async def test_backend_override_emits_structured_log_provider_profile(
 
 
 @pytest.mark.anyio
-async def test_backend_override_threads_effective_backend_to_init_session(
+async def test_backend_incompatibility_gate_rejects_before_init_session(
     tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
-    """When backend_override is set, init_session receives the overridden backend
-    (ClaudeCodeBackend), not the orchestrator backend (Codex)."""
+    """When skill requires claude-code and effective backend is codex,
+    the incompatibility gate rejects before init_session is called."""
+    import json
+    from unittest.mock import MagicMock
+
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    fake_backend = MagicMock(spec=CodingAgentBackend)
+    fake_backend.name = "codex"
+    fake_backend.capabilities.anthropic_provider_capable = False
+    tool_ctx_kitchen_open.backend = fake_backend
+
+    mock_ssm = MagicMock()
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+
+    mock_skill_info = MagicMock()
+    mock_skill_info.backend_requirements = frozenset({"claude-code"})
+    mock_resolver = MagicMock()
+    mock_resolver.resolve.return_value = mock_skill_info
+    tool_ctx_kitchen_open.skill_resolver = mock_resolver
+
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a, **kw: ("default", {}),
+    )
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution.resolve_target_skill",
+        lambda cmd, resolver: ("/autoskillit:test-skill", "test-skill"),
+    )
+
+    result = await run_skill("/autoskillit:test-skill", str(tmp_path))
+    data = json.loads(result)
+    assert data.get("status") == "crashed"
+    mock_ssm.init_session.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_provider_override_threads_effective_backend_to_init_session(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    """When provider_override triggers backend_override, init_session receives
+    the overridden backend (ClaudeCodeBackend), not the orchestrator backend (Codex)."""
     from unittest.mock import MagicMock
 
     from autoskillit.core import ValidatedAddDir
@@ -342,7 +377,7 @@ async def test_backend_override_threads_effective_backend_to_init_session(
     tool_ctx_kitchen_open.session_skill_manager = mock_ssm
 
     mock_skill_info = MagicMock()
-    mock_skill_info.backend_requirements = frozenset({"claude-code"})
+    mock_skill_info.backend_requirements = frozenset()
     mock_resolver = MagicMock()
     mock_resolver.resolve.return_value = mock_skill_info
     tool_ctx_kitchen_open.skill_resolver = mock_resolver
@@ -352,7 +387,13 @@ async def test_backend_override_threads_effective_backend_to_init_session(
     monkeypatch.setattr(_feat, lambda *a, **kw: True)
     monkeypatch.setattr(
         "autoskillit.server._guards._resolve_provider_profile",
-        lambda *a, **kw: ("default", {}),
+        lambda *a, **kw: (
+            "minimax",
+            {
+                "ANTHROPIC_BASE_URL": "https://api.minimax.chat/v1/anthropic",
+                "ANTHROPIC_API_KEY": "minimax-key-placeholder",
+            },
+        ),
     )
     monkeypatch.setattr(
         "autoskillit.server.tools.tools_execution.resolve_target_skill",
@@ -367,75 +408,6 @@ async def test_backend_override_threads_effective_backend_to_init_session(
         "init_session must NOT receive the orchestrator backend"
     )
     assert init_backend.name == "claude-code"
-
-
-@pytest.mark.anyio
-async def test_backend_override_skill_md_uses_effective_conventions(
-    tool_ctx_kitchen_open, tmp_path, monkeypatch
-) -> None:
-    """SKILL.md path uses the effective backend's conventions.skills_subdir,
-    not a hardcoded '.claude/skills'."""
-    from unittest.mock import MagicMock
-
-    from autoskillit.core import ValidatedAddDir
-    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
-    from tests.fakes import InMemoryHeadlessExecutor
-
-    executor = InMemoryHeadlessExecutor()
-    tool_ctx_kitchen_open.executor = executor
-    fake_backend = MagicMock(spec=CodingAgentBackend)
-    fake_backend.name = "codex"
-    fake_backend.capabilities.anthropic_provider_capable = False
-    tool_ctx_kitchen_open.backend = fake_backend
-
-    session_dir = tmp_path / "session"
-    session_dir.mkdir()
-    skill_md = session_dir / ".claude" / "skills" / "test-skill" / "SKILL.md"
-    skill_md.parent.mkdir(parents=True)
-    skill_md.write_text("name: test-skill\n")
-
-    fake_validated = ValidatedAddDir(path=str(session_dir))
-    mock_ssm = MagicMock()
-    mock_ssm.init_session.return_value = fake_validated
-    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
-
-    mock_skill_info = MagicMock()
-    mock_skill_info.backend_requirements = frozenset({"claude-code"})
-    mock_resolver = MagicMock()
-    mock_resolver.resolve.return_value = mock_skill_info
-    tool_ctx_kitchen_open.skill_resolver = mock_resolver
-
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
-    monkeypatch.setattr(_feat, lambda *a, **kw: True)
-    monkeypatch.setattr(
-        "autoskillit.server._guards._resolve_provider_profile",
-        lambda *a, **kw: ("default", {}),
-    )
-    monkeypatch.setattr(
-        "autoskillit.server.tools.tools_execution.resolve_target_skill",
-        lambda cmd, resolver: ("/autoskillit:test-skill", "test-skill"),
-    )
-
-    result_json = await run_skill("/autoskillit:test-skill", str(tmp_path))
-    assert "SKILL.md not found" not in str(result_json), (
-        "SKILL.md at .claude/skills/ should be found when effective backend is claude-code"
-    )
-
-    session_dir_codex = tmp_path / "session_codex"
-    session_dir_codex.mkdir()
-    codex_skill_md = session_dir_codex / "skills" / "test-skill" / "SKILL.md"
-    codex_skill_md.parent.mkdir(parents=True)
-    codex_skill_md.write_text("name: test-skill\n")
-
-    fake_validated_codex = ValidatedAddDir(path=str(session_dir_codex))
-    mock_ssm.reset_mock()
-    mock_ssm.init_session.return_value = fake_validated_codex
-
-    result_json2 = await run_skill("/autoskillit:test-skill", str(tmp_path))
-    assert "SKILL.md not found" in str(result_json2), (
-        "SKILL.md at codex 'skills/' should NOT be found when effective backend is claude-code"
-    )
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_execution_backend_mixing.py
+++ b/tests/server/test_tools_execution_backend_mixing.py
@@ -7,6 +7,8 @@ containing ANTHROPIC_BASE_URL.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from autoskillit.server.tools.tools_execution import run_skill
@@ -434,3 +436,9 @@ async def test_backend_override_skill_md_uses_effective_conventions(
     assert "SKILL.md not found" in str(result_json2), (
         "SKILL.md at codex 'skills/' should NOT be found when effective backend is claude-code"
     )
+
+
+@pytest.mark.anyio
+async def test_no_skill_requires_claude_logic() -> None:
+    source = Path("src/autoskillit/server/tools/tools_execution.py").read_text()
+    assert "_skill_requires_claude" not in source

--- a/tests/server/test_tools_execution_backend_mixing.py
+++ b/tests/server/test_tools_execution_backend_mixing.py
@@ -150,56 +150,6 @@ async def test_skill_backend_requirement_triggers_incompatibility_gate(
 
 
 @pytest.mark.anyio
-async def test_skill_without_backend_requirement_no_override(
-    tool_ctx_kitchen_open, tmp_path, monkeypatch
-) -> None:
-    """Skill with empty backend_requirements on a non-claude backend -> no override."""
-    from unittest.mock import MagicMock
-
-    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
-    from tests.fakes import InMemoryHeadlessExecutor
-
-    executor = InMemoryHeadlessExecutor()
-    tool_ctx_kitchen_open.executor = executor
-    fake_backend = MagicMock(spec=CodingAgentBackend)
-    fake_backend.name = "codex"
-    fake_backend.capabilities.anthropic_provider_capable = False
-    tool_ctx_kitchen_open.backend = fake_backend
-    tool_ctx_kitchen_open.session_skill_manager = None
-
-    mock_skill_info = MagicMock()
-    mock_skill_info.backend_requirements = frozenset()
-    mock_resolver = MagicMock()
-    mock_resolver.resolve.return_value = mock_skill_info
-    tool_ctx_kitchen_open.skill_resolver = mock_resolver
-
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
-    monkeypatch.setattr(_feat, lambda *a, **kw: True)
-    monkeypatch.setattr(
-        "autoskillit.server._guards._resolve_provider_profile",
-        lambda *a, **kw: ("default", {}),
-    )
-    monkeypatch.setattr(
-        "autoskillit.server.tools.tools_execution.resolve_target_skill",
-        lambda cmd, resolver: ("/autoskillit:test-skill", "test-skill"),
-    )
-
-    captured: dict = {}
-    original_run = executor.run
-
-    async def spy_run(*args, **kwargs):
-        captured.update(kwargs)
-        return await original_run(*args, **kwargs)
-
-    monkeypatch.setattr(executor, "run", spy_run)
-
-    await run_skill("/autoskillit:probe", str(tmp_path))
-
-    assert captured.get("backend_override") is None
-
-
-@pytest.mark.anyio
 async def test_backend_incompatibility_does_not_emit_override_log(
     tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:

--- a/tests/server/test_tools_execution_backend_mixing.py
+++ b/tests/server/test_tools_execution_backend_mixing.py
@@ -363,5 +363,12 @@ async def test_provider_override_threads_effective_backend_to_init_session(
 
 @pytest.mark.anyio
 async def test_no_skill_requires_claude_logic() -> None:
-    source = Path("src/autoskillit/server/tools/tools_execution.py").read_text()
+    source = (
+        Path(__file__).parents[2]
+        / "src"
+        / "autoskillit"
+        / "server"
+        / "tools"
+        / "tools_execution.py"
+    ).read_text()
     assert "_skill_requires_claude" not in source

--- a/tests/server/test_tools_execution_backend_mixing.py
+++ b/tests/server/test_tools_execution_backend_mixing.py
@@ -145,8 +145,8 @@ async def test_skill_backend_requirement_triggers_incompatibility_gate(
 
     result = await run_skill("/autoskillit:probe", str(tmp_path))
     data = json.loads(result)
-    assert data.get("status") == "crashed"
-    assert "requires backend" in data.get("error", "")
+    assert data.get("subtype") == "crashed"
+    assert "requires backend" in data.get("result", "")
 
 
 @pytest.mark.anyio
@@ -342,7 +342,8 @@ async def test_backend_incompatibility_gate_rejects_before_init_session(
 
     result = await run_skill("/autoskillit:test-skill", str(tmp_path))
     data = json.loads(result)
-    assert data.get("status") == "crashed"
+    assert data.get("subtype") == "crashed"
+    assert "requires backend" in data.get("result", "")
     mock_ssm.init_session.assert_not_called()
 
 

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -322,26 +322,18 @@ async def test_run_skill_passes_backend_to_init_session(
 
 
 @pytest.mark.anyio
-async def test_run_skill_passes_effective_backend_to_init_session_when_override(
+async def test_run_skill_incompatible_backend_rejects_before_init_session(
     tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
-    """When backend_override is triggered, init_session receives the overridden
-    backend object, not tool_ctx.backend."""
+    """When skill requires claude-code and effective backend is codex (no provider override),
+    the incompatibility gate rejects before init_session is called."""
+    import json
     from unittest.mock import MagicMock
 
-    from autoskillit.core import ValidatedAddDir
     from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
     from tests.fakes import InMemoryHeadlessExecutor
 
-    session_dir = tmp_path / "session"
-    session_dir.mkdir()
-    skill_md = session_dir / ".claude" / "skills" / "test-skill" / "SKILL.md"
-    skill_md.parent.mkdir(parents=True)
-    skill_md.write_text("name: test-skill\n")
-
-    fake_validated = ValidatedAddDir(path=str(session_dir))
     mock_ssm = MagicMock()
-    mock_ssm.init_session.return_value = fake_validated
     tool_ctx_kitchen_open.session_skill_manager = mock_ssm
 
     fake_backend = MagicMock(spec=CodingAgentBackend)
@@ -366,12 +358,11 @@ async def test_run_skill_passes_effective_backend_to_init_session_when_override(
         lambda cmd, resolver: ("/autoskillit:test-skill", "test-skill"),
     )
 
-    await run_skill("/autoskillit:test-skill", str(tmp_path))
-
-    mock_ssm.init_session.assert_called_once()
-    init_backend = mock_ssm.init_session.call_args.kwargs.get("backend")
-    assert init_backend is not fake_backend
-    assert init_backend.name == "claude-code"
+    result = await run_skill("/autoskillit:test-skill", str(tmp_path))
+    data = json.loads(result)
+    assert data.get("status") == "crashed"
+    assert "requires backend" in data.get("error", "")
+    mock_ssm.init_session.assert_not_called()
 
 
 class TestOutputDirParameter:

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -341,10 +341,20 @@ async def test_run_skill_incompatible_backend_rejects_before_init_session(
     fake_backend.capabilities.anthropic_provider_capable = False
     tool_ctx_kitchen_open.backend = fake_backend
 
-    mock_skill_info = MagicMock()
-    mock_skill_info.backend_requirements = frozenset({"claude-code"})
+    from pathlib import Path
+
+    from autoskillit.core.types import SkillSource
+    from autoskillit.workspace.skills import SkillInfo
+
+    skill_info = SkillInfo(
+        name="test-skill",
+        source=SkillSource.BUNDLED,
+        path=Path("/fake/SKILL.md"),
+        backend_requirements=frozenset({"claude-code"}),
+        uses_capabilities=frozenset({"open_kitchen"}),
+    )
     mock_resolver = MagicMock()
-    mock_resolver.resolve.return_value = mock_skill_info
+    mock_resolver.resolve.return_value = skill_info
     tool_ctx_kitchen_open.skill_resolver = mock_resolver
 
     tool_ctx_kitchen_open.executor = InMemoryHeadlessExecutor()

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -360,8 +360,8 @@ async def test_run_skill_incompatible_backend_rejects_before_init_session(
 
     result = await run_skill("/autoskillit:test-skill", str(tmp_path))
     data = json.loads(result)
-    assert data.get("status") == "crashed"
-    assert "requires backend" in data.get("error", "")
+    assert data.get("subtype") == "crashed"
+    assert "requires backend" in data.get("result", "")
     mock_ssm.init_session.assert_not_called()
 
 

--- a/tests/skills_extended/test_apply_review_dimensions_skill.py
+++ b/tests/skills_extended/test_apply_review_dimensions_skill.py
@@ -28,7 +28,7 @@ def test_skill_frontmatter() -> None:
     assert isinstance(fm, dict), "SKILL.md frontmatter is not a YAML mapping"
     assert fm["name"] == "apply-review-dimensions"
     assert fm["categories"] == ["research"]
-    assert fm["backend_requirements"] == ["claude-code"]
+    assert "backend_requirements" not in fm
 
 
 def test_skill_sections() -> None:

--- a/tests/skills_extended/test_classify_experiment_type_skill.py
+++ b/tests/skills_extended/test_classify_experiment_type_skill.py
@@ -34,7 +34,7 @@ def test_skill_frontmatter() -> None:
     assert isinstance(fm, dict), "SKILL.md frontmatter is not a YAML mapping"
     assert fm["name"] == "classify-experiment-type"
     assert fm["categories"] == ["research"]
-    assert fm["backend_requirements"] == ["claude-code"]
+    assert "backend_requirements" not in fm
 
 
 def test_skill_sections() -> None:

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -777,15 +777,15 @@ def test_resolve_instance_cache_caches_none(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 class TestBackendRequirements:
-    def test_parse_backend_requirements_from_frontmatter(self, tmp_path) -> None:
+    def test_backend_requirements_derived_from_capabilities(self, tmp_path) -> None:
         from autoskillit.workspace.skills import _skill_info_from_frontmatter
 
         skill_md = tmp_path / "SKILL.md"
-        skill_md.write_text("---\nname: test\nbackend_requirements: [claude-code]\n---\n# content")
+        skill_md.write_text("---\nname: test\nuses_capabilities: [open_kitchen]\n---\n# content")
         info = _skill_info_from_frontmatter("test", SkillSource.BUNDLED, skill_md)
         assert info.backend_requirements == frozenset({"claude-code"})
 
-    def test_empty_backend_requirements(self, tmp_path) -> None:
+    def test_empty_capabilities_yields_empty_backend_requirements(self, tmp_path) -> None:
         from autoskillit.workspace.skills import _skill_info_from_frontmatter
 
         skill_md = tmp_path / "SKILL.md"
@@ -793,44 +793,44 @@ class TestBackendRequirements:
         info = _skill_info_from_frontmatter("test", SkillSource.BUNDLED, skill_md)
         assert info.backend_requirements == frozenset()
 
-    def test_non_list_backend_requirements_coerced_to_list(self, tmp_path) -> None:
+    def test_non_mcp_capabilities_yield_empty_backend_requirements(self, tmp_path) -> None:
         from autoskillit.workspace.skills import _skill_info_from_frontmatter
 
         skill_md = tmp_path / "SKILL.md"
-        skill_md.write_text("---\nname: test\nbackend_requirements: claude-code\n---\n# content")
+        skill_md.write_text(
+            "---\nname: test\nuses_capabilities: [agent_subagent, claude_dir]\n---\n# content"
+        )
         info = _skill_info_from_frontmatter("test", SkillSource.BUNDLED, skill_md)
-        assert info.backend_requirements == frozenset({"claude-code"})
+        assert info.backend_requirements == frozenset()
 
-    def test_invalid_backend_name_pruned_with_warning(self, tmp_path) -> None:
+    def test_unknown_capability_pruned_with_warning(self, tmp_path) -> None:
         import structlog.testing
 
         from autoskillit.workspace.skills import _skill_info_from_frontmatter
 
         skill_md = tmp_path / "SKILL.md"
-        skill_md.write_text("---\nname: test\nbackend_requirements: [claude_code]\n---\n# content")
+        skill_md.write_text(
+            "---\nname: test\nuses_capabilities: [nonexistent_cap]\n---\n# content"
+        )
         with structlog.testing.capture_logs() as logs:
             info = _skill_info_from_frontmatter("test", SkillSource.BUNDLED, skill_md)
         assert info.backend_requirements == frozenset()
-        assert any(log["event"] == "unrecognized_backend_requirements" for log in logs)
+        assert any(log["event"] == "unrecognized_uses_capabilities" for log in logs)
 
-    def test_valid_backend_names_no_warning(self, tmp_path, caplog) -> None:
-        import logging
-
+    def test_mixed_capabilities_derive_backend_requirements(self, tmp_path) -> None:
         from autoskillit.workspace.skills import _skill_info_from_frontmatter
 
         skill_md = tmp_path / "SKILL.md"
         skill_md.write_text(
-            "---\nname: test\nbackend_requirements: [claude-code, codex]\n---\n# content"
+            "---\nname: test\nuses_capabilities: [agent_subagent, run_skill]\n---\n# content"
         )
-        with caplog.at_level(logging.WARNING, logger="autoskillit.workspace.skills"):
-            info = _skill_info_from_frontmatter("test", SkillSource.BUNDLED, skill_md)
-        assert info.backend_requirements == frozenset({"claude-code", "codex"})
-        assert "unrecognized_backend_requirements" not in caplog.text
+        info = _skill_info_from_frontmatter("test", SkillSource.BUNDLED, skill_md)
+        assert info.backend_requirements == frozenset({"claude-code"})
 
-    def test_investigate_skill_has_claude_code_requirement(self) -> None:
+    def test_investigate_skill_has_no_backend_requirement(self) -> None:
         info = DefaultSkillResolver().resolve("investigate")
         assert info is not None
-        assert "claude-code" in info.backend_requirements
+        assert info.backend_requirements == frozenset()
 
     def test_skill_info_default_backend_requirements(self) -> None:
         from autoskillit.workspace.skills import SkillInfo
@@ -850,7 +850,8 @@ class TestSkillInfoSchemaExhaustiveness:
 
         dc_fields = {f.name for f in dataclasses.fields(SkillInfo)}
         constructor_only = {"name", "source", "path"}
-        parseable_fields = dc_fields - constructor_only
+        derived_fields = {"backend_requirements"}
+        parseable_fields = dc_fields - constructor_only - derived_fields
 
         source = inspect.getsource(_skill_info_from_frontmatter)
         tree = ast.parse(source)

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -838,6 +838,24 @@ class TestBackendRequirements:
         info = SkillInfo(name="test", source=SkillSource.BUNDLED, path=Path("/fake/SKILL.md"))
         assert info.backend_requirements == frozenset()
 
+    def test_backend_requirements_derived_not_read_from_yaml(self, tmp_path) -> None:
+        """backend_requirements in SKILL.md YAML is ignored — derived from uses_capabilities."""
+        from autoskillit.workspace.skills import _skill_info_from_frontmatter
+
+        skill_dir = tmp_path / "test-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: test-skill\nbackend_requirements: [claude-code]\n"
+            "uses_capabilities: [claude_dir]\n---\nTest skill.\n"
+        )
+        info = _skill_info_from_frontmatter(
+            "test-skill", SkillSource.PROJECT, skill_dir / "SKILL.md"
+        )
+        assert info.backend_requirements == frozenset(), (
+            "backend_requirements should be derived from uses_capabilities "
+            "(claude_dir → frozenset()), not read from YAML"
+        )
+
 
 class TestSkillInfoSchemaExhaustiveness:
     def test_all_skillinfo_fields_parsed_by_frontmatter_function(self) -> None:

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -849,7 +849,7 @@ class TestBackendRequirements:
             "uses_capabilities: [claude_dir]\n---\nTest skill.\n"
         )
         info = _skill_info_from_frontmatter(
-            "test-skill", SkillSource.PROJECT, skill_dir / "SKILL.md"
+            "test-skill", SkillSource.BUNDLED, skill_dir / "SKILL.md"
         )
         assert info.backend_requirements == frozenset(), (
             "backend_requirements should be derived from uses_capabilities "


### PR DESCRIPTION
## Summary

The `SKILL_CAPABILITY_REGISTRY` has a hand-coded `required_backends` field on each `SkillCapabilityDef` that contradicts the registry's own `codex_status` field. All 6 non-`claude_dir` capabilities are marked `required_backends=frozenset({"claude-code"})` even though Codex natively supports them all. This causes `_skill_requires_claude` to force every `run_skill` dispatch to Claude Code, `_should_inject_skill` to silently exclude all skills from Codex sessions, and `rules_backend_compat` to emit spurious warnings for Codex recipes.

The fix converts `required_backends` from a stored field to a `@property` derived from `codex_status`, making contradictions structurally impossible: only `"not-applicable"` capabilities (MCP-specific tools like `open_kitchen`, `run_skill`, `test_check`) map to `frozenset({"claude-code"})`; all others (`"works-as-is"`, `"degraded"`, `"fix-required"`) map to `frozenset()`. Additionally, `_skill_info_from_frontmatter` is updated to derive `SkillInfo.backend_requirements` from `uses_capabilities` via the registry rather than reading it from SKILL.md YAML.

Part B will cover test infrastructure updates (rewriting/deleting affected test cases across 6 test files) and template documentation cleanup — implement as a separate task.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260603-135240-162480/.autoskillit/temp/rectify/rectify_skill_capability_registry_part_a_2026-06-03_140000.md`

Closes #3675

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 62 | 32.6k | 2.1M | 128.2k | 57 | 111.4k | 27m 5s |
| review_approach* | opus[1m] | 1 | 3.0k | 5.3k | 283.2k | 46.8k | 14 | 33.5k | 4m 9s |
| dry_walkthrough* | opus | 2 | 3.0k | 25.0k | 2.3M | 115.7k | 92 | 174.5k | 11m 50s |
| implement* | opus[1m] | 2 | 117 | 23.6k | 2.2M | 70.9k | 126 | 94.7k | 8m 53s |
| audit_impl* | opus[1m] | 2 | 71 | 39.4k | 687.5k | 88.3k | 49 | 146.6k | 23m 50s |
| prepare_pr* | MiniMax-M3 | 1 | 49.8k | 4.0k | 173.1k | 53.1k | 12 | 0 | 60s |
| compose_pr* | MiniMax-M3 | 1 | 39.4k | 1.3k | 284.1k | 42.5k | 13 | 0 | 47s |
| review_pr* | opus[1m] | 1 | 2.1k | 25.9k | 1.8M | 169.4k | 38 | 153.8k | 12m 4s |
| resolve_review* | opus[1m] | 1 | 57 | 13.3k | 1.5M | 88.0k | 48 | 71.8k | 8m 28s |
| **Total** | | | 97.5k | 170.5k | 11.3M | 169.4k | | 786.2k | 1h 38m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 321 | 6931.6 | 295.0 | 73.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 38 | 38244.6 | 1889.6 | 350.8 |
| **Total** | **359** | 31372.8 | 2190.0 | 474.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 5.4k | 140.2k | 8.5M | 611.7k | 1h 24m |
| opus | 1 | 3.0k | 25.0k | 2.3M | 174.5k | 11m 50s |
| MiniMax-M3 | 2 | 89.1k | 5.3k | 457.2k | 0 | 1m 47s |