### PR TITLE
Implementation Plan: Resolve Dual Token Store and DI Gap (#3689)

### DIFF
--- a/src/autoskillit/cli/fleet/_fleet_display.py
+++ b/src/autoskillit/cli/fleet/_fleet_display.py
@@ -95,15 +95,15 @@ def _humanize(n: int | float | None) -> str:
 def _aggregate_totals(state: CampaignState) -> dict[str, int]:
     """Sum token_usage across all dispatches."""
     totals: dict[str, int] = {
-        "input_tokens": 0,
-        "output_tokens": 0,
+        "input": 0,
+        "output": 0,
         "cache_read": 0,
         "cache_creation": 0,
     }
     for d in state.dispatches:
         tu = d.token_usage
-        totals["input_tokens"] += tu.get("input_tokens", 0)
-        totals["output_tokens"] += tu.get("output_tokens", 0)
+        totals["input"] += tu.get("input", 0)
+        totals["output"] += tu.get("output", 0)
         totals["cache_read"] += tu.get("cache_read", 0)
         totals["cache_creation"] += tu.get("cache_creation", 0)
     return totals
@@ -119,8 +119,8 @@ def _build_status_rows(state: CampaignState) -> list[tuple[str, ...]]:
                 d.name,
                 str(d.status),
                 _fmt_elapsed(d),
-                _humanize(tu.get("input_tokens", 0)),
-                _humanize(tu.get("output_tokens", 0)),
+                _humanize(tu.get("input", 0)),
+                _humanize(tu.get("output", 0)),
                 _humanize(tu.get("cache_read", 0)),
                 _humanize(tu.get("cache_creation", 0)),
                 d.dispatched_session_log_dir or "-",
@@ -133,8 +133,8 @@ def _build_status_rows(state: CampaignState) -> list[tuple[str, ...]]:
             "TOTAL",
             "",
             "",
-            _humanize(totals["input_tokens"]),
-            _humanize(totals["output_tokens"]),
+            _humanize(totals["input"]),
+            _humanize(totals["output"]),
             _humanize(totals["cache_read"]),
             _humanize(totals["cache_creation"]),
             "",
@@ -168,8 +168,8 @@ def _cross_check_tokens(state: CampaignState, state_totals: dict[str, int]) -> N
         return
 
     for label, state_key, log_key in [
-        ("input_tokens", "input_tokens", "input_tokens"),
-        ("output_tokens", "output_tokens", "output_tokens"),
+        ("input", "input", "input_tokens"),
+        ("output", "output", "output_tokens"),
         ("cache_read", "cache_read", "cache_read_tokens"),
         ("cache_creation", "cache_creation", "cache_write_tokens"),
     ]:

--- a/src/autoskillit/smoke_utils/_telemetry.py
+++ b/src/autoskillit/smoke_utils/_telemetry.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import regex as _regex
 
 from autoskillit.core import DISPATCH_ID_ENV_VAR, PR_TELEMETRY_SECTIONS
+
+if TYPE_CHECKING:
+    from autoskillit.core import TokenLog
 
 assert len(PR_TELEMETRY_SECTIONS) == 3, (  # noqa: S101
     f"_PR_SECTION_RE assumes exactly 3 sections; got {len(PR_TELEMETRY_SECTIONS)}"
@@ -28,6 +32,7 @@ def patch_pr_token_summary(
     order_id: str = "",
     log_dir: str = "",
     timeout: int = 60,
+    token_log: TokenLog | None = None,
 ) -> dict[str, str]:
     import os  # noqa: PLC0415
     import subprocess  # noqa: PLC0415
@@ -45,19 +50,19 @@ def patch_pr_token_summary(
     effective_order_id = order_id or os.environ.get(DISPATCH_ID_ENV_VAR, "")
 
     log_root = resolve_log_dir(log_dir)
-    token_log = DefaultTokenLog()
+    effective_token_log = token_log if token_log is not None else DefaultTokenLog()
     if effective_order_id:
-        count = token_log.load_from_log_dir(log_root, order_id_filter=effective_order_id)
+        count = effective_token_log.load_from_log_dir(log_root, order_id_filter=effective_order_id)
     else:
-        count = token_log.load_from_log_dir(log_root, cwd_filter=cwd)
+        count = effective_token_log.load_from_log_dir(log_root, cwd_filter=cwd)
 
     if count == 0:
         return {"success": "false", "error": "No sessions found", "sessions_loaded": "0"}
 
     scope_kwargs: dict[str, str] = {"order_id": effective_order_id} if effective_order_id else {}
-    steps = token_log.get_report(**scope_kwargs)
-    total = token_log.compute_total(**scope_kwargs)
-    model_totals = token_log.compute_model_totals(**scope_kwargs)
+    steps = effective_token_log.get_report(**scope_kwargs)
+    total = effective_token_log.compute_total(**scope_kwargs)
+    model_totals = effective_token_log.compute_model_totals(**scope_kwargs)
     combined = TelemetryFormatter.format_pr_telemetry_block(steps, total, model_totals)
 
     try:

--- a/tests/cli/_fleet_helpers.py
+++ b/tests/cli/_fleet_helpers.py
@@ -170,7 +170,7 @@ def _make_state_with_tokens(*, input_total: int) -> CampaignState:
         DispatchRecord(
             name="dispatch-1",
             status=DispatchStatus.SUCCESS,
-            token_usage={"input_tokens": input_total},
+            token_usage={"input": input_total},
         )
     ]
     return CampaignState(

--- a/tests/cli/test_fleet_status.py
+++ b/tests/cli/test_fleet_status.py
@@ -105,8 +105,8 @@ def test_fleet_status_json_includes_totals(
         "cid01",
         "test",
         token_usage={
-            "input_tokens": 100,
-            "output_tokens": 50,
+            "input": 100,
+            "output": 50,
             "cache_creation": 10,
             "cache_read": 20,
         },
@@ -115,8 +115,8 @@ def test_fleet_status_json_includes_totals(
     with pytest.raises(SystemExit):
         _fleet_status("cid01", json_output=True)
     data = json.loads(capsys.readouterr().out)
-    assert data["totals"]["input_tokens"] == 100
-    assert data["totals"]["output_tokens"] == 50
+    assert data["totals"]["input"] == 100
+    assert data["totals"]["output"] == 50
     assert data["totals"]["cache_read"] == 20
     assert data["totals"]["cache_creation"] == 10
 
@@ -260,7 +260,7 @@ def test_status_table_shows_totals_row(
         tmp_path,
         "cid01",
         "test",
-        token_usage={"input_tokens": 100, "output_tokens": 50},
+        token_usage={"input": 100, "output": 50},
     )
     monkeypatch.chdir(tmp_path)
     with pytest.raises(SystemExit):
@@ -289,3 +289,27 @@ def test_fleet_status_exits_when_disabled(monkeypatch: pytest.MonkeyPatch, tmp_p
         _fleet_status(None)
     assert exc_info.value.code == 1
     assert "fleet" in checked_features
+
+
+def test_aggregate_totals_uses_canonical_keys() -> None:
+    """_aggregate_totals reads canonical keys (input/output) from DispatchRecord.
+
+    Regression guard: previously this function read input_tokens/output_tokens
+    but normalize_dispatch_token_usage writes input/output, so totals were
+    always 0 unless callers populated the long-named keys manually.
+    """
+    from autoskillit.cli.fleet._fleet_display import _aggregate_totals
+
+    state = _make_state_with_tokens(input_total=5000)
+    totals = _aggregate_totals(state)
+    assert totals["input"] == 5000
+
+
+def test_build_status_rows_shows_nonzero_tokens() -> None:
+    """_build_status_rows renders non-zero input/output from canonical keys."""
+    from autoskillit.cli.fleet._fleet_display import _build_status_rows
+
+    state = _make_state_with_tokens(input_total=10000)
+    rows = _build_status_rows(state)
+    dispatch_row = rows[0]
+    assert dispatch_row[3] != "0"

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -6,7 +6,7 @@ import json
 import re
 import subprocess
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -883,6 +883,45 @@ def test_section_re_covers_all_pr_telemetry_sections() -> None:
     matched = m.group(0)
     for section in PR_TELEMETRY_SECTIONS:
         assert section in matched, f"{section} not consumed by section_re"
+
+
+# T_PTS15
+@patch("time.sleep")
+@patch("subprocess.run")
+def test_pts_uses_injected_token_log(
+    mock_run: MagicMock, _mock_sleep: MagicMock, tmp_path: Path
+) -> None:
+    """patch_pr_token_summary uses injected token_log instead of constructing a new one.
+
+    Regression guard for the DI gap: callers with a pre-loaded DefaultTokenLog
+    should be able to inject it to avoid redundant disk I/O, and the function
+    must not replace the injected instance with a fresh DefaultTokenLog.
+    """
+    from autoskillit.pipeline import DefaultTokenLog
+    from autoskillit.smoke_utils._telemetry import patch_pr_token_summary
+
+    cwd = "/clone/test"
+    _write_test_sessions(
+        tmp_path,
+        [
+            {
+                "dir_name": "s1",
+                "cwd": cwd,
+                "step_name": "plan",
+                "input_tokens": 1000,
+                "output_tokens": 500,
+            },
+        ],
+    )
+
+    token_log = DefaultTokenLog()
+    token_log.load_from_log_dir(tmp_path, cwd_filter=cwd)
+    sentinel_id = id(token_log)
+
+    mock_run.side_effect = _make_gh_mock(get_body="## Summary\nTest PR")
+    result = patch_pr_token_summary(PR_URL, cwd, log_dir=str(tmp_path), token_log=token_log)
+    assert result["success"] == "true"
+    assert id(token_log) == sentinel_id, "injected token_log must not be replaced"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix two validated audit findings: (1) a key-name mismatch between how `normalize_dispatch_token_usage` writes canonical token keys (`"input"`, `"output"`) and how `_fleet_display.py` consumers read them (`"input_tokens"`, `"output_tokens"`), which makes Store A always return 0 for input/output and renders cross-check warnings meaningless; (2) add a `token_log` injection slot to `patch_pr_token_summary()` in `smoke_utils/_telemetry.py` so tests can inject alternatives without filesystem I/O.

Closes #3689

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260603-233007-501343/.autoskillit/temp/make-plan/resolve_dual_token_store_and_di_gap_plan_2026-06-03_233500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 127 | 21.4k | 3.5M | 106.5k | 80 | 95.3k | 19m 42s |
| verify* | sonnet | 1 | 60 | 8.7k | 254.1k | 50.7k | 21 | 34.1k | 3m 45s |
| implement* | MiniMax-M3 | 1 | 69.3k | 12.7k | 3.2M | 80.2k | 115 | 0 | 9m 29s |
| audit_impl* | sonnet | 1 | 46 | 8.7k | 128.8k | 38.2k | 16 | 46.1k | 3m 47s |
| prepare_pr* | MiniMax-M3 | 1 | 41.3k | 2.4k | 154.0k | 44.6k | 14 | 0 | 1m 0s |
| compose_pr* | MiniMax-M3 | 1 | 37.1k | 1.5k | 185.4k | 38.6k | 15 | 0 | 59s |
| review_pr* | sonnet | 2 | 298 | 65.1k | 1.7M | 82.2k | 94 | 125.6k | 13m 43s |
| resolve_review* | sonnet | 1 | 181 | 7.4k | 987.7k | 53.8k | 44 | 37.7k | 4m 4s |
| **Total** | | | 148.4k | 127.9k | 10.2M | 106.5k | | 338.8k | 56m 32s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 114 | 28264.7 | 0.0 | 111.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **114** | 89338.7 | 2971.9 | 1122.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 127 | 21.4k | 3.5M | 95.3k | 19m 42s |
| sonnet | 4 | 585 | 89.9k | 3.1M | 243.5k | 25m 20s |
| MiniMax-M3 | 3 | 147.7k | 16.6k | 3.6M | 0 | 11m 29s |