### PR TITLE
[FIX] Add food_truck_resume Parametrize Variant to Codex Flag Contract Tests

### DIFF
--- a/src/autoskillit/execution/backends/__init__.py
+++ b/src/autoskillit/execution/backends/__init__.py
@@ -20,6 +20,8 @@ from .claude import (
     ClaudeStreamParser,
 )
 from .codex import (
+    CODEX_EXEC_FLAGS,
+    CODEX_TOP_LEVEL_ONLY_FLAGS,
     CodexBackend,
     CodexEnvPolicy,
     CodexFlags,
@@ -48,6 +50,8 @@ def get_backend(name: str) -> CodingAgentBackend:
 
 __all__ = [
     "BACKEND_REGISTRY",
+    "CODEX_EXEC_FLAGS",
+    "CODEX_TOP_LEVEL_ONLY_FLAGS",
     "ClaudeCodeBackend",
     "ClaudeEnvPolicy",
     "ClaudeResultParser",

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -70,6 +70,8 @@ from autoskillit.execution.backends._codex_config import (
 from autoskillit.execution.backends._codex_parse import CodexResultParser, CodexStreamParser
 
 __all__ = [
+    "CODEX_EXEC_FLAGS",
+    "CODEX_TOP_LEVEL_ONLY_FLAGS",
     "CodexBackend",
     "CodexEnvPolicy",
     "CodexFlags",
@@ -84,17 +86,30 @@ logger = get_logger(__name__)
 class CodexFlags(StrEnum):
     JSON = "--json"
     SANDBOX = "--sandbox"
-    ASK_FOR_APPROVAL = "--ask-for-approval"
-    ASK_FOR_APPROVAL_SHORT = "-a"
     MODEL = "--model"
     MODEL_SHORT = "-m"
     ADD_DIR = "--add-dir"
-    IGNORE_USER_CONFIG = "--ignore-user-config"
-    EPHEMERAL = "--ephemeral"
     RESUME_SUBCOMMAND = "resume"
-    LAST = "--last"
     CONFIG_OVERRIDE = "-c"
     DANGEROUSLY_BYPASS = "--dangerously-bypass-approvals-and-sandbox"
+
+
+CODEX_EXEC_FLAGS: frozenset[str] = frozenset(
+    {
+        CodexFlags.JSON,
+        CodexFlags.SANDBOX,
+        CodexFlags.MODEL,
+        CodexFlags.CONFIG_OVERRIDE,
+        CodexFlags.ADD_DIR,
+    }
+)
+
+CODEX_TOP_LEVEL_ONLY_FLAGS: frozenset[str] = frozenset(
+    {
+        CodexFlags.DANGEROUSLY_BYPASS,
+        CodexFlags.MODEL_SHORT,
+    }
+)
 
 
 CODEX_ENV_DENYLIST: frozenset[str] = frozenset(
@@ -606,8 +621,6 @@ class CodexBackend:
             CodexFlags.JSON,
             CodexFlags.SANDBOX,
             "workspace-write",
-            CodexFlags.ASK_FOR_APPROVAL_SHORT,
-            "never",
             CodexFlags.CONFIG_OVERRIDE,
             _IMAGE_GENERATION_DISABLED,
         ]
@@ -715,8 +728,6 @@ class CodexBackend:
             CodexFlags.JSON,
             CodexFlags.SANDBOX,
             "read-only",
-            CodexFlags.ASK_FOR_APPROVAL_SHORT,
-            "never",
             CodexFlags.CONFIG_OVERRIDE,
             "web_search=disabled",
             CodexFlags.CONFIG_OVERRIDE,

--- a/src/autoskillit/execution/headless/_headless_helpers.py
+++ b/src/autoskillit/execution/headless/_headless_helpers.py
@@ -38,8 +38,6 @@ _CODEX_VALUE_BEARING_FLAGS: frozenset[str] = frozenset(
         CodexFlags.MODEL,
         CodexFlags.MODEL_SHORT,
         CodexFlags.ADD_DIR,
-        CodexFlags.ASK_FOR_APPROVAL,
-        CodexFlags.ASK_FOR_APPROVAL_SHORT,
         CodexFlags.SANDBOX,
         CodexFlags.CONFIG_OVERRIDE,
     }

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -31,6 +31,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_backend_dispatch.py` | End-to-end tests verifying run_headless_core routes command construction through ctx.backend |
 | `test_diff_annotator.py` | Behavioral tests for execution/diff_annotator.py |
 | `test_exit_classification.py` | Unit tests for classify_infra_exit and InfraExitCategory enum |
+| `test_codex_flag_contracts.py` | Contract tests for Codex CLI flags: registry audit, metadata coverage, value-bearing subset |
 | `test_flag_contracts.py` | Contract tests for Claude CLI flags |
 | `test_flush_completeness_guard.py` | Structural guard: every required-container field must appear in flush output |
 | `test_flush_provider_integration.py` | Integration seam tests: provider fields forwarded from _execute_claude_headless to flush_session_log |

--- a/tests/execution/backends/test_backend_registry.py
+++ b/tests/execution/backends/test_backend_registry.py
@@ -40,8 +40,10 @@ class TestBackendRegistry:
 
         expected = {
             "BACKEND_REGISTRY",
+            "CODEX_EXEC_FLAGS",
             "CODEX_MCP_STARTUP_TIMEOUT_SEC",
             "CODEX_MCP_TOOL_TIMEOUT_FLOOR",
+            "CODEX_TOP_LEVEL_ONLY_FLAGS",
             "ClaudeCodeBackend",
             "ClaudeEnvPolicy",
             "ClaudeResultParser",

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -55,15 +55,10 @@ class TestCodexFlags:
         expected = {
             "JSON",
             "SANDBOX",
-            "ASK_FOR_APPROVAL",
-            "ASK_FOR_APPROVAL_SHORT",
             "MODEL",
             "MODEL_SHORT",
             "ADD_DIR",
-            "IGNORE_USER_CONFIG",
-            "EPHEMERAL",
             "RESUME_SUBCOMMAND",
-            "LAST",
             "CONFIG_OVERRIDE",
             "DANGEROUSLY_BYPASS",
         }
@@ -583,7 +578,7 @@ class TestCodexBuildSkillSessionCmd:
         assert CodexFlags.RESUME_SUBCOMMAND in spec.cmd
         assert "sess-abc123" in spec.cmd
         assert "--sandbox" in spec.cmd
-        assert "-a" in spec.cmd
+        assert "-a" not in spec.cmd
 
     def test_completion_marker_with_profile(self) -> None:
         spec = CodexBackend().build_skill_session_cmd(
@@ -901,9 +896,8 @@ class TestCodexBuildFoodTruckCmd:
 
     def test_approval_never(self) -> None:
         spec = CodexBackend().build_food_truck_cmd(**self.BASE)
-        assert "-a" in spec.cmd
-        idx = spec.cmd.index("-a")
-        assert spec.cmd[idx + 1] == "never"
+        assert "-a" not in spec.cmd
+        assert "never" not in spec.cmd
 
     def test_no_add_dir_flag(self) -> None:
         spec = CodexBackend().build_food_truck_cmd(**self.BASE)

--- a/tests/execution/test_codex_flag_contracts.py
+++ b/tests/execution/test_codex_flag_contracts.py
@@ -77,6 +77,9 @@ class TestCodexFlagRegistryAudit:
                 **{**SKILL_BASE, "resume_session_id": "sess-test"},
             ),
             lambda: CodexBackend().build_food_truck_cmd(**FOOD_TRUCK_BASE),
+            lambda: CodexBackend().build_food_truck_cmd(
+                **{**FOOD_TRUCK_BASE, "resume_session_id": "sess-test"},
+            ),
             lambda: CodexBackend().build_headless_cmd("do stuff"),
             lambda: CodexBackend().build_resume_cmd(
                 resume_session_id="sess-test", prompt="continue"
@@ -86,6 +89,7 @@ class TestCodexFlagRegistryAudit:
             "skill_session",
             "skill_session_resume",
             "food_truck",
+            "food_truck_resume",
             "headless",
             "resume",
         ],
@@ -145,6 +149,9 @@ class TestNoApprovalFlagInExecBuilders:
                 **{**SKILL_BASE, "resume_session_id": "sess-test"},
             ),
             lambda: CodexBackend().build_food_truck_cmd(**FOOD_TRUCK_BASE),
+            lambda: CodexBackend().build_food_truck_cmd(
+                **{**FOOD_TRUCK_BASE, "resume_session_id": "sess-test"},
+            ),
             lambda: CodexBackend().build_headless_cmd("do stuff"),
             lambda: CodexBackend().build_resume_cmd(
                 resume_session_id="sess-test", prompt="continue"
@@ -154,6 +161,7 @@ class TestNoApprovalFlagInExecBuilders:
             "skill_session",
             "skill_session_resume",
             "food_truck",
+            "food_truck_resume",
             "headless",
             "resume",
         ],

--- a/tests/execution/test_codex_flag_contracts.py
+++ b/tests/execution/test_codex_flag_contracts.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core import BareResume, DirectInstall, NamedResume, NoResume, OutputFormat
+from autoskillit.execution.backends.codex import (
+    CODEX_EXEC_FLAGS,
+    CODEX_TOP_LEVEL_ONLY_FLAGS,
+    CodexBackend,
+    CodexFlags,
+)
+from autoskillit.execution.headless._headless_helpers import _CODEX_VALUE_BEARING_FLAGS
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+def _extract_flags(cmd: tuple[str, ...] | list[str]) -> set[str]:
+    return {tok for tok in cmd if tok.startswith("-")}
+
+
+SKILL_BASE: dict[str, object] = {
+    "skill_command": "/test-skill",
+    "cwd": "/work",
+    "completion_marker": "%%DONE%%",
+    "model": None,
+    "plugin_source": None,
+    "output_format": OutputFormat.JSON,
+}
+
+FOOD_TRUCK_BASE: dict[str, object] = {
+    "orchestrator_prompt": "dispatch the work",
+    "plugin_source": DirectInstall(plugin_dir=Path("/pkg")),
+    "cwd": "/work",
+    "completion_marker": "%%DONE%%",
+}
+
+
+class TestCodexExecFlagValues:
+    def test_json_value(self) -> None:
+        assert CodexFlags.JSON == "--json"
+
+    def test_sandbox_value(self) -> None:
+        assert CodexFlags.SANDBOX == "--sandbox"
+
+    def test_model_value(self) -> None:
+        assert CodexFlags.MODEL == "--model"
+
+    def test_model_short_value(self) -> None:
+        assert CodexFlags.MODEL_SHORT == "-m"
+
+    def test_add_dir_value(self) -> None:
+        assert CodexFlags.ADD_DIR == "--add-dir"
+
+    def test_resume_subcommand_value(self) -> None:
+        assert CodexFlags.RESUME_SUBCOMMAND == "resume"
+
+    def test_config_override_value(self) -> None:
+        assert CodexFlags.CONFIG_OVERRIDE == "-c"
+
+    def test_dangerously_bypass_value(self) -> None:
+        assert CodexFlags.DANGEROUSLY_BYPASS == "--dangerously-bypass-approvals-and-sandbox"
+
+
+class TestCodexFlagRegistryAudit:
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_ID", raising=False)
+        monkeypatch.delenv("AUTOSKILLIT_KITCHEN_SESSION_ID", raising=False)
+
+    @pytest.mark.parametrize(
+        "builder_call",
+        [
+            lambda: CodexBackend().build_skill_session_cmd(**SKILL_BASE),
+            lambda: CodexBackend().build_skill_session_cmd(
+                **{**SKILL_BASE, "resume_session_id": "sess-test"},
+            ),
+            lambda: CodexBackend().build_food_truck_cmd(**FOOD_TRUCK_BASE),
+            lambda: CodexBackend().build_headless_cmd("do stuff"),
+            lambda: CodexBackend().build_resume_cmd(
+                resume_session_id="sess-test", prompt="continue"
+            ),
+        ],
+        ids=[
+            "skill_session",
+            "skill_session_resume",
+            "food_truck",
+            "headless",
+            "resume",
+        ],
+    )
+    def test_exec_builder_flags_are_all_in_codex_exec_flags(self, builder_call) -> None:
+        spec = builder_call()
+        flags = _extract_flags(spec.cmd)
+        unknown = flags - CODEX_EXEC_FLAGS
+        assert not unknown, (
+            f"Builder produced flags not valid for codex exec: {unknown}. "
+            f"If this flag is valid for codex exec, add it to CODEX_EXEC_FLAGS."
+        )
+
+
+class TestCodexExecFlagMetadataCoverage:
+    def test_every_flag_member_is_categorized(self) -> None:
+        flag_members = {m for m in CodexFlags if str(m).startswith("-")}
+        categorized = CODEX_EXEC_FLAGS | CODEX_TOP_LEVEL_ONLY_FLAGS
+        uncategorized = flag_members - categorized
+        assert not uncategorized, (
+            f"CodexFlags members not categorized in CODEX_EXEC_FLAGS or "
+            f"CODEX_TOP_LEVEL_ONLY_FLAGS: {uncategorized}. "
+            f"Add to the appropriate set."
+        )
+
+    def test_exec_and_top_level_are_disjoint(self) -> None:
+        overlap = CODEX_EXEC_FLAGS & CODEX_TOP_LEVEL_ONLY_FLAGS
+        assert not overlap, f"Flags in both sets: {overlap}"
+
+    def test_all_categorized_flags_are_valid_members(self) -> None:
+        all_flags = frozenset(CodexFlags)
+        categorized = CODEX_EXEC_FLAGS | CODEX_TOP_LEVEL_ONLY_FLAGS
+        invalid = categorized - all_flags
+        assert not invalid, f"Categorized flags not in CodexFlags: {invalid}"
+
+
+class TestCodexValueBearingFlagsSubset:
+    def test_value_bearing_is_subset_of_codex_flags(self) -> None:
+        all_flags = frozenset(CodexFlags)
+        invalid = _CODEX_VALUE_BEARING_FLAGS - all_flags
+        assert not invalid, (
+            f"_CODEX_VALUE_BEARING_FLAGS contains entries not in CodexFlags: {invalid}"
+        )
+
+
+class TestNoApprovalFlagInExecBuilders:
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_ID", raising=False)
+        monkeypatch.delenv("AUTOSKILLIT_KITCHEN_SESSION_ID", raising=False)
+
+    @pytest.mark.parametrize(
+        "builder_call",
+        [
+            lambda: CodexBackend().build_skill_session_cmd(**SKILL_BASE),
+            lambda: CodexBackend().build_skill_session_cmd(
+                **{**SKILL_BASE, "resume_session_id": "sess-test"},
+            ),
+            lambda: CodexBackend().build_food_truck_cmd(**FOOD_TRUCK_BASE),
+            lambda: CodexBackend().build_headless_cmd("do stuff"),
+            lambda: CodexBackend().build_resume_cmd(
+                resume_session_id="sess-test", prompt="continue"
+            ),
+        ],
+        ids=[
+            "skill_session",
+            "skill_session_resume",
+            "food_truck",
+            "headless",
+            "resume",
+        ],
+    )
+    def test_no_approval_flag_in_exec_builders(self, builder_call) -> None:
+        spec = builder_call()
+        assert "-a" not in spec.cmd
+        assert "--ask-for-approval" not in spec.cmd
+
+    def test_no_approval_flag_in_value_bearing_flags(self) -> None:
+        assert "-a" not in _CODEX_VALUE_BEARING_FLAGS
+        assert "--ask-for-approval" not in _CODEX_VALUE_BEARING_FLAGS
+
+
+class TestInteractiveCmdUsesNoExecOnlyFlags:
+    @pytest.mark.parametrize(
+        "resume_spec",
+        [NoResume(), NamedResume(session_id="sess-test"), BareResume()],
+        ids=["no_resume", "named_resume", "bare_resume"],
+    )
+    def test_interactive_excludes_exec_only_flags(self, resume_spec) -> None:
+        spec = CodexBackend().build_interactive_cmd(resume_spec=resume_spec)
+        flags = _extract_flags(spec.cmd)
+        assert "--json" not in flags
+        assert "--sandbox" not in flags

--- a/tests/execution/test_commands_invariants.py
+++ b/tests/execution/test_commands_invariants.py
@@ -219,6 +219,31 @@ def test_cwd_in_headless_exclusive_vars() -> None:
     assert "AUTOSKILLIT_CWD" in _HEADLESS_EXCLUSIVE_VARS
 
 
+@pytest.mark.parametrize(
+    "builder_call",
+    [
+        lambda: CodexBackend().build_skill_session_cmd(
+            "/investigate foo",
+            cwd="/tmp",
+            completion_marker="%%DONE%%",
+        ),
+        lambda: CodexBackend().build_food_truck_cmd(
+            orchestrator_prompt="L3 orchestrator",
+            plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
+            cwd="/tmp",
+            completion_marker="%%DONE%%",
+        ),
+        lambda: CodexBackend().build_headless_cmd("do stuff"),
+        lambda: CodexBackend().build_resume_cmd(resume_session_id="sess-test", prompt="continue"),
+    ],
+    ids=["skill_session", "food_truck", "headless", "resume"],
+)
+def test_codex_exec_builders_start_with_codex_exec(builder_call) -> None:
+    spec = builder_call()
+    assert spec.cmd[0] == "codex"
+    assert spec.cmd[1] == "exec"
+
+
 def test_session_deadline_not_in_l1_subprocess_env(monkeypatch) -> None:
     monkeypatch.setenv("AUTOSKILLIT_SESSION_DEADLINE", "9999999999.0")
     spec = ClaudeCodeBackend().build_skill_session_cmd(


### PR DESCRIPTION
## Summary

Add a `food_truck_resume` parametrize entry to both `TestNoApprovalFlagInExecBuilders` and `TestCodexFlagRegistryAudit` in `tests/execution/test_codex_flag_contracts.py`. The `build_food_truck_cmd` function has a real resume branch (appends `CodexFlags.RESUME_SUBCOMMAND` when `resume_session_id` is truthy, codex.py:740-742) that is currently not exercised by either test class. Both classes share the identical parametrize list and should both gain the new variant, mirroring the existing `skill_session` / `skill_session_resume` pattern.

## Requirements

## Architecture Impact

## Closes #3687

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260603-225831-699990/.autoskillit/temp/make-plan/remediation_codex_flag_scope_immunity_plan_2026-06-04_000200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 2.1k | 22.5k | 2.6M | 127.4k | 70 | 110.7k | 27m 22s |
| review_approach* | opus[1m] | 1 | 25 | 5.1k | 232.7k | 42.3k | 13 | 28.1k | 3m 25s |
| dry_walkthrough* | opus | 2 | 2.4k | 19.4k | 1.6M | 86.3k | 75 | 131.5k | 9m 28s |
| implement* | opus[1m] | 2 | 108 | 17.7k | 2.5M | 81.7k | 102 | 91.6k | 8m 38s |
| audit_impl* | opus[1m] | 2 | 945 | 24.6k | 566.7k | 61.8k | 35 | 84.6k | 11m 52s |
| make_plan* | opus[1m] | 1 | 47 | 5.2k | 513.2k | 57.2k | 20 | 43.1k | 2m 44s |
| prepare_pr* | MiniMax-M3 | 1 | 41.8k | 1.3k | 277.1k | 42.6k | 15 | 0 | 1m 0s |
| compose_pr* | MiniMax-M3 | 1 | 36.5k | 1.3k | 348.3k | 39.8k | 15 | 0 | 1m 1s |
| review_pr* | opus[1m] | 1 | 35 | 25.8k | 392.8k | 73.0k | 26 | 59.0k | 5m 22s |
| resolve_review* | opus[1m] | 1 | 31 | 4.5k | 669.2k | 63.7k | 29 | 47.1k | 4m 57s |
| **Total** | | | 84.1k | 127.4k | 9.6M | 127.4k | | 595.7k | 1h 15m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 262 | 9375.0 | 349.7 | 67.5 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **262** | 36771.7 | 2273.7 | 486.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 7 | 3.3k | 105.5k | 7.4M | 464.3k | 1h 4m |
| opus | 1 | 2.4k | 19.4k | 1.6M | 131.5k | 9m 28s |
| MiniMax-M3 | 2 | 78.3k | 2.5k | 625.3k | 0 | 2m 1s |