### PR TITLE
[FIX] Codex Backend Systemic Builder Divergence — Shared Base, Closed Categorization, and Semantic Flag Validation

### DIFF
--- a/src/autoskillit/execution/backends/__init__.py
+++ b/src/autoskillit/execution/backends/__init__.py
@@ -22,6 +22,8 @@ from .claude import (
 from .codex import (
     CODEX_EXEC_FLAGS,
     CODEX_TOP_LEVEL_ONLY_FLAGS,
+    NON_VARIADIC_CODEX_FLAGS,
+    VARIADIC_CODEX_FLAGS,
     CodexBackend,
     CodexEnvPolicy,
     CodexFlags,
@@ -66,6 +68,8 @@ __all__ = [
     "CodexStreamParser",
     "CODEX_MCP_STARTUP_TIMEOUT_SEC",
     "CODEX_MCP_TOOL_TIMEOUT_FLOOR",
+    "NON_VARIADIC_CODEX_FLAGS",
+    "VARIADIC_CODEX_FLAGS",
     "_is_autoskillit_registered",
     "_read_codex_config",
     "_serialize_toml",

--- a/src/autoskillit/execution/backends/_claude_prompt.py
+++ b/src/autoskillit/execution/backends/_claude_prompt.py
@@ -56,6 +56,20 @@ _HEADLESS_ENV_HARDENING: dict[str, str] = {
 # additions to that set do not silently change interactive env filtering.
 _INTERACTIVE_ENV_EXCLUSIONS: frozenset[str] = frozenset(_HEADLESS_ENV_HARDENING)
 
+_PROVIDER_EXTRAS_BASE_DENYLIST: frozenset[str] = frozenset(
+    {
+        "AUTOSKILLIT_SESSION_TYPE",
+        "AUTOSKILLIT_HEADLESS",
+    }
+)
+
+_SKILL_SESSION_EXTRAS_DENYLIST: frozenset[str] = _PROVIDER_EXTRAS_BASE_DENYLIST | frozenset(
+    {
+        "MAX_MCP_OUTPUT_TOKENS",
+        "AUTOSKILLIT_SKILL_NAME",
+    }
+)
+
 # Variables that _build_skill_session_cmd_impl controls exclusively. They must not
 # leak from the host process environment — the caller opts in via explicit
 # parameters (exit_after_stop_delay_ms, scenario_step_name, allowed_write_prefix, etc.).

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -56,6 +56,7 @@ from autoskillit.execution.backends._claude_prompt import (
     _MAX_MCP_OUTPUT_TOKENS_VALUE,
     _PROVIDER_EXTRAS_BASE_DENYLIST,
     _SESSION_BASELINE_ENV,
+    _SKILL_SESSION_EXTRAS_DENYLIST,
     PromptBuildContext,
     _apply_output_format,
     _compose_resume_prompt,
@@ -606,7 +607,7 @@ class ClaudeCodeBackend:
         extras["AUTOSKILLIT_SKILL_NAME"] = extract_skill_name(skill_command) or ""
         if provider_extras:
             for k, v in provider_extras.items():
-                if k not in _PROVIDER_EXTRAS_BASE_DENYLIST:
+                if k not in _SKILL_SESSION_EXTRAS_DENYLIST:
                     extras[k] = v
         if profile_name:
             extras["AUTOSKILLIT_PROVIDER_PROFILE"] = profile_name

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -54,6 +54,7 @@ from autoskillit.execution.backends._claude_prompt import (
     _HEADLESS_EXCLUSIVE_VARS,
     _INTERACTIVE_ENV_EXCLUSIONS,
     _MAX_MCP_OUTPUT_TOKENS_VALUE,
+    _PROVIDER_EXTRAS_BASE_DENYLIST,
     _SESSION_BASELINE_ENV,
     PromptBuildContext,
     _apply_output_format,
@@ -605,7 +606,7 @@ class ClaudeCodeBackend:
         extras["AUTOSKILLIT_SKILL_NAME"] = extract_skill_name(skill_command) or ""
         if provider_extras:
             for k, v in provider_extras.items():
-                if k not in ("AUTOSKILLIT_SESSION_TYPE", "AUTOSKILLIT_HEADLESS"):
+                if k not in _PROVIDER_EXTRAS_BASE_DENYLIST:
                     extras[k] = v
         if profile_name:
             extras["AUTOSKILLIT_PROVIDER_PROFILE"] = profile_name
@@ -703,7 +704,7 @@ class ClaudeCodeBackend:
             extras["AUTOSKILLIT_CWD"] = cwd
         if env_extras:
             for k, v in env_extras.items():
-                if k not in ("AUTOSKILLIT_SESSION_TYPE", "AUTOSKILLIT_HEADLESS"):
+                if k not in _PROVIDER_EXTRAS_BASE_DENYLIST:
                     extras[k] = v
 
         filtered_base = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -141,6 +141,22 @@ CODEX_ENV_PREFIX_DENYLIST: tuple[str, ...] = ("CLAUDE_CODE_",)
 _IMAGE_GENERATION_DISABLED = "features.image_generation=false"
 
 
+def _codex_exec_base(
+    *,
+    sandbox: str,
+    json: bool = True,
+    extra_overrides: Sequence[str] = (),
+) -> list[str]:
+    cmd: list[str] = ["codex", "exec"]
+    if json:
+        cmd.append(CodexFlags.JSON)
+    cmd.extend([CodexFlags.SANDBOX, sandbox])
+    for override in extra_overrides:
+        cmd.extend([CodexFlags.CONFIG_OVERRIDE, override])
+    cmd.extend([CodexFlags.CONFIG_OVERRIDE, _IMAGE_GENERATION_DISABLED])
+    return cmd
+
+
 @dataclass(frozen=True, slots=True)
 class CodexEnvPolicy:
     denylist_prefixes: tuple[str, ...] = CODEX_ENV_PREFIX_DENYLIST
@@ -485,15 +501,7 @@ class CodexBackend:
         add_dirs: Sequence[str] = (),
         env_extras: Mapping[str, str] | None = None,
     ) -> CmdSpec:
-        cmd: list[str] = [
-            "codex",
-            "exec",
-            CodexFlags.JSON,
-            CodexFlags.SANDBOX,
-            "workspace-write",
-            CodexFlags.CONFIG_OVERRIDE,
-            _IMAGE_GENERATION_DISABLED,
-        ]
+        cmd = _codex_exec_base(sandbox="workspace-write")
         if model:
             cmd += [CodexFlags.MODEL, self.translate_model(model)]
             for override in self.model_config_overrides(model):
@@ -630,15 +638,7 @@ class CodexBackend:
             required=SKILL_SESSION_REQUIRED_ENV | {MCP_CLIENT_BACKEND_ENV_VAR},
         )
 
-        cmd: list[str] = [
-            "codex",
-            "exec",
-            CodexFlags.JSON,
-            CodexFlags.SANDBOX,
-            "workspace-write",
-            CodexFlags.CONFIG_OVERRIDE,
-            _IMAGE_GENERATION_DISABLED,
-        ]
+        cmd = _codex_exec_base(sandbox="workspace-write")
         if model:
             cmd += [CodexFlags.MODEL, self.translate_model(model)]
             for override in self.model_config_overrides(model):
@@ -737,17 +737,7 @@ class CodexBackend:
             required=ORCHESTRATOR_SESSION_REQUIRED_ENV | {MCP_CLIENT_BACKEND_ENV_VAR},
         )
 
-        cmd: list[str] = [
-            "codex",
-            "exec",
-            CodexFlags.JSON,
-            CodexFlags.SANDBOX,
-            "read-only",
-            CodexFlags.CONFIG_OVERRIDE,
-            "web_search=disabled",
-            CodexFlags.CONFIG_OVERRIDE,
-            _IMAGE_GENERATION_DISABLED,
-        ]
+        cmd = _codex_exec_base(sandbox="read-only", extra_overrides=["web_search=disabled"])
         if model:
             cmd += [CodexFlags.MODEL, self.translate_model(model)]
             for override in self.model_config_overrides(model):
@@ -839,11 +829,7 @@ class CodexBackend:
         if not resume_session_id.strip():
             msg = "resume_session_id must be a non-empty string"
             raise ValueError(msg)
-        cmd: list[str] = ["codex", "exec"]
-        if output_format == OutputFormat.JSON:
-            cmd.append(CodexFlags.JSON)
-        cmd.extend([CodexFlags.SANDBOX, "read-only"])
-        cmd.extend([CodexFlags.CONFIG_OVERRIDE, _IMAGE_GENERATION_DISABLED])
+        cmd = _codex_exec_base(sandbox="read-only", json=(output_format == OutputFormat.JSON))
         cmd.append(CodexFlags.RESUME_SUBCOMMAND)
         cmd.append(resume_session_id)
         cmd.append(prompt)

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -56,7 +56,9 @@ from autoskillit.core import (
 from autoskillit.execution.backends._claude_prompt import (
     _HEADLESS_EXCLUSIVE_VARS,
     _MAX_MCP_OUTPUT_TOKENS_VALUE,
+    _PROVIDER_EXTRAS_BASE_DENYLIST,
     _SESSION_BASELINE_ENV,
+    _SKILL_SESSION_EXTRAS_DENYLIST,
     PromptBuildContext,
     _compose_resume_prompt,
     _ensure_skill_prefix,
@@ -633,12 +635,7 @@ class CodexBackend:
         extras["AUTOSKILLIT_SKILL_NAME"] = extract_skill_name(skill_command) or ""
         if provider_extras:
             for k, v in provider_extras.items():
-                if k not in (
-                    "AUTOSKILLIT_SESSION_TYPE",
-                    "AUTOSKILLIT_HEADLESS",
-                    "MAX_MCP_OUTPUT_TOKENS",
-                    "AUTOSKILLIT_SKILL_NAME",
-                ):
+                if k not in _SKILL_SESSION_EXTRAS_DENYLIST:
                     extras[k] = v
         if profile_name:
             extras["AUTOSKILLIT_PROVIDER_PROFILE"] = profile_name
@@ -737,7 +734,7 @@ class CodexBackend:
             extras["AUTOSKILLIT_CWD"] = cwd
         if env_extras:
             for k, v in env_extras.items():
-                if k not in ("AUTOSKILLIT_SESSION_TYPE", "AUTOSKILLIT_HEADLESS"):
+                if k not in _PROVIDER_EXTRAS_BASE_DENYLIST:
                     extras[k] = v
 
         filtered_base = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -76,6 +76,8 @@ __all__ = [
     "CodexEnvPolicy",
     "CodexFlags",
     "CodexSessionLocator",
+    "NON_VARIADIC_CODEX_FLAGS",
+    "VARIADIC_CODEX_FLAGS",
     "ensure_codex_mcp_registered",
 ]
 
@@ -108,6 +110,19 @@ CODEX_TOP_LEVEL_ONLY_FLAGS: frozenset[str] = frozenset(
     {
         CodexFlags.DANGEROUSLY_BYPASS,
         CodexFlags.MODEL_SHORT,
+    }
+)
+
+VARIADIC_CODEX_FLAGS: frozenset[str] = frozenset({CodexFlags.ADD_DIR, CodexFlags.CONFIG_OVERRIDE})
+
+NON_VARIADIC_CODEX_FLAGS: frozenset[str] = frozenset(
+    {
+        CodexFlags.JSON,
+        CodexFlags.SANDBOX,
+        CodexFlags.MODEL,
+        CodexFlags.MODEL_SHORT,
+        CodexFlags.RESUME_SUBCOMMAND,
+        CodexFlags.DANGEROUSLY_BYPASS,
     }
 )
 

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -157,6 +157,33 @@ def _codex_exec_base(
     return cmd
 
 
+def _codex_exec_extras(
+    *,
+    session_type: str,
+    include_session_baseline: bool = False,
+    include_agent_backend_flat: bool = False,
+    applicable_guards: frozenset[str] | None = None,
+) -> dict[str, str]:
+    extras: dict[str, str] = {}
+    if include_session_baseline:
+        extras.update(_SESSION_BASELINE_ENV)
+    extras.update(
+        {
+            "AUTOSKILLIT_HEADLESS": "1",
+            "AUTOSKILLIT_HEADLESS_AUTO_GATE": "1",
+            "AUTOSKILLIT_SESSION_TYPE": session_type,
+            AGENT_BACKEND_DYNACONF_ENV_VAR: AGENT_BACKEND_CODEX,
+            MCP_CLIENT_BACKEND_ENV_VAR: AGENT_BACKEND_CODEX,
+            FOOD_TRUCK_TOOL_TAGS_ENV_VAR: "",
+        }
+    )
+    if include_agent_backend_flat:
+        extras[AGENT_BACKEND_ENV_VAR] = AGENT_BACKEND_CODEX
+    if applicable_guards is not None:
+        extras[AUTOSKILLIT_APPLICABLE_GUARDS] = ",".join(sorted(applicable_guards))
+    return extras
+
+
 @dataclass(frozen=True, slots=True)
 class CodexEnvPolicy:
     denylist_prefixes: tuple[str, ...] = CODEX_ENV_PREFIX_DENYLIST
@@ -510,14 +537,7 @@ class CodexBackend:
             cmd += [CodexFlags.ADD_DIR, d]
         cmd.append(prompt)
         filtered_base = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}
-        headless_extras: dict[str, str] = {
-            "AUTOSKILLIT_HEADLESS": "1",
-            "AUTOSKILLIT_HEADLESS_AUTO_GATE": "1",
-            "AUTOSKILLIT_SESSION_TYPE": "",
-            AGENT_BACKEND_DYNACONF_ENV_VAR: AGENT_BACKEND_CODEX,
-            MCP_CLIENT_BACKEND_ENV_VAR: AGENT_BACKEND_CODEX,
-            FOOD_TRUCK_TOOL_TAGS_ENV_VAR: "",
-        }
+        headless_extras = _codex_exec_extras(session_type="")
         if env_extras:
             headless_extras.update(env_extras)
         env = self.env_policy().build_env(filtered_base, extras=headless_extras)
@@ -589,18 +609,13 @@ class CodexBackend:
             ),
         )
 
-        extras: dict[str, str] = {
-            "AUTOSKILLIT_HEADLESS": "1",
-            "AUTOSKILLIT_HEADLESS_AUTO_GATE": "1",
-            "AUTOSKILLIT_SESSION_TYPE": SESSION_TYPE_SKILL,
-            "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
-            AGENT_BACKEND_ENV_VAR: AGENT_BACKEND_CODEX,
-            AGENT_BACKEND_DYNACONF_ENV_VAR: AGENT_BACKEND_CODEX,
-            MCP_CLIENT_BACKEND_ENV_VAR: AGENT_BACKEND_CODEX,
-            FOOD_TRUCK_TOOL_TAGS_ENV_VAR: "",
-            AUTOSKILLIT_APPLICABLE_GUARDS: ",".join(sorted(self.capabilities.applicable_guards)),
-            "MCP_CONNECTION_NONBLOCKING": "0",
-        }
+        extras = _codex_exec_extras(
+            session_type=SESSION_TYPE_SKILL,
+            include_agent_backend_flat=True,
+            applicable_guards=self.capabilities.applicable_guards,
+        )
+        extras["MAX_MCP_OUTPUT_TOKENS"] = _MAX_MCP_OUTPUT_TOKENS_VALUE
+        extras["MCP_CONNECTION_NONBLOCKING"] = "0"
         if scenario_step_name:
             extras["SCENARIO_STEP_NAME"] = scenario_step_name
         campaign_id = os.environ.get(CAMPAIGN_ID_ENV_VAR)
@@ -697,18 +712,13 @@ class CodexBackend:
             ),
         )
 
-        extras: dict[str, str] = {
-            "AUTOSKILLIT_HEADLESS": "1",
-            "AUTOSKILLIT_SESSION_TYPE": SESSION_TYPE_ORCHESTRATOR,
-            "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
-            AGENT_BACKEND_ENV_VAR: AGENT_BACKEND_CODEX,
-            AGENT_BACKEND_DYNACONF_ENV_VAR: AGENT_BACKEND_CODEX,
-            MCP_CLIENT_BACKEND_ENV_VAR: AGENT_BACKEND_CODEX,
-            FOOD_TRUCK_TOOL_TAGS_ENV_VAR: "",
-            AUTOSKILLIT_APPLICABLE_GUARDS: ",".join(sorted(self.capabilities.applicable_guards)),
-            "AUTOSKILLIT_HEADLESS_AUTO_GATE": "1",
-            "MCP_CONNECTION_NONBLOCKING": "0",
-        }
+        extras = _codex_exec_extras(
+            session_type=SESSION_TYPE_ORCHESTRATOR,
+            include_agent_backend_flat=True,
+            applicable_guards=self.capabilities.applicable_guards,
+        )
+        extras["MAX_MCP_OUTPUT_TOKENS"] = _MAX_MCP_OUTPUT_TOKENS_VALUE
+        extras["MCP_CONNECTION_NONBLOCKING"] = "0"
         if scenario_step_name:
             extras["SCENARIO_STEP_NAME"] = scenario_step_name
         campaign_id = os.environ.get(CAMPAIGN_ID_ENV_VAR)
@@ -834,17 +844,7 @@ class CodexBackend:
         cmd.append(resume_session_id)
         cmd.append(prompt)
         filtered_base = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}
-        resume_extras: dict[str, str] = dict(_SESSION_BASELINE_ENV)
-        resume_extras.update(
-            {
-                "AUTOSKILLIT_HEADLESS": "1",
-                "AUTOSKILLIT_HEADLESS_AUTO_GATE": "1",
-                "AUTOSKILLIT_SESSION_TYPE": "",
-                AGENT_BACKEND_DYNACONF_ENV_VAR: AGENT_BACKEND_CODEX,
-                MCP_CLIENT_BACKEND_ENV_VAR: AGENT_BACKEND_CODEX,
-                FOOD_TRUCK_TOOL_TAGS_ENV_VAR: "",
-            }
-        )
+        resume_extras = _codex_exec_extras(session_type="", include_session_baseline=True)
         if env_extras:
             resume_extras.update(env_extras)
         env = self.env_policy().build_env(

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -84,6 +84,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_tools_execution_decomposition.py` | Structural decomposition guard for tools_execution.py split |
 | `test_transforms_hygiene.py` | Structural guards for FastMCP visibility tag hygiene |
 | `test_variadic_ordering.py` | Architectural invariant: positional initial_prompt must precede all variadic CLI flags in build_interactive_cmd |
+| `test_codex_exec_builder_invariants.py` | Cross-builder invariant matrix: parametrized tests asserting shared structural properties across all four Codex exec builders |
 | `test_codex_flag_metadata_coverage.py` | Closed categorization guard: every CodexFlags member must appear in VARIADIC_CODEX_FLAGS or NON_VARIADIC_CODEX_FLAGS; model alias/effort key parity |
 | `test_provider_extras_denylist.py` | Structural and AST enforcement: provider-extras filter sites must use named *_DENYLIST constants |
 | `test_flag_metadata_coverage.py` | Closed categorization guard: every ClaudeFlags member must appear in VARIADIC_CLAUDE_FLAGS or NON_VARIADIC_CLAUDE_FLAGS |

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -84,6 +84,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_tools_execution_decomposition.py` | Structural decomposition guard for tools_execution.py split |
 | `test_transforms_hygiene.py` | Structural guards for FastMCP visibility tag hygiene |
 | `test_variadic_ordering.py` | Architectural invariant: positional initial_prompt must precede all variadic CLI flags in build_interactive_cmd |
+| `test_codex_flag_metadata_coverage.py` | Closed categorization guard: every CodexFlags member must appear in VARIADIC_CODEX_FLAGS or NON_VARIADIC_CODEX_FLAGS; model alias/effort key parity |
 | `test_flag_metadata_coverage.py` | Closed categorization guard: every ClaudeFlags member must appear in VARIADIC_CLAUDE_FLAGS or NON_VARIADIC_CLAUDE_FLAGS |
 | `test_interactive_ordering_gate.py` | AST guard: _session_launch.py and _cook.py must import and call assert_interactive_ordering before subprocess invocation |
 | `test_watcher_signal_consistency.py` | Structural guard: all process watchers must call `_has_active_execution_marker` |

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -85,6 +85,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_transforms_hygiene.py` | Structural guards for FastMCP visibility tag hygiene |
 | `test_variadic_ordering.py` | Architectural invariant: positional initial_prompt must precede all variadic CLI flags in build_interactive_cmd |
 | `test_codex_flag_metadata_coverage.py` | Closed categorization guard: every CodexFlags member must appear in VARIADIC_CODEX_FLAGS or NON_VARIADIC_CODEX_FLAGS; model alias/effort key parity |
+| `test_provider_extras_denylist.py` | Structural and AST enforcement: provider-extras filter sites must use named *_DENYLIST constants |
 | `test_flag_metadata_coverage.py` | Closed categorization guard: every ClaudeFlags member must appear in VARIADIC_CLAUDE_FLAGS or NON_VARIADIC_CLAUDE_FLAGS |
 | `test_interactive_ordering_gate.py` | AST guard: _session_launch.py and _cook.py must import and call assert_interactive_ordering before subprocess invocation |
 | `test_watcher_signal_consistency.py` | Structural guard: all process watchers must call `_has_active_execution_marker` |

--- a/tests/arch/test_codex_exec_builder_invariants.py
+++ b/tests/arch/test_codex_exec_builder_invariants.py
@@ -90,7 +90,7 @@ _REINJECTED_BY_BUILDER: dict[str, set[str]] = {
         "AUTOSKILLIT_CWD",
         "AUTOSKILLIT_COMPLETION_MARKER",
     },
-    "resume": set(),
+    "resume": {"MAX_MCP_OUTPUT_TOKENS"},
 }
 
 

--- a/tests/arch/test_codex_exec_builder_invariants.py
+++ b/tests/arch/test_codex_exec_builder_invariants.py
@@ -1,0 +1,105 @@
+"""Cross-builder invariant matrix: parametrized tests across all four Codex exec builders."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core import (
+    AGENT_BACKEND_DYNACONF_ENV_VAR,
+    CODEX_MCP_ENV_FORWARD_VARS,
+    MCP_CLIENT_BACKEND_ENV_VAR,
+    DirectInstall,
+    OutputFormat,
+)
+from autoskillit.execution.backends.codex import _IMAGE_GENERATION_DISABLED, CodexBackend
+from autoskillit.execution.commands import _HEADLESS_EXCLUSIVE_VARS
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+def _build_headless():
+    return CodexBackend().build_headless_cmd("test prompt")
+
+
+def _build_skill_session():
+    return CodexBackend().build_skill_session_cmd(
+        skill_command="/test-skill",
+        cwd="/work",
+        completion_marker="%%DONE%%",
+        model=None,
+        plugin_source=None,
+        output_format=OutputFormat.JSON,
+    )
+
+
+def _build_food_truck():
+    return CodexBackend().build_food_truck_cmd(
+        orchestrator_prompt="dispatch",
+        plugin_source=DirectInstall(plugin_dir=Path("/pkg")),
+        cwd="/work",
+        completion_marker="%%DONE%%",
+    )
+
+
+def _build_resume():
+    return CodexBackend().build_resume_cmd(resume_session_id="sess-abc", prompt="continue")
+
+
+ALL_BUILDERS = [_build_headless, _build_skill_session, _build_food_truck, _build_resume]
+BUILDER_IDS = ["headless", "skill_session", "food_truck", "resume"]
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_ID", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_KITCHEN_SESSION_ID", raising=False)
+
+
+@pytest.mark.parametrize("builder", ALL_BUILDERS, ids=BUILDER_IDS)
+def test_all_exec_builders_start_with_codex_exec(builder) -> None:
+    spec = builder()
+    assert spec.cmd[0] == "codex"
+    assert spec.cmd[1] == "exec"
+
+
+@pytest.mark.parametrize("builder", ALL_BUILDERS, ids=BUILDER_IDS)
+def test_all_exec_builders_have_sandbox(builder) -> None:
+    spec = builder()
+    assert "--sandbox" in spec.cmd
+
+
+@pytest.mark.parametrize("builder", ALL_BUILDERS, ids=BUILDER_IDS)
+def test_all_exec_builders_have_image_generation_disabled(builder) -> None:
+    spec = builder()
+    assert _IMAGE_GENERATION_DISABLED in spec.cmd
+
+
+@pytest.mark.parametrize("builder", ALL_BUILDERS, ids=BUILDER_IDS)
+def test_all_exec_builders_filter_headless_exclusive_vars(builder, monkeypatch) -> None:
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "leaked")
+    spec = builder()
+    reinjected = {
+        "AUTOSKILLIT_SESSION_TYPE",
+        "MAX_MCP_OUTPUT_TOKENS",
+        "AUTOSKILLIT_SKILL_NAME",
+    }
+    leaking = (
+        _HEADLESS_EXCLUSIVE_VARS - reinjected - CODEX_MCP_ENV_FORWARD_VARS
+    ) & spec.env.keys()
+    assert not leaking, f"_HEADLESS_EXCLUSIVE_VARS leaked: {leaking}"
+
+
+@pytest.mark.parametrize("builder", ALL_BUILDERS, ids=BUILDER_IDS)
+def test_all_exec_builders_have_autoskillit_headless(builder) -> None:
+    spec = builder()
+    assert "AUTOSKILLIT_HEADLESS" in spec.env
+    assert spec.env["AUTOSKILLIT_HEADLESS"] == "1"
+
+
+@pytest.mark.parametrize("builder", ALL_BUILDERS, ids=BUILDER_IDS)
+def test_all_exec_builders_have_backend_env_vars(builder) -> None:
+    spec = builder()
+    assert AGENT_BACKEND_DYNACONF_ENV_VAR in spec.env
+    assert MCP_CLIENT_BACKEND_ENV_VAR in spec.env

--- a/tests/arch/test_codex_exec_builder_invariants.py
+++ b/tests/arch/test_codex_exec_builder_invariants.py
@@ -76,15 +76,33 @@ def test_all_exec_builders_have_image_generation_disabled(builder) -> None:
     assert _IMAGE_GENERATION_DISABLED in spec.cmd
 
 
-@pytest.mark.parametrize("builder", ALL_BUILDERS, ids=BUILDER_IDS)
-def test_all_exec_builders_filter_headless_exclusive_vars(builder, monkeypatch) -> None:
-    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "leaked")
-    spec = builder()
-    reinjected = {
+_REINJECTED_BY_BUILDER: dict[str, set[str]] = {
+    "headless": set(),
+    "skill_session": {
         "AUTOSKILLIT_SESSION_TYPE",
         "MAX_MCP_OUTPUT_TOKENS",
         "AUTOSKILLIT_SKILL_NAME",
-    }
+        "AUTOSKILLIT_CWD",
+    },
+    "food_truck": {
+        "AUTOSKILLIT_SESSION_TYPE",
+        "MAX_MCP_OUTPUT_TOKENS",
+        "AUTOSKILLIT_CWD",
+        "AUTOSKILLIT_COMPLETION_MARKER",
+    },
+    "resume": set(),
+}
+
+
+@pytest.mark.parametrize(
+    ("builder", "builder_id"), list(zip(ALL_BUILDERS, BUILDER_IDS)), ids=BUILDER_IDS
+)
+def test_all_exec_builders_filter_headless_exclusive_vars(
+    builder, builder_id, monkeypatch
+) -> None:
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "leaked")
+    spec = builder()
+    reinjected = _REINJECTED_BY_BUILDER[builder_id]
     leaking = (
         _HEADLESS_EXCLUSIVE_VARS - reinjected - CODEX_MCP_ENV_FORWARD_VARS
     ) & spec.env.keys()

--- a/tests/arch/test_codex_flag_metadata_coverage.py
+++ b/tests/arch/test_codex_flag_metadata_coverage.py
@@ -1,0 +1,59 @@
+"""Flag metadata coverage: every CodexFlags member must be categorized."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.execution.backends.codex import (
+    NON_VARIADIC_CODEX_FLAGS,
+    VARIADIC_CODEX_FLAGS,
+    CodexFlags,
+)
+from autoskillit.execution.headless._headless_helpers import _CODEX_VALUE_BEARING_FLAGS
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+def test_every_codex_flag_is_categorized():
+    all_flags = frozenset(CodexFlags)
+    categorized = VARIADIC_CODEX_FLAGS | NON_VARIADIC_CODEX_FLAGS
+    uncategorized = all_flags - categorized
+    assert not uncategorized, (
+        f"CodexFlags members not categorized as variadic (repeating) "
+        f"or non-variadic (single-occurrence): {uncategorized}. "
+        f"Add to VARIADIC_CODEX_FLAGS or NON_VARIADIC_CODEX_FLAGS."
+    )
+
+
+def test_variadic_and_non_variadic_codex_are_disjoint():
+    overlap = VARIADIC_CODEX_FLAGS & NON_VARIADIC_CODEX_FLAGS
+    assert not overlap, f"Flags in both sets: {overlap}"
+
+
+def test_all_categorized_codex_flags_are_valid_members():
+    all_flags = frozenset(CodexFlags)
+    categorized = VARIADIC_CODEX_FLAGS | NON_VARIADIC_CODEX_FLAGS
+    invalid = categorized - all_flags
+    assert not invalid, f"Categorized flags not in CodexFlags: {invalid}"
+
+
+def test_codex_value_bearing_flags_subset_of_categorized():
+    categorized = VARIADIC_CODEX_FLAGS | NON_VARIADIC_CODEX_FLAGS
+    all_flags = frozenset(CodexFlags)
+    for entry in _CODEX_VALUE_BEARING_FLAGS:
+        assert entry in all_flags, (
+            f"_CODEX_VALUE_BEARING_FLAGS entry {entry!r} is not a live CodexFlags member"
+        )
+        assert entry in categorized, (
+            f"_CODEX_VALUE_BEARING_FLAGS entry {entry!r} is not in "
+            f"VARIADIC_CODEX_FLAGS or NON_VARIADIC_CODEX_FLAGS"
+        )
+
+
+def test_codex_model_aliases_and_effort_mapping_key_parity():
+    from autoskillit.core import CODEX_EFFORT_MAPPING, CODEX_MODEL_ALIASES
+
+    assert CODEX_MODEL_ALIASES.keys() == CODEX_EFFORT_MAPPING.keys(), (
+        f"CODEX_MODEL_ALIASES keys {set(CODEX_MODEL_ALIASES)} != "
+        f"CODEX_EFFORT_MAPPING keys {set(CODEX_EFFORT_MAPPING)}"
+    )

--- a/tests/arch/test_provider_extras_denylist.py
+++ b/tests/arch/test_provider_extras_denylist.py
@@ -1,0 +1,56 @@
+"""Provider-extras denylist: structural and AST enforcement."""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from autoskillit.core import pkg_root
+from autoskillit.execution.backends._claude_prompt import (
+    _PROVIDER_EXTRAS_BASE_DENYLIST,
+    _SKILL_SESSION_EXTRAS_DENYLIST,
+)
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+def test_provider_extras_base_denylist_is_frozen() -> None:
+    assert isinstance(_PROVIDER_EXTRAS_BASE_DENYLIST, frozenset)
+
+
+def test_skill_session_denylist_is_superset_of_base() -> None:
+    assert _SKILL_SESSION_EXTRAS_DENYLIST >= _PROVIDER_EXTRAS_BASE_DENYLIST
+
+
+def test_all_provider_extras_filter_sites_use_named_constant() -> None:
+    backends_dir = pkg_root() / "execution" / "backends"
+    violations: list[str] = []
+
+    for filename in ("codex.py", "claude.py"):
+        filepath = backends_dir / filename
+        source = filepath.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=filename)
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Compare):
+                continue
+            if not any(isinstance(op, ast.NotIn) for op in node.ops):
+                continue
+            for comparator in node.comparators:
+                if not isinstance(comparator, ast.Tuple):
+                    continue
+                str_values = set()
+                for elt in comparator.elts:
+                    if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                        str_values.add(elt.value)
+                if (
+                    "AUTOSKILLIT_SESSION_TYPE" in str_values
+                    and "AUTOSKILLIT_HEADLESS" in str_values
+                ):
+                    violations.append(
+                        f"{filename}:{node.lineno}: inline tuple literal in "
+                        f"provider_extras/env_extras filter — use a *_DENYLIST constant"
+                    )
+
+    assert not violations, "Inline filter tuples found:\n" + "\n".join(violations)

--- a/tests/execution/backends/test_backend_registry.py
+++ b/tests/execution/backends/test_backend_registry.py
@@ -56,6 +56,8 @@ class TestBackendRegistry:
             "CodexScenarioPlayer",
             "CodexSessionLocator",
             "CodexStreamParser",
+            "NON_VARIADIC_CODEX_FLAGS",
+            "VARIADIC_CODEX_FLAGS",
             "_is_autoskillit_registered",
             "_read_codex_config",
             "_serialize_toml",

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -626,6 +626,7 @@ class TestCodexBuildSkillSessionCmd:
             "AUTOSKILLIT_SESSION_TYPE",
             "MAX_MCP_OUTPUT_TOKENS",
             "AUTOSKILLIT_SKILL_NAME",
+            "AUTOSKILLIT_CWD",
         }
         leaking = (
             _HEADLESS_EXCLUSIVE_VARS - reinjected - CODEX_MCP_ENV_FORWARD_VARS
@@ -1024,7 +1025,12 @@ class TestCodexBuildFoodTruckCmd:
 
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "leaked")
         spec = CodexBackend().build_food_truck_cmd(**self.BASE)
-        reinjected = {"AUTOSKILLIT_SESSION_TYPE", "MAX_MCP_OUTPUT_TOKENS"}
+        reinjected = {
+            "AUTOSKILLIT_SESSION_TYPE",
+            "MAX_MCP_OUTPUT_TOKENS",
+            "AUTOSKILLIT_CWD",
+            "AUTOSKILLIT_COMPLETION_MARKER",
+        }
         leaking = (
             _HEADLESS_EXCLUSIVE_VARS - reinjected - CODEX_MCP_ENV_FORWARD_VARS
         ) & spec.env.keys()

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -616,6 +616,22 @@ class TestCodexBuildSkillSessionCmd:
         spec = CodexBackend().build_skill_session_cmd(**self.BASE)
         assert "--json" in spec.cmd
 
+    def test_skill_session_cmd_uses_filtered_base_env(self, monkeypatch) -> None:
+        from autoskillit.core import CODEX_MCP_ENV_FORWARD_VARS
+        from autoskillit.execution.commands import _HEADLESS_EXCLUSIVE_VARS
+
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "leaked")
+        spec = CodexBackend().build_skill_session_cmd(**self.BASE)
+        reinjected = {
+            "AUTOSKILLIT_SESSION_TYPE",
+            "MAX_MCP_OUTPUT_TOKENS",
+            "AUTOSKILLIT_SKILL_NAME",
+        }
+        leaking = (
+            _HEADLESS_EXCLUSIVE_VARS - reinjected - CODEX_MCP_ENV_FORWARD_VARS
+        ) & spec.env.keys()
+        assert not leaking, f"_HEADLESS_EXCLUSIVE_VARS leaked into skill session env: {leaking}"
+
 
 class TestCodexBuildSkillSessionCmdConfigAdapter:
     def test_config_adapter_matches_flat_params(self) -> None:
@@ -1001,6 +1017,18 @@ class TestCodexBuildFoodTruckCmd:
     def test_non_resume_json_present(self) -> None:
         spec = CodexBackend().build_food_truck_cmd(**self.BASE)
         assert "--json" in spec.cmd
+
+    def test_food_truck_cmd_uses_filtered_base_env(self, monkeypatch) -> None:
+        from autoskillit.core import CODEX_MCP_ENV_FORWARD_VARS
+        from autoskillit.execution.commands import _HEADLESS_EXCLUSIVE_VARS
+
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "leaked")
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        reinjected = {"AUTOSKILLIT_SESSION_TYPE", "MAX_MCP_OUTPUT_TOKENS"}
+        leaking = (
+            _HEADLESS_EXCLUSIVE_VARS - reinjected - CODEX_MCP_ENV_FORWARD_VARS
+        ) & spec.env.keys()
+        assert not leaking, f"_HEADLESS_EXCLUSIVE_VARS leaked into food truck env: {leaking}"
 
 
 class TestCodexEnsurePreLaunchConfigValidation:

--- a/tests/execution/backends/test_codex_exec_base.py
+++ b/tests/execution/backends/test_codex_exec_base.py
@@ -1,0 +1,77 @@
+"""Tests for _codex_exec_base shared command preamble factory."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+from autoskillit.execution.backends.codex import CodexBackend, _codex_exec_base
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class TestCodexExecBase:
+    def test_returns_expected_preamble(self) -> None:
+        result = _codex_exec_base(sandbox="workspace-write")
+        assert result == [
+            "codex",
+            "exec",
+            "--json",
+            "--sandbox",
+            "workspace-write",
+            "-c",
+            "features.image_generation=false",
+        ]
+
+    def test_with_approval_never(self) -> None:
+        result = _codex_exec_base(sandbox="workspace-write", approval="never")
+        assert "-a" in result
+        idx = result.index("-a")
+        assert result[idx + 1] == "never"
+
+    def test_without_json(self) -> None:
+        result = _codex_exec_base(sandbox="read-only", json=False)
+        assert "--json" not in result
+
+    def test_with_extra_overrides(self) -> None:
+        result = _codex_exec_base(sandbox="read-only", extra_overrides=["web_search=disabled"])
+        config_indices = [i for i, v in enumerate(result) if v == "-c"]
+        assert len(config_indices) == 2
+        assert result[config_indices[0] + 1] == "web_search=disabled"
+        assert result[config_indices[1] + 1] == "features.image_generation=false"
+
+
+class TestNoRawCodexExecListLiteral:
+    pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+    def test_no_raw_codex_exec_list_literal_in_codex_backend(self) -> None:
+        source = inspect.getsource(CodexBackend)
+        tree = ast.parse(source)
+
+        class_body = tree.body[0]
+        assert isinstance(class_body, ast.ClassDef)
+
+        for node in ast.walk(class_body):
+            if not isinstance(node, ast.List):
+                continue
+            elts = node.elts
+            if len(elts) < 2:
+                continue
+            first_two = []
+            for e in elts[:2]:
+                if isinstance(e, ast.Constant) and isinstance(e.value, str):
+                    first_two.append(e.value)
+            if first_two == ["codex", "exec"]:
+                func_name = "<unknown>"
+                for parent in ast.walk(class_body):
+                    if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        for child in ast.walk(parent):
+                            if child is node:
+                                func_name = parent.name
+                                break
+                raise AssertionError(
+                    f"Raw ['codex', 'exec', ...] list literal found in "
+                    f"CodexBackend.{func_name}. Use _codex_exec_base() instead."
+                )

--- a/tests/execution/backends/test_codex_exec_base.py
+++ b/tests/execution/backends/test_codex_exec_base.py
@@ -25,12 +25,6 @@ class TestCodexExecBase:
             "features.image_generation=false",
         ]
 
-    def test_with_approval_never(self) -> None:
-        result = _codex_exec_base(sandbox="workspace-write", approval="never")
-        assert "-a" in result
-        idx = result.index("-a")
-        assert result[idx + 1] == "never"
-
     def test_without_json(self) -> None:
         result = _codex_exec_base(sandbox="read-only", json=False)
         assert "--json" not in result

--- a/tests/execution/backends/test_codex_exec_extras.py
+++ b/tests/execution/backends/test_codex_exec_extras.py
@@ -1,0 +1,94 @@
+"""Tests for _codex_exec_extras shared env baseline factory."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+from autoskillit.core import (
+    AGENT_BACKEND_DYNACONF_ENV_VAR,
+    AUTOSKILLIT_APPLICABLE_GUARDS,
+    FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
+    MCP_CLIENT_BACKEND_ENV_VAR,
+    SESSION_TYPE_SKILL,
+)
+from autoskillit.execution.backends.codex import CodexBackend, _codex_exec_extras
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class TestCodexExecExtras:
+    def test_baseline(self) -> None:
+        result = _codex_exec_extras(session_type=SESSION_TYPE_SKILL)
+        assert result["AUTOSKILLIT_HEADLESS"] == "1"
+        assert result["AUTOSKILLIT_HEADLESS_AUTO_GATE"] == "1"
+        assert result["AUTOSKILLIT_SESSION_TYPE"] == SESSION_TYPE_SKILL
+        assert AGENT_BACKEND_DYNACONF_ENV_VAR in result
+        assert MCP_CLIENT_BACKEND_ENV_VAR in result
+        assert FOOD_TRUCK_TOOL_TAGS_ENV_VAR in result
+
+    def test_includes_session_baseline(self) -> None:
+        result = _codex_exec_extras(session_type="", include_session_baseline=True)
+        assert "MAX_MCP_OUTPUT_TOKENS" in result
+        assert "MCP_CONNECTION_NONBLOCKING" in result
+
+    def test_includes_guards(self) -> None:
+        result = _codex_exec_extras(
+            session_type=SESSION_TYPE_SKILL, applicable_guards=frozenset({"g1", "g2"})
+        )
+        assert AUTOSKILLIT_APPLICABLE_GUARDS in result
+        assert result[AUTOSKILLIT_APPLICABLE_GUARDS] == "g1,g2"
+
+    def test_empty_guards_writes_empty_string(self) -> None:
+        result = _codex_exec_extras(session_type=SESSION_TYPE_SKILL, applicable_guards=frozenset())
+        assert result[AUTOSKILLIT_APPLICABLE_GUARDS] == ""
+
+    def test_no_guards_omits_key(self) -> None:
+        result = _codex_exec_extras(session_type="")
+        assert AUTOSKILLIT_APPLICABLE_GUARDS not in result
+
+    def test_includes_agent_backend_flat(self) -> None:
+        from autoskillit.core import AGENT_BACKEND_ENV_VAR
+
+        result = _codex_exec_extras(
+            session_type=SESSION_TYPE_SKILL, include_agent_backend_flat=True
+        )
+        assert AGENT_BACKEND_ENV_VAR in result
+
+
+_BASELINE_KEYS = {
+    "AUTOSKILLIT_HEADLESS",
+    "AUTOSKILLIT_HEADLESS_AUTO_GATE",
+    AGENT_BACKEND_DYNACONF_ENV_VAR,
+}
+
+
+class TestNoRawHeadlessExtrasDict:
+    pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+    def test_no_raw_headless_extras_dict_in_codex_backend(self) -> None:
+        source = inspect.getsource(CodexBackend)
+        tree = ast.parse(source)
+
+        class_body = tree.body[0]
+        assert isinstance(class_body, ast.ClassDef)
+
+        for func_node in ast.walk(class_body):
+            if not isinstance(func_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for node in ast.walk(func_node):
+                if not isinstance(node, ast.Dict):
+                    continue
+                str_keys = set()
+                for k in node.keys:
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                        str_keys.add(k.value)
+                    elif isinstance(k, ast.Attribute) and isinstance(k.attr, str):
+                        str_keys.add(k.attr)
+                if _BASELINE_KEYS <= str_keys:
+                    raise AssertionError(
+                        f"Raw baseline headless extras dict literal found in "
+                        f"CodexBackend.{func_node.name}. Use _codex_exec_extras() instead."
+                    )


### PR DESCRIPTION
## Summary

The Codex backend has four `codex exec`-targeting builder methods that independently construct command arrays and environment dicts from scratch. This copy-paste architecture guarantees that fixes applied to one builder are missed by others — causing 7+ reactive fix cycles in 13 days. The root cause is three reinforcing structural failures: (1) no shared base for exec builders, (2) zero semantic testing of flags, and (3) `CodexFlags` lacking the closed-categorization enforcement that `ClaudeFlags` already has.

This PR eliminates the copy-paste root cause by extracting a shared `_codex_exec_base()` factory for the command preamble and a shared `_codex_exec_extras()` factory for the environment baseline, then adding closed-categorization arch tests for `CodexFlags` that mirror the existing `ClaudeFlags` pattern, and extending env-leakage and cross-builder invariant tests to cover all four exec builders uniformly.

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

Closes #3699

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260603-233722-005352/.autoskillit/temp/rectify/rectify_codex_backend_systemic_builder_divergence_2026-06-04_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 7.5k | 26.6k | 3.4M | 135.9k | 85 | 119.1k | 27m 19s |
| review_approach* | opus[1m] | 1 | 25 | 6.5k | 265.3k | 59.1k | 13 | 67.5k | 6m 35s |
| dry_walkthrough* | opus | 1 | 43 | 17.6k | 1.5M | 136.2k | 42 | 119.3k | 8m 28s |
| implement* | opus[1m] | 1 | 162 | 30.1k | 10.4M | 155.2k | 148 | 138.4k | 10m 22s |
| audit_impl* | opus[1m] | 1 | 1.9k | 17.1k | 320.0k | 74.5k | 19 | 59.5k | 6m 22s |
| prepare_pr* | MiniMax-M3 | 1 | 47.9k | 5.2k | 275.3k | 54.1k | 12 | 0 | 1m 48s |
| compose_pr* | MiniMax-M3 | 1 | 40.0k | 1.3k | 407.2k | 42.6k | 15 | 0 | 1m 4s |
| review_pr* | opus[1m] | 1 | 41 | 22.9k | 893.9k | 96.7k | 41 | 80.6k | 7m 37s |
| resolve_review* | opus[1m] | 1 | 37 | 6.3k | 992.6k | 61.3k | 44 | 45.2k | 4m 3s |
| resolve_pre_review_conflicts* | opus[1m] | 1 | 55 | 10.9k | 2.6M | 92.6k | 77 | 76.2k | 3m 47s |
| diagnose_ci* | MiniMax-M3 | 1 | 45.2k | 843 | 202.4k | 46.4k | 7 | 0 | 53s |
| resolve_ci* | opus[1m] | 1 | 44 | 4.5k | 876.4k | 62.6k | 40 | 45.7k | 3m 42s |
| **Total** | | | 142.9k | 149.8k | 22.2M | 155.2k | | 751.6k | 1h 22m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 633 | 16502.5 | 218.7 | 47.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 3 | 330868.7 | 15066.7 | 2090.3 |
| resolve_pre_review_conflicts | 380 | 6785.0 | 200.6 | 28.8 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 6 | 146061.8 | 7624.5 | 756.0 |
| **Total** | **1022** | 21704.4 | 735.4 | 146.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 8 | 9.8k | 124.9k | 19.8M | 632.3k | 1h 9m |
| opus | 1 | 43 | 17.6k | 1.5M | 119.3k | 8m 28s |
| MiniMax-M3 | 3 | 133.1k | 7.4k | 884.9k | 0 | 3m 46s |