### PR TITLE
Consolidate Duplicated Formatting Utilities (#3688)

### DIFF
--- a/src/autoskillit/cli/fleet/_fleet_display.py
+++ b/src/autoskillit/cli/fleet/_fleet_display.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from autoskillit.core import TerminalColumn, get_logger
+from autoskillit.pipeline.telemetry_fmt import TelemetryFormatter
 
 logger = get_logger(__name__)
 
@@ -79,19 +80,6 @@ def _fmt_elapsed(dispatch: DispatchRecord) -> str:
     return f"{hours}h {mins}m"
 
 
-def _humanize(n: int | float | None) -> str:
-    """Humanize token counts: 1234 -> '1.2k', 1234567 -> '1.2M'."""
-    if n is None or n == 0:
-        return "0"
-    if not isinstance(n, (int, float)):
-        return "0"
-    if n >= 1_000_000:
-        return f"{n / 1_000_000:.1f}M"
-    if n >= 1_000:
-        return f"{n / 1_000:.1f}k"
-    return str(int(n))
-
-
 def _aggregate_totals(state: CampaignState) -> dict[str, int]:
     """Sum token_usage across all dispatches."""
     totals: dict[str, int] = {
@@ -119,10 +107,10 @@ def _build_status_rows(state: CampaignState) -> list[tuple[str, ...]]:
                 d.name,
                 str(d.status),
                 _fmt_elapsed(d),
-                _humanize(tu.get("input", 0)),
-                _humanize(tu.get("output", 0)),
-                _humanize(tu.get("cache_read", 0)),
-                _humanize(tu.get("cache_creation", 0)),
+                TelemetryFormatter._humanize(tu.get("input", 0)),
+                TelemetryFormatter._humanize(tu.get("output", 0)),
+                TelemetryFormatter._humanize(tu.get("cache_read", 0)),
+                TelemetryFormatter._humanize(tu.get("cache_creation", 0)),
                 d.dispatched_session_log_dir or "-",
             )
         )
@@ -133,10 +121,10 @@ def _build_status_rows(state: CampaignState) -> list[tuple[str, ...]]:
             "TOTAL",
             "",
             "",
-            _humanize(totals["input"]),
-            _humanize(totals["output"]),
-            _humanize(totals["cache_read"]),
-            _humanize(totals["cache_creation"]),
+            TelemetryFormatter._humanize(totals["input"]),
+            TelemetryFormatter._humanize(totals["output"]),
+            TelemetryFormatter._humanize(totals["cache_read"]),
+            TelemetryFormatter._humanize(totals["cache_creation"]),
             "",
         )
     )

--- a/src/autoskillit/cli/fleet/_fleet_display.py
+++ b/src/autoskillit/cli/fleet/_fleet_display.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from autoskillit.core import TerminalColumn, get_logger
-from autoskillit.pipeline.telemetry_fmt import TelemetryFormatter
+from autoskillit.pipeline import TelemetryFormatter
 
 logger = get_logger(__name__)
 

--- a/tests/cli/test_fleet_split.py
+++ b/tests/cli/test_fleet_split.py
@@ -6,7 +6,7 @@ pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 def test_fleet_display_importable():
-    from autoskillit.cli.fleet._fleet_display import _build_status_rows, _humanize  # noqa: F401
+    from autoskillit.cli.fleet._fleet_display import _build_status_rows  # noqa: F401
 
 
 def test_fleet_lifecycle_importable():

--- a/tests/infra/test_token_summary_filters.py
+++ b/tests/infra/test_token_summary_filters.py
@@ -45,6 +45,20 @@ def test_tsa_humanize_preserves_decimal() -> None:
     )
 
 
+def test_fmt_duration_output_equivalent_to_canonical() -> None:
+    """Hook _fmt_duration must produce identical output to TelemetryFormatter._fmt_duration."""
+    from autoskillit.hooks.token_summary_hook import _fmt_duration as hook_fmt_duration
+    from autoskillit.pipeline.telemetry_fmt import TelemetryFormatter
+
+    cases = [4.0, 45.7, 492.0, 3720.0, 0.0, 59.9, 60.0, 3599.9, 3600.0]
+    for seconds in cases:
+        hook_out = hook_fmt_duration(seconds)
+        canonical_out = TelemetryFormatter._fmt_duration(seconds)
+        assert hook_out == canonical_out, (
+            f"_fmt_duration({seconds}) diverged: hook={hook_out!r}, canonical={canonical_out!r}"
+        )
+
+
 def test_non_anthropic_step_marked_in_format_table() -> None:
     """Hook _format_table marks non-Anthropic step names with * and adds footnote."""
     from autoskillit.hooks.token_summary_hook import _format_table

--- a/tests/infra/test_token_summary_filters.py
+++ b/tests/infra/test_token_summary_filters.py
@@ -59,6 +59,20 @@ def test_fmt_duration_output_equivalent_to_canonical() -> None:
         )
 
 
+def test_humanize_output_equivalent_to_canonical() -> None:
+    """Hook _humanize must produce identical output to TelemetryFormatter._humanize."""
+    from autoskillit.hooks.token_summary_hook import _humanize as hook_humanize
+    from autoskillit.pipeline.telemetry_fmt import TelemetryFormatter
+
+    cases = [0, 0.0, None, 1, 999, 1000, 1500, 999999, 1_000_000, 1_200_000, 45.7, -1]
+    for val in cases:
+        hook_out = hook_humanize(val)
+        canonical_out = TelemetryFormatter._humanize(val)
+        assert hook_out == canonical_out, (
+            f"_humanize({val!r}) diverged: hook={hook_out!r}, canonical={canonical_out!r}"
+        )
+
+
 def test_non_anthropic_step_marked_in_format_table() -> None:
     """Hook _format_table marks non-Anthropic step names with * and adds footnote."""
     from autoskillit.hooks.token_summary_hook import _format_table


### PR DESCRIPTION
## Summary

Eliminate the duplicated `_humanize` function in `cli/fleet/_fleet_display.py` by replacing it with an import of the canonical `TelemetryFormatter._humanize` from `pipeline/telemetry_fmt.py`. Add a missing output-equivalence test for `_fmt_duration` between `hooks/token_summary_hook.py` and `TelemetryFormatter._fmt_duration`, following the established pattern from test `1g`. The hook copies of both functions remain unchanged (stdlib-only constraint).

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260604-005532-547884/.autoskillit/temp/make-plan/consolidate_duplicated_formatting_utilities_plan_2026-06-04_005532.md`

Closes #3688

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 3.5k | 9.3k | 921.3k | 79.8k | 37 | 63.2k | 7m 45s |
| verify* | sonnet | 1 | 2.0k | 5.9k | 388.3k | 42.3k | 29 | 25.7k | 2m 29s |
| implement* | MiniMax-M3 | 1 | 62.8k | 4.6k | 1.3M | 66.3k | 47 | 0 | 2m 54s |
| fix* | sonnet | 1 | 134 | 5.0k | 589.7k | 43.3k | 40 | 27.5k | 3m 11s |
| audit_impl* | sonnet | 1 | 52 | 4.0k | 175.7k | 35.7k | 12 | 22.8k | 3m 0s |
| prepare_pr* | MiniMax-M3 | 1 | 40.4k | 1.9k | 228.9k | 41.8k | 11 | 0 | 1m 7s |
| compose_pr* | MiniMax-M3 | 1 | 35.3k | 1.3k | 186.3k | 38.2k | 12 | 0 | 57s |
| review_pr* | sonnet | 1 | 180 | 15.6k | 954.5k | 56.8k | 49 | 40.8k | 4m 3s |
| resolve_review* | sonnet | 1 | 173 | 14.3k | 1.1M | 72.7k | 58 | 56.0k | 5m 47s |
| **Total** | | | 144.6k | 61.9k | 5.9M | 79.8k | | 235.9k | 31m 17s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 46 | 28479.5 | 0.0 | 99.3 |
| fix | 2 | 294868.0 | 13748.5 | 2498.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 14 | 80164.6 | 3997.6 | 1022.1 |
| **Total** | **62** | 94792.3 | 3805.5 | 997.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 3.5k | 9.3k | 921.3k | 63.2k | 7m 45s |
| sonnet | 5 | 2.6k | 44.8k | 3.2M | 172.7k | 18m 33s |
| MiniMax-M3 | 3 | 138.5k | 7.8k | 1.7M | 0 | 4m 58s |