### PR TITLE
Wire Phoropter Types into core.types Public Surface

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -178,6 +178,7 @@ from .types import QUOTA_BUDGET_EXCEEDED_TRIGGER as QUOTA_BUDGET_EXCEEDED_TRIGGE
 from .types import QUOTA_GUARD_DENY_TRIGGER as QUOTA_GUARD_DENY_TRIGGER
 from .types import QUOTA_POST_BUDGET_EXCEEDED_TRIGGER as QUOTA_POST_BUDGET_EXCEEDED_TRIGGER
 from .types import QUOTA_POST_WARNING_TRIGGER as QUOTA_POST_WARNING_TRIGGER
+from .types import READING_TOKEN_PATTERN as READING_TOKEN_PATTERN
 from .types import RECIPE_PACK_REGISTRY as RECIPE_PACK_REGISTRY
 from .types import RECIPE_PACK_TAGS as RECIPE_PACK_TAGS
 from .types import REQUIRED_CONSUMER_FIELDS as REQUIRED_CONSUMER_FIELDS
@@ -241,6 +242,8 @@ from .types import CodexEventData as CodexEventData
 from .types import CodingAgentBackend as CodingAgentBackend
 from .types import CompletionRequiredResolver as CompletionRequiredResolver
 from .types import ContaminationOutcome as ContaminationOutcome
+from .types import CrossDomainAssessment as CrossDomainAssessment
+from .types import CrossDomainPrescription as CrossDomainPrescription
 from .types import DatabaseReader as DatabaseReader
 from .types import DirectInstall as DirectInstall
 from .types import DispatchGateType as DispatchGateType
@@ -283,12 +286,15 @@ from .types import NoResume as NoResume
 from .types import OutputFormat as OutputFormat
 from .types import OutputPatternResolver as OutputPatternResolver
 from .types import PackDef as PackDef
+from .types import PhoropterPhaseSkip as PhoropterPhaseSkip
+from .types import PhoropterPrescription as PhoropterPrescription
 from .types import PluginSource as PluginSource
 from .types import ProcessStaleError as ProcessStaleError
 from .types import PromptContractError as PromptContractError
 from .types import ProviderOutcome as ProviderOutcome
 from .types import PRState as PRState
 from .types import QuotaRefreshTask as QuotaRefreshTask
+from .types import ReadingToken as ReadingToken
 from .types import ReadOnlyResolver as ReadOnlyResolver
 from .types import RecipeIdentity as RecipeIdentity
 from .types import RecipeLoadError as RecipeLoadError
@@ -320,6 +326,7 @@ from .types import SubprocessResult as SubprocessResult
 from .types import SubprocessRunner as SubprocessRunner
 from .types import SupportsDebug as SupportsDebug
 from .types import SupportsLogger as SupportsLogger
+from .types import SynthesisStrategy as SynthesisStrategy
 from .types import TerminationAction as TerminationAction
 from .types import TerminationReason as TerminationReason
 from .types import TestResult as TestResult

--- a/src/autoskillit/core/types/__init__.py
+++ b/src/autoskillit/core/types/__init__.py
@@ -32,6 +32,8 @@ from ._type_helpers import *  # noqa: F401, F403
 from ._type_helpers import __all__ as _helpers_all
 from ._type_inspector import *  # noqa: F401, F403
 from ._type_inspector import __all__ as _inspector_all
+from ._type_phoropter import *  # noqa: F401, F403
+from ._type_phoropter import __all__ as _phoropter_all
 from ._type_plugin_source import *  # noqa: F401, F403
 from ._type_plugin_source import __all__ as _plugin_source_all
 from ._type_protocols_backend import *  # noqa: F401, F403
@@ -75,6 +77,7 @@ __all__ = (
     + _figure_spec_all
     + _helpers_all
     + _inspector_all
+    + _phoropter_all
     + _plugin_source_all
     + _protocols_logging_all
     + _protocols_execution_all

--- a/tests/core/test_kitchen_state.py
+++ b/tests/core/test_kitchen_state.py
@@ -219,13 +219,16 @@ def test_find_caller_session_id_returns_fresh_marker(tmp_path, monkeypatch):
 
 
 def test_find_caller_session_id_picks_freshest_by_mtime(tmp_path, monkeypatch):
-    import time
+    import os
 
     from autoskillit.core.runtime.kitchen_state import find_caller_session_id, write_marker
 
     monkeypatch.setenv("AUTOSKILLIT_STATE_DIR", str(tmp_path))
     write_marker("sess-old", "recipe-1")
-    time.sleep(0.05)
+    # Backdate sess-old by 10s so mtime ordering is filesystem-resolution-independent
+    old_json = tmp_path / "kitchen_state" / "sess-old.json"
+    past = old_json.stat().st_mtime - 10.0
+    os.utime(old_json, (past, past))
     write_marker("sess-new", "recipe-2")
     result = find_caller_session_id()
     assert result == "sess-new"

--- a/tests/core/test_types_structure.py
+++ b/tests/core/test_types_structure.py
@@ -100,7 +100,7 @@ def test_subprocess_termination_contract_variable_still_defined() -> None:
 
 
 def test_phoropter_symbols_importable_from_types_hub() -> None:
-    """All _type_phoropter symbols must be importable from autoskillit.core.types."""
+    """All phoropter-related symbols must be importable from autoskillit.core.types."""
     import dataclasses
 
     from autoskillit.core.types import (
@@ -110,9 +110,11 @@ def test_phoropter_symbols_importable_from_types_hub() -> None:
         PhoropterPhaseSkip,
         PhoropterPrescription,
         ReadingToken,
+        SynthesisStrategy,
     )
 
     assert isinstance(READING_TOKEN_PATTERN, str)
+    assert issubclass(SynthesisStrategy, str)
     assert dataclasses.is_dataclass(PhoropterPrescription)
     assert dataclasses.is_dataclass(ReadingToken)
     assert dataclasses.is_dataclass(PhoropterPhaseSkip)

--- a/tests/core/test_types_structure.py
+++ b/tests/core/test_types_structure.py
@@ -97,3 +97,54 @@ def test_subprocess_termination_contract_variable_still_defined() -> None:
     import autoskillit.core.types._type_subprocess as m
 
     assert hasattr(m, "_TERMINATION_CONTRACT")
+
+
+def test_phoropter_symbols_importable_from_types_hub() -> None:
+    """All _type_phoropter symbols must be importable from autoskillit.core.types."""
+    import dataclasses
+
+    from autoskillit.core.types import (
+        READING_TOKEN_PATTERN,
+        CrossDomainAssessment,
+        CrossDomainPrescription,
+        PhoropterPhaseSkip,
+        PhoropterPrescription,
+        ReadingToken,
+    )
+
+    assert isinstance(READING_TOKEN_PATTERN, str)
+    assert dataclasses.is_dataclass(PhoropterPrescription)
+    assert dataclasses.is_dataclass(ReadingToken)
+    assert dataclasses.is_dataclass(PhoropterPhaseSkip)
+    assert dataclasses.is_dataclass(CrossDomainPrescription)
+    assert dataclasses.is_dataclass(CrossDomainAssessment)
+
+
+def test_phoropter_symbols_importable_from_core_gateway() -> None:
+    """All seven phoropter-related symbols must resolve via autoskillit.core (lazy stub)."""
+    from autoskillit.core import (
+        READING_TOKEN_PATTERN,
+        CrossDomainAssessment,
+        CrossDomainPrescription,
+        PhoropterPhaseSkip,
+        PhoropterPrescription,
+        ReadingToken,
+        SynthesisStrategy,
+    )
+
+    assert isinstance(READING_TOKEN_PATTERN, str)
+    assert issubclass(SynthesisStrategy, str)
+    assert callable(PhoropterPrescription)
+    assert callable(ReadingToken)
+    assert callable(PhoropterPhaseSkip)
+    assert callable(CrossDomainPrescription)
+    assert callable(CrossDomainAssessment)
+
+
+def test_phoropter_all_in_types_all() -> None:
+    """Every _type_phoropter.__all__ member must appear in core.types.__all__."""
+    from autoskillit.core.types import __all__ as types_all
+    from autoskillit.core.types._type_phoropter import __all__ as phoropter_all
+
+    missing = set(phoropter_all) - set(types_all)
+    assert not missing, f"Missing from core.types.__all__: {missing}"

--- a/tests/core/test_types_structure.py
+++ b/tests/core/test_types_structure.py
@@ -124,6 +124,8 @@ def test_phoropter_symbols_importable_from_types_hub() -> None:
 
 def test_phoropter_symbols_importable_from_core_gateway() -> None:
     """All seven phoropter-related symbols must resolve via autoskillit.core (lazy stub)."""
+    import dataclasses
+
     from autoskillit.core import (
         READING_TOKEN_PATTERN,
         CrossDomainAssessment,
@@ -136,11 +138,11 @@ def test_phoropter_symbols_importable_from_core_gateway() -> None:
 
     assert isinstance(READING_TOKEN_PATTERN, str)
     assert issubclass(SynthesisStrategy, str)
-    assert callable(PhoropterPrescription)
-    assert callable(ReadingToken)
-    assert callable(PhoropterPhaseSkip)
-    assert callable(CrossDomainPrescription)
-    assert callable(CrossDomainAssessment)
+    assert dataclasses.is_dataclass(PhoropterPrescription)
+    assert dataclasses.is_dataclass(ReadingToken)
+    assert dataclasses.is_dataclass(PhoropterPhaseSkip)
+    assert dataclasses.is_dataclass(CrossDomainPrescription)
+    assert dataclasses.is_dataclass(CrossDomainAssessment)
 
 
 def test_phoropter_all_in_types_all() -> None:


### PR DESCRIPTION
## Summary

Wire the six `_type_phoropter` symbols and the related `SynthesisStrategy` enum (from `_type_enums`) into the `core.types` re-export hub (`__init__.py`) and the `core/__init__.pyi` lazy-loader stub. The `_type_phoropter.py` module and its tests already exist (delivered by T2-P1-A2-WP1). This task adds the import pair and `__all__` extension to the re-export hub, then inserts seven alphabetically-ordered `from .types import X as X` lines into the `.pyi` stub so the lazy-loader can resolve them at runtime via `autoskillit.core`.

Closes #3702

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260604-031235-843864/.autoskillit/temp/make-plan/wire_phoropter_types_plan_2026-06-04_031500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 80 | 11.4k | 1.4M | 76.7k | 58 | 94.9k | 4m 51s |
| verify* | sonnet | 1 | 116 | 9.2k | 714.8k | 64.9k | 41 | 48.2k | 2m 50s |
| implement* | MiniMax-M3 | 1 | 70.8k | 9.9k | 2.3M | 70.5k | 88 | 0 | 8m 17s |
| merge_gate_fix* | sonnet | 1 | 166 | 14.9k | 1.0M | 64.7k | 54 | 48.0k | 9m 35s |
| audit_impl* | sonnet | 1 | 468 | 15.5k | 325.5k | 51.9k | 25 | 36.3k | 5m 41s |
| prepare_pr* | MiniMax-M3 | 1 | 41.6k | 1.6k | 194.9k | 44.0k | 12 | 0 | 57s |
| compose_pr* | MiniMax-M3 | 1 | 36.5k | 1.2k | 185.4k | 38.2k | 12 | 0 | 50s |
| review_pr* | sonnet | 3 | 420 | 69.3k | 2.4M | 70.2k | 125 | 152.8k | 16m 20s |
| resolve_review* | sonnet | 1 | 229 | 14.0k | 1.5M | 69.9k | 70 | 53.7k | 7m 4s |
| **Total** | | | 150.4k | 146.9k | 9.9M | 76.7k | | 433.9k | 56m 28s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 61 | 37385.8 | 0.0 | 161.9 |
| merge_gate_fix | 7 | 146644.0 | 6864.1 | 2122.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 16 | 90746.6 | 3356.1 | 872.9 |
| **Total** | **84** | 118152.5 | 5165.9 | 1749.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 80 | 11.4k | 1.4M | 94.9k | 4m 51s |
| sonnet | 5 | 1.4k | 122.8k | 5.9M | 339.0k | 41m 33s |
| MiniMax-M3 | 3 | 149.0k | 12.7k | 2.7M | 0 | 10m 4s |