### PR TITLE
Implementation Plan: Enforce *Def/*Spec Naming Convention via Automated Guard

### DIFF
--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -462,6 +462,7 @@ classified `REJECT` with `category: "arch_violation"`.
 | No print | `test_ast_rules.py` (ARCH-001) | `print()` in production `src/` code |
 | No StrEnum-to-string compare | `test_ast_rules.py` (ARCH-010) | Comparing StrEnum fields to raw string literals |
 | Dataclass slots | `test_dataclass_slots.py` | `dataclass(frozen=True)` decorator without `slots=True` |
+| *Def/*Spec naming | `test_def_spec_naming.py` | `*Def` class that is not a `NamedTuple` or `@dataclass(frozen=True)`; `*Spec` class that is not a `@dataclass` or `TypedDict` |
 | Import layer ordering | `test_layer_enforcement.py` | Importing from a higher IL layer (e.g., IL-2 recipe/ imported by IL-0 core/) |
 | Anyio migration | `test_anyio_migration.py` | `asyncio.sleep`, `asyncio.Event`, `asyncio.to_thread` in `execution/process.py` |
 | Protocol types on ToolContext | `test_subpackage_isolation.py` | Concrete class types instead of Protocol types for ToolContext service fields |

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -36,6 +36,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_cascade_map_guard.py` | REQ-GUARD-001..003, 005: CI guard validating cascade maps against AST-derived reverse import graph |
 | `test_channel_b_timeout_guard.py` | AST guard: Channel B tests must use timeout >= TimeoutTier.CHANNEL_B |
 | `test_dataclass_slots.py` | Architectural invariant: every @dataclass(frozen=True) must also have slots=True |
+| `test_def_spec_naming.py` | Architectural guard: *Def classes must be NamedTuple or frozen dataclass; *Spec classes must be dataclass or TypedDict |
 | `test_cli_decomposition.py` | AST-level tests enforcing CLI decomposition and hook security hardening |
 | `test_dispatch_timeout_guard.py` | AST guard: _run_dispatch must call resolve_dispatch_timeout with no hardcoded 'or 1800' or falsy timeout patterns |
 | `test_doctor_readonly.py` | AST guard: run_doctor() must not perform filesystem mutations (REQ-DOCTOR-READONLY) |

--- a/tests/arch/test_def_spec_naming.py
+++ b/tests/arch/test_def_spec_naming.py
@@ -13,8 +13,11 @@ pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 
 _SRC = pathlib.Path(__file__).parent.parent.parent / "src" / "autoskillit"
 
+# Classes exempt from the *Def naming rule. Entries must be class names (str) and each
+# exempted class must carry an inline comment explaining why it deviates from the convention.
 _EXEMPT_DEF: frozenset[str] = frozenset()
 
+# Classes exempt from the *Spec naming rule. Same policy as _EXEMPT_DEF above.
 _EXEMPT_SPEC: frozenset[str] = frozenset()
 
 
@@ -72,7 +75,10 @@ def _is_typeddict(node: ast.ClassDef) -> bool:
 
 
 def _invalid_def_classes(path: pathlib.Path) -> list[tuple[int, str]]:
-    tree = ast.parse(path.read_text())
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []
     violations = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.ClassDef):
@@ -88,7 +94,10 @@ def _invalid_def_classes(path: pathlib.Path) -> list[tuple[int, str]]:
 
 
 def _invalid_spec_classes(path: pathlib.Path) -> list[tuple[int, str]]:
-    tree = ast.parse(path.read_text())
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []
     violations = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.ClassDef):
@@ -107,7 +116,7 @@ def test_def_classes_are_immutable() -> None:
     """Every class ending in *Def must be a NamedTuple or @dataclass(frozen=True)."""
     assert _SRC.is_dir(), f"Source directory not found: {_SRC}"
     all_violations: list[str] = []
-    for py_file in sorted(_SRC.rglob("*.py")):
+    for py_file in sorted(f for f in _SRC.rglob("*.py") if "__pycache__" not in f.parts):
         for lineno, cls_name in _invalid_def_classes(py_file):
             rel = py_file.relative_to(_SRC.parent.parent)
             all_violations.append(f"  {rel}:{lineno}  {cls_name}")
@@ -121,7 +130,7 @@ def test_spec_classes_are_dataclass_or_typeddict() -> None:
     """Every class ending in *Spec must be a @dataclass or TypedDict."""
     assert _SRC.is_dir(), f"Source directory not found: {_SRC}"
     all_violations: list[str] = []
-    for py_file in sorted(_SRC.rglob("*.py")):
+    for py_file in sorted(f for f in _SRC.rglob("*.py") if "__pycache__" not in f.parts):
         for lineno, cls_name in _invalid_spec_classes(py_file):
             rel = py_file.relative_to(_SRC.parent.parent)
             all_violations.append(f"  {rel}:{lineno}  {cls_name}")

--- a/tests/arch/test_def_spec_naming.py
+++ b/tests/arch/test_def_spec_naming.py
@@ -1,0 +1,211 @@
+"""Architectural guard: *Def/*Spec naming convention — structural form must match suffix.
+
+*Def classes must be NamedTuple or @dataclass(frozen=True).
+*Spec classes must be @dataclass (any) or TypedDict.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+_SRC = pathlib.Path(__file__).parent.parent.parent / "src" / "autoskillit"
+
+_EXEMPT_DEF: frozenset[str] = frozenset()
+
+_EXEMPT_SPEC: frozenset[str] = frozenset()
+
+
+def _is_namedtuple(node: ast.ClassDef) -> bool:
+    return any(
+        (isinstance(b, ast.Name) and b.id == "NamedTuple")
+        or (isinstance(b, ast.Attribute) and b.attr == "NamedTuple")
+        for b in node.bases
+    )
+
+
+def _is_dataclass(node: ast.ClassDef, *, require_frozen: bool = False) -> bool:
+    for dec in node.decorator_list:
+        if isinstance(dec, ast.Name) and dec.id == "dataclass":
+            return not require_frozen
+        if (
+            isinstance(dec, ast.Attribute)
+            and isinstance(dec.value, ast.Name)
+            and dec.value.id == "dataclasses"
+            and dec.attr == "dataclass"
+        ):
+            return not require_frozen
+        if not isinstance(dec, ast.Call):
+            continue
+        func = dec.func
+        if isinstance(func, ast.Name) and func.id == "dataclass":
+            pass
+        elif (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "dataclasses"
+            and func.attr == "dataclass"
+        ):
+            pass
+        else:
+            continue
+        if not require_frozen:
+            return True
+        return any(
+            isinstance(kw, ast.keyword)
+            and kw.arg == "frozen"
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value is True
+            for kw in dec.keywords
+        )
+    return False
+
+
+def _is_typeddict(node: ast.ClassDef) -> bool:
+    return any(
+        (isinstance(b, ast.Name) and b.id == "TypedDict")
+        or (isinstance(b, ast.Attribute) and b.attr == "TypedDict")
+        for b in node.bases
+    )
+
+
+def _invalid_def_classes(path: pathlib.Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text())
+    violations = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if not node.name.endswith("Def"):
+            continue
+        if node.name in _EXEMPT_DEF:
+            continue
+        if _is_namedtuple(node) or _is_dataclass(node, require_frozen=True):
+            continue
+        violations.append((node.lineno, node.name))
+    return violations
+
+
+def _invalid_spec_classes(path: pathlib.Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text())
+    violations = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if not node.name.endswith("Spec"):
+            continue
+        if node.name in _EXEMPT_SPEC:
+            continue
+        if _is_dataclass(node) or _is_typeddict(node):
+            continue
+        violations.append((node.lineno, node.name))
+    return violations
+
+
+def test_def_classes_are_immutable() -> None:
+    """Every class ending in *Def must be a NamedTuple or @dataclass(frozen=True)."""
+    assert _SRC.is_dir(), f"Source directory not found: {_SRC}"
+    all_violations: list[str] = []
+    for py_file in sorted(_SRC.rglob("*.py")):
+        for lineno, cls_name in _invalid_def_classes(py_file):
+            rel = py_file.relative_to(_SRC.parent.parent)
+            all_violations.append(f"  {rel}:{lineno}  {cls_name}")
+    assert not all_violations, (
+        f"Found {len(all_violations)} *Def class(es) that are not NamedTuple "
+        f"or @dataclass(frozen=True):\n" + "\n".join(all_violations)
+    )
+
+
+def test_spec_classes_are_dataclass_or_typeddict() -> None:
+    """Every class ending in *Spec must be a @dataclass or TypedDict."""
+    assert _SRC.is_dir(), f"Source directory not found: {_SRC}"
+    all_violations: list[str] = []
+    for py_file in sorted(_SRC.rglob("*.py")):
+        for lineno, cls_name in _invalid_spec_classes(py_file):
+            rel = py_file.relative_to(_SRC.parent.parent)
+            all_violations.append(f"  {rel}:{lineno}  {cls_name}")
+    assert not all_violations, (
+        f"Found {len(all_violations)} *Spec class(es) that are not "
+        f"@dataclass or TypedDict:\n" + "\n".join(all_violations)
+    )
+
+
+# --- Calibration tests ---
+
+
+def test_def_guard_catches_plain_dataclass(tmp_path: pathlib.Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text("from dataclasses import dataclass\n\n@dataclass\nclass BadDef:\n    x: int\n")
+    assert _invalid_def_classes(src) == [(4, "BadDef")]
+
+
+def test_def_guard_catches_plain_class(tmp_path: pathlib.Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text("class PlainDef:\n    x: int\n")
+    assert _invalid_def_classes(src) == [(1, "PlainDef")]
+
+
+def test_def_guard_allows_frozen_dataclass(tmp_path: pathlib.Path) -> None:
+    src = tmp_path / "good.py"
+    src.write_text(
+        "from dataclasses import dataclass\n\n"
+        "@dataclass(frozen=True)\n"
+        "class GoodDef:\n"
+        "    x: int\n"
+    )
+    assert _invalid_def_classes(src) == []
+
+
+def test_def_guard_allows_frozen_dataclass_module_qualified(tmp_path: pathlib.Path) -> None:
+    src = tmp_path / "good.py"
+    src.write_text(
+        "import dataclasses\n\n"
+        "@dataclasses.dataclass(frozen=True, slots=True)\n"
+        "class GoodDef:\n"
+        "    x: int\n"
+    )
+    assert _invalid_def_classes(src) == []
+
+
+def test_def_guard_allows_namedtuple(tmp_path: pathlib.Path) -> None:
+    src = tmp_path / "good.py"
+    src.write_text("from typing import NamedTuple\n\nclass GoodDef(NamedTuple):\n    x: int\n")
+    assert _invalid_def_classes(src) == []
+
+
+def test_spec_guard_catches_plain_class(tmp_path: pathlib.Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text("class BadSpec:\n    x: int\n")
+    assert _invalid_spec_classes(src) == [(1, "BadSpec")]
+
+
+def test_spec_guard_catches_namedtuple(tmp_path: pathlib.Path) -> None:
+    src = tmp_path / "bad.py"
+    src.write_text("from typing import NamedTuple\n\nclass BadSpec(NamedTuple):\n    x: int\n")
+    assert _invalid_spec_classes(src) == [(3, "BadSpec")]
+
+
+def test_spec_guard_allows_dataclass(tmp_path: pathlib.Path) -> None:
+    src = tmp_path / "good.py"
+    src.write_text(
+        "from dataclasses import dataclass\n\n@dataclass\nclass GoodSpec:\n    x: int\n"
+    )
+    assert _invalid_spec_classes(src) == []
+
+
+def test_spec_guard_allows_frozen_dataclass(tmp_path: pathlib.Path) -> None:
+    src = tmp_path / "good.py"
+    src.write_text(
+        "from dataclasses import dataclass\n\n"
+        "@dataclass(frozen=True, slots=True)\n"
+        "class GoodSpec:\n"
+        "    x: int\n"
+    )
+    assert _invalid_spec_classes(src) == []
+
+
+def test_spec_guard_allows_typeddict(tmp_path: pathlib.Path) -> None:
+    src = tmp_path / "good.py"
+    src.write_text("from typing import TypedDict\n\nclass GoodSpec(TypedDict):\n    x: int\n")
+    assert _invalid_spec_classes(src) == []


### PR DESCRIPTION
## Summary

Add a new AST-based architectural guard test (`tests/arch/test_def_spec_naming.py`) that enforces the `*Def`/`*Spec` naming convention documented in CLAUDE.md. The test scans all classes in `src/autoskillit/` and verifies:

- Classes ending in `Def` are either `NamedTuple` or `@dataclass(frozen=True)`
- Classes ending in `Spec` are either `@dataclass` (frozen or not) or `TypedDict`

Follows the standalone AST guard pattern established by `test_dataclass_slots.py`. Includes 10 calibration tests to validate detection accuracy and empty allowlists for future documented deviations. Updates `tests/arch/CLAUDE.md` to register the new file and adds the constraint to the resolve-review Architectural Constraint Catalog.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260604-042255-530142/.autoskillit/temp/make-plan/enforce_def_spec_naming_convention_via_automated_guard_plan_2026-06-04_042930.md`

Closes #3691

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 4.6k | 25.4k | 1.1M | 98.4k | 37 | 86.9k | 13m 45s |
| verify* | sonnet | 1 | 68 | 10.4k | 362.4k | 70.4k | 23 | 53.7k | 12m 15s |
| implement* | MiniMax-M3 | 1 | 56.7k | 6.2k | 960.1k | 61.4k | 51 | 0 | 3m 15s |
| audit_impl* | sonnet | 1 | 54 | 11.3k | 181.3k | 41.4k | 18 | 37.1k | 4m 7s |
| prepare_pr* | MiniMax-M3 | 1 | 40.8k | 2.0k | 159.1k | 43.8k | 14 | 0 | 56s |
| compose_pr* | MiniMax-M3 | 1 | 34.7k | 1.2k | 149.3k | 38.2k | 13 | 0 | 1m 0s |
| review_pr* | sonnet | 1 | 140 | 37.0k | 928.0k | 87.5k | 44 | 71.7k | 7m 48s |
| resolve_review* | sonnet | 1 | 165 | 8.8k | 1.2M | 72.1k | 52 | 55.9k | 4m 11s |
| **Total** | | | 137.2k | 102.3k | 5.0M | 98.4k | | 305.3k | 47m 21s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 213 | 4507.4 | 0.0 | 29.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 17 | 69859.4 | 3288.3 | 518.4 |
| **Total** | **230** | 21704.5 | 1327.6 | 444.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 4.6k | 25.4k | 1.1M | 86.9k | 13m 45s |
| sonnet | 4 | 427 | 67.5k | 2.7M | 218.5k | 28m 23s |
| MiniMax-M3 | 3 | 132.2k | 9.4k | 1.3M | 0 | 5m 12s |