### PR TITLE
Implementation Plan: Provide the Single Authoritative Phoropter Registry

### DIFF
--- a/src/autoskillit/assets/phoropter-registry.yaml
+++ b/src/autoskillit/assets/phoropter-registry.yaml
@@ -1,0 +1,68 @@
+schema_version: 1
+
+families:
+  arch-lens:
+    description: Architectural diagram generation across 13 structural lenses
+    output_type: diagram
+    mode_label: Architecture Impact
+    lens_count: 13
+    default_enabled: true
+    failure_mode: continue
+    arg_interface: 1-arg
+    dial_skill: prepare-pr
+    synthesis:
+      strategy: null
+    step_naming:
+      prefix: null
+    status: implemented
+
+  exp-lens:
+    description: Experiment design assessment across 18 methodological lenses
+    output_type: assessment
+    mode_label: Experiment Design
+    lens_count: 18
+    default_enabled: true
+    failure_mode: continue
+    arg_interface: 2-arg
+    dial_skill: prepare-research-pr
+    synthesis:
+      strategy: priority_hierarchy
+    step_naming:
+      prefix: null
+    status: implemented
+
+  vis-lens:
+    description: Figure specification output across 12 visualization lenses
+    output_type: figure_spec
+    mode_label: Visualization Plan
+    lens_count: 12
+    default_enabled: true
+    failure_mode: continue
+    arg_interface: 2-arg
+    dial_skill: select-vis-lenses
+    synthesis:
+      strategy: priority_hierarchy
+      skill: synthesize-vis-plan
+    step_naming:
+      prefix: vis
+    phase_skip:
+      skip_field: context.is_silent_type
+      skip_semantics: skip_when_true
+      applies_to: apply
+    lens_metadata: {}
+    status: implemented
+
+  refactor-lens:
+    description: Future refactoring assessment for codebase evolution analysis
+    output_type: assessment
+    mode_label: Refactoring Assessment
+    lens_count: 0
+    default_enabled: false
+    failure_mode: continue
+    arg_interface: 2-arg
+    dial_skill: null
+    synthesis:
+      strategy: electre_iii
+    step_naming:
+      prefix: refactor
+    status: designed

--- a/src/autoskillit/assets/phoropter-registry.yaml
+++ b/src/autoskillit/assets/phoropter-registry.yaml
@@ -49,7 +49,7 @@ families:
       skip_field: context.is_silent_type
       skip_semantics: skip_when_true
       applies_to: apply
-    lens_metadata: {}
+    lens_metadata: {}  # vis-lens-specific extension point; other families omit this field intentionally
     status: implemented
 
   refactor-lens:

--- a/tests/assets/CLAUDE.md
+++ b/tests/assets/CLAUDE.md
@@ -8,3 +8,4 @@ Vendored asset integrity tests.
 |------|---------|
 | `__init__.py` | empty |
 | `test_mermaid_vendored.py` | REQ-R741-A01/A04: Vendored mermaid.min.js presence and size |
+| `test_phoropter_registry.py` | T2-P1-A5-WP1: Phoropter registry YAML schema and field validation |

--- a/tests/assets/test_phoropter_registry.py
+++ b/tests/assets/test_phoropter_registry.py
@@ -51,7 +51,7 @@ def test_schema_version_is_one(registry_data: dict) -> None:
     )
 
 
-def test_families_has_exactly_four_entries(registry_data: dict) -> None:
+def test_families_keys_match_expected_set(registry_data: dict) -> None:
     """families must contain exactly the four expected phoropter lens families."""
     families = registry_data.get("families", {})
     assert set(families.keys()) == EXPECTED_FAMILIES, (

--- a/tests/assets/test_phoropter_registry.py
+++ b/tests/assets/test_phoropter_registry.py
@@ -1,0 +1,146 @@
+"""T2-P1-A5-WP1: Phoropter registry YAML schema and field validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import load_yaml, pkg_root
+
+pytestmark = [pytest.mark.medium]
+
+REGISTRY_PATH = pkg_root() / "assets" / "phoropter-registry.yaml"
+EXPECTED_FAMILIES = {"arch-lens", "exp-lens", "vis-lens", "refactor-lens"}
+REQUIRED_FIELDS = frozenset(
+    {
+        "description",
+        "output_type",
+        "mode_label",
+        "lens_count",
+        "default_enabled",
+        "failure_mode",
+        "arg_interface",
+        "dial_skill",
+        "synthesis",
+        "step_naming",
+        "status",
+    }
+)
+
+
+@pytest.fixture(scope="module")
+def registry_data() -> dict:
+    return load_yaml(REGISTRY_PATH)
+
+
+def test_registry_file_exists() -> None:
+    """phoropter-registry.yaml must exist at the canonical assets path."""
+    assert REGISTRY_PATH.exists(), f"phoropter-registry.yaml not found at {REGISTRY_PATH}"
+    assert REGISTRY_PATH.is_file(), f"{REGISTRY_PATH} is not a regular file"
+
+
+def test_registry_is_valid_yaml() -> None:
+    """Loading the file with load_yaml() must yield a dict."""
+    data = load_yaml(REGISTRY_PATH)
+    assert isinstance(data, dict), f"Expected dict, got {type(data).__name__}"
+
+
+def test_schema_version_is_one(registry_data: dict) -> None:
+    """schema_version must be the integer 1 (not the string '1')."""
+    assert registry_data.get("schema_version") == 1, (
+        f"Expected schema_version=1, got {registry_data.get('schema_version')!r}"
+    )
+
+
+def test_families_has_exactly_four_entries(registry_data: dict) -> None:
+    """families must contain exactly the four expected phoropter lens families."""
+    families = registry_data.get("families", {})
+    assert set(families.keys()) == EXPECTED_FAMILIES, (
+        f"Expected families={EXPECTED_FAMILIES}, got {set(families.keys())}"
+    )
+
+
+def test_all_families_have_required_fields(registry_data: dict) -> None:
+    """Each family entry must include every required field."""
+    families = registry_data["families"]
+    for name, entry in families.items():
+        missing = REQUIRED_FIELDS - set(entry.keys())
+        assert not missing, f"Family {name!r} missing required fields: {sorted(missing)}"
+
+
+def test_arch_lens_fields(registry_data: dict) -> None:
+    """arch-lens entry must match the documented field values."""
+    entry = registry_data["families"]["arch-lens"]
+    assert entry["output_type"] == "diagram"
+    assert entry["lens_count"] == 13
+    assert entry["arg_interface"] == "1-arg"
+    assert entry["dial_skill"] == "prepare-pr"
+    assert entry["synthesis"]["strategy"] is None
+    assert entry["step_naming"]["prefix"] is None
+    assert entry["status"] == "implemented"
+    assert entry["default_enabled"] is True
+    assert entry["failure_mode"] == "continue"
+    assert "phase_skip" not in entry
+
+
+def test_exp_lens_fields(registry_data: dict) -> None:
+    """exp-lens entry must match the documented field values."""
+    entry = registry_data["families"]["exp-lens"]
+    assert entry["output_type"] == "assessment"
+    assert entry["lens_count"] == 18
+    assert entry["arg_interface"] == "2-arg"
+    assert entry["dial_skill"] == "prepare-research-pr"
+    assert entry["synthesis"]["strategy"] == "priority_hierarchy"
+    assert "skill" not in entry["synthesis"]
+    assert entry["step_naming"]["prefix"] is None
+    assert entry["status"] == "implemented"
+    assert "phase_skip" not in entry
+
+
+def test_vis_lens_fields(registry_data: dict) -> None:
+    """vis-lens entry must match the documented field values."""
+    entry = registry_data["families"]["vis-lens"]
+    assert entry["output_type"] == "figure_spec"
+    assert entry["lens_count"] == 12
+    assert entry["arg_interface"] == "2-arg"
+    assert entry["dial_skill"] == "select-vis-lenses"
+    assert entry["synthesis"]["strategy"] == "priority_hierarchy"
+    assert entry["synthesis"]["skill"] == "synthesize-vis-plan"
+    assert entry["step_naming"]["prefix"] == "vis"
+    assert entry["status"] == "implemented"
+    assert entry["phase_skip"]["skip_field"] == "context.is_silent_type"
+    assert entry["phase_skip"]["skip_semantics"] == "skip_when_true"
+    assert entry["phase_skip"]["applies_to"] == "apply"
+    assert "lens_metadata" in entry
+    assert isinstance(entry["lens_metadata"], dict)
+
+
+def test_refactor_lens_fields(registry_data: dict) -> None:
+    """refactor-lens entry must match the documented field values."""
+    entry = registry_data["families"]["refactor-lens"]
+    assert entry["lens_count"] == 0
+    assert entry["default_enabled"] is False
+    assert entry["synthesis"]["strategy"] == "electre_iii"
+    assert entry["step_naming"]["prefix"] == "refactor"
+    assert entry["status"] == "designed"
+    assert entry["dial_skill"] is None
+    assert "phase_skip" not in entry
+
+
+def test_dial_skill_present_on_every_family(registry_data: dict) -> None:
+    """Every family must declare dial_skill (value may be None for unimplemented families)."""
+    families = registry_data["families"]
+    for name, entry in families.items():
+        assert "dial_skill" in entry, f"Family {name!r} missing dial_skill key"
+
+
+def test_lens_counts_match_actual_directories(registry_data: dict) -> None:
+    """For implemented families, the directory glob count must equal the registry's lens_count."""
+    families = registry_data["families"]
+    skills_root = pkg_root() / "skills_extended"
+    for slug in ("arch-lens", "exp-lens", "vis-lens"):
+        entry = families[slug]
+        matches = list(skills_root.glob(f"{slug}-*"))
+        assert len(matches) == entry["lens_count"], (
+            f"{slug}: registry claims {entry['lens_count']} lenses but "
+            f"{skills_root} contains {len(matches)} matching directories"
+        )


### PR DESCRIPTION
## Summary

Create `src/autoskillit/assets/phoropter-registry.yaml` — a machine-readable catalog of all four phoropter lens families (arch-lens, exp-lens, vis-lens, refactor-lens). This is a pure data file with no Python loader; downstream phases consume it via standard `pkg_root() / "assets" / "phoropter-registry.yaml"` path resolution and `load_yaml()`. No existing Python files are modified.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260604-044935-681695/.autoskillit/temp/make-plan/t2-p1-a5-wp1-phoropter-registry_plan_2026-06-04_050300.md`

Closes #3703

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 752 | 10.1k | 535.4k | 60.3k | 27 | 46.9k | 10m 32s |
| verify* | sonnet | 1 | 76 | 6.6k | 322.7k | 44.5k | 24 | 27.8k | 4m 41s |
| implement* | MiniMax-M3 | 1 | 48.7k | 9.1k | 1.7M | 57.4k | 74 | 0 | 5m 26s |
| audit_impl* | sonnet | 1 | 46 | 11.1k | 143.9k | 37.8k | 17 | 34.8k | 3m 37s |
| prepare_pr* | MiniMax-M3 | 1 | 40.2k | 2.1k | 157.3k | 43.4k | 11 | 0 | 1m 0s |
| compose_pr* | MiniMax-M3 | 1 | 34.7k | 1.1k | 149.0k | 38.0k | 13 | 0 | 44s |
| review_pr* | sonnet | 1 | 156 | 32.0k | 928.4k | 75.8k | 47 | 60.3k | 6m 21s |
| resolve_review* | sonnet | 1 | 165 | 8.8k | 1.0M | 61.3k | 48 | 45.2k | 3m 45s |
| **Total** | | | 124.8k | 81.0k | 5.0M | 75.8k | | 215.1k | 36m 8s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 221 | 7907.0 | 0.0 | 41.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 251243.0 | 11305.2 | 2204.8 |
| **Total** | **225** | 22173.8 | 955.8 | 359.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 752 | 10.1k | 535.4k | 46.9k | 10m 32s |
| sonnet | 4 | 443 | 58.6k | 2.4M | 168.1k | 18m 25s |
| MiniMax-M3 | 3 | 123.6k | 12.3k | 2.1M | 0 | 7m 11s |