### PR TITLE
Implementation Plan: Provide the Authoritative Phoropter Types Test File

### DIFF
--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -51,6 +51,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_types.py` | Tests for shared type contracts — enum exhaustiveness |
 | `test_types_structure.py` | Tests for core/types.py split into focused sub-modules (P8-F2) |
 | `test_type_results_execution.py` | Tests for _type_results_execution.py — execution-scoped types |
+| `test_types_phoropter.py` | Authoritative phoropter type tests — frozen invariants, `__all__` guard, gateway accessibility for all `_type_phoropter` and `SynthesisStrategy` types |
 | `test_validated_worktree_path.py` | Tests for ValidatedWorktreePath construction contracts |
 | `test_version_snapshot.py` | Tests for core/_version_snapshot.py |
 | `test_version_snapshot_codex_routing.py` | Codex version snapshot routing tests — verifies collect_version_snapshot() routes codex_version correctly by AUTOSKILLIT_AGENT_BACKEND |

--- a/tests/core/test_types_phoropter.py
+++ b/tests/core/test_types_phoropter.py
@@ -82,6 +82,9 @@ class TestCrossdomainStubs:
 
 
 def test_all_guard() -> None:
+    # SynthesisStrategy is intentionally absent: defined in _type_enums, not _type_phoropter.
+    # It reaches autoskillit.core via a separate re-export path
+    # (verified by test_importable_from_gateway).
     from autoskillit.core.types._type_phoropter import __all__ as phoropter_all
 
     assert set(phoropter_all) == {

--- a/tests/core/test_types_phoropter.py
+++ b/tests/core/test_types_phoropter.py
@@ -1,0 +1,109 @@
+"""Authoritative phoropter type tests — frozen, exported, accessible."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from autoskillit.core import (
+    CrossDomainAssessment,
+    CrossDomainPrescription,
+    PhoropterPhaseSkip,
+    PhoropterPrescription,
+    SynthesisStrategy,
+)
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+class TestPhoropterPrescription:
+    def test_frozen_rejects_mutation(self) -> None:
+        obj = PhoropterPrescription(selected_lenses="a", lens_context_paths="b")
+        with pytest.raises(FrozenInstanceError):
+            obj.selected_lenses = "x"  # type: ignore[misc]
+
+    def test_failure_mode_default_is_continue(self) -> None:
+        obj = PhoropterPrescription(selected_lenses="a", lens_context_paths="b")
+        assert obj.failure_mode == "continue"
+
+
+class TestSynthesisStrategy:
+    def test_exhaustive_members(self) -> None:
+        assert set(SynthesisStrategy) == {
+            SynthesisStrategy.NULL,
+            SynthesisStrategy.PRIORITY_HIERARCHY,
+            SynthesisStrategy.ELECTRE_III,
+            SynthesisStrategy.DEX,
+            SynthesisStrategy.CUSTOM,
+        }
+
+    def test_str_enum_equality(self) -> None:
+        assert SynthesisStrategy.NULL == "null"
+
+
+class TestPhoropterPhaseSkip:
+    def test_skip_when_true_accepted(self) -> None:
+        obj = PhoropterPhaseSkip(skip_field="ctx.x", skip_semantics="skip_when_true")
+        assert obj.skip_semantics == "skip_when_true"
+
+    def test_skip_when_false_accepted(self) -> None:
+        obj = PhoropterPhaseSkip(skip_field="ctx.x", skip_semantics="skip_when_false")
+        assert obj.skip_semantics == "skip_when_false"
+
+    def test_frozen(self) -> None:
+        obj = PhoropterPhaseSkip(skip_field="f", skip_semantics="skip_when_true")
+        with pytest.raises(FrozenInstanceError):
+            obj.skip_field = "x"  # type: ignore[misc]
+
+    def test_applies_to_defaults_to_empty_string(self) -> None:
+        obj = PhoropterPhaseSkip(skip_field="context.x", skip_semantics="skip_when_true")
+        assert obj.applies_to == ""
+
+
+class TestCrossdomainStubs:
+    def test_cross_domain_prescription_instantiable(self) -> None:
+        obj = CrossDomainPrescription(family_names=("a", "b"))
+        assert obj.family_names == ("a", "b")
+
+    def test_cross_domain_assessment_instantiable(self) -> None:
+        obj = CrossDomainAssessment(family_names=("a",))
+        assert obj.family_names == ("a",)
+
+    def test_cross_domain_prescription_frozen(self) -> None:
+        obj = CrossDomainPrescription(family_names=("a",))
+        with pytest.raises(FrozenInstanceError):
+            obj.family_names = ("x",)  # type: ignore[misc]
+
+    def test_cross_domain_assessment_frozen(self) -> None:
+        obj = CrossDomainAssessment(family_names=("a",))
+        with pytest.raises(FrozenInstanceError):
+            obj.family_names = ("x",)  # type: ignore[misc]
+
+
+def test_all_guard() -> None:
+    from autoskillit.core.types._type_phoropter import __all__ as phoropter_all
+
+    assert set(phoropter_all) == {
+        "PhoropterPrescription",
+        "ReadingToken",
+        "READING_TOKEN_PATTERN",
+        "PhoropterPhaseSkip",
+        "CrossDomainPrescription",
+        "CrossDomainAssessment",
+    }
+
+
+def test_importable_from_gateway() -> None:
+    import autoskillit.core as core
+
+    for name in (
+        "PhoropterPrescription",
+        "ReadingToken",
+        "READING_TOKEN_PATTERN",
+        "PhoropterPhaseSkip",
+        "CrossDomainPrescription",
+        "CrossDomainAssessment",
+        "SynthesisStrategy",
+    ):
+        assert hasattr(core, name), f"{name} not importable from autoskillit.core"


### PR DESCRIPTION
## Summary

Create `tests/core/test_types_phoropter.py` — the authoritative test file verifying every IL-0 phoropter type from `_type_phoropter.py` is correctly frozen (`FrozenInstanceError`), exported via `__all__`, and accessible through the `autoskillit.core` gateway. The file contains four test classes (`TestPhoropterPrescription`, `TestSynthesisStrategy`, `TestPhoropterPhaseSkip`, `TestCrossdomainStubs`) plus two module-level guard tests (`test_all_guard`, `test_importable_from_gateway`).

**Key design decision:** The existing file at `tests/core/types/test_type_phoropter.py` (from T2-P1-A2) uses `AttributeError` for frozen checks because it was written when the types were NamedTuples. The current types are `@dataclass(frozen=True)` which raises `FrozenInstanceError`. This new file uses the correct `FrozenInstanceError` pattern (matching the `InspectorEvidence.test_frozen` canonical pattern in `test_inspector_types.py`) and imports from the `autoskillit.core` gateway (not from internal modules).

Closes #3704

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260604-055915-100911/.autoskillit/temp/make-plan/provide-authoritative-test-file-phoropter-types_plan_2026-06-04_060300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 171 | 520 | 2.9M | 78.1k | 57 | 369.4k | 8m 28s |
| verify* | sonnet | 1 | 60 | 9.8k | 240.6k | 47.2k | 22 | 30.6k | 3m 37s |
| implement* | MiniMax-M3 | 1 | 70.8k | 4.8k | 1.2M | 67.5k | 47 | 0 | 3m 22s |
| audit_impl* | sonnet | 1 | 2.1k | 5.6k | 140.0k | 34.1k | 14 | 25.3k | 2m 31s |
| prepare_pr* | MiniMax-M3 | 1 | 39.5k | 2.6k | 116.9k | 43.8k | 13 | 0 | 1m 5s |
| compose_pr* | MiniMax-M3 | 1 | 36.5k | 1.4k | 148.2k | 38.3k | 11 | 0 | 51s |
| review_pr* | sonnet | 1 | 140 | 13.2k | 709.0k | 55.0k | 37 | 39.0k | 3m 56s |
| resolve_review* | sonnet | 1 | 165 | 8.3k | 1.0M | 64.0k | 46 | 47.8k | 3m 51s |
| **Total** | | | 149.4k | 46.1k | 6.5M | 78.1k | | 512.1k | 27m 43s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 110 | 10768.1 | 0.0 | 43.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 3 | 337426.7 | 15945.0 | 2750.3 |
| **Total** | **113** | 57171.8 | 4532.0 | 407.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 171 | 520 | 2.9M | 369.4k | 8m 28s |
| sonnet | 4 | 2.4k | 36.9k | 2.1M | 142.7k | 13m 56s |
| MiniMax-M3 | 3 | 146.8k | 8.7k | 1.4M | 0 | 5m 18s |