### PR TITLE
Implementation Plan: Make vis_dial capture block in research-design.yaml match research.yaml

### DIFF
--- a/src/autoskillit/recipes/research-design.json
+++ b/src/autoskillit/recipes/research-design.json
@@ -206,11 +206,14 @@
         "skill_command": "/autoskillit:select-vis-lenses ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "vis_dial",
-        "output_dir": "{{AUTOSKILLIT_TEMP}}/dial"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/select-vis-lenses"
       },
       "capture": {
         "selected_lenses": "${{ result.selected_lenses }}",
-        "lens_context_paths": "${{ result.lens_context_paths }}"
+        "lens_context_paths": "${{ result.lens_context_paths }}",
+        "disambiguation_rule_applied": "${{ result.disambiguation_rule_applied }}",
+        "tier_c_lens": "${{ result.tier_c_lens }}",
+        "methodology_tradition": "${{ result.methodology_tradition }}"
       },
       "on_success": "vis_apply",
       "on_failure": "escalate_stop"
@@ -222,10 +225,10 @@
         "skill_command": "/autoskillit:vis-lens-{slug} {context_path} ${{ context.experiment_plan }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "vis_apply",
-        "output_dir": "{{AUTOSKILLIT_TEMP}}/apply"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/run-vis-lenses"
       },
       "capture_list": {
-        "all_figure_spec_paths": "${{ result.figure_spec_path }}"
+        "vis_lens_output_paths": "${{ result.diagram_path }}"
       },
       "optional_context_refs": [
         "selected_lenses",
@@ -239,10 +242,10 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:synthesize-vis-plan ${{ inputs.source_dir }} ${{ context.experiment_plan }} {{AUTOSKILLIT_TEMP}}/apply",
+        "skill_command": "/autoskillit:synthesize-vis-plan ${{ inputs.source_dir }} ${{ context.experiment_plan }} {{AUTOSKILLIT_TEMP}}/run-vis-lenses --tier-c-lens=${{ context.tier_c_lens }} --methodology-tradition=${{ context.methodology_tradition }} --disambiguation-rule-applied=${{ context.disambiguation_rule_applied }}",
         "cwd": "${{ inputs.source_dir }}",
         "step_name": "vis_synthesize",
-        "output_dir": "{{AUTOSKILLIT_TEMP}}/synthesize"
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/synthesize-vis-plan"
       },
       "capture": {
         "visualization_plan_path": "${{ result.visualization_plan_path }}",

--- a/src/autoskillit/recipes/research-design.yaml
+++ b/src/autoskillit/recipes/research-design.yaml
@@ -181,10 +181,13 @@ steps:
       skill_command: "/autoskillit:select-vis-lenses ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: vis_dial
-      output_dir: "{{AUTOSKILLIT_TEMP}}/dial"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/select-vis-lenses"
     capture:
       selected_lenses: "${{ result.selected_lenses }}"
       lens_context_paths: "${{ result.lens_context_paths }}"
+      disambiguation_rule_applied: "${{ result.disambiguation_rule_applied }}"
+      tier_c_lens: "${{ result.tier_c_lens }}"
+      methodology_tradition: "${{ result.methodology_tradition }}"
     on_success: vis_apply
     on_failure: escalate_stop
 
@@ -195,9 +198,9 @@ steps:
       skill_command: "/autoskillit:vis-lens-{slug} {context_path} ${{ context.experiment_plan }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: vis_apply
-      output_dir: "{{AUTOSKILLIT_TEMP}}/apply"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/run-vis-lenses"
     capture_list:
-      all_figure_spec_paths: "${{ result.figure_spec_path }}"
+      vis_lens_output_paths: "${{ result.diagram_path }}"
     optional_context_refs: [selected_lenses, lens_context_paths]
     retries: 0
     on_success: vis_synthesize
@@ -207,10 +210,10 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: "/autoskillit:synthesize-vis-plan ${{ inputs.source_dir }} ${{ context.experiment_plan }} {{AUTOSKILLIT_TEMP}}/apply"
+      skill_command: "/autoskillit:synthesize-vis-plan ${{ inputs.source_dir }} ${{ context.experiment_plan }} {{AUTOSKILLIT_TEMP}}/run-vis-lenses --tier-c-lens=${{ context.tier_c_lens }} --methodology-tradition=${{ context.methodology_tradition }} --disambiguation-rule-applied=${{ context.disambiguation_rule_applied }}"
       cwd: "${{ inputs.source_dir }}"
       step_name: vis_synthesize
-      output_dir: "{{AUTOSKILLIT_TEMP}}/synthesize"
+      output_dir: "{{AUTOSKILLIT_TEMP}}/synthesize-vis-plan"
     capture:
       visualization_plan_path: "${{ result.visualization_plan_path }}"
       report_plan_path: "${{ result.report_plan_path }}"

--- a/tests/recipe/test_bundled_recipes_research_design.py
+++ b/tests/recipe/test_bundled_recipes_research_design.py
@@ -231,7 +231,7 @@ class TestResearchDesignRecipeStructure:
         assert recipe.steps["vis_apply"].phoropter_family is None
 
     def test_vis_apply_capture_list(self, recipe) -> None:
-        assert "all_figure_spec_paths" in recipe.steps["vis_apply"].capture_list
+        assert "vis_lens_output_paths" in recipe.steps["vis_apply"].capture_list
 
     def test_vis_apply_retries_zero(self, recipe) -> None:
         assert recipe.steps["vis_apply"].retries == 0

--- a/tests/recipe/test_bundled_recipes_research_design.py
+++ b/tests/recipe/test_bundled_recipes_research_design.py
@@ -224,7 +224,13 @@ class TestResearchDesignRecipeStructure:
 
     def test_vis_dial_captures(self, recipe) -> None:
         capture = recipe.steps["vis_dial"].capture
-        for key in ("selected_lenses", "lens_context_paths"):
+        for key in (
+            "selected_lenses",
+            "lens_context_paths",
+            "disambiguation_rule_applied",
+            "tier_c_lens",
+            "methodology_tradition",
+        ):
             assert key in capture, f"vis_dial missing capture key: {key}"
 
     def test_vis_apply_phoropter_family(self, recipe) -> None:


### PR DESCRIPTION
## Summary

Align three vis-lens pipeline steps in `src/autoskillit/recipes/research-design.yaml` with their canonical counterparts in `src/autoskillit/recipes/research.yaml`. Six edits bring the `vis_dial`, `vis_apply`, and `vis_synthesize` steps into parity: adding three Tier-C token captures to `vis_dial`, renaming output directories to match the canonical paths, renaming the `vis_apply` capture_list key/value, and updating the `vis_synthesize` skill_command with Tier-C named flags. After editing, regenerate the contract card and compiled JSON.

Closes #3705

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260604-065723-917591/.autoskillit/temp/make-plan/vis-dial-tier-c-capture-alignment_plan_2026-06-04_070300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 48 | 10.6k | 617.1k | 70.4k | 26 | 57.4k | 5m 18s |
| verify* | sonnet | 1 | 580 | 7.7k | 356.9k | 56.0k | 24 | 39.4k | 2m 48s |
| implement* | MiniMax-M3 | 1 | 49.5k | 7.7k | 1.5M | 54.4k | 86 | 0 | 5m 3s |
| fix* | sonnet | 1 | 126 | 4.5k | 612.6k | 52.0k | 37 | 35.6k | 3m 35s |
| audit_impl* | sonnet | 1 | 2.7k | 12.4k | 231.6k | 47.0k | 20 | 32.6k | 5m 54s |
| prepare_pr* | MiniMax-M3 | 1 | 42.2k | 2.4k | 328.3k | 45.6k | 18 | 0 | 1m 21s |
| compose_pr* | MiniMax-M3 | 1 | 37.1k | 1.2k | 147.0k | 38.2k | 12 | 0 | 46s |
| review_pr* | sonnet | 1 | 140 | 14.1k | 712.4k | 56.2k | 43 | 40.7k | 3m 58s |
| resolve_review* | sonnet | 1 | 165 | 5.5k | 939.7k | 60.3k | 43 | 43.9k | 3m 16s |
| **Total** | | | 132.6k | 66.3k | 5.5M | 70.4k | | 249.6k | 32m 2s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 28 | 54431.1 | 0.0 | 275.9 |
| fix | 2 | 306296.5 | 17820.0 | 2244.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 117463.1 | 5488.8 | 690.9 |
| **Total** | **38** | 143939.1 | 6569.1 | 1743.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 48 | 10.6k | 617.1k | 57.4k | 5m 18s |
| sonnet | 5 | 3.7k | 44.3k | 2.9M | 192.2k | 19m 34s |
| MiniMax-M3 | 3 | 128.8k | 11.3k | 2.0M | 0 | 7m 10s |