### PR TITLE
Fix WORKTREE_PATH persistence and sidecar comment placement

### DIFF
--- a/src/autoskillit/skills_extended/implement-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-experiment/SKILL.md
@@ -105,6 +105,8 @@ WORKTREE_NAME="research-$(date +%Y%m%d-%H%M%S)"
 eval "$(bash "{{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh" "${WORKTREE_NAME}" "{{AUTOSKILLIT_TEMP}}")"
 ```
 
+The Bash tool output will display three `KEY='VALUE'` lines. **Read `WORKTREE_PATH` from that output** — it is an absolute path to the worktree (a sibling directory outside this repo). Use this literal path in every subsequent `cd` and file reference. Shell variables do not persist across Bash tool calls.
+
 ### Step 1 (cont.) — Emit Structured Tokens Early
 
 Immediately after the worktree is created, output these tokens so the

--- a/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
@@ -108,6 +108,8 @@ WORKTREE_NAME="impl-{plan_name}-$(date +%Y%m%d-%H%M%S)"
 eval "$(bash "{{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh" "${WORKTREE_NAME}" "{{AUTOSKILLIT_TEMP}}")"
 ```
 
+The Bash tool output will display three `KEY='VALUE'` lines. **Read `WORKTREE_PATH` from that output** — it is an absolute path to the worktree (a sibling directory outside this repo). Use this literal path in every subsequent `cd` and file reference. Shell variables do not persist across Bash tool calls.
+
 ### Step 1 (cont.): Emit Structured Tokens Early
 
 Immediately after the worktree is created, output these tokens on their own

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -172,8 +172,8 @@ cd "${WORKTREE_PATH}" && \
   AUTOSKILLIT_TEST_FILTER="${AUTOSKILLIT_TEST_FILTER:-conservative}" \
   AUTOSKILLIT_TEST_BASE_REF=$(cat "{{AUTOSKILLIT_TEMP}}/worktrees/${WORKTREE_NAME}/base-branch") \
   {test_command}
-```
 # Note: {{AUTOSKILLIT_TEMP}}/worktrees/ is sidecar metadata inside the main repo — not the worktree path.
+```
 
 If tests fail, fix the issue and re-run.
 

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -97,6 +97,8 @@ WORKTREE_NAME="impl-{plan_name}-$(date +%Y%m%d-%H%M%S)"
 eval "$(bash "{{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh" "${WORKTREE_NAME}" "{{AUTOSKILLIT_TEMP}}")"
 ```
 
+The Bash tool output will display three `KEY='VALUE'` lines. **Read `WORKTREE_PATH` from that output** — it is an absolute path to the worktree (a sibling directory outside this repo, e.g. `../../worktrees/<name>`). Use this literal path in every subsequent `cd` and file reference. Shell variables do not persist across Bash tool calls.
+
 ### Step 2: Deep System Understanding (Subagents) (SINGLE MESSAGE)
 
 **Issue ALL Task tool calls in a single message — one per item — so they execute in parallel. Do NOT iterate across multiple turns.**
@@ -171,12 +173,14 @@ cd "${WORKTREE_PATH}" && \
   AUTOSKILLIT_TEST_BASE_REF=$(cat "{{AUTOSKILLIT_TEMP}}/worktrees/${WORKTREE_NAME}/base-branch") \
   {test_command}
 ```
+# Note: {{AUTOSKILLIT_TEMP}}/worktrees/ is sidecar metadata inside the main repo — not the worktree path.
 
 If tests fail, fix the issue and re-run.
 
 ### Step 6: Rebase for Squash-and-Merge
 
 ```bash
+# Sidecar metadata (inside main repo) — not the worktree path
 CURRENT_BRANCH=$(cat "{{AUTOSKILLIT_TEMP}}/worktrees/${WORKTREE_NAME}/base-branch")
 REMOTE=$(git remote get-url upstream >/dev/null 2>&1 && echo upstream || echo origin)
 git fetch "$REMOTE"
@@ -195,6 +199,7 @@ Do not merge until user confirms first!
 Then emit these structured output tokens on their own lines so recipe capture blocks can extract them:
 
 ```bash
+# Sidecar metadata (inside main repo) — not the worktree path
 CURRENT_BRANCH=$(cat "{{AUTOSKILLIT_TEMP}}/worktrees/${WORKTREE_NAME}/base-branch")
 ```
 

--- a/tests/contracts/test_instruction_surface.py
+++ b/tests/contracts/test_instruction_surface.py
@@ -833,7 +833,7 @@ class TestWorktreePathPersistenceContract:
     @pytest.mark.parametrize("skill_name", WORKTREE_SKILLS)
     def test_worktree_skills_instruct_path_capture_from_output(self, skill_name):
         text = self._skill_text(skill_name)
-        assert re.search(r"(?i)bash tool.{0,30}output", text), (
+        assert re.search(r"(?i)bash tool.{0,30}output.{0,100}WORKTREE_PATH", text, re.DOTALL), (
             f"{skill_name}/SKILL.md must instruct the agent to read WORKTREE_PATH "
             "from the Bash tool output (shell variables do not persist across tool calls)"
         )

--- a/tests/contracts/test_instruction_surface.py
+++ b/tests/contracts/test_instruction_surface.py
@@ -814,3 +814,33 @@ def test_orchestrator_tool_name_matches_open_kitchen_hook_matcher(mcp_prefix: st
         assert re.search(matcher, qualified_name), (
             f"Prompt tool name '{qualified_name}' does not match hook matcher '{matcher}'"
         )
+
+
+class TestWorktreePathPersistenceContract:
+    """Worktree-creating skills must instruct the agent to capture WORKTREE_PATH
+    from Bash tool output, since shell variables do not persist across tool calls."""
+
+    WORKTREE_SKILLS = [
+        "implement-worktree",
+        "implement-worktree-no-merge",
+        "implement-experiment",
+    ]
+
+    def _skill_text(self, skill_name: str) -> str:
+        skills_dir = _project_root() / "src" / "autoskillit" / "skills_extended"
+        return (skills_dir / skill_name / "SKILL.md").read_text()
+
+    @pytest.mark.parametrize("skill_name", WORKTREE_SKILLS)
+    def test_worktree_skills_instruct_path_capture_from_output(self, skill_name):
+        text = self._skill_text(skill_name)
+        assert re.search(r"(?i)bash tool.{0,30}output", text), (
+            f"{skill_name}/SKILL.md must instruct the agent to read WORKTREE_PATH "
+            "from the Bash tool output (shell variables do not persist across tool calls)"
+        )
+
+    def test_sidecar_paths_have_metadata_disambiguation(self):
+        text = self._skill_text("implement-worktree")
+        assert "metadata" in text.lower() or "sidecar" in text.lower(), (
+            "implement-worktree/SKILL.md must clarify that "
+            "{{AUTOSKILLIT_TEMP}}/worktrees/ is metadata, not the worktree path"
+        )


### PR DESCRIPTION
## Summary

The `implement-worktree`, `implement-worktree-no-merge`, and `implement-experiment` SKILL.md files use `eval "$(bash create_impl_worktree.sh ...)"` to bind `WORKTREE_PATH` in Step 1, but each Bash tool call runs in an isolated shell, so the bound variable does not persist to subsequent tool calls. The agent then falls back to inferring the path from sidecar metadata references, mistaking the sidecar directory for the actual worktree. This PR adds a path-capture instruction after each eval block instructing the agent to read `WORKTREE_PATH` from Bash tool output and use it as a literal absolute path. It also adds sidecar disambiguation comments in `implement-worktree/SKILL.md` clarifying that `{{AUTOSKILLIT_TEMP}}/worktrees/` is metadata inside the main repo, not the worktree itself. The new Step 5 comment is moved inside the bash code fence to match the placement pattern in Steps 6 and 7.

<details>
<summary>Individual Group Plans</summary>

### Group 1: Fix WORKTREE_PATH Persistence Across Bash Tool Calls
The `implement-worktree`, `implement-worktree-no-merge`, and `implement-experiment` SKILL.md files use `eval "$(bash create_impl_worktree.sh ...)"` to bind `WORKTREE_PATH` in Step 1. The eval pattern is correct — the script emits clean `KEY='VALUE'` lines — but each Bash tool runs in an isolated shell, so the bound variable does not persist to subsequent tool calls. The agent then falls back to inferring the path from sidecar metadata references (`{{AUTOSKILLIT_TEMP}}/worktrees/${WORKTREE_NAME}/base-branch`), mistaking the sidecar directory for the actual worktree.

The fix adds a brief instruction after the eval block in Step 1 telling the agent to read the `WORKTREE_PATH` value from the Bash tool output and use it as a literal absolute path in all subsequent commands. It also adds a parenthetical note on sidecar path references clarifying they point to metadata inside the main repo, not the worktree itself.

### Group 2: Fix Step 5 Sidecar Comment Placement in implement-worktree SKILL.md
Move the sidecar disambiguation comment from outside the Step 5 bash code fence to inside it, matching the placement pattern already used in Steps 6 and 7. Currently the `# Note:` line sits after the closing triple-backtick, where `#` is a Markdown H1 heading rather than a bash comment — breaking consistency with Steps 6/7 and potentially confusing the agent.

</details>

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/impl-20260604-081759-298780/.autoskillit/temp/make-plan/worktree_path_persistence_plan_2026-06-04_082200.md`
- `/home/talon/projects/autoskillit-runs/impl-20260604-081759-298780/.autoskillit/temp/make-plan/worktree_path_persistence_plan_2026-06-04_090000.md`

Closes #3408

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 4.6k | 19.6k | 1.6M | 84.9k | 73 | 102.6k | 11m 34s |
| verify* | sonnet | 2 | 2.9k | 18.2k | 742.1k | 51.0k | 52 | 61.7k | 8m 1s |
| implement* | MiniMax-M3 | 2 | 1.9M | 18.9k | 0 | 0 | 103 | 0 | 10m 53s |
| audit_impl* | sonnet | 2 | 1.7k | 27.9k | 497.7k | 48.1k | 43 | 69.2k | 12m 55s |
| prepare_pr* | MiniMax-M3 | 1 | 160.7k | 3.3k | 0 | 0 | 12 | 0 | 1m 34s |
| compose_pr* | MiniMax-M3 | 1 | 239.2k | 1.9k | 0 | 0 | 15 | 0 | 1m 4s |
| review_pr* | sonnet | 1 | 118 | 15.8k | 593.0k | 58.4k | 33 | 41.9k | 4m 27s |
| resolve_review* | sonnet | 1 | 157 | 12.3k | 983.1k | 64.8k | 47 | 48.7k | 5m 6s |
| **Total** | | | 2.3M | 117.7k | 4.5M | 84.9k | | 324.1k | 55m 37s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 41 | 0.0 | 0.0 | 460.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 491543.0 | 24350.0 | 6151.5 |
| **Total** | **43** | 103615.8 | 7537.1 | 2737.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 4.6k | 19.6k | 1.6M | 102.6k | 11m 34s |
| sonnet | 4 | 4.8k | 74.1k | 2.8M | 221.5k | 30m 31s |
| MiniMax-M3 | 3 | 2.3M | 24.0k | 0 | 0 | 13m 32s |