### PR TITLE
Implementation Plan: Rewrite test_select_review_dimensions_* Functions to Post-A5 Registry Values

### DIFF
--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -2588,102 +2588,67 @@ def test_pre_iteration_cleanup_noop_when_dir_empty(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# T_SRD1–T_SRD8: select_review_dimensions callable
+# T_SRD1–T_SRD6: select_review_dimensions callable
 # ---------------------------------------------------------------------------
 
 
 def test_select_review_dimensions_happy_path(tmp_path: Path) -> None:
-    """select_review_dimensions sorts by tier and excludes S dimensions."""
+    """Registry-grounded benchmark type returns 8 non-S lenses in H→M→L order."""
     from autoskillit.recipe import get_experiment_type_by_name
     from autoskillit.smoke_utils import select_review_dimensions
 
-    spec = get_experiment_type_by_name("causal_inference")
+    spec = get_experiment_type_by_name("benchmark")
     assert spec is not None
-    expected_count = sum(1 for v in spec.dimension_weights.values() if v != "S")
+    expected_dims = {d for d, w in spec.dimension_weights.items() if w != "S"}
 
     result = select_review_dimensions(
-        experiment_type="causal_inference",
+        experiment_type="benchmark",
         output_dir=str(tmp_path),
     )
     lenses = result["selected_lenses"].split(",")
-    assert len(lenses) == expected_count
+    assert len(lenses) == 8
+    assert set(lenses) == expected_dims
     manifest = json.loads(Path(result["dimensions_manifest_path"]).read_text())
     tiers = list(manifest.values())
     expected_order = sorted(tiers, key=lambda t: {"H": 0, "M": 1, "L": 2}.get(t, 3))
     assert tiers == expected_order
 
 
-def test_select_review_dimensions_all_s_returns_empty(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """All-S weights returns empty outputs and writes no file."""
-    from autoskillit.recipe import ExperimentTypeSpec
-    from autoskillit.smoke_utils import select_review_dimensions
-
-    all_s_spec = ExperimentTypeSpec(
-        name="all_s_fake",
-        classification_triggers=[],
-        dimension_weights={"causal_structure": "S", "variance_protocol": "S"},
-        applicable_lenses={},
-        red_team_focus={},
-        l1_severity={},
-    )
-    monkeypatch.setattr(
-        "autoskillit.recipe.get_experiment_type_by_name",
-        lambda _name, **_kw: all_s_spec,
-    )
-    result = select_review_dimensions(
-        experiment_type="all_s_fake",
-        output_dir=str(tmp_path),
-    )
-    assert result["selected_lenses"] == ""
-    assert result["lens_context_paths"] == ""
-    assert result["dimensions_manifest_path"] == ""
-    assert not list(tmp_path.iterdir())
-
-
-def test_select_review_dimensions_empty_weights_returns_empty(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Empty dimension_weights from registry returns empty outputs."""
-    from autoskillit.recipe import ExperimentTypeSpec
-    from autoskillit.smoke_utils import select_review_dimensions
-
-    empty_spec = ExperimentTypeSpec(
-        name="empty_weights_fake",
-        classification_triggers=[],
-        dimension_weights={},
-        applicable_lenses={},
-        red_team_focus={},
-        l1_severity={},
-    )
-    monkeypatch.setattr(
-        "autoskillit.recipe.get_experiment_type_by_name",
-        lambda _name, **_kw: empty_spec,
-    )
-    result = select_review_dimensions(
-        experiment_type="empty_weights_fake",
-        output_dir=str(tmp_path),
-    )
-    assert result == {
-        "selected_lenses": "",
-        "lens_context_paths": "",
-        "dimensions_manifest_path": "",
-    }
-    assert not list(tmp_path.iterdir())
-
-
 def test_select_review_dimensions_creates_output_dir(tmp_path: Path) -> None:
-    """Missing output_dir is created by the function."""
+    """Benchmark experiment type creates missing output_dir and writes manifest."""
     from autoskillit.smoke_utils import select_review_dimensions
 
     out = tmp_path / "nested" / "output"
     assert not out.exists()
     result = select_review_dimensions(
-        experiment_type="causal_inference",
+        experiment_type="benchmark",
         output_dir=str(out),
     )
     assert out.exists()
+    assert Path(result["dimensions_manifest_path"]).exists()
+
+
+def test_select_review_dimensions_qualitative_type_returns_active_dims(
+    tmp_path: Path,
+) -> None:
+    """Qualitative-interpretive type returns only its 2 active L-tier dimensions."""
+    from autoskillit.recipe import get_experiment_type_by_name
+    from autoskillit.smoke_utils import select_review_dimensions
+
+    spec = get_experiment_type_by_name("qualitative_interpretive")
+    assert spec is not None
+    expected_dims = {d for d, w in spec.dimension_weights.items() if w != "S"}
+
+    result = select_review_dimensions(
+        experiment_type="qualitative_interpretive",
+        output_dir=str(tmp_path),
+    )
+    lenses = result["selected_lenses"].split(",")
+    assert len(lenses) == 2
+    assert set(lenses) == expected_dims
+    assert "data_acquisition" in lenses
+    assert "agent_implementability" in lenses
+    assert "causal_structure" not in lenses
     assert Path(result["dimensions_manifest_path"]).exists()
 
 

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -2606,7 +2606,7 @@ def test_select_review_dimensions_happy_path(tmp_path: Path) -> None:
         output_dir=str(tmp_path),
     )
     lenses = result["selected_lenses"].split(",")
-    assert len(lenses) == 8
+    assert len(lenses) == len(expected_dims)
     assert set(lenses) == expected_dims
     manifest = json.loads(Path(result["dimensions_manifest_path"]).read_text())
     tiers = list(manifest.values())
@@ -2644,7 +2644,7 @@ def test_select_review_dimensions_qualitative_type_returns_active_dims(
         output_dir=str(tmp_path),
     )
     lenses = result["selected_lenses"].split(",")
-    assert len(lenses) == 2
+    assert len(lenses) == len(expected_dims)
     assert set(lenses) == expected_dims
     assert "data_acquisition" in lenses
     assert "agent_implementability" in lenses


### PR DESCRIPTION
## Summary

Rewrite the original five `test_select_review_dimensions_*` functions in `tests/test_smoke_utils.py` to use registry-grounded experiment types (`benchmark`, `qualitative_interpretive`) instead of `causal_inference` or monkeypatch-injected fakes. Two tests are rewritten in place (`happy_path`, `creates_output_dir`), two are removed as redundant with A5-WP2 additions (`all_s_returns_empty`, `empty_weights_returns_empty`), and one is created to replace the already-removed `causal_modifier_upgrades` (`qualitative_type_returns_active_dims`). The three A5-WP2 tests (`registry_happy_path`, `unknown_type_returns_empty`, `empty_type_returns_empty`) remain untouched.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260604-100621-890366/.autoskillit/temp/make-plan/t2_p2_a8_wp1_rewrite_test_select_review_dimensions_plan_2026-06-04_101500.md`

Closes #3709

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 3.4k | 23.8k | 1.1M | 84.0k | 36 | 67.0k | 11m 25s |
| verify* | sonnet | 1 | 1.2k | 6.3k | 322.6k | 44.3k | 24 | 28.9k | 2m 50s |
| implement* | MiniMax-M3 | 1 | 1.1M | 8.4k | 0 | 0 | 49 | 0 | 3m 41s |
| audit_impl* | sonnet | 1 | 44 | 7.4k | 141.4k | 35.6k | 11 | 26.0k | 3m 24s |
| prepare_pr* | MiniMax-M3 | 1 | 242.2k | 4.4k | 0 | 0 | 15 | 0 | 2m 2s |
| compose_pr* | MiniMax-M3 | 1 | 187.9k | 2.0k | 0 | 0 | 12 | 0 | 60s |
| review_pr* | sonnet | 1 | 140 | 13.3k | 721.6k | 54.9k | 40 | 38.7k | 3m 53s |
| resolve_review* | sonnet | 1 | 173 | 6.3k | 998.3k | 57.3k | 51 | 41.1k | 3m 16s |
| **Total** | | | 1.5M | 71.8k | 3.2M | 84.0k | | 201.8k | 31m 35s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 95 | 0.0 | 0.0 | 88.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 249571.8 | 10269.2 | 1572.2 |
| **Total** | **99** | 32700.7 | 2037.9 | 725.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 3.4k | 23.8k | 1.1M | 67.0k | 11m 25s |
| sonnet | 4 | 1.5k | 33.2k | 2.2M | 134.7k | 13m 25s |
| MiniMax-M3 | 3 | 1.5M | 14.8k | 0 | 0 | 6m 44s |