### PR TITLE
Cached File-Backed Loader for Phoropter Family Prefix Map

### DIFF
--- a/src/autoskillit/recipe/_api_cache.py
+++ b/src/autoskillit/recipe/_api_cache.py
@@ -226,8 +226,12 @@ def _clear_stale_caches() -> None:
         _ML_SUB_AREA_CACHE,
     )
     from autoskillit.recipe.rules.rules_blocks import _BUDGETS_CACHE  # noqa: PLC0415
+    from autoskillit.recipe.rules.rules_phoropter_adjacency import (  # noqa: PLC0415
+        _PREFIXES_CACHE,
+    )
 
     _BUDGETS_CACHE.clear()
+    _PREFIXES_CACHE.clear()
     _MANIFEST_CACHE.clear()
     _ML_SUB_AREA_CACHE.clear()
     _SKILL_NAMES_CACHE.clear()

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -40,7 +40,7 @@ See each subdirectory's CLAUDE.md for details.
 | `rules_merge_queue.py` | Merge queue push routing: `queued_branch` error route enforcement |
 | `rules_optional_capture.py` | Optional capture guard enforcement |
 | `rules_packs.py` | Pack validation (names must exist in `PACK_REGISTRY`) |
-| `rules_phoropter_adjacency.py` | Phoropter phase-order and step-interleaving adjacency rules |
+| `rules_phoropter_adjacency.py` | Phoropter phase-order and step-interleaving adjacency rules; family-prefix loader backed by phoropter-registry.yaml |
 | `rules_pseudocode_sync.py` | SKILL.md pseudocode constant-reference divergence from run_python callables |
 | `rules_reachability.py` | Symbolic BFS reachability; capture-inversion detection |
 | `rules_audit_impl_topology.py` | audit-impl-diff-topology-mismatch semantic rule |

--- a/src/autoskillit/recipe/rules/rules_phoropter_adjacency.py
+++ b/src/autoskillit/recipe/rules/rules_phoropter_adjacency.py
@@ -9,11 +9,32 @@ phase counter.  Route-action steps are also transparent.
 
 from __future__ import annotations
 
-from autoskillit.core import Severity
+from pathlib import Path
+
+from autoskillit.core import Severity, load_yaml, pkg_root
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._api_cache import YamlFileCache
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 _PHOROPTER_PHASES: tuple[str, ...] = ("dial", "apply", "synthesize")
+
+_PREFIXES_CACHE = YamlFileCache()
+
+
+def _load_registry_yaml(path: Path) -> dict[str, str | None]:
+    try:
+        data = load_yaml(path)
+    except FileNotFoundError:
+        return {}
+    result: dict[str, str | None] = {}
+    for family_name, entry in data.get("families", {}).items():
+        result[family_name] = entry.get("step_naming", {}).get("prefix")
+    return result
+
+
+def _load_family_prefixes() -> dict[str, str | None]:
+    path = pkg_root() / "assets" / "phoropter-registry.yaml"
+    return _PREFIXES_CACHE.get_or_load(path, _load_registry_yaml)
 
 
 @semantic_rule(

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -97,6 +97,7 @@ SINGLETON_ALLOWED_MODULES: frozenset[str] = frozenset(
         "_contracts_manifest",  # recipe/_contracts_manifest.py: _MANIFEST_CACHE = YamlFileCache()
         "methodology_venue_appendix",  # recipe/methodology_venue_appendix.py: _ML_SUB_AREA_CACHE
         "rules_blocks",  # recipe/rules/rules_blocks.py: _BUDGETS_CACHE = YamlFileCache()
+        "rules_phoropter_adjacency",  # recipe/rules/rules_phoropter_adjacency.py: _PREFIXES_CACHE
     }
 )
 _SINGLETON_SAFE_CALL_NAMES: frozenset[str] = frozenset(

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -1097,6 +1097,13 @@ class TestHeadlessExecutorCompletionMarker:
 class TestHeadlessExecutorIdleOutputTimeout:
     """Protocol conformance and resolution logic for idle_output_timeout."""
 
+    @pytest.fixture(autouse=True)
+    def _no_clone_guard(self, monkeypatch):
+        monkeypatch.setattr(
+            "autoskillit.execution.headless._headless_execute.is_git_main_checkout",
+            lambda _: False,
+        )
+
     def test_headless_executor_accepts_idle_output_timeout(self) -> None:
         import inspect
 
@@ -1247,6 +1254,13 @@ class TestContractNudge:
     with file_path triggers CONTRACT_RECOVERY while _extract_missing_token_hints
     can still find the file_path for hints.
     """
+
+    @pytest.fixture(autouse=True)
+    def _no_clone_guard(self, monkeypatch):
+        monkeypatch.setattr(
+            "autoskillit.execution.headless._headless_execute.is_git_main_checkout",
+            lambda _: False,
+        )
 
     def _main_session_ndjson(
         self, marker: str, *, include_token: bool = False, session_id: str = "sess-main"
@@ -1670,6 +1684,13 @@ def test_build_skill_result_surfaces_last_stop_reason():
 class TestEarlyStopRecovery:
     """EARLY_STOP must trigger nudge recovery, not fall through to on_failure."""
 
+    @pytest.fixture(autouse=True)
+    def _no_clone_guard(self, monkeypatch):
+        monkeypatch.setattr(
+            "autoskillit.execution.headless._headless_execute.is_git_main_checkout",
+            lambda _: False,
+        )
+
     def _early_stop_subprocess_result(
         self, result_text: str, session_id: str = "sess-123"
     ) -> SubprocessResult:
@@ -1736,6 +1757,13 @@ class TestEarlyStopRecovery:
 
 class TestNudgeBackendGuard:
     """Backend capability guard for _attempt_contract_nudge nudge recovery."""
+
+    @pytest.fixture(autouse=True)
+    def _no_clone_guard(self, monkeypatch):
+        monkeypatch.setattr(
+            "autoskillit.execution.headless._headless_execute.is_git_main_checkout",
+            lambda _: False,
+        )
 
     def _main_subprocess_result(
         self, marker: str, session_id: str = "sess-main"

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -1059,15 +1059,21 @@ def test_lru_cache_helpers_cleared_on_process_staleness(tmp_path, monkeypatch):
         load_ml_sub_area_folding,
     )
     from autoskillit.recipe.rules.rules_blocks import _BUDGETS_CACHE, _block_budgets
+    from autoskillit.recipe.rules.rules_phoropter_adjacency import (
+        _PREFIXES_CACHE,
+        _load_family_prefixes,
+    )
 
     monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
 
     _block_budgets()
     load_bundled_manifest()
     load_ml_sub_area_folding()
+    _load_family_prefixes()
     assert _BUDGETS_CACHE._value is not _MISSING
     assert _MANIFEST_CACHE._value is not _MISSING
     assert _ML_SUB_AREA_CACHE._value is not _MISSING
+    assert _PREFIXES_CACHE._value is not _MISSING
 
     monkeypatch.setattr(cache_mod, "_PROCESS_START_PKG_MTIME", 1000)
     monkeypatch.setattr(cache_mod, "_STALENESS_LAST_CHECK", 0.0)
@@ -1086,6 +1092,7 @@ def test_lru_cache_helpers_cleared_on_process_staleness(tmp_path, monkeypatch):
     assert _BUDGETS_CACHE._value is _MISSING
     assert _MANIFEST_CACHE._value is _MISSING
     assert _ML_SUB_AREA_CACHE._value is _MISSING
+    assert _PREFIXES_CACHE._value is _MISSING
 
 
 def test_mid_process_yaml_only_update(tmp_path, monkeypatch):

--- a/tests/recipe/test_deep_staleness.py
+++ b/tests/recipe/test_deep_staleness.py
@@ -335,6 +335,33 @@ def test_block_budgets_missing_file_returns_empty_dict(tmp_path, monkeypatch):
     assert result == {}
 
 
+def test_phoropter_prefix_mtime_change_forces_fresh_read(tmp_path, monkeypatch):
+    """_load_family_prefixes re-reads when phoropter-registry.yaml changes on disk."""
+    from autoskillit.recipe.rules.rules_phoropter_adjacency import (
+        _PREFIXES_CACHE,
+        _load_family_prefixes,
+    )
+
+    assets_dir = tmp_path / "assets"
+    assets_dir.mkdir()
+    registry_path = assets_dir / "phoropter-registry.yaml"
+    registry_path.write_text("families:\n  vis-lens:\n    step_naming:\n      prefix: vis\n")
+
+    monkeypatch.setattr(
+        "autoskillit.recipe.rules.rules_phoropter_adjacency.pkg_root",
+        lambda: tmp_path,
+    )
+    _PREFIXES_CACHE.clear()
+
+    r1 = _load_family_prefixes()
+    assert r1["vis-lens"] == "vis"
+
+    registry_path.write_text("families:\n  vis-lens:\n    step_naming:\n      prefix: viz\n")
+
+    r2 = _load_family_prefixes()
+    assert r2["vis-lens"] == "viz"
+
+
 def test_ml_sub_area_folding_mtime_change_forces_fresh_read(tmp_path, monkeypatch):
     """load_ml_sub_area_folding re-reads when YAML changes on disk."""
     from autoskillit.recipe.methodology_venue_appendix import (

--- a/tests/recipe/test_deep_staleness.py
+++ b/tests/recipe/test_deep_staleness.py
@@ -356,10 +356,12 @@ def test_phoropter_prefix_mtime_change_forces_fresh_read(tmp_path, monkeypatch):
     r1 = _load_family_prefixes()
     assert r1["vis-lens"] == "vis"
 
-    registry_path.write_text("families:\n  vis-lens:\n    step_naming:\n      prefix: viz\n")
+    registry_path.write_text(
+        "families:\n  vis-lens:\n    step_naming:\n      prefix: viz-updated\n"
+    )
 
     r2 = _load_family_prefixes()
-    assert r2["vis-lens"] == "viz"
+    assert r2["vis-lens"] == "viz-updated"
 
 
 def test_ml_sub_area_folding_mtime_change_forces_fresh_read(tmp_path, monkeypatch):

--- a/tests/recipe/test_rules_phoropter_adjacency.py
+++ b/tests/recipe/test_rules_phoropter_adjacency.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from autoskillit.core import Severity
@@ -303,3 +305,72 @@ def test_non_canonical_phase_between_canonical_phases_is_transparent():
     phoropter_rules = {"phoropter-phase-order", "phoropter-step-interleaving"}
     findings = [f for f in run_semantic_rules(recipe) if f.rule in phoropter_rules]
     assert len(findings) == 0
+
+
+# --- family prefix loader tests ---
+
+
+def test_load_family_prefixes_vis_lens_has_prefix():
+    from autoskillit.recipe.rules.rules_phoropter_adjacency import (
+        _PREFIXES_CACHE,
+        _load_family_prefixes,
+    )
+
+    _PREFIXES_CACHE.clear()
+    result = _load_family_prefixes()
+    assert result["vis-lens"] == "vis"
+    _PREFIXES_CACHE.clear()
+
+
+def test_load_family_prefixes_review_design_key_absent():
+    from autoskillit.recipe.rules.rules_phoropter_adjacency import (
+        _PREFIXES_CACHE,
+        _load_family_prefixes,
+    )
+
+    _PREFIXES_CACHE.clear()
+    result = _load_family_prefixes()
+    assert result.get("review-design") is None
+    _PREFIXES_CACHE.clear()
+
+
+def test_load_family_prefixes_file_not_found_returns_empty(monkeypatch):
+    from autoskillit.recipe.rules.rules_phoropter_adjacency import (
+        _PREFIXES_CACHE,
+        _load_family_prefixes,
+    )
+
+    _PREFIXES_CACHE.clear()
+    monkeypatch.setattr(
+        "autoskillit.recipe.rules.rules_phoropter_adjacency.load_yaml",
+        lambda _: (_ for _ in ()).throw(FileNotFoundError("mock")),
+    )
+    result = _load_family_prefixes()
+    assert result == {}
+    _PREFIXES_CACHE.clear()
+
+
+def test_load_family_prefixes_cache_hit(monkeypatch):
+    from autoskillit.recipe.rules.rules_phoropter_adjacency import (
+        _PREFIXES_CACHE,
+        _load_family_prefixes,
+        _load_registry_yaml,
+    )
+
+    _PREFIXES_CACHE.clear()
+    call_count = 0
+    original = _load_registry_yaml
+
+    def counting_loader(path: Path) -> dict[str, str | None]:
+        nonlocal call_count
+        call_count += 1
+        return original(path)
+
+    monkeypatch.setattr(
+        "autoskillit.recipe.rules.rules_phoropter_adjacency._load_registry_yaml",
+        counting_loader,
+    )
+    _load_family_prefixes()
+    _load_family_prefixes()
+    assert call_count == 1
+    _PREFIXES_CACHE.clear()

--- a/tests/recipe/test_rules_phoropter_adjacency.py
+++ b/tests/recipe/test_rules_phoropter_adjacency.py
@@ -340,10 +340,13 @@ def test_load_family_prefixes_file_not_found_returns_empty(monkeypatch):
         _load_family_prefixes,
     )
 
+    def _raise_file_not_found(_):
+        raise FileNotFoundError("mock")
+
     _PREFIXES_CACHE.clear()
     monkeypatch.setattr(
         "autoskillit.recipe.rules.rules_phoropter_adjacency.load_yaml",
-        lambda _: (_ for _ in ()).throw(FileNotFoundError("mock")),
+        _raise_file_not_found,
     )
     result = _load_family_prefixes()
     assert result == {}


### PR DESCRIPTION
## Summary

Add a `YamlFileCache`-backed loader to `rules_phoropter_adjacency.py` that reads `phoropter-registry.yaml`, extracts the `step_naming.prefix` field for each family, and returns a `dict[str, str | None]` mapping family name to prefix. Wire the new cache into `_api_cache._clear_stale_caches()` so it participates in the staleness invalidation cycle. Add four unit tests in the adjacency test file, extend the staleness integration test in `test_api.py`, add an mtime-change re-read test in `test_deep_staleness.py`, and register the new module in the singleton allowlist.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260604-105417-435161/.autoskillit/temp/make-plan/t2_p3_a1_wp1_cached_family_prefix_loader_plan_2026-06-04_105700.md`

Closes #3710

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 2.2k | 15.3k | 1.1M | 89.9k | 45 | 78.6k | 8m 2s |
| verify* | sonnet | 1 | 78 | 12.1k | 370.6k | 54.3k | 28 | 37.7k | 5m 0s |
| implement* | MiniMax-M3 | 1 | 3.5M | 15.8k | 0 | 0 | 125 | 0 | 9m 39s |
| fix* | sonnet | 2 | 939 | 83.4k | 15.8M | 173.4k | 328 | 274.8k | 43m 1s |
| dispatch:60155013-0c6d-4bed-a578-6d337e736e78* | sonnet | 1 | 122 | 5.5k | 997.8k | 78.6k | 40 | 54.2k | 49m 57s |
| audit_impl* | sonnet | 1 | 453 | 11.2k | 181.0k | 40.2k | 18 | 35.7k | 5m 34s |
| prepare_pr* | MiniMax-M3 | 1 | 203.3k | 1.6k | 0 | 0 | 14 | 0 | 50s |
| compose_pr* | MiniMax-M3 | 1 | 222.8k | 1.6k | 0 | 0 | 14 | 0 | 1m 1s |
| review_pr* | sonnet | 1 | 166 | 28.7k | 973.2k | 75.1k | 50 | 60.2k | 6m 46s |
| resolve_review* | sonnet | 1 | 181 | 12.9k | 1.2M | 72.8k | 54 | 56.5k | 6m 5s |
| **Total** | | | 3.9M | 188.1k | 20.6M | 173.4k | | 597.7k | 2h 16m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 135 | 0.0 | 0.0 | 117.1 |
| fix | 34 | 463742.5 | 8083.2 | 2452.4 |
| dispatch:60155013-0c6d-4bed-a578-6d337e736e78 | 0 | — | — | — |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 5 | 232681.2 | 11305.8 | 2583.4 |
| **Total** | **174** | 118222.0 | 3435.3 | 1081.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.2k | 15.3k | 1.1M | 78.6k | 8m 2s |
| sonnet | 6 | 1.9k | 153.8k | 19.5M | 519.1k | 1h 56m |
| MiniMax-M3 | 3 | 3.9M | 19.1k | 0 | 0 | 11m 31s |