### PR TITLE
Implementation Plan: Provide a single reusable predicate that resolves any step name to its phoropter phase string or None

### DIFF
--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -40,7 +40,7 @@ See each subdirectory's CLAUDE.md for details.
 | `rules_merge_queue.py` | Merge queue push routing: `queued_branch` error route enforcement |
 | `rules_optional_capture.py` | Optional capture guard enforcement |
 | `rules_packs.py` | Pack validation (names must exist in `PACK_REGISTRY`) |
-| `rules_phoropter_adjacency.py` | Phoropter phase-order and step-interleaving adjacency rules; family-prefix loader backed by phoropter-registry.yaml |
+| `rules_phoropter_adjacency.py` | Phoropter phase-order and step-interleaving adjacency rules; canonical phase predicate `_canonical_phase_for_step`; family-prefix loader backed by phoropter-registry.yaml |
 | `rules_pseudocode_sync.py` | SKILL.md pseudocode constant-reference divergence from run_python callables |
 | `rules_reachability.py` | Symbolic BFS reachability; capture-inversion detection |
 | `rules_audit_impl_topology.py` | audit-impl-diff-topology-mismatch semantic rule |

--- a/src/autoskillit/recipe/rules/rules_phoropter_adjacency.py
+++ b/src/autoskillit/recipe/rules/rules_phoropter_adjacency.py
@@ -37,6 +37,22 @@ def _load_family_prefixes() -> dict[str, str | None]:
     return _PREFIXES_CACHE.get_or_load(path, _load_registry_yaml)
 
 
+def _canonical_phase_for_step(
+    step_name: str,
+    family: str | None,
+    prefixes: dict[str, str | None],
+) -> str | None:
+    if step_name in _PHOROPTER_PHASES:
+        return step_name
+    if family is not None:
+        prefix = prefixes.get(family)
+        if prefix is not None:
+            for phase in _PHOROPTER_PHASES:
+                if step_name == f"{prefix}_{phase}":
+                    return phase
+    return None
+
+
 @semantic_rule(
     name="phoropter-phase-order",
     description="Phoropter family steps must follow the dial→apply→synthesize phase progression.",
@@ -46,6 +62,7 @@ def _check_phoropter_phase_order(ctx: ValidationContext) -> list[RuleFinding]:
     if not any(step.phoropter_family for step in ctx.recipe.steps.values()):
         return []
 
+    prefixes = _load_family_prefixes()
     findings: list[RuleFinding] = []
     expected_next: dict[str, str] = {}
     errored_families: set[str] = set()
@@ -58,30 +75,31 @@ def _check_phoropter_phase_order(ctx: ValidationContext) -> list[RuleFinding]:
             continue
         if step.action == "route":
             continue
-        if step_name not in _PHOROPTER_PHASES:
+        canonical = _canonical_phase_for_step(step_name, family, prefixes)
+        if canonical is None:
             continue
 
         expected_phase = expected_next.get(family, "dial")
-        if step_name != expected_phase:
+        if canonical != expected_phase:
             findings.append(
                 RuleFinding(
                     rule="phoropter-phase-order",
                     severity=Severity.ERROR,
                     step_name=step_name,
                     message=(
-                        f"Step '{step_name}' in phoropter family '{family}' is out of order: "
-                        f"expected phase '{expected_phase}', got '{step_name}'."
+                        f"Step '{step_name}' (canonical: '{canonical}') in phoropter family "
+                        f"'{family}' is out of order: expected phase '{expected_phase}', "
+                        f"got '{canonical}'."
                     ),
                 )
             )
             errored_families.add(family)
         else:
-            if step_name in _PHOROPTER_PHASES:
-                phase_idx = _PHOROPTER_PHASES.index(step_name)
-                if phase_idx + 1 < len(_PHOROPTER_PHASES):
-                    expected_next[family] = _PHOROPTER_PHASES[phase_idx + 1]
-                else:
-                    expected_next.pop(family, None)
+            phase_idx = _PHOROPTER_PHASES.index(canonical)
+            if phase_idx + 1 < len(_PHOROPTER_PHASES):
+                expected_next[family] = _PHOROPTER_PHASES[phase_idx + 1]
+            else:
+                expected_next.pop(family, None)
 
     return findings
 
@@ -95,23 +113,30 @@ def _check_phoropter_interleaving(ctx: ValidationContext) -> list[RuleFinding]:
     if not any(step.phoropter_family for step in ctx.recipe.steps.values()):
         return []
 
+    prefixes = _load_family_prefixes()
     findings: list[RuleFinding] = []
     in_progress: dict[str, str] = {}
     next_expected: dict[str, int] = {}
+    completed: set[str] = set()
 
     for step_name, step in ctx.recipe.steps.items():
         family = step.phoropter_family
         if family is not None:
             if step.action == "route":
                 continue
+            if family in completed:
+                continue
+            canonical = _canonical_phase_for_step(step_name, family, prefixes)
+            if canonical is None:
+                continue
             in_progress[family] = step_name
-            if step_name in _PHOROPTER_PHASES:
-                idx = _PHOROPTER_PHASES.index(step_name)
-                if idx == next_expected.get(family, 0):
-                    next_expected[family] = idx + 1
-                    if idx + 1 == len(_PHOROPTER_PHASES):
-                        del in_progress[family]
-                        del next_expected[family]
+            idx = _PHOROPTER_PHASES.index(canonical)
+            if idx == next_expected.get(family, 0):
+                next_expected[family] = idx + 1
+                if idx + 1 == len(_PHOROPTER_PHASES):
+                    del in_progress[family]
+                    del next_expected[family]
+                    completed.add(family)
         else:
             for fam, last_phase in list(in_progress.items()):
                 findings.append(

--- a/tests/recipe/test_rules_phoropter_adjacency.py
+++ b/tests/recipe/test_rules_phoropter_adjacency.py
@@ -452,9 +452,13 @@ def test_iterative_discovery_pattern():
 # --- prefixed step phase-order tests ---
 
 
-def test_prefixed_steps_correct_order_no_findings():
+def test_prefixed_steps_correct_order_no_findings(monkeypatch):
     import autoskillit.recipe  # noqa: F401
 
+    monkeypatch.setattr(
+        "autoskillit.recipe.rules.rules_phoropter_adjacency._load_family_prefixes",
+        lambda: {"vis-lens": "vis"},
+    )
     recipe = _make_recipe(
         {
             "vis_dial": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
@@ -466,9 +470,13 @@ def test_prefixed_steps_correct_order_no_findings():
     assert not findings
 
 
-def test_prefixed_steps_wrong_order_error_with_canonical():
+def test_prefixed_steps_wrong_order_error_with_canonical(monkeypatch):
     import autoskillit.recipe  # noqa: F401
 
+    monkeypatch.setattr(
+        "autoskillit.recipe.rules.rules_phoropter_adjacency._load_family_prefixes",
+        lambda: {"vis-lens": "vis"},
+    )
     recipe = _make_recipe(
         {
             "vis_apply": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
@@ -514,9 +522,13 @@ def test_canonical_steps_regression_guard():
     assert not findings
 
 
-def test_mixed_two_family_correct_order_no_findings():
+def test_mixed_two_family_correct_order_no_findings(monkeypatch):
     import autoskillit.recipe  # noqa: F401
 
+    monkeypatch.setattr(
+        "autoskillit.recipe.rules.rules_phoropter_adjacency._load_family_prefixes",
+        lambda: {"vis-lens": "vis"},
+    )
     recipe = _make_recipe(
         {
             "dial": RecipeStep(tool="run_skill", phoropter_family="review-design"),
@@ -547,9 +559,13 @@ def test_non_canonical_family_step_no_interleaving():
     assert not findings
 
 
-def test_sequential_family_exemption():
+def test_sequential_family_exemption(monkeypatch):
     import autoskillit.recipe  # noqa: F401
 
+    monkeypatch.setattr(
+        "autoskillit.recipe.rules.rules_phoropter_adjacency._load_family_prefixes",
+        lambda: {"refactor-lens": "refactor"},
+    )
     recipe = _make_recipe(
         {
             "dial": RecipeStep(tool="run_skill", phoropter_family="fam-a"),

--- a/tests/recipe/test_rules_phoropter_adjacency.py
+++ b/tests/recipe/test_rules_phoropter_adjacency.py
@@ -377,3 +377,220 @@ def test_load_family_prefixes_cache_hit(monkeypatch):
     _load_family_prefixes()
     assert call_count == 1
     _PREFIXES_CACHE.clear()
+
+
+# --- _canonical_phase_for_step unit tests ---
+
+
+def test_canonical_step_name_any_family():
+    from autoskillit.recipe.rules.rules_phoropter_adjacency import _canonical_phase_for_step
+
+    prefixes = {"vis-lens": "vis"}
+    assert _canonical_phase_for_step("dial", "vis-lens", prefixes) == "dial"
+    assert _canonical_phase_for_step("apply", "vis-lens", prefixes) == "apply"
+    assert _canonical_phase_for_step("synthesize", "vis-lens", prefixes) == "synthesize"
+
+
+def test_canonical_step_name_family_none():
+    from autoskillit.recipe.rules.rules_phoropter_adjacency import _canonical_phase_for_step
+
+    assert _canonical_phase_for_step("dial", None, {}) == "dial"
+    assert _canonical_phase_for_step("apply", None, {}) == "apply"
+    assert _canonical_phase_for_step("synthesize", None, {}) == "synthesize"
+
+
+def test_prefixed_match_correct_family():
+    from autoskillit.recipe.rules.rules_phoropter_adjacency import _canonical_phase_for_step
+
+    prefixes = {"vis-lens": "vis"}
+    assert _canonical_phase_for_step("vis_dial", "vis-lens", prefixes) == "dial"
+    assert _canonical_phase_for_step("vis_apply", "vis-lens", prefixes) == "apply"
+    assert _canonical_phase_for_step("vis_synthesize", "vis-lens", prefixes) == "synthesize"
+
+
+def test_prefixed_name_none_prefix_entry():
+    from autoskillit.recipe.rules.rules_phoropter_adjacency import _canonical_phase_for_step
+
+    prefixes = {"vis-lens": None}
+    assert _canonical_phase_for_step("vis_dial", "vis-lens", prefixes) is None
+
+
+def test_prefixed_name_family_none():
+    from autoskillit.recipe.rules.rules_phoropter_adjacency import _canonical_phase_for_step
+
+    prefixes = {"vis-lens": "vis"}
+    assert _canonical_phase_for_step("vis_dial", None, prefixes) is None
+
+
+def test_unrecognized_step_name_returns_none():
+    from autoskillit.recipe.rules.rules_phoropter_adjacency import _canonical_phase_for_step
+
+    prefixes = {"vis-lens": "vis"}
+    assert _canonical_phase_for_step("select_review_dimensions", "vis-lens", prefixes) is None
+
+
+# --- iterative-discovery pattern ---
+
+
+def test_iterative_discovery_pattern():
+    from autoskillit.recipe.rules.rules_phoropter_adjacency import _canonical_phase_for_step
+
+    prefixes = {"vis-lens": "vis", "arch-lens": None}
+    step_name = "vis_dial"
+    found_family = None
+    found_phase = None
+    for candidate_family in prefixes:
+        phase = _canonical_phase_for_step(step_name, candidate_family, prefixes)
+        if phase is not None:
+            found_family = candidate_family
+            found_phase = phase
+            break
+    assert found_family == "vis-lens"
+    assert found_phase == "dial"
+
+
+# --- prefixed step phase-order tests ---
+
+
+def test_prefixed_steps_correct_order_no_findings():
+    import autoskillit.recipe  # noqa: F401
+
+    recipe = _make_recipe(
+        {
+            "vis_dial": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+            "vis_apply": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+            "vis_synthesize": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-phase-order"]
+    assert not findings
+
+
+def test_prefixed_steps_wrong_order_error_with_canonical():
+    import autoskillit.recipe  # noqa: F401
+
+    recipe = _make_recipe(
+        {
+            "vis_apply": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+            "vis_dial": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+            "vis_synthesize": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-phase-order"]
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.ERROR
+    assert findings[0].step_name == "vis_apply"
+    assert "vis_apply" in findings[0].message
+    assert "apply" in findings[0].message
+
+
+def test_prefixed_steps_family_none_transparency():
+    """Prefixed steps with family=None are transparent via the outer family guard,
+    not via _canonical_phase_for_step."""
+    import autoskillit.recipe  # noqa: F401
+
+    recipe = _make_recipe(
+        {
+            "vis_dial": RecipeStep(tool="run_skill"),
+            "vis_apply": RecipeStep(tool="run_skill"),
+            "vis_synthesize": RecipeStep(tool="run_skill"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-phase-order"]
+    assert not findings
+
+
+def test_canonical_steps_regression_guard():
+    import autoskillit.recipe  # noqa: F401
+
+    recipe = _make_recipe(
+        {
+            "dial": RecipeStep(tool="run_skill", phoropter_family="review-design"),
+            "apply": RecipeStep(tool="run_skill", phoropter_family="review-design"),
+            "synthesize": RecipeStep(tool="run_skill", phoropter_family="review-design"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-phase-order"]
+    assert not findings
+
+
+def test_mixed_two_family_correct_order_no_findings():
+    import autoskillit.recipe  # noqa: F401
+
+    recipe = _make_recipe(
+        {
+            "dial": RecipeStep(tool="run_skill", phoropter_family="review-design"),
+            "vis_dial": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+            "apply": RecipeStep(tool="run_skill", phoropter_family="review-design"),
+            "vis_apply": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+            "synthesize": RecipeStep(tool="run_skill", phoropter_family="review-design"),
+            "vis_synthesize": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-phase-order"]
+    assert not findings
+
+
+# --- canonical-entry interleaving tests ---
+
+
+def test_non_canonical_family_step_no_interleaving():
+    import autoskillit.recipe  # noqa: F401
+
+    recipe = _make_recipe(
+        {
+            "select_review_dimensions": RecipeStep(tool="run_python", phoropter_family="test-fam"),
+            "plain-step": RecipeStep(tool="run_cmd"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-step-interleaving"]
+    assert not findings
+
+
+def test_sequential_family_exemption():
+    import autoskillit.recipe  # noqa: F401
+
+    recipe = _make_recipe(
+        {
+            "dial": RecipeStep(tool="run_skill", phoropter_family="fam-a"),
+            "apply": RecipeStep(tool="run_skill", phoropter_family="fam-a"),
+            "synthesize": RecipeStep(tool="run_skill", phoropter_family="fam-a"),
+            "routing-step": RecipeStep(tool="run_cmd"),
+            "refactor_dial": RecipeStep(tool="run_skill", phoropter_family="refactor-lens"),
+            "refactor_apply": RecipeStep(tool="run_skill", phoropter_family="refactor-lens"),
+            "refactor_synthesize": RecipeStep(tool="run_skill", phoropter_family="refactor-lens"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-step-interleaving"]
+    assert not findings
+
+
+def test_in_progress_interleaving_still_fires():
+    import autoskillit.recipe  # noqa: F401
+
+    recipe = _make_recipe(
+        {
+            "dial": RecipeStep(tool="run_skill", phoropter_family="test-fam"),
+            "apply": RecipeStep(tool="run_skill", phoropter_family="test-fam"),
+            "plain-step": RecipeStep(tool="run_cmd"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-step-interleaving"]
+    assert len(findings) == 1
+    assert findings[0].step_name == "plain-step"
+    assert "test-fam" in findings[0].message
+
+
+def test_standalone_synthesize_does_not_complete_family():
+    import autoskillit.recipe  # noqa: F401
+
+    recipe = _make_recipe(
+        {
+            "synthesize": RecipeStep(tool="run_skill", phoropter_family="test-fam"),
+            "plain-step": RecipeStep(tool="run_cmd"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-step-interleaving"]
+    assert len(findings) == 1
+    assert findings[0].step_name == "plain-step"
+    assert "test-fam" in findings[0].message


### PR DESCRIPTION
## Summary

Add `_canonical_phase_for_step(step_name, family, prefixes) -> str | None` to `rules_phoropter_adjacency.py`, positioned immediately above `_check_phoropter_phase_order` (after `_load_family_prefixes`). This function resolves canonical step names (e.g. `"dial"`) and family-prefixed step names (e.g. `"vis_dial"`) to their canonical phase string, returning `None` for unrecognized names. Both `_check_phoropter_phase_order` and `_check_phoropter_interleaving` are then refactored to use this predicate, replacing ad-hoc `_PHOROPTER_PHASES` membership checks. The interleaving rule gains a `completed: set[str]` to track families that have finished their full sequence, and non-canonical family steps become transparent (no longer update `in_progress`).

Closes #3711

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260604-123721-325886/.autoskillit/temp/make-plan/t2-p3-a2-wp1-canonical-phase-predicate_plan_2026-06-04_123900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.3k | 24.3k | 1.2M | 108.5k | 38 | 109.3k | 13m 34s |
| verify* | sonnet | 1 | 84 | 10.6k | 501.2k | 71.3k | 31 | 54.7k | 3m 18s |
| implement* | MiniMax-M3 | 1 | 947.8k | 8.6k | 0 | 0 | 55 | 0 | 4m 0s |
| fix* | sonnet | 1 | 78 | 3.8k | 320.1k | 44.6k | 25 | 28.4k | 2m 26s |
| audit_impl* | sonnet | 1 | 52 | 11.5k | 177.8k | 39.6k | 15 | 36.2k | 5m 14s |
| prepare_pr* | MiniMax-M3 | 1 | 212.5k | 2.6k | 0 | 0 | 11 | 0 | 1m 15s |
| compose_pr* | MiniMax-M3 | 1 | 289.9k | 2.0k | 0 | 0 | 18 | 0 | 1m 5s |
| review_pr* | sonnet | 1 | 134 | 31.1k | 788.7k | 76.3k | 41 | 85.2k | 7m 8s |
| resolve_review* | sonnet | 1 | 253 | 18.5k | 2.1M | 90.7k | 78 | 74.9k | 7m 34s |
| **Total** | | | 1.5M | 113.0k | 5.2M | 108.5k | | 388.6k | 45m 37s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 278 | 0.0 | 0.0 | 31.1 |
| fix | 0 | — | — | — |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 24 | 88723.4 | 3119.8 | 770.9 |
| **Total** | **302** | 17079.5 | 1286.9 | 374.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.3k | 24.3k | 1.2M | 109.3k | 13m 34s |
| sonnet | 5 | 601 | 75.5k | 3.9M | 279.4k | 25m 42s |
| MiniMax-M3 | 3 | 1.5M | 13.3k | 0 | 0 | 6m 21s |