### PR TITLE
Rectify: Skill Contract Input Type Semantic Validation

### DIFF
--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2385,7 +2385,7 @@ skills:
   file-audit-issues:
     inputs:
       - name: run_dir
-        type: file_path
+        type: directory_path
         required: false
     outputs:
       - name: issue_urls

--- a/tests/contracts/CLAUDE.md
+++ b/tests/contracts/CLAUDE.md
@@ -39,6 +39,7 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `test_github_ops.py` | Contract tests: GitHub operation semantics in SKILL.md files |
 | `test_hook_bridge_coverage.py` | REQ-BRIDGE-001: quota guard hook config bridge must produce exactly the keys that resolve_quota_settings() reads |
 | `test_implement_experiment_contracts.py` | Contract tests for implement-experiment SKILL.md — test infrastructure requirements |
+| `test_input_type_semantic_correctness.py` | Cross-validate skill_contracts.yaml path input types against SKILL.md content |
 | `test_instruction_surface.py` | Contract tests: every instruction surface must carry the pipeline tool restriction |
 | `test_issue_body_discipline.py` | Cross-skill contract: no SKILL.md may append validation summaries to issue bodies |
 | `test_issue_content_fidelity.py` | Cross-skill contract: content fidelity for issue body assembly |

--- a/tests/contracts/test_input_type_semantic_correctness.py
+++ b/tests/contracts/test_input_type_semantic_correctness.py
@@ -1,0 +1,102 @@
+"""Cross-validate skill_contracts.yaml path input types against SKILL.md content."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from autoskillit.core.io import load_yaml
+
+pytestmark = [pytest.mark.layer("contracts"), pytest.mark.medium]
+
+_CONTRACTS_YAML = Path(__file__).parents[2] / "src/autoskillit/recipe/skill_contracts.yaml"
+
+
+def _infer_path_kind_from_skillmd(
+    input_name: str, skillmd_text: str
+) -> Literal["file", "directory", "ambiguous"]:
+    if input_name.endswith(("_dir", "_directory")) or input_name == "run_dir":
+        return "directory"
+    if input_name.endswith("_path") and not any(
+        kw in input_name for kw in ("dir", "folder", "workspace")
+    ):
+        return "file"
+
+    placeholder = f"{{{input_name}}}"
+    mentions = [m.start() for m in re.finditer(re.escape(input_name), skillmd_text, re.IGNORECASE)]
+    mentions.extend(
+        m.start() for m in re.finditer(re.escape(placeholder), skillmd_text, re.IGNORECASE)
+    )
+    if not mentions:
+        return "ambiguous"
+
+    dir_re = re.compile(
+        r"\b(directory|directories|folder|glob\b.*inside|files\s+in\s+the|files\s+under)\b",
+        re.IGNORECASE,
+    )
+    file_re = re.compile(
+        r"\b(read\s+the\s+file|parse\s+the\s+file|load.*\bfile\b|\.md\b|\.yaml\b|\.json\b)\b",
+        re.IGNORECASE,
+    )
+
+    dir_count = 0
+    file_count = 0
+    for pos in mentions:
+        window = skillmd_text[max(0, pos - 200) : pos + 200]
+        dir_count += len(dir_re.findall(window))
+        file_count += len(file_re.findall(window))
+
+    if dir_count > 0 and file_count == 0:
+        return "directory"
+    if file_count > 0 and dir_count == 0:
+        return "file"
+    return "ambiguous"
+
+
+def _collect_path_input_params() -> list[tuple[str, str, str]]:
+    raw = load_yaml(_CONTRACTS_YAML)
+    skills = raw.get("skills", {})
+    result = []
+    for skill_name, contract in sorted(skills.items()):
+        for inp in contract.get("inputs", []):
+            if inp.get("type") in ("file_path", "directory_path"):
+                result.append((skill_name, inp["name"], inp["type"]))
+    return result
+
+
+_PATH_INPUT_PARAMS = _collect_path_input_params()
+
+
+def _resolve_skillmd(skill_name: str) -> str | None:
+    from autoskillit.workspace.skills import bundled_skills_dir, bundled_skills_extended_dir
+
+    for base in (bundled_skills_dir(), bundled_skills_extended_dir()):
+        md = base / skill_name / "SKILL.md"
+        if md.is_file():
+            return md.read_text()
+    return None
+
+
+@pytest.mark.parametrize(
+    "skill_name,input_name,declared_type",
+    _PATH_INPUT_PARAMS,
+    ids=[f"{s}-{i}" for s, i, _ in _PATH_INPUT_PARAMS],
+)
+def test_input_type_matches_skillmd(skill_name: str, input_name: str, declared_type: str) -> None:
+    """Declared input type in skill_contracts.yaml must match SKILL.md intent."""
+    skillmd = _resolve_skillmd(skill_name)
+    if skillmd is None:
+        pytest.skip(f"No SKILL.md found for {skill_name}")
+
+    inferred = _infer_path_kind_from_skillmd(input_name, skillmd)
+    if inferred == "ambiguous":
+        pytest.skip(f"Ambiguous inference for {skill_name}.{input_name}")
+
+    expected_type = "file_path" if inferred == "file" else "directory_path"
+    assert declared_type == expected_type, (
+        f"{skill_name}.{input_name}: declared as {declared_type!r} in skill_contracts.yaml "
+        f"but SKILL.md indicates it should be {expected_type!r}"
+    )

--- a/tests/contracts/test_input_type_semantic_correctness.py
+++ b/tests/contracts/test_input_type_semantic_correctness.py
@@ -20,6 +20,8 @@ def _infer_path_kind_from_skillmd(
 ) -> Literal["file", "directory", "ambiguous"]:
     if input_name.endswith(("_dir", "_directory")) or input_name == "run_dir":
         return "directory"
+    if "worktree" in input_name or input_name == "workspace":
+        return "directory"
     if input_name.endswith("_path") and not any(
         kw in input_name for kw in ("dir", "folder", "workspace")
     ):

--- a/tests/contracts/test_skill_contracts.py
+++ b/tests/contracts/test_skill_contracts.py
@@ -221,6 +221,41 @@ def test_all_exp_lens_skills_have_contracts(skills):
     assert not missing, f"exp-lens skills missing contracts: {sorted(missing)}"
 
 
+_CONTRACTLESS_SKILLS: frozenset[str] = frozenset(
+    {
+        "audit-arch",
+        "audit-bugs",
+        "audit-cohesion",
+        "audit-defense-standards",
+        "audit-docs",
+        "audit-review-decisions",
+        "close-kitchen",
+        "elaborate-phase",
+        "make-arch-diag",
+        "make-experiment-diag",
+        "make-req",
+        "open-kitchen",
+        "reload-session",
+        "setup-project",
+        "smoke-task",
+        "validate-review-decisions",
+        "verify-diag",
+    }
+)
+
+
+def test_all_bundled_skills_have_contracts(skills):
+    """Every bundled skill must have a contract entry in skill_contracts.yaml."""
+    from autoskillit.workspace.skills import DefaultSkillResolver
+
+    resolver = DefaultSkillResolver()
+    all_skills = [s.name for s in resolver.list_all()]
+    missing = [
+        name for name in all_skills if name not in skills and name not in _CONTRACTLESS_SKILLS
+    ]
+    assert not missing, f"Bundled skills missing contracts: {sorted(missing)}"
+
+
 _EXP_LENS_SKILLS: Final[list[str]] = sorted(
     name for name in load_yaml(_CONTRACTS_YAML).get("skills", {}) if name.startswith("exp-lens-")
 )

--- a/tests/server/test_tools_execution_input_gates.py
+++ b/tests/server/test_tools_execution_input_gates.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Literal
 
 import pytest
 
@@ -479,6 +483,86 @@ def _make_input_contract_resolver():
     from autoskillit.recipe._contracts_manifest import resolve_input_specs
 
     return resolve_input_specs
+
+
+def _collect_all_path_input_specs() -> list[tuple[str, str, str]]:
+    from autoskillit.core.io import load_yaml
+
+    yaml_path = Path(__file__).parents[2] / "src/autoskillit/recipe/skill_contracts.yaml"
+    raw = load_yaml(yaml_path)
+    result = []
+    for skill_name, contract in sorted(raw.get("skills", {}).items()):
+        for inp in contract.get("inputs", []):
+            if inp.get("type") in ("file_path", "directory_path"):
+                result.append((skill_name, inp["name"], inp["type"]))
+    return result
+
+
+_ALL_PATH_INPUT_SPECS = _collect_all_path_input_specs()
+
+
+class TestInputContractRealContracts:
+    """Gate integration tests using real contract declarations."""
+
+    @pytest.mark.parametrize(
+        "skill_name,input_name,declared_type",
+        _ALL_PATH_INPUT_SPECS,
+        ids=[f"{s}-{i}" for s, i, _ in _ALL_PATH_INPUT_SPECS],
+    )
+    def test_gate_accepts_correct_path_type(
+        self, tmp_path, skill_name: str, input_name: str, declared_type: str
+    ):
+        """Gate must accept the correct filesystem entity for every declared path input."""
+        from autoskillit.core import InputSpec
+        from autoskillit.server._guards import _check_input_contracts
+
+        narrowed: Literal["file_path", "directory_path"] = (
+            "file_path" if declared_type == "file_path" else "directory_path"
+        )
+        if narrowed == "file_path":
+            target = tmp_path / "test_input.md"
+            target.write_text("test")
+        else:
+            target = tmp_path / "test_input_dir"
+            target.mkdir()
+        spec = InputSpec(name=input_name, type=narrowed, required=True, position=0)
+        result = _check_input_contracts(
+            f"/autoskillit:{skill_name} {target}",
+            str(tmp_path),
+            resolver=lambda skill_command, _s=spec: (_s,),
+        )
+        assert result is None
+
+    @pytest.mark.parametrize(
+        "skill_name,input_name,declared_type",
+        _ALL_PATH_INPUT_SPECS,
+        ids=[f"{s}-{i}" for s, i, _ in _ALL_PATH_INPUT_SPECS],
+    )
+    def test_gate_rejects_wrong_path_type(
+        self, tmp_path, skill_name: str, input_name: str, declared_type: str
+    ):
+        """Gate must reject the WRONG filesystem entity for every declared path input."""
+        from autoskillit.core import InputSpec
+        from autoskillit.server._guards import _check_input_contracts
+
+        narrowed: Literal["file_path", "directory_path"] = (
+            "file_path" if declared_type == "file_path" else "directory_path"
+        )
+        if narrowed == "file_path":
+            wrong_target = tmp_path / "wrong_dir"
+            wrong_target.mkdir()
+        else:
+            wrong_target = tmp_path / "wrong_file.md"
+            wrong_target.write_text("test")
+        spec = InputSpec(name=input_name, type=narrowed, required=True, position=0)
+        result = _check_input_contracts(
+            f"/autoskillit:{skill_name} {wrong_target}",
+            str(tmp_path),
+            resolver=lambda skill_command, _s=spec: (_s,),
+        )
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["success"] is False
 
 
 class TestInputContractIntegration:


### PR DESCRIPTION
## Summary

The `file-audit-issues` skill declares its `run_dir` input as `type: file_path` in `skill_contracts.yaml`, but the skill expects a directory. The gate validator calls `Path.is_file()` which rejects directories, blocking the skill. The root architectural weakness is that `skill_contracts.yaml` input types are never cross-validated against what skills actually consume — two separate sources of truth (SKILL.md and skill_contracts.yaml) can silently drift with no test to catch it. The fix is a universal contract-level test that cross-references every `file_path`/`directory_path` declaration against the corresponding SKILL.md content and a parametrized gate-integration test that exercises every skill with path inputs.

## Requirements

The `file-audit-issues` skill's `run_dir` input is declared as `type: file_path` in `src/autoskillit/recipe/skill_contracts.yaml`, but the skill actually expects a **directory** containing `ticket_body_*.md` files. The gate validator in `server/_guards.py:222-223` calls `Path.is_file()` on the argument, which returns `False` for a directory, producing a gate error that blocks the skill from running.

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

Closes #3698

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260604-130605-396314/.autoskillit/temp/rectify/rectify_contract_type_semantic_validation_2026-06-04_131500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 207 | 1.4k | 6.8M | 123.1k | 84 | 531.1k | 22m 17s |
| review_approach* | opus[1m] | 1 | 4.1k | 5.2k | 199.3k | 48.6k | 11 | 35.1k | 5m 4s |
| dry_walkthrough* | opus | 1 | 49 | 7.3k | 757.1k | 82.0k | 36 | 65.1k | 6m 22s |
| implement* | opus[1m] | 1 | 99 | 16.2k | 3.2M | 96.4k | 82 | 79.8k | 7m 21s |
| audit_impl* | opus[1m] | 1 | 36 | 11.3k | 319.7k | 54.5k | 23 | 39.9k | 7m 28s |
| prepare_pr* | MiniMax-M3 | 1 | 546.7k | 3.5k | 0 | 0 | 16 | 0 | 2m 8s |
| compose_pr* | MiniMax-M3 | 1 | 271.6k | 1.1k | 0 | 0 | 10 | 0 | 50s |
| review_pr* | opus[1m] | 1 | 30 | 40.4k | 715.3k | 96.9k | 32 | 80.6k | 9m 9s |
| resolve_review* | opus[1m] | 1 | 37 | 8.9k | 505.7k | 59.2k | 24 | 42.5k | 6m 58s |
| **Total** | | | 823.0k | 95.3k | 12.5M | 123.1k | | 874.2k | 1h 7m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 224 | 14112.4 | 356.1 | 72.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **224** | 55597.5 | 3902.6 | 425.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 4.6k | 83.4k | 11.7M | 809.0k | 58m 19s |
| opus | 1 | 49 | 7.3k | 757.1k | 65.1k | 6m 22s |
| MiniMax-M3 | 2 | 818.4k | 4.6k | 0 | 0 | 2m 58s |