### PR TITLE
Implementation Plan: Restore phoropter_family: vis-lens on vis-lens steps in research-design.yaml

### DIFF
--- a/src/autoskillit/recipes/research-design.json
+++ b/src/autoskillit/recipes/research-design.json
@@ -202,6 +202,7 @@
     "vis_dial": {
       "tool": "run_skill",
       "model": "",
+      "phoropter_family": "vis-lens",
       "with": {
         "skill_command": "/autoskillit:select-vis-lenses ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}",
         "cwd": "${{ inputs.source_dir }}",
@@ -221,6 +222,7 @@
     "vis_apply": {
       "tool": "run_skill",
       "model": "",
+      "phoropter_family": "vis-lens",
       "with": {
         "skill_command": "/autoskillit:vis-lens-{slug} {context_path} ${{ context.experiment_plan }}",
         "cwd": "${{ inputs.source_dir }}",
@@ -241,6 +243,7 @@
     "vis_synthesize": {
       "tool": "run_skill",
       "model": "",
+      "phoropter_family": "vis-lens",
       "with": {
         "skill_command": "/autoskillit:synthesize-vis-plan ${{ inputs.source_dir }} ${{ context.experiment_plan }} {{AUTOSKILLIT_TEMP}}/run-vis-lenses --tier-c-lens=${{ context.tier_c_lens }} --methodology-tradition=${{ context.methodology_tradition }} --disambiguation-rule-applied=${{ context.disambiguation_rule_applied }}",
         "cwd": "${{ inputs.source_dir }}",

--- a/src/autoskillit/recipes/research-design.yaml
+++ b/src/autoskillit/recipes/research-design.yaml
@@ -177,6 +177,7 @@ steps:
   vis_dial:
     tool: run_skill
     model: ""
+    phoropter_family: vis-lens
     with:
       skill_command: "/autoskillit:select-vis-lenses ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}"
       cwd: "${{ inputs.source_dir }}"
@@ -194,6 +195,7 @@ steps:
   vis_apply:
     tool: run_skill
     model: ""
+    phoropter_family: vis-lens
     with:
       skill_command: "/autoskillit:vis-lens-{slug} {context_path} ${{ context.experiment_plan }}"
       cwd: "${{ inputs.source_dir }}"
@@ -209,6 +211,7 @@ steps:
   vis_synthesize:
     tool: run_skill
     model: ""
+    phoropter_family: vis-lens
     with:
       skill_command: "/autoskillit:synthesize-vis-plan ${{ inputs.source_dir }} ${{ context.experiment_plan }} {{AUTOSKILLIT_TEMP}}/run-vis-lenses --tier-c-lens=${{ context.tier_c_lens }} --methodology-tradition=${{ context.methodology_tradition }} --disambiguation-rule-applied=${{ context.disambiguation_rule_applied }}"
       cwd: "${{ inputs.source_dir }}"

--- a/tests/recipe/test_bundled_recipes_research_design.py
+++ b/tests/recipe/test_bundled_recipes_research_design.py
@@ -214,7 +214,7 @@ class TestResearchDesignRecipeStructure:
     # ----- vis-lens renamed step tests (T29-T37) -----
 
     def test_vis_dial_phoropter_family(self, recipe) -> None:
-        assert recipe.steps["vis_dial"].phoropter_family is None
+        assert recipe.steps["vis_dial"].phoropter_family == "vis-lens"
 
     def test_vis_dial_on_success(self, recipe) -> None:
         assert recipe.steps["vis_dial"].on_success == "vis_apply"
@@ -234,7 +234,7 @@ class TestResearchDesignRecipeStructure:
             assert key in capture, f"vis_dial missing capture key: {key}"
 
     def test_vis_apply_phoropter_family(self, recipe) -> None:
-        assert recipe.steps["vis_apply"].phoropter_family is None
+        assert recipe.steps["vis_apply"].phoropter_family == "vis-lens"
 
     def test_vis_apply_capture_list(self, recipe) -> None:
         assert "vis_lens_output_paths" in recipe.steps["vis_apply"].capture_list
@@ -249,7 +249,7 @@ class TestResearchDesignRecipeStructure:
         assert recipe.steps["vis_apply"].on_failure == "vis_synthesize"
 
     def test_vis_synthesize_phoropter_family(self, recipe) -> None:
-        assert recipe.steps["vis_synthesize"].phoropter_family is None
+        assert recipe.steps["vis_synthesize"].phoropter_family == "vis-lens"
 
     def test_vis_synthesize_on_success(self, recipe) -> None:
         assert recipe.steps["vis_synthesize"].on_success == "create_worktree"


### PR DESCRIPTION
## Summary

Add `phoropter_family: vis-lens` as a top-level step field to the three vis-lens phoropter steps (`vis_dial`, `vis_apply`, `vis_synthesize`) in `src/autoskillit/recipes/research-design.yaml`. The annotation is placed after `model: ""` and before `with:`, matching the field-ordering convention established by the `review-design` family steps in the same recipe. Contract regeneration is run for verification but contracts are gitignored and not committed. Test assertion updates are delegated to T2-P3-A7-WP1.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260604-141232-808290/.autoskillit/temp/make-plan/restore-vis-lens-phoropter-family_plan_2026-06-04_141600.md`

Closes #3712

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 3 | 169 | 23.1k | 3.0M | 67.2k | 131 | 144.6k | 11m 34s |
| verify* | sonnet | 2 | 160 | 10.8k | 738.9k | 53.3k | 50 | 64.2k | 4m 34s |
| implement* | MiniMax-M3 | 2 | 2.2M | 9.4k | 0 | 0 | 102 | 0 | 7m 6s |
| fix* | sonnet | 2 | 300 | 15.1k | 1.7M | 65.9k | 99 | 90.1k | 9m 26s |
| audit_impl* | sonnet | 2 | 93 | 16.4k | 408.9k | 44.9k | 35 | 54.2k | 6m 39s |
| dispatch:c7934f20-c45e-4f7a-bb34-8c8d01084a0b* | sonnet | 1 | 186 | 10.8k | 1.6M | 84.1k | 62 | 59.7k | 31m 19s |
| prepare_pr* | MiniMax-M3 | 1 | 333.3k | 3.5k | 0 | 0 | 22 | 0 | 1m 36s |
| compose_pr* | MiniMax-M3 | 1 | 184.1k | 1.1k | 0 | 0 | 12 | 0 | 42s |
| review_pr* | sonnet | 3 | 376 | 35.9k | 1.8M | 57.7k | 113 | 112.7k | 9m 41s |
| **Total** | | | 2.7M | 126.1k | 9.4M | 84.1k | | 525.5k | 1h 22m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 12 | 0.0 | 0.0 | 787.0 |
| fix | 12 | 144590.4 | 7506.2 | 1257.2 |
| audit_impl | 0 | — | — | — |
| dispatch:c7934f20-c45e-4f7a-bb34-8c8d01084a0b | 300 | 5486.8 | 199.1 | 36.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **324** | 28901.4 | 1621.8 | 389.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 169 | 23.1k | 3.0M | 144.6k | 11m 34s |
| sonnet | 5 | 1.1k | 89.0k | 6.4M | 380.9k | 1h 1m |
| MiniMax-M3 | 3 | 2.7M | 14.0k | 0 | 0 | 9m 25s |