### PR TITLE
Implementation Plan: Pipeline and core test deduplication (#3696)

### DIFF
--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -7,6 +7,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | File | Purpose |
 |------|---------|
 | `__init__.py` | empty |
+| `conftest.py` | Shared autouse fixture clearing the `collect_version_snapshot` cache for all tests in `tests/core/` |
 | `test_add_dir_validation.py` | Tests for ValidatedAddDir and validate_add_dir |
 | `test_canonical_token_usage.py` | Tests for CanonicalTokenUsage frozen dataclass — factory methods, merge, and immutability |
 | `test_capture.py` | Tests for CaptureEntrySpec and resolve_payload_field |

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core._version_snapshot import collect_version_snapshot
+
+
+@pytest.fixture(autouse=True)
+def _clear_snapshot_cache():
+    collect_version_snapshot.cache_clear()
+    yield
+    collect_version_snapshot.cache_clear()

--- a/tests/core/test_backend_gating_core.py
+++ b/tests/core/test_backend_gating_core.py
@@ -11,13 +11,6 @@ from autoskillit.core._version_snapshot import collect_version_snapshot
 pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
-@pytest.fixture(autouse=True)
-def _clear_snapshot_cache():
-    collect_version_snapshot.cache_clear()
-    yield
-    collect_version_snapshot.cache_clear()
-
-
 def _make_backend(name: str, version: str = "", plugins: list | None = None) -> Mock:
     """Create a mock CodingAgentBackend with the given identity and return values."""
     mock = Mock()

--- a/tests/core/test_version_snapshot.py
+++ b/tests/core/test_version_snapshot.py
@@ -13,13 +13,6 @@ from autoskillit.core._version_snapshot import collect_version_snapshot
 pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
-@pytest.fixture(autouse=True)
-def _clear_snapshot_cache():
-    collect_version_snapshot.cache_clear()
-    yield
-    collect_version_snapshot.cache_clear()
-
-
 def test_collect_version_snapshot_returns_required_keys():
     result = collect_version_snapshot()
     assert set(result.keys()) == {

--- a/tests/core/test_version_snapshot_codex_routing.py
+++ b/tests/core/test_version_snapshot_codex_routing.py
@@ -9,13 +9,6 @@ from autoskillit.core._version_snapshot import collect_version_snapshot
 pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
-@pytest.fixture(autouse=True)
-def _clear_snapshot_cache():
-    collect_version_snapshot.cache_clear()
-    yield
-    collect_version_snapshot.cache_clear()
-
-
 def test_codex_version_populated_with_codex_backend() -> None:
     backend = Mock()
     backend.name = "codex"

--- a/tests/pipeline/test_audit.py
+++ b/tests/pipeline/test_audit.py
@@ -631,9 +631,7 @@ def _write_audit_session_order_id(
     timestamp: str = "2026-05-01T00:00:00+00:00",
 ) -> None:
     """Write audit session with order_id in the index entry."""
-    from pathlib import Path as _Path
-
-    session_dir = _Path(log_root) / "sessions" / dir_name
+    session_dir = Path(log_root) / "sessions" / dir_name
     session_dir.mkdir(parents=True, exist_ok=True)
     (session_dir / "audit_log.json").write_text(json.dumps(records))
     index_entry = {
@@ -642,7 +640,7 @@ def _write_audit_session_order_id(
         "session_id": dir_name,
         "order_id": order_id,
     }
-    with (_Path(log_root) / "sessions.jsonl").open("a") as f:
+    with (Path(log_root) / "sessions.jsonl").open("a") as f:
         f.write(json.dumps(index_entry) + "\n")
 
 
@@ -678,9 +676,7 @@ def _write_audit_session_dispatch_id(
     timestamp: str = "2026-05-01T00:00:00+00:00",
 ) -> None:
     """Write audit session with dispatch_id in the index entry."""
-    from pathlib import Path as _Path
-
-    session_dir = _Path(log_root) / "sessions" / dir_name
+    session_dir = Path(log_root) / "sessions" / dir_name
     session_dir.mkdir(parents=True, exist_ok=True)
     (session_dir / "audit_log.json").write_text(json.dumps(records))
     index_entry = {
@@ -689,7 +685,7 @@ def _write_audit_session_dispatch_id(
         "session_id": dir_name,
         "dispatch_id": dispatch_id,
     }
-    with (_Path(log_root) / "sessions.jsonl").open("a") as f:
+    with (Path(log_root) / "sessions.jsonl").open("a") as f:
         f.write(json.dumps(index_entry) + "\n")
 
 
@@ -741,8 +737,6 @@ def test_iter_session_log_entries_dispatch_id_filter_empty_passes_all(tmp_path):
 
 def test_iter_entries_dispatch_id_filter_combined_with_campaign_id(tmp_path):
     """dispatch_id_filter AND campaign_id_filter apply as AND logic."""
-    from pathlib import Path as _Path
-
     from autoskillit.pipeline.audit import _iter_session_log_entries
 
     for dir_name, dispatch_id, campaign_id in [
@@ -750,7 +744,7 @@ def test_iter_entries_dispatch_id_filter_combined_with_campaign_id(tmp_path):
         ("wrong-did", "d2", "c1"),
         ("wrong-cid", "d1", "c2"),
     ]:
-        session_dir = _Path(tmp_path) / "sessions" / dir_name
+        session_dir = Path(tmp_path) / "sessions" / dir_name
         session_dir.mkdir(parents=True, exist_ok=True)
         (session_dir / "audit_log.json").write_text(json.dumps([_valid_failure_record_dict()]))
         index_entry = {
@@ -760,7 +754,7 @@ def test_iter_entries_dispatch_id_filter_combined_with_campaign_id(tmp_path):
             "dispatch_id": dispatch_id,
             "campaign_id": campaign_id,
         }
-        with (_Path(tmp_path) / "sessions.jsonl").open("a") as f:
+        with (Path(tmp_path) / "sessions.jsonl").open("a") as f:
             f.write(json.dumps(index_entry) + "\n")
 
     results = list(
@@ -778,8 +772,6 @@ def test_iter_entries_dispatch_id_filter_combined_with_campaign_id(tmp_path):
 
 def test_iter_session_log_entries_dispatch_id_combined_with_order_id(tmp_path):
     """dispatch_id_filter AND order_id_filter apply as AND logic."""
-    from pathlib import Path as _Path
-
     from autoskillit.pipeline.audit import _iter_session_log_entries
 
     for dir_name, dispatch_id, order_id in [
@@ -787,7 +779,7 @@ def test_iter_session_log_entries_dispatch_id_combined_with_order_id(tmp_path):
         ("dispatch-only", "d1", "o2"),
         ("order-only", "d2", "o1"),
     ]:
-        session_dir = _Path(tmp_path) / "sessions" / dir_name
+        session_dir = Path(tmp_path) / "sessions" / dir_name
         session_dir.mkdir(parents=True, exist_ok=True)
         (session_dir / "audit_log.json").write_text(json.dumps([_valid_failure_record_dict()]))
         index_entry = {
@@ -797,7 +789,7 @@ def test_iter_session_log_entries_dispatch_id_combined_with_order_id(tmp_path):
             "dispatch_id": dispatch_id,
             "order_id": order_id,
         }
-        with (_Path(tmp_path) / "sessions.jsonl").open("a") as f:
+        with (Path(tmp_path) / "sessions.jsonl").open("a") as f:
             f.write(json.dumps(index_entry) + "\n")
 
     results = list(

--- a/tests/pipeline/test_pr_gates.py
+++ b/tests/pipeline/test_pr_gates.py
@@ -240,11 +240,6 @@ class TestPRGatesVocabularyContract:
         assert isinstance(pr_gates.KNOWN_REVIEW_STATES, frozenset)
         assert "CHANGES_REQUESTED" in pr_gates.KNOWN_REVIEW_STATES
 
-    def test_changes_requested_in_known_review_states(self):
-        from autoskillit.pipeline.pr_gates import KNOWN_REVIEW_STATES
-
-        assert "CHANGES_REQUESTED" in KNOWN_REVIEW_STATES
-
     def test_ci_passing_conclusions_constant_exists(self):
         from autoskillit.pipeline import pr_gates
 


### PR DESCRIPTION
## Summary

Three validated test-quality findings from the tests audit: (1) delete a subset test in `test_pr_gates.py`, (2) extract a duplicated autouse fixture into a new `tests/core/conftest.py`, and (3) remove redundant local `Path as _Path` re-imports in `test_audit.py`. All changes are test-only — no production code is modified.

Closes #3696

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260604-141626-809045/.autoskillit/temp/make-plan/pipeline_and_core_test_deduplication_plan_2026-06-04_141900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 74 | 8.7k | 1.0M | 63.9k | 43 | 47.4k | 4m 39s |
| verify* | sonnet | 1 | 76 | 8.2k | 349.0k | 53.9k | 33 | 37.3k | 3m 11s |
| implement* | MiniMax-M3 | 1 | 853.0k | 7.5k | 0 | 0 | 66 | 0 | 4m 11s |
| audit_impl* | sonnet | 1 | 44 | 6.6k | 144.6k | 38.1k | 13 | 27.0k | 3m 23s |
| prepare_pr* | MiniMax-M3 | 1 | 234.9k | 2.0k | 0 | 0 | 17 | 0 | 1m 2s |
| compose_pr* | MiniMax-M3 | 1 | 221.8k | 1.3k | 0 | 0 | 14 | 0 | 54s |
| review_pr* | sonnet | 3 | 366 | 77.7k | 2.0M | 72.8k | 118 | 159.0k | 16m 15s |
| **Total** | | | 1.3M | 112.0k | 3.5M | 72.8k | | 270.7k | 33m 38s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 63 | 0.0 | 0.0 | 119.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **63** | 55579.5 | 4296.1 | 1778.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 74 | 8.7k | 1.0M | 47.4k | 4m 39s |
| sonnet | 3 | 486 | 92.5k | 2.5M | 223.3k | 22m 51s |
| MiniMax-M3 | 3 | 1.3M | 10.9k | 0 | 0 | 6m 7s |