### PR TITLE
Implementation Plan: Restore phoropter_family: vis-lens on vis-lens steps in research.yaml

### DIFF
--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -228,6 +228,7 @@
     "vis_dial": {
       "tool": "run_skill",
       "model": "",
+      "phoropter_family": "vis-lens",
       "with": {
         "skill_command": "/autoskillit:select-vis-lenses ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}",
         "cwd": "${{ inputs.source_dir }}",
@@ -247,6 +248,7 @@
     "vis_apply": {
       "tool": "run_skill",
       "model": "",
+      "phoropter_family": "vis-lens",
       "with": {
         "skill_command": "/autoskillit:vis-lens-{slug} {context_path}",
         "cwd": "${{ inputs.source_dir }}",
@@ -264,6 +266,7 @@
     "vis_synthesize": {
       "tool": "run_skill",
       "model": "",
+      "phoropter_family": "vis-lens",
       "with": {
         "skill_command": "/autoskillit:synthesize-vis-plan ${{ inputs.source_dir }} ${{ context.experiment_plan }} {{AUTOSKILLIT_TEMP}}/run-vis-lenses --tier-c-lens=${{ context.tier_c_lens }} --methodology-tradition=${{ context.methodology_tradition }} --disambiguation-rule-applied=${{ context.disambiguation_rule_applied }}",
         "cwd": "${{ inputs.source_dir }}",

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -231,6 +231,7 @@ steps:
   vis_dial:
     tool: run_skill
     model: ""
+    phoropter_family: vis-lens
     with:
       skill_command: "/autoskillit:select-vis-lenses ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}"
       cwd: "${{ inputs.source_dir }}"
@@ -248,6 +249,7 @@ steps:
   vis_apply:
     tool: run_skill
     model: ""
+    phoropter_family: vis-lens
     with:
       skill_command: "/autoskillit:vis-lens-{slug} {context_path}"
       cwd: "${{ inputs.source_dir }}"
@@ -271,6 +273,7 @@ steps:
   vis_synthesize:
     tool: run_skill
     model: ""
+    phoropter_family: vis-lens
     with:
       skill_command: "/autoskillit:synthesize-vis-plan ${{ inputs.source_dir }} ${{ context.experiment_plan }} {{AUTOSKILLIT_TEMP}}/run-vis-lenses --tier-c-lens=${{ context.tier_c_lens }} --methodology-tradition=${{ context.methodology_tradition }} --disambiguation-rule-applied=${{ context.disambiguation_rule_applied }}"
       cwd: "${{ inputs.source_dir }}"

--- a/tests/recipe/test_plan_visualization_step.py
+++ b/tests/recipe/test_plan_visualization_step.py
@@ -30,16 +30,16 @@ def test_vis_synthesize_step_exists(recipe) -> None:
 
 
 def test_vis_dial_phoropter_family(recipe) -> None:
-    """vis-lens steps no longer carry phoropter_family after rename."""
-    assert recipe.steps["vis_dial"].phoropter_family is None
+    """vis-lens steps carry phoropter_family: vis-lens."""
+    assert recipe.steps["vis_dial"].phoropter_family == "vis-lens"
 
 
 def test_vis_apply_phoropter_family(recipe) -> None:
-    assert recipe.steps["vis_apply"].phoropter_family is None
+    assert recipe.steps["vis_apply"].phoropter_family == "vis-lens"
 
 
 def test_vis_synthesize_phoropter_family(recipe) -> None:
-    assert recipe.steps["vis_synthesize"].phoropter_family is None
+    assert recipe.steps["vis_synthesize"].phoropter_family == "vis-lens"
 
 
 def test_vis_dial_captures_disambiguation_fields(recipe) -> None:


### PR DESCRIPTION
## Summary

Restore the `phoropter_family: vis-lens` annotation on the `vis_dial`, `vis_apply`, and `vis_synthesize` step blocks in `src/autoskillit/recipes/research.yaml` (stripped as a Phase 1 workaround), regenerate the compiled recipe JSON, and update three test assertions in `tests/recipe/test_plan_visualization_step.py` from `is None` to `== "vis-lens"`.

The sister recipe `research-design.yaml` already carries these annotations correctly (lines 180, 198, 214). This change brings `research.yaml` into parity.

Closes #3713

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260604-145532-517099/.autoskillit/temp/make-plan/restore-vis-lens-phoropter-family_plan_2026-06-04_145700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 50 | 6.4k | 934.9k | 82.1k | 33 | 67.9k | 4m 21s |
| verify* | sonnet | 1 | 60 | 5.5k | 222.1k | 39.8k | 17 | 24.2k | 2m 50s |
| implement* | MiniMax-M3 | 1 | 1.8M | 7.0k | 0 | 0 | 71 | 0 | 7m 5s |
| audit_impl* | sonnet | 1 | 44 | 3.9k | 144.8k | 40.4k | 14 | 43.9k | 3m 9s |
| prepare_pr* | MiniMax-M3 | 1 | 154.9k | 2.4k | 0 | 0 | 11 | 0 | 55s |
| compose_pr* | MiniMax-M3 | 1 | 222.0k | 1.3k | 0 | 0 | 13 | 0 | 47s |
| review_pr* | sonnet | 3 | 380 | 32.6k | 2.1M | 57.1k | 108 | 107.5k | 9m 11s |
| **Total** | | | 2.2M | 59.2k | 3.4M | 82.1k | | 243.6k | 28m 19s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 14 | 0.0 | 0.0 | 499.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **14** | 244083.0 | 17399.3 | 4229.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 50 | 6.4k | 934.9k | 67.9k | 4m 21s |
| sonnet | 3 | 484 | 42.1k | 2.5M | 175.7k | 15m 11s |
| MiniMax-M3 | 3 | 2.2M | 10.7k | 0 | 0 | 8m 47s |