### PR TITLE
Implementation Plan: Prove Multi-Family Adjacency Rules Handle Route-Action and Phase-Order

### DIFF
--- a/tests/recipe/test_rules_phoropter_adjacency.py
+++ b/tests/recipe/test_rules_phoropter_adjacency.py
@@ -610,3 +610,46 @@ def test_standalone_synthesize_does_not_complete_family():
     assert len(findings) == 1
     assert findings[0].step_name == "plain-step"
     assert "test-fam" in findings[0].message
+
+
+def test_route_action_between_complete_sequential_family_blocks_is_transparent(monkeypatch):
+    import autoskillit.recipe  # noqa: F401
+
+    monkeypatch.setattr(
+        "autoskillit.recipe.rules.rules_phoropter_adjacency._load_family_prefixes",
+        lambda: {"vis-lens": "vis"},
+    )
+    recipe = _make_recipe(
+        {
+            "dial": RecipeStep(tool="run_skill", phoropter_family="review-design"),
+            "apply": RecipeStep(tool="run_skill", phoropter_family="review-design"),
+            "synthesize": RecipeStep(tool="run_skill", phoropter_family="review-design"),
+            "routing-step": RecipeStep(action="route"),
+            "vis_dial": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+            "vis_apply": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+            "vis_synthesize": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-step-interleaving"]
+    assert len(findings) == 0
+
+
+def test_two_family_phase_order_no_findings(monkeypatch):
+    import autoskillit.recipe  # noqa: F401
+
+    monkeypatch.setattr(
+        "autoskillit.recipe.rules.rules_phoropter_adjacency._load_family_prefixes",
+        lambda: {"vis-lens": "vis"},
+    )
+    recipe = _make_recipe(
+        {
+            "dial": RecipeStep(tool="run_skill", phoropter_family="review-design"),
+            "apply": RecipeStep(tool="run_skill", phoropter_family="review-design"),
+            "synthesize": RecipeStep(tool="run_skill", phoropter_family="review-design"),
+            "vis_dial": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+            "vis_apply": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+            "vis_synthesize": RecipeStep(tool="run_skill", phoropter_family="vis-lens"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "phoropter-phase-order"]
+    assert len(findings) == 0


### PR DESCRIPTION
## Summary

Add two test functions to `tests/recipe/test_rules_phoropter_adjacency.py` that prove the evolved multi-family adjacency rules correctly handle: (b) a route-action step between two complete sequential family blocks produces zero interleaving findings, and (f) two families — review-design with canonical names and vis-lens with family-prefixed names — in correct phase order produce zero phase-order findings. No production code changes are needed.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260604-155126-414607/.autoskillit/temp/make-plan/t2-p3-a9-wp1-prove-multi-family-adjacency_plan_2026-06-04_155500.md`

Closes #3715

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 75 | 8.1k | 1.2M | 75.1k | 39 | 52.8k | 4m 50s |
| verify* | sonnet | 1 | 1.1k | 7.1k | 507.7k | 49.8k | 29 | 28.1k | 3m 38s |
| implement* | MiniMax-M3 | 1 | 884.7k | 4.6k | 0 | 0 | 46 | 0 | 4m 7s |
| audit_impl* | sonnet | 1 | 1.3k | 3.8k | 165.3k | 39.1k | 14 | 21.8k | 2m 11s |
| prepare_pr* | MiniMax-M3 | 1 | 267.1k | 2.1k | 0 | 0 | 10 | 0 | 1m 6s |
| compose_pr* | MiniMax-M3 | 1 | 183.8k | 1.2k | 0 | 0 | 12 | 0 | 45s |
| **Total** | | | 1.3M | 26.8k | 1.8M | 75.1k | | 102.7k | 16m 39s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 43 | 0.0 | 0.0 | 106.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **43** | 42562.3 | 2388.9 | 623.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 75 | 8.1k | 1.2M | 52.8k | 4m 50s |
| sonnet | 2 | 2.4k | 10.9k | 673.0k | 49.9k | 5m 49s |
| MiniMax-M3 | 3 | 1.3M | 7.8k | 0 | 0 | 5m 59s |