### PR TITLE
Small server-package test cleanups

### DIFF
--- a/.autoskillit/test-source-map.json
+++ b/.autoskillit/test-source-map.json
@@ -14234,6 +14234,7 @@
     "tests/server/test_lifespan_skill_boot.py",
     "tests/server/test_lock_ingredients.py",
     "tests/server/test_mcp_overrides.py",
+    "tests/server/test_notify_module.py",
     "tests/server/test_open_kitchen_deferred_recall.py",
     "tests/server/test_open_kitchen_staleness.py",
     "tests/server/test_pipeline_tracker.py",

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -30,6 +30,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_mcp_overrides.py` | Tests for MCP tool ingredient_overrides parameter propagation |
 | `test_misc_module.py` | Contract tests: server._misc module |
 | `test_no_raw_signal_handler.py` | AST guard: no raw signal.signal(SIGTERM, ...) in cli/app.py |
+| `test_notify_module.py` | Contract tests: server._notify module |
 | `test_perform_merge_editable_guard.py` | Integration tests verifying perform_merge() aborts before cleanup on poisoned installs |
 | `test_profile_to_env.py` | Tests for _profile_to_env — ProviderProfileDef to env dict conversion in _guards.py |
 | `test_quota_refresh_loop.py` | Tests for _quota_refresh_loop in server/_misc.py |

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -77,7 +77,7 @@ async def test_lifespan_calls_finalize_on_cancellation():
 
 
 @pytest.mark.asyncio
-async def test_lifespan_sets_startup_ready_event():
+async def test_lifespan_sets_startup_ready_event(monkeypatch):
     """_startup_ready must be set to a real Event and signalled after lifespan yield."""
     from autoskillit.server import _autoskillit_lifespan, _state
 
@@ -89,24 +89,17 @@ async def test_lifespan_sets_startup_ready_event():
     mock_ctx.audit.load_from_log_dir = MagicMock(return_value=0)
     mock_ctx.session_skill_manager = None
 
-    # Reset _startup_ready to None before test
-    original = _state._startup_ready
-    _state._startup_ready = None
+    monkeypatch.setattr(_state, "_startup_ready", None)
 
-    try:
-        with patch("autoskillit.server._lifespan._get_ctx_or_none", return_value=mock_ctx):
-            async with _autoskillit_lifespan(MagicMock()):
-                # _startup_ready is assigned synchronously before yield
-                assert _state._startup_ready is not None, (
-                    "_startup_ready must be assigned an asyncio.Event during lifespan"
-                )
-                # Background task may not have completed yet — await the event
-                await asyncio.wait_for(_state._startup_ready.wait(), timeout=5.0)
-                assert _state._startup_ready.is_set(), (
-                    "_startup_ready event must be signalled after deferred_initialize completes"
-                )
-    finally:
-        _state._startup_ready = original
+    with patch("autoskillit.server._lifespan._get_ctx_or_none", return_value=mock_ctx):
+        async with _autoskillit_lifespan(MagicMock()):
+            assert _state._startup_ready is not None, (
+                "_startup_ready must be assigned an asyncio.Event during lifespan"
+            )
+            await asyncio.wait_for(_state._startup_ready.wait(), timeout=5.0)
+            assert _state._startup_ready.is_set(), (
+                "_startup_ready event must be signalled after deferred_initialize completes"
+            )
 
 
 # T-WT-4: MCP lifespan startup detects broken hooks

--- a/tests/server/test_misc_module.py
+++ b/tests/server/test_misc_module.py
@@ -33,14 +33,6 @@ async def test_resolve_repo_from_remote_returns_empty_for_file_url(tmp_path: Pat
     assert result == ""
 
 
-def test_notify_module_exports():
-    from autoskillit.server._notify import _get_ctx_or_none, _notify, track_response_size
-
-    assert callable(_notify)
-    assert callable(track_response_size)
-    assert callable(_get_ctx_or_none)
-
-
 def test_misc_module_exports():
     from autoskillit.server._misc import (
         _HOOK_CONFIG_FILENAME,

--- a/tests/server/test_notify_module.py
+++ b/tests/server/test_notify_module.py
@@ -1,0 +1,15 @@
+"""Contract tests: server._notify module."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+def test_notify_module_exports():
+    from autoskillit.server._notify import _get_ctx_or_none, _notify, track_response_size
+
+    assert callable(_notify)
+    assert callable(track_response_size)
+    assert callable(_get_ctx_or_none)

--- a/tests/server/test_tools_status_summaries.py
+++ b/tests/server/test_tools_status_summaries.py
@@ -18,13 +18,12 @@ from autoskillit.server.tools.tools_status import (
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
-@pytest.fixture(autouse=True)
-def _fleet_session(monkeypatch):
-    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
-
-
 class TestGetTokenSummary:
     """get_token_summary is a gated tool that returns accumulated token usage."""
+
+    @pytest.fixture(autouse=True)
+    def _set_fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
 
     @pytest.mark.anyio
     async def test_gate_closed_returns_gate_error(self, tool_ctx):
@@ -197,6 +196,10 @@ class TestGetTokenSummary:
 class TestGetTimingSummary:
     """get_timing_summary is a gated tool that returns accumulated wall-clock timing."""
 
+    @pytest.fixture(autouse=True)
+    def _set_fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
     @pytest.mark.anyio
     async def test_gate_closed_returns_gate_error(self, tool_ctx):
         """get_timing_summary returns gate_error when kitchen gate is closed."""
@@ -267,6 +270,10 @@ class TestGetTimingSummary:
 class TestGetTokenSummaryFormat:
     """Tests for get_token_summary format parameter."""
 
+    @pytest.fixture(autouse=True)
+    def _set_fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
     @pytest.mark.anyio
     async def test_format_json_default(self, tool_ctx_kitchen_open):
         """format='json' (default) returns JSON dict."""
@@ -310,6 +317,10 @@ class TestGetTokenSummaryFormat:
 class TestGetTimingSummaryFormat:
     """Tests for get_timing_summary format parameter."""
 
+    @pytest.fixture(autouse=True)
+    def _set_fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
     @pytest.mark.anyio
     async def test_format_json_default(self, tool_ctx_kitchen_open):
         """format='json' (default) returns JSON dict."""
@@ -332,6 +343,10 @@ class TestGetTimingSummaryFormat:
 
 
 class TestTokenSummaryWallClock:
+    @pytest.fixture(autouse=True)
+    def _set_fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
     @pytest.mark.anyio
     async def test_wall_clock_seconds_merged_from_timing_log(self, tool_ctx_kitchen_open):
         from autoskillit.pipeline.timings import DefaultTimingLog
@@ -419,6 +434,10 @@ class TestTokenSummaryWallClock:
 
 
 class TestClearMarkerWritten:
+    @pytest.fixture(autouse=True)
+    def _set_fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
     @pytest.mark.parametrize(
         "fn,kwargs",
         [
@@ -468,6 +487,7 @@ async def test_get_token_summary_not_contaminated_by_prior_pipeline(
     Entries written by a prior pipeline run must not appear in the summary,
     even if the server was restarted with those sessions present in the log dir.
     """
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
     from unittest.mock import patch
 
     from autoskillit.server import _state
@@ -536,6 +556,10 @@ async def test_get_token_summary_not_contaminated_by_prior_pipeline(
 
 class TestOrderIdFilterOnSummaryTools:
     """Group D: order_id filter params on get_token_summary and get_timing_summary."""
+
+    @pytest.fixture(autouse=True)
+    def _set_fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
 
     @pytest.mark.anyio
     async def test_get_token_summary_order_id_filter_isolates_issue(


### PR DESCRIPTION
## Summary

Three validated audit findings in `tests/server/`: (1) remove module-level autouse fleet fixture in `test_tools_status_summaries.py` and scope it to the classes that need it, (2) move `test_notify_module_exports` from `test_misc_module.py` to a new `test_notify_module.py` to honor the one-source-module-per-test-file convention, (3) replace bare `_state._startup_ready` assignment with `monkeypatch.setattr` in `test_lifespan.py`.


Closes #3694

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260604-172425-730113/.autoskillit/temp/make-plan/small_server_package_test_cleanups_plan_2026-06-04_172500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 48 | 9.7k | 675.4k | 71.2k | 29 | 52.1k | 7m 59s |
| verify* | opus[1m] | 1 | 48 | 9.8k | 649.5k | 73.6k | 34 | 51.4k | 5m 57s |
| implement* | MiniMax-M3 | 1 | 2.3M | 7.8k | 0 | 0 | 74 | 0 | 6m 14s |
| audit_impl* | opus[1m] | 1 | 23 | 6.6k | 174.8k | 44.0k | 12 | 29.2k | 3m 9s |
| prepare_pr* | MiniMax-M3 | 1 | 281.0k | 2.1k | 0 | 0 | 15 | 0 | 1m 24s |
| compose_pr* | MiniMax-M3 | 1 | 345.4k | 1.3k | 0 | 0 | 15 | 0 | 1m 4s |
| review_pr* | opus[1m] | 1 | 779 | 25.5k | 686.2k | 77.1k | 29 | 55.1k | 7m 0s |
| resolve_review* | opus[1m] | 1 | 33 | 5.1k | 822.7k | 61.3k | 30 | 39.5k | 5m 2s |
| **Total** | | | 2.9M | 68.0k | 3.0M | 77.1k | | 227.4k | 37m 53s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 90 | 0.0 | 0.0 | 86.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **90** | 33429.4 | 2526.3 | 755.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 5 | 931 | 56.8k | 3.0M | 227.4k | 29m 9s |
| MiniMax-M3 | 3 | 2.9M | 11.3k | 0 | 0 | 8m 43s |