### PR TITLE
[FIX] Sentinel Reuse in parse_l3_result_block on Resumed Dispatches

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -566,7 +566,7 @@ async def _run_dispatch(
     if resume_session_id:
         _resume_jsonl = claude_code_log_path(str(tool_ctx.project_dir), resume_session_id)
         if _resume_jsonl is not None and _resume_jsonl.exists():
-            resume_line_offset = sum(1 for _ in _resume_jsonl.open(encoding="utf-8"))
+            resume_line_offset = len(_resume_jsonl.read_text(encoding="utf-8").splitlines())
 
     completion_marker = identity.completion_marker
     sentinel_contract = identity.sentinel_contract

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -562,6 +562,12 @@ async def _run_dispatch(
                     f"JSONL log for session {resume_session_id} not found",
                 )
 
+    resume_line_offset = 0
+    if resume_session_id:
+        _resume_jsonl = claude_code_log_path(str(tool_ctx.project_dir), resume_session_id)
+        if _resume_jsonl is not None and _resume_jsonl.exists():
+            resume_line_offset = sum(1 for _ in _resume_jsonl.open(encoding="utf-8"))
+
     completion_marker = identity.completion_marker
     sentinel_contract = identity.sentinel_contract
     from autoskillit.fleet.sidecar import sidecar_path as compute_sidecar_path  # noqa: PLC0415
@@ -758,12 +764,21 @@ async def _run_dispatch(
                 additional_jsonl_paths.append(path)
 
         jsonl_path = claude_code_log_path(str(tool_ctx.project_dir), skill_result.session_id or "")
+        if resume_line_offset and skill_result.session_id and resume_session_id:
+            if skill_result.session_id != resume_session_id:
+                logger.warning(
+                    "resume_line_offset_invalidated",
+                    resume_session_id=resume_session_id,
+                    actual_session_id=skill_result.session_id,
+                )
+                resume_line_offset = 0
         parsed_result = parse_l3_result_block(
             stdout=skill_result.result or "",
             expected_dispatch_id=dispatch_id,
             assistant_messages_path=jsonl_path,
             prior_dispatch_ids=prior_ids or None,
             additional_jsonl_paths=additional_jsonl_paths or None,
+            resume_line_offset=resume_line_offset,
         )
 
     _issue_urls_raw = effective_ingredients.get("issue_urls", "") if effective_ingredients else ""
@@ -785,6 +800,24 @@ async def _run_dispatch(
         checkpoint=dispatch_checkpoint,
         subtype=skill_result.subtype,
     )
+
+    _branch_name = ""
+    if sidecar_entries and tool_ctx.runner is not None:
+        for _entry in sidecar_entries:
+            if _entry.pr_url:
+                try:
+                    _pr_info = await tool_ctx.runner(
+                        ["gh", "pr", "view", _entry.pr_url, "--json", "headRefName"],
+                        cwd=tool_ctx.project_dir,
+                        timeout=15,
+                    )
+                    if _pr_info.returncode == 0 and _pr_info.stdout:
+                        import json as _json  # noqa: PLC0415
+
+                        _branch_name = _json.loads(_pr_info.stdout).get("headRefName", "")
+                except Exception:
+                    logger.debug("branch_name_extraction_failed", exc_info=True)
+                break
 
     _labels_cleaned = False
     if final_status not in (DispatchStatus.SUCCESS, DispatchStatus.RESUMABLE):
@@ -832,6 +865,7 @@ async def _run_dispatch(
         ended_at=ended_at,
         sidecar_path=dispatch_sidecar_path,
         labels_cleaned=_labels_cleaned,
+        branch_name=_branch_name,
         resume_checkpoint=_checkpoint_to_dict(dispatch_checkpoint),
     )
 

--- a/src/autoskillit/fleet/_reset.py
+++ b/src/autoskillit/fleet/_reset.py
@@ -60,6 +60,8 @@ class ResetReport:
     prs_closed: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
     state_updated: bool = False
+    has_protected_artifacts: bool = False
+    protected_prs: list[str] = field(default_factory=list)
 
 
 def find_dispatch_in_campaigns(
@@ -164,8 +166,12 @@ async def reset_dispatch_artifacts(
     runner: SubprocessRunner,
     github_client: GitHubFetcher | None,
     target_state: IssueLabelState,
+    force: bool = False,
 ) -> ResetReport:
-    report = ResetReport(dispatch_name=dispatch.name, branch_name=dispatch.name)
+    report = ResetReport(
+        dispatch_name=dispatch.name,
+        branch_name=dispatch.branch_name or dispatch.name,
+    )
     remove_labels, add_labels = compute_reset_labels(target_state)
 
     sidecar_result = None
@@ -200,20 +206,47 @@ async def reset_dispatch_artifacts(
         pr_urls = [e.pr_url for e in sidecar_result.entries if e.pr_url is not None]
 
     if not pr_urls and dispatch.sidecar_path is not None:
-        try:
-            gh_result = await runner(
-                ["gh", "pr", "list", "--head", dispatch.name, "--json", "url", "--limit", "5"],
-                cwd=project_dir,
-                timeout=15,
+        for _head_name in dict.fromkeys(
+            [dispatch.name]
+            + (
+                [dispatch.branch_name]
+                if dispatch.branch_name and dispatch.branch_name != dispatch.name
+                else []
             )
-            if gh_result.returncode == 0 and gh_result.stdout:
-                parsed = json.loads(gh_result.stdout)
-                pr_urls = [item["url"] for item in parsed if "url" in item]
-        except Exception as exc:
-            logger.warning("pr_fallback_search_failed", error=str(exc))
-            report.errors.append(f"pr_fallback_search: {exc}")
+        ):
+            try:
+                gh_result = await runner(
+                    ["gh", "pr", "list", "--head", _head_name, "--json", "url", "--limit", "5"],
+                    cwd=project_dir,
+                    timeout=15,
+                )
+                if gh_result.returncode == 0 and gh_result.stdout:
+                    parsed = json.loads(gh_result.stdout)
+                    pr_urls = [item["url"] for item in parsed if "url" in item]
+                    if pr_urls:
+                        break
+            except Exception as exc:
+                logger.warning("pr_fallback_search_failed", error=str(exc))
+                report.errors.append(f"pr_fallback_search: {exc}")
 
     for pr_url in pr_urls:
+        if not force:
+            try:
+                _view_result = await runner(
+                    ["gh", "pr", "view", pr_url, "--json", "reviewDecision,state"],
+                    cwd=project_dir,
+                    timeout=15,
+                )
+                if _view_result.returncode == 0 and _view_result.stdout:
+                    _pr_data = json.loads(_view_result.stdout)
+                    _is_open = _pr_data.get("state") == "OPEN"
+                    _review = _pr_data.get("reviewDecision", "")
+                    if _is_open and _review in ("APPROVED", "CHANGES_REQUESTED"):
+                        report.has_protected_artifacts = True
+                        report.protected_prs.append(pr_url)
+                        continue
+            except Exception:
+                logger.debug("pr_protection_check_failed", pr_url=pr_url, exc_info=True)
         try:
             close_result = await runner(
                 [

--- a/src/autoskillit/fleet/_reset.py
+++ b/src/autoskillit/fleet/_reset.py
@@ -246,7 +246,10 @@ async def reset_dispatch_artifacts(
                         report.protected_prs.append(pr_url)
                         continue
             except Exception:
-                logger.debug("pr_protection_check_failed", pr_url=pr_url, exc_info=True)
+                logger.warning("pr_protection_check_failed", pr_url=pr_url, exc_info=True)
+                report.has_protected_artifacts = True
+                report.protected_prs.append(pr_url)
+                continue
         try:
             close_result = await runner(
                 [

--- a/src/autoskillit/fleet/result_parser.py
+++ b/src/autoskillit/fleet/result_parser.py
@@ -40,11 +40,14 @@ def _is_parent_assistant_record(obj: dict) -> bool:
     return True
 
 
-def _extract_text_from_jsonl(path: Path) -> str:
+def _extract_text_from_jsonl(path: Path, skip_lines: int = 0) -> str:
     """Read a Claude Code session JSONL and extract assistant text blocks.
 
     Reads all lines, filters for type=="assistant" records, extracts text
     from message.content blocks. Returns concatenated text (oldest-first).
+
+    When *skip_lines* > 0, the first *skip_lines* lines are skipped before
+    extraction — used to scope reads to content written after a resume boundary.
     """
     try:
         raw = path.read_text(encoding="utf-8")
@@ -52,7 +55,7 @@ def _extract_text_from_jsonl(path: Path) -> str:
         return ""
 
     texts: list[str] = []
-    for line in raw.splitlines():
+    for line in raw.splitlines()[skip_lines:]:
         line = line.strip()
         if not line:
             continue
@@ -158,6 +161,7 @@ def parse_l3_result_block(
     assistant_messages_path: Path | None = None,
     prior_dispatch_ids: Sequence[str] | None = None,
     additional_jsonl_paths: Sequence[Path] | None = None,
+    resume_line_offset: int = 0,
 ) -> L3ParseResult:
     """Parse an L3 result block from food truck dispatch output.
 
@@ -184,7 +188,7 @@ def parse_l3_result_block(
     jsonl_text: str | None = None
     if assistant_messages_path is not None:
         jsonl_text = _collapse_hr_split_delimiters(
-            _extract_text_from_jsonl(assistant_messages_path)
+            _extract_text_from_jsonl(assistant_messages_path, skip_lines=resume_line_offset)
         )
         positions = _scan_for_sentinel(jsonl_text, open_sentinel, close_sentinel)
         if positions is not None:

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -122,6 +122,7 @@ class DispatchRecord:
     ended_at: float = 0.0
     sidecar_path: str | None = None
     labels_cleaned: bool = False
+    branch_name: str = ""
     attempt_history: list[dict[str, Any]] = field(default_factory=list)
     resume_checkpoint: dict[str, Any] = field(default_factory=dict)
     wait_seconds: float | None = None
@@ -154,6 +155,7 @@ class DispatchRecord:
             "ended_at": self.ended_at,
             "sidecar_path": self.sidecar_path,
             "labels_cleaned": self.labels_cleaned,
+            "branch_name": self.branch_name,
             "attempt_history": list(self.attempt_history),
             "resume_checkpoint": dict(self.resume_checkpoint),
             "wait_seconds": self.wait_seconds,
@@ -212,6 +214,7 @@ class DispatchRecord:
             ended_at=d.get("ended_at", 0.0),
             sidecar_path=d.get("sidecar_path"),
             labels_cleaned=d.get("labels_cleaned", False),
+            branch_name=d.get("branch_name", ""),
             attempt_history=d.get("attempt_history", []),
             resume_checkpoint=d.get("resume_checkpoint", {}),
             wait_seconds=d.get("wait_seconds"),

--- a/src/autoskillit/fleet/summary.py
+++ b/src/autoskillit/fleet/summary.py
@@ -169,7 +169,8 @@ def parse_campaign_summary(
 
     Returns CampaignSummary on success, ParseFailure with a specific kind on any failure.
     """
-    match = _SUMMARY_PATTERN.search(text)
+    _matches = list(_SUMMARY_PATTERN.finditer(text))
+    match = _matches[-1] if _matches else None
     if match is None:
         return ParseFailure(
             ParseFailureKind.SENTINEL_MISSING, "No campaign summary sentinel found"

--- a/src/autoskillit/server/tools/tools_fleet_reset.py
+++ b/src/autoskillit/server/tools/tools_fleet_reset.py
@@ -147,6 +147,7 @@ async def reset_dispatch(
             runner=tool_ctx.runner,
             github_client=tool_ctx.github_client,
             target_state=target_state,
+            force=force,
         )
 
         state_updated = await update_campaign_state(
@@ -174,6 +175,8 @@ async def reset_dispatch(
                 "prs_closed": report.prs_closed,
                 "state_updated": report.state_updated,
                 "errors": report.errors,
+                "has_protected_artifacts": report.has_protected_artifacts,
+                "protected_prs": report.protected_prs,
                 "reset_to": reset_to,
             }
         )

--- a/tests/fleet/test_reset.py
+++ b/tests/fleet/test_reset.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -193,3 +194,98 @@ class TestUpdateCampaignState:
         assert state is not None
         d = next(d for d in state.dispatches if d.name == "d-test2")
         assert d.labels_cleaned is True
+
+
+class TestResetProtectedArtifacts:
+    @pytest.mark.anyio
+    async def test_open_reviewed_pr_blocks_without_force(self, tmp_path: Path) -> None:
+        """reset_dispatch_artifacts discovers open PRs via branch_name and protects them."""
+        dispatch = DispatchRecord(
+            name="issue-42",
+            branch_name="issue-42-20260604",
+            sidecar_path=str(tmp_path / "gone.jsonl"),
+            status=DispatchStatus.FAILURE,
+        )
+
+        async def _runner(cmd, **_kwargs):
+            if "pr" in cmd and "list" in cmd:
+                if "--head" in cmd:
+                    head_idx = cmd.index("--head") + 1
+                    head_val = cmd[head_idx]
+                    if head_val == "issue-42":
+                        return _make_subprocess_result(stdout="[]")
+                    elif head_val == "issue-42-20260604":
+                        return _make_subprocess_result(
+                            stdout=json.dumps([{"url": "https://github.com/o/r/pull/3757"}])
+                        )
+                return _make_subprocess_result(stdout="[]")
+            if "pr" in cmd and "view" in cmd:
+                return _make_subprocess_result(
+                    stdout=json.dumps({"state": "OPEN", "reviewDecision": "APPROVED"})
+                )
+            return _make_subprocess_result()
+
+        report = await reset_dispatch_artifacts(
+            dispatch,
+            project_dir=tmp_path,
+            worktrees_dir=tmp_path / "wt",
+            runner=_runner,
+            github_client=None,
+            target_state=IssueLabelState.FAIL,
+        )
+        assert report.has_protected_artifacts is True
+        assert "https://github.com/o/r/pull/3757" in report.protected_prs
+        assert "https://github.com/o/r/pull/3757" not in report.prs_closed
+
+    @pytest.mark.anyio
+    async def test_force_bypasses_protection(self, tmp_path: Path) -> None:
+        """force=True closes reviewed PRs without protection check."""
+        dispatch = DispatchRecord(
+            name="issue-42",
+            branch_name="issue-42-20260604",
+            sidecar_path=str(tmp_path / "gone.jsonl"),
+            status=DispatchStatus.FAILURE,
+        )
+
+        async def _runner(cmd, **_kwargs):
+            if "pr" in cmd and "list" in cmd:
+                if "--head" in cmd:
+                    head_idx = cmd.index("--head") + 1
+                    head_val = cmd[head_idx]
+                    if head_val == "issue-42-20260604":
+                        return _make_subprocess_result(
+                            stdout=json.dumps([{"url": "https://github.com/o/r/pull/3757"}])
+                        )
+                return _make_subprocess_result(stdout="[]")
+            return _make_subprocess_result()
+
+        report = await reset_dispatch_artifacts(
+            dispatch,
+            project_dir=tmp_path,
+            worktrees_dir=tmp_path / "wt",
+            runner=_runner,
+            github_client=None,
+            target_state=IssueLabelState.FAIL,
+            force=True,
+        )
+        assert report.has_protected_artifacts is False
+        assert "https://github.com/o/r/pull/3757" in report.prs_closed
+
+    @pytest.mark.anyio
+    async def test_branch_name_field_populated_in_report(self, tmp_path: Path) -> None:
+        """ResetReport.branch_name uses dispatch.branch_name when available."""
+        dispatch = DispatchRecord(
+            name="issue-42",
+            branch_name="issue-42-20260604-153012",
+            status=DispatchStatus.FAILURE,
+        )
+        runner = AsyncMock(return_value=_make_subprocess_result())
+        report = await reset_dispatch_artifacts(
+            dispatch,
+            project_dir=tmp_path,
+            worktrees_dir=tmp_path / "wt",
+            runner=runner,
+            github_client=None,
+            target_state=IssueLabelState.FAIL,
+        )
+        assert report.branch_name == "issue-42-20260604-153012"

--- a/tests/fleet/test_result_parser.py
+++ b/tests/fleet/test_result_parser.py
@@ -660,7 +660,7 @@ def test_prior_id_sentinel_scoped_by_resume_offset(tmp_path: Path) -> None:
 
 
 def test_resume_line_offset_zero_preserves_existing_behavior(tmp_path: Path) -> None:
-    """resume_line_offset=0 (default) reads the entire JSONL, preserving backward compat."""
+    """resume_line_offset=0 reads entire JSONL; prior-ID accepted via prior_dispatch_ids."""
     prior_id = "aaaa1111-bbbb-cccc-dddd-eeee2222ffff"
     new_id = "xxxx9999-yyyy-zzzz-wwww-vvvv8888uuuu"
 

--- a/tests/fleet/test_result_parser.py
+++ b/tests/fleet/test_result_parser.py
@@ -573,3 +573,110 @@ def test_clean_sentinel_regression_guard() -> None:
     result = parse_l3_result_block(stdout=stdout, expected_dispatch_id=DISPATCH_ID)
     assert result.outcome == "completed_clean"
     assert result.payload == payload
+
+
+# ---------------------------------------------------------------------------
+# Resume-scoped JSONL extraction tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_text_from_jsonl_skip_lines(tmp_path: Path) -> None:
+    """_extract_text_from_jsonl with skip_lines returns only text from lines N+ onward."""
+    from autoskillit.fleet.result_parser import _extract_text_from_jsonl
+
+    messages_run1 = [f"RUN_1_MARKER message {i}" for i in range(5)]
+    messages_run2 = [f"RUN_2_MARKER message {i}" for i in range(5)]
+    jsonl_path = make_jsonl_file(tmp_path, messages_run1 + messages_run2)
+
+    text = _extract_text_from_jsonl(jsonl_path, skip_lines=5)
+    assert "RUN_2_MARKER" in text
+    assert "RUN_1_MARKER" not in text
+
+
+def test_stale_prior_id_sentinel_returns_no_sentinel_with_offset(tmp_path: Path) -> None:
+    """Shared JSONL with prior-run failure sentinel returns no_sentinel when offset skips it."""
+    prior_id = "aaaa1111-bbbb-cccc-dddd-eeee2222ffff"
+    new_id = "xxxx9999-yyyy-zzzz-wwww-vvvv8888uuuu"
+
+    prior_run_messages = [
+        "Some prior run output",
+        f"---l3-result::{prior_id}---\n"
+        f'{{"success": false, "reason": "context_exhausted"}}\n'
+        f"---end-l3-result::{prior_id}---",
+    ]
+    # Lines 0-9 are prior run (10 JSONL lines with make_jsonl_file producing 1 line per message)
+    # Actually make_jsonl_file creates exactly len(messages) lines
+    resumed_run_messages = [
+        "Resumed run output line 1",
+        "Resumed run output line 2",
+        "Resumed run output line 3",
+    ]
+    all_messages = prior_run_messages + resumed_run_messages
+    jsonl_path = make_jsonl_file(tmp_path, all_messages)
+
+    result = parse_l3_result_block(
+        stdout="",
+        expected_dispatch_id=new_id,
+        assistant_messages_path=jsonl_path,
+        prior_dispatch_ids=[prior_id],
+        resume_line_offset=len(prior_run_messages),
+    )
+    assert result.outcome == "no_sentinel"
+
+
+def test_prior_id_sentinel_scoped_by_resume_offset(tmp_path: Path) -> None:
+    """Stage 3b only searches JSONL content after the resume offset."""
+    prior_id = "aaaa1111-bbbb-cccc-dddd-eeee2222ffff"
+    new_id = "xxxx9999-yyyy-zzzz-wwww-vvvv8888uuuu"
+
+    # 5 lines with prior-ID failure sentinel
+    prior_lines = [
+        "Prior run message 1",
+        "Prior run message 2",
+        f"---l3-result::{prior_id}---\n"
+        f'{{"success": false, "reason": "context_exhausted"}}\n'
+        f"---end-l3-result::{prior_id}---",
+        "Prior run message 4",
+        "Prior run message 5",
+    ]
+    # 5 lines with resumed-run content, no sentinel
+    resumed_lines = [
+        "Resumed message 1",
+        "Resumed message 2",
+        "Resumed message 3",
+        "Resumed message 4",
+        "Resumed message 5",
+    ]
+    jsonl_path = make_jsonl_file(tmp_path, prior_lines + resumed_lines)
+
+    result = parse_l3_result_block(
+        stdout="",
+        expected_dispatch_id=new_id,
+        assistant_messages_path=jsonl_path,
+        prior_dispatch_ids=[prior_id],
+        resume_line_offset=len(prior_lines),
+    )
+    assert result.outcome == "no_sentinel"
+
+
+def test_resume_line_offset_zero_preserves_existing_behavior(tmp_path: Path) -> None:
+    """resume_line_offset=0 (default) reads the entire JSONL, preserving backward compat."""
+    prior_id = "aaaa1111-bbbb-cccc-dddd-eeee2222ffff"
+    new_id = "xxxx9999-yyyy-zzzz-wwww-vvvv8888uuuu"
+
+    messages = [
+        f"---l3-result::{prior_id}---\n"
+        f'{{"success": true, "reason": "completed"}}\n'
+        f"---end-l3-result::{prior_id}---",
+    ]
+    jsonl_path = make_jsonl_file(tmp_path, messages)
+
+    result = parse_l3_result_block(
+        stdout="",
+        expected_dispatch_id=new_id,
+        assistant_messages_path=jsonl_path,
+        prior_dispatch_ids=[prior_id],
+        resume_line_offset=0,
+    )
+    # Without offset, the prior-ID sentinel IS found (existing behavior)
+    assert result.outcome == "completed_clean"

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -549,6 +549,26 @@ class TestAttemptHistoryFields:
         assert roundtripped.attempt_history == [{"dispatch_id": "attempt-1", "status": "failure"}]
 
 
+class TestBranchNameField:
+    def test_branch_name_default_empty(self) -> None:
+        rec = DispatchRecord(name="d1")
+        assert rec.branch_name == ""
+
+    def test_branch_name_in_to_dict(self) -> None:
+        rec = DispatchRecord(name="d1", branch_name="feat-branch-20260604")
+        d = rec.to_dict()
+        assert d["branch_name"] == "feat-branch-20260604"
+
+    def test_branch_name_from_dict_missing_defaults_empty(self) -> None:
+        rec = DispatchRecord.from_dict({"name": "d1"})
+        assert rec.branch_name == ""
+
+    def test_branch_name_round_trips_through_to_dict(self) -> None:
+        rec = DispatchRecord(name="d1", branch_name="feat-branch-20260604")
+        roundtripped = DispatchRecord.from_dict(rec.to_dict())
+        assert roundtripped.branch_name == "feat-branch-20260604"
+
+
 class TestResumeCount:
     def test_resume_count_default_zero(self) -> None:
         """T5.1: DispatchRecord(name='x').resume_count defaults to 0."""

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -385,6 +385,7 @@ class TestDispatchRecordToDict:
             "ended_at",
             "sidecar_path",
             "attempt_history",
+            "branch_name",
             "resume_checkpoint",
             "wait_seconds",
             "resets_at",

--- a/tests/fleet/test_summary.py
+++ b/tests/fleet/test_summary.py
@@ -308,3 +308,15 @@ def test_campaign_summary_accepts_prior_campaign_id() -> None:
     text = _make_sentinel_text(prior_summary, campaign_id=prior_cid)
     result = parse_campaign_summary(text, current_cid, prior_campaign_ids=[prior_cid])
     assert isinstance(result, CampaignSummary)
+
+
+def test_campaign_summary_last_match_wins() -> None:
+    """When text contains two campaign-summary blocks, parse_campaign_summary returns the last."""
+    from autoskillit.fleet import CampaignSummary, parse_campaign_summary
+
+    first_data = {**_VALID_SUMMARY_DICT, "campaign_name": "First Run"}
+    second_data = {**_VALID_SUMMARY_DICT, "campaign_name": "Second Run"}
+    text = _make_sentinel_text(first_data) + "\n\nsome text\n\n" + _make_sentinel_text(second_data)
+    result = parse_campaign_summary(text, _VALID_CAMPAIGN_ID)
+    assert isinstance(result, CampaignSummary)
+    assert result.campaign_name == "Second Run"

--- a/tests/server/test_tools_fleet_reset.py
+++ b/tests/server/test_tools_fleet_reset.py
@@ -426,12 +426,21 @@ class TestResetDispatchProtection:
     async def test_reset_dispatch_surfaces_protected_artifacts(
         self, build_ctx_open, tmp_path, monkeypatch
     ) -> None:
-        """Tool response includes has_protected_artifacts and protected_prs fields."""
+        """has_protected_artifacts=True and PR URL present when OPEN+APPROVED."""
         sidecar = tmp_path / "sidecar.jsonl"
         _write_sidecar(sidecar, pr_url="https://github.com/owner/repo/pull/1")
         state_path = _setup_state(tmp_path, sidecar_path=str(sidecar))
         tool_ctx = build_ctx_open()
         _setup_tool(tool_ctx, monkeypatch, state_path)
+
+        async def _runner(cmd, **_kwargs):
+            if "pr" in cmd and "view" in cmd:
+                return _make_subprocess_result(
+                    stdout=json.dumps({"state": "OPEN", "reviewDecision": "APPROVED"}),
+                )
+            return _make_subprocess_result()
+
+        tool_ctx.runner = _runner
 
         from autoskillit.server.tools.tools_fleet_reset import reset_dispatch
 
@@ -439,6 +448,5 @@ class TestResetDispatchProtection:
         result = json.loads(raw)
 
         assert result["success"] is True
-        assert "has_protected_artifacts" in result
-        assert "protected_prs" in result
-        assert isinstance(result["protected_prs"], list)
+        assert result["has_protected_artifacts"] is True
+        assert "https://github.com/owner/repo/pull/1" in result["protected_prs"]

--- a/tests/server/test_tools_fleet_reset.py
+++ b/tests/server/test_tools_fleet_reset.py
@@ -419,3 +419,26 @@ class TestResetDispatchEdgeCases:
         state = json.loads(resume_state_path.read_text())
         assert "impl-issue-42" not in state["resume_attempted"]
         assert "d-abc123" not in state["resume_attempted"]
+
+
+class TestResetDispatchProtection:
+    @pytest.mark.anyio
+    async def test_reset_dispatch_surfaces_protected_artifacts(
+        self, build_ctx_open, tmp_path, monkeypatch
+    ) -> None:
+        """Tool response includes has_protected_artifacts and protected_prs fields."""
+        sidecar = tmp_path / "sidecar.jsonl"
+        _write_sidecar(sidecar, pr_url="https://github.com/owner/repo/pull/1")
+        state_path = _setup_state(tmp_path, sidecar_path=str(sidecar))
+        tool_ctx = build_ctx_open()
+        _setup_tool(tool_ctx, monkeypatch, state_path)
+
+        from autoskillit.server.tools.tools_fleet_reset import reset_dispatch
+
+        raw = await reset_dispatch(dispatch_id="d-abc123", reset_to="queued")
+        result = json.loads(raw)
+
+        assert result["success"] is True
+        assert "has_protected_artifacts" in result
+        assert "protected_prs" in result
+        assert isinstance(result["protected_prs"], list)


### PR DESCRIPTION
## Summary

Three architectural weaknesses converge to produce false-failure classification and unauthorized artifact destruction on resumed fleet dispatches:

1. **Cross-run data contamination** — `_extract_text_from_jsonl` reads the entire JSONL file without resume-boundary awareness. When `--resume` appends to the same JSONL, `parse_l3_result_block` Stage 3 (prior-ID fallback) finds the prior run's failure sentinel and returns it as the current run's result.
2. **Destructive actions without artifact verification** — `reset_dispatch` proceeds without checking whether the dispatch actually created artifacts worth preserving (open PRs with reviews). The `reset_resume_gate` only checks that a resume was *attempted*, not what it *accomplished*.
3. **Branch-name assumption mismatch** — `reset_dispatch_artifacts` PR discovery uses `dispatch.name` as the `--head` branch filter, but the actual PR branch may have a different name (timestamped, uniquified). PR #3757 survived by accident because this lookup failed silently.

The architectural solution makes the JSONL extraction layer resume-boundary-aware, adds a pre-destructive artifact-existence check to the reset pipeline, and closes the branch-name discovery gap — eliminating the three bug classes structurally rather than patching the specific incident.

## Requirements

Sentinel reuse across `--resume` sessions causes false-failure classification in `parse_l3_result_block`, leading to unauthorized destructive `reset_dispatch` calls. Discovered during issue #3696 processing where the L3 orchestrator destroyed pipeline artifacts after a resumed L2 had already completed successfully (PR #3757 created, reviewed, CI green).

The fix must:
- Make JSONL extraction resume-boundary-aware so downstream sentinel scanning cannot accidentally return stale prior-run results
- Add artifact-presence pre-checks to the reset pipeline to prevent destruction of valuable artifacts
- Close the branch-name discovery gap so PRs are discoverable regardless of branch name variance
- Provide structural immunity rather than patching the specific incident

Closes #3763

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260604-170030-877243/.autoskillit/temp/rectify/rectify_sentinel_reuse_resume_2026-06-04_230000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 88 | 33.4k | 3.5M | 144.7k | 77 | 147.4k | 26m 26s |
| review_approach* | opus[1m] | 1 | 24 | 4.5k | 236.1k | 53.0k | 10 | 33.5k | 5m 29s |
| dry_walkthrough* | opus | 2 | 92 | 20.8k | 2.8M | 111.2k | 102 | 172.2k | 12m 7s |
| implement* | opus[1m] | 2 | 129 | 22.7k | 4.3M | 130.9k | 116 | 167.0k | 12m 7s |
| audit_impl* | opus[1m] | 2 | 67 | 26.5k | 542.0k | 72.3k | 37 | 86.2k | 12m 9s |
| make_plan* | opus[1m] | 1 | 1.1k | 5.1k | 436.6k | 55.3k | 19 | 36.1k | 3m 11s |
| prepare_pr* | MiniMax-M3 | 1 | 774.7k | 4.1k | 0 | 0 | 27 | 0 | 2m 37s |
| compose_pr* | MiniMax-M3 | 1 | 270.6k | 1.7k | 0 | 0 | 13 | 0 | 1m 13s |
| review_pr* | opus[1m] | 1 | 31 | 40.9k | 866.8k | 103.1k | 33 | 81.5k | 11m 3s |
| resolve_review* | opus[1m] | 1 | 49 | 13.7k | 1.6M | 83.9k | 43 | 62.4k | 11m 41s |
| **Total** | | | 1.0M | 173.5k | 14.2M | 144.7k | | 786.1k | 1h 38m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 385 | 11067.8 | 433.7 | 59.0 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 9 | 175182.0 | 6928.1 | 1525.4 |
| **Total** | **394** | 36073.1 | 1995.2 | 440.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 7 | 1.5k | 146.9k | 11.5M | 613.9k | 1h 22m |
| opus | 1 | 92 | 20.8k | 2.8M | 172.2k | 12m 7s |
| MiniMax-M3 | 2 | 1.0M | 5.8k | 0 | 0 | 3m 50s |