### PR TITLE
Rectify: Git Detection Structural Validation — Centralized Primitive with Walk-Past Semantics

### DIFF
--- a/src/autoskillit/core/paths.py
+++ b/src/autoskillit/core/paths.py
@@ -17,7 +17,9 @@ import importlib.resources as ir
 import os
 import subprocess
 import sys
+from enum import Enum
 from pathlib import Path
+from typing import NamedTuple
 
 
 def default_log_dir() -> Path:
@@ -101,6 +103,35 @@ def find_latest_session_id(cwd: str | None = None) -> str | None:
     return jsonl_files[0].stem
 
 
+class _GitAncestorKind(Enum):
+    MAIN = "main"
+    WORKTREE = "worktree"
+
+
+class _GitAncestorResult(NamedTuple):
+    kind: _GitAncestorKind
+    root: Path
+
+
+def _find_git_ancestor(path: Path) -> _GitAncestorResult | None:
+    """Walk the ancestor chain to find the nearest structurally valid git root.
+
+    A .git *file* indicates a linked worktree.  A .git *directory* is only
+    accepted when it contains a ``HEAD`` file (matching git's own
+    ``setup.c:is_git_directory()``).  Empty/stale .git directories are
+    walked past so a valid repo higher in the tree can still be found.
+    """
+    for parent in [path, *path.parents]:
+        git_path = parent / ".git"
+        if git_path.is_file():
+            return _GitAncestorResult(_GitAncestorKind.WORKTREE, parent)
+        if git_path.is_dir():
+            if (git_path / "HEAD").is_file():
+                return _GitAncestorResult(_GitAncestorKind.MAIN, parent)
+            continue
+    return None
+
+
 def is_git_worktree(path: Path) -> bool:
     """Return True if path is inside a git linked worktree.
 
@@ -111,13 +142,8 @@ def is_git_worktree(path: Path) -> bool:
     Uses only filesystem operations — no subprocess or git required.
     This is the fast, reliable heuristic for pre-install validation.
     """
-    for parent in [path, *path.parents]:
-        git_path = parent / ".git"
-        if git_path.is_file():
-            return True  # .git file = linked worktree
-        if git_path.is_dir():
-            return False  # .git dir = main checkout
-    return False  # not in a git repo
+    result = _find_git_ancestor(path)
+    return result is not None and result.kind == _GitAncestorKind.WORKTREE
 
 
 def is_git_main_checkout(path: Path) -> bool:
@@ -129,13 +155,8 @@ def is_git_main_checkout(path: Path) -> bool:
     This is the semantic inverse of ``is_git_worktree()`` for the "main checkout"
     case — it differs in that "not in a git repo" returns False (not True).
     """
-    for parent in [path, *path.parents]:
-        git_path = parent / ".git"
-        if git_path.is_dir():
-            return True
-        if git_path.is_file():
-            return False
-    return False
+    result = _find_git_ancestor(path)
+    return result is not None and result.kind == _GitAncestorKind.MAIN
 
 
 def is_in_git_repo(path: Path) -> bool:
@@ -145,11 +166,7 @@ def is_in_git_repo(path: Path) -> bool:
     Use this when the caller needs "any git context" without caring about
     the worktree vs main checkout distinction.
     """
-    for parent in [path, *path.parents]:
-        git_path = parent / ".git"
-        if git_path.is_file() or git_path.is_dir():
-            return True
-    return False
+    return _find_git_ancestor(path) is not None
 
 
 def resolve_main_worktree(path: Path) -> Path | None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,16 @@ class TimeoutTier:
 _structlog_proxies: list[object] = []
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _detect_tmp_git_contamination():
+    """Fail fast if /tmp/.git exists — prevents 35+ phantom test failures."""
+    if _Path("/tmp/.git").exists():
+        pytest.fail(
+            "/tmp/.git exists — this contaminates is_git_main_checkout() for tests "
+            "using cwd='/tmp'. Remove it before running the test suite."
+        )
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _structlog_session_init():
     """One-time structlog proxy cache flush and proxy inventory per worker session.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,11 +88,24 @@ _structlog_proxies: list[object] = []
 
 @pytest.fixture(autouse=True, scope="session")
 def _detect_tmp_git_contamination():
-    """Fail fast if /tmp/.git exists — prevents 35+ phantom test failures."""
-    if _Path("/tmp/.git").exists():
+    """Fail fast if /tmp/.git is a structurally valid git repo.
+
+    An empty /tmp/.git directory is harmless — _find_git_ancestor() walks past
+    it (no HEAD file).  Only a valid git repo at /tmp contaminates tests that
+    use cwd='/tmp'.
+    """
+    tmp_git = _Path("/tmp/.git")
+    if tmp_git.is_dir() and (tmp_git / "HEAD").is_file():
         pytest.fail(
-            "/tmp/.git exists — this contaminates is_git_main_checkout() for tests "
-            "using cwd='/tmp'. Remove it before running the test suite."
+            "/tmp/.git exists with a valid HEAD — this contaminates "
+            "is_git_main_checkout() for tests using cwd='/tmp'. "
+            "Remove it before running the test suite."
+        )
+    if tmp_git.is_file():
+        pytest.fail(
+            "/tmp/.git is a worktree pointer file — this contaminates "
+            "is_git_worktree() for tests using cwd='/tmp'. "
+            "Remove it before running the test suite."
         )
 
 

--- a/tests/core/test_paths.py
+++ b/tests/core/test_paths.py
@@ -13,10 +13,13 @@ pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 class TestWorktreeDetection:
     def test_detects_main_checkout_as_not_worktree(self, tmp_path: Path) -> None:
         """A directory with a .git DIRECTORY is the main checkout, not a worktree."""
-        from autoskillit.core.paths import is_git_worktree
+        from autoskillit.core.paths import is_git_main_checkout, is_git_worktree
 
-        (tmp_path / ".git").mkdir()
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
         assert is_git_worktree(tmp_path) is False
+        assert is_git_main_checkout(tmp_path) is True
 
     def test_detects_linked_worktree_via_git_file(self, tmp_path: Path) -> None:
         """A directory with a .git FILE is a linked worktree."""
@@ -168,7 +171,9 @@ class TestIsGitMainCheckout:
     def test_git_directory_returns_true(self, tmp_path: Path) -> None:
         from autoskillit.core.paths import is_git_main_checkout
 
-        (tmp_path / ".git").mkdir()
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
         assert is_git_main_checkout(tmp_path) is True
 
     def test_git_file_returns_false(self, tmp_path: Path) -> None:
@@ -180,7 +185,9 @@ class TestIsGitMainCheckout:
     def test_nested_directory_returns_true(self, tmp_path: Path) -> None:
         from autoskillit.core.paths import is_git_main_checkout
 
-        (tmp_path / ".git").mkdir()
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
         subdir = tmp_path / "src" / "pkg"
         subdir.mkdir(parents=True)
         assert is_git_main_checkout(subdir) is True
@@ -190,7 +197,9 @@ class TestIsInGitRepo:
     def test_returns_true_for_git_directory(self, tmp_path: Path) -> None:
         from autoskillit.core.paths import is_in_git_repo
 
-        (tmp_path / ".git").mkdir()
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
         assert is_in_git_repo(tmp_path) is True
 
     def test_returns_true_for_git_file(self, tmp_path: Path) -> None:
@@ -207,7 +216,9 @@ class TestIsInGitRepo:
     def test_returns_true_for_nested_main_checkout(self, tmp_path: Path) -> None:
         from autoskillit.core.paths import is_in_git_repo
 
-        (tmp_path / ".git").mkdir()
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
         subdir = tmp_path / "src" / "pkg"
         subdir.mkdir(parents=True)
         assert is_in_git_repo(subdir) is True
@@ -237,7 +248,9 @@ class TestIsInGitRepo:
 
         checkout = tmp_path / "checkout"
         checkout.mkdir()
-        (checkout / ".git").mkdir()
+        checkout_git = checkout / ".git"
+        checkout_git.mkdir()
+        (checkout_git / "HEAD").write_text("ref: refs/heads/main\n")
 
         worktree = tmp_path / "worktree"
         worktree.mkdir()
@@ -245,6 +258,93 @@ class TestIsInGitRepo:
 
         for p in (bare, checkout, worktree):
             assert is_in_git_repo(p) == (is_git_worktree(p) or is_git_main_checkout(p))
+
+
+class TestEmptyGitDirectoryRejection:
+    """Empty .git directories (no HEAD) must not be treated as valid repos."""
+
+    def test_is_git_main_checkout_rejects_empty_git_dir(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import is_git_main_checkout
+
+        (tmp_path / ".git").mkdir()
+        assert is_git_main_checkout(tmp_path) is False
+
+    def test_is_in_git_repo_rejects_empty_git_dir(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import is_in_git_repo
+
+        (tmp_path / ".git").mkdir()
+        assert is_in_git_repo(tmp_path) is False
+
+    def test_worktree_walks_past_empty_git_to_valid_parent_worktree(self, tmp_path: Path) -> None:
+        """is_git_worktree must walk past empty .git dir to find parent worktree."""
+        from autoskillit.core.paths import is_git_worktree
+
+        (tmp_path / ".git").write_text("gitdir: /path/to/main/.git/worktrees/foo\n")
+        child = tmp_path / "subdir"
+        child.mkdir()
+        (child / ".git").mkdir()  # empty — no HEAD
+        assert is_git_worktree(child) is True
+
+
+class TestFindGitAncestor:
+    """Contract tests for the centralized primitive."""
+
+    def test_returns_none_for_plain_directory(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import _find_git_ancestor
+
+        assert _find_git_ancestor(tmp_path) is None
+
+    def test_returns_main_for_valid_git_dir(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import _find_git_ancestor, _GitAncestorKind
+
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
+        result = _find_git_ancestor(tmp_path)
+        assert result is not None
+        assert result.kind == _GitAncestorKind.MAIN
+        assert result.root == tmp_path
+
+    def test_returns_worktree_for_git_file(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import _find_git_ancestor, _GitAncestorKind
+
+        (tmp_path / ".git").write_text("gitdir: /path/to/main/.git/worktrees/foo\n")
+        result = _find_git_ancestor(tmp_path)
+        assert result is not None
+        assert result.kind == _GitAncestorKind.WORKTREE
+        assert result.root == tmp_path
+
+    def test_skips_empty_git_dir(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import _find_git_ancestor
+
+        (tmp_path / ".git").mkdir()  # empty — no HEAD
+        assert _find_git_ancestor(tmp_path) is None
+
+    def test_walks_past_empty_to_valid_main_parent(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import _find_git_ancestor, _GitAncestorKind
+
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
+        child = tmp_path / "subdir"
+        child.mkdir()
+        (child / ".git").mkdir()  # empty
+        result = _find_git_ancestor(child)
+        assert result is not None
+        assert result.kind == _GitAncestorKind.MAIN
+        assert result.root == tmp_path
+
+    def test_walks_past_empty_to_valid_worktree_parent(self, tmp_path: Path) -> None:
+        from autoskillit.core.paths import _find_git_ancestor, _GitAncestorKind
+
+        (tmp_path / ".git").write_text("gitdir: /path/to/main/.git/worktrees/foo\n")
+        child = tmp_path / "subdir"
+        child.mkdir()
+        (child / ".git").mkdir()  # empty
+        result = _find_git_ancestor(child)
+        assert result is not None
+        assert result.kind == _GitAncestorKind.WORKTREE
+        assert result.root == tmp_path
 
 
 class TestDefaultLogDir:


### PR DESCRIPTION
## Summary

Three git-detection functions in `src/autoskillit/core/paths.py` (`is_git_worktree`, `is_git_main_checkout`, `is_in_git_repo`) each independently walk the ancestor chain checking `.git` entries, but none validate that a `.git` directory is structurally sound (contains a `HEAD` file). An empty `.git` directory created by any process on the machine fools all three into reporting a valid git repo. The architectural fix replaces the three independent walks with a single shared primitive `_find_git_ancestor()` that centralizes structural validation and walk-past semantics — making it impossible for any current or future caller to skip the validation.

Closes #3759

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260604-191313-742573/.autoskillit/temp/rectify/rectify_git_detection_structural_validation_2026-06-04_193500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 63 | 27.5k | 1.5M | 117.4k | 43 | 95.2k | 15m 7s |
| review_approach* | opus[1m] | 1 | 8.1k | 5.7k | 243.0k | 60.6k | 11 | 41.8k | 7m 44s |
| dry_walkthrough* | opus | 1 | 29 | 7.5k | 713.8k | 93.0k | 25 | 70.8k | 4m 51s |
| implement* | opus[1m] | 1 | 56 | 8.6k | 1.2M | 76.8k | 41 | 55.0k | 3m 20s |
| audit_impl* | opus[1m] | 1 | 36 | 10.7k | 367.1k | 60.4k | 22 | 39.4k | 4m 53s |
| prepare_pr* | MiniMax-M3 | 1 | 213.4k | 1.6k | 0 | 0 | 12 | 0 | 1m 0s |
| compose_pr* | MiniMax-M3 | 1 | 308.8k | 1.2k | 0 | 0 | 15 | 0 | 1m 1s |
| review_pr* | opus[1m] | 3 | 82 | 45.9k | 1.4M | 67.0k | 78 | 135.0k | 11m 30s |
| **Total** | | | 530.5k | 108.8k | 5.3M | 117.4k | | 437.3k | 49m 29s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 179 | 6611.2 | 307.3 | 48.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **179** | 29801.3 | 2442.9 | 607.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 5 | 8.3k | 98.4k | 4.6M | 366.4k | 42m 36s |
| opus | 1 | 29 | 7.5k | 713.8k | 70.8k | 4m 51s |
| MiniMax-M3 | 2 | 522.2k | 2.9k | 0 | 0 | 2m 1s |