### PR TITLE
[FIX] Rectify: Planner Pipeline Elaboration Stub Lifecycle — Orphaned Blocks and Manifest-Content Divergence

### DIFF
--- a/src/autoskillit/planner/CLAUDE.md
+++ b/src/autoskillit/planner/CLAUDE.md
@@ -9,7 +9,7 @@ IL-1 progressive resolution planner — phases, work packages, manifest generati
 | `__init__.py` | Re-exports `expand_assignments`, `expand_wps`, `finalize_wp_manifest`, `validate_plan`, `compile_plan` |
 | `_sort_utils.py` | Natural sort key utility: `_NATURAL_SORT_RE`, `_natural_sort_key()` |
 | `_dag_ops.py` | Shared DAG primitives: `topological_sort`, `find_sccs`, `break_cycles_greedy_fas`, `filter_self_references` |
-| `manifests.py` | `expand_assignments`, `expand_wps`, `finalize_wp_manifest`, `build_phase_assignment_manifest`, `build_phase_wp_manifest` |
+| `manifests.py` | `expand_assignments`, `expand_wps`, `finalize_wp_manifest`, `reconcile_wp_files`, `build_phase_assignment_manifest`, `build_phase_wp_manifest` |
 | `merge.py` | `merge_tier_dir`, `merge_files`, `build_plan_snapshot`, `extract_item`, `replace_item` — JSON interchange merge tooling |
 | `validation.py` | `validate_plan` — DAG cycle check, structural completeness, sizing bounds, duplicate-deliverable detection |
 | `schema.py` | Planner data contracts: `PhaseResult`, `AssignmentResult`, `WPResult`, `PlanDocument` TypedDicts |

--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -14,6 +14,7 @@ from autoskillit.planner.manifests import (
     expand_assignments,
     expand_wps,
     finalize_wp_manifest,
+    reconcile_wp_files,
     resolve_task_input,
 )
 from autoskillit.planner.merge import (
@@ -63,6 +64,7 @@ __all__ = [
     "expand_assignments",
     "expand_wps",
     "finalize_wp_manifest",
+    "reconcile_wp_files",
     "resolve_task_input",
     "validate_plan",
     "PlannerManifest",

--- a/src/autoskillit/planner/lifecycle.py
+++ b/src/autoskillit/planner/lifecycle.py
@@ -56,26 +56,27 @@ def load_lifecycle_registry(planner_dir: Path) -> dict[str, Any]:
     wp_dir = planner_dir / "work_packages"
     registry_path = wp_dir / _REGISTRY_FILENAME
 
+    defaults: dict[str, Any] = {
+        "voided_phases": [],
+        "voided_assignments": [],
+        "absorbed": {},
+        "voided_wps": {},
+    }
+
     if registry_path.exists():
         loaded = read_versioned_json(registry_path, LIFECYCLE_REGISTRY_VERSION)
         if loaded:
-            return {
-                "voided_phases": loaded.get("voided_phases", []),
-                "voided_assignments": loaded.get("voided_assignments", []),
-                "absorbed": loaded.get("absorbed", {}),
-                "voided_wps": loaded.get("voided_wps", {}),
-            }
+            result = dict(defaults)
+            result.update(loaded)
+            return result
 
     legacy_path = wp_dir / _LEGACY_FILENAME
     if legacy_path.exists():
         logger.warning("lifecycle_registry_fallback", path=str(legacy_path))
         loaded = read_versioned_json(legacy_path, 1)
         if loaded:
-            return {
-                "voided_phases": [],
-                "voided_assignments": [],
-                "absorbed": loaded.get("absorbed", {}),
-                "voided_wps": {},
-            }
+            result = dict(defaults)
+            result["absorbed"] = loaded.get("absorbed", {})
+            return result
 
-    return {"voided_phases": [], "voided_assignments": [], "absorbed": {}, "voided_wps": {}}
+    return dict(defaults)

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -547,17 +547,23 @@ def reconcile_wp_files(planner_dir: str) -> dict[str, str]:
 
     archived_dir = wp_dir / "archived"
     archived_dir.mkdir(exist_ok=True)
+    moved_ids: list[str] = []
     for orphan_id in sorted(orphan_ids):
         src = disk_ids[orphan_id]
-        src.rename(archived_dir / src.name)
+        try:
+            src.rename(archived_dir / src.name)
+            moved_ids.append(orphan_id)
+        except OSError:
+            logger.warning("reconcile_wp_files: rename failed", orphan_id=orphan_id)
 
-    record_lifecycle_event(
-        planner_path,
-        "archived_stubs",
-        {oid: {"reason": "elaboration_failed_orphan"} for oid in orphan_ids},
-    )
-    logger.info("reconcile_wp_files", archived_count=len(orphan_ids))
+    if moved_ids:
+        record_lifecycle_event(
+            planner_path,
+            "archived_stubs",
+            {oid: {"reason": "elaboration_failed_orphan"} for oid in moved_ids},
+        )
+    logger.info("reconcile_wp_files", archived_count=len(moved_ids))
     return {
-        "archived_count": str(len(orphan_ids)),
-        "archived_ids": ",".join(sorted(orphan_ids)),
+        "archived_count": str(len(moved_ids)),
+        "archived_ids": ",".join(sorted(moved_ids)),
     }

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -8,9 +8,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TypedDict
 
-from autoskillit.core import atomic_write, get_logger, write_versioned_json
+from autoskillit.core import atomic_write, get_logger, read_versioned_json, write_versioned_json
 from autoskillit.planner._sort_utils import _natural_sort_key
-from autoskillit.planner.lifecycle import record_lifecycle_event
+from autoskillit.planner.lifecycle import load_lifecycle_registry, record_lifecycle_event
 from autoskillit.planner.schema import (
     ASSIGN_ID_RE,
     ASSIGN_RESULT_FILE_RE,
@@ -28,6 +28,12 @@ from autoskillit.planner.schema import (
 from autoskillit.planner.validation import discover_tier_files
 
 logger = get_logger(__name__)
+
+
+def _status_from_content(data: dict) -> str:
+    if data.get("elaboration_failed"):
+        return "elaboration_failed"
+    return "done"
 
 
 class _PhaseBucket(TypedDict):
@@ -266,7 +272,7 @@ def finalize_wp_manifest(work_packages_dir: str, output_dir: str) -> dict[str, s
             {
                 "id": data["id"],
                 "name": data["name"],
-                "status": "done",
+                "status": _status_from_content(data),
                 "result_path": str(f),
                 "metadata": {},
             }
@@ -494,3 +500,56 @@ def resolve_task_input(task: str, planner_dir: str) -> TaskResolutionResult:
     atomic_write(out, task)
     label = _derive_label(task, "")
     return TaskResolutionResult(task_file_path=str(out), task_label=label)
+
+
+def reconcile_wp_files(planner_dir: str) -> dict[str, str]:
+    planner_path = Path(planner_dir)
+    wp_dir = planner_path / "work_packages"
+    if not wp_dir.is_dir():
+        return {"archived_count": "0", "archived_ids": ""}
+
+    active_ids: set[str] = set()
+    for candidate in ("consolidated_wps.json", "refined_wps.json"):
+        candidate_path = planner_path / candidate
+        if candidate_path.exists():
+            doc = read_versioned_json(candidate_path, 1)
+            if doc:
+                active_ids = {wp["id"] for wp in doc.get("work_packages", [])}
+                break
+    else:
+        logger.warning("reconcile_wp_files: no consolidated or refined WPs file found")
+        return {"archived_count": "0", "archived_ids": ""}
+
+    registry = load_lifecycle_registry(planner_path)
+    excluded_ids = set(registry.get("absorbed", {}).keys()) | set(
+        registry.get("voided_wps", {}).keys()
+    )
+
+    disk_ids: dict[str, Path] = {}
+    for f in wp_dir.glob("*_result.json"):
+        if f.parent != wp_dir:
+            continue
+        stem = f.name.removesuffix("_result.json")
+        if WP_RESULT_FILE_RE.match(f.name):
+            disk_ids[stem] = f
+
+    orphan_ids = {wid for wid in disk_ids if wid not in active_ids and wid not in excluded_ids}
+    if not orphan_ids:
+        return {"archived_count": "0", "archived_ids": ""}
+
+    archived_dir = wp_dir / "archived"
+    archived_dir.mkdir(exist_ok=True)
+    for orphan_id in sorted(orphan_ids):
+        src = disk_ids[orphan_id]
+        src.rename(archived_dir / src.name)
+
+    record_lifecycle_event(
+        planner_path,
+        "archived_stubs",
+        {oid: {"reason": "elaboration_failed_orphan"} for oid in orphan_ids},
+    )
+    logger.info("reconcile_wp_files", archived_count=len(orphan_ids))
+    return {
+        "archived_count": str(len(orphan_ids)),
+        "archived_ids": ",".join(sorted(orphan_ids)),
+    }

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -509,6 +509,7 @@ def reconcile_wp_files(planner_dir: str) -> dict[str, str]:
         return {"archived_count": "0", "archived_ids": ""}
 
     active_ids: set[str] = set()
+    found_but_unreadable: list[str] = []
     for candidate in ("consolidated_wps.json", "refined_wps.json"):
         candidate_path = planner_path / candidate
         if candidate_path.exists():
@@ -516,8 +517,15 @@ def reconcile_wp_files(planner_dir: str) -> dict[str, str]:
             if doc:
                 active_ids = {wp["id"] for wp in doc.get("work_packages", [])}
                 break
+            found_but_unreadable.append(candidate)
     else:
-        logger.warning("reconcile_wp_files: no consolidated or refined WPs file found")
+        if found_but_unreadable:
+            logger.warning(
+                "reconcile_wp_files: WP files exist but are unreadable",
+                unreadable=found_but_unreadable,
+            )
+        else:
+            logger.warning("reconcile_wp_files: no consolidated or refined WPs file found")
         return {"archived_count": "0", "archived_ids": ""}
 
     registry = load_lifecycle_registry(planner_path)

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -400,17 +400,44 @@ def _check_version_bump_steps(
     return findings
 
 
+_TERMINAL_WP_STATUSES = frozenset({"done"})
+
+
 def _check_failed_wps(wp_manifest: dict | None) -> list[ValidationFinding]:
     if wp_manifest is None:
         return []
     findings: list[ValidationFinding] = []
     for item in wp_manifest.get("items", []):
-        if item.get("status") == "failed":
+        status = item.get("status", "")
+        if status and status not in _TERMINAL_WP_STATUSES:
             findings.append(
                 {
-                    "message": f"WP {item.get('id', '<unknown>')} has status 'failed'",
+                    "message": f"WP {item.get('id', '<unknown>')} has status '{status}'",
                     "severity": "error",
                     "check": "failed_wps",
+                }
+            )
+    return findings
+
+
+def _check_stub_consistency(
+    wp_results: dict[str, dict], wp_manifest: dict | None
+) -> list[ValidationFinding]:
+    if wp_manifest is None:
+        return []
+    manifest_status: dict[str, str] = {}
+    for item in wp_manifest.get("items", []):
+        wid = item.get("id", "")
+        if wid:
+            manifest_status[wid] = item.get("status", "")
+    findings: list[ValidationFinding] = []
+    for wp_id, wp in wp_results.items():
+        if wp.get("elaboration_failed") and manifest_status.get(wp_id) == "done":
+            findings.append(
+                {
+                    "message": f"WP {wp_id} has status 'done' but elaboration_failed in content",
+                    "severity": "error",
+                    "check": "stub_consistency",
                 }
             )
     return findings
@@ -447,6 +474,7 @@ def validate_plan(output_dir: str) -> dict[str, str]:
     all_findings.extend(_check_duplicate_files_touched(wp_results))
     all_findings.extend(_check_version_bump_steps(wp_results))
     all_findings.extend(_check_failed_wps(wp_manifest))
+    all_findings.extend(_check_stub_consistency(wp_results, wp_manifest))
 
     discovery_warnings: list[ValidationFinding] = []
     for f in phase_rejected:

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2728,6 +2728,16 @@ callable_contracts:
       type: str
     - name: source_commit
       type: str
+  autoskillit.planner.reconcile_wp_files:
+    inputs:
+    - name: planner_dir
+      type: directory_path
+      required: true
+    outputs:
+    - name: archived_count
+      type: str
+    - name: archived_ids
+      type: str
   autoskillit.planner.finalize_wp_manifest:
     inputs:
     - name: work_packages_dir

--- a/src/autoskillit/recipes/planner.json
+++ b/src/autoskillit/recipes/planner.json
@@ -352,6 +352,15 @@
       "capture": {
         "consolidated_wps_path": "${{ result.consolidated_wps_path }}"
       },
+      "on_success": "reconcile_wp_files",
+      "on_failure": "escalate_stop"
+    },
+    "reconcile_wp_files": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.planner.reconcile_wp_files",
+        "planner_dir": "${{ context.planner_dir }}"
+      },
       "on_success": "validate_task_alignment",
       "on_failure": "escalate_stop"
     },

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -359,6 +359,14 @@ steps:
       planner_dir: "${{ context.planner_dir }}"
     capture:
       consolidated_wps_path: "${{ result.consolidated_wps_path }}"
+    on_success: reconcile_wp_files
+    on_failure: escalate_stop
+
+  reconcile_wp_files:
+    tool: run_python
+    with:
+      callable: autoskillit.planner.reconcile_wp_files
+      planner_dir: "${{ context.planner_dir }}"
     on_success: validate_task_alignment
     on_failure: escalate_stop
 

--- a/src/autoskillit/skills_extended/planner-refine/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine/SKILL.md
@@ -56,7 +56,8 @@ retries) before escalation.
 Read `$1`. Extract the `findings` array (contains only error-severity findings as structured
 dicts). Extract the `message` field from each finding for classification. Group by type:
 
-- **failed_wps**: Findings matching `WP .* has status 'failed'`
+- **failed_wps**: Findings matching `WP .* has status '(?!done')[^']*'` (any non-done status including `elaboration_failed`)
+- **stub_consistency**: Findings matching `WP .* has status 'done' but elaboration_failed in content` — route to the same re-elaboration action as `failed_wps` (re-run `finalize_wp_manifest` to regenerate the manifest from content, then re-elaborate the stub WP)
 - **sizing_violations**: Findings matching `WP .* has \d+ deliverables`
 - **duplicate_deliverables**: Findings matching `Deliverable '.*' claimed by multiple WPs`
 - **dep_references**: Findings matching `WP .* depends on unknown WP`
@@ -72,9 +73,9 @@ dicts). Extract the `message` field from each finding for classification. Group 
 
 ### Step 3: Fix each finding type
 
-**Failed WPs** — re-elaborate:
-- For each failed WP ID, read its entry from `wp_manifest.json` (provides `name`, `scope`,
-  `estimated_files`)
+**Failed WPs** (including `elaboration_failed` and `stub_consistency` findings) — re-elaborate:
+- For each failed WP ID, read its `{id}_result.json` from `{$2}/work_packages/` (provides
+  `name`, `scope`, `estimated_files`) and its entry from `wp_manifest.json` for status context
 - Spawn a sub-agent with `model: "sonnet"` per failed WP. Provide: WP name, scope,
   estimated_files, and the relevant portion of `wp_index.json` for context
 - Sub-agent writes a corrected `{$2}/work_packages/{id}_result.json`
@@ -167,6 +168,7 @@ issues_fixed = <N>
 ```
 
 `N` = count of findings addressed from the `findings` array (failed_wps +
-duplicate_deliverables + dep_references). Sizing-violation, missing-element, malformed-ID,
-and DAG-cycle findings are excluded from the count (they are escalated as critical, not
-fixed). Files-touched overlap findings are in the `warnings` array and are not actionable.
+stub_consistency + duplicate_deliverables + dep_references). Sizing-violation,
+missing-element, malformed-ID, and DAG-cycle findings are excluded from the count
+(they are escalated as critical, not fixed). Files-touched overlap findings are in the
+`warnings` array and are not actionable.

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -172,7 +172,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)
     ("src/autoskillit/planner/consolidation.py", 357),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
-    ("src/autoskillit/planner/manifests.py", 293),
+    ("src/autoskillit/planner/manifests.py", 299),
     # _cmd_rpc_issues.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
     ("src/autoskillit/recipe/_cmd_rpc_issues.py", 77),
 }

--- a/tests/planner/conftest.py
+++ b/tests/planner/conftest.py
@@ -93,6 +93,7 @@ def make_minimal_output_dir(
     depends_on_override: dict[str, list[str]] | None = None,
     extra_phases: list[int] | None = None,
     extra_assignments: list[tuple[int, int]] | None = None,
+    stub_wp_ids: set[str] | None = None,
 ) -> Path:
     phases_dir = tmp_path / "phases"
     assigns_dir = tmp_path / "assignments"
@@ -118,26 +119,42 @@ def make_minimal_output_dir(
                 ),
             )
 
+    _stub_ids = stub_wp_ids or set()
     for p in range(1, num_phases + 1):
         for a in range(1, 2):
             for w in range(1, wps_per_assignment + 1):
                 wp_id = f"P{p}-A{a}-WP{w}"
-                deliverables = (
-                    deliverables_override
-                    if deliverables_override is not None
-                    else [f"src/mod_{wp_id}.py"]
-                )
-                deps = (depends_on_override or {}).get(wp_id, [])
-                write_json(
-                    wps_dir / f"{wp_id}_result.json",
-                    make_wp_result(wp_id, deliverables=deliverables, depends_on=deps),
-                )
+                if wp_id in _stub_ids:
+                    write_json(
+                        wps_dir / f"{wp_id}_result.json",
+                        make_wp_result(
+                            wp_id,
+                            allow_stub=True,
+                            elaboration_failed=True,
+                            deliverables=[],
+                            technical_steps=[],
+                            acceptance_criteria=[],
+                        ),
+                    )
+                else:
+                    deliverables = (
+                        deliverables_override
+                        if deliverables_override is not None
+                        else [f"src/mod_{wp_id}.py"]
+                    )
+                    deps = (depends_on_override or {}).get(wp_id, [])
+                    write_json(
+                        wps_dir / f"{wp_id}_result.json",
+                        make_wp_result(wp_id, deliverables=deliverables, depends_on=deps),
+                    )
 
     manifest_items = []
     for p in range(1, num_phases + 1):
         for a in range(1, 2):
             for w in range(1, wps_per_assignment + 1):
-                manifest_items.append({"id": f"P{p}-A{a}-WP{w}", "status": "done"})
+                wp_id = f"P{p}-A{a}-WP{w}"
+                status = "elaboration_failed" if wp_id in _stub_ids else "done"
+                manifest_items.append({"id": wp_id, "status": status})
     write_json(
         wps_dir / "wp_manifest.json",
         {"pass_name": "work_packages", "items": manifest_items},

--- a/tests/planner/test_manifests_finalize.py
+++ b/tests/planner/test_manifests_finalize.py
@@ -272,3 +272,83 @@ def test_finalize_wp_manifest_upper_bound_violation_warns_not_fails(tmp_path: Pa
         result = finalize_wp_manifest(str(wp_dir), str(tmp_path))
 
     assert "manifest_path" in result
+
+
+def test_finalize_wp_manifest_stub_gets_elaboration_failed_status(tmp_path: Path) -> None:
+    """Test 1.1: finalize_wp_manifest must set 'elaboration_failed' status for stubs."""
+    from autoskillit.planner.manifests import finalize_wp_manifest
+
+    wp_dir = tmp_path / "work_packages"
+    wp_dir.mkdir()
+
+    write_json(wp_dir / "P1-A1-WP1_result.json", make_wp_result("P1-A1-WP1"))
+    write_json(
+        wp_dir / "P1-A1-WP2_result.json",
+        make_wp_result(
+            "P1-A1-WP2",
+            allow_stub=True,
+            elaboration_failed=True,
+            deliverables=[],
+            technical_steps=[],
+            acceptance_criteria=[],
+        ),
+    )
+
+    result = finalize_wp_manifest(str(wp_dir), str(tmp_path))
+    manifest = json.loads(Path(result["manifest_path"]).read_text())
+    items_by_id = {item["id"]: item for item in manifest["items"]}
+    assert items_by_id["P1-A1-WP1"]["status"] == "done"
+    assert items_by_id["P1-A1-WP2"]["status"] == "elaboration_failed"
+
+
+def test_reconcile_wp_files_archives_orphaned_stubs(tmp_path: Path) -> None:
+    """Test 2.1: reconcile_wp_files archives orphaned stubs."""
+    from autoskillit.planner.lifecycle import load_lifecycle_registry
+    from autoskillit.planner.manifests import reconcile_wp_files
+
+    wp_dir = tmp_path / "work_packages"
+    wp_dir.mkdir()
+
+    write_json(wp_dir / "P1-A1-WP1_result.json", make_wp_result("P1-A1-WP1"))
+    write_json(
+        wp_dir / "P1-A1-WP2_result.json",
+        make_wp_result(
+            "P1-A1-WP2",
+            allow_stub=True,
+            elaboration_failed=True,
+            deliverables=[],
+            technical_steps=[],
+            acceptance_criteria=[],
+        ),
+    )
+
+    consolidated = {
+        "task": "test",
+        "source_dir": "/src",
+        "work_packages": [{"id": "P1-A1-WP1", "name": "WP1"}],
+        "schema_version": 1,
+    }
+    write_json(tmp_path / "consolidated_wps.json", consolidated)
+
+    result = reconcile_wp_files(str(tmp_path))
+    assert result["archived_count"] == "1"
+    assert "P1-A1-WP2" in result["archived_ids"]
+    assert (wp_dir / "archived" / "P1-A1-WP2_result.json").exists()
+    assert (wp_dir / "P1-A1-WP1_result.json").exists()
+    assert not (wp_dir / "P1-A1-WP2_result.json").exists()
+
+    registry = load_lifecycle_registry(tmp_path)
+    assert "P1-A1-WP2" in registry.get("archived_stubs", {})
+
+
+def test_reconcile_wp_files_no_active_file_returns_early(tmp_path: Path) -> None:
+    """reconcile_wp_files returns early when no consolidated/refined WPs file exists."""
+    from autoskillit.planner.manifests import reconcile_wp_files
+
+    wp_dir = tmp_path / "work_packages"
+    wp_dir.mkdir()
+    write_json(wp_dir / "P1-A1-WP1_result.json", make_wp_result("P1-A1-WP1"))
+
+    result = reconcile_wp_files(str(tmp_path))
+    assert result["archived_count"] == "0"
+    assert (wp_dir / "P1-A1-WP1_result.json").exists()

--- a/tests/planner/test_planner_api.py
+++ b/tests/planner/test_planner_api.py
@@ -60,6 +60,7 @@ def test_planner_all_exports() -> None:
         "DiscoveryResult",
         "discover_tier_files",
         "load_lifecycle_registry",
+        "reconcile_wp_files",
         "record_lifecycle_event",
     }
 

--- a/tests/planner/test_validation_checks.py
+++ b/tests/planner/test_validation_checks.py
@@ -12,7 +12,9 @@ from autoskillit.planner.validation import (
     _check_dep_id_format,
     _check_duplicate_deliverables,
     _check_duplicate_files_touched,
+    _check_failed_wps,
     _check_sizing_bounds,
+    _check_stub_consistency,
     validate_plan,
 )
 from tests.planner.conftest import (
@@ -451,3 +453,44 @@ def test_validate_plan_with_voided_wps_passes(tmp_path: Path) -> None:
 
     result = validate_plan(str(tmp_path))
     assert result["verdict"] == "pass"
+
+
+def test_check_failed_wps_detects_elaboration_failed_status() -> None:
+    """Test 1.2: _check_failed_wps must detect elaboration_failed status."""
+    wp_manifest = {
+        "items": [
+            {"id": "P1-A1-WP1", "status": "done"},
+            {"id": "P1-A1-WP2", "status": "elaboration_failed"},
+        ]
+    }
+    findings = _check_failed_wps(wp_manifest)
+    assert len(findings) == 1
+    assert findings[0]["check"] == "failed_wps"
+    assert "P1-A1-WP2" in findings[0]["message"]
+    assert "'elaboration_failed'" in findings[0]["message"]
+
+
+def test_check_stub_consistency_catches_manifest_disk_mismatch() -> None:
+    """Test 3.1: _check_stub_consistency catches manifest-content mismatch."""
+    wp_results = {
+        "P1-A1-WP1": {"id": "P1-A1-WP1", "elaboration_failed": True},
+    }
+    wp_manifest = {"items": [{"id": "P1-A1-WP1", "status": "done"}]}
+    findings = _check_stub_consistency(wp_results, wp_manifest)
+    assert len(findings) == 1
+    assert findings[0]["check"] == "stub_consistency"
+    assert findings[0]["severity"] == "error"
+    assert (
+        findings[0]["message"]
+        == "WP P1-A1-WP1 has status 'done' but elaboration_failed in content"
+    )
+
+
+def test_check_stub_consistency_no_false_positive_when_status_correct() -> None:
+    """No finding when manifest correctly has elaboration_failed status."""
+    wp_results = {
+        "P1-A1-WP1": {"id": "P1-A1-WP1", "elaboration_failed": True},
+    }
+    wp_manifest = {"items": [{"id": "P1-A1-WP1", "status": "elaboration_failed"}]}
+    findings = _check_stub_consistency(wp_results, wp_manifest)
+    assert findings == []

--- a/tests/planner/test_validation_core.py
+++ b/tests/planner/test_validation_core.py
@@ -209,3 +209,64 @@ def test_validation_json_schema_version_2(tmp_path: Path) -> None:
     validation = json.loads((tmp_path / "validation.json").read_text())
     assert validation["schema_version"] == 2
     assert "warnings" in validation
+
+
+def test_stub_through_validation_produces_failed_wps_finding(tmp_path: Path) -> None:
+    """Test 1.3: End-to-end stub-through-validation produces failed_wps finding."""
+    from autoskillit.planner.manifests import finalize_wp_manifest
+    from tests.planner.conftest import (
+        make_assignment_result,
+        make_phase_result,
+        make_wp_result,
+    )
+
+    phases_dir = tmp_path / "phases"
+    assigns_dir = tmp_path / "assignments"
+    wp_dir = tmp_path / "work_packages"
+
+    write_json(phases_dir / "P1_result.json", make_phase_result(1))
+    write_json(assigns_dir / "P1-A1_result.json", make_assignment_result(1, 1))
+    write_json(wp_dir / "P1-A1-WP1_result.json", make_wp_result("P1-A1-WP1"))
+    write_json(
+        wp_dir / "P1-A1-WP2_result.json",
+        make_wp_result(
+            "P1-A1-WP2",
+            allow_stub=True,
+            elaboration_failed=True,
+            deliverables=[],
+            technical_steps=[],
+            acceptance_criteria=[],
+        ),
+    )
+
+    finalize_wp_manifest(str(wp_dir), str(tmp_path))
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "fail"
+
+    validation = json.loads((tmp_path / "validation.json").read_text())
+    checks = {f["check"] for f in validation["findings"]}
+    assert "failed_wps" in checks
+    assert "sizing_bounds" in checks
+
+
+def test_validate_plan_ignores_archived_stubs(tmp_path: Path) -> None:
+    """Test 2.2: validate_plan does not see archived stubs."""
+    make_minimal_output_dir(tmp_path)
+
+    archived_dir = tmp_path / "work_packages" / "archived"
+    archived_dir.mkdir()
+    write_json(
+        archived_dir / "P1-A2-WP1_result.json",
+        {
+            "id": "P1-A2-WP1",
+            "name": "Archived stub",
+            "elaboration_failed": True,
+            "deliverables": [],
+        },
+    )
+
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "pass"
+    validation = json.loads((tmp_path / "validation.json").read_text())
+    all_messages = " ".join(f["message"] for f in validation["findings"])
+    assert "P1-A2-WP1" not in all_messages

--- a/tests/recipe/test_planner_recipe.py
+++ b/tests/recipe/test_planner_recipe.py
@@ -40,6 +40,7 @@ def test_planner_recipe_has_required_steps(planner_recipe):
         "finalize_wp_manifest",
         "merge_wps",
         "refine_wps",
+        "reconcile_wp_files",
         "validate_task_alignment",
         "reconcile_deps",
         "validate",


### PR DESCRIPTION
## Summary

The planner pipeline has a structural defect in how elaboration failure stubs flow through the WP lifecycle. When a `wp-elaborator` L0 subagent fails, the `planner-elaborate-wps` skill writes a stub with `elaboration_failed: true` and `deliverables: []`. However, `finalize_wp_manifest()` unconditionally records `"status": "done"` for all WPs — including stubs. This makes the stub indistinguishable from a successfully elaborated WP at the manifest level. Downstream, `validation.py` scans the disk directory via glob (not the consolidated WP list), finds the orphaned stub, and reports a `sizing_bounds` error. The `planner-refine` skill's re-elaboration path only fires for `status: 'failed'` entries in the manifest, so the stub enters a dead-end escalation loop.

The architectural weakness is threefold:
1. **Status-content divergence**: The manifest records optimistic status without verifying artifact content
2. **Orphaned artifact lifecycle**: No stage owns cleanup of stubs excluded from `refined_wps.json`
3. **Dead-code validation check**: `_check_failed_wps()` checks for `status == "failed"` but no code path ever writes that status

This plan introduces **content-derived manifest status** (mirroring the fleet's proven `DispatchStatus` FSM pattern where status and content are co-derived), a **lifecycle-aware file reconciliation step**, and a **defense-in-depth cross-validation** between manifest status and artifact content. These changes make the entire class of status-content divergence bugs structurally impossible in the planner subsystem.

Part B will cover broader planner lifecycle tracking improvements (untracked absorptions, voided-phase context file cleanup, merge-emptied WP lifecycle events).

## Requirements

The planner pipeline failed during the `validate` → `refine` loop because WP `P3-A4-WP1` ("Create test_backend_sandbox_invariants.py") has `elaboration_failed: true` and 0 deliverables. The `wp-elaborator` L0 subagent failed to produce valid JSON during `planner-elaborate-wps` for Phase 3, resulting in a failure stub that cannot pass the `sizing_bounds` validation check (`DELIVERABLE_BOUNDS = (1, 5)`). The `refine` skill cannot auto-fix this because the WP has manifest status `"done"` (not `"failed"`), causing the sizing-bounds escalation path instead of the re-elaboration path.

The remaining 15 of 16 consolidated WPs are valid and ready for implementation.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260604-230820-165242/.autoskillit/temp/rectify/rectify_planner_stub_lifecycle_2026-06-04_232500.md`

Closes #3780

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 3.1k | 26.0k | 1.8M | 127.7k | 53 | 108.1k | 15m 46s |
| review_approach* | opus[1m] | 1 | 3.3k | 6.2k | 248.6k | 60.9k | 11 | 42.8k | 7m 46s |
| dry_walkthrough* | opus | 1 | 47 | 11.9k | 1.3M | 87.0k | 44 | 87.1k | 6m 17s |
| implement* | opus[1m] | 1 | 106 | 20.5k | 6.1M | 124.3k | 118 | 102.3k | 8m 22s |
| audit_impl* | opus[1m] | 1 | 1.3k | 15.5k | 314.5k | 55.0k | 20 | 51.1k | 6m 34s |
| prepare_pr* | MiniMax-M3 | 1 | 47.1k | 1.8k | 175.2k | 50.5k | 13 | 0 | 1m 4s |
| compose_pr* | MiniMax-M3 | 1 | 37.1k | 1.3k | 232.3k | 40.0k | 10 | 0 | 56s |
| review_pr* | opus[1m] | 1 | 39 | 47.7k | 794.6k | 110.8k | 31 | 90.2k | 11m 51s |
| resolve_review* | opus[1m] | 1 | 47 | 11.3k | 1.3M | 72.5k | 33 | 50.7k | 8m 5s |
| **Total** | | | 92.2k | 142.1k | 12.3M | 127.7k | | 532.2k | 1h 6m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 368 | 16683.8 | 277.9 | 55.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 36 | 34735.3 | 1407.3 | 313.4 |
| **Total** | **404** | 30383.3 | 1317.4 | 351.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 7.9k | 127.1k | 10.5M | 445.1k | 58m 26s |
| opus | 1 | 47 | 11.9k | 1.3M | 87.1k | 6m 17s |
| MiniMax-M3 | 2 | 84.2k | 3.1k | 407.5k | 0 | 1m 59s |