### PR TITLE
[FIX] Codex Capability Classification Immunity — test_check reclassification

### DIFF
--- a/src/autoskillit/core/types/_type_constants_registries.py
+++ b/src/autoskillit/core/types/_type_constants_registries.py
@@ -329,7 +329,7 @@ SKILL_CAPABILITY_REGISTRY: dict[str, SkillCapabilityDef] = {
     ),
     "test_check": SkillCapabilityDef(
         description="test_check MCP tool (headless test runner)",
-        codex_status="not-applicable",
+        codex_status="works-as-is",
     ),
     "claude_dir": SkillCapabilityDef(
         description="Reads/writes .claude/ directory structure",

--- a/tests/arch/test_skill_capability_registry.py
+++ b/tests/arch/test_skill_capability_registry.py
@@ -88,14 +88,16 @@ def test_codex_status_consistent_with_required_backends():
     assert not violations, "\n".join(f"  {v}" for v in violations)
 
 
-_MCP_TOOL_CAPABILITIES = {"run_skill", "test_check", "open_kitchen"}
+# test_check removed: reclassified to works-as-is (#3781);
+# cross-layer test is the authoritative guard.
+_NOT_APPLICABLE_MCP_CAPABILITIES = {"run_skill", "open_kitchen"}
 
 
 def test_mcp_tools_require_claude_code():
     from autoskillit.core.types._type_constants_env import AGENT_BACKEND_CLAUDE_CODE
 
     violations = []
-    for cap_name in _MCP_TOOL_CAPABILITIES:
+    for cap_name in _NOT_APPLICABLE_MCP_CAPABILITIES:
         cap = SKILL_CAPABILITY_REGISTRY.get(cap_name)
         if cap and cap.required_backends != frozenset({AGENT_BACKEND_CLAUDE_CODE}):
             violations.append(
@@ -103,8 +105,8 @@ def test_mcp_tools_require_claude_code():
                 f"got {cap.required_backends!r}"
             )
     assert not violations, (
-        "MCP tools must derive required_backends from codex_status='not-applicable':\n"
-        + "\n".join(f"  {v}" for v in violations)
+        "Not-applicable MCP capabilities must derive required_backends"
+        " from codex_status='not-applicable':\n" + "\n".join(f"  {v}" for v in violations)
     )
 
 
@@ -112,3 +114,90 @@ def test_required_backends_is_derived_property():
     from autoskillit.core.types._type_constants_registries import SkillCapabilityDef
 
     assert "required_backends" not in SkillCapabilityDef.__dataclass_fields__
+
+
+def test_headless_tools_not_marked_not_applicable():
+    from autoskillit.core.types._type_constants_registries import HEADLESS_TOOLS
+
+    violations = []
+    for tool_name in sorted(HEADLESS_TOOLS):
+        cap = SKILL_CAPABILITY_REGISTRY.get(tool_name)
+        if cap and cap.codex_status == "not-applicable":
+            violations.append(f"{tool_name}: in HEADLESS_TOOLS but codex_status='not-applicable'")
+    assert not violations, (
+        "HEADLESS_TOOLS are accessible in Codex headless sessions — "
+        "codex_status='not-applicable' is contradictory:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )
+    assert SKILL_CAPABILITY_REGISTRY["test_check"].codex_status == "works-as-is", (
+        "test_check must be classified as works-as-is, not just != not-applicable"
+    )
+
+
+@pytest.mark.anyio
+async def test_codex_status_matches_tool_visibility(monkeypatch):
+    from autoskillit.core.types._type_constants_registries import (
+        GATED_TOOLS,
+        HEADLESS_TOOLS,
+        UNGATED_TOOLS,
+    )
+    from autoskillit.server import mcp
+    from autoskillit.server._session_type import _apply_session_type_visibility
+
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "skill")
+    monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+    monkeypatch.setenv("AUTOSKILLIT_HEADLESS_AUTO_GATE", "1")
+
+    _apply_session_type_visibility()
+    tools = await mcp.list_tools()
+    tool_names = {t.name for t in tools}
+
+    assert "test_check" in tool_names, (
+        "test_check must be visible in SKILL+HEADLESS — env misconfigured?"
+    )
+
+    _skill_blocking_gated_tools = {"run_skill", "open_kitchen"}
+    mcp_tool_caps = set(SKILL_CAPABILITY_REGISTRY) & (GATED_TOOLS | HEADLESS_TOOLS | UNGATED_TOOLS)
+
+    violations = []
+    for cap_name in sorted(mcp_tool_caps):
+        cap = SKILL_CAPABILITY_REGISTRY[cap_name]
+        visible = cap_name in tool_names
+        has_skill_gate = cap_name in _skill_blocking_gated_tools
+
+        if visible and not has_skill_gate and cap.codex_status == "not-applicable":
+            violations.append(
+                f"{cap_name}: visible in Codex SKILL+HEADLESS session "
+                f"but codex_status='not-applicable'"
+            )
+
+    assert not violations, (
+        "Tools visible in Codex sessions must not be classified as not-applicable:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )
+
+
+def test_reclassified_skills_have_empty_backend_requirements():
+    from autoskillit.workspace.skills import DefaultSkillResolver
+
+    resolver = DefaultSkillResolver()
+    previously_blocked = [
+        "dry-walkthrough",
+        "implement-experiment",
+        "implement-worktree",
+        "plan-experiment",
+        "setup-project",
+    ]
+    violations = []
+    for skill_name in previously_blocked:
+        info = resolver.resolve(skill_name)
+        assert info is not None, f"Skill {skill_name!r} not found by resolver"
+        if info.backend_requirements != frozenset():
+            violations.append(
+                f"{skill_name}: backend_requirements={info.backend_requirements!r}, "
+                f"expected frozenset()"
+            )
+    assert not violations, (
+        "Reclassifying test_check should unblock these skills on all backends:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )

--- a/tests/arch/test_skill_capability_registry.py
+++ b/tests/arch/test_skill_capability_registry.py
@@ -201,6 +201,6 @@ def test_reclassified_skills_have_empty_backend_requirements():
                 f"expected frozenset()"
             )
     assert not violations, (
-        "Reclassifying test_check should unblock these skills on all backends:\n"
+        "Previously blocked skills must have empty backend_requirements:\n"
         + "\n".join(f"  {v}" for v in violations)
     )

--- a/tests/arch/test_skill_capability_registry.py
+++ b/tests/arch/test_skill_capability_registry.py
@@ -129,6 +129,9 @@ def test_headless_tools_not_marked_not_applicable():
         "codex_status='not-applicable' is contradictory:\n"
         + "\n".join(f"  {v}" for v in violations)
     )
+
+
+def test_test_check_codex_status_is_works_as_is():
     assert SKILL_CAPABILITY_REGISTRY["test_check"].codex_status == "works-as-is", (
         "test_check must be classified as works-as-is, not just != not-applicable"
     )


### PR DESCRIPTION
## Summary

`SKILL_CAPABILITY_REGISTRY["test_check"]` classifies `codex_status="not-applicable"`, but `test_check` is fully visible and callable in Codex SKILL+HEADLESS sessions via the env-forwarding bridge (`_codex_exec_extras()` → `config.toml` env_vars whitelist → `_apply_session_type_visibility()` → `headless` + `kitchen-core` tags). This blocks 5 skills from Codex unnecessarily. The misclassification persisted through 5 fix iterations because no test validates `codex_status` classifications against MCP runtime visibility — all existing tests validate internal registry consistency (self-referential).

Part A fixes the immediate misclassification, removes the self-referential test lock, and adds a cross-layer validation test that derives the expected `codex_status` from the tag-visibility system. Part B will address the false-positive capability detection regex and extend the cross-layer pattern to `HookDef.codex_status`.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260604-235648-308634/.autoskillit/temp/rectify/rectify_codex_capability_classification_immunity_2026-06-05_000500.md`

Closes #3781

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 94 | 25.2k | 3.0M | 154.4k | 72 | 132.6k | 16m 54s |
| review_approach* | opus[1m] | 1 | 1.4k | 5.2k | 277.3k | 49.6k | 13 | 30.4k | 3m 10s |
| dry_walkthrough* | opus | 1 | 568 | 14.0k | 2.3M | 110.2k | 58 | 88.0k | 6m 56s |
| implement* | opus[1m] | 1 | 60 | 8.1k | 1.3M | 66.2k | 43 | 44.0k | 3m 54s |
| audit_impl* | opus[1m] | 1 | 2.3k | 9.3k | 214.0k | 43.1k | 15 | 34.0k | 4m 10s |
| prepare_pr* | MiniMax-M3 | 1 | 47.8k | 1.4k | 362.6k | 50.8k | 14 | 0 | 1m 1s |
| compose_pr* | MiniMax-M3 | 1 | 36.8k | 1.4k | 190.8k | 39.1k | 9 | 0 | 1m 0s |
| review_pr* | opus[1m] | 1 | 29 | 12.1k | 545.9k | 63.0k | 28 | 41.0k | 3m 4s |
| resolve_review* | opus[1m] | 1 | 44 | 6.4k | 1.1M | 69.8k | 34 | 48.0k | 4m 27s |
| **Total** | | | 89.0k | 83.0k | 9.3M | 154.4k | | 418.2k | 44m 40s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 99 | 13205.4 | 444.6 | 82.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 5 | 211276.2 | 9600.2 | 1272.8 |
| **Total** | **104** | 89317.9 | 4020.7 | 798.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 3.9k | 66.3k | 6.4M | 330.1k | 35m 42s |
| opus | 1 | 568 | 14.0k | 2.3M | 88.0k | 6m 56s |
| MiniMax-M3 | 2 | 84.6k | 2.8k | 553.4k | 0 | 2m 1s |