### PR TITLE
Parametric Structural Tests for Arch-Lens Skills

### DIFF
--- a/tests/skills/CLAUDE.md
+++ b/tests/skills/CLAUDE.md
@@ -11,6 +11,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 | `test_adversarial_review_contracts.py` | Contract tests verifying adversarial review agents, maxTurns sufficiency, and SendMessage continuation protocol in make-plan and rectify SKILL.md files |
 | `test_analyze_prs_contracts.py` | Contract tests for analyze-prs SKILL.md batch branch naming convention |
 | `test_arch_lens_context_path.py` | Tests that all arch-lens skills have ## Arguments section and context_path handling |
+| `test_arch_lens_structural.py` | Structural assertions for arch-lens skills (all 13 slugs) |
 | `test_audit_arch_preflight_contracts.py` | Audit-arch skill preflight contract tests |
 | `test_audit_arch_selfvalidation_contracts.py` | Audit-arch skill self-validation contract tests |
 | `test_audit_impl_diff_discipline.py` | Structural guards for audit-impl diff discipline: Step 2 variable usage, Step 3 data source prohibition, diff size guard |

--- a/tests/skills/test_arch_lens_structural.py
+++ b/tests/skills/test_arch_lens_structural.py
@@ -40,7 +40,9 @@ def _frontmatter(text: str) -> dict:
     lines = text.splitlines()
     if lines[0].strip() != "---":
         return {}
-    end = next(i for i, ln in enumerate(lines[1:], 1) if ln.strip() == "---")
+    end = next((i for i, ln in enumerate(lines[1:], 1) if ln.strip() == "---"), None)
+    if end is None:
+        return {}
     return load_yaml("\n".join(lines[1:end]))
 
 

--- a/tests/skills/test_arch_lens_structural.py
+++ b/tests/skills/test_arch_lens_structural.py
@@ -96,7 +96,7 @@ def test_frontmatter_activate_deps(slug: str) -> None:
 @pytest.mark.parametrize("slug", ARCH_LENS_SLUGS)
 def test_mermaid_load_instruction(slug: str) -> None:
     text = _read(slug)
-    assert "LOAD" in text and "mermaid" in text, (
+    assert any("LOAD" in ln and "mermaid" in ln for ln in text.splitlines()), (
         f"arch-lens-{slug} must contain mandatory mermaid skill LOAD instruction"
     )
 

--- a/tests/skills/test_arch_lens_structural.py
+++ b/tests/skills/test_arch_lens_structural.py
@@ -1,0 +1,106 @@
+"""Structural assertions for arch-lens skills."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core.io import load_yaml
+
+SKILLS_DIR = Path(__file__).parents[2] / "src/autoskillit/skills_extended"
+
+ARCH_LENS_SLUGS = [
+    "c4-container",
+    "concurrency",
+    "data-lineage",
+    "deployment",
+    "development",
+    "error-resilience",
+    "module-dependency",
+    "operational",
+    "process-flow",
+    "repository-access",
+    "scenarios",
+    "security",
+    "state-lifecycle",
+]
+
+pytestmark = [pytest.mark.layer("skills"), pytest.mark.medium]
+
+
+def _read(slug: str) -> str:
+    path = SKILLS_DIR / f"arch-lens-{slug}" / "SKILL.md"
+    assert path.exists(), f"arch-lens-{slug}/SKILL.md is missing"
+    return path.read_text()
+
+
+def _frontmatter(text: str) -> dict:
+    """Parse YAML frontmatter between the first pair of '---' delimiters."""
+    lines = text.splitlines()
+    if lines[0].strip() != "---":
+        return {}
+    end = next(i for i, ln in enumerate(lines[1:], 1) if ln.strip() == "---")
+    return load_yaml("\n".join(lines[1:end]))
+
+
+@pytest.mark.parametrize("slug", ARCH_LENS_SLUGS)
+def test_skill_md_exists(slug: str) -> None:
+    path = SKILLS_DIR / f"arch-lens-{slug}" / "SKILL.md"
+    assert path.exists(), f"arch-lens-{slug}/SKILL.md missing"
+
+
+@pytest.mark.parametrize("slug", ARCH_LENS_SLUGS)
+def test_has_arguments_section(slug: str) -> None:
+    assert "## Arguments" in _read(slug), f"arch-lens-{slug} missing ## Arguments section"
+
+
+@pytest.mark.parametrize("slug", ARCH_LENS_SLUGS)
+def test_documents_context_path(slug: str) -> None:
+    assert "context_path" in _read(slug), f"arch-lens-{slug} must document context_path"
+
+
+@pytest.mark.parametrize("slug", ARCH_LENS_SLUGS)
+def test_has_step_0(slug: str) -> None:
+    assert "Step 0" in _read(slug), f"arch-lens-{slug} must have Step 0 for argument parsing"
+
+
+@pytest.mark.parametrize("slug", ARCH_LENS_SLUGS)
+def test_diagram_path_token(slug: str) -> None:
+    assert "diagram_path" in _read(slug), f"arch-lens-{slug} must mention diagram_path"
+
+
+@pytest.mark.parametrize("slug", ARCH_LENS_SLUGS)
+def test_arch_diag_prefix_in_output_path(slug: str) -> None:
+    assert "arch_diag_" in _read(slug), f"arch-lens-{slug} output path must use arch_diag_ prefix"
+
+
+@pytest.mark.parametrize("slug", ARCH_LENS_SLUGS)
+def test_frontmatter_categories(slug: str) -> None:
+    fm = _frontmatter(_read(slug))
+    assert fm.get("categories") == ["arch-lens"], (
+        f"arch-lens-{slug} frontmatter must have categories: [arch-lens]"
+    )
+
+
+@pytest.mark.parametrize("slug", ARCH_LENS_SLUGS)
+def test_frontmatter_activate_deps(slug: str) -> None:
+    fm = _frontmatter(_read(slug))
+    assert fm.get("activate_deps") == ["mermaid"], (
+        f"arch-lens-{slug} frontmatter must have activate_deps: [mermaid]"
+    )
+
+
+@pytest.mark.parametrize("slug", ARCH_LENS_SLUGS)
+def test_mermaid_load_instruction(slug: str) -> None:
+    text = _read(slug)
+    assert "LOAD" in text and "mermaid" in text, (
+        f"arch-lens-{slug} must contain mandatory mermaid skill LOAD instruction"
+    )
+
+
+@pytest.mark.parametrize("slug", ARCH_LENS_SLUGS)
+def test_autoskillit_temp_write_path(slug: str) -> None:
+    assert "{{AUTOSKILLIT_TEMP}}" in _read(slug), (
+        f"arch-lens-{slug} must use {{{{AUTOSKILLIT_TEMP}}}} in write path"
+    )


### PR DESCRIPTION
## Summary

Create `tests/skills/test_arch_lens_structural.py` — a parametric structural test file covering all 13 arch-lens slugs with 10 `@pytest.mark.parametrize` test functions. The file mirrors the pattern established by `tests/skills/test_vis_lens_structural.py`, adapted for arch-lens specifics: single `context_path` argument, `arch_diag_` output prefix, `categories: [arch-lens]` frontmatter, and mermaid skill LOAD instruction verification.

Closes #3721

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-3721-20260605-004041-416104/.autoskillit/temp/make-plan/t2_p4_a6_wp1_arch_lens_structural_tests_plan_2026-06-05_004500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 534 | 8.9k | 780.1k | 72.2k | 28 | 51.0k | 7m 25s |
| verify* | opus | 1 | 44 | 7.0k | 355.7k | 64.1k | 22 | 41.9k | 4m 53s |
| implement* | MiniMax-M3 | 1 | 48.2k | 3.8k | 719.6k | 51.4k | 28 | 0 | 2m 25s |
| audit_impl* | opus | 1 | 2.1k | 10.2k | 169.2k | 40.2k | 14 | 30.5k | 3m 13s |
| prepare_pr* | MiniMax-M3 | 1 | 41.0k | 1.2k | 196.4k | 42.7k | 12 | 0 | 50s |
| compose_pr* | MiniMax-M3 | 1 | 36.8k | 908 | 186.4k | 38.3k | 9 | 0 | 54s |
| review_pr* | opus | 1 | 30 | 12.6k | 582.6k | 60.4k | 25 | 38.5k | 3m 20s |
| resolve_review* | opus | 1 | 45 | 9.9k | 1.1M | 72.6k | 35 | 51.0k | 5m 36s |
| **Total** | | | 128.7k | 54.4k | 4.1M | 72.6k | | 212.9k | 28m 38s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 107 | 6724.9 | 0.0 | 35.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 185999.0 | 8496.0 | 1656.3 |
| **Total** | **113** | 36335.2 | 1884.4 | 481.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 534 | 8.9k | 780.1k | 51.0k | 7m 25s |
| opus | 4 | 2.2k | 39.7k | 2.2M | 161.9k | 17m 3s |
| MiniMax-M3 | 3 | 126.0k | 5.9k | 1.1M | 0 | 4m 9s |