### PR TITLE
Insert sandbox_mode into SkillSessionConfig

### DIFF
--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -259,6 +259,7 @@ class SkillSessionConfig:
     resume_session_id: str = ""
     resume_checkpoint: SessionCheckpoint | None = None
     resume_message: str | None = None
+    sandbox_mode: str = "workspace-write"
     backend_override: str | None = None
 
 

--- a/tests/core/test_backend_dataclasses.py
+++ b/tests/core/test_backend_dataclasses.py
@@ -288,6 +288,7 @@ def test_skill_session_config_fields_exhaustive():
         "resume_session_id",
         "resume_checkpoint",
         "resume_message",
+        "sandbox_mode",
         "backend_override",
     }
 
@@ -312,6 +313,7 @@ def test_skill_session_config_defaults():
     assert cfg.resume_session_id == ""
     assert cfg.resume_checkpoint is None
     assert cfg.resume_message is None
+    assert cfg.sandbox_mode == "workspace-write"
     assert cfg.backend_override is None
 
 
@@ -344,4 +346,5 @@ def test_skill_session_config_field_types():
     assert hints["resume_session_id"] is str
     assert hints["resume_checkpoint"] == SessionCheckpoint | None
     assert hints["resume_message"] == str | None
+    assert hints["sandbox_mode"] is str
     assert hints["backend_override"] == str | None


### PR DESCRIPTION
## Summary

Add a new `sandbox_mode: str = 'workspace-write'` field to the `SkillSessionConfig` frozen dataclass in `_type_backend.py`, positioned between `resume_message` and `backend_override`. Update the three structural lock tests in `test_backend_dataclasses.py` to cover the new field (fields-exhaustive, defaults, field-types). No imports, no decorator changes, no other files touched.

Closes #3783

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260605-004602-510259/.autoskillit/temp/make-plan/insert_sandbox_mode_into_skill_session_config_plan_2026-06-05_005300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 44 | 3.9k | 365.9k | 50.3k | 15 | 30.5k | 2m 24s |
| verify* | sonnet | 1 | 1.4k | 5.0k | 359.0k | 48.2k | 23 | 26.6k | 2m 32s |
| implement* | MiniMax-M3 | 1 | 52.0k | 6.2k | 1.7M | 54.3k | 77 | 0 | 5m 52s |
| audit_impl* | sonnet | 1 | 952 | 6.5k | 171.3k | 43.6k | 15 | 25.0k | 3m 54s |
| prepare_pr* | MiniMax-M3 | 1 | 41.2k | 1.5k | 154.0k | 42.4k | 13 | 0 | 56s |
| compose_pr* | MiniMax-M3 | 1 | 37.4k | 2.0k | 187.1k | 39.0k | 13 | 0 | 1m 10s |
| review_pr* | sonnet | 3 | 380 | 29.9k | 2.1M | 57.5k | 119 | 102.1k | 8m 40s |
| **Total** | | | 133.4k | 54.9k | 5.0M | 57.5k | | 184.1k | 25m 30s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 4 | 422448.5 | 0.0 | 1553.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **4** | 1261105.5 | 46014.5 | 13726.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 44 | 3.9k | 365.9k | 30.5k | 2m 24s |
| sonnet | 3 | 2.8k | 41.4k | 2.6M | 153.6k | 15m 7s |
| MiniMax-M3 | 3 | 130.5k | 9.6k | 2.0M | 0 | 7m 58s |