### PR TITLE
Implementation Plan: Wire sync_hooks_to_codex_config Non-Fatal + DANGEROUSLY_BYPASS_HOOK_TRUST Flag

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -99,6 +99,7 @@ class CodexFlags(StrEnum):
     RESUME_SUBCOMMAND = "resume"
     CONFIG_OVERRIDE = "-c"
     DANGEROUSLY_BYPASS = "--dangerously-bypass-approvals-and-sandbox"
+    DANGEROUSLY_BYPASS_HOOK_TRUST = "--dangerously-bypass-hook-trust"
 
 
 CODEX_EXEC_FLAGS: frozenset[str] = frozenset(
@@ -108,6 +109,7 @@ CODEX_EXEC_FLAGS: frozenset[str] = frozenset(
         CodexFlags.MODEL,
         CodexFlags.CONFIG_OVERRIDE,
         CodexFlags.ADD_DIR,
+        CodexFlags.DANGEROUSLY_BYPASS_HOOK_TRUST,
     }
 )
 
@@ -128,6 +130,7 @@ NON_VARIADIC_CODEX_FLAGS: frozenset[str] = frozenset(
         CodexFlags.MODEL_SHORT,
         CodexFlags.RESUME_SUBCOMMAND,
         CodexFlags.DANGEROUSLY_BYPASS,
+        CodexFlags.DANGEROUSLY_BYPASS_HOOK_TRUST,
     }
 )
 
@@ -151,6 +154,7 @@ def _codex_exec_base(
     sandbox: str,
     json: bool = True,
     extra_overrides: Sequence[str] = (),
+    bypass_hook_trust: bool = False,
 ) -> list[str]:
     cmd: list[str] = ["codex", "exec"]
     if json:
@@ -159,6 +163,9 @@ def _codex_exec_base(
     for override in extra_overrides:
         cmd.extend([CodexFlags.CONFIG_OVERRIDE, override])
     cmd.extend([CodexFlags.CONFIG_OVERRIDE, _IMAGE_GENERATION_DISABLED])
+    if bypass_hook_trust:
+        # Safe: --sandbox workspace-write already restricts filesystem writes.
+        cmd.append(CodexFlags.DANGEROUSLY_BYPASS_HOOK_TRUST)
     return cmd
 
 
@@ -658,7 +665,10 @@ class CodexBackend:
             required=SKILL_SESSION_REQUIRED_ENV | {MCP_CLIENT_BACKEND_ENV_VAR},
         )
 
-        cmd = _codex_exec_base(sandbox="workspace-write")
+        cmd = _codex_exec_base(
+            sandbox="workspace-write",
+            bypass_hook_trust=self.capabilities.mcp_config_capable,
+        )
         if model:
             cmd += [CodexFlags.MODEL, self.translate_model(model)]
             for override in self.model_config_overrides(model):
@@ -752,7 +762,11 @@ class CodexBackend:
             required=ORCHESTRATOR_SESSION_REQUIRED_ENV | {MCP_CLIENT_BACKEND_ENV_VAR},
         )
 
-        cmd = _codex_exec_base(sandbox="read-only", extra_overrides=["web_search=disabled"])
+        cmd = _codex_exec_base(
+            sandbox="read-only",
+            extra_overrides=["web_search=disabled"],
+            bypass_hook_trust=self.capabilities.mcp_config_capable,
+        )
         if model:
             cmd += [CodexFlags.MODEL, self.translate_model(model)]
             for override in self.model_config_overrides(model):
@@ -959,11 +973,12 @@ class CodexBackend:
 
     def ensure_pre_launch(self) -> list[str]:
         os.environ[MCP_CLIENT_BACKEND_ENV_VAR] = AGENT_BACKEND_CODEX
+        errors: list[str] = []
         try:
             ensure_codex_mcp_registered()
         except Exception as exc:
             logger.warning("codex_mcp_registration_failed", exc_info=True)
-            return [f"Failed to ensure MCP registration: {exc}"]
+            errors.append(f"Failed to ensure MCP registration: {exc}")
 
         try:
             sync_hooks_to_codex_config(
@@ -971,9 +986,10 @@ class CodexBackend:
             )
         except Exception as exc:
             logger.warning("codex_hook_sync_failed", exc_info=True)
-            return [f"Failed to sync hooks to Codex config: {exc}"]
+            errors.append(f"Failed to sync hooks to Codex config: {exc}")
 
-        return _validate_codex_config()
+        errors.extend(_validate_codex_config())
+        return errors
 
     def build_inspector_cmd(self, prompt: str, *, model: str = "") -> CmdSpec:
         raise RuntimeError("build_inspector_cmd not yet implemented — lands in #3534")

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -61,6 +61,7 @@ class TestCodexFlags:
             "RESUME_SUBCOMMAND",
             "CONFIG_OVERRIDE",
             "DANGEROUSLY_BYPASS",
+            "DANGEROUSLY_BYPASS_HOOK_TRUST",
         }
         actual = {m.name for m in CodexFlags}
         assert actual == expected
@@ -409,6 +410,10 @@ class TestCodexHeadlessCmd:
         spec = CodexBackend().build_headless_cmd("do stuff")
         assert "--output-format" not in spec.cmd
 
+    def test_bypass_hook_trust_absent_from_headless_cmd(self) -> None:
+        spec = CodexBackend().build_headless_cmd("do stuff")
+        assert "--dangerously-bypass-hook-trust" not in spec.cmd
+
 
 class TestCodexResumeCmd:
     def test_positional_structure(self) -> None:
@@ -468,6 +473,10 @@ class TestCodexResumeCmd:
         reinjected = frozenset(_SESSION_BASELINE_ENV.keys()) | CODEX_MCP_ENV_FORWARD_VARS
         leaking = (_HEADLESS_EXCLUSIVE_VARS - reinjected) & spec.env.keys()
         assert not leaking, f"_HEADLESS_EXCLUSIVE_VARS leaked into resume env: {leaking}"
+
+    def test_bypass_hook_trust_absent_from_resume_cmd(self) -> None:
+        spec = CodexBackend().build_resume_cmd(resume_session_id="s1", prompt="go")
+        assert "--dangerously-bypass-hook-trust" not in spec.cmd
 
 
 class TestCodexHeadlessCmdEnv:
@@ -636,6 +645,10 @@ class TestCodexBuildSkillSessionCmd:
             _HEADLESS_EXCLUSIVE_VARS - reinjected - CODEX_MCP_ENV_FORWARD_VARS
         ) & spec.env.keys()
         assert not leaking, f"_HEADLESS_EXCLUSIVE_VARS leaked into skill session env: {leaking}"
+
+    def test_bypass_hook_trust_present_in_skill_session_cmd(self) -> None:
+        spec = CodexBackend().build_skill_session_cmd(**self.BASE)
+        assert "--dangerously-bypass-hook-trust" in spec.cmd
 
 
 class TestCodexBuildSkillSessionCmdConfigAdapter:
@@ -1040,6 +1053,10 @@ class TestCodexBuildFoodTruckCmd:
         ) & spec.env.keys()
         assert not leaking, f"_HEADLESS_EXCLUSIVE_VARS leaked into food truck env: {leaking}"
 
+    def test_bypass_hook_trust_present_in_food_truck_cmd(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.BASE)
+        assert "--dangerously-bypass-hook-trust" in spec.cmd
+
 
 class TestCodexEnsurePreLaunchConfigValidation:
     @pytest.fixture(autouse=True)
@@ -1209,6 +1226,9 @@ class TestCodexEnsurePreLaunchConfigValidation:
         def failing_sync(**kw):
             raise RuntimeError("TOML write failed")
 
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 0, stdout='{"checks": {}}')
+
         monkeypatch.setattr(
             "autoskillit.execution.backends.codex.sync_hooks_to_codex_config", failing_sync
         )
@@ -1216,8 +1236,30 @@ class TestCodexEnsurePreLaunchConfigValidation:
             "autoskillit.execution.backends.codex.ensure_codex_mcp_registered",
             lambda **kw: False,
         )
+        monkeypatch.setattr(subprocess, "run", fake_run)
         errors = CodexBackend().ensure_pre_launch()
         assert any("hook" in e.lower() or "sync" in e.lower() for e in errors)
+
+    def test_ensure_pre_launch_hook_sync_failure_is_non_fatal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def failing_sync(**kw):
+            raise RuntimeError("sync failed")
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 0, stdout='{"checks": {}}')
+
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.sync_hooks_to_codex_config", failing_sync
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.ensure_codex_mcp_registered",
+            lambda **kw: False,
+        )
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        errors = CodexBackend().ensure_pre_launch()
+        assert any("sync" in e.lower() for e in errors)
+        assert not any("codex" in e.lower() and "validation" in e.lower() for e in errors)
 
     def test_ensure_pre_launch_integration_registration_succeeds_then_validates(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/execution/backends/test_codex_exec_base.py
+++ b/tests/execution/backends/test_codex_exec_base.py
@@ -7,14 +7,14 @@ import inspect
 
 import pytest
 
-from autoskillit.execution.backends.codex import CodexBackend, _codex_exec_base
+from autoskillit.execution.backends.codex import CodexBackend, CodexFlags, _codex_exec_base
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 class TestCodexExecBase:
     def test_returns_expected_preamble(self) -> None:
-        result = _codex_exec_base(sandbox="workspace-write")
+        result = _codex_exec_base(sandbox="workspace-write", bypass_hook_trust=False)
         assert result == [
             "codex",
             "exec",
@@ -35,6 +35,15 @@ class TestCodexExecBase:
         assert len(config_indices) == 2
         assert result[config_indices[0] + 1] == "web_search=disabled"
         assert result[config_indices[1] + 1] == "features.image_generation=false"
+
+    def test_bypass_hook_trust_appends_flag(self) -> None:
+        result = _codex_exec_base(sandbox="workspace-write", bypass_hook_trust=True)
+        assert CodexFlags.DANGEROUSLY_BYPASS_HOOK_TRUST in result
+        config_indices = [i for i, v in enumerate(result) if v == "-c"]
+        last_config_end = config_indices[-1] + 1
+        trust_idx = result.index(CodexFlags.DANGEROUSLY_BYPASS_HOOK_TRUST)
+        assert trust_idx > last_config_end
+        assert trust_idx == len(result) - 1
 
 
 class TestNoRawCodexExecListLiteral:

--- a/tests/execution/test_codex_flag_contracts.py
+++ b/tests/execution/test_codex_flag_contracts.py
@@ -62,6 +62,9 @@ class TestCodexExecFlagValues:
     def test_dangerously_bypass_value(self) -> None:
         assert CodexFlags.DANGEROUSLY_BYPASS == "--dangerously-bypass-approvals-and-sandbox"
 
+    def test_dangerously_bypass_hook_trust_value(self) -> None:
+        assert CodexFlags.DANGEROUSLY_BYPASS_HOOK_TRUST == "--dangerously-bypass-hook-trust"
+
 
 class TestCodexFlagRegistryAudit:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Refactor `ensure_pre_launch()` from early-return error handling to error-accumulation so all pre-launch phases (MCP registration, hook sync, config validation) execute independently regardless of earlier failures. Add `DANGEROUSLY_BYPASS_HOOK_TRUST` as a new `CodexFlags` enum member, register it in `CODEX_EXEC_FLAGS` and `NON_VARIADIC_CODEX_FLAGS`, add a `bypass_hook_trust` parameter to `_codex_exec_base()`, and wire it into `build_skill_session_cmd()` and `build_food_truck_cmd()` gated on `self.capabilities.mcp_config_capable`.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260605-031428-654791/.autoskillit/temp/make-plan/add_sync_hooks_bypass_trust_plan_2026-06-05_031800.md`

Closes #3786

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 2.6k | 20.8k | 1.6M | 118.2k | 52 | 97.1k | 13m 11s |
| verify* | sonnet | 1 | 1.4k | 11.3k | 552.5k | 62.7k | 31 | 41.1k | 5m 48s |
| implement* | MiniMax-M3 | 1 | 97.7k | 11.5k | 3.9M | 79.0k | 100 | 0 | 7m 55s |
| audit_impl* | sonnet | 1 | 821 | 8.8k | 170.8k | 44.1k | 14 | 31.6k | 4m 5s |
| prepare_pr* | MiniMax-M3 | 1 | 45.9k | 2.4k | 211.3k | 49.3k | 15 | 0 | 1m 7s |
| compose_pr* | MiniMax-M3 | 1 | 35.1k | 1.9k | 151.2k | 38.9k | 12 | 0 | 58s |
| review_pr* | sonnet | 1 | 180 | 23.2k | 1.2M | 74.8k | 48 | 53.8k | 6m 6s |
| resolve_review* | sonnet | 1 | 125 | 17.2k | 907.8k | 80.4k | 45 | 59.5k | 6m 10s |
| **Total** | | | 183.7k | 97.1k | 8.7M | 118.2k | | 283.2k | 45m 21s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 84 | 46605.9 | 0.0 | 137.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **84** | 103835.7 | 3371.5 | 1156.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.6k | 20.8k | 1.6M | 97.1k | 13m 11s |
| sonnet | 4 | 2.5k | 60.5k | 2.8M | 186.1k | 22m 9s |
| MiniMax-M3 | 3 | 178.6k | 15.8k | 4.3M | 0 | 9m 59s |