### PR TITLE
Implementation Plan: Add AUTOSKILLIT_WRITE_GUARD_TOOL_NAMES Env-Var Override to write_guard.py

### DIFF
--- a/src/autoskillit/hooks/guards/CLAUDE.md
+++ b/src/autoskillit/hooks/guards/CLAUDE.md
@@ -36,7 +36,7 @@ PreToolUse guard scripts — standalone Python processes enforcing tool-call pol
 | `skill_command_guard.py` | Blocks `run_skill` with non-slash `skill_command` |
 | `unsafe_install_guard.py` | Blocks `pip install -e` targeting system Python |
 | `skill_load_guard.py` | Denies native tools until Skill tool is called in non-Anthropic headless skill sessions; bypasses when `AUTOSKILLIT_APPLICABLE_GUARDS` does not contain the guard's filename stem, and for subagents (`agent_id`) |
-| `write_guard.py` | Blocks Write/Edit/Bash/apply_patch outside allowed prefix in write-scoped sessions |
+| `write_guard.py` | Blocks tool calls outside allowed prefix in write-scoped sessions; tool set driven by `AUTOSKILLIT_WRITE_GUARD_TOOL_NAMES` env var (default: Write/Edit/Bash/apply_patch) |
 
 ## Architecture Notes
 

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -1,5 +1,6 @@
-"""PreToolUse hook: blocks Write/Edit/Bash/apply_patch outside
-the allowed prefix in write-scoped sessions."""
+"""PreToolUse hook: blocks tool calls outside the allowed prefix
+in write-scoped sessions. Tool set driven by AUTOSKILLIT_WRITE_GUARD_TOOL_NAMES
+(default: Write, Edit, Bash, apply_patch)."""
 
 from __future__ import annotations
 
@@ -248,7 +249,18 @@ def main() -> None:
         return
 
     tool_name = data.get("tool_name", "")
-    if tool_name not in ("Write", "Edit", "Bash", "apply_patch") and "run_cmd" not in tool_name:
+
+    raw_tool_names = os.environ.get("AUTOSKILLIT_WRITE_GUARD_TOOL_NAMES", "")
+    parsed_names = [t.strip() for t in raw_tool_names.split(",") if t.strip()]
+    # Default must match CLAUDE_CODE_CAPABILITIES.write_guard_tool_names
+    # in core/types/_type_backend.py
+    effective_tool_names: frozenset[str] = (
+        frozenset(parsed_names)
+        if parsed_names
+        else frozenset({"Write", "Edit", "Bash", "apply_patch"})
+    )
+
+    if tool_name not in effective_tool_names and "run_cmd" not in tool_name:
         sys.exit(0)
 
     tool_input = data.get("tool_input", {})

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -1,6 +1,15 @@
 """PreToolUse hook: blocks tool calls outside the allowed prefix
-in write-scoped sessions. Tool set driven by AUTOSKILLIT_WRITE_GUARD_TOOL_NAMES
-(default: Write, Edit, Bash, apply_patch)."""
+in write-scoped sessions.
+
+Two gate mechanisms operate together:
+1. Named-tool gate: controlled by AUTOSKILLIT_WRITE_GUARD_TOOL_NAMES (default:
+   Write, Edit, Bash, apply_patch). Tool calls not in this set pass through
+   immediately with no prefix check.
+2. run_cmd bypass: any tool whose name contains the substring "run_cmd" is
+   unconditionally routed into the Bash command analysis path regardless of
+   AUTOSKILLIT_WRITE_GUARD_TOOL_NAMES. This ensures Codex's run_cmd tool is
+   always subject to command-level write checks. The env var cannot suppress
+   or extend this bypass."""
 
 from __future__ import annotations
 

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -314,6 +314,14 @@ class TestWriteGuardToolNamesEnvVar:
         parsed = json.loads(result)
         assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
 
+    def test_env_var_whitespace_only_falls_back_to_default_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("AUTOSKILLIT_WRITE_GUARD_TOOL_NAMES", "   ")
+        result = _run_hook(_build_event("Write", "/outside/foo.py"))
+        parsed = json.loads(result)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+
     def test_env_var_with_apply_patch_denies_codex_patch_outside_prefix(
         self, monkeypatch: pytest.MonkeyPatch
     ):

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -293,6 +293,46 @@ class TestWriteGuardCodexPatchFormat:
         assert "file_b.rs" in paths
 
 
+class TestWriteGuardToolNamesEnvVar:
+    """AUTOSKILLIT_WRITE_GUARD_TOOL_NAMES env var overrides the hardcoded tool set."""
+
+    PREFIX = "/clone/.autoskillit/temp/"
+
+    @pytest.fixture(autouse=True)
+    def _enable_headless(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", self.PREFIX)
+
+    def test_env_var_set_allows_non_listed_tool_passthrough(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AUTOSKILLIT_WRITE_GUARD_TOOL_NAMES", "apply_patch,Bash")
+        result = _run_hook(_build_event("Write", "/outside/foo.py"))
+        assert result == ""
+
+    def test_env_var_empty_string_falls_back_to_default_set(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AUTOSKILLIT_WRITE_GUARD_TOOL_NAMES", "")
+        result = _run_hook(_build_event("Write", "/outside/foo.py"))
+        parsed = json.loads(result)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_env_var_with_apply_patch_denies_codex_patch_outside_prefix(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("AUTOSKILLIT_WRITE_GUARD_TOOL_NAMES", "apply_patch,Bash")
+        patch = (
+            "*** Begin Patch\n"
+            "*** Update File: /outside/credentials.rs\n"
+            "@@ -1,3 +1,4 @@\n"
+            "+new line\n"
+            "*** End Patch"
+        )
+        result = _run_hook(_build_apply_patch_event(patch))
+        parsed = json.loads(result)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert (
+            "read-only skill session" in parsed["hookSpecificOutput"]["permissionDecisionReason"]
+        )
+
+
 class TestWriteGuardBashBypass:
     """write_guard intercepts Bash tool calls containing file-modifying commands."""
 


### PR DESCRIPTION
## Summary

Replace the hardcoded tool-name tuple in `write_guard.py`'s `main()` with an env-var-driven `effective_tool_names` frozenset read from `AUTOSKILLIT_WRITE_GUARD_TOOL_NAMES`. When the env var is set and non-empty, split on comma and strip whitespace to build the frozenset. When empty or absent, fall back to the current default set `{'Write', 'Edit', 'Bash', 'apply_patch'}`. The `"run_cmd"` substring check remains unconditional. Add 3 tests in a new `TestWriteGuardToolNamesEnvVar` class. Update the module docstring and CLAUDE.md table entry to reflect the env-var-driven behavior.

**Pre-existing work (no changes needed):**
- `_extract_paths_from_patch()` already handles Codex `*** Update File:`, `*** Add File:`, and `*** Delete File:` markers via `_CODEX_FILE_MARKERS` (line 189).
- The `_extract_paths_from_patch()` docstring already mentions both unified diff and Codex formats (line 195).
- `TestWriteGuardCodexPatchFormat` class already exists with 7 tests covering all Codex patch scenarios.
- `AUTOSKILLIT_WRITE_GUARD_TOOL_NAMES` constant is defined in `core/types/_type_constants_env.py` (line 68).
- Both backends (Claude and Codex) already inject the env var into headless sessions.


Closes #3788

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260605-053915-538950/.autoskillit/temp/make-plan/make-write-guard-py-correctly-extract-file-paths_plan_2026-06-05_055000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 61 | 11.8k | 1.0M | 85.8k | 30 | 67.6k | 9m 52s |
| verify* | sonnet | 1 | 92 | 7.2k | 474.5k | 51.4k | 31 | 29.7k | 3m 15s |
| implement* | MiniMax-M3 | 1 | 68.6k | 4.4k | 1.3M | 68.8k | 39 | 0 | 8m 35s |
| audit_impl* | sonnet | 1 | 46 | 5.0k | 167.8k | 41.3k | 16 | 24.0k | 2m 35s |
| prepare_pr* | MiniMax-M3 | 1 | 43.1k | 5.2k | 209.3k | 48.6k | 19 | 0 | 2m 19s |
| compose_pr* | MiniMax-M3 | 1 | 37.6k | 1.3k | 185.2k | 38.5k | 12 | 0 | 51s |
| review_pr* | sonnet | 1 | 108 | 15.2k | 624.8k | 62.8k | 36 | 42.4k | 4m 19s |
| resolve_review* | sonnet | 1 | 193 | 11.6k | 1.4M | 74.7k | 54 | 53.4k | 5m 45s |
| **Total** | | | 149.8k | 61.7k | 5.3M | 85.8k | | 217.1k | 37m 34s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 60 | 21745.6 | 0.0 | 74.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 21 | 64430.9 | 2542.0 | 553.3 |
| **Total** | **81** | 65930.3 | 2680.1 | 761.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 61 | 11.8k | 1.0M | 67.6k | 9m 52s |
| sonnet | 4 | 439 | 38.9k | 2.6M | 149.5k | 15m 56s |
| MiniMax-M3 | 3 | 149.3k | 10.9k | 1.7M | 0 | 11m 46s |