### PR TITLE
Implementation Plan: Populate sandbox_mode in SkillSessionConfig and Consume in CodexBackend

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -588,6 +588,7 @@ class CodexBackend:
         resume_session_id: str = "",
         resume_checkpoint: SessionCheckpoint | None = None,
         resume_message: str | None = None,
+        sandbox_mode: str = "workspace-write",
     ) -> CmdSpec:
         if config is not None:
             completion_marker = config.completion_marker
@@ -606,6 +607,7 @@ class CodexBackend:
             resume_session_id = config.resume_session_id
             resume_checkpoint = config.resume_checkpoint
             resume_message = config.resume_message
+            sandbox_mode = config.sandbox_mode
         _has_prefix = bool(profile_name) and skill_command.strip().startswith("/")
 
         if resume_session_id:
@@ -673,7 +675,7 @@ class CodexBackend:
         )
 
         cmd = _codex_exec_base(
-            sandbox="workspace-write",
+            sandbox=sandbox_mode,
             bypass_hook_trust=self.capabilities.mcp_config_capable,
         )
         if model:

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -190,6 +190,9 @@ async def run_headless_core(
             resume_session_id=resume_session_id,
             resume_checkpoint=resume_checkpoint,
             resume_message=resume_message,
+            sandbox_mode="read-only"
+            if readonly_skill
+            else ctx.backend.capabilities.default_skill_sandbox_mode,
         )
         step_backend: CodingAgentBackend | None = None
         if backend_override is not None:

--- a/tests/arch/test_capability_consumption.py
+++ b/tests/arch/test_capability_consumption.py
@@ -75,11 +75,6 @@ _FORWARD_DECLARED: dict[str, ForwardDeclaredField] = {
         rationale="patch path extraction routing — consumer in write_guard.py P2",
         added_date=date(2026, 6, 5),
     ),
-    "default_skill_sandbox_mode": ForwardDeclaredField(
-        issue=3776,
-        rationale="sandbox mode routing — consumer in CodexBackend.build_skill_session_cmd P2",
-        added_date=date(2026, 6, 5),
-    ),
 }
 
 

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -692,6 +692,7 @@ class TestCodexBuildSkillSessionCmdConfigAdapter:
             resume_session_id="s1",
             resume_checkpoint=chk,
             resume_message="resume-msg",
+            sandbox_mode="read-only",
         )
         via_config = CodexBackend().build_skill_session_cmd("/test", cwd="/tmp", config=config)
         via_flat = CodexBackend().build_skill_session_cmd(
@@ -712,9 +713,16 @@ class TestCodexBuildSkillSessionCmdConfigAdapter:
             resume_session_id="s1",
             resume_checkpoint=chk,
             resume_message="resume-msg",
+            sandbox_mode="read-only",
         )
         assert via_config.cmd == via_flat.cmd
         assert via_config.env == via_flat.env
+
+    def test_config_sandbox_mode_propagates(self) -> None:
+        config = SkillSessionConfig(sandbox_mode="read-only")
+        spec = CodexBackend().build_skill_session_cmd("/test", cwd="/tmp", config=config)
+        idx = spec.cmd.index("--sandbox")
+        assert spec.cmd[idx + 1] == "read-only"
 
     def test_config_path_returns_cmdspec(self) -> None:
         config = SkillSessionConfig(completion_marker="%%DONE%%", output_format=OutputFormat.JSON)


### PR DESCRIPTION
## Summary

Wire the `sandbox_mode` data flow end-to-end: populate `sandbox_mode` in the `SkillSessionConfig` constructor in `run_headless_core()` from `readonly_skill` / `ctx.backend.capabilities.default_skill_sandbox_mode`, consume `config.sandbox_mode` in `CodexBackend.build_skill_session_cmd()` replacing the hardcoded `"workspace-write"` literal, remove `default_skill_sandbox_mode` from `_FORWARD_DECLARED` since it now has a production consumer, and add a test verifying non-default `sandbox_mode` propagates through the config adapter path. The three structural lock tests in `test_backend_dataclasses.py` already cover `sandbox_mode` (P1-A6 confirmed landed).

Closes #3789

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260605-063206-933738/.autoskillit/temp/make-plan/populate_sandbox_mode_plan_2026-06-05_063700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 2.0k | 11.0k | 775.8k | 73.4k | 33 | 54.4k | 8m 22s |
| verify* | sonnet | 1 | 68 | 7.3k | 327.2k | 51.6k | 24 | 29.9k | 3m 28s |
| implement* | MiniMax-M3 | 1 | 62.5k | 12.6k | 2.9M | 72.0k | 118 | 0 | 14m 53s |
| audit_impl* | sonnet | 1 | 456 | 6.8k | 206.8k | 41.6k | 15 | 26.7k | 4m 1s |
| prepare_pr* | MiniMax-M3 | 1 | 45.7k | 2.5k | 246.0k | 47.2k | 15 | 0 | 1m 32s |
| compose_pr* | MiniMax-M3 | 1 | 41.1k | 1.5k | 231.0k | 41.5k | 15 | 0 | 1m 8s |
| review_pr* | sonnet | 3 | 278 | 41.1k | 1.5M | 61.7k | 97 | 116.0k | 10m 30s |
| **Total** | | | 152.1k | 82.8k | 6.2M | 73.4k | | 227.0k | 43m 58s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 20 | 147146.0 | 0.0 | 629.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **20** | 311183.4 | 11348.4 | 4142.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.0k | 11.0k | 775.8k | 54.4k | 8m 22s |
| sonnet | 3 | 802 | 55.2k | 2.0M | 172.6k | 18m 0s |
| MiniMax-M3 | 3 | 149.3k | 16.6k | 3.4M | 0 | 17m 34s |