### PR TITLE
impl-3723: Parametrized Universal Assertion Body of test_phoropter_lens_structure

### DIFF
--- a/src/autoskillit/assets/phoropter-registry.yaml
+++ b/src/autoskillit/assets/phoropter-registry.yaml
@@ -14,6 +14,8 @@ families:
       strategy: null
     step_naming:
       prefix: null
+    activate_deps: [mermaid]
+    output_prefix: ""
     status: implemented
 
   exp-lens:
@@ -29,6 +31,8 @@ families:
       strategy: priority_hierarchy
     step_naming:
       prefix: null
+    activate_deps: [mermaid]
+    output_prefix: ""
     status: implemented
 
   vis-lens:
@@ -49,7 +53,12 @@ families:
       skip_field: context.is_silent_type
       skip_semantics: skip_when_true
       applies_to: apply
-    lens_metadata: {}  # vis-lens-specific extension point; other families omit this field intentionally
+    lens_metadata:
+      methodology-norms:
+        special_assertions: [tradition_slug, two_stage_matching]
+    activate_deps: [mermaid]
+    output_prefix: "vis_spec_"
+    composite_slugs: [always-on]
     status: implemented
 
   refactor-lens:

--- a/tests/assets/test_phoropter_registry.py
+++ b/tests/assets/test_phoropter_registry.py
@@ -79,6 +79,8 @@ def test_arch_lens_fields(registry_data: dict) -> None:
     assert entry["status"] == "implemented"
     assert entry["default_enabled"] is True
     assert entry["failure_mode"] == "continue"
+    assert entry["activate_deps"] == ["mermaid"]
+    assert entry["output_prefix"] == ""
     assert "phase_skip" not in entry
 
 
@@ -93,6 +95,8 @@ def test_exp_lens_fields(registry_data: dict) -> None:
     assert "skill" not in entry["synthesis"]
     assert entry["step_naming"]["prefix"] is None
     assert entry["status"] == "implemented"
+    assert entry["activate_deps"] == ["mermaid"]
+    assert entry["output_prefix"] == ""
     assert "phase_skip" not in entry
 
 
@@ -112,6 +116,13 @@ def test_vis_lens_fields(registry_data: dict) -> None:
     assert entry["phase_skip"]["applies_to"] == "apply"
     assert "lens_metadata" in entry
     assert isinstance(entry["lens_metadata"], dict)
+    assert entry["activate_deps"] == ["mermaid"]
+    assert entry["output_prefix"] == "vis_spec_"
+    assert entry["composite_slugs"] == ["always-on"]
+    assert entry["lens_metadata"]["methodology-norms"]["special_assertions"] == [
+        "tradition_slug",
+        "two_stage_matching",
+    ]
 
 
 def test_refactor_lens_fields(registry_data: dict) -> None:

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -721,6 +721,7 @@ class TestCodexBuildSkillSessionCmdConfigAdapter:
     def test_config_sandbox_mode_propagates(self) -> None:
         config = SkillSessionConfig(sandbox_mode="read-only")
         spec = CodexBackend().build_skill_session_cmd("/test", cwd="/tmp", config=config)
+        assert "--sandbox" in spec.cmd
         idx = spec.cmd.index("--sandbox")
         assert spec.cmd[idx + 1] == "read-only"
 

--- a/tests/skills/test_phoropter_structural.py
+++ b/tests/skills/test_phoropter_structural.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.core import load_yaml, pkg_root
+from autoskillit.workspace.skill_format import parse_frontmatter_content
 
 SKILLS_DIR = pkg_root() / "skills_extended"
 
@@ -27,3 +28,55 @@ def test_discovery_is_non_empty_and_covers_all_families() -> None:
     discovered_families = {family for family, _ in _LENS_PAIRS}
     for expected in _IMPLEMENTED_FAMILIES:
         assert expected in discovered_families, f"{expected} not found in discovered lens pairs"
+
+
+@pytest.mark.parametrize("family,slug", _LENS_PAIRS)
+def test_phoropter_lens_structure(family: str, slug: str) -> None:
+    family_meta = _REGISTRY["families"][family]
+
+    path = SKILLS_DIR / f"{family}-{slug}" / "SKILL.md"
+    assert path.exists(), f"{family}-{slug}/SKILL.md is missing"
+
+    text = path.read_text()
+
+    assert "## Arguments" in text, f"{family}-{slug} missing ## Arguments section"
+    assert "context_path" in text, f"{family}-{slug} must document context_path"
+    assert "Step 0" in text, f"{family}-{slug} must have Step 0"
+    assert "diagram_path" in text, f"{family}-{slug} must mention diagram_path"
+
+    fm = parse_frontmatter_content(text)
+    assert fm.get("categories") == [family], (
+        f"{family}-{slug} frontmatter categories must be [{family}], got {fm.get('categories')}"
+    )
+    assert fm.get("activate_deps") == family_meta["activate_deps"], (
+        f"{family}-{slug} frontmatter activate_deps must be {family_meta['activate_deps']}, "
+        f"got {fm.get('activate_deps')}"
+    )
+
+    if family_meta["arg_interface"] == "2-arg":
+        assert "experiment_plan_path" in text, (
+            f"{family}-{slug} (2-arg) must document experiment_plan_path"
+        )
+
+    if family == "vis-lens":
+        if slug in family_meta.get("composite_slugs", []):
+            assert "yaml:spec-index" in text, (
+                f"{family}-{slug} (composite) must contain yaml:spec-index"
+            )
+        else:
+            assert "yaml:figure-spec" in text, f"{family}-{slug} must contain yaml:figure-spec"
+
+    if family_meta.get("output_prefix"):
+        assert family_meta["output_prefix"] in text, (
+            f"{family}-{slug} output path must use {family_meta['output_prefix']} prefix"
+        )
+
+    entry = family_meta.get("lens_metadata", {}).get(slug, {})
+    special = entry.get("special_assertions", [])
+    if "tradition_slug" in special and "two_stage_matching" in special:
+        assert "tradition_slug" in text, f"{family}-{slug} must document tradition_slug"
+        assert "Stage A" in text or "stage A" in text, f"{family}-{slug} must document Stage A"
+        assert "Stage B" in text or "stage B" in text, f"{family}-{slug} must document Stage B"
+        assert "venue_specific_appendices" in text or "venue appendix" in text, (
+            f"{family}-{slug} must document venue_specific_appendices"
+        )


### PR DESCRIPTION
## Summary

Implement the parametrized `test_phoropter_lens_structure` function in `tests/skills/test_phoropter_structural.py` with 7 universal assertions, 3 conditional assertion blocks, and 1 special_assertions block. Extend `phoropter-registry.yaml` with `activate_deps`, `output_prefix`, `composite_slugs`, and per-slug `special_assertions` fields so all branching is registry-driven.

## Requirements

## Goal

Implement the parametrized universal assertion body of test_phoropter_lens_structure in the test file scaffolded by T2-P5-A1-WP1, so that all 43 existing lenses across arch-lens, exp-lens, and vis-lens families are checked for the seven structural invariants that hold unconditionally across every (family, slug) pair.

## Context

- Phase: Family-Generic Registry-Driven Structural Test (Milestone: 5-family-generic-registry-driven-structural-test)
- Assignment: T2-P5-A2 (Write @pytest.mark.parametrize structural test with universal and registry-driven conditional assertions)
- Depends on: T2-P5-A1-WP1, T2-P4-A6-WP1
- Depended on by: T2-P5-A3-WP1, T2-P5-A5-WP1

## Deliverables

- `tests/skills/test_phoropter_structural.py — parametrized test_phoropter_lens_structure function body with all 7 universal assertions`
- `tests/skills/test_phoropter_structural.py — three conditional assertion blocks added inside test_phoropter_lens_structure`
- `src/autoskillit/assets/phoropter-registry.yaml — composite_slugs list added to vis-lens family entry; output_prefix field added to all family entries`
- `tests/skills/test_phoropter_structural.py — special_assertions conditional block with all four methodology-norms sub-assertions`
- `src/autoskillit/assets/phoropter-registry.yaml — special_assertions: [tradition_slug, two_stage_matching] on the methodology-norms entry`

## Acceptance Criteria

- test_phoropter_lens_structure is parametrized over _LENS_PAIRS and generates one test case per (family, slug) pair (expected: 43 pairs for arch-lens×13 + exp-lens×18 + vis-lens×12).
- The SKILL.md path construction uses the full family key from the registry (e.g. SKILLS_DIR / 'arch-lens-c4-container' / 'SKILL.md'), not a truncated prefix.
- All seven assertions execute unconditionally for every (family, slug) pair with no conditional branches inside the function body.
- parse_frontmatter_content is used (not an inline ad-hoc frontmatter parser) for assertions 6 and 7.
- The activate_deps assertion compares against the value from the registry entry for that family, not a hardcoded literal.
- Failure messages include the full family-slug identifier for every assertion.
- task test-all passes with the new parametrized test function contributing 43 passing test cases.
- No slug lists are hardcoded in this function; all parametrization flows through _LENS_PAIRS built from the registry.
- Running the parametrized test against all exp-lens slugs (18) asserts 'experiment_plan_path' in each SKILL.md text because exp-lens arg_interface == '2-arg' in the registry.
- Running the parametrized test against all vis-lens slugs (12) asserts 'experiment_plan_path' in each SKILL.md text because vis-lens arg_interface == '2-arg' in the registry.
- Running the parametrized test against all arch-lens slugs (13) does NOT assert 'experiment_plan_path' because arch-lens arg_interface == '1-arg' in the registry.
- For vis-lens slugs in composite_slugs (currently 'always-on'), the test asserts 'yaml:spec-index' in text and does not assert 'yaml:figure-spec'.
- For all other vis-lens slugs (11 non-composite), the test asserts 'yaml:figure-spec' in text and does not assert 'yaml:spec-index'.
- For all vis-lens slugs, the test asserts 'vis_spec_' in text because output_prefix == 'vis_spec_' in the registry.
- For exp-lens and arch-lens slugs, the vis_spec_ block is skipped (output_prefix != 'vis_spec_').
- No hardcoded slug lists appear in the three new conditional blocks — all branching derives from the registry data loaded at module scope.
- All three conditional blocks live inside test_phoropter_lens_structure; no new top-level test functions are introduced by this WP.
- phoropter-registry.yaml vis-lens entry contains composite_slugs: [always-on] and output_prefix: 'vis_spec_'.
- task test-all passes with these assertions in place against the current codebase.
- The parametrized test_phoropter_lens_structure fires all four sub-assertions exactly for the methodology-norms slug and none for any other vis-lens slug.
- Assertion (1) 'tradition_slug' in text passes for methodology-norms.
- Assertion (2) ('Stage A' in text or 'stage A' in text) passes for methodology-norms.
- Assertion (3) ('Stage B' in text or 'stage B' in text) passes for methodology-norms.
- Assertion (4) ('venue_specific_appendices' in text or 'venue appendix' in text) passes for methodology-norms.
- The conditional block is gated on entry.get('special_assertions', []) containing both 'tradition_slug' and 'two_stage_matching' — no slug string literals appear in the test.
- phoropter-registry.yaml entry for methodology-norms carries special_assertions: [tradition_slug, two_stage_matching].
- task test-check passes with no regressions across the full test suite.

Closes #3723

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-3723-20260605-065010-370270/.autoskillit/temp/make-plan/impl_3723_parametrized_phoropter_lens_structure_plan_2026-06-05_070500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 13 | 3.4k | 362.4k | 95.2k | 45 | 12.0k | 16m 14s |
| verify* | opus | 1 | 35 | 6.8k | 376.6k | 66.1k | 21 | 43.9k | 4m 56s |
| implement* | MiniMax-M3 | 1 | 54.1k | 4.7k | 1.0M | 58.2k | 36 | 0 | 4m 53s |
| audit_impl* | opus | 1 | 2.4k | 9.9k | 170.8k | 42.3k | 12 | 32.4k | 3m 33s |
| prepare_pr* | MiniMax-M3 | 1 | 43.3k | 2.3k | 251.1k | 47.3k | 12 | 0 | 1m 12s |
| compose_pr* | MiniMax-M3 | 1 | 40.7k | 2.7k | 189.9k | 40.7k | 13 | 0 | 1m 22s |
| review_pr* | opus | 2 | 58 | 43.2k | 1.1M | 83.1k | 59 | 97.1k | 18m 2s |
| resolve_review* | opus | 2 | 91 | 19.3k | 2.3M | 84.2k | 82 | 148.7k | 10m 48s |
| **Total** | | | 140.8k | 92.4k | 5.8M | 95.2k | | 334.1k | 1h 1m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 75 | 13456.2 | 0.0 | 62.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 1 | 2334060.0 | 148724.0 | 19329.0 |
| **Total** | **76** | 76856.5 | 4396.4 | 1215.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 13 | 3.4k | 362.4k | 12.0k | 16m 14s |
| opus | 4 | 2.6k | 79.2k | 4.0M | 322.2k | 37m 20s |
| MiniMax-M3 | 3 | 138.1k | 9.7k | 1.5M | 0 | 7m 27s |