### PR TITLE
[FIX] Replace backend-name string comparison with capability field lookup in _extract_file_changes()

### DIFF
--- a/src/autoskillit/execution/headless/_headless_evidence.py
+++ b/src/autoskillit/execution/headless/_headless_evidence.py
@@ -9,7 +9,6 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from autoskillit.core import (
-    AGENT_BACKEND_CLAUDE_CODE,
     CODEX_CONTEXT_EXHAUSTION_MARKER,
     AgentSessionResult,
     CliSubtype,
@@ -163,7 +162,7 @@ def _compute_write_evidence(
 
 
 def _extract_file_changes(stdout: str, backend: CodingAgentBackend) -> list[str]:
-    if backend.name == AGENT_BACKEND_CLAUDE_CODE:
+    if backend.capabilities.write_detection_strategy == "tool_names":
         return []
     agent_result = backend.result_parser().parse_stdout(stdout)
     return list(agent_result.raw.get("file_changes", []))

--- a/tests/arch/test_capability_consumption.py
+++ b/tests/arch/test_capability_consumption.py
@@ -65,11 +65,6 @@ _FORWARD_DECLARED: dict[str, ForwardDeclaredField] = {
         ),
         added_date=date(2026, 6, 2),
     ),
-    "write_detection_strategy": ForwardDeclaredField(
-        issue=3776,
-        rationale="write evidence strategy routing — consumer in _headless_evidence.py P2",
-        added_date=date(2026, 6, 5),
-    ),
     "patch_format": ForwardDeclaredField(
         issue=3776,
         rationale="patch path extraction routing — consumer in write_guard.py P2",

--- a/tests/arch/test_no_backend_name_bypass.py
+++ b/tests/arch/test_no_backend_name_bypass.py
@@ -13,7 +13,6 @@ _EXEMPT_FILES: frozenset[str] = frozenset(
         "server/_factory.py",  # Feature-gated backend swap (pre-capabilities)
         "cli/_marketplace.py",  # Marketplace — Claude Code-only install guard
         "execution/recording.py",  # Replay setup: fmt == "codex" Compare for player selection
-        "execution/headless/_headless_evidence.py",  # Claude-specific evidence extraction
         "execution/headless/_headless_result.py",  # Claude-specific result parsing
         "core/_version_snapshot.py",  # Version snapshot — routes codex_version by backend name
         "execution/headless/_headless_helpers.py",  # assert_headless_cmd claude -p flag check

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -26,6 +26,7 @@ CODEX_API_ERROR_SIGNAL_STRINGS: tuple[str, ...] = tuple(
 
 def _mock_backend(**kw: Any) -> Mock:
     """Build a mock backend with all-False/empty capability baseline."""
+    kw.setdefault("write_detection_strategy", "tool_names")
     caps = BackendCapabilities(**kw)
     backend = Mock()
     backend.name = "claude-code"

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock
 import pytest
 import structlog.testing
 
-from autoskillit.core import AGENT_BACKEND_CLAUDE_CODE
+from autoskillit.core import AGENT_BACKEND_CLAUDE_CODE, BackendCapabilities
 from autoskillit.core.types import (
     AgentSessionResult,
     CliSubtype,
@@ -299,6 +299,7 @@ class TestBackendDelegatedWriteToolNames:
 
         mock_backend = Mock()
         mock_backend.name = AGENT_BACKEND_CLAUDE_CODE
+        mock_backend.capabilities = BackendCapabilities(write_detection_strategy="tool_names")
         mock_backend.write_tool_names.return_value = frozenset({"CustomWrite"})
         stdout = (
             _make_tool_use_line("CustomWrite", {"file_path": "/a/b.py", "content": "x"})
@@ -393,6 +394,7 @@ class TestBackendDelegatedWriteToolNames:
 
         mock_backend = Mock()
         mock_backend.name = AGENT_BACKEND_CLAUDE_CODE
+        mock_backend.capabilities = BackendCapabilities(write_detection_strategy="tool_names")
         stdout = _success_session_json("Done")
         result = _sr(0, stdout, "", TerminationReason.NATURAL_EXIT)
         _build_skill_result(result, backend=mock_backend)
@@ -415,6 +417,7 @@ class TestBackendDelegatedWriteToolNames:
 
         mock_backend = Mock()
         mock_backend.name = AGENT_BACKEND_CLAUDE_CODE
+        mock_backend.capabilities = BackendCapabilities(write_detection_strategy="tool_names")
         stdout = _success_session_json("Done")
         result = _sr(0, stdout, "", TerminationReason.STALE)
         _build_skill_result(result, backend=mock_backend)
@@ -437,6 +440,7 @@ class TestBackendDelegatedWriteToolNames:
 
         mock_backend = Mock()
         mock_backend.name = AGENT_BACKEND_CLAUDE_CODE
+        mock_backend.capabilities = BackendCapabilities(write_detection_strategy="tool_names")
         stdout = _success_session_json("Done")
         result = _sr(0, stdout, "", TerminationReason.IDLE_STALL)
         _build_skill_result(result, backend=mock_backend)
@@ -459,6 +463,7 @@ class TestBackendDelegatedWriteToolNames:
 
         mock_backend = Mock()
         mock_backend.name = AGENT_BACKEND_CLAUDE_CODE
+        mock_backend.capabilities = BackendCapabilities(write_detection_strategy="tool_names")
         stdout = _success_session_json("Done")
         result = _sr(0, stdout, "", TerminationReason.TIMED_OUT)
         _build_skill_result(result, backend=mock_backend)


### PR DESCRIPTION
## Summary

Replace the sole `backend.name == AGENT_BACKEND_CLAUDE_CODE` comparison in `_extract_file_changes()` with `backend.capabilities.write_detection_strategy == "tool_names"`, remove the now-unused `AGENT_BACKEND_CLAUDE_CODE` import, and clean up the forward-declaration exemption and backend-name bypass exemption that are no longer needed.

## Requirements

---
plan_id: 87b5e4de-45c2-4344-8f31-256e5dff2ce7
source_commit: 9c69e0e28b0b251068a89ebd59a9786da3e1460c
---

### Goal

Replace the sole backend-name string comparison in _extract_file_changes() with a capability field lookup (write_detection_strategy == 'tool_names'), satisfying the production-consumer requirement for the new field added by P1-A1-WP1, and clean up the now-unnecessary forward-declaration and bypass exemption in lockstep.

### Deliverables

- `src/autoskillit/execution/headless/_headless_evidence.py` — routing change (line 166 comparison + line 12 import removal)
- `tests/arch/test_capability_consumption.py` — write_detection_strategy entry removed from _FORWARD_DECLARED
- `tests/arch/test_no_backend_name_bypass.py` — _headless_evidence.py entry removed from _EXEMPT_FILES

### Acceptance Criteria

- test_no_backend_name_string_comparisons passes without _headless_evidence.py in _EXEMPT_FILES
- test_all_capability_fields_have_production_consumers passes — write_detection_strategy has exactly one read site
- test_forward_declared_fields_have_no_consumers passes — write_detection_strategy is no longer in _FORWARD_DECLARED
- mypy passes with no attribute access errors
- ruff check passes with no unused import errors
- task test-all exits 0 with no regressions

Closes #3791

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260605-080505-626285/.autoskillit/temp/make-plan/wp1_replace_backend_name_comparison_plan_2026-06-05_080505.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 59 | 7.9k | 893.6k | 84.2k | 33 | 62.4k | 6m 11s |
| verify* | opus[1m] | 1 | 30 | 5.4k | 668.2k | 76.5k | 29 | 54.3k | 6m 12s |
| implement* | MiniMax-M3 | 1 | 51.7k | 4.7k | 997.3k | 54.8k | 45 | 0 | 4m 3s |
| fix* | opus[1m] | 1 | 50 | 6.4k | 1.3M | 74.9k | 48 | 52.7k | 9m 5s |
| audit_impl* | opus[1m] | 1 | 23 | 10.2k | 174.4k | 42.8k | 13 | 33.3k | 5m 22s |
| prepare_pr* | MiniMax-M3 | 1 | 43.2k | 2.4k | 242.8k | 44.7k | 11 | 0 | 1m 9s |
| compose_pr* | MiniMax-M3 | 1 | 37.2k | 1.5k | 234.7k | 40.5k | 12 | 0 | 58s |
| review_pr* | opus[1m] | 1 | 28 | 18.6k | 490.6k | 67.3k | 32 | 45.4k | 4m 25s |
| resolve_review* | opus[1m] | 1 | 36 | 5.4k | 1.1M | 72.9k | 34 | 51.0k | 4m 54s |
| **Total** | | | 132.3k | 62.5k | 6.2M | 84.2k | | 299.1k | 42m 23s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 9 | 110812.4 | 0.0 | 522.8 |
| fix | 8 | 168505.1 | 6586.1 | 803.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **17** | 363088.6 | 17592.9 | 3676.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 226 | 54.0k | 4.7M | 299.1k | 36m 12s |
| MiniMax-M3 | 3 | 132.1k | 8.5k | 1.5M | 0 | 6m 11s |