### PR TITLE
Introduce IL-0 Frozen Dataclass Types for Tradition Manifest

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -248,8 +248,8 @@ from .types import ContaminationOutcome as ContaminationOutcome
 from .types import CrossDomainAssessment as CrossDomainAssessment
 from .types import CrossDomainPrescription as CrossDomainPrescription
 from .types import DatabaseReader as DatabaseReader
-from .types import DirectInstall as DirectInstall
 from .types import DialingConfig as DialingConfig
+from .types import DirectInstall as DirectInstall
 from .types import DispatchGateType as DispatchGateType
 from .types import DispatchIdentity as DispatchIdentity
 from .types import EnvPolicy as EnvPolicy

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -249,6 +249,7 @@ from .types import CrossDomainAssessment as CrossDomainAssessment
 from .types import CrossDomainPrescription as CrossDomainPrescription
 from .types import DatabaseReader as DatabaseReader
 from .types import DirectInstall as DirectInstall
+from .types import DialingConfig as DialingConfig
 from .types import DispatchGateType as DispatchGateType
 from .types import DispatchIdentity as DispatchIdentity
 from .types import EnvPolicy as EnvPolicy
@@ -273,6 +274,7 @@ from .types import InspectorVerdict as InspectorVerdict
 from .types import IssueLabelState as IssueLabelState
 from .types import KillReason as KillReason
 from .types import LabelDef as LabelDef
+from .types import LensEntry as LensEntry
 from .types import LoadReport as LoadReport
 from .types import LoadResult as LoadResult
 from .types import MarketplaceInstall as MarketplaceInstall
@@ -337,6 +339,7 @@ from .types import TestRunner as TestRunner
 from .types import TimingLog as TimingLog
 from .types import TokenFactory as TokenFactory
 from .types import TokenLog as TokenLog
+from .types import TraditionManifest as TraditionManifest
 from .types import ValidatedAddDir as ValidatedAddDir
 from .types import ValidatedWorktreePath as ValidatedWorktreePath
 from .types import WorkspaceManager as WorkspaceManager

--- a/src/autoskillit/core/types/CLAUDE.md
+++ b/src/autoskillit/core/types/CLAUDE.md
@@ -35,10 +35,11 @@ Type re-export hub and all typed building blocks for the autoskillit package (IL
 | `_type_phoropter.py` | Phoropter family/phase types: `PhoropterPrescription`, `ReadingToken`, `READING_TOKEN_PATTERN`, `PhoropterPhaseSkip`, `CrossDomainPrescription`, `CrossDomainAssessment` |
 | `_type_resume.py` | `ResumeSpec` discriminated union: `NoResume | BareResume | NamedResume` |
 | `_type_plugin_source.py` | `PluginSource` discriminated union: `DirectInstall | MarketplaceInstall` |
+| `_type_tradition_manifest.py` | `TraditionManifest`, `LensEntry`, `DialingConfig` frozen dataclasses with `from_yaml_path` YAML loader |
 
 ## Architecture Notes
 
-Internal dependency DAG: enums -> constants_registries -> constants_features; enums -> results -> protocols -> helpers; enums -> phoropter. All modules have zero `autoskillit` imports outside this sub-package (IL-0 hard constraint). Production code imports from `autoskillit.core`, not from this package directly.
+Internal dependency DAG: enums -> constants_registries -> constants_features; enums -> results -> protocols -> helpers; enums -> phoropter; enums + phoropter -> tradition_manifest. All modules have zero `autoskillit` imports outside this sub-package (IL-0 hard constraint). Production code imports from `autoskillit.core`, not from this package directly.
 
 ## Extension Bundle Pattern
 

--- a/src/autoskillit/core/types/CLAUDE.md
+++ b/src/autoskillit/core/types/CLAUDE.md
@@ -35,7 +35,7 @@ Type re-export hub and all typed building blocks for the autoskillit package (IL
 | `_type_phoropter.py` | Phoropter family/phase types: `PhoropterPrescription`, `ReadingToken`, `READING_TOKEN_PATTERN`, `PhoropterPhaseSkip`, `CrossDomainPrescription`, `CrossDomainAssessment` |
 | `_type_resume.py` | `ResumeSpec` discriminated union: `NoResume | BareResume | NamedResume` |
 | `_type_plugin_source.py` | `PluginSource` discriminated union: `DirectInstall | MarketplaceInstall` |
-| `_type_tradition_manifest.py` | `TraditionManifest`, `LensEntry`, `DialingConfig` frozen dataclasses with `from_yaml_path` YAML loader |
+| `_type_tradition_manifest.py` | `TraditionManifest`, `LensEntry`, `DialingConfig` frozen dataclasses with `from_dict`/`from_yaml_path` loaders |
 
 ## Architecture Notes
 

--- a/src/autoskillit/core/types/__init__.py
+++ b/src/autoskillit/core/types/__init__.py
@@ -62,6 +62,8 @@ from ._type_subprocess import *  # noqa: F401, F403
 from ._type_subprocess import __all__ as _subprocess_all
 from ._type_token import *  # noqa: F401, F403
 from ._type_token import __all__ as _token_all
+from ._type_tradition_manifest import *  # noqa: F401, F403
+from ._type_tradition_manifest import __all__ as _tradition_manifest_all
 
 __all__ = (
     _backend_all
@@ -92,4 +94,5 @@ __all__ = (
     + _session_env_all
     + _subprocess_all
     + _token_all
+    + _tradition_manifest_all
 )

--- a/src/autoskillit/core/types/_type_tradition_manifest.py
+++ b/src/autoskillit/core/types/_type_tradition_manifest.py
@@ -76,14 +76,16 @@ class TraditionManifest:
         if dialing_raw and isinstance(dialing_raw, dict):
             synthesis = dialing_raw.get("synthesis_strategy")
             always = dialing_raw.get("always_run")
+            try:
+                synth = SynthesisStrategy(synthesis) if synthesis else SynthesisStrategy.NULL
+            except ValueError as exc:
+                raise ValueError(f"Invalid dialing.synthesis_strategy {synthesis!r}") from exc
             dialing = DialingConfig(
                 selection_strategy=dialing_raw.get("selection_strategy", ""),
                 min_lenses=dialing_raw.get("min_lenses", 1),
                 max_lenses=dialing_raw.get("max_lenses", 1),
                 always_run=tuple(always) if always else (),
-                synthesis_strategy=SynthesisStrategy(synthesis)
-                if synthesis
-                else SynthesisStrategy.NULL,
+                synthesis_strategy=synth,
             )
         else:
             dialing = DialingConfig()
@@ -119,7 +121,10 @@ class TraditionManifest:
     def from_yaml_path(cls, path: Path) -> TraditionManifest:
         from autoskillit.core.io import load_yaml
 
-        raw = load_yaml(path)
+        try:
+            raw = load_yaml(path)
+        except Exception as exc:
+            raise ValueError(f"Failed to load tradition manifest from {path}") from exc
         if not isinstance(raw, dict):
             raise ValueError(f"Expected a YAML mapping, got {type(raw).__name__}")
         return cls.from_dict(raw)

--- a/src/autoskillit/core/types/_type_tradition_manifest.py
+++ b/src/autoskillit/core/types/_type_tradition_manifest.py
@@ -4,17 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import ClassVar
-
-import yaml
+from typing import Any, ClassVar
 
 from ._type_enums import SynthesisStrategy
 from ._type_phoropter import PhoropterPhaseSkip
-
-try:
-    from yaml import CSafeLoader as _Loader
-except ImportError:
-    _Loader = yaml.SafeLoader  # type: ignore[misc,assignment]
 
 __all__ = ["TraditionManifest", "LensEntry", "DialingConfig"]
 
@@ -68,11 +61,7 @@ class TraditionManifest:
     )
 
     @classmethod
-    def from_yaml_path(cls, path: Path) -> TraditionManifest:
-        with open(path, "rb") as fh:
-            raw = yaml.load(fh, Loader=_Loader)
-        if not isinstance(raw, dict):
-            raise ValueError(f"Expected a YAML mapping, got {type(raw).__name__}")
+    def from_dict(cls, raw: dict[str, Any]) -> TraditionManifest:
         missing = cls._REQUIRED_KEYS - raw.keys()
         if missing:
             raise ValueError(f"Missing required field(s): {', '.join(sorted(missing))}")
@@ -125,3 +114,12 @@ class TraditionManifest:
             lenses=lenses,
             dialing=dialing,
         )
+
+    @classmethod
+    def from_yaml_path(cls, path: Path) -> TraditionManifest:
+        from autoskillit.core.io import load_yaml
+
+        raw = load_yaml(path)
+        if not isinstance(raw, dict):
+            raise ValueError(f"Expected a YAML mapping, got {type(raw).__name__}")
+        return cls.from_dict(raw)

--- a/src/autoskillit/core/types/_type_tradition_manifest.py
+++ b/src/autoskillit/core/types/_type_tradition_manifest.py
@@ -1,0 +1,127 @@
+"""Tradition manifest types. Zero autoskillit imports (IL-0)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar
+
+import yaml
+
+from ._type_enums import SynthesisStrategy
+from ._type_phoropter import PhoropterPhaseSkip
+
+try:
+    from yaml import CSafeLoader as _Loader
+except ImportError:
+    _Loader = yaml.SafeLoader  # type: ignore[misc,assignment]
+
+__all__ = ["TraditionManifest", "LensEntry", "DialingConfig"]
+
+
+@dataclass(frozen=True, slots=True)
+class LensEntry:
+    slug: str = ""
+    analytical_mode: str = ""
+    primary_question: str = ""
+    tradition: str = ""
+    codification_level: str = ""
+    diagram_direction: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class DialingConfig:
+    selection_strategy: str = ""
+    min_lenses: int = 1
+    max_lenses: int = 1
+    always_run: tuple[str, ...] = ()
+    synthesis_strategy: SynthesisStrategy = SynthesisStrategy.NULL
+
+
+@dataclass(frozen=True, slots=True)
+class TraditionManifest:
+    name: str
+    description: str
+    output_type: str
+    step_count: int
+    mode_label: str
+    context_file_schema: str
+    default_enabled: bool
+    failure_mode: str
+    step_name_prefix: str
+    phase_skip: PhoropterPhaseSkip | None = None
+    lenses: tuple[LensEntry, ...] = ()
+    dialing: DialingConfig = field(default_factory=DialingConfig)
+
+    _REQUIRED_KEYS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "name",
+            "description",
+            "output_type",
+            "step_count",
+            "mode_label",
+            "context_file_schema",
+            "default_enabled",
+            "failure_mode",
+            "step_name_prefix",
+        }
+    )
+
+    @classmethod
+    def from_yaml_path(cls, path: Path) -> TraditionManifest:
+        with open(path, "rb") as fh:
+            raw = yaml.load(fh, Loader=_Loader)
+        if not isinstance(raw, dict):
+            raise ValueError(f"Expected a YAML mapping, got {type(raw).__name__}")
+        missing = cls._REQUIRED_KEYS - raw.keys()
+        if missing:
+            raise ValueError(f"Missing required field(s): {', '.join(sorted(missing))}")
+
+        lenses_raw = raw.get("lenses") or ()
+        lenses = tuple(
+            LensEntry(**{k: v for k, v in entry.items() if k in LensEntry.__dataclass_fields__})
+            for entry in lenses_raw
+        )
+
+        dialing_raw = raw.get("dialing")
+        if dialing_raw and isinstance(dialing_raw, dict):
+            synthesis = dialing_raw.get("synthesis_strategy")
+            always = dialing_raw.get("always_run")
+            dialing = DialingConfig(
+                selection_strategy=dialing_raw.get("selection_strategy", ""),
+                min_lenses=dialing_raw.get("min_lenses", 1),
+                max_lenses=dialing_raw.get("max_lenses", 1),
+                always_run=tuple(always) if always else (),
+                synthesis_strategy=SynthesisStrategy(synthesis)
+                if synthesis
+                else SynthesisStrategy.NULL,
+            )
+        else:
+            dialing = DialingConfig()
+
+        skip_raw = raw.get("phase_skip")
+        if skip_raw and isinstance(skip_raw, dict):
+            phase_skip = PhoropterPhaseSkip(
+                **{
+                    k: v
+                    for k, v in skip_raw.items()
+                    if k in PhoropterPhaseSkip.__dataclass_fields__
+                }
+            )
+        else:
+            phase_skip = None
+
+        return cls(
+            name=raw["name"],
+            description=raw["description"],
+            output_type=raw["output_type"],
+            step_count=raw["step_count"],
+            mode_label=raw["mode_label"],
+            context_file_schema=raw["context_file_schema"],
+            default_enabled=raw["default_enabled"],
+            failure_mode=raw["failure_mode"],
+            step_name_prefix=raw["step_name_prefix"],
+            phase_skip=phase_skip,
+            lenses=lenses,
+            dialing=dialing,
+        )

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -250,6 +250,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     ),
     "_type_exceptions": frozenset({"core", "fleet", "recipe", "server"}),
     "_type_phoropter": frozenset({"core"}),
+    "_type_tradition_manifest": frozenset({"core"}),
     "_step_context": frozenset({"core", "execution", "pipeline", "server"}),
     "_execution_marker": frozenset({"core", "execution", "fleet", "server"}),
     "bash_write_targets": frozenset({"core", "execution"}),

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -803,7 +803,10 @@ def test_no_subpackage_exceeds_10_files() -> None:
             (PhoropterPrescription, ReadingToken, PhoropterPhaseSkip,
             CrossDomainPrescription, CrossDomainAssessment) for the phoropter
             registry system, bringing the core/types count to 29.
-            Exempt at 35 files (core/types: 29).
+            _type_tradition_manifest.py adds TraditionManifest, LensEntry,
+            DialingConfig frozen dataclasses with from_yaml_path YAML loader
+            for the tradition manifest system, bringing the core/types count to 30.
+            Exempt at 35 files (core/types: 30).
           cli/ — REQ-CNST-003-E5: cli/ retains _terminal_table.py as a re-export shim
             for backward-compatible cli/ imports; canonical implementation lives in
             core/_terminal_table.py. Also contains _terminal.py — the terminal state
@@ -864,7 +867,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "recipe": 42,  # was 33; +9 from CI/graph/dataflow splits
         "execution": 18,
         "core": 21,
-        "core/types": 29,
+        "core/types": 30,
         "cli": 21,
         "hooks": 13,
         "pipeline": 12,

--- a/tests/arch/test_subpackage_structure.py
+++ b/tests/arch/test_subpackage_structure.py
@@ -43,6 +43,7 @@ class TestCoreSubpackages:
             "_type_session_env",
             "_type_subprocess",
             "_type_token",
+            "_type_tradition_manifest",
         }
         actual = {p.stem for p in (SRC / "core" / "types").glob("_type_*.py")}
         assert actual == expected

--- a/tests/core/types/test_type_tradition_manifest.py
+++ b/tests/core/types/test_type_tradition_manifest.py
@@ -1,0 +1,197 @@
+"""Tests for _type_tradition_manifest.py — tradition manifest frozen types."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core.types._type_enums import SynthesisStrategy
+from autoskillit.core.types._type_tradition_manifest import (
+    DialingConfig,
+    LensEntry,
+    TraditionManifest,
+)
+from autoskillit.core.types._type_tradition_manifest import (
+    __all__ as _module_all,
+)
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+_MINIMAL_YAML = """\
+name: test-tradition
+description: A test tradition
+output_type: diagram
+step_count: 3
+mode_label: Test Mode
+context_file_schema: test_schema
+default_enabled: true
+failure_mode: continue
+step_name_prefix: test
+"""
+
+_FULL_YAML = """\
+name: full-tradition
+description: Full tradition with all fields
+output_type: assessment
+step_count: 5
+mode_label: Full Mode
+context_file_schema: full_schema
+default_enabled: false
+failure_mode: abort
+step_name_prefix: full
+lenses:
+  - slug: lens-a
+    analytical_mode: structural
+    primary_question: "How is it built?"
+    tradition: arch
+    codification_level: high
+    diagram_direction: TB
+  - slug: lens-b
+    analytical_mode: behavioral
+dialing:
+  selection_strategy: coverage
+  min_lenses: 2
+  max_lenses: 5
+  always_run:
+    - lens-a
+  synthesis_strategy: priority_hierarchy
+phase_skip:
+  skip_field: context.is_silent_type
+  skip_semantics: skip_when_true
+  applies_to: apply
+"""
+
+_REQUIRED_FIELDS = [
+    "name",
+    "description",
+    "output_type",
+    "step_count",
+    "mode_label",
+    "context_file_schema",
+    "default_enabled",
+    "failure_mode",
+    "step_name_prefix",
+]
+
+
+class TestRoundTrip:
+    def test_minimal_yaml_round_trip(self, tmp_path: Path) -> None:
+        p = tmp_path / "tradition.yaml"
+        p.write_text(_MINIMAL_YAML)
+        m = TraditionManifest.from_yaml_path(p)
+        assert m.name == "test-tradition"
+        assert m.description == "A test tradition"
+        assert m.output_type == "diagram"
+        assert m.step_count == 3
+        assert m.mode_label == "Test Mode"
+        assert m.context_file_schema == "test_schema"
+        assert m.default_enabled is True
+        assert m.failure_mode == "continue"
+        assert m.step_name_prefix == "test"
+        assert m.phase_skip is None
+        assert m.lenses == ()
+        assert m.dialing == DialingConfig()
+
+    def test_full_yaml_round_trip(self, tmp_path: Path) -> None:
+        p = tmp_path / "tradition.yaml"
+        p.write_text(_FULL_YAML)
+        m = TraditionManifest.from_yaml_path(p)
+        assert m.name == "full-tradition"
+        assert m.step_count == 5
+        assert m.default_enabled is False
+        assert len(m.lenses) == 2
+        assert m.lenses[0].slug == "lens-a"
+        assert m.lenses[0].analytical_mode == "structural"
+        assert m.lenses[1].slug == "lens-b"
+        assert m.lenses[1].analytical_mode == "behavioral"
+        assert m.lenses[1].primary_question == ""
+        assert m.dialing.selection_strategy == "coverage"
+        assert m.dialing.min_lenses == 2
+        assert m.dialing.max_lenses == 5
+        assert m.dialing.always_run == ("lens-a",)
+        assert m.dialing.synthesis_strategy == SynthesisStrategy.PRIORITY_HIERARCHY
+        assert m.phase_skip is not None
+        assert m.phase_skip.skip_field == "context.is_silent_type"
+        assert m.phase_skip.skip_semantics == "skip_when_true"
+        assert m.phase_skip.applies_to == "apply"
+
+
+class TestFrozen:
+    def test_lens_entry_frozen(self) -> None:
+        le = LensEntry(slug="a")
+        with pytest.raises(AttributeError):
+            le.slug = "b"  # type: ignore[misc]
+
+    def test_dialing_config_frozen(self) -> None:
+        dc = DialingConfig()
+        with pytest.raises(AttributeError):
+            dc.min_lenses = 99  # type: ignore[misc]
+
+    def test_tradition_manifest_frozen(self) -> None:
+        m = TraditionManifest(
+            name="x",
+            description="x",
+            output_type="x",
+            step_count=1,
+            mode_label="x",
+            context_file_schema="x",
+            default_enabled=True,
+            failure_mode="x",
+            step_name_prefix="x",
+        )
+        with pytest.raises(AttributeError):
+            m.name = "y"  # type: ignore[misc]
+
+
+class TestDefaults:
+    def test_lens_entry_defaults(self) -> None:
+        le = LensEntry()
+        assert le.slug == ""
+        assert le.analytical_mode == ""
+        assert le.primary_question == ""
+        assert le.tradition == ""
+        assert le.codification_level == ""
+        assert le.diagram_direction == ""
+
+    def test_dialing_config_defaults(self) -> None:
+        dc = DialingConfig()
+        assert dc.selection_strategy == ""
+        assert dc.min_lenses == 1
+        assert dc.max_lenses == 1
+        assert dc.always_run == ()
+        assert dc.synthesis_strategy == SynthesisStrategy.NULL
+
+
+class TestMissingFields:
+    @pytest.mark.parametrize("missing_field", _REQUIRED_FIELDS)
+    def test_missing_required_field_raises_value_error(
+        self, tmp_path: Path, missing_field: str
+    ) -> None:
+        lines = [ln for ln in _MINIMAL_YAML.splitlines() if not ln.startswith(f"{missing_field}:")]
+        p = tmp_path / "bad.yaml"
+        p.write_text("\n".join(lines) + "\n")
+        with pytest.raises(ValueError, match=missing_field):
+            TraditionManifest.from_yaml_path(p)
+
+
+class TestAllGuard:
+    def test_module_all(self) -> None:
+        assert _module_all == ["TraditionManifest", "LensEntry", "DialingConfig"]
+
+
+class TestSlots:
+    def test_all_dataclasses_have_slots(self) -> None:
+        for cls in (LensEntry, DialingConfig, TraditionManifest):
+            assert "__slots__" in vars(cls), f"{cls.__name__} missing __slots__"
+
+
+class TestGatewayReexport:
+    def test_importable_from_core_types(self) -> None:
+        from autoskillit.core.types import DialingConfig as DC
+        from autoskillit.core.types import LensEntry as LE
+        from autoskillit.core.types import TraditionManifest as TM
+
+        assert TM is TraditionManifest
+        assert LE is LensEntry
+        assert DC is DialingConfig

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -105,6 +105,7 @@ class TestModuleCascadeCore:
             "_type_inspector",
             "_type_phoropter",
             "_type_token",
+            "_type_tradition_manifest",
             "_type_constants_env",
             "_type_constants_features",
             "_type_constants_registries",


### PR DESCRIPTION
## Summary

Add `_type_tradition_manifest.py` to `src/autoskillit/core/types/` containing three frozen dataclasses (`LensEntry`, `DialingConfig`, `TraditionManifest`) with a `from_yaml_path` classmethod for stdlib-only YAML loading. Wire the new module into the `__init__.py` re-export hub, the `core/__init__.pyi` lazy-loader stub, all registry guard tests, and the CLAUDE.md file table. Add a comprehensive test suite covering round-trip YAML, frozen mutation guards, defaults, and ValueError on missing required fields.

Closes #3718

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-3718-20260605-090705-309946/.autoskillit/temp/make-plan/t2-p4-a3-wp2-tradition-manifest-types_plan_2026-06-05_091500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 53 | 16.5k | 1.0M | 81.1k | 41 | 64.9k | 9m 6s |
| verify* | opus | 1 | 57 | 16.8k | 2.4M | 98.5k | 77 | 98.7k | 8m 18s |
| implement* | MiniMax-M3 | 1 | 44.5k | 2.2k | 413.6k | 45.0k | 16 | 0 | 6m 39s |
| dispatch:44be7b0a-85b5-4ddd-8843-06589f289c1b* | sonnet | 1 | 66 | 3.9k | 468.3k | 68.9k | 17 | 47.9k | 28m 28s |
| retry_worktree* | opus | 1 | 55 | 18.8k | 3.4M | 125.5k | 88 | 126.7k | 14m 44s |
| fix* | opus | 1 | 35 | 1.9k | 312.2k | 46.5k | 15 | 24.3k | 3m 56s |
| audit_impl* | opus | 1 | 35 | 18.5k | 374.6k | 67.5k | 21 | 45.5k | 7m 40s |
| prepare_pr* | opus | 1 | 24 | 2.1k | 223.4k | 45.2k | 14 | 23.7k | 51s |
| compose_pr* | opus | 1 | 23 | 1.5k | 194.3k | 36.0k | 11 | 13.8k | 36s |
| review_pr* | opus | 1 | 40 | 32.3k | 781.5k | 87.8k | 32 | 66.0k | 7m 42s |
| resolve_review* | opus | 1 | 50 | 8.5k | 854.7k | 70.8k | 33 | 49.1k | 7m 23s |
| **Total** | | | 45.0k | 122.8k | 10.4M | 125.5k | | 560.6k | 1h 35m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 0 | — | — | — |
| dispatch:44be7b0a-85b5-4ddd-8843-06589f289c1b | 0 | — | — | — |
| retry_worktree | 341 | 9917.1 | 371.7 | 55.1 |
| fix | 0 | — | — | — |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 13 | 65743.8 | 3776.8 | 652.6 |
| **Total** | **354** | 29385.8 | 1583.7 | 347.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 53 | 16.5k | 1.0M | 64.9k | 9m 6s |
| opus | 8 | 319 | 100.3k | 8.5M | 447.8k | 51m 12s |
| MiniMax-M3 | 1 | 44.5k | 2.2k | 413.6k | 0 | 6m 39s |
| sonnet | 1 | 66 | 3.9k | 468.3k | 47.9k | 28m 28s |