### PR TITLE
Forward sandbox_mode from SkillSessionConfig to _build_skill_session_cmd_impl

### DIFF
--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -509,6 +509,7 @@ class ClaudeCodeBackend:
                 resume_session_id=config.resume_session_id,
                 resume_checkpoint=config.resume_checkpoint,
                 resume_message=config.resume_message,
+                sandbox_mode=config.sandbox_mode,
             )
         return self._build_skill_session_cmd_impl(
             skill_command,
@@ -552,6 +553,7 @@ class ClaudeCodeBackend:
         resume_session_id: str = "",
         resume_checkpoint: SessionCheckpoint | None = None,
         resume_message: str | None = None,
+        sandbox_mode: str = "workspace-write",
     ) -> CmdSpec:
         _has_prefix = bool(profile_name) and skill_command.strip().startswith("/")
 

--- a/tests/contracts/test_backend_protocol.py
+++ b/tests/contracts/test_backend_protocol.py
@@ -216,6 +216,7 @@ def test_build_skill_session_cmd_config_delegates_to_impl():
         resume_session_id="sess-1",
         resume_checkpoint=SessionCheckpoint(step_name="chk"),
         resume_message="resume-msg",
+        sandbox_mode="read-only",
     )
     sentinel = CmdSpec(cmd=("sentinel",), env={})
 
@@ -247,6 +248,7 @@ def test_build_skill_session_cmd_config_delegates_to_impl():
     assert kw["resume_session_id"] == config.resume_session_id
     assert kw["resume_checkpoint"] == config.resume_checkpoint
     assert kw["resume_message"] == config.resume_message
+    assert kw["sandbox_mode"] == config.sandbox_mode
 
 
 def test_build_skill_session_cmd_impl_exists():


### PR DESCRIPTION
## Summary

Add `sandbox_mode: str = "workspace-write"` as a keyword parameter to `ClaudeCodeBackend._build_skill_session_cmd_impl`, forward `config.sandbox_mode` in the `build_skill_session_cmd` config branch, and extend the delegation contract test to assert the forwarding. The parameter is accepted but intentionally not consumed in the Claude Code command builder (Claude Code has no `--sandbox` CLI equivalent).

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260605-115909-553822/.autoskillit/temp/make-plan/ensure_sandbox_mode_forwarding_plan_2026-06-05_120500.md`

Closes #3793

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 45 | 4.1k | 460.4k | 60.5k | 18 | 40.2k | 2m 15s |
| verify* | opus[1m] | 1 | 38 | 5.6k | 558.4k | 69.1k | 28 | 46.9k | 4m 20s |
| implement* | MiniMax-M3 | 1 | 44.0k | 2.0k | 645.4k | 46.5k | 23 | 0 | 1m 47s |
| audit_impl* | opus[1m] | 1 | 966 | 3.0k | 172.3k | 40.7k | 11 | 21.7k | 1m 56s |
| prepare_pr* | MiniMax-M3 | 1 | 39.0k | 1.3k | 156.7k | 41.9k | 12 | 0 | 42s |
| compose_pr* | MiniMax-M3 | 1 | 38.3k | 1.3k | 343.6k | 39.4k | 13 | 0 | 1m 22s |
| review_pr* | opus[1m] | 3 | 81 | 19.2k | 1.2M | 53.4k | 74 | 118.6k | 6m 17s |
| **Total** | | | 122.4k | 36.5k | 3.5M | 69.1k | | 227.4k | 18m 42s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 4 | 161351.0 | 0.0 | 495.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **4** | 873426.2 | 56855.2 | 9121.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 4 | 1.1k | 31.8k | 2.3M | 227.4k | 14m 50s |
| MiniMax-M3 | 3 | 121.3k | 4.6k | 1.1M | 0 | 3m 52s |