### PR TITLE
[FIX] Backend prompt sigil immunity for Codex skill injection

### DIFF
--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -135,6 +135,10 @@ class BackendCapabilities:
     supports_context_window_suffix: bool = field(default=False)
     # Gates backend-specific prompt supplements that warn against reading raw package files
     has_unguarded_filesystem_access: bool = field(default=False)
+    # Native skill invocation prefix character used by this backend's model/CLI.
+    # Claude Code uses "/" (slash-commands via the Skill tool).
+    # Codex uses "$" (dollar-mention via extract_tool_mentions).
+    skill_sigil: str = "/"
 
 
 ALL_PROJECT_LOCAL_SKILL_SEARCH_DIRS: tuple[str, ...] = (
@@ -217,6 +221,7 @@ CLAUDE_CODE_CAPABILITIES: BackendCapabilities = BackendCapabilities(
     plugin_install_capable=True,
     inspector_capable=False,
     supports_context_window_suffix=True,
+    skill_sigil="/",
 )
 
 

--- a/src/autoskillit/execution/backends/_claude_prompt.py
+++ b/src/autoskillit/execution/backends/_claude_prompt.py
@@ -114,11 +114,17 @@ def _apply_output_format(cmd: list[str], output_format: OutputFormat) -> None:
             cmd.append(flag)
 
 
-def _ensure_skill_prefix(skill_command: str, *, provider_profile: str = "") -> str:
+def _ensure_skill_prefix(
+    skill_command: str, *, provider_profile: str = "", skill_sigil: str = "/"
+) -> str:
     """Prompt-formatting helper: wrap slash-commands for headless session loading.
 
     Transforms `/foo args` into `Use the /foo skill args` so non-Claude models
     recognize the slash command as a Skill tool invocation rather than a task description.
+
+    When skill_sigil is not "/" (e.g. "$" for Codex), the leading "/" is replaced
+    with the target sigil and the command is returned as a raw token (no "Use the …
+    skill" prose wrapper), since non-Claude backends parse raw sigil-prefixed tokens.
 
     This is NOT a validator. Non-slash input passes through unchanged by design —
     runtime validation is enforced by the skill_command_guard PreToolUse hook.
@@ -128,6 +134,11 @@ def _ensure_skill_prefix(skill_command: str, *, provider_profile: str = "") -> s
         parts = stripped.split(None, 1)
         slash_cmd = parts[0]
         rest = parts[1] if len(parts) > 1 else ""
+
+        if skill_sigil != "/":
+            translated = skill_sigil + slash_cmd.lstrip("/")
+            return f"{translated} {rest}".rstrip() if rest else translated
+
         formatted = f"Use the {slash_cmd} skill"
         if rest:
             formatted += f" {rest}"

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -555,19 +555,27 @@ class ClaudeCodeBackend:
         resume_message: str | None = None,
         sandbox_mode: str = "workspace-write",
     ) -> CmdSpec:
-        _has_prefix = bool(profile_name) and skill_command.strip().startswith("/")
+        _has_prefix = (
+            bool(profile_name)
+            and skill_command.strip().startswith("/")
+            and self.capabilities.skill_sigil == "/"
+        )
 
         if resume_session_id:
             effective_prompt = _compose_resume_prompt(
                 base_prompt=_ensure_skill_prefix(
-                    skill_command, provider_profile=profile_name or ""
+                    skill_command,
+                    provider_profile=profile_name or "",
+                    skill_sigil=self.capabilities.skill_sigil,
                 ),
                 resume_checkpoint=resume_checkpoint,
                 resume_message=resume_message,
             )
         else:
             effective_prompt = _ensure_skill_prefix(
-                skill_command, provider_profile=profile_name or ""
+                skill_command,
+                provider_profile=profile_name or "",
+                skill_sigil=self.capabilities.skill_sigil,
             )
 
         prompt = apply_prompt_injector_chain(

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -492,6 +492,7 @@ class CodexBackend:
             anthropic_provider_capable=False,
             inspector_capable=False,
             has_unguarded_filesystem_access=True,
+            skill_sigil="$",
         )
 
     @property
@@ -608,19 +609,27 @@ class CodexBackend:
             resume_checkpoint = config.resume_checkpoint
             resume_message = config.resume_message
             sandbox_mode = config.sandbox_mode
-        _has_prefix = bool(profile_name) and skill_command.strip().startswith("/")
+        _has_prefix = (
+            bool(profile_name)
+            and skill_command.strip().startswith("/")
+            and self.capabilities.skill_sigil == "/"
+        )
 
         if resume_session_id:
             effective_prompt = _compose_resume_prompt(
                 base_prompt=_ensure_skill_prefix(
-                    skill_command, provider_profile=profile_name or ""
+                    skill_command,
+                    provider_profile=profile_name or "",
+                    skill_sigil=self.capabilities.skill_sigil,
                 ),
                 resume_checkpoint=resume_checkpoint,
                 resume_message=resume_message,
             )
         else:
             effective_prompt = _ensure_skill_prefix(
-                skill_command, provider_profile=profile_name or ""
+                skill_command,
+                provider_profile=profile_name or "",
+                skill_sigil=self.capabilities.skill_sigil,
             )
 
         prompt = apply_prompt_injector_chain(

--- a/src/autoskillit/execution/headless/_headless_helpers.py
+++ b/src/autoskillit/execution/headless/_headless_helpers.py
@@ -173,7 +173,7 @@ def _derive_step_name_from_skill_command(skill_command: str) -> str:
     stripped = skill_command.strip()
     if not stripped:
         return ""
-    token = stripped.split()[0].lstrip("/")
+    token = stripped.split()[0].lstrip("/$")
     if ":" in token:
         token = token.rsplit(":", 1)[-1]
     return token

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -688,7 +688,15 @@ def _build_skill_result(
 
     write_path_warnings: list[str] = []
     if cwd and supports_claude_format_stdout:
-        write_path_warnings = _scan_jsonl_write_paths(result.stdout, cwd)
+        _wtn = backend.capabilities.write_guard_tool_names
+        if _wtn:
+            write_path_warnings = _scan_jsonl_write_paths(
+                result.stdout,
+                cwd,
+                write_tool_names=_wtn,
+            )
+        else:
+            write_path_warnings = _scan_jsonl_write_paths(result.stdout, cwd)
         if write_path_warnings:
             logger.warning(
                 "write_path_warnings_detected",

--- a/src/autoskillit/execution/headless/_headless_scan.py
+++ b/src/autoskillit/execution/headless/_headless_scan.py
@@ -14,16 +14,13 @@ import os
 from autoskillit.core import extract_bash_write_targets
 from autoskillit.execution.session._session_model import _is_parent_assistant_record
 
-_DEFAULT_WRITE_TOOL_NAMES: frozenset[str] = frozenset({"Write", "Edit"})
-_DEFAULT_BASH_TOOL_NAME: str = "Bash"
-
 
 def _scan_jsonl_write_paths(
     stdout: str,
     cwd: str,
     *,
-    write_tool_names: frozenset[str] = _DEFAULT_WRITE_TOOL_NAMES,
-    bash_tool_name: str = _DEFAULT_BASH_TOOL_NAME,
+    write_tool_names: frozenset[str] = frozenset({"Write", "Edit"}),
+    bash_tool_name: str = "Bash",
 ) -> list[str]:
     """Scan raw JSONL stdout for Write/Edit/Bash tool calls outside cwd.
 

--- a/src/autoskillit/execution/headless/_headless_scan.py
+++ b/src/autoskillit/execution/headless/_headless_scan.py
@@ -14,11 +14,17 @@ import os
 from autoskillit.core import extract_bash_write_targets
 from autoskillit.execution.session._session_model import _is_parent_assistant_record
 
-_WRITE_TOOL_NAMES: frozenset[str] = frozenset({"Write", "Edit"})
-_BASH_TOOL_NAME: str = "Bash"
+_DEFAULT_WRITE_TOOL_NAMES: frozenset[str] = frozenset({"Write", "Edit"})
+_DEFAULT_BASH_TOOL_NAME: str = "Bash"
 
 
-def _scan_jsonl_write_paths(stdout: str, cwd: str) -> list[str]:
+def _scan_jsonl_write_paths(
+    stdout: str,
+    cwd: str,
+    *,
+    write_tool_names: frozenset[str] = _DEFAULT_WRITE_TOOL_NAMES,
+    bash_tool_name: str = _DEFAULT_BASH_TOOL_NAME,
+) -> list[str]:
     """Scan raw JSONL stdout for Write/Edit/Bash tool calls outside cwd.
 
     Parses assistant records from the JSONL stream and extracts file_path
@@ -58,7 +64,7 @@ def _scan_jsonl_write_paths(stdout: str, cwd: str) -> list[str]:
             if not isinstance(inputs, dict):
                 continue
 
-            if tool_name in _WRITE_TOOL_NAMES:
+            if tool_name in write_tool_names:
                 file_path = inputs.get("file_path", "")
                 if (
                     isinstance(file_path, str)
@@ -70,7 +76,7 @@ def _scan_jsonl_write_paths(stdout: str, cwd: str) -> list[str]:
                         f"{tool_name} tool targeted '{file_path}' outside session cwd '{cwd}'"
                     )
 
-            elif tool_name == _BASH_TOOL_NAME:
+            elif tool_name == bash_tool_name:
                 command = inputs.get("command", "")
                 if isinstance(command, str):
                     targets = extract_bash_write_targets(command, cwd)

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -133,7 +133,11 @@ def _require_enabled() -> str | None:
 
 
 def _validate_skill_command(skill_command: str) -> str | None:
-    """Return error JSON if skill_command does not start with '/', None if OK."""
+    """Return error JSON if skill_command does not start with '/'.
+
+    Validates the MCP-layer input format, which is always slash-prefixed.
+    Backend-specific sigil translation happens downstream in _ensure_skill_prefix().
+    """
     if not skill_command.strip().startswith("/"):
         return gate_error_result(
             "run_skill requires a slash-command as skill_command.\n"

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -971,10 +971,10 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "enforcement add required branching that pushes the module over the 1000-line limit",
     ),
     "execution/backends/codex.py": (
-        1010,
-        "REQ-CNST-010-E9: Codex backend — write_guard_tool_names env injection added 7 lines "
-        "to _codex_exec_extras, capabilities property, and call sites; module reaches 1002 "
-        "lines in WP1 of the write-guard phase",
+        1020,
+        "REQ-CNST-010-E9: Codex backend — skill_sigil capability threading adds multi-line "
+        "keyword args to _ensure_skill_prefix call sites and _has_prefix guard; "
+        "write_guard_tool_names env injection adds 7 lines to _codex_exec_extras",
     ),
 }
 

--- a/tests/contracts/CLAUDE.md
+++ b/tests/contracts/CLAUDE.md
@@ -97,6 +97,7 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `test_source_attribution_contracts.py` | Cross-skill contract: source-attribution prohibition in dual-source skills |
 | `test_project_local_skill_delivery_contract.py` | Symmetric delivery contract tests for project-local skill overrides |
 | `test_translate_model_suffix_contract.py` | Contract: translate_model suffix preservation tied to backend capability flag |
+| `test_backend_prompt_conventions.py` | Contract: backend prompt output must match declared skill_sigil capability |
 
 ## Architecture Notes
 

--- a/tests/contracts/test_backend_prompt_conventions.py
+++ b/tests/contracts/test_backend_prompt_conventions.py
@@ -8,6 +8,8 @@ from autoskillit.core import CmdSpec, SkillSessionConfig
 from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.backends.codex import CodexBackend
 
+pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
+
 
 def _extract_prompt(spec: CmdSpec) -> str:
     """Extract the prompt string from a CmdSpec, dispatching by backend command shape."""

--- a/tests/contracts/test_backend_prompt_conventions.py
+++ b/tests/contracts/test_backend_prompt_conventions.py
@@ -1,0 +1,61 @@
+"""Contract tests: backend prompt output must match declared skill_sigil."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import CmdSpec, SkillSessionConfig
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
+from autoskillit.execution.backends.codex import CodexBackend
+
+
+def _extract_prompt(spec: CmdSpec) -> str:
+    """Extract the prompt string from a CmdSpec, dispatching by backend command shape."""
+    cmd = list(spec.cmd)
+    if "-p" in cmd:
+        return cmd[cmd.index("-p") + 1]
+    return cmd[-1]
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_ID", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_KITCHEN_SESSION_ID", raising=False)
+
+
+@pytest.mark.parametrize("backend", [ClaudeCodeBackend(), CodexBackend()])
+def test_skill_prompt_uses_backend_sigil(backend):
+    """Prompt produced by build_skill_session_cmd must contain the backend's declared sigil."""
+    spec = backend.build_skill_session_cmd("/test-skill arg", "/tmp")
+    prompt = _extract_prompt(spec)
+    sigil = backend.capabilities.skill_sigil
+    assert f"{sigil}test-skill" in prompt or f"{sigil}autoskillit:test-skill" in prompt
+
+
+@pytest.mark.parametrize("backend", [ClaudeCodeBackend(), CodexBackend()])
+def test_skill_prompt_does_not_contain_wrong_sigil(backend):
+    """Prompt must not contain another backend's sigil prefix for the skill name."""
+    spec = backend.build_skill_session_cmd("/test-skill arg", "/tmp")
+    prompt = _extract_prompt(spec)
+    wrong_sigils = {"/", "$"} - {backend.capabilities.skill_sigil}
+    for wrong in wrong_sigils:
+        assert f"Use the {wrong}test-skill skill" not in prompt
+
+
+@pytest.mark.parametrize(
+    "backend,skill_cmd,expect_preamble_reference",
+    [
+        (ClaudeCodeBackend(), "/test-skill", True),
+        (CodexBackend(), "/test-skill", False),
+    ],
+)
+def test_narration_suppression_matches_preamble(backend, skill_cmd, expect_preamble_reference):
+    """Narration suppression must reference 'loading skill instructions' only with preamble."""
+    spec = backend.build_skill_session_cmd(
+        skill_cmd, "/tmp", config=SkillSessionConfig(profile_name="test-profile")
+    )
+    prompt = _extract_prompt(spec)
+    if expect_preamble_reference:
+        assert "After loading the skill instructions" in prompt
+    else:
+        assert "After loading the skill instructions" not in prompt

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -119,6 +119,7 @@ def test_backend_capabilities_field_count():
         "write_detection_strategy",
         "patch_format",
         "default_skill_sandbox_mode",
+        "skill_sigil",
     }
     assert tuple_fields == {"env_denylist_prefixes"}
 
@@ -165,6 +166,7 @@ def test_backend_capabilities_field_names_locked():
         "plugin_install_capable",
         "inspector_capable",
         "supports_context_window_suffix",
+        "skill_sigil",
     }
     actual = {f.name for f in dataclasses.fields(BackendCapabilities)}
     assert actual == expected
@@ -212,6 +214,7 @@ def test_claude_code_capabilities_field_values():
     assert CLAUDE_CODE_CAPABILITIES.write_detection_strategy == "tool_names"
     assert CLAUDE_CODE_CAPABILITIES.patch_format == "unified_diff"
     assert CLAUDE_CODE_CAPABILITIES.default_skill_sandbox_mode == ""
+    assert CLAUDE_CODE_CAPABILITIES.skill_sigil == "/"
 
 
 def test_backend_capabilities_frozenset_defaults():

--- a/tests/core/test_type_helpers.py
+++ b/tests/core/test_type_helpers.py
@@ -40,3 +40,25 @@ def test_extract_positional_args_returns_non_path_only():
 
     result = extract_positional_args("/skill-name foo bar")
     assert result == ["foo", "bar"]
+
+
+class TestExtractSkillName:
+    def test_slash_prefix(self):
+        from autoskillit.core import extract_skill_name
+
+        assert extract_skill_name("/test-skill args") == "test-skill"
+
+    def test_namespaced_slash_prefix(self):
+        from autoskillit.core import extract_skill_name
+
+        assert extract_skill_name("/autoskillit:make-plan foo") == "make-plan"
+
+    def test_dollar_prefix_returns_none(self):
+        from autoskillit.core import extract_skill_name
+
+        assert extract_skill_name("$test-skill args") is None
+
+    def test_no_prefix_returns_none(self):
+        from autoskillit.core import extract_skill_name
+
+        assert extract_skill_name("test-skill args") is None

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -757,7 +757,7 @@ class TestCodexBuildSkillSessionCmdConfigAdapter:
             output_format=OutputFormat.JSON,
         )
         assert isinstance(spec, CmdSpec)
-        assert any("/test-skill" in s for s in spec.cmd)
+        assert any("$test-skill" in s for s in spec.cmd)
 
 
 class TestCodexBuildInteractiveCmd:

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -160,6 +160,9 @@ class TestCodexBackend:
     def test_capabilities_record_capable_false(self) -> None:
         assert CodexBackend().capabilities.record_capable is False
 
+    def test_capabilities_skill_sigil_dollar(self) -> None:
+        assert CodexBackend().capabilities.skill_sigil == "$"
+
     def test_binary_name(self) -> None:
         assert CodexBackend().binary_name() == "codex"
 

--- a/tests/execution/headless/test_headless_helpers.py
+++ b/tests/execution/headless/test_headless_helpers.py
@@ -1,0 +1,44 @@
+"""Behavioral tests for _headless_helpers private helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class TestDeriveStepNameFromSkillCommand:
+    def test_strips_slash(self):
+        from autoskillit.execution.headless._headless_helpers import (
+            _derive_step_name_from_skill_command,
+        )
+
+        assert _derive_step_name_from_skill_command("/autoskillit:make-plan foo") == "make-plan"
+
+    def test_strips_dollar(self):
+        from autoskillit.execution.headless._headless_helpers import (
+            _derive_step_name_from_skill_command,
+        )
+
+        assert _derive_step_name_from_skill_command("$autoskillit:make-plan foo") == "make-plan"
+
+    def test_bare_slash_command(self):
+        from autoskillit.execution.headless._headless_helpers import (
+            _derive_step_name_from_skill_command,
+        )
+
+        assert _derive_step_name_from_skill_command("/sous-chef") == "sous-chef"
+
+    def test_bare_dollar_command(self):
+        from autoskillit.execution.headless._headless_helpers import (
+            _derive_step_name_from_skill_command,
+        )
+
+        assert _derive_step_name_from_skill_command("$sous-chef") == "sous-chef"
+
+    def test_empty_input(self):
+        from autoskillit.execution.headless._headless_helpers import (
+            _derive_step_name_from_skill_command,
+        )
+
+        assert _derive_step_name_from_skill_command("") == ""

--- a/tests/execution/headless/test_headless_scan.py
+++ b/tests/execution/headless/test_headless_scan.py
@@ -1,0 +1,49 @@
+"""Tests for _headless_scan parameterized tool-name dispatch."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.execution.headless import _scan_jsonl_write_paths
+from tests.execution.conftest import _make_tool_use_line
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class TestScanJsonlCustomToolNames:
+    CWD = "/clone/worktree"
+
+    def test_accepts_custom_write_tool_names(self):
+        line = _make_tool_use_line(
+            "apply_patch", {"file_path": "/other/repo/file.py", "content": "x"}
+        )
+        warnings = _scan_jsonl_write_paths(
+            line,
+            self.CWD,
+            write_tool_names=frozenset({"apply_patch"}),
+        )
+        assert len(warnings) == 1
+        assert "apply_patch" in warnings[0]
+
+    def test_default_write_tool_names_still_work(self):
+        line = _make_tool_use_line("Write", {"file_path": "/other/repo/file.py", "content": "x"})
+        warnings = _scan_jsonl_write_paths(line, self.CWD)
+        assert len(warnings) == 1
+
+    def test_custom_names_ignore_default_names(self):
+        line = _make_tool_use_line("Write", {"file_path": "/other/repo/file.py", "content": "x"})
+        warnings = _scan_jsonl_write_paths(
+            line,
+            self.CWD,
+            write_tool_names=frozenset({"apply_patch"}),
+        )
+        assert warnings == []
+
+    def test_accepts_custom_bash_tool_name(self):
+        line = _make_tool_use_line("Shell", {"command": "echo hello > /other/repo/file.py"})
+        warnings = _scan_jsonl_write_paths(
+            line,
+            self.CWD,
+            bash_tool_name="Shell",
+        )
+        assert len(warnings) >= 1

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -955,6 +955,15 @@ class TestEnsureSkillPrefix:
         assert "FIRST ACTION" not in result
         assert result == "Fix the bug"
 
+    def test_dollar_sigil_transforms_slash_to_dollar(self):
+        result = _ensure_skill_prefix("/test-skill args", skill_sigil="$")
+        assert result.startswith("$test-skill")
+        assert "Use the /test-skill skill" not in result
+
+    def test_slash_sigil_preserves_current_behavior(self):
+        result = _ensure_skill_prefix("/test-skill args", skill_sigil="/")
+        assert "Use the /test-skill skill" in result
+
 
 class TestStalenessReturnsNeedsRetry:
     """Stale SubprocessResult triggers needs_retry response."""


### PR DESCRIPTION
## Summary

Every skill invocation via the Codex backend silently fails because the shared prompt construction function `_ensure_skill_prefix()` hardcodes the `/` sigil, while Codex requires `$`. The root cause is that `BackendCapabilities` has no field declaring the backend's native skill invocation convention, forcing shared prompt code to assume Claude Code's conventions. This is part of a systemic pattern: 64+ reactive fixes in 98 commits to `src/autoskillit/execution/backends/` — each fixing one more leaked Claude Code assumption rather than providing structural immunity.

The architectural solution adds a `skill_sigil` capability field to `BackendCapabilities`, threads it through `_ensure_skill_prefix()` and the `_has_prefix` computation in both backends, and introduces contract tests that verify each backend's prompt output matches its declared sigil. This makes the entire class of sigil-mismatch bugs impossible: a new backend must declare its sigil, and the contract test immediately fails if the prompt doesn't match.

## Requirements

### Problem

Every skill in the AutoSkillit implementation pipeline fails when run via the Codex backend due to a **prompt sigil mismatch**. AutoSkillit transforms `/dry-walkthrough args` into `"Use the /dry-walkthrough skill args"`, but Codex CLI uses `$` (not `/`) as its skill invocation sigil. Codex's `extract_tool_mentions()` scanner only triggers on `$` bytes — the `/` prefix is completely ignored, so the SKILL.md body is never injected into the model's context.

### Observed Failure Chain

1. `make-plan` via Codex — needed a prior fix just to run
2. `dry-walkthrough` via Codex — ran but returned `zero_writes` (model never saw skill instructions, never wrote the "Dry-walkthrough verified = TRUE" stamp)
3. `implement-worktree-no-merge` — gate-rejected because stamp was missing

### Root Cause Analysis

**AutoSkillit side:** `_ensure_skill_prefix()` in `src/autoskillit/execution/backends/_claude_prompt.py:117-144` transforms `/foo args` → `"Use the /foo skill args"`. This is correct for Claude Code (which uses the `Skill` tool to load skills), but Codex uses a completely different mechanism.

**Codex side (verified in Codex source at ~/projects/codex):**
- `codex-rs/utils/plugins/src/mention_syntax.rs:3` — `TOOL_MENTION_SIGIL: char = '$'`
- `codex-rs/core-skills/src/injection.rs:284-348` — `extract_tool_mentions()` scans text byte-by-byte for `$`; `/` is completely ignored
- `codex-rs/exec/src/lib.rs:743-746` — `codex exec` constructs `UserInput::Text` from the CLI prompt; there is no `--skill` flag or `UserInput::Skill` mechanism for headless mode
- `codex-rs/ext/skills/src/selection.rs:36-63` — the ext skills path ALSO scans `UserInput::Text` for `$` mentions

### Fix

1. Add `skill_sigil` capability field to `BackendCapabilities` (default `"/"`, Codex declares `"$"`)
2. Thread the sigil through `_ensure_skill_prefix()` in `_claude_prompt.py`
3. Update `_has_prefix` computation in both backends to use the backend's declared sigil
4. Add contract tests that verify each backend's prompt output matches its declared sigil

## Implementation Plan

Closes #3819

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260605-114718-296020/.autoskillit/temp/rectify/rectify_backend_prompt_sigil_immunity_2026-06-05_114718.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 82 | 20.8k | 2.5M | 131.5k | 65 | 109.5k | 23m 4s |
| review_approach* | opus[1m] | 1 | 24 | 4.8k | 221.9k | 46.7k | 11 | 27.4k | 3m 57s |
| dry_walkthrough* | opus | 3 | 1.0k | 26.4k | 2.6M | 102.9k | 116 | 227.7k | 13m 47s |
| implement* | opus[1m] | 3 | 156 | 23.3k | 3.5M | 82.3k | 144 | 121.3k | 11m 36s |
| audit_impl* | opus[1m] | 3 | 769 | 28.0k | 829.1k | 65.7k | 50 | 102.2k | 23m 10s |
| make_plan* | opus[1m] | 1 | 47 | 3.6k | 493.6k | 50.5k | 19 | 29.6k | 1m 47s |
| prepare_pr* | MiniMax-M3 | 1 | 45.4k | 3.3k | 210.1k | 50.3k | 12 | 0 | 1m 5s |
| compose_pr* | MiniMax-M3 | 1 | 40.1k | 2.0k | 324.7k | 42.9k | 13 | 0 | 1m 2s |
| review_pr* | opus[1m] | 1 | 28 | 25.0k | 539.4k | 81.1k | 33 | 61.0k | 5m 42s |
| resolve_review* | opus[1m] | 1 | 43 | 6.9k | 920.5k | 65.2k | 36 | 43.2k | 4m 16s |
| **Total** | | | 87.7k | 144.0k | 12.2M | 131.5k | | 721.9k | 1h 29m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 280 | 12385.8 | 433.4 | 83.4 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **280** | 43569.4 | 2578.2 | 514.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 7 | 1.1k | 112.4k | 9.0M | 494.2k | 1h 13m |
| opus | 1 | 1.0k | 26.4k | 2.6M | 227.7k | 13m 47s |
| MiniMax-M3 | 2 | 85.5k | 5.3k | 534.9k | 0 | 2m 7s |