### PR TITLE
Create tests/backend/test_codex_hooks_round_trip.py and infrastructure registries

### DIFF
--- a/tests/arch/test_size_markers.py
+++ b/tests/arch/test_size_markers.py
@@ -14,6 +14,7 @@ TESTS_ROOT = Path(__file__).resolve().parent.parent
 SIZE_DIRECTORIES: dict[str, str] = {
     "arch": "arch",
     "assets": "assets",
+    "backend": "backend",
     "cli": "cli",
     "config": "config",
     "contracts": "contracts",

--- a/tests/backend/test_codex_hooks_round_trip.py
+++ b/tests/backend/test_codex_hooks_round_trip.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from autoskillit.cli._hooks_codex import (
+    generate_codex_hooks_config,
+    sync_hooks_to_codex_config,
+)
+from autoskillit.execution.backends._codex_config import _serialize_toml
+from autoskillit.hooks import HOOK_REGISTRY
+
+pytestmark = [pytest.mark.medium]
+
+
+@pytest.fixture()
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    return home
+
+
+class TestCodexHooksConfigRoundTrip:
+    def test_returns_dict_not_list(self):
+        result = generate_codex_hooks_config()
+        assert isinstance(result, dict)
+
+    def test_dict_keys_are_event_types(self):
+        result = generate_codex_hooks_config()
+        assert len(result) > 0
+        assert set(result.keys()).issubset({"PreToolUse", "PostToolUse", "SessionStart"})
+
+    def test_dict_values_are_lists_of_dicts(self):
+        result = generate_codex_hooks_config()
+        for event_type, entries in result.items():
+            assert isinstance(entries, list), f"{event_type} value is not a list"
+            for entry in entries:
+                assert isinstance(entry, dict), f"{event_type} entry is not a dict"
+
+    def test_no_event_key_on_inner_entries(self):
+        result = generate_codex_hooks_config()
+        for event_type, entries in result.items():
+            for entry in entries:
+                assert "event" not in entry, (
+                    f"Inner entry in {event_type} has 'event' key (pre-Phase-2 flat format)"
+                )
+
+    def test_toml_serialization_produces_nested_key_syntax(self):
+        config = generate_codex_hooks_config()
+        toml_str = _serialize_toml({"hooks": config})
+        assert "[[hooks.PreToolUse]]" in toml_str
+
+    def test_round_trip_via_tomllib(self):
+        config = generate_codex_hooks_config()
+        toml_str = _serialize_toml({"hooks": config})
+        parsed = tomllib.loads(toml_str)
+        assert "hooks" in parsed
+        assert isinstance(parsed["hooks"], dict)
+
+    def test_round_trip_preserves_hook_commands(self):
+        config = generate_codex_hooks_config()
+        toml_str = _serialize_toml({"hooks": config})
+        parsed = tomllib.loads(toml_str)
+        for event_type, entries in parsed["hooks"].items():
+            for entry in entries:
+                for hook in entry.get("hooks", []):
+                    assert hook.get("type") == "command", (
+                        f"Hook in {event_type} missing type='command'"
+                    )
+                    assert "command" in hook, f"Hook in {event_type} missing 'command' key"
+
+    def test_excludes_interactive_only(self):
+        interactive_scripts: set[str] = set()
+        for hook_def in HOOK_REGISTRY:
+            if hook_def.session_scope == "interactive_only":
+                interactive_scripts.update(hook_def.scripts)
+        assert len(interactive_scripts) > 0, "No interactive_only hooks found in registry"
+
+        result = generate_codex_hooks_config()
+        for event_type, entries in result.items():
+            for entry in entries:
+                for hook in entry.get("hooks", []):
+                    cmd = hook.get("command", "")
+                    for script in interactive_scripts:
+                        script_name = Path(script).stem
+                        assert script_name not in cmd, (
+                            f"interactive_only script {script!r} found in "
+                            f"{event_type} command: {cmd}"
+                        )
+
+
+class TestSyncHooksToCodexConfig:
+    def test_creates_config_toml_from_missing(self, fake_home: Path):
+        result = sync_hooks_to_codex_config()
+        config_path = fake_home / ".codex" / "config.toml"
+        assert config_path.exists()
+        assert result is True
+
+    def test_written_file_is_valid_toml(self, fake_home: Path):
+        sync_hooks_to_codex_config()
+        config_path = fake_home / ".codex" / "config.toml"
+        tomllib.loads(config_path.read_text())
+
+    def test_hooks_section_is_dict_not_list(self, fake_home: Path):
+        sync_hooks_to_codex_config()
+        config_path = fake_home / ".codex" / "config.toml"
+        parsed = tomllib.loads(config_path.read_text())
+        assert isinstance(parsed["hooks"], dict)
+
+    def test_hooks_section_has_event_type_keys(self, fake_home: Path):
+        sync_hooks_to_codex_config()
+        config_path = fake_home / ".codex" / "config.toml"
+        parsed = tomllib.loads(config_path.read_text())
+        hooks = parsed["hooks"]
+        assert any(k in hooks for k in ("PreToolUse", "PostToolUse", "SessionStart"))
+
+    def test_idempotent_returns_false(self, fake_home: Path):
+        first = sync_hooks_to_codex_config()
+        second = sync_hooks_to_codex_config()
+        assert first is True
+        assert second is False
+
+    def test_idempotent_does_not_modify_file(self, fake_home: Path):
+        sync_hooks_to_codex_config()
+        config_path = fake_home / ".codex" / "config.toml"
+        mtime_before = config_path.stat().st_mtime_ns
+        sync_hooks_to_codex_config()
+        assert config_path.stat().st_mtime_ns == mtime_before
+
+    def test_preserves_foreign_hooks(self, fake_home: Path):
+        codex_dir = fake_home / ".codex"
+        codex_dir.mkdir(parents=True)
+        config_path = codex_dir / "config.toml"
+        config_path.write_text(
+            "[hooks]\n"
+            "[[hooks.SomeOtherTool]]\n"
+            'matcher = "ForeignMatcher"\n'
+            "[[hooks.SomeOtherTool.hooks]]\n"
+            'command = "python3 /usr/local/foreign.py"\n',
+        )
+        sync_hooks_to_codex_config()
+        parsed = tomllib.loads(config_path.read_text())
+        assert "SomeOtherTool" in parsed["hooks"]
+
+    def test_codex_dir_created_if_absent(self, fake_home: Path):
+        codex_dir = fake_home / ".codex"
+        assert not codex_dir.exists()
+        sync_hooks_to_codex_config()
+        assert codex_dir.exists()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ _SIZE_DIRS: frozenset[str] = frozenset(
     {
         "arch",
         "assets",
+        "backend",
         "cli",
         "config",
         "contracts",

--- a/tests/infra/test_ci_shard_config.py
+++ b/tests/infra/test_ci_shard_config.py
@@ -14,6 +14,7 @@ WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "tests.yml"
 KNOWN_GENERAL_SHARD_DIRS = {
     "arch",
     "assets",
+    "backend",
     "cli",
     "config",
     "docs",


### PR DESCRIPTION
## Summary

Create `tests/backend/__init__.py` (empty package marker) and `tests/backend/test_codex_hooks_round_trip.py` containing two test classes — `TestCodexHooksConfigRoundTrip` (8 tests validating `generate_codex_hooks_config()` return shape, TOML serialization, and round-trip fidelity) and `TestSyncHooksToCodexConfig` (8 tests validating `sync_hooks_to_codex_config()` file creation, idempotency, foreign hook preservation, and directory creation via `fake_home` fixture).

These are behavioral contract tests distinct from the structural tests in `tests/hooks/test_codex_hooks.py`. The `backend` directory is intentionally outside the layer-marker enforcement scope (`LAYER_DIRECTORIES` and `_LAYER_DIRS` do not include `backend`), so `pytestmark = [pytest.mark.medium]` with no `layer()` marker is correct.

Closes #3795

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260605-132054-784432/.autoskillit/temp/make-plan/create_tests_backend_codex_hooks_round_trip_plan_2026-06-05_140000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 5.5k | 15.4k | 1.6M | 103.6k | 50 | 82.0k | 8m 51s |
| verify* | opus[1m] | 1 | 57 | 10.2k | 1.2M | 74.3k | 44 | 52.0k | 6m 3s |
| implement* | MiniMax-M3 | 1 | 51.3k | 4.6k | 977.3k | 55.6k | 32 | 0 | 7m 25s |
| audit_impl* | opus[1m] | 1 | 23 | 9.9k | 175.7k | 44.7k | 12 | 34.1k | 3m 38s |
| prepare_pr* | MiniMax-M3 | 1 | 49.1k | 1.6k | 306.9k | 50.6k | 13 | 0 | 1m 1s |
| compose_pr* | MiniMax-M3 | 1 | 36.7k | 1.5k | 270.4k | 39.8k | 13 | 0 | 56s |
| review_pr* | opus[1m] | 3 | 85 | 34.7k | 1.4M | 61.1k | 69 | 146.3k | 9m 4s |
| **Total** | | | 142.9k | 77.8k | 6.0M | 103.6k | | 314.4k | 37m 2s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 155 | 6304.9 | 0.0 | 29.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **155** | 38760.7 | 2028.2 | 502.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 4 | 5.7k | 70.2k | 4.5M | 314.4k | 27m 38s |
| MiniMax-M3 | 3 | 137.2k | 7.6k | 1.6M | 0 | 9m 23s |