### PR TITLE
[FEATURE] Add Distinguishing Prose Paragraph to synthesize-vis-plan SKILL.md

### DIFF
--- a/src/autoskillit/skills_extended/synthesize-vis-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/synthesize-vis-plan/SKILL.md
@@ -28,6 +28,14 @@ lens). The priority hierarchy in Step 1 maps directly to these tiers.
 - on_success: `create_worktree`
 - on_failure: `escalate_stop`
 
+This skill is the vis-lens-specific implementation of phoropter synthesis. It
+expects `yaml:figure-spec` blocks as input, applies the fixed four-level
+priority hierarchy (accessibility > anti-pattern > methodology-norms >
+chart-select), consumes Tier-C routing args sourced from `select-vis-lenses`,
+and produces three-file output (visualization-plan.md, report-plan.md,
+visualization-plan-trace.md). For family-agnostic synthesis with a configurable
+hierarchy and token-based input, use `phoropter-priority-synthesis` instead.
+
 ## Arguments
 
 ```


### PR DESCRIPTION
## Summary

Insert a single prose paragraph after the three-bullet "When to Use" list in `src/autoskillit/skills_extended/synthesize-vis-plan/SKILL.md` (line 29) and before `## Arguments` (line 31). The paragraph distinguishes `synthesize-vis-plan` (vis-lens-specific, `yaml:figure-spec` parsing, fixed priority hierarchy, Tier-C routing args, three-file output) from `phoropter-priority-synthesis` (family-agnostic, configurable hierarchy, token-based input). No other file is modified.

Closes #3728

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-3728-20260605-141902-297535/.autoskillit/temp/make-plan/impl-3728-add-prose-paragraph-synthesize-vis-plan_plan_2026-06-05_142300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.6k | 5.1k | 485.1k | 54.9k | 20 | 35.4k | 2m 26s |
| verify* | opus | 1 | 41 | 5.7k | 720.0k | 62.2k | 28 | 40.1k | 2m 53s |
| implement* | MiniMax-M3 | 1 | 46.1k | 2.0k | 457.6k | 46.5k | 20 | 0 | 1m 25s |
| audit_impl* | opus | 1 | 687 | 2.5k | 168.3k | 39.3k | 9 | 19.6k | 2m 9s |
| prepare_pr* | MiniMax-M3 | 1 | 39.6k | 1.3k | 242.4k | 42.7k | 12 | 0 | 49s |
| compose_pr* | MiniMax-M3 | 1 | 36.2k | 1.0k | 149.3k | 38.2k | 10 | 0 | 39s |
| review_pr* | opus | 3 | 81 | 17.0k | 1.2M | 50.9k | 69 | 86.1k | 5m 27s |
| **Total** | | | 124.2k | 34.7k | 3.4M | 62.2k | | 181.1k | 15m 51s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 8 | 57199.4 | 0.0 | 250.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **8** | 422040.1 | 22640.5 | 4337.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.6k | 5.1k | 485.1k | 35.4k | 2m 26s |
| opus | 3 | 809 | 25.3k | 2.0M | 145.7k | 10m 31s |
| MiniMax-M3 | 3 | 121.8k | 4.3k | 849.2k | 0 | 2m 54s |