### PR TITLE
Append TestExtractPathsFromPatch and TestWriteGuardCodexPatchFormatXfail Tests

### DIFF
--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -1269,3 +1269,101 @@ class TestShellVariableWriteGuardIntegration:
         )
         result = _extract_bash_write_targets(cmd)
         assert result is None or result == []
+
+
+try:
+    from autoskillit.hooks.guards.write_guard import _extract_paths_from_patch as _probe_fn
+
+    _CODEX_FORMAT_SUPPORTED = bool(_probe_fn("*** Update File: /tmp/probe.py\n"))
+except ImportError:
+    _CODEX_FORMAT_SUPPORTED = False
+
+
+class TestExtractPathsFromPatch:
+    def test_empty_string_returns_empty_list(self):
+        from autoskillit.hooks.guards.write_guard import _extract_paths_from_patch
+
+        assert _extract_paths_from_patch("") == []
+
+    def test_single_plus_plus_plus_b_line_returns_path(self):
+        from autoskillit.hooks.guards.write_guard import _extract_paths_from_patch
+
+        patch = "--- a/old.py\n+++ b/foo.py\n@@ -1 +1 @@\n-old\n+new"
+        assert _extract_paths_from_patch(patch) == ["foo.py"]
+
+    def test_multi_file_patch_returns_all_paths_in_order(self):
+        from autoskillit.hooks.guards.write_guard import _extract_paths_from_patch
+
+        patch = (
+            "--- a/alpha.py\n+++ b/alpha.py\n@@ -1 +1 @@\n-old\n+new\n"
+            "--- a/beta.py\n+++ b/beta.py\n@@ -1 +1 @@\n-old\n+new"
+        )
+        assert _extract_paths_from_patch(patch) == ["alpha.py", "beta.py"]
+
+    def test_non_plus_plus_plus_b_lines_are_excluded(self):
+        from autoskillit.hooks.guards.write_guard import _extract_paths_from_patch
+
+        patch = "--- a/foo.py\n@@ -1 +1 @@\n context line\n"
+        assert _extract_paths_from_patch(patch) == []
+
+    def test_subdirectory_path_is_extracted_correctly(self):
+        from autoskillit.hooks.guards.write_guard import _extract_paths_from_patch
+
+        assert _extract_paths_from_patch("+++ b/src/foo.py") == ["src/foo.py"]
+
+
+class TestWriteGuardCodexPatchFormatXfail:
+    """Xfail-guarded integration tests for Codex patch format via _run_hook."""
+
+    @pytest.fixture(autouse=True)
+    def _enable_headless(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        allowed = str(tmp_path / ".autoskillit" / "temp")
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", allowed)
+        self._allowed = allowed
+
+    @pytest.mark.xfail(
+        not _CODEX_FORMAT_SUPPORTED,
+        reason="P2 Codex patch format support not yet merged",
+        strict=False,
+    )
+    def test_codex_patch_within_prefix_allowed(self):
+        patch = f"*** Update File: {self._allowed}/plan.md\n"
+        result = _run_hook(_build_apply_patch_event(patch))
+        assert result == ""
+
+    @pytest.mark.xfail(
+        not _CODEX_FORMAT_SUPPORTED,
+        reason="P2 Codex patch format support not yet merged",
+        strict=False,
+    )
+    def test_codex_patch_outside_prefix_denied(self):
+        patch = "*** Update File: /outside/bar.py\n"
+        result = _run_hook(_build_apply_patch_event(patch))
+        parsed = json.loads(result)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    @pytest.mark.xfail(
+        not _CODEX_FORMAT_SUPPORTED,
+        reason="P2 Codex patch format support not yet merged",
+        strict=False,
+    )
+    def test_codex_mixed_format_patch_no_crash(self):
+        patch = f"+++ b/{self._allowed}/a.py\n*** Update File: {self._allowed}/b.py\n"
+        result = _run_hook(_build_apply_patch_event(patch))
+        assert isinstance(result, str)
+
+    @pytest.mark.xfail(
+        not _CODEX_FORMAT_SUPPORTED,
+        reason="P2 Codex patch format support not yet merged",
+        strict=False,
+    )
+    def test_codex_empty_patch_triggers_no_paths_deny(self):
+        patch = "*** Begin Patch\n*** End Patch\n"
+        result = _run_hook(_build_apply_patch_event(patch))
+        parsed = json.loads(result)
+        assert parsed["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert (
+            "no target paths found in patch"
+            in parsed["hookSpecificOutput"]["permissionDecisionReason"]
+        )


### PR DESCRIPTION
Append `TestExtractPathsFromPatch` (5 pure-function unit tests) and 4 xfail-guarded Codex integration tests to `tests/hooks/test_write_guard.py`. A naming collision with the existing `TestWriteGuardCodexPatchFormat` class (added by P2-A3-WP2 in commit 78baa2d0) requires renaming the new class to `TestWriteGuardCodexPatchFormatXfail`.

**Key finding — file state drift since issue authoring:** The issue was authored at source commit `9c69e0e2` when the file had 1145 lines ending with `TestShellVariableWriteGuardIntegration`. Since then, two commits added 127 lines: `TestWriteGuardCodexPatchFormat` (7 tests, line 218) and `TestWriteGuardToolNamesEnvVar` (4 tests, line 296). The file now has 1271 lines. All line references in this plan use current line numbers.

**Naming collision resolution:** The issue requests class name `TestWriteGuardCodexPatchFormat`, but that name already exists at line 218 (added by the P2 dependency). Python modules cannot contain two classes with the same name without shadowing. The new class is renamed to `TestWriteGuardCodexPatchFormatXfail` to distinguish it from the existing P2 class while preserving discoverability.

**Sentinel status:** `_extract_paths_from_patch` at `src/autoskillit/hooks/guards/write_guard.py:202` already handles Codex markers (`*** Update File:`, `*** Add File:`, `*** Delete File:`) via `_CODEX_FILE_MARKERS` (line 199). Therefore `_CODEX_FORMAT_SUPPORTED` will evaluate to `True`, and the xfail decorators will not activate — all 4 tests should pass directly.

## Requirements

- _extract_paths_from_patch('') returns [] (test_empty_string_returns_empty_list passes)
- _extract_paths_from_patch on a single-file unified diff with '+++ b/foo.py' returns ['foo.py'] (test_single_plus_plus_plus_b_line_returns_path passes)
- _extract_paths_from_patch on a two-file patch returns both paths in document order (test_multi_file_patch_returns_all_paths_in_order passes)
- _extract_paths_from_patch on a string with only '--- a/foo.py', hunk headers, and context lines (no '+++ b/') returns [] (test_non_plus_plus_plus_b_lines_are_excluded passes)
- _extract_paths_from_patch('+++ b/src/foo.py') returns ['src/foo.py'] (test_subdirectory_path_is_extracted_correctly passes)
- No monkeypatch or environment fixtures are used in any test in the class
- The new class is appended after TestShellVariableWriteGuardIntegration and does not modify any of the existing 108 tests
- The class inherits the file-level pytestmark of [pytest.mark.layer('infra'), pytest.mark.small] — no class-level pytestmark override is added
- All five tests pass under task test-check without errors
- tests/hooks/test_write_guard.py contains class TestWriteGuardCodexPatchFormat appended after TestShellVariableWriteGuardIntegration with no modifications to any of the 108 pre-existing tests.
- The class contains exactly 4 test methods: test_codex_patch_within_prefix_allowed, test_codex_patch_outside_prefix_denied, test_codex_mixed_format_patch_no_crash, test_codex_empty_patch_triggers_no_paths_deny.
- Each test method carries @pytest.mark.xfail(not _CODEX_FORMAT_SUPPORTED, reason='P2 Codex patch format support not yet merged', strict=False) — when P2 has not landed, all 4 tests are marked xfail; when P2 has landed, all 4 pass normally.
- Detection logic: _CODEX_FORMAT_SUPPORTED is True iff _extract_paths_from_patch('*** Update File: /tmp/probe.py\n') returns a non-empty list; evaluated once at module load time; ImportError from the probe causes _CODEX_FORMAT_SUPPORTED=False (safe fallback).
- test_codex_patch_within_prefix_allowed: with a '*** Update File: <path>' patch where <path> is inside the allowed prefix, _run_hook returns '' (approved).
- test_codex_patch_outside_prefix_denied: with a '*** Update File: /outside/bar.py' patch, _run_hook returns JSON with decision == 'deny'.
- test_codex_mixed_format_patch_no_crash: _run_hook with a patch containing both '+++ b/<path>' and '*** Update File: <path>' lines completes without raising an exception and returns a str.
- test_codex_empty_patch_triggers_no_paths_deny: _run_hook with an empty or Codex-format-only patch that yields no extractable paths returns JSON with decision == 'deny' and reason containing 'no target paths found in patch'.
- The class inherits the file-level pytestmark [pytest.mark.layer('infra'), pytest.mark.small] without adding a conflicting class-level pytestmark.
- All 4 tests use only the existing _run_hook() and _build_apply_patch_event() file-level helpers — no new helper functions or fixtures are added.

Closes #3797

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260605-141941-397351/.autoskillit/temp/make-plan/append_test_extract_paths_and_codex_format_plan_2026-06-05_142700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 919 | 17.2k | 1.0M | 78.1k | 38 | 60.9k | 10m 13s |
| verify* | opus[1m] | 1 | 38 | 8.1k | 1.2M | 71.3k | 41 | 49.1k | 4m 46s |
| implement* | MiniMax-M3 | 1 | 50.9k | 4.1k | 700.9k | 49.6k | 25 | 0 | 2m 19s |
| audit_impl* | opus[1m] | 1 | 2.0k | 6.6k | 172.9k | 41.1k | 11 | 28.3k | 3m 12s |
| prepare_pr* | MiniMax-M3 | 1 | 45.5k | 2.6k | 292.5k | 47.3k | 18 | 0 | 1m 11s |
| compose_pr* | MiniMax-M3 | 1 | 38.5k | 2.0k | 194.7k | 41.0k | 11 | 0 | 1m 0s |
| review_pr* | opus[1m] | 1 | 30 | 14.6k | 601.5k | 65.3k | 28 | 43.6k | 4m 15s |
| resolve_review* | opus[1m] | 1 | 41 | 5.2k | 794.3k | 64.2k | 30 | 42.5k | 3m 3s |
| **Total** | | | 138.0k | 60.3k | 5.0M | 78.1k | | 224.3k | 30m 2s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 98 | 7152.5 | 0.0 | 41.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **98** | 50585.6 | 2288.9 | 615.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 5 | 3.0k | 51.7k | 3.8M | 224.3k | 25m 31s |
| MiniMax-M3 | 3 | 135.0k | 8.6k | 1.2M | 0 | 4m 31s |