### PR TITLE
T2-P5-A3-WP1 Phoropter Dial Skill and Step Naming Assertions

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -784,6 +784,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "skills/test_vis_lens_methodology_norms.py",
             "skills/test_audit_impl_diff_discipline.py",
             "skills/test_skill_variable_threading.py",
+            "skills/test_phoropter_structural.py",
             "smoke_utils",
         }
     ),

--- a/tests/skills/CLAUDE.md
+++ b/tests/skills/CLAUDE.md
@@ -34,7 +34,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 | `test_open_integration_pr_domain_analysis.py` | Open integration PR domain analysis tests |
 | `test_open_research_pr_decomposition.py` | Structural guards: decomposed research-PR skills must not invoke sub-skills via the Skill tool |
 | `test_phase2_skills.py` | Phase 2 tests: open-kitchen and close-kitchen SKILL.md files |
-| `test_phoropter_structural.py` | Registry-driven structural test: loads phoropter-registry.yaml and discovers (family, slug) pairs from skills_extended directory scan |
+| `test_phoropter_structural.py` | Registry-driven structural test: loads phoropter-registry.yaml for lens discovery, asserts dial-skill SKILL.md existence and output token emission (selected_lenses, lens_context_paths), and verifies recipe step naming conventions against registry step_naming.prefix |
 | `test_plan_experiment_schema_contracts.py` | Contract tests: plan-experiment YAML frontmatter schema and revision_guidance argument |
 | `test_planner_extract_domain.py` | Planner extract domain tests |
 | `test_planner_refine_cycle_breaking.py` | Tests for planner-refine SKILL.md 2-node cycle-breaking documentation |

--- a/tests/skills/test_phoropter_structural.py
+++ b/tests/skills/test_phoropter_structural.py
@@ -34,6 +34,10 @@ _DIAL_SKILL_MAP: dict[str, str | None] = {
     "exp-lens": None,
 }
 
+_DIAL_SKILL_PAIRS: list[tuple[str, str]] = [
+    (family, skill) for family, skill in _DIAL_SKILL_MAP.items() if skill is not None
+]
+
 RESEARCH_RECIPE = load_recipe(builtin_recipes_dir() / "research.yaml")
 RESEARCH_DESIGN_RECIPE = load_recipe(builtin_recipes_dir() / "research-design.yaml")
 
@@ -106,26 +110,20 @@ def test_phoropter_lens_structure(family: str, slug: str) -> None:
         )
 
 
-def test_vis_lens_dial_skill_skill_md_exists() -> None:
-    assert (SKILLS_DIR / "select-vis-lenses" / "SKILL.md").exists()
+@pytest.mark.parametrize("family,dial_skill", _DIAL_SKILL_PAIRS)
+def test_dial_skill_skill_md_exists(family: str, dial_skill: str) -> None:
+    assert (SKILLS_DIR / dial_skill / "SKILL.md").exists(), (
+        f"{family} dial skill {dial_skill}/SKILL.md is missing"
+    )
 
 
-def test_vis_lens_dial_skill_emits_output_tokens() -> None:
-    text = (SKILLS_DIR / "select-vis-lenses" / "SKILL.md").read_text()
-    assert "selected_lenses" in text
-    assert "lens_context_paths" in text
-
-
-def test_review_design_dial_skill_skill_md_exists() -> None:
-    assert (SKILLS_DIR / "classify-experiment-type" / "SKILL.md").exists()
-
-
-def test_review_design_dial_skill_emits_output_tokens() -> None:
-    # For classify-experiment-type, selected_lenses and lens_context_paths
-    # refer to review dimensions, not vis-lens context paths.
-    text = (SKILLS_DIR / "classify-experiment-type" / "SKILL.md").read_text()
-    assert "selected_lenses" in text
-    assert "lens_context_paths" in text
+@pytest.mark.parametrize("family,dial_skill", _DIAL_SKILL_PAIRS)
+def test_dial_skill_emits_output_tokens(family: str, dial_skill: str) -> None:
+    text = (SKILLS_DIR / dial_skill / "SKILL.md").read_text()
+    assert "selected_lenses" in text, f"{family} dial skill {dial_skill} must emit selected_lenses"
+    assert "lens_context_paths" in text, (
+        f"{family} dial skill {dial_skill} must emit lens_context_paths"
+    )
 
 
 def test_prefixed_step_naming_convention() -> None:

--- a/tests/skills/test_phoropter_structural.py
+++ b/tests/skills/test_phoropter_structural.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.core import load_yaml, pkg_root
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.workspace.skill_format import parse_frontmatter_content
 
 SKILLS_DIR = pkg_root() / "skills_extended"
@@ -19,6 +20,29 @@ _LENS_PAIRS: list[tuple[str, str]] = sorted(
 _IMPLEMENTED_FAMILIES = frozenset({"vis-lens", "arch-lens", "exp-lens"})
 
 _EXPECTED_LENS_COUNT = sum(meta["lens_count"] for meta in _REGISTRY["families"].values())
+
+# TODO: load from src/autoskillit/assets/phoropter-registry.yaml (T2-P1-A5)
+# once that file provides a machine-readable dial_skill → output_tokens mapping.
+_DIAL_SKILL_MAP: dict[str, str | None] = {
+    "vis-lens": "select-vis-lenses",
+    "review-design": "classify-experiment-type",
+    # arch-lens and exp-lens dial skills (prepare-pr, prepare-research-pr) DO emit
+    # selected_lenses and lens_context_paths tokens, but they are PR-preparation
+    # skills — not lens-selection dial skills.  This map tracks only families whose
+    # dial skill's primary purpose is lens/dimension selection.
+    "arch-lens": None,
+    "exp-lens": None,
+}
+
+RESEARCH_RECIPE = load_recipe(builtin_recipes_dir() / "research.yaml")
+RESEARCH_DESIGN_RECIPE = load_recipe(builtin_recipes_dir() / "research-design.yaml")
+
+_RECIPE_FAMILIES: frozenset[str] = frozenset(
+    step.phoropter_family
+    for recipe in (RESEARCH_RECIPE, RESEARCH_DESIGN_RECIPE)
+    for step in recipe.steps.values()
+    if step.phoropter_family and step.phoropter_family in _REGISTRY["families"]
+)
 
 pytestmark = [pytest.mark.layer("skills"), pytest.mark.medium]
 
@@ -80,3 +104,77 @@ def test_phoropter_lens_structure(family: str, slug: str) -> None:
         assert "venue_specific_appendices" in text or "venue appendix" in text, (
             f"{family}-{slug} must document venue_specific_appendices"
         )
+
+
+def test_vis_lens_dial_skill_skill_md_exists() -> None:
+    assert (SKILLS_DIR / "select-vis-lenses" / "SKILL.md").exists()
+
+
+def test_vis_lens_dial_skill_emits_output_tokens() -> None:
+    text = (SKILLS_DIR / "select-vis-lenses" / "SKILL.md").read_text()
+    assert "selected_lenses" in text
+    assert "lens_context_paths" in text
+
+
+def test_review_design_dial_skill_skill_md_exists() -> None:
+    assert (SKILLS_DIR / "classify-experiment-type" / "SKILL.md").exists()
+
+
+def test_review_design_dial_skill_emits_output_tokens() -> None:
+    # For classify-experiment-type, selected_lenses and lens_context_paths
+    # refer to review dimensions, not vis-lens context paths.
+    text = (SKILLS_DIR / "classify-experiment-type" / "SKILL.md").read_text()
+    assert "selected_lenses" in text
+    assert "lens_context_paths" in text
+
+
+def test_prefixed_step_naming_convention() -> None:
+    recipes = [RESEARCH_RECIPE, RESEARCH_DESIGN_RECIPE]
+    for family_name, meta in _REGISTRY["families"].items():
+        if family_name not in _RECIPE_FAMILIES:
+            continue
+        prefix = meta.get("step_naming", {}).get("prefix")
+        if not prefix:
+            continue
+        expected = [f"{prefix}_dial", f"{prefix}_apply", f"{prefix}_synthesize"]
+        assert any(all(name in recipe.steps for name in expected) for recipe in recipes), (
+            f"Family {family_name} (prefix={prefix!r}) requires steps "
+            f"{expected} in at least one recipe"
+        )
+
+
+def test_canonical_step_naming_convention() -> None:
+    recipes = [RESEARCH_RECIPE, RESEARCH_DESIGN_RECIPE]
+    canonical_names = ["dial", "apply", "synthesize"]
+    for family_name, meta in _REGISTRY["families"].items():
+        if family_name not in _RECIPE_FAMILIES:
+            continue
+        prefix = meta.get("step_naming", {}).get("prefix")
+        if prefix is not None:
+            continue
+        assert any(
+            all(
+                name in recipe.steps and recipe.steps[name].phoropter_family == family_name
+                for name in canonical_names
+            )
+            for recipe in recipes
+        ), (
+            f"Family {family_name} (canonical naming) requires steps "
+            f"{canonical_names} with phoropter_family={family_name!r} "
+            f"in at least one recipe"
+        )
+
+
+def test_vis_lens_phoropter_family_annotation() -> None:
+    """Verify vis-lens steps carry phoropter_family == 'vis-lens' (post-P3 state)."""
+    vis_meta = _REGISTRY["families"]["vis-lens"]
+    prefix = vis_meta["step_naming"]["prefix"]
+    step_names = [f"{prefix}_dial", f"{prefix}_apply", f"{prefix}_synthesize"]
+    for recipe in (RESEARCH_RECIPE, RESEARCH_DESIGN_RECIPE):
+        for step_name in step_names:
+            assert step_name in recipe.steps, f"{step_name} missing from {recipe.name}"
+            assert recipe.steps[step_name].phoropter_family == "vis-lens", (
+                f"{step_name} in {recipe.name} must have "
+                f"phoropter_family='vis-lens', got "
+                f"{recipe.steps[step_name].phoropter_family!r}"
+            )


### PR DESCRIPTION
## Summary

Add 7 new test functions, the `_DIAL_SKILL_MAP` constant, and module-scope recipe loads to `tests/skills/test_phoropter_structural.py`. The tests assert that families with dial skills have discoverable SKILL.md files emitting `selected_lenses` and `lens_context_paths` tokens, and that recipe step naming follows the registry's `step_naming.prefix` convention.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-3724-20260605-144843-128093/.autoskillit/temp/make-plan/t2_p5_a3_wp1_dial_skill_assertions_plan_2026-06-05_150600.md`

Closes #3724

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 68 | 25.0k | 1.6M | 97.5k | 53 | 75.8k | 12m 17s |
| verify* | opus | 1 | 45 | 6.4k | 420.6k | 63.2k | 26 | 41.0k | 3m 48s |
| implement* | MiniMax-M3 | 1 | 60.9k | 8.1k | 1.4M | 63.9k | 65 | 0 | 6m 8s |
| audit_impl* | opus | 1 | 23 | 8.2k | 171.8k | 42.7k | 12 | 30.2k | 3m 33s |
| prepare_pr* | MiniMax-M3 | 1 | 46.8k | 1.6k | 340.1k | 47.6k | 15 | 0 | 1m 0s |
| compose_pr* | MiniMax-M3 | 1 | 35.9k | 1.1k | 227.0k | 38.7k | 12 | 0 | 56s |
| review_pr* | opus | 3 | 307 | 40.2k | 1.8M | 64.5k | 78 | 120.6k | 12m 45s |
| resolve_review* | opus | 1 | 61 | 8.8k | 1.0M | 75.0k | 42 | 53.6k | 4m 3s |
| **Total** | | | 144.2k | 99.4k | 7.0M | 97.5k | | 321.3k | 44m 33s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 101 | 13822.7 | 0.0 | 80.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 34 | 30437.8 | 1576.4 | 258.8 |
| **Total** | **135** | 51631.2 | 2379.7 | 736.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 68 | 25.0k | 1.6M | 75.8k | 12m 17s |
| opus | 4 | 436 | 63.6k | 3.4M | 245.4k | 24m 10s |
| MiniMax-M3 | 3 | 143.7k | 10.8k | 2.0M | 0 | 8m 5s |