### PR TITLE
Prove Backend Sandbox Flag Invariants

### DIFF
--- a/tests/execution/backends/test_backend_sandbox_invariants.py
+++ b/tests/execution/backends/test_backend_sandbox_invariants.py
@@ -25,7 +25,9 @@ class TestCodexSandboxInvariants:
         spec: CmdSpec = CodexBackend().build_skill_session_cmd(
             "/test-skill", cwd="", config=config
         )
-        assert spec.cmd[spec.cmd.index("--sandbox") + 1] == sandbox_mode
+        positions = [i for i, v in enumerate(spec.cmd) if v == "--sandbox"]
+        assert len(positions) == 1, f"expected exactly one --sandbox, got {len(positions)}"
+        assert spec.cmd[positions[0] + 1] == sandbox_mode
 
     def test_build_food_truck_cmd_sandbox_read_only(self) -> None:
         spec: CmdSpec = CodexBackend().build_food_truck_cmd(
@@ -34,8 +36,9 @@ class TestCodexSandboxInvariants:
             cwd="",
             completion_marker="%%DONE%%",
         )
-        assert "--sandbox" in spec.cmd
-        assert spec.cmd[spec.cmd.index("--sandbox") + 1] == "read-only"
+        positions = [i for i, v in enumerate(spec.cmd) if v == "--sandbox"]
+        assert len(positions) == 1, f"expected exactly one --sandbox, got {len(positions)}"
+        assert spec.cmd[positions[0] + 1] == "read-only"
 
 
 class TestClaudeCodeSandboxAbsence:

--- a/tests/execution/backends/test_backend_sandbox_invariants.py
+++ b/tests/execution/backends/test_backend_sandbox_invariants.py
@@ -1,0 +1,51 @@
+"""Contract tests: backend sandbox flag invariants."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core import CmdSpec, DirectInstall, OutputFormat, SkillSessionConfig
+from autoskillit.execution.backends import ClaudeCodeBackend, CodexBackend
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_ID", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_KITCHEN_SESSION_ID", raising=False)
+
+
+class TestCodexSandboxInvariants:
+    @pytest.mark.parametrize("sandbox_mode", ["workspace-write", "read-only"])
+    def test_build_skill_session_cmd_sandbox_mode(self, sandbox_mode: str) -> None:
+        config = SkillSessionConfig(sandbox_mode=sandbox_mode)
+        spec: CmdSpec = CodexBackend().build_skill_session_cmd(
+            "/test-skill", cwd="", config=config
+        )
+        assert spec.cmd[spec.cmd.index("--sandbox") + 1] == sandbox_mode
+
+    def test_build_food_truck_cmd_sandbox_read_only(self) -> None:
+        spec: CmdSpec = CodexBackend().build_food_truck_cmd(
+            orchestrator_prompt="dispatch",
+            plugin_source=DirectInstall(plugin_dir=Path("/pkg")),
+            cwd="",
+            completion_marker="%%DONE%%",
+        )
+        assert "--sandbox" in spec.cmd
+        assert spec.cmd[spec.cmd.index("--sandbox") + 1] == "read-only"
+
+
+class TestClaudeCodeSandboxAbsence:
+    def test_build_skill_session_cmd_no_sandbox_flag(self) -> None:
+        spec: CmdSpec = ClaudeCodeBackend().build_skill_session_cmd(
+            "/test-skill",
+            cwd="",
+            completion_marker="%%DONE%%",
+            model=None,
+            plugin_source=None,
+            output_format=OutputFormat.JSON,
+        )
+        assert "--sandbox" not in spec.cmd


### PR DESCRIPTION
## Summary

Add `tests/execution/backends/test_backend_sandbox_invariants.py` — a contract test module that proves three sandbox flag invariants across backends: (1) `CodexBackend.build_skill_session_cmd` propagates `config.sandbox_mode` into the `--sandbox` CLI flag, (2) `CodexBackend.build_food_truck_cmd` always emits `--sandbox read-only` regardless of config, and (3) `ClaudeCodeBackend.build_skill_session_cmd` never emits `--sandbox` at all.

Closes #3798

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260605-150740-628221/.autoskillit/temp/make-plan/prove-backend-sandbox-invariants_plan_2026-06-05_151600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 46 | 5.7k | 510.1k | 58.8k | 23 | 39.5k | 2m 55s |
| verify* | opus[1m] | 1 | 2.9k | 12.5k | 2.4M | 88.0k | 77 | 65.8k | 5m 39s |
| implement* | MiniMax-M3 | 1 | 51.1k | 2.5k | 682.4k | 54.4k | 21 | 0 | 3m 44s |
| audit_impl* | opus[1m] | 1 | 23 | 3.2k | 173.4k | 41.7k | 11 | 22.1k | 1m 39s |
| prepare_pr* | MiniMax-M3 | 1 | 43.7k | 1.8k | 425.6k | 46.3k | 20 | 0 | 1m 14s |
| compose_pr* | MiniMax-M3 | 1 | 37.0k | 1.3k | 269.4k | 39.5k | 16 | 0 | 53s |
| review_pr* | opus[1m] | 1 | 28 | 9.1k | 458.5k | 55.6k | 23 | 33.8k | 2m 29s |
| resolve_review* | opus[1m] | 1 | 36 | 5.0k | 1.1M | 69.5k | 32 | 47.5k | 5m 8s |
| **Total** | | | 134.8k | 41.0k | 6.0M | 88.0k | | 208.7k | 23m 43s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 51 | 13380.6 | 0.0 | 49.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 9 | 121191.1 | 5276.6 | 556.1 |
| **Total** | **60** | 99559.6 | 3478.2 | 683.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 5 | 3.1k | 35.4k | 4.6M | 208.7k | 17m 51s |
| MiniMax-M3 | 3 | 131.7k | 5.6k | 1.4M | 0 | 5m 51s |