### PR TITLE
P3-A6-WP1 Guard Script Existence Tests

### DIFF
--- a/tests/backend/test_guard_script_existence.py
+++ b/tests/backend/test_guard_script_existence.py
@@ -1,0 +1,33 @@
+"""Per-backend guard-file filesystem consistency."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
+from autoskillit.execution.backends.codex import CodexBackend
+from autoskillit.hook_registry import HOOKS_DIR
+
+pytestmark = [pytest.mark.medium]
+
+
+def test_claude_code_applicable_guards_exist_on_disk() -> None:
+    backend = ClaudeCodeBackend()
+    guards = backend.capabilities.applicable_guards
+    assert guards, "applicable_guards must be non-empty"
+    for name in sorted(guards):
+        script = HOOKS_DIR / "guards" / f"{name}.py"
+        assert script.is_file(), (
+            f"ClaudeCodeBackend declares applicable_guard {name!r} but {script} does not exist"
+        )
+
+
+def test_codex_applicable_guards_exist_on_disk() -> None:
+    backend = CodexBackend()
+    guards = backend.capabilities.applicable_guards
+    assert guards, "applicable_guards must be non-empty"
+    for name in sorted(guards):
+        script = HOOKS_DIR / "guards" / f"{name}.py"
+        assert script.is_file(), (
+            f"CodexBackend declares applicable_guard {name!r} but {script} does not exist"
+        )


### PR DESCRIPTION
## Summary

Create `tests/backend/test_guard_script_existence.py` with two tests that assert per-backend guard-file filesystem consistency: one verifying every guard name in `ClaudeCodeBackend.capabilities.applicable_guards` resolves to a real `.py` file under `HOOKS_DIR/guards/`, and one asserting `CodexBackend.capabilities.applicable_guards` is exactly `frozenset()`.

**Issue discrepancy — CodexBackend is NOT empty:** The issue states `CodexBackend.capabilities.applicable_guards` is `frozenset()` and prescribes `test_codex_applicable_guards_is_empty_frozenset`. However, the current codebase (`src/autoskillit/execution/backends/codex.py:477`) defines `applicable_guards=frozenset({"write_guard"})`. The prescribed test would fail immediately. The correct test mirrors the Claude Code pattern — asserting each Codex guard resolves to a real file on disk — and is named `test_codex_applicable_guards_exist_on_disk`.

**Overlap with existing test:** `tests/arch/test_capability_consistency.py` already has `TestApplicableGuardsExistOnDisk` parametrized over `BACKEND_REGISTRY`. The issue explicitly scopes this WP to direct per-backend assertions without `BACKEND_REGISTRY` iteration ("No BACKEND_REGISTRY parametrize is used — scope stays within A6's charter"). The new tests are intentionally non-parametrized, importing each backend class directly. Both test suites can coexist — the arch test provides registry-wide coverage, while the backend tests provide focused per-backend contracts.

Closes #3800

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260605-164503-890740/.autoskillit/temp/make-plan/b-p3-a6-wp1-guard-script-existence_plan_2026-06-05_165500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 51 | 7.3k | 889.5k | 70.5k | 31 | 52.2k | 4m 23s |
| verify* | opus[1m] | 1 | 36 | 8.2k | 1.1M | 75.1k | 43 | 53.0k | 3m 6s |
| implement* | MiniMax-M3 | 1 | 45.1k | 3.1k | 611.4k | 48.0k | 25 | 0 | 3m 39s |
| audit_impl* | opus[1m] | 1 | 23 | 2.8k | 172.9k | 41.1k | 10 | 20.9k | 1m 42s |
| prepare_pr* | MiniMax-M3 | 1 | 40.6k | 1.9k | 160.7k | 43.7k | 9 | 0 | 51s |
| compose_pr* | MiniMax-M3 | 1 | 37.5k | 1.9k | 274.8k | 40.6k | 14 | 0 | 1m 8s |
| review_pr* | opus[1m] | 1 | 29 | 8.5k | 507.3k | 54.7k | 23 | 32.7k | 2m 47s |
| resolve_review* | opus[1m] | 1 | 32 | 5.0k | 796.2k | 64.8k | 29 | 43.0k | 4m 38s |
| **Total** | | | 123.4k | 38.8k | 4.5M | 75.1k | | 201.8k | 22m 17s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 33 | 18528.5 | 0.0 | 93.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **33** | 136491.5 | 6114.7 | 1175.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 5 | 171 | 32.0k | 3.5M | 201.8k | 16m 39s |
| MiniMax-M3 | 3 | 123.2k | 6.8k | 1.0M | 0 | 5m 38s |