### PR TITLE
[IMPL] T2-P6-A8-WP1: Phoropter execution contract documentation

### DIFF
--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -134,6 +134,9 @@ Taskfile.yml:
 docs/**/*.md:
   - docs/
 
+docs/**/*.yaml:
+  - docs/
+
 README.md:
   - docs/
 

--- a/docs/phoropter/README.md
+++ b/docs/phoropter/README.md
@@ -2,7 +2,7 @@
 
 The phoropter framework organises documentation lenses into a Dial → Apply → Synthesize phase structure across four lens families: arch-lens, exp-lens, vis-lens, and review-design.
 
-- execution-contract.md — execution contract governing lens phase transitions and output guarantees
-- ADDING_A_LENS_FAMILY.md — step-by-step guide for authoring a new lens family
-- recipe-blocks/README.md — reusable recipe blocks for phoropter pipelines
+- [execution-contract.md](execution-contract.md) — execution contract governing lens phase transitions and output guarantees
+- [family-guide.md](family-guide.md) — step-by-step guide for authoring a new lens family
+- [recipe-blocks/README.md](recipe-blocks/README.md) — reusable recipe blocks for phoropter pipelines
 - [catalog.md](../skills/catalog.md) — full skill catalog including all lens skills

--- a/docs/phoropter/execution-contract.md
+++ b/docs/phoropter/execution-contract.md
@@ -1,0 +1,127 @@
+# Phoropter Execution Contract
+
+This document is the authoritative reference for phoropter execution contracts. It defines the universal invariants that every phoropter family must satisfy at recipe validation time and at runtime. The accompanying [family-guide.md](family-guide.md) walks through the process of authoring a new family that conforms to this contract.
+
+## §1. The Phoropter Pattern
+
+The phoropter is a recipe-level primitive that organises documentation lenses into a three-phase pipeline: **dial → apply → synthesize**. Each phoropter family groups a set of analytical lenses (e.g., arch-lens, exp-lens, vis-lens) and routes their execution through this pipeline.
+
+Two semantic rules enforce the pattern at recipe validation time (both are `ERROR` severity in `src/autoskillit/recipe/rules/rules_phoropter_adjacency.py`):
+
+- **`phoropter-phase-order`** — steps within a `phoropter_family` must follow the `dial → apply → synthesize` progression. The canonical phase tuple is `_PHOROPTER_PHASES = ("dial", "apply", "synthesize")`. Out-of-order steps produce an `ERROR` finding.
+- **`phoropter-step-interleaving`** — non-phoropter steps must not interrupt an in-progress family sequence. If a step with no `phoropter_family` annotation appears between canonical phase steps of an active family, an `ERROR` finding is emitted.
+
+Steps with `action: route` are transparent to both rules — routing does not advance or interrupt a family sequence.
+
+## §2. Universal Contracts
+
+Every phoropter family must satisfy exactly five contracts. These are enforced by the two semantic rules above plus the step-level configuration knobs in §4.
+
+| Contract | Description |
+|----------|-------------|
+| (i) Dial precedes Apply | Within each family, the `dial` phase must appear before `apply` in recipe declaration order. Enforced by `phoropter-phase-order`. |
+| (ii) Apply precedes Synthesize | Within each family, `apply` must appear before `synthesize`. Enforced by `phoropter-phase-order`. |
+| (iii) Synthesize is sole verdict-emitting step | Only the `synthesize` step produces the family's final output (verdict, plan, or assessment). Dial selects; Apply evaluates; Synthesize aggregates. |
+| (iv) No non-phoropter interruption | Steps without `phoropter_family` must not appear between canonical phase steps of an in-progress family sequence. Enforced by `phoropter-step-interleaving`. Non-canonical steps within the family (e.g., `select_review_dimensions`, `silent_type_gate`) are transparent. |
+| (v) Scoped temp directory | Each step writes only to its scoped `AUTOSKILLIT_TEMP` subdirectory. Cross-step data flows through `capture`/`context` tokens, not shared filesystem paths. |
+
+## §3. Phase Responsibilities
+
+The three phases have distinct, non-overlapping responsibilities:
+
+### Dial — Selection and Classification
+
+Determines which lenses to apply, classifies the experiment type, and emits tokens consumed by downstream phases. The dial step is the family's gatekeeper.
+
+- **Examples:**
+  - `classify-experiment-type` (review-design family)
+  - `select-vis-lenses` (vis-lens family)
+  - `prepare-pr` (arch-lens family)
+  - `prepare-research-pr` (exp-lens family)
+- **Pre-filtering:** Dial skills may compute conditional values (e.g., `is_silent_type`) that downstream steps use for `skip_when_true`/`skip_when_false` gating.
+
+### Apply — Evaluation and Analysis
+
+Each selected lens runs against the target, producing per-lens output files (diagrams, assessments, figure specs).
+
+- This phase may be skipped conditionally via the `optional_phases` knob (§4).
+- The apply step may use `capture_list` for multi-lens fan-out (e.g., `vis_apply` captures `vis_lens_output_paths` into a list).
+- Retry semantics (`retries: N`, `on_exhausted`) are common on apply steps — lens evaluation can be expensive.
+
+### Synthesize — Aggregation and Verdict
+
+Reads all per-lens outputs from the capture directory and produces a unified result. The synthesis strategy (§6) determines how conflicts between lens outputs are resolved.
+
+- Synthesize is the only phase that emits the family's final output tokens (e.g., `verdict`, `visualization_plan_path`, `architecture_impact`).
+- The synthesis skill is invoked with the capture directory containing all per-lens output files.
+
+## §4. Configuration Knobs
+
+Four knobs control phoropter family behavior. The first three are configured per-family in `src/autoskillit/assets/phoropter-registry.yaml`; the fourth is a step-level field.
+
+| Knob | Values | Description |
+|------|--------|-------------|
+| `apply_mode` | `eager` (default), `lazy` | Controls whether the apply phase runs all selected lenses (`eager`) or stops at the first decisive result (`lazy`). Currently all families use `eager`. |
+| `synthesis_algorithm` | `null`, `priority_hierarchy`, `electre_iii`, `dex` | Selects the synthesis strategy for the synthesize phase. See §6 for the full catalog. Configured per-family in `phoropter-registry.yaml` under `synthesis.strategy`. |
+| `optional_phases` | List of phase names | Phases that may be skipped via `PhoropterPhaseSkip` configuration. Currently only `apply` is skippable. Configured per-family in `phoropter-registry.yaml` under `phase_skip`. |
+| `PhoropterPhaseSkip` | `skip_when_true` / `skip_when_false` | Conditional phase skipping. The `skip_field` names a context variable; `skip_semantics` determines whether the phase is skipped when the field is truthy or falsy. |
+
+**PhoropterPhaseSkip in detail:**
+
+- `skip_when_true` — The phase is skipped when the named context variable is truthy. Canonical example: vis-lens skips the `apply` phase when `context.is_silent_type` is true (configured in `phoropter-registry.yaml` as `phase_skip.skip_field: context.is_silent_type`, `phase_skip.skip_semantics: skip_when_true`). In recipe YAML, this maps to `skip_when_true: context.is_silent_type` on the apply step.
+- `skip_when_false` — The phase runs only when the named context variable is truthy. E.g., `skip_when_false: inputs.review_design` on the `dial` step skips the entire review-design family when the `review_design` input is not provided.
+
+**RecipeStep fields (from `src/autoskillit/recipe/schema.py`):**
+
+```python
+phoropter_family: str | None = None   # Associates the step with a phoropter family
+skip_when_true: str | None = None     # Context variable; step skipped when truthy
+skip_when_false: str | None = None    # Context variable; step skipped when falsy
+```
+
+## §5. Step Naming Conventions
+
+The phoropter framework supports two step-naming cases, driven by the `step_naming.prefix` field in `phoropter-registry.yaml`.
+
+| Aspect | Sole-Family (Case A) | Coexisting Families (Case B) |
+|--------|---------------------|------------------------------|
+| Step keys | `dial`, `apply`, `synthesize` (bare canonical) | Primary family: `dial`, `apply`, `synthesize`; Additional families: `{prefix}_dial`, `{prefix}_apply`, `{prefix}_synthesize` |
+| `phoropter_family` annotation | Required on each step — associates the step with the family | Required on primary family steps; **omitted** on prefixed family steps |
+| Phase resolution | `_canonical_phase_for_step()` matches step name directly against `_PHOROPTER_PHASES` | `_canonical_phase_for_step()` strips the family prefix (from `phoropter-registry.yaml` `step_naming.prefix`) and matches the suffix |
+| When to use | Recipe contains a single phoropter family | Recipe contains two or more families that must coexist |
+
+**Concrete example:**
+
+In `research-design.yaml` and `research.yaml`, the `review-design` family uses canonical step keys (`dial`, `apply`, `synthesize`) with `phoropter_family: review-design` on each. The `vis-lens` family uses prefixed step keys (`vis_dial`, `vis_apply`, `vis_synthesize`) without `phoropter_family` annotation. The `vis` prefix is configured in `phoropter-registry.yaml` under `families.vis-lens.step_naming.prefix: vis`.
+
+**Why `phoropter_family` is omitted on prefixed steps:**
+
+When `phoropter_family` is set, the `phoropter-step-interleaving` rule treats any non-family step between canonical phases as an interleaving violation. In multi-family recipes, routing steps and the other family's steps would trigger false errors. Omitting `phoropter_family` on prefixed steps makes them invisible to the interleaving rule, while the phase-order rule still validates them via prefix-based phase resolution.
+
+## §6. SynthesisStrategy Catalog
+
+The `SynthesisStrategy` enum in `src/autoskillit/core/types/_type_enums.py` defines the recognized synthesis algorithms:
+
+| Strategy | Enum Value | Families | Status | Description |
+|----------|-----------|----------|--------|-------------|
+| `null` | `SynthesisStrategy.NULL` | arch-lens | Implemented | Identity pass-through. Concatenates lens output `.md` files in lexicographic order without conflict resolution. Implemented in `phoropter-null-synthesis` skill. |
+| `priority_hierarchy` | `SynthesisStrategy.PRIORITY_HIERARCHY` | exp-lens, vis-lens | Implemented | Configurable priority hierarchy for inter-lens conflict resolution. Default hierarchy: `accessibility > anti-pattern > methodology-norms > chart-select`. Implemented in `phoropter-priority-synthesis` (configurable via `--hierarchy`) and `synthesize-vis-plan` (hardcoded hierarchy). |
+| `electre_iii` | `SynthesisStrategy.ELECTRE_III` | refactor-lens (designed) | Planned | Outranking-based multi-criteria decision analysis. Targeted at the future refactor-lens family where lens outputs have continuous-valued scores requiring threshold-based concordance/discordance analysis. |
+| `dex` | `SynthesisStrategy.DEX` | (candidate) | Research candidate | Categorical multi-attribute decision modeling via symbolic attribute hierarchies. Based on [DEXi (2025)](https://kt.ijs.si/MarkoBohanec/dexi.html). Produces categorical outputs (e.g., "acceptable"/"unacceptable") rather than ranked lists. Feasibility evaluation required before implementing for exp-lens or refactor-lens synthesis. |
+
+Note: The `SynthesisStrategy` enum also includes a `CUSTOM` value for future extension.
+
+## §7. IL-0 Type Cross-Reference
+
+Six phoropter types are defined in the IL-0 core types layer (`src/autoskillit/core/types/_type_phoropter.py` and `_type_enums.py`):
+
+| Type | Module | Status | Fields | Purpose |
+|------|--------|--------|--------|---------|
+| `PhoropterPrescription` | `_type_phoropter.py` | Implemented | `selected_lenses: str`, `lens_context_paths: str`, `failure_mode: str = "continue"` | Dial phase output — records which lenses were selected and their context paths. |
+| `ReadingToken` | `_type_phoropter.py` | Implemented | `output_prefix: str`, `path_value: str` | Structured capture of a single lens reading (path to output file with its prefix). `READING_TOKEN_PATTERN` regex: `r"^(?P<prefix>\w+) = (?P<path>/.+)$"`. |
+| `PhoropterPhaseSkip` | `_type_phoropter.py` | Implemented | `skip_field: str`, `skip_semantics: Literal["skip_when_true", "skip_when_false"]`, `applies_to: str = ""` | Configuration for conditional phase skipping (see §4). |
+| `CrossDomainPrescription` | `_type_phoropter.py` | Implemented | `family_names: tuple[str, ...]`, `merged_lenses: str = ""`, `merge_strategy: str = "union"` | Multi-family lens selection when families share a recipe context. |
+| `CrossDomainAssessment` | `_type_phoropter.py` | Implemented | `family_names: tuple[str, ...]`, `synthesis_strategy: SynthesisStrategy = SynthesisStrategy.NULL`, `combined_output: str = ""` | Multi-family synthesis assessment combining outputs across family boundaries. |
+| `SynthesisStrategy` | `_type_enums.py` | Implemented | `NULL`, `PRIORITY_HIERARCHY`, `ELECTRE_III`, `DEX`, `CUSTOM` | Enum of recognized synthesis algorithms (see §6 catalog). |
+
+All types are frozen dataclasses with `slots=True` (except `SynthesisStrategy` which is a `StrEnum`). All are exported from `src/autoskillit/core/types/` via the `__init__.py` re-export hub.

--- a/docs/phoropter/execution-contract.md
+++ b/docs/phoropter/execution-contract.md
@@ -62,7 +62,7 @@ Four knobs control phoropter family behavior. The first three are configured per
 | Knob | Values | Description |
 |------|--------|-------------|
 | `apply_mode` | `eager` (default), `lazy` | Controls whether the apply phase runs all selected lenses (`eager`) or stops at the first decisive result (`lazy`). Currently all families use `eager`. |
-| `synthesis_algorithm` | `null`, `priority_hierarchy`, `electre_iii`, `dex` | Selects the synthesis strategy for the synthesize phase. See §6 for the full catalog. Configured per-family in `phoropter-registry.yaml` under `synthesis.strategy`. |
+| `synthesis.strategy` | `null`, `priority_hierarchy`, `electre_iii`, `dex` | Selects the synthesis strategy for the synthesize phase. See §6 for the full catalog. Configured per-family in `phoropter-registry.yaml`. |
 | `optional_phases` | List of phase names | Phases that may be skipped via `PhoropterPhaseSkip` configuration. Currently only `apply` is skippable. Configured per-family in `phoropter-registry.yaml` under `phase_skip`. |
 | `PhoropterPhaseSkip` | `skip_when_true` / `skip_when_false` | Conditional phase skipping. The `skip_field` names a context variable; `skip_semantics` determines whether the phase is skipped when the field is truthy or falsy. |
 

--- a/docs/phoropter/family-guide.md
+++ b/docs/phoropter/family-guide.md
@@ -35,7 +35,7 @@ The tradition manifest declares the family's metadata, lens list, and configurat
 
 - `synthesis_strategy` — Enum: `priority_hierarchy`, `electre_iii`, `dex`, `custom` (or null for null strategy)
 - `step_name_prefix` — `null`/absent → canonical names; set → prefixed names (e.g., `vis` → `vis_dial`, `vis_apply`, `vis_synthesize`)
-- `arg_interface` — Enum: `one_arg`, `two_arg`
+- `arg_interface` — Enum: `one_arg`, `two_arg` (mapped to `1-arg`/`2-arg` in `phoropter-registry.yaml`)
 - `output_prefix` — Prefix for output file names
 - `dialing` — `DialingConfig` with `selection_strategy` (`identity`/`property_set`), optional `min_lenses`, `max_lenses`, `always_run`, `synthesis_strategy`
 - `phase_skip` — `PhaseSkip` with required `skip_field` and `skip_semantics` (`skip_when_true`/`skip_when_false`); optional `applies_to`

--- a/docs/phoropter/family-guide.md
+++ b/docs/phoropter/family-guide.md
@@ -1,0 +1,187 @@
+# Phoropter Family Authoring Guide
+
+Step-by-step guide for authoring a new phoropter lens family. This document walks through the seven touchpoints required to add a new family to the phoropter framework. For the formal contracts each step must satisfy, see [execution-contract.md](execution-contract.md).
+
+## §1. Choose a Synthesis Strategy
+
+Before creating any files, decide which synthesis strategy your family will use. The four recognized strategies (see [execution-contract.md §6](execution-contract.md#6-synthesisstrategy-catalog)):
+
+| Strategy | When to Use | Implementation |
+|----------|-------------|----------------|
+| `null` | Lens outputs do not conflict and are simply concatenated in lexicographic filename order. | Implemented in `phoropter-null-synthesis` skill. Used by arch-lens. |
+| `priority_hierarchy` | Inter-lens conflicts are resolved by a configurable priority ordering. | Implemented in `phoropter-priority-synthesis` (configurable via `--hierarchy`) and `synthesize-vis-plan` (hardcoded). Default: `accessibility > anti-pattern > methodology-norms > chart-select`. Used by exp-lens and vis-lens. |
+| `electre_iii` | Lens outputs have continuous-valued scores requiring threshold-based concordance/discordance analysis. | Planned; targeted at the future refactor-lens family for outranking-based multi-criteria decision analysis. |
+| `dex` | Categorical outputs ("acceptable"/"unacceptable") are needed instead of ranked lists. | Research candidate; based on [DEXi (2025)](https://kt.ijs.si/MarkoBohanec/dexi.html). Evaluate feasibility before implementing for exp-lens or refactor-lens synthesis. |
+
+The `SynthesisStrategy` enum and related types are defined in `src/autoskillit/core/types/_type_enums.py` and `src/autoskillit/core/types/_type_phoropter.py`.
+
+## §2. Create the Tradition Manifest
+
+The tradition manifest declares the family's metadata, lens list, and configuration. The schema is defined in `src/autoskillit/assets/tradition-manifest-schema/tradition-manifest.schema.json`.
+
+**Required top-level fields:**
+
+- `name` — Human-readable family name
+- `description` — One-line description
+- `output_type` — Enum: `mermaid_diagram`, `figure_spec`, `structured_markdown`
+- `step_count` — Number of lenses in the family
+- `mode_label` — Display label (e.g., "Architecture Impact", "Visualization Plan")
+- `context_file_schema` — Schema describing the context file structure
+- `default_enabled` — Boolean; whether the family is enabled by default
+- `failure_mode` — Enum: `continue`, `halt`
+- `lenses` — Array of `LensEntry` objects (each with `slug`, `analytical_mode`, `primary_question`, `tradition`)
+
+**Optional top-level fields:**
+
+- `synthesis_strategy` — Enum: `priority_hierarchy`, `electre_iii`, `dex`, `custom` (or null for null strategy)
+- `step_name_prefix` — `null`/absent → canonical names; set → prefixed names (e.g., `vis` → `vis_dial`, `vis_apply`, `vis_synthesize`)
+- `arg_interface` — Enum: `one_arg`, `two_arg`
+- `output_prefix` — Prefix for output file names
+- `dialing` — `DialingConfig` with `selection_strategy` (`identity`/`property_set`), optional `min_lenses`, `max_lenses`, `always_run`, `synthesis_strategy`
+- `phase_skip` — `PhaseSkip` with required `skip_field` and `skip_semantics` (`skip_when_true`/`skip_when_false`); optional `applies_to`
+
+**File placement:** `src/autoskillit/recipes/methodology-traditions/{tradition-name}.yaml` (resolved by `BUNDLED_METHODOLOGY_TRADITIONS_DIR` in `src/autoskillit/recipe/methodology_tradition_registry.py`).
+
+**Minimal annotated example:**
+
+```yaml
+name: Example Lens Family
+description: Demonstrates the phoropter family configuration schema.
+output_type: structured_markdown
+step_count: 3
+mode_label: Example Analysis
+context_file_schema: example-context-v1
+default_enabled: true
+failure_mode: continue
+step_name_prefix: ex
+arg_interface: two_arg
+output_prefix: "ex_"
+lenses:
+  - slug: lens-alpha
+    analytical_mode: descriptive
+    primary_question: "What does the system do?"
+    tradition: example-tradition
+  - slug: lens-beta
+    analytical_mode: evaluative
+    primary_question: "How well does it do it?"
+    tradition: example-tradition
+  - slug: lens-gamma
+    analytical_mode: prescriptive
+    primary_question: "How could it improve?"
+    tradition: example-tradition
+phase_skip:
+  skip_field: context.is_silent_type
+  skip_semantics: skip_when_true
+  applies_to: apply
+```
+
+## §3. Register in phoropter-registry.yaml
+
+Add a family entry to `src/autoskillit/assets/phoropter-registry.yaml` under the `families` key.
+
+**Required fields:**
+
+- `family_id` (top-level key) — kebab-case identifier (e.g., `vis-lens`, `arch-lens`)
+- `description` — One-line description
+- `output_type` — Output format (`diagram`, `assessment`, `figure_spec`)
+- `mode_label` — Display label
+- `lens_count` — Number of lenses
+- `default_enabled` — Boolean
+- `failure_mode` — `continue` or `halt`
+- `arg_interface` — `1-arg` (arch-lens: context_path only) or `2-arg` (exp-lens/vis-lens: context_path + experiment_plan_path)
+- `dial_skill` — Skill invoked during the dial phase
+- `synthesis.strategy` — Must match §1 catalog value
+- `step_naming.prefix` — `null` for canonical names, string for prefixed names
+- `status` — `implemented`, `designed`, or `planned`
+
+**Optional fields:**
+
+- `synthesis.skill` — Skill name for synthesis invocation
+- `phase_skip` — Conditional phase skipping configuration (see [execution-contract.md §4](execution-contract.md#4-configuration-knobs))
+- `lens_metadata` — Per-lens metadata overrides
+- `activate_deps` — Required dependency features (e.g., `[mermaid]`)
+- `output_prefix` — Prefix for output file names
+- `composite_slugs` — Lens slugs that are always included
+
+**Annotated example entry:**
+
+```yaml
+families:
+  example-lens:
+    description: Example family for demonstration purposes
+    output_type: assessment
+    mode_label: Example Assessment
+    lens_count: 3
+    default_enabled: true
+    failure_mode: continue
+    arg_interface: 2-arg
+    dial_skill: prepare-example-pr
+    synthesis:
+      strategy: priority_hierarchy
+      skill: phoropter-priority-synthesis
+    step_naming:
+      prefix: ex
+    status: designed
+```
+
+## §4. Generate Lens SKILL.md Files
+
+Each lens in the family needs a `SKILL.md` file generated from the `lens-skill-template.md` template (`src/autoskillit/assets/lens-skill-template.md` — Phase 4 artifact, prerequisite T2-P4-A1-WP2).
+
+**Template variables:**
+
+- `{name}` — Human-readable lens name
+- `{categories}` — Comma-separated category tags
+- `{dial_skill}` — Dial phase skill name
+- `{apply_skill}` — Apply phase skill name (usually the lens itself)
+- `{synthesize_skill}` — Synthesize phase skill name
+- `{family}` — Family identifier
+- `{slug}` — Lens slug suffix
+- `{mode_label}` — Display mode label
+- `{mode_value}` — Mode value for context
+- `{primary_question}` — The analytical question the lens answers
+- `{focus_areas}` — Comma-separated focus areas
+- `{description}` — One-line description
+- `{hook_echo}` — Hook echo message
+- `{arg_count}` — Number of positional arguments
+- `{step_count}` — Number of steps in the lens workflow
+- `{output_type}` — Output format
+- `{output_prefix}` — Output file prefix
+- `{parent_skill}` — Parent skill for lens grouping
+
+**Argument interface distinction:**
+
+- **1-arg** (arch-lens): `{context_path}` only. The lens receives a single path to the PR context or codebase root.
+- **2-arg** (exp-lens, vis-lens): `{context_path} {experiment_plan_path}`. The lens receives both the context and the experiment plan.
+
+## §5. Select Step Naming Convention
+
+Driven by the `phoropter-phase-order` rule in `src/autoskillit/recipe/rules/rules_phoropter_adjacency.py`:
+
+- **Case A (sole family):** Use canonical step keys (`dial`, `apply`, `synthesize`) and add `phoropter_family: {family-id}` annotation on each step. The rule's `_PHOROPTER_PHASES` tuple `("dial", "apply", "synthesize")` matches these names directly.
+- **Case B (coexisting families):** Use prefixed step keys (`{prefix}_dial`, `{prefix}_apply`, `{prefix}_synthesize`) without `phoropter_family` annotation. Omitting the annotation avoids `phoropter-step-interleaving` false errors when recipe-level routing steps separate family steps.
+
+**Concrete example:** vis-lens coexisting with review-design in `research.yaml` uses `vis_dial`, `vis_apply`, `vis_synthesize` with no `phoropter_family`; review-design uses `dial`, `apply`, `synthesize` with `phoropter_family: review-design`. For full details on step naming, see [execution-contract.md §5](execution-contract.md#5-step-naming-conventions).
+
+## §6. Wire Recipe Steps
+
+Provide copy-pasteable YAML snippet patterns from [recipe-blocks/](recipe-blocks/README.md):
+
+- [single-family-canonical.yaml](recipe-blocks/single-family-canonical.yaml) for Case A
+- [multi-family-prefixed.yaml](recipe-blocks/multi-family-prefixed.yaml) for Case B
+- [null-synthesis-config.yaml](recipe-blocks/null-synthesis-config.yaml) for null synthesis
+- [priority-synthesis-config.yaml](recipe-blocks/priority-synthesis-config.yaml) for priority hierarchy synthesis
+
+**Routing chain:** The `on_success` routing follows `dial → apply → synthesize`. The `skip_when_true` bypass pattern means: when `skip_when_true` evaluates to truthy, the step is skipped and control passes to the step named in `on_success` (or `on_failure` if configured as fallthrough).
+
+## §7. Verification Checklist
+
+Before merging a new phoropter family, verify all seven touchpoints:
+
+1. **Entry present in `src/autoskillit/assets/phoropter-registry.yaml`** with all required fields.
+2. **P5 family-generic structural test auto-discovers** the family via registry — no manual test update required.
+3. **`src/autoskillit/recipe/skill_contracts.yaml`** entries for each new lens skill and the family's dial/synthesize skills.
+4. **`docs/skills/catalog.md`** updated with new family section listing all lenses.
+5. **`docs/skills/subsets.md`** updated with new category row for the family's tool subset tag.
+6. **`docs/glossary.md`** updated with new family term (enforced by `tests/docs/test_glossary_spelling.py`).
+7. **`PACK_REGISTRY`** entry added to `src/autoskillit/core/types/_type_constants_registries.py` with `PackDef(default_enabled, description)`.

--- a/docs/phoropter/family-guide.md
+++ b/docs/phoropter/family-guide.md
@@ -126,7 +126,7 @@ families:
 
 ## §4. Generate Lens SKILL.md Files
 
-Each lens in the family needs a `SKILL.md` file generated from the `lens-skill-template.md` template (`src/autoskillit/assets/lens-skill-template.md` — Phase 4 artifact, prerequisite T2-P4-A1-WP2).
+Each lens in the family needs a `SKILL.md` file following the template variable conventions below.
 
 **Template variables:**
 

--- a/docs/phoropter/family-guide.md
+++ b/docs/phoropter/family-guide.md
@@ -13,7 +13,7 @@ Before creating any files, decide which synthesis strategy your family will use.
 | `electre_iii` | Lens outputs have continuous-valued scores requiring threshold-based concordance/discordance analysis. | Planned; targeted at the future refactor-lens family for outranking-based multi-criteria decision analysis. |
 | `dex` | Categorical outputs ("acceptable"/"unacceptable") are needed instead of ranked lists. | Research candidate; based on [DEXi (2025)](https://kt.ijs.si/MarkoBohanec/dexi.html). Evaluate feasibility before implementing for exp-lens or refactor-lens synthesis. |
 
-The `SynthesisStrategy` enum and related types are defined in `src/autoskillit/core/types/_type_enums.py` and `src/autoskillit/core/types/_type_phoropter.py`.
+The `SynthesisStrategy` enum and `PhoropterPrescription` types are defined in `src/autoskillit/core/types/_type_enums.py` and `src/autoskillit/core/types/_type_phoropter.py`.
 
 ## §2. Create the Tradition Manifest
 

--- a/docs/phoropter/recipe-blocks/README.md
+++ b/docs/phoropter/recipe-blocks/README.md
@@ -1,0 +1,10 @@
+# Recipe Blocks
+
+Reusable YAML recipe fragments demonstrating phoropter step configuration patterns. Each file contains annotated step blocks that can be adapted for new recipes. See [execution-contract.md](../execution-contract.md) for the contracts these patterns satisfy.
+
+| File | Pattern | When to Use |
+|------|---------|-------------|
+| [single-family-canonical.yaml](single-family-canonical.yaml) | Canonical step keys with `phoropter_family` annotation | Recipe contains a single phoropter family (Case A) |
+| [multi-family-prefixed.yaml](multi-family-prefixed.yaml) | Prefixed step keys without `phoropter_family` on secondary families | Recipe contains two or more coexisting phoropter families (Case B) |
+| [null-synthesis-config.yaml](null-synthesis-config.yaml) | Null synthesis via `phoropter-null-synthesis` | Family uses identity pass-through aggregation (arch-lens) |
+| [priority-synthesis-config.yaml](priority-synthesis-config.yaml) | Priority hierarchy via `phoropter-priority-synthesis` | Family uses configurable priority-based conflict resolution (vis-lens) |

--- a/docs/phoropter/recipe-blocks/multi-family-prefixed.yaml
+++ b/docs/phoropter/recipe-blocks/multi-family-prefixed.yaml
@@ -47,6 +47,7 @@ apply:
   retries: 2
   on_success: synthesize
   on_failure: synthesize
+  on_exhausted: synthesize
 
 synthesize:
   tool: run_python

--- a/docs/phoropter/recipe-blocks/multi-family-prefixed.yaml
+++ b/docs/phoropter/recipe-blocks/multi-family-prefixed.yaml
@@ -1,0 +1,103 @@
+# multi-family-prefixed.yaml
+#
+# Multi-family coexistence with prefixed step naming (Case B).
+# When two or more phoropter families share a recipe, the primary
+# family uses canonical step keys WITH phoropter_family annotation;
+# secondary families use prefixed step keys WITHOUT phoropter_family.
+#
+# phoropter_family is intentionally absent from vis-lens steps.
+# Setting phoropter_family on prefixed steps would cause the
+# phoropter-step-interleaving rule to emit false errors whenever
+# recipe-level routing steps (e.g. on_result branches, revise loops)
+# separate the family's phase steps.  A future evolution of the
+# adjacency rule may introduce a registry-aware interleaving check
+# that removes this constraint.
+#
+# Primary family: review-design (canonical keys, annotated)
+# Secondary family: vis-lens (vis_ prefix, unannotated)
+
+# ── review-design family (primary) ────────────────────────────────
+
+dial:
+  tool: run_skill
+  skill_command: >-
+    /autoskillit:classify-experiment-type
+    ${{ context.experiment_plan }}
+    ${{ context.scope_report }}
+  phoropter_family: review-design
+  capture:
+    experiment_type: "${{ result.experiment_type }}"
+    is_silent_type: "${{ result.is_silent_type }}"
+    classification_timestamp: "${{ result.classification_timestamp }}"
+  on_success: apply
+  on_failure: escalate_stop
+
+apply:
+  tool: run_skill
+  skill_command: >-
+    /autoskillit:apply-review-dimensions
+    ${{ context.experiment_plan }}
+    ${{ context.scope_report }}
+    ${{ context.dimensions_manifest_path }}
+  phoropter_family: review-design
+  skip_when_true: context.is_silent_type
+  capture:
+    findings_manifest_path: "${{ result.findings_manifest_path }}"
+    evaluation_dashboard: "${{ result.evaluation_dashboard }}"
+  retries: 2
+  on_success: synthesize
+  on_failure: synthesize
+
+synthesize:
+  tool: run_python
+  callable: autoskillit.smoke_utils.aggregate_review_verdict
+  phoropter_family: review-design
+  capture:
+    verdict: "${{ result.verdict }}"
+    revision_guidance: "${{ result.revision_guidance }}"
+  on_success: vis_dial
+  on_failure: vis_dial
+
+# ── vis-lens family (secondary, prefixed) ─────────────────────────
+
+vis_dial:
+  tool: run_skill
+  skill_command: >-
+    /autoskillit:select-vis-lenses
+    ${{ inputs.source_dir }}
+    ${{ context.experiment_plan }}
+    ${{ context.scope_report }}
+  capture:
+    selected_lenses: "${{ result.selected_lenses }}"
+    lens_context_paths: "${{ result.lens_context_paths }}"
+    disambiguation_rule_applied: "${{ result.disambiguation_rule_applied }}"
+    tier_c_lens: "${{ result.tier_c_lens }}"
+    methodology_tradition: "${{ result.methodology_tradition }}"
+  on_success: vis_apply
+  on_failure: escalate_stop
+
+vis_apply:
+  tool: run_skill
+  skill_command: >-
+    /autoskillit:vis-lens-{slug}
+    {context_path}
+    ${{ context.experiment_plan }}
+  capture_list:
+    vis_lens_output_paths: "${{ result.diagram_path }}"
+  retries: 0
+  on_success: vis_synthesize
+  on_failure: vis_synthesize
+
+vis_synthesize:
+  tool: run_skill
+  skill_command: >-
+    /autoskillit:synthesize-vis-plan
+    ${{ inputs.source_dir }}
+    ${{ context.experiment_plan }}
+    {{AUTOSKILLIT_TEMP}}/run-vis-lenses
+  capture:
+    visualization_plan_path: "${{ result.visualization_plan_path }}"
+    report_plan_path: "${{ result.report_plan_path }}"
+    visualization_plan_trace_path: "${{ result.visualization_plan_trace_path }}"
+  on_success: next_stage
+  on_failure: escalate_stop

--- a/docs/phoropter/recipe-blocks/multi-family-prefixed.yaml
+++ b/docs/phoropter/recipe-blocks/multi-family-prefixed.yaml
@@ -9,9 +9,7 @@
 # Setting phoropter_family on prefixed steps would cause the
 # phoropter-step-interleaving rule to emit false errors whenever
 # recipe-level routing steps (e.g. on_result branches, revise loops)
-# separate the family's phase steps.  A future evolution of the
-# adjacency rule may introduce a registry-aware interleaving check
-# that removes this constraint.
+# separate the family's phase steps.
 #
 # Primary family: review-design (canonical keys, annotated)
 # Secondary family: vis-lens (vis_ prefix, unannotated)

--- a/docs/phoropter/recipe-blocks/null-synthesis-config.yaml
+++ b/docs/phoropter/recipe-blocks/null-synthesis-config.yaml
@@ -1,0 +1,16 @@
+# null-synthesis-config.yaml
+#
+# Null synthesis configuration for identity pass-through aggregation.
+# Used by arch-lens family where lens outputs do not conflict and are
+# simply concatenated in lexicographic filename order.
+
+synthesize:
+  tool: run_skill
+  skill_command: >-
+    /autoskillit:phoropter-null-synthesis
+    ${{ inputs.source_dir }}
+    ${{ context.capture_dir }}
+  capture:
+    synthesis_result_path: "${{ result.synthesis_result_path }}"
+  on_success: next_stage
+  on_failure: escalate_stop

--- a/docs/phoropter/recipe-blocks/priority-synthesis-config.yaml
+++ b/docs/phoropter/recipe-blocks/priority-synthesis-config.yaml
@@ -1,0 +1,20 @@
+# priority-synthesis-config.yaml
+#
+# Priority hierarchy synthesis for conflict-resolution aggregation.
+# Used by vis-lens family where inter-lens figure specification
+# conflicts are resolved by a configurable priority ordering.
+# Default hierarchy: accessibility > anti-pattern > methodology-norms > chart-select.
+
+synthesize:
+  tool: run_skill
+  skill_command: >-
+    /autoskillit:phoropter-priority-synthesis
+    ${{ inputs.source_dir }}
+    ${{ context.capture_dir }}
+    --hierarchy=accessibility,anti-pattern,methodology-norms,chart-select
+  capture:
+    synthesis_result_path: "${{ result.synthesis_result_path }}"
+    report_path: "${{ result.report_path }}"
+    synthesis_trace_path: "${{ result.synthesis_trace_path }}"
+  on_success: next_stage
+  on_failure: escalate_stop

--- a/docs/phoropter/recipe-blocks/single-family-canonical.yaml
+++ b/docs/phoropter/recipe-blocks/single-family-canonical.yaml
@@ -1,0 +1,51 @@
+# single-family-canonical.yaml
+#
+# Sole-family canonical step naming (Case A).
+# When a recipe contains exactly one phoropter family, use the bare
+# canonical step keys: dial, apply, synthesize.  Each step MUST carry
+# the phoropter_family annotation so the phoropter-phase-order and
+# phoropter-step-interleaving semantic rules can validate the sequence.
+#
+# Family used: review-design (arch-lens uses a different dial skill;
+# substitute skill_command values as appropriate for your family).
+
+dial:
+  tool: run_skill
+  skill_command: >-
+    /autoskillit:classify-experiment-type
+    ${{ context.experiment_plan }}
+    ${{ context.scope_report }}
+  phoropter_family: review-design
+  capture:
+    experiment_type: "${{ result.experiment_type }}"
+    is_silent_type: "${{ result.is_silent_type }}"
+    classification_timestamp: "${{ result.classification_timestamp }}"
+  on_success: apply
+  on_failure: escalate_stop
+
+apply:
+  tool: run_skill
+  skill_command: >-
+    /autoskillit:apply-review-dimensions
+    ${{ context.experiment_plan }}
+    ${{ context.scope_report }}
+    ${{ context.dimensions_manifest_path }}
+  phoropter_family: review-design
+  skip_when_true: context.is_silent_type
+  capture:
+    findings_manifest_path: "${{ result.findings_manifest_path }}"
+    evaluation_dashboard: "${{ result.evaluation_dashboard }}"
+  retries: 2
+  on_success: synthesize
+  on_failure: synthesize
+  on_exhausted: synthesize
+
+synthesize:
+  tool: run_python
+  callable: autoskillit.smoke_utils.aggregate_review_verdict
+  phoropter_family: review-design
+  capture:
+    verdict: "${{ result.verdict }}"
+    revision_guidance: "${{ result.revision_guidance }}"
+  on_success: next_stage
+  on_failure: escalate_stop


### PR DESCRIPTION
## Summary

This work package produces a single authoritative markdown document at `docs/phoropter/execution-contract.md` that records the phoropter execution contracts, shape, configuration knobs, step naming conventions, synthesis strategy catalog, and forward-looking IL-0 type cross-references — enabling new family authors and recipe maintainers to understand the constraints without reading source code. The first plan creates a 7-section authoring guide at `docs/phoropter/family-guide.md` and the `docs/phoropter/recipe-blocks/` directory containing `README.md` plus four YAML recipe fragments. The second plan remediates a documentation gap in `family-guide.md` Section 1 by naming `PhoropterPrescription` explicitly alongside `SynthesisStrategy` when cross-referencing IL-0 types.

<details>
<summary>Individual Group Plans</summary>

### Group 1: T2-P6-A8-WP1 execution contract documentation
This work package covers creating a single authoritative markdown document at `docs/phoropter/execution-contract.md` that records the phoropter execution contracts, shape, configuration knobs, step naming conventions, synthesis strategy catalog, and forward-looking IL-0 type cross-references. Seven sections are required: Pattern & Rules, Universal Contracts (5 ordering/isolation guarantees), Phase Responsibilities, Configuration Knobs, Step Naming Conventions, SynthesisStrategy Catalog, and IL-0 Type Cross-Reference. The plan also creates a 7-section authoring guide at `docs/phoropter/family-guide.md` and the `docs/phoropter/recipe-blocks/` directory containing `README.md` plus four YAML recipe fragments (single-family-canonical, multi-family-prefixed, null-synthesis-config, priority-synthesis-config). `docs/phoropter/README.md` is updated to use proper markdown links for BFS reachability. Zero Python file modifications.

### Group 2: T2-P6-A8-WP1 execution contract remediation
This plan remediates a documentation gap in `docs/phoropter/family-guide.md` Section 1: the issue's technical step 18 and the plan step 7 both require naming `PhoropterPrescription` alongside `SynthesisStrategy` when cross-referencing IL-0 types. The current text substitutes a vague phrase "related types" that fails to meet this requirement. The fix replaces the vague phrase with the explicit type name `PhoropterPrescription` on line 16 of `family-guide.md`. The type `PhoropterPrescription` exists at `src/autoskillit/core/types/_type_phoropter.py:21` and is already fully documented in `execution-contract.md` Section 7.

</details>

Closes #3731

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/impl-3731-20260605-165025-395823/.autoskillit/temp/make-plan/t2-p6-a8-wp1-execution-contract_plan_2026-06-05_170000.md`
- `/home/talon/projects/autoskillit-runs/impl-3731-20260605-165025-395823/.autoskillit/temp/make-plan/t2-p6-a8-wp1-execution-contract-remediation_plan_2026-06-05_171800.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 91 | 19.3k | 1.0M | 64.1k | 44 | 93.2k | 9m 6s |
| verify* | opus | 2 | 100 | 21.0k | 2.4M | 83.3k | 81 | 86.7k | 13m 22s |
| implement* | MiniMax-M3 | 2 | 113.2k | 13.1k | 2.6M | 74.7k | 84 | 0 | 6m 56s |
| fix* | opus | 1 | 43 | 3.7k | 878.0k | 68.8k | 34 | 46.6k | 4m 57s |
| audit_impl* | opus | 2 | 58 | 13.1k | 570.5k | 70.8k | 30 | 81.2k | 13m 36s |
| prepare_pr* | MiniMax-M3 | 1 | 52.1k | 2.3k | 358.9k | 54.8k | 13 | 0 | 1m 13s |
| compose_pr* | MiniMax-M3 | 1 | 38.7k | 1.6k | 266.3k | 39.9k | 12 | 0 | 1m 2s |
| review_pr* | opus | 2 | 175 | 47.9k | 1.3M | 88.6k | 67 | 131.9k | 16m 10s |
| dispatch:322fe7f4-d63f-4881-8fb5-50cbf1a5863e* | sonnet | 1 | 322 | 15.7k | 3.2M | 94.0k | 87 | 69.8k | 1h 11m |
| resolve_review* | opus | 2 | 91 | 14.0k | 2.3M | 77.4k | 79 | 89.1k | 9m 23s |
| **Total** | | | 204.9k | 151.6k | 14.9M | 94.0k | | 598.5k | 2h 27m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 522 | 5072.2 | 0.0 | 25.0 |
| fix | 3 | 292678.3 | 15517.3 | 1236.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| dispatch:322fe7f4-d63f-4881-8fb5-50cbf1a5863e | 437 | 7278.8 | 159.8 | 36.0 |
| resolve_review | 11 | 208078.8 | 8098.9 | 1268.5 |
| **Total** | **973** | 15276.5 | 615.1 | 155.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 91 | 19.3k | 1.0M | 93.2k | 9m 6s |
| opus | 5 | 467 | 99.7k | 7.4M | 435.4k | 57m 30s |
| MiniMax-M3 | 3 | 204.0k | 16.9k | 3.3M | 0 | 9m 12s |
| sonnet | 1 | 322 | 15.7k | 3.2M | 69.8k | 1h 11m |