### PR TITLE
[RECLASSIFY] run_skill codex_status to works-as-is with exhaustive session-type matrix test

### DIFF
--- a/src/autoskillit/core/types/_type_constants_registries.py
+++ b/src/autoskillit/core/types/_type_constants_registries.py
@@ -325,7 +325,7 @@ SKILL_CAPABILITY_REGISTRY: dict[str, SkillCapabilityDef] = {
     ),
     "run_skill": SkillCapabilityDef(
         description="run_skill MCP tool call (headless session dispatch)",
-        codex_status="not-applicable",
+        codex_status="works-as-is",
     ),
     "test_check": SkillCapabilityDef(
         description="test_check MCP tool (headless test runner)",

--- a/tests/arch/test_skill_capability_registry.py
+++ b/tests/arch/test_skill_capability_registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.core.types._type_constants_registries import SKILL_CAPABILITY_REGISTRY
+from autoskillit.core.types._type_enums import SessionType
 from autoskillit.workspace.skills import _read_skill_frontmatter
 from tests.arch._helpers import _iter_skill_dirs
 
@@ -88,9 +89,7 @@ def test_codex_status_consistent_with_required_backends():
     assert not violations, "\n".join(f"  {v}" for v in violations)
 
 
-# test_check removed: reclassified to works-as-is (#3781);
-# cross-layer test is the authoritative guard.
-_NOT_APPLICABLE_MCP_CAPABILITIES = {"run_skill", "open_kitchen"}
+_NOT_APPLICABLE_MCP_CAPABILITIES = {"open_kitchen"}
 
 
 def test_mcp_tools_require_claude_code():
@@ -137,46 +136,126 @@ def test_test_check_codex_status_is_works_as_is():
     )
 
 
+def test_run_skill_codex_status_is_works_as_is():
+    assert SKILL_CAPABILITY_REGISTRY["run_skill"].codex_status == "works-as-is", (
+        "run_skill must be classified as works-as-is — it is callable from "
+        "Codex ORCHESTRATOR+HEADLESS sessions via kitchen-core tag visibility"
+    )
+
+
+_CODEX_SESSION_CONTEXTS: list[tuple[str, dict[str, str]]] = [
+    (
+        "skill+headless+autogate",
+        {
+            "AUTOSKILLIT_SESSION_TYPE": "skill",
+            "AUTOSKILLIT_HEADLESS": "1",
+            "AUTOSKILLIT_HEADLESS_AUTO_GATE": "1",
+        },
+    ),
+    (
+        "orchestrator+headless",
+        {
+            "AUTOSKILLIT_SESSION_TYPE": "orchestrator",
+            "AUTOSKILLIT_HEADLESS": "1",
+        },
+    ),
+    (
+        "orchestrator+headless+tags",
+        {
+            "AUTOSKILLIT_SESSION_TYPE": "orchestrator",
+            "AUTOSKILLIT_HEADLESS": "1",
+            "AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS": "plan-review",
+        },
+    ),
+    (
+        "fleet",
+        {
+            "AUTOSKILLIT_SESSION_TYPE": "fleet",
+        },
+    ),
+]
+
+_TESTED_SESSION_TYPES = {
+    env_vars.get("AUTOSKILLIT_SESSION_TYPE", "skill") for _, env_vars in _CODEX_SESSION_CONTEXTS
+}
+
+_ALL_SESSION_TYPES = {st.value for st in SessionType}
+
+_UNTESTED_SESSION_TYPES = _ALL_SESSION_TYPES - _TESTED_SESSION_TYPES
+
+
+def test_all_session_types_covered_by_visibility_matrix():
+    assert not _UNTESTED_SESSION_TYPES, (
+        f"Session types not covered by _CODEX_SESSION_CONTEXTS: "
+        f"{sorted(_UNTESTED_SESSION_TYPES)}. Add a context entry for each."
+    )
+
+
 @pytest.mark.anyio
-async def test_codex_status_matches_tool_visibility(monkeypatch):
+@pytest.mark.parametrize(
+    "ctx_label,env_vars",
+    _CODEX_SESSION_CONTEXTS,
+    ids=[c[0] for c in _CODEX_SESSION_CONTEXTS],
+)
+async def test_codex_status_vs_visibility_matrix(ctx_label, env_vars, monkeypatch):
+    """No tag-gated tool visible in any Codex session context may be classified not-applicable.
+
+    Scoped to GATED_TOOLS | HEADLESS_TOOLS — free-range tools (UNGATED_TOOLS like
+    open_kitchen) are always visible regardless of session type, so their codex_status
+    is not meaningfully testable via tag visibility alone.
+    """
     from autoskillit.core.types._type_constants_registries import (
         GATED_TOOLS,
         HEADLESS_TOOLS,
-        UNGATED_TOOLS,
     )
     from autoskillit.server import mcp
     from autoskillit.server._session_type import _apply_session_type_visibility
 
-    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "skill")
-    monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
-    monkeypatch.setenv("AUTOSKILLIT_HEADLESS_AUTO_GATE", "1")
+    for key, val in env_vars.items():
+        monkeypatch.setenv(key, val)
+    for key in ("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", "AUTOSKILLIT_HEADLESS_AUTO_GATE"):
+        if key not in env_vars:
+            monkeypatch.delenv(key, raising=False)
 
     _apply_session_type_visibility()
     tools = await mcp.list_tools()
     tool_names = {t.name for t in tools}
 
-    assert "test_check" in tool_names, (
-        "test_check must be visible in SKILL+HEADLESS — env misconfigured?"
-    )
-
-    _skill_blocking_gated_tools = {"run_skill", "open_kitchen"}
-    mcp_tool_caps = set(SKILL_CAPABILITY_REGISTRY) & (GATED_TOOLS | HEADLESS_TOOLS | UNGATED_TOOLS)
+    tag_gated_caps = set(SKILL_CAPABILITY_REGISTRY) & (GATED_TOOLS | HEADLESS_TOOLS)
 
     violations = []
-    for cap_name in sorted(mcp_tool_caps):
+    for cap_name in sorted(tag_gated_caps):
         cap = SKILL_CAPABILITY_REGISTRY[cap_name]
-        visible = cap_name in tool_names
-        has_skill_gate = cap_name in _skill_blocking_gated_tools
-
-        if visible and not has_skill_gate and cap.codex_status == "not-applicable":
+        if cap_name in tool_names and cap.codex_status == "not-applicable":
             violations.append(
-                f"{cap_name}: visible in Codex SKILL+HEADLESS session "
-                f"but codex_status='not-applicable'"
+                f"{cap_name}: visible in {ctx_label} but codex_status='not-applicable'"
             )
 
     assert not violations, (
-        "Tools visible in Codex sessions must not be classified as not-applicable:\n"
-        + "\n".join(f"  {v}" for v in violations)
+        f"Tag-gated tools visible in Codex {ctx_label} sessions must not be "
+        f"classified as not-applicable:\n" + "\n".join(f"  {v}" for v in violations)
+    )
+
+
+@pytest.mark.anyio
+async def test_run_skill_visible_in_orchestrator_is_not_blocked(monkeypatch):
+    """run_skill is visible in ORCHESTRATOR+HEADLESS — codex_status must not be not-applicable."""
+    from autoskillit.server import mcp
+    from autoskillit.server._session_type import _apply_session_type_visibility
+
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+    monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+    monkeypatch.delenv("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", raising=False)
+
+    _apply_session_type_visibility()
+    tools = await mcp.list_tools()
+    tool_names = {t.name for t in tools}
+
+    assert "run_skill" in tool_names, "run_skill must be visible in ORCHESTRATOR+HEADLESS sessions"
+    cap = SKILL_CAPABILITY_REGISTRY["run_skill"]
+    assert cap.codex_status != "not-applicable", (
+        "run_skill is visible in Codex ORCHESTRATOR+HEADLESS sessions — "
+        "codex_status='not-applicable' is a misclassification"
     )
 
 
@@ -189,6 +268,8 @@ def test_reclassified_skills_have_empty_backend_requirements():
         "implement-experiment",
         "implement-worktree",
         "plan-experiment",
+        "planner-elaborate-assignments",
+        "select-directions",
         "setup-project",
     ]
     violations = []

--- a/tests/arch/test_skill_capability_registry.py
+++ b/tests/arch/test_skill_capability_registry.py
@@ -213,7 +213,11 @@ async def test_codex_status_vs_visibility_matrix(ctx_label, env_vars, monkeypatc
 
     for key, val in env_vars.items():
         monkeypatch.setenv(key, val)
-    for key in ("AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS", "AUTOSKILLIT_HEADLESS_AUTO_GATE"):
+    for key in (
+        "AUTOSKILLIT_FOOD_TRUCK_TOOL_TAGS",
+        "AUTOSKILLIT_HEADLESS_AUTO_GATE",
+        "AUTOSKILLIT_HEADLESS",
+    ):
         if key not in env_vars:
             monkeypatch.delenv(key, raising=False)
 

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -825,7 +825,7 @@ class TestBackendRequirements:
             "---\nname: test\nuses_capabilities: [agent_subagent, run_skill]\n---\n# content"
         )
         info = _skill_info_from_frontmatter("test", SkillSource.BUNDLED, skill_md)
-        assert info.backend_requirements == frozenset({"claude-code"})
+        assert info.backend_requirements == frozenset()
 
     def test_investigate_skill_has_no_backend_requirement(self) -> None:
         info = DefaultSkillResolver().resolve("investigate")


### PR DESCRIPTION
## Summary

The `SKILL_CAPABILITY_REGISTRY` has a manually-declared `codex_status` field on each capability entry. When `codex_status="not-applicable"`, the derived `required_backends` property returns `frozenset({"claude-code"})`, which cascades through three enforcement layers (runtime gate, skill injection filter, recipe validation) to block any skill declaring that capability from running on Codex. The `run_skill` capability is classified `not-applicable` despite being fully callable from Codex ORCHESTRATOR+HEADLESS sessions — the identical bug pattern that was fixed for `test_check` two days ago (commit `c9aac2db5`, #3804).

The architectural weakness is that `codex_status` is a free-form static declaration validated only against its own internal consistency (self-referential tests), not against actual MCP runtime visibility. The existing cross-layer test (`test_codex_status_matches_tool_visibility`) only covers SKILL+HEADLESS sessions and explicitly exempts `run_skill` via a hardcoded `_skill_blocking_gated_tools` set — so the misclassification passes CI.

The immunity plan replaces the single-session-type cross-layer test with an exhaustive parametrized matrix covering ALL Codex-relevant session types, removes the exemption set that masked the bug, and adds a structural guard ensuring new session types automatically generate test coverage.

## Requirements

The `run_skill` `codex_status="not-applicable"` Misclassification Blocks 14 Skills from Codex Backend.

**Root Cause:** `SKILL_CAPABILITY_REGISTRY["run_skill"]` has `codex_status="not-applicable"` when it should be `"works-as-is"`. This single misclassification cascades through three enforcement layers: runtime gate, skill injection filter, and recipe validation.

**Test Gap:** All existing validation tests are self-referential, checking the registry against itself rather than against runtime behavior. The cross-layer test `test_codex_status_matches_tool_visibility` only checks SKILL+HEADLESS sessions; `run_skill` operates in ORCHESTRATOR+HEADLESS.

**Affected Components:** `_type_constants_registries.py:326-329` (run_skill entry), runtime gate, skill injection filter, `_skill_info_from_frontmatter`, recipe validation, test fixture exemption sets.

**Recommendation:** Reclassify `run_skill` from `not-applicable` to `works-as-is`, and add a cross-layer ORCHESTRATOR+HEADLESS visibility validation test. This is a 1-line data change with test infrastructure updates.

**What this unblocks:** 14 skills become available under Codex.

Closes #3836

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260605-174550-118435/.autoskillit/temp/rectify/rectify_codex_status_misclassification_2026-06-05_180200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 7.6k | 20.7k | 1.9M | 122.9k | 42 | 101.0k | 21m 17s |
| review_approach* | opus[1m] | 1 | 2.8k | 5.4k | 236.4k | 55.0k | 12 | 36.0k | 4m 33s |
| dry_walkthrough* | opus | 1 | 1.6k | 6.6k | 902.6k | 72.3k | 31 | 50.1k | 4m 47s |
| implement* | opus[1m] | 1 | 55 | 8.2k | 966.4k | 63.7k | 39 | 41.5k | 4m 17s |
| audit_impl* | opus[1m] | 1 | 33 | 10.5k | 215.3k | 44.6k | 16 | 34.0k | 4m 11s |
| prepare_pr* | MiniMax-M3 | 1 | 48.7k | 1.7k | 318.1k | 51.2k | 14 | 0 | 1m 6s |
| compose_pr* | MiniMax-M3 | 1 | 37.3k | 1.5k | 192.0k | 39.7k | 11 | 0 | 1m 0s |
| review_pr* | opus[1m] | 1 | 29 | 14.9k | 547.1k | 66.8k | 32 | 46.2k | 4m 15s |
| resolve_review* | opus[1m] | 1 | 41 | 4.7k | 813.3k | 65.6k | 28 | 44.3k | 7m 8s |
| **Total** | | | 98.2k | 74.3k | 6.1M | 122.9k | | 353.2k | 52m 37s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 131 | 7377.2 | 317.2 | 62.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 135544.5 | 7385.8 | 783.5 |
| **Total** | **137** | 44356.2 | 2578.0 | 542.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 10.6k | 64.5k | 4.7M | 303.1k | 45m 43s |
| opus | 1 | 1.6k | 6.6k | 902.6k | 50.1k | 4m 47s |
| MiniMax-M3 | 2 | 86.0k | 3.2k | 510.1k | 0 | 2m 6s |