### PR TITLE
Rectify: Fabricated Skill Name Acceptance and Recipe Routing Divergence

### DIFF
--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -49,6 +49,7 @@ from autoskillit.recipe._recipe_composition import (
     _resolve_hidden_inputs_in_content,
     _resolve_skip_guards_in_content,
     _validate_no_dangling_routes,
+    _validate_route_consistency,
 )
 from autoskillit.recipe._recipe_ingredients import (
     DeferredGuard,
@@ -413,6 +414,14 @@ def load_and_validate(
             _dangling_errors = _validate_no_dangling_routes(active_recipe)
             if _dangling_errors:
                 errors.extend(f"[post-prune] dangling route: {e}" for e in _dangling_errors)
+                raw = ""
+            # Cross-check: raw YAML route refs must match the Python model exactly.
+            # Catches any refs that the model repaired but the YAML repair pass missed.
+            _route_consistency_errors = _validate_route_consistency(raw, active_recipe)
+            if _route_consistency_errors:
+                errors.extend(
+                    f"[post-prune] route consistency: {e}" for e in _route_consistency_errors
+                )
                 raw = ""
             t0 = _t("prune_skipped_steps", t0, name)
 

--- a/src/autoskillit/recipe/_recipe_composition.py
+++ b/src/autoskillit/recipe/_recipe_composition.py
@@ -71,6 +71,34 @@ def _validate_no_dangling_routes(recipe: Recipe) -> list[str]:
     return errors
 
 
+def _validate_route_consistency(raw: str, recipe: Recipe) -> list[str]:
+    """Return error strings for route targets in raw YAML that are absent from the Python model.
+
+    Cross-checks the two parallel representations (Python model and raw YAML string) after
+    all pruning and content mutations. Catches any step names that were repaired in the model
+    but missed by the raw-YAML repair pass.
+    """
+    raw_targets: set[str] = set()
+    for match in re.finditer(
+        r"(?m)^[ \t]+(?:on_success|on_failure|on_context_limit|on_rate_limit|on_exhausted)"
+        r":[ \t]+(\S+)",
+        raw,
+    ):
+        raw_targets.add(match.group(1))
+    for match in re.finditer(r"(?m)^[ \t]+route:[ \t]+(\S+)", raw):
+        raw_targets.add(match.group(1))
+
+    model_targets: set[str] = set()
+    for step in recipe.steps.values():
+        model_targets.update(_collect_all_route_targets(step))
+
+    errors: list[str] = []
+    raw_only = raw_targets - model_targets - _TERMINAL_TARGETS
+    for target in sorted(raw_only):
+        errors.append(f"Raw YAML references step '{target}' which is not in the Python model")
+    return errors
+
+
 FALSY_STRINGS: frozenset[str] = frozenset({"false", "0", "no", ""})
 
 
@@ -417,7 +445,41 @@ def _resolve_skip_guards_in_content(
                 )
             continue
         if not is_truthy:
+            # Derive redirect target using the same logic as _prune_skipped_steps
+            if step.on_success is not None:
+                redirect = step.on_success
+            elif step.on_result is not None and step.on_result.conditions:
+                redirect = next(
+                    (c.route for c in step.on_result.conditions if c.when is None), None
+                )
+            else:
+                redirect = None
+
+            # Strip the pruned step's YAML block
             raw = _strip_step_block(raw, step_name)
+
+            # Repair route refs in surviving steps' raw YAML
+            if redirect is not None:
+                route_fields = (
+                    "on_success",
+                    "on_failure",
+                    "on_context_limit",
+                    "on_rate_limit",
+                    "on_exhausted",
+                )
+                for field in route_fields:
+                    raw = re.sub(
+                        rf"(?m)^([ \t]+{re.escape(field)}:[ \t]+){re.escape(step_name)}"
+                        rf"([ \t]*(?:#.*)?)$",
+                        rf"\g<1>{redirect}\g<2>",
+                        raw,
+                    )
+                # Handle on_result conditions (route: step_name)
+                raw = re.sub(
+                    rf"(?m)^([ \t]+route:[ \t]+){re.escape(step_name)}([ \t]*(?:#.*)?)$",
+                    rf"\g<1>{redirect}\g<2>",
+                    raw,
+                )
             continue
         raw = re.sub(
             rf"(?m)({_step_block_pattern(re.escape(step_name))})",

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -652,6 +652,16 @@ async def run_skill(
                 if tool_ctx.skill_resolver and target_name
                 else None
             )
+            if target_name and _skill_info is None:
+                return SkillResult.crashed(
+                    exception=RuntimeError(
+                        f"Skill '{target_name}' not found in any discovery source "
+                        f"(bundled skills/, skills_extended/, or project-local). "
+                        f"Cannot launch session for undiscoverable skill name."
+                    ),
+                    skill_command=resolved_command,
+                    order_id=effective_order_id,
+                ).to_json()
 
             _provider_override = (
                 provider_extras
@@ -798,6 +808,15 @@ async def run_skill(
                 closure: frozenset[str] = frozenset()
                 if target_name:
                     closure = tool_ctx.session_skill_manager.compute_skill_closure(target_name)
+                    if not closure and target_name:
+                        return SkillResult.crashed(
+                            exception=RuntimeError(
+                                f"Skill '{target_name}' resolved to an empty closure. "
+                                f"This indicates the skill exists but has no injectable content."
+                            ),
+                            skill_command=resolved_command,
+                            order_id=effective_order_id,
+                        ).to_json()
                     allow_only = closure if closure else None
 
                 session_id = f"headless-{uuid4().hex[:12]}"
@@ -846,6 +865,23 @@ async def run_skill(
                                 session_id=session_id,
                                 order_id=effective_order_id,
                             ).to_json()
+                    else:
+                        # Defense-in-depth: should be unreachable after the pre-init
+                        # existence gate (3a), but if reached, reject rather than proceed.
+                        logger.error(
+                            "unknown_skill_reached_init",
+                            target=target_name,
+                            session_id=session_id,
+                        )
+                        return SkillResult.crashed(
+                            exception=RuntimeError(
+                                f"Skill '{target_name}' unknown to resolver after session init. "
+                                f"This should have been caught by the pre-init existence gate."
+                            ),
+                            skill_command=resolved_command,
+                            session_id=session_id,
+                            order_id=effective_order_id,
+                        ).to_json()
                     # Replay-path sessions inherit write scope from their original
                     # snapshot — they don't need re-augmentation because the snapshot
                     # was built from a live session that already had the full prefix set.

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -808,7 +808,7 @@ async def run_skill(
                 closure: frozenset[str] = frozenset()
                 if target_name:
                     closure = tool_ctx.session_skill_manager.compute_skill_closure(target_name)
-                    if not closure and target_name:
+                    if not closure:
                         return SkillResult.crashed(
                             exception=RuntimeError(
                                 f"Skill '{target_name}' resolved to an empty closure. "
@@ -817,7 +817,7 @@ async def run_skill(
                             skill_command=resolved_command,
                             order_id=effective_order_id,
                         ).to_json()
-                    allow_only = closure if closure else None
+                    allow_only = closure
 
                 session_id = f"headless-{uuid4().hex[:12]}"
                 _cleanup_session_id = session_id

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -833,6 +833,10 @@ every step at full fidelity regardless of session length.
 - Your ONLY authority for routing decisions is the recipe's declared routing
   fields (on_result, on_success, on_failure, on_exhausted, on_context_limit).
   No other source may override them.
+- If routing references a step name that has no definition in the loaded recipe
+  YAML, halt with `success=false` and `reason=undefined_step`. Do NOT fabricate
+  a skill command from the step name. Do NOT infer what the step might do from
+  its name.
 
 ---
 

--- a/tests/arch/test_pyright_suppression_allowlist.py
+++ b/tests/arch/test_pyright_suppression_allowlist.py
@@ -23,6 +23,7 @@ PRODUCTION_ALLOWLIST: dict[tuple[str, int], str] = {
         245,
     ): "lazy-registry: method added by _register_rule_module() side effects",
     ("recipe/_api.py", 273): "global-mutated variable set by _finalize_registry()",
+    ("recipe/_api.py", 274): "lazy-registry: RULE_REGISTRY_HASH set by _finalize_registry()",
 }
 
 TEST_ALLOWLIST: dict[tuple[str, int], str] = {

--- a/tests/arch/test_pyright_suppression_allowlist.py
+++ b/tests/arch/test_pyright_suppression_allowlist.py
@@ -22,7 +22,6 @@ PRODUCTION_ALLOWLIST: dict[tuple[str, int], str] = {
         "recipe/__init__.py",
         245,
     ): "lazy-registry: method added by _register_rule_module() side effects",
-    ("recipe/_api.py", 273): "global-mutated variable set by _finalize_registry()",
     ("recipe/_api.py", 274): "lazy-registry: RULE_REGISTRY_HASH set by _finalize_registry()",
 }
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -965,10 +965,10 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "for ingredient key validation; splitting would cross import-layer boundaries",
     ),
     "tools_execution.py": (
-        1020,
+        1060,
         "REQ-CNST-010-E8: execution tool handlers — run_cmd/run_python/run_skill are the "
-        "three primary execution paths; auto-promotion of work_dir from args and tier-gate "
-        "enforcement add required branching that pushes the module over the 1000-line limit",
+        "three primary execution paths; fail-closed existence gate and empty-closure gate "
+        "for fabricated skill name rejection add defense-in-depth checks",
     ),
     "execution/backends/codex.py": (
         1030,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -436,21 +436,18 @@ def tool_ctx_kitchen_open(tool_ctx):
     the test is not testing gate-boot behavior itself. This fixture
     mirrors the post-lifespan-boot state for interactive sessions.
 
-    Installs a permissive skill_resolver so tests using dummy skill names
-    (e.g. "/test skill") pass the existence gate. Tests that verify
-    rejection behavior must override skill_resolver with their own mock.
-    """
-    from unittest.mock import MagicMock
+    Sets skill_resolver=None so run_skill skips all skill-name resolution
+    gates (existence gate, empty-closure gate, _is_known_skill check).
+    target_name stays None and the session runs unrestricted — matching
+    pre-gate behavior for tests that don't exercise skill resolution.
 
+    Tests that verify rejection behavior or specific skill resolution
+    must explicitly set tool_ctx.skill_resolver to their own mock.
+    """
     from autoskillit.pipeline.gate import DefaultGateState
 
     tool_ctx.gate = DefaultGateState(enabled=True)
-
-    permissive_resolver = MagicMock()
-    permissive_resolver.resolve.return_value = MagicMock(
-        source=MagicMock(value="bundled_extended"), backend_requirements=frozenset()
-    )
-    tool_ctx.skill_resolver = permissive_resolver
+    tool_ctx.skill_resolver = None
     return tool_ctx
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -435,10 +435,22 @@ def tool_ctx_kitchen_open(tool_ctx):
     Use when the test requires a tool that calls _require_enabled() and
     the test is not testing gate-boot behavior itself. This fixture
     mirrors the post-lifespan-boot state for interactive sessions.
+
+    Installs a permissive skill_resolver so tests using dummy skill names
+    (e.g. "/test skill") pass the existence gate. Tests that verify
+    rejection behavior must override skill_resolver with their own mock.
     """
+    from unittest.mock import MagicMock
+
     from autoskillit.pipeline.gate import DefaultGateState
 
     tool_ctx.gate = DefaultGateState(enabled=True)
+
+    permissive_resolver = MagicMock()
+    permissive_resolver.resolve.return_value = MagicMock(
+        source=MagicMock(value="bundled_extended"), backend_requirements=frozenset()
+    )
+    tool_ctx.skill_resolver = permissive_resolver
     return tool_ctx
 
 

--- a/tests/recipe/test_hidden_ingredients.py
+++ b/tests/recipe/test_hidden_ingredients.py
@@ -493,6 +493,121 @@ def test_prune_on_result_only_step_repairs_upstream_routes() -> None:
                 assert cond.route != "skippable"
 
 
+def test_resolve_skip_guards_repairs_route_refs_in_raw_yaml(tmp_path: Path) -> None:
+    """After pruning a step, surviving steps' route refs to it are updated in raw YAML."""
+    from autoskillit.recipe import load_and_validate
+
+    recipe_dir = tmp_path / ".autoskillit" / "recipes"
+    recipe_dir.mkdir(parents=True)
+    yaml_text = """\
+name: test-route-repair
+description: Test route repair in raw YAML
+recipe_version: "0.0.1"
+kitchen_rules:
+  - no native tools
+ingredients:
+  enable_optional:
+    description: Enable optional step
+    default: "false"
+    hidden: true
+steps:
+  start:
+    tool: run_cmd
+    with:
+      cmd: echo start
+    on_success: optional_step
+  optional_step:
+    tool: run_skill
+    optional: true
+    skip_when_false: inputs.enable_optional
+    with:
+      skill_command: /autoskillit:check /tmp/x.md
+      cwd: /tmp
+    on_success: done
+    on_failure: done
+  done:
+    action: stop
+    message: done
+"""
+    (recipe_dir / "test-route-repair.yaml").write_text(yaml_text)
+
+    result = load_and_validate(
+        "test-route-repair",
+        project_dir=tmp_path,
+        ingredient_overrides={"enable_optional": "false"},
+    )
+    content = result["content"]
+    # Pruned step block should be gone
+    assert "  optional_step:" not in content
+    # Surviving step must NOT reference the pruned step name in a route field
+    assert "on_success: optional_step" not in content
+    # Route should be redirected to the pruned step's own on_success ("done")
+    assert "on_success: done" in content
+
+
+def test_model_content_route_consistency_after_pruning(tmp_path: Path) -> None:
+    """After pruning, raw YAML route references match the Python model (no stale targets)."""
+    import re as stdlib_re
+
+    from autoskillit.recipe import load_and_validate
+
+    recipe_dir = tmp_path / ".autoskillit" / "recipes"
+    recipe_dir.mkdir(parents=True)
+    yaml_text = """\
+name: test-consistency
+description: Test model/content consistency
+recipe_version: "0.0.1"
+kitchen_rules:
+  - no native tools
+ingredients:
+  enable_optional:
+    description: Enable optional step
+    default: "false"
+    hidden: true
+steps:
+  start:
+    tool: run_cmd
+    with:
+      cmd: echo start
+    on_success: optional_step
+  optional_step:
+    tool: run_skill
+    optional: true
+    skip_when_false: inputs.enable_optional
+    with:
+      skill_command: /autoskillit:check /tmp/x.md
+      cwd: /tmp
+    on_success: done
+    on_failure: done
+  done:
+    action: stop
+    message: done
+"""
+    (recipe_dir / "test-consistency.yaml").write_text(yaml_text)
+
+    result = load_and_validate(
+        "test-consistency",
+        project_dir=tmp_path,
+        ingredient_overrides={"enable_optional": "false"},
+    )
+    # Content must not be blanked by a consistency error
+    assert result["content"]
+    content = result["content"]
+    # Extract all route targets referenced in the raw YAML
+    route_field_re = (
+        r"(?m)^[ \t]+"
+        r"(?:on_success|on_failure|on_context_limit|on_rate_limit|on_exhausted)"
+        r":[ \t]+(\S+)"
+    )
+    raw_targets: set[str] = set()
+    for m in stdlib_re.finditer(route_field_re, content):
+        raw_targets.add(m.group(1))
+    for m in stdlib_re.finditer(r"(?m)^[ \t]+route:[ \t]+(\S+)", content):
+        raw_targets.add(m.group(1))
+    # Pruned step must not appear as any route target in the raw YAML
+    assert "optional_step" not in raw_targets
+
+
 def test_prune_repairs_upstream_on_result_pointing_to_pruned_step() -> None:
     """_prune_skipped_steps repairs on_result.conditions routes on upstream steps."""
     from autoskillit.recipe._recipe_composition import _prune_skipped_steps

--- a/tests/server/test_lifespan_fleet_boot.py
+++ b/tests/server/test_lifespan_fleet_boot.py
@@ -487,11 +487,7 @@ class TestFoodTruckAutoGateBoot:
         tool_ctx.gate = DefaultGateState(enabled=False)
         tool_ctx.executor = InMemoryHeadlessExecutor()
         tool_ctx.quota_refresh_task = None
-        permissive_resolver = MagicMock()
-        permissive_resolver.resolve.return_value = MagicMock(
-            source=MagicMock(value="bundled_extended"), backend_requirements=frozenset()
-        )
-        tool_ctx.skill_resolver = permissive_resolver
+        tool_ctx.skill_resolver = None
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
         monkeypatch.setenv(FOOD_TRUCK_TOOL_TAGS_ENV_VAR, "kitchen-core")

--- a/tests/server/test_lifespan_fleet_boot.py
+++ b/tests/server/test_lifespan_fleet_boot.py
@@ -487,6 +487,11 @@ class TestFoodTruckAutoGateBoot:
         tool_ctx.gate = DefaultGateState(enabled=False)
         tool_ctx.executor = InMemoryHeadlessExecutor()
         tool_ctx.quota_refresh_task = None
+        permissive_resolver = MagicMock()
+        permissive_resolver.resolve.return_value = MagicMock(
+            source=MagicMock(value="bundled_extended"), backend_requirements=frozenset()
+        )
+        tool_ctx.skill_resolver = permissive_resolver
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
         monkeypatch.setenv(FOOD_TRUCK_TOOL_TAGS_ENV_VAR, "kitchen-core")

--- a/tests/server/test_tools_execution_backend_mixing.py
+++ b/tests/server/test_tools_execution_backend_mixing.py
@@ -217,7 +217,9 @@ async def test_backend_override_emits_structured_log_provider_profile(
     tool_ctx_kitchen_open.session_skill_manager = None
 
     mock_resolver = MagicMock()
-    mock_resolver.resolve.return_value = None
+    mock_resolver.resolve.return_value = MagicMock(
+        source=MagicMock(value="bundled_extended"), backend_requirements=frozenset()
+    )
     tool_ctx_kitchen_open.skill_resolver = mock_resolver
 
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -627,6 +627,7 @@ async def test_run_skill_is_known_skill_else_branch_rejects_unknown_after_init(
     assert result.get("subtype") == "crashed"
     assert not result.get("success", True)
     mock_ssm.init_session.assert_called_once()
+    assert mock_resolver.resolve.call_count == 3
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -516,10 +516,12 @@ async def test_run_skill_cleans_up_on_skill_md_not_found(
     mock_ssm.init_session.return_value = ValidatedAddDir(path=str(tmp_path))
     mock_ssm.compute_skill_closure.return_value = frozenset({"target-skill"})
     mock_ssm.cleanup_session.side_effect = lambda sid: cleanup_calls.append(sid) or True
-    # Return None from resolver so resolve_target_skill returns (cmd, name)
-    # without accessing .source on the info object
+    # Return a valid skill_info so the pre-init existence gate passes; the test
+    # exercises the SKILL.md-not-found crash path after init_session succeeds.
     mock_resolver = MagicMock()
-    mock_resolver.resolve.return_value = None
+    mock_resolver.resolve.return_value = MagicMock(
+        source=MagicMock(value="bundled"), backend_requirements=frozenset()
+    )
     tool_ctx_kitchen_open.session_skill_manager = mock_ssm
     tool_ctx_kitchen_open.skill_resolver = mock_resolver
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
@@ -528,6 +530,99 @@ async def test_run_skill_cleans_up_on_skill_md_not_found(
 
     assert len(cleanup_calls) == 1
     assert not result.get("success", True)
+
+
+@pytest.mark.anyio
+async def test_run_skill_rejects_fabricated_skill_name(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+) -> None:
+    """run_skill crashes before session creation for a skill not in any discovery source."""
+    import json
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import ValidatedAddDir
+
+    mock_ssm = MagicMock()
+    mock_ssm.init_session.return_value = ValidatedAddDir(path=str(tmp_path))
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+
+    mock_resolver = MagicMock()
+    mock_resolver.resolve.return_value = None  # Skill not in any source
+    tool_ctx_kitchen_open.skill_resolver = mock_resolver
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    result = json.loads(await run_skill("/autoskillit:this-skill-does-not-exist", str(tmp_path)))
+
+    assert result.get("subtype") == "crashed"
+    assert not result.get("success", True)
+    mock_ssm.init_session.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_run_skill_empty_closure_not_expanded_to_unrestricted(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+) -> None:
+    """An empty frozenset from compute_skill_closure is rejected, not expanded to allow_only=None.
+
+    Before the fix, the empty frozenset collapsed to None (unrestricted); after the fix,
+    run_skill returns a crash result and init_session is never called.
+    """
+    import json
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import ValidatedAddDir
+
+    mock_ssm = MagicMock()
+    mock_ssm.init_session.return_value = ValidatedAddDir(path=str(tmp_path))
+    mock_ssm.compute_skill_closure.return_value = frozenset()  # Empty — simulates unknown skill
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+
+    mock_resolver = MagicMock()
+    mock_resolver.resolve.return_value = MagicMock(
+        source=MagicMock(value="bundled_extended"), backend_requirements=frozenset()
+    )
+    tool_ctx_kitchen_open.skill_resolver = mock_resolver
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    result = json.loads(await run_skill("/autoskillit:some-skill", str(tmp_path)))
+
+    assert result.get("subtype") == "crashed"
+    assert not result.get("success", True)
+    mock_ssm.init_session.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_run_skill_is_known_skill_else_branch_rejects_unknown_after_init(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+) -> None:
+    """Defense-in-depth: resolver returning None after init crashes, not silently proceeds."""
+    import json
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import ValidatedAddDir
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    mock_ssm = MagicMock()
+    mock_ssm.init_session.return_value = ValidatedAddDir(path=str(tmp_path))
+    mock_ssm.compute_skill_closure.return_value = frozenset({"some-skill"})
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+
+    # First call returns non-None (passes the pre-init existence gate 3a),
+    # second call returns None (simulates resolver cache invalidation after init).
+    mock_resolver = MagicMock()
+    mock_resolver.resolve.side_effect = [
+        MagicMock(source=MagicMock(value="bundled"), backend_requirements=frozenset()),
+        None,
+    ]
+    tool_ctx_kitchen_open.skill_resolver = mock_resolver
+    tool_ctx_kitchen_open.executor = InMemoryHeadlessExecutor()
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    result = json.loads(await run_skill("/autoskillit:some-skill", str(tmp_path)))
+
+    assert result.get("subtype") == "crashed"
+    assert not result.get("success", True)
+    mock_ssm.init_session.assert_called_once()
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -607,11 +607,15 @@ async def test_run_skill_is_known_skill_else_branch_rejects_unknown_after_init(
     mock_ssm.compute_skill_closure.return_value = frozenset({"some-skill"})
     tool_ctx_kitchen_open.session_skill_manager = mock_ssm
 
-    # First call returns non-None (passes the pre-init existence gate 3a),
-    # second call returns None (simulates resolver cache invalidation after init).
+    # Call 1 (resolve_target_skill): returns valid info for namespace resolution.
+    # Call 2 (_skill_info gate 3a): returns valid info to pass existence gate.
+    # Call 3 (_is_known_skill after init): returns None — simulates resolver
+    # cache invalidation between pre-init and post-init checks.
+    _valid_info = MagicMock(source=MagicMock(value="bundled"), backend_requirements=frozenset())
     mock_resolver = MagicMock()
     mock_resolver.resolve.side_effect = [
-        MagicMock(source=MagicMock(value="bundled"), backend_requirements=frozenset()),
+        _valid_info,
+        _valid_info,
         None,
     ]
     tool_ctx_kitchen_open.skill_resolver = mock_resolver

--- a/tests/server/test_tools_status_kitchen.py
+++ b/tests/server/test_tools_status_kitchen.py
@@ -182,14 +182,8 @@ class TestGetPipelineReport:
 
     @pytest.mark.anyio
     async def test_accumulates_failures_from_run_skill(self, tool_ctx):
-        from unittest.mock import MagicMock
-
         tool_ctx.gate = DefaultGateState(enabled=True)
-        permissive_resolver = MagicMock()
-        permissive_resolver.resolve.return_value = MagicMock(
-            source=MagicMock(value="bundled"), backend_requirements=frozenset()
-        )
-        tool_ctx.skill_resolver = permissive_resolver
+        tool_ctx.skill_resolver = None
         tool_ctx.runner.push(
             _make_result(
                 returncode=1,

--- a/tests/server/test_tools_status_kitchen.py
+++ b/tests/server/test_tools_status_kitchen.py
@@ -182,8 +182,14 @@ class TestGetPipelineReport:
 
     @pytest.mark.anyio
     async def test_accumulates_failures_from_run_skill(self, tool_ctx):
+        from unittest.mock import MagicMock
 
         tool_ctx.gate = DefaultGateState(enabled=True)
+        permissive_resolver = MagicMock()
+        permissive_resolver.resolve.return_value = MagicMock(
+            source=MagicMock(value="bundled"), backend_requirements=frozenset()
+        )
+        tool_ctx.skill_resolver = permissive_resolver
         tool_ctx.runner.push(
             _make_result(
                 returncode=1,


### PR DESCRIPTION
## Summary

Two independent but compounding architectural weaknesses allow fabricated/nonexistent skill names to silently pass every server-side gate and launch unrestricted headless sessions:

1. **Fail-open skill resolution**: `compute_skill_closure()` returns `frozenset()` for unknown skills. The caller in `run_skill` converts this empty frozenset to `allow_only=None` via `closure if closure else None`, which means "inject all skills." The `_is_known_skill` post-init check only validates when the skill IS known, skipping the rejection path entirely for unknown skills.

2. **Model/content divergence in recipe pruning**: `_prune_skipped_steps()` correctly repairs routing references in the Python `Recipe` model but `_resolve_skip_guards_in_content()` only strips the pruned step's YAML block — it does NOT update routing references (`on_success:`, `on_failure:`, etc.) in surviving steps' raw YAML. The LLM sees stale route targets pointing to nonexistent steps, which can trigger skill-name fabrication.

The immunity plan addresses the structural class: **identifier resolution gates that fail-open instead of fail-closed**, and **dual-representation mutations that lack post-hoc consistency verification**.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260606-090928-899852/.autoskillit/temp/rectify/rectify_fabricated_skill_names_2026-06-06_091500.md`

Closes #3841

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 62 | 20.9k | 2.3M | 118.9k | 57 | 121.2k | 23m 34s |
| review_approach* | sonnet | 1 | 2.8k | 6.9k | 234.6k | 47.9k | 17 | 52.3k | 8m 5s |
| dry_walkthrough* | opus | 1 | 52 | 13.4k | 872.9k | 74.7k | 31 | 74.9k | 8m 34s |
| implement* | sonnet | 1 | 436 | 43.6k | 4.6M | 123.1k | 140 | 123.0k | 14m 29s |
| audit_impl* | sonnet | 1 | 952 | 16.6k | 883.9k | 68.0k | 43 | 50.3k | 6m 43s |
| prepare_pr* | MiniMax-M3 | 1 | 46.8k | 2.2k | 164.4k | 48.2k | 12 | 0 | 1m 0s |
| compose_pr* | MiniMax-M3 | 1 | 35.7k | 2.5k | 191.4k | 39.7k | 13 | 0 | 1m 9s |
| review_pr* | sonnet | 1 | 196 | 42.4k | 1.7M | 103.0k | 59 | 82.0k | 11m 1s |
| resolve_review* | opus | 1 | 39 | 15.0k | 1.5M | 89.5k | 38 | 67.5k | 9m 57s |
| **Total** | | | 87.1k | 163.5k | 12.4M | 123.1k | | 571.3k | 1h 24m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 327 | 14181.3 | 376.2 | 133.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 5 | 298937.2 | 13498.8 | 2994.6 |
| **Total** | **332** | 37372.5 | 1720.8 | 492.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 62 | 20.9k | 2.3M | 121.2k | 23m 34s |
| sonnet | 4 | 4.4k | 109.6k | 7.4M | 307.7k | 40m 19s |
| opus | 2 | 91 | 28.3k | 2.4M | 142.4k | 18m 32s |
| MiniMax-M3 | 2 | 82.6k | 4.7k | 355.9k | 0 | 2m 9s |