### PR TITLE
Rectify: Verdict Graceful Degradation Immunity

### DIFF
--- a/src/autoskillit/hooks/guards/skill_cmd_guard.py
+++ b/src/autoskillit/hooks/guards/skill_cmd_guard.py
@@ -48,6 +48,17 @@ PATH_ARG_SKILLS: frozenset[str] = frozenset(
     }
 )
 
+# Skills that take git branch names as positional arguments.
+# When these skills receive a path-like first argument (starts with '/'),
+# the invocation is malformed — branch names cannot start with '/'.
+# This set must match exactly the skills whose SKILL.md files document
+# branch-name argument parsing (verified by TestBranchArgSkillsContract).
+BRANCH_ARG_SKILLS: frozenset[str] = frozenset(
+    {
+        "review-pr",
+    }
+)
+
 # Token prefixes that unambiguously identify a filesystem path argument.
 _PATH_PREFIXES: tuple[str, ...] = ("/", "./", ".autoskillit/")
 
@@ -101,7 +112,17 @@ def main() -> None:
         sys.exit(0)
 
     skill_name = m.group(1)
-    if skill_name not in PATH_ARG_SKILLS:
+    if skill_name not in PATH_ARG_SKILLS and skill_name not in BRANCH_ARG_SKILLS:
+        sys.exit(0)
+
+    if skill_name in BRANCH_ARG_SKILLS:
+        args_str = skill_command[m.end() :].strip()
+        if args_str and args_str.split()[0].startswith("/"):
+            _deny(
+                f"{SKILL_CMD_DENY_TRIGGER} '{skill_name}': "
+                f"first argument looks like a filesystem path but '{skill_name}' "
+                f"expects a git branch name. Branch names cannot start with '/'."
+            )
         sys.exit(0)
 
     args_str = skill_command[m.end() :].strip()

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -171,6 +171,9 @@ from autoskillit.recipe.rules import (  # noqa: E402
 )
 from autoskillit.recipe.rules import rules_tools as _rules_tools  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_verdict as _rules_verdict  # noqa: E402 F401
+from autoskillit.recipe.rules import (
+    rules_verdict_degradation as _rules_verdict_degradation,  # noqa: E402 F401
+)
 from autoskillit.recipe.rules import rules_worktree as _rules_worktree  # noqa: E402 F401
 from autoskillit.recipe.rules.campaign import (  # noqa: E402
     rules_campaign_capture as _rules_campaign_capture,  # noqa: F401

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -1,6 +1,6 @@
 # rules/
 
-Semantic validation rule modules for recipe analysis (45 flat rule files + 4 subdirectories).
+Semantic validation rule modules for recipe analysis (46 flat rule files + 4 subdirectories).
 
 ## Subdirectories
 
@@ -61,6 +61,7 @@ See each subdirectory's CLAUDE.md for details.
 | `rules_terminal_convergence.py` | Success-stop reason uniqueness; detects convergent success paths with shared reasons |
 | `rules_tools.py` | MCP tool name validity (must be in known tool sets) |
 | `rules_verdict.py` | Skill verdict routing completeness and cross-step consistency |
+| `rules_verdict_degradation.py` | verdict-ungated-degradation: errors when degradation path emits a verdict used by nominal success path |
 | `rules_worktree.py` | Worktree and retry validation rules |
 
 ## Architecture Notes

--- a/src/autoskillit/recipe/rules/rules_verdict_degradation.py
+++ b/src/autoskillit/recipe/rules/rules_verdict_degradation.py
@@ -1,0 +1,134 @@
+"""Semantic rule: verdict-ungated-degradation.
+
+Detects skill SKILL.md files where the graceful-degradation path emits the
+same verdict as the nominal (work-performed) path.  A zero-validation run
+becomes indistinguishable from a real review, allowing it to advance the
+pipeline to CI/merge.
+"""
+
+from __future__ import annotations
+
+import regex as re
+
+from autoskillit.core import Severity, get_logger
+from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._skill_helpers import (
+    _resolve_skill_md,
+    get_allowed_values_for_skill,
+)
+from autoskillit.recipe.contracts import resolve_skill_name
+from autoskillit.recipe.registry import RuleFinding, semantic_rule
+
+logger = get_logger(__name__)
+
+# Patterns that identify a graceful-degradation trigger line in SKILL.md.
+_DEGRADATION_TRIGGER_RE = re.compile(r"unavailable|graceful.{0,20}degrada", re.IGNORECASE)
+
+# Matches a verdict emit instruction: `verdict=X` or `verdict = X` or `Output verdict=X`.
+_VERDICT_EMIT_RE = re.compile(r"\bverdict\s*=\s*(\w+)")
+
+
+def _find_degradation_verdict(content: str) -> str | None:
+    """Return the verdict emitted on the graceful-degradation path, or None."""
+    lines = content.splitlines()
+    for i, line in enumerate(lines):
+        if _DEGRADATION_TRIGGER_RE.search(line):
+            # Search within 15 lines after the trigger for a verdict= emit.
+            window = "\n".join(lines[i : i + 15])
+            m = _VERDICT_EMIT_RE.search(window)
+            if m:
+                return m.group(1)
+    return None
+
+
+def _find_nominal_verdicts(content: str) -> set[str]:
+    """Return verdict values emitted outside the degradation block.
+
+    Excludes lines within 15 lines of any degradation trigger so that the
+    nominal path check is independent of what the degradation path emits.
+    """
+    lines = content.splitlines()
+    excluded: set[int] = set()
+    for i, line in enumerate(lines):
+        if _DEGRADATION_TRIGGER_RE.search(line):
+            for j in range(i, min(len(lines), i + 15)):
+                excluded.add(j)
+
+    nominal_content = "\n".join(line for i, line in enumerate(lines) if i not in excluded)
+    return set(_VERDICT_EMIT_RE.findall(nominal_content))
+
+
+@semantic_rule(
+    name="verdict-ungated-degradation",
+    description=(
+        "Verdict-emitting skills with graceful-degradation paths must not "
+        "emit a verdict that is semantically indistinguishable from the "
+        "nominal success verdict"
+    ),
+    severity=Severity.ERROR,
+)
+def _check_verdict_ungated_degradation(ctx: ValidationContext) -> list[RuleFinding]:
+    """Fire when a skill's degradation path emits the same verdict as the nominal path.
+
+    This makes zero-validation exits structurally distinguishable from real reviews
+    at the SKILL.md instruction level.  Any future regression back to a shared
+    verdict is caught at ``task test-all`` time.
+    """
+    findings: list[RuleFinding] = []
+
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+
+        skill_cmd = step.with_args.get("skill_command", "")
+        name = resolve_skill_name(skill_cmd)
+        if not name:
+            continue
+
+        # Only analyse skills that declare a verdict output with allowed_values.
+        allowed_by_output = get_allowed_values_for_skill(name)
+        verdict_allowed = allowed_by_output.get("verdict")
+        if not verdict_allowed:
+            continue
+
+        # Locate and read the SKILL.md.
+        skill_md_path = _resolve_skill_md(name)
+        if skill_md_path is None:
+            continue
+        try:
+            skill_md_content = skill_md_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            logger.warning(
+                "could not read %s; skipping verdict-ungated-degradation check",
+                skill_md_path,
+            )
+            continue
+
+        # Check that a degradation trigger phrase is present.
+        if not _DEGRADATION_TRIGGER_RE.search(skill_md_content):
+            continue
+
+        degradation_verdict = _find_degradation_verdict(skill_md_content)
+        if degradation_verdict is None:
+            continue
+
+        nominal_verdicts = _find_nominal_verdicts(skill_md_content)
+
+        # The bug: the degradation verdict is ALSO used on the nominal path.
+        if degradation_verdict in nominal_verdicts and degradation_verdict in verdict_allowed:
+            findings.append(
+                RuleFinding(
+                    rule="verdict-ungated-degradation",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"Skill '{name}' emits verdict='{degradation_verdict}' on its "
+                        f"graceful-degradation path but '{degradation_verdict}' is also "
+                        f"used by the nominal (work-performed) path.  A zero-validation "
+                        f"run is indistinguishable from a real review.  Use a distinct "
+                        f"verdict (e.g., 'needs_human') for degradation paths."
+                    ),
+                )
+            )
+
+    return findings

--- a/src/autoskillit/recipe/rules/rules_verdict_degradation.py
+++ b/src/autoskillit/recipe/rules/rules_verdict_degradation.py
@@ -87,12 +87,7 @@ def _find_nominal_verdicts(content: str) -> set[str]:
     severity=Severity.ERROR,
 )
 def _check_verdict_ungated_degradation(ctx: ValidationContext) -> list[RuleFinding]:
-    """Fire when a skill's degradation path emits the same verdict as the nominal path.
-
-    This makes zero-validation exits structurally distinguishable from real reviews
-    at the SKILL.md instruction level.  Any future regression back to a shared
-    verdict is caught at ``task test-all`` time.
-    """
+    """Scan recipe steps for skills whose SKILL.md shares a verdict across both paths."""
     findings: list[RuleFinding] = []
 
     for step_name, step in ctx.recipe.steps.items():

--- a/src/autoskillit/recipe/rules/rules_verdict_degradation.py
+++ b/src/autoskillit/recipe/rules/rules_verdict_degradation.py
@@ -27,31 +27,50 @@ _DEGRADATION_TRIGGER_RE = re.compile(r"unavailable|graceful.{0,20}degrada", re.I
 # Matches a verdict emit instruction: `verdict=X` or `verdict = X` or `Output verdict=X`.
 _VERDICT_EMIT_RE = re.compile(r"\bverdict\s*=\s*(\w+)")
 
+_STEP_HEADING_RE = re.compile(r"^#{1,3}\s+Step\s+\d", re.IGNORECASE)
+
+_NEGATION_RE = re.compile(r"\bnot\b|\bnever\b|\bmust not\b|\bdo not\b", re.IGNORECASE)
+
+_SAFE_DEGRADATION_VERDICTS: frozenset[str] = frozenset({"needs_human", "changes_requested"})
+
 
 def _find_degradation_verdict(content: str) -> str | None:
     """Return the verdict emitted on the graceful-degradation path, or None."""
     lines = content.splitlines()
     for i, line in enumerate(lines):
-        if _DEGRADATION_TRIGGER_RE.search(line):
-            # Search within 15 lines after the trigger for a verdict= emit.
-            window = "\n".join(lines[i : i + 15])
-            m = _VERDICT_EMIT_RE.search(window)
-            if m:
-                return m.group(1)
+        if not _DEGRADATION_TRIGGER_RE.search(line):
+            continue
+        if _NEGATION_RE.search(line):
+            continue
+        end = min(len(lines), i + 15)
+        for j in range(i + 1, end):
+            if _STEP_HEADING_RE.match(lines[j]):
+                end = j
+                break
+        window = "\n".join(lines[i:end])
+        m = _VERDICT_EMIT_RE.search(window)
+        if m:
+            return m.group(1)
     return None
 
 
 def _find_nominal_verdicts(content: str) -> set[str]:
     """Return verdict values emitted outside the degradation block.
 
-    Excludes lines within 15 lines of any degradation trigger so that the
-    nominal path check is independent of what the degradation path emits.
+    Excludes lines within 15 lines of any degradation trigger (that is not
+    negated) so that the nominal path check is independent of what the
+    degradation path emits.  Also stops the exclusion window at step headings.
     """
     lines = content.splitlines()
     excluded: set[int] = set()
     for i, line in enumerate(lines):
-        if _DEGRADATION_TRIGGER_RE.search(line):
-            for j in range(i, min(len(lines), i + 15)):
+        if _DEGRADATION_TRIGGER_RE.search(line) and not _NEGATION_RE.search(line):
+            end = min(len(lines), i + 15)
+            for j in range(i + 1, end):
+                if _STEP_HEADING_RE.match(lines[j]):
+                    end = j
+                    break
+            for j in range(i, end):
                 excluded.add(j)
 
     nominal_content = "\n".join(line for i, line in enumerate(lines) if i not in excluded)
@@ -113,6 +132,9 @@ def _check_verdict_ungated_degradation(ctx: ValidationContext) -> list[RuleFindi
             continue
 
         nominal_verdicts = _find_nominal_verdicts(skill_md_content)
+
+        if degradation_verdict in _SAFE_DEGRADATION_VERDICTS:
+            continue
 
         # The bug: the degradation verdict is ALSO used on the nominal path.
         if degradation_verdict in nominal_verdicts and degradation_verdict in verdict_allowed:

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -650,6 +650,8 @@ skills:
     - "verdict = approved_with_comments\n%%ORDER_UP%%"
     - "verdict = changes_requested\n%%REVIEW_GATE::LOOP_REQUIRED%%\n%%ORDER_UP%%"
     - "verdict = needs_human\n%%REVIEW_GATE::CLEAR%%\n%%ORDER_UP%%"
+    negative_examples:
+    - "verdict = approved\n%%ORDER_UP%%"
 
   arch-lens-c4-container:
     inputs:

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -1137,7 +1137,7 @@
         "review_loop_count",
         "review_verdict"
       ],
-      "note": "Compound iteration + blocking guard. Routes back to pre_review_cleanup (then annotate_pr_diff) only when had_blocking=true AND max_exceeded=false. had_blocking is true when previous_verdict=changes_requested OR (local_review_rounds > 0 AND iteration < local_review_rounds), ensuring local review rounds are fully exhausted before exiting to CI.\n"
+      "note": "Compound iteration + blocking guard. Routes back to pre_review_cleanup (then annotate_pr_diff) only when had_blocking=true AND max_exceeded=false. had_blocking is true when previous_verdict=changes_requested OR (local_review_rounds > 0 AND iteration < local_review_rounds AND verdict not in LOCAL_ROUND_EXEMPT_VERDICTS). approved_with_comments and needs_human yield had_blocking=false unconditionally — approved_with_comments because its resolve pass is one-shot, needs_human because it indicates review was skipped (graceful degradation) and re-review would be pointless.\n"
     },
     "pre_review_cleanup": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -1020,8 +1020,10 @@ steps:
       Compound iteration + blocking guard. Routes back to pre_review_cleanup (then
       annotate_pr_diff) only when had_blocking=true AND max_exceeded=false. had_blocking
       is true when previous_verdict=changes_requested OR (local_review_rounds > 0 AND
-      iteration < local_review_rounds), ensuring local review rounds are fully exhausted
-      before exiting to CI.
+      iteration < local_review_rounds AND verdict not in LOCAL_ROUND_EXEMPT_VERDICTS).
+      approved_with_comments and needs_human yield had_blocking=false unconditionally
+      — approved_with_comments because its resolve pass is one-shot, needs_human because
+      it indicates review was skipped (graceful degradation) and re-review would be pointless.
 
   pre_review_cleanup:
     tool: run_python

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -1233,7 +1233,7 @@
         "review_prev_iteration",
         "review_verdict"
       ],
-      "note": "Compound iteration + blocking guard. Routes back to pre_review_cleanup (then annotate_pr_diff) only when had_blocking=true AND max_exceeded=false. had_blocking is true when previous_verdict=changes_requested OR (local_review_rounds > 0 AND iteration < local_review_rounds AND verdict not in LOCAL_ROUND_EXEMPT_VERDICTS). approved_with_comments yields had_blocking=false unconditionally because its resolve pass is one-shot, regardless of local_review_rounds.\n"
+      "note": "Compound iteration + blocking guard. Routes back to pre_review_cleanup (then annotate_pr_diff) only when had_blocking=true AND max_exceeded=false. had_blocking is true when previous_verdict=changes_requested OR (local_review_rounds > 0 AND iteration < local_review_rounds AND verdict not in LOCAL_ROUND_EXEMPT_VERDICTS). approved_with_comments and needs_human yield had_blocking=false unconditionally — approved_with_comments because its resolve pass is one-shot, needs_human because it indicates review was skipped (graceful degradation) and re-review would be pointless.\n"
     },
     "pre_review_cleanup": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1131,8 +1131,9 @@ steps:
       annotate_pr_diff) only when had_blocking=true AND max_exceeded=false. had_blocking
       is true when previous_verdict=changes_requested OR (local_review_rounds > 0 AND
       iteration < local_review_rounds AND verdict not in LOCAL_ROUND_EXEMPT_VERDICTS).
-      approved_with_comments yields had_blocking=false unconditionally because its
-      resolve pass is one-shot, regardless of local_review_rounds.
+      approved_with_comments and needs_human yield had_blocking=false unconditionally
+      — approved_with_comments because its resolve pass is one-shot, needs_human because
+      it indicates review was skipped (graceful degradation) and re-review would be pointless.
 
       '
   pre_review_cleanup:

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -1349,7 +1349,7 @@
         "review_loop_count",
         "review_verdict"
       ],
-      "note": "Compound iteration + blocking guard. Routes back to pre_review_cleanup (then annotate_pr_diff) only when had_blocking=true AND max_exceeded=false. had_blocking is true when previous_verdict=changes_requested OR (local_review_rounds > 0 AND iteration < local_review_rounds), ensuring local review rounds are fully exhausted before exiting to CI.\n"
+      "note": "Compound iteration + blocking guard. Routes back to pre_review_cleanup (then annotate_pr_diff) only when had_blocking=true AND max_exceeded=false. had_blocking is true when previous_verdict=changes_requested OR (local_review_rounds > 0 AND iteration < local_review_rounds AND verdict not in LOCAL_ROUND_EXEMPT_VERDICTS). approved_with_comments and needs_human yield had_blocking=false unconditionally — approved_with_comments because its resolve pass is one-shot, needs_human because it indicates review was skipped (graceful degradation) and re-review would be pointless.\n"
     },
     "pre_review_cleanup": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1214,8 +1214,10 @@ steps:
     note: 'Compound iteration + blocking guard. Routes back to pre_review_cleanup (then
       annotate_pr_diff) only when had_blocking=true AND max_exceeded=false. had_blocking
       is true when previous_verdict=changes_requested OR (local_review_rounds > 0 AND
-      iteration < local_review_rounds), ensuring local review rounds are fully exhausted
-      before exiting to CI.
+      iteration < local_review_rounds AND verdict not in LOCAL_ROUND_EXEMPT_VERDICTS).
+      approved_with_comments and needs_human yield had_blocking=false unconditionally
+      — approved_with_comments because its resolve pass is one-shot, needs_human because
+      it indicates review was skipped (graceful degradation) and re-review would be pointless.
 
       '
   pre_review_cleanup:

--- a/src/autoskillit/skills_extended/audit-claims/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-claims/SKILL.md
@@ -44,7 +44,7 @@ comments and emits a verdict for recipe routing.
 
 - Create files outside `{{AUTOSKILLIT_TEMP}}/audit-claims/`
 - Approve a PR that has `changes_requested` findings
-- Post review comments when `gh` is unavailable — output `verdict=approved` and exit 0
+- Post review comments when `gh` is unavailable — output `verdict=needs_human` and exit 0
 - Review files outside the PR diff — scope all audit to diff content only
 - Modify any source code
 - Run deterministic diff annotation (claim positions are report-level, not line-level)
@@ -56,7 +56,7 @@ comments and emits a verdict for recipe routing.
 - Use the explicit `pr_url` argument instead of re-discovering via `gh pr list`
 - Output `verdict=` on the final line
 - Exit 0 in all normal cases; verdict drives recipe routing via on_result, not exit code
-- Exit non-zero only for unrecoverable errors (e.g., gh CLI truly unavailable after graceful degradation)
+- Exit non-zero only for unrecoverable errors (e.g., gh CLI truly unavailable after graceful degradation has already output verdict=needs_human)
 - Spawn all subagents via `Agent(model="sonnet")`
 - Deduplicate findings by (file, line) pairs before posting
 - Issue all Task calls in a single message to maximize parallelism
@@ -92,7 +92,7 @@ gh repo view --json nameWithOwner -q .nameWithOwner -C "$worktree_path"
 
 If `gh` is unavailable or not authenticated:
 - Log "gh unavailable — skipping citation audit"
-- Output `verdict=approved`
+- Output `verdict=needs_human`
 - Exit 0 (graceful degradation)
 
 ### Step 2: Get PR Diff

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -44,7 +44,7 @@ by the recipe pipeline after `open_pr_step` opens the PR.
 
 - Create files outside `{{AUTOSKILLIT_TEMP}}/review-pr/`
 - Approve a PR that has `changes_requested` findings
-- Post review comments when `gh` is unavailable — output `verdict=approved` and exit 0
+- Post review comments when `gh` is unavailable — output `verdict=needs_human` and exit 0
 - Review files outside the PR diff — scope all audit to diff content only
 - Modify any source code
 - Run subagents in the background (`run_in_background: true` is prohibited)
@@ -55,7 +55,7 @@ by the recipe pipeline after `open_pr_step` opens the PR.
 - Find the PR by feature branch at invocation time (not from a pre-captured URL)
 - Output `verdict=` on the final line
 - Exit 0 in all normal cases; verdict drives recipe routing via on_result, not exit code
-- Exit non-zero only for unrecoverable errors (e.g., gh CLI truly unavailable after graceful degradation has already output verdict=approved)
+- Exit non-zero only for unrecoverable errors (e.g., gh CLI truly unavailable after graceful degradation has already output verdict=needs_human)
 - Tag the authenticated GitHub user (`gh api user -q .login`) in escalation comments (`needs_human` verdict) — omit the mention silently if username derivation fails
 - Spawn all subagents via `Agent(model="sonnet")`
 - Deduplicate findings by (file, line) pairs before posting
@@ -110,7 +110,8 @@ gh pr list --head "$feature_branch" --base "$base_branch" \
 
 If `gh` is unavailable or not authenticated, or no PR is found:
 - Log "No PR found or gh unavailable — skipping review"
-- Output `verdict=approved`
+- Output `verdict=needs_human`
+- Output `%%REVIEW_GATE::CLEAR%%`
 - Exit 0 (graceful degradation)
 
 ### Step 1.5: Fetch Prior Review Thread Context

--- a/src/autoskillit/skills_extended/review-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-research-pr/SKILL.md
@@ -41,7 +41,7 @@ a summary verdict. Called by the recipe pipeline after `open_research_pr` opens 
 
 - Create files outside `{{AUTOSKILLIT_TEMP}}/review-research-pr/`
 - Approve a PR that has `changes_requested` findings
-- Post review comments when `gh` is unavailable — output `verdict=approved` and exit 0
+- Post review comments when `gh` is unavailable — output `verdict=needs_human` and exit 0
 - Review files outside the PR diff — scope all audit to diff content only
 - Modify any source code
 - Flag the absence of a clear experimental conclusion as a deficiency — inconclusive
@@ -54,7 +54,7 @@ a summary verdict. Called by the recipe pipeline after `open_research_pr` opens 
 - Issue all Task calls in a single message to maximize parallelism
 - Output `verdict=` on the final line
 - Exit 0 in all normal cases; verdict drives recipe routing via on_result, not exit code
-- Exit non-zero only for unrecoverable errors (e.g., gh CLI truly unavailable after graceful degradation has already output verdict=approved)
+- Exit non-zero only for unrecoverable errors (e.g., gh CLI truly unavailable after graceful degradation has already output verdict=needs_human)
 - Tag the authenticated GitHub user (`gh api user -q .login`) in escalation comments (`needs_human` verdict) — omit the mention silently if username derivation fails
 - Spawn all subagents via `Agent(model="sonnet")`
 - Deduplicate findings by (file, line) pairs before posting
@@ -93,7 +93,7 @@ gh pr list --head "$feature_branch" --base "$base_branch" \
 
 If `gh` is unavailable or not authenticated, or no PR is found:
 - Log "No PR found or gh unavailable — skipping review"
-- Output `verdict=approved`
+- Output `verdict=needs_human`
 - Exit 0 (graceful degradation)
 
 ### Step 2: Get PR Diff and Metadata

--- a/src/autoskillit/smoke_utils/_review.py
+++ b/src/autoskillit/smoke_utils/_review.py
@@ -131,10 +131,12 @@ def annotate_pr_diff(
 # Verdicts exempt from local_review_rounds re-review.
 # Verdicts in this set yield ``had_blocking=false`` unconditionally regardless
 # of ``local_review_rounds``. ``approved_with_comments`` is exempt because its
-# resolve pass is one-shot — re-reviewing after resolved warnings adds no value.
+# resolve pass is one-shot. ``needs_human`` is exempt because it indicates review
+# was skipped (graceful degradation) and re-review would be pointless.
 LOCAL_ROUND_EXEMPT_VERDICTS: frozenset[str] = frozenset(
     {
         "approved_with_comments",
+        "needs_human",
     }
 )
 

--- a/tests/arch/test_pyright_suppression_allowlist.py
+++ b/tests/arch/test_pyright_suppression_allowlist.py
@@ -20,7 +20,7 @@ _PYRIGHT_RE = re.compile(r"#\s*pyright:\s*ignore|#.*--\s*pyright:\s*ignore")
 PRODUCTION_ALLOWLIST: dict[tuple[str, int], str] = {
     (
         "recipe/__init__.py",
-        245,
+        248,
     ): "lazy-registry: method added by _register_rule_module() side effects",
     ("recipe/_api.py", 274): "lazy-registry: RULE_REGISTRY_HASH set by _finalize_registry()",
 }

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -872,7 +872,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "hooks": 13,
         "pipeline": 12,
         "fleet": 22,  # REQ-CNST-003-E9: _dispatch_reaper.py; +_sidecar_synthesis.py; +_reset.py
-        "recipe/rules": 45,  # +3: failure_verdict_bypass, stop_sentinel_direction, pseudocode_sync
+        "recipe/rules": 46,  # +verdict_degradation
         "server/tools": 25,  # _auto_overrides.py + _cancellation_shield.py + tools_fleet_reset.py
         "hooks/guards": 31,  # +fleet_claim_guard, +reset_resume_gate
     }

--- a/tests/contracts/test_instruction_surface.py
+++ b/tests/contracts/test_instruction_surface.py
@@ -650,6 +650,33 @@ class TestSkillCommandParsingContract:
             "skill_cmd_guard.PATH_ARG_SKILLS. Update the hardcoded list."
         )
 
+    def test_hook_branch_arg_skills_matches_contract_list(self):
+        mod = self._load_hook_module()
+        assert set(mod.BRANCH_ARG_SKILLS) == set(TestBranchArgSkillsContract.BRANCH_ARG_SKILLS), (
+            "TestBranchArgSkillsContract.BRANCH_ARG_SKILLS is out of sync with "
+            "skill_cmd_guard.BRANCH_ARG_SKILLS. Update the hardcoded list."
+        )
+
+
+class TestBranchArgSkillsContract:
+    """Branch-argument skills must document branch-name argument handling in their SKILL.md."""
+
+    BRANCH_ARG_SKILLS = ["review-pr"]
+    SENTINEL = "branch"
+
+    def test_branch_arg_skills_have_branch_detection_instructions(self):
+        skills_root = _project_root() / "src" / "autoskillit" / "skills_extended"
+        missing = []
+        for skill_name in self.BRANCH_ARG_SKILLS:
+            skill_md = skills_root / skill_name / "SKILL.md"
+            content = skill_md.read_text().lower()
+            if self.SENTINEL not in content:
+                missing.append(skill_name)
+        assert not missing, (
+            f"These SKILL.md files lack branch-argument instructions "
+            f"(missing '{self.SENTINEL}'): {missing}"
+        )
+
 
 class TestResolveFailuresDirtyTreeContract:
     """resolve-failures SKILL.md must document dirty tree pre-check."""

--- a/tests/hooks/test_review_gate_post_hook.py
+++ b/tests/hooks/test_review_gate_post_hook.py
@@ -313,3 +313,65 @@ def test_approved_with_comments_no_gate_tag_produces_no_state(tmp_path):
         "approved_with_comments must leave the full gate state unchanged — "
         f"expected {existing!r}, got {state!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# T2-11: verdict=approved without gate tag leaves stale LOOP_REQUIRED state
+# (characterization test — documents danger of current design)
+# ---------------------------------------------------------------------------
+
+
+def test_approved_without_gate_tag_leaves_stale_state(tmp_path):
+    """T2-11: Stale LOOP_REQUIRED state persists when approved has no gate tag."""
+    state_path = tmp_path / _STATE_FILE_RELPATH
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = {
+        "gate": "LOOP_REQUIRED",
+        "review_verdict": "changes_requested",
+        "check_review_loop_called": False,
+        "pr_number": "1290",
+        "set_at": "2026-04-26T04:30:00+00:00",
+    }
+    state_path.write_text(json.dumps(existing))
+
+    event = _build_run_skill_event("verdict=approved\n%%ORDER_UP%%")
+    _run_hook(event, tmp_dir=tmp_path)
+
+    state = _read_state(tmp_path)
+    assert state is not None, (
+        "verdict=approved without %%REVIEW_GATE:: tag must NOT clear stale state — "
+        "only an explicit %%REVIEW_GATE::CLEAR%% tag should do that."
+    )
+    assert state == existing, (
+        f"Stale state must be unchanged. Expected {existing!r}, got {state!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T2-12: verdict=needs_human with CLEAR tag removes stale LOOP_REQUIRED state
+# ---------------------------------------------------------------------------
+
+
+def test_needs_human_with_clear_tag_removes_stale_state(tmp_path):
+    """T2-12: verdict=needs_human + %%REVIEW_GATE::CLEAR%% clears stale state."""
+    state_path = tmp_path / _STATE_FILE_RELPATH
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "gate": "LOOP_REQUIRED",
+                "review_verdict": "changes_requested",
+                "check_review_loop_called": False,
+                "pr_number": "1290",
+                "set_at": "2026-04-26T04:30:00+00:00",
+            }
+        )
+    )
+
+    event = _build_run_skill_event(f"verdict=needs_human\n{_TAG_CLEAR}\n%%ORDER_UP%%")
+    _run_hook(event, tmp_dir=tmp_path)
+
+    state = _read_state(tmp_path)
+    assert state is None, (
+        "verdict=needs_human + %%REVIEW_GATE::CLEAR%% must delete the stale state file."
+    )

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -152,8 +152,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils/_review.py", 101),
     ("src/autoskillit/smoke_utils/_review.py", 102),
     ("src/autoskillit/smoke_utils/_review.py", 120),
-    ("src/autoskillit/smoke_utils/_review.py", 315),
-    ("src/autoskillit/smoke_utils/_review.py", 407),
+    ("src/autoskillit/smoke_utils/_review.py", 317),
+    ("src/autoskillit/smoke_utils/_review.py", 409),
     # smoke_utils/_git.py — partitions, merge queue data
     # Line 110 is a list-payload write site (dual membership: also in list_sites
     # in test_allowlist_includes_list_payloads_as_documented). The AST scanner catches

--- a/tests/infra/test_skill_cmd_check.py
+++ b/tests/infra/test_skill_cmd_check.py
@@ -255,3 +255,49 @@ class TestSkillCmdCheckDeny:
         result = _run_hook({"skill_command": _CANONICAL_BUG})
         reason = result["hookSpecificOutput"]["permissionDecisionReason"]
         assert "relocate" in reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# BRANCH_ARG_SKILLS contract
+# ---------------------------------------------------------------------------
+
+
+class TestBranchArgSkillsContract:
+    """Branch-argument skills must deny path-like first arguments."""
+
+    BRANCH_ARG_SKILLS = ["review-pr"]
+
+    def _load_hook_module(self):
+        import importlib.util
+        import pathlib
+
+        hook_path = (
+            pathlib.Path(__file__).parents[2]
+            / "src"
+            / "autoskillit"
+            / "hooks"
+            / "guards"
+            / "skill_cmd_guard.py"
+        )
+        spec = importlib.util.spec_from_file_location("skill_cmd_guard", hook_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_hook_branch_arg_skills_matches_contract_list(self):
+        """skill_cmd_guard.BRANCH_ARG_SKILLS must match this contract list."""
+        mod = self._load_hook_module()
+        assert set(mod.BRANCH_ARG_SKILLS) == set(self.BRANCH_ARG_SKILLS), (
+            "TestBranchArgSkillsContract.BRANCH_ARG_SKILLS is out of sync with "
+            "skill_cmd_guard.BRANCH_ARG_SKILLS. Update the hardcoded list."
+        )
+
+    def test_branch_arg_skill_denies_path_like_first_arg(self):
+        """review-pr invoked with a /path-like first arg must be denied."""
+        result = _run_hook({"skill_command": "/autoskillit:review-pr /home/user/repo main"})
+        assert _decision(result) == "deny"
+
+    def test_branch_arg_skill_allows_valid_branch_name(self):
+        """review-pr invoked with a valid branch name must be allowed."""
+        result = _run_hook({"skill_command": "/autoskillit:review-pr feature/my-branch main"})
+        assert _decision(result) == "allow"

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -189,6 +189,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_rules_tools.py` | Tests for tools semantic validation rule |
 | `test_rules_unsatisfied_input.py` | Tests for unsatisfied_input semantic validation rule |
 | `test_rules_verdict.py` | Tests for verdict semantic validation rule |
+| `test_rules_verdict_degradation.py` | Tests for verdict-ungated-degradation semantic rule |
 | `test_rules_weak_constraint.py` | Tests for weak_constraint semantic validation rule |
 | `test_rules_worktree.py` | Tests for worktree semantic validation rule |
 | `test_schema.py` | Tests for Recipe, RecipeStep, and DataFlowWarning schema |

--- a/tests/recipe/test_rules_verdict_degradation.py
+++ b/tests/recipe/test_rules_verdict_degradation.py
@@ -1,0 +1,171 @@
+"""Tests for the verdict-ungated-degradation semantic rule.
+
+Verifies that skills with graceful-degradation paths cannot emit a verdict
+that is semantically indistinguishable from the nominal success verdict.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import autoskillit.recipe.rules.rules_verdict_degradation as _rvd
+import pytest
+
+import autoskillit.recipe.contracts as _contracts
+from autoskillit.core.types import Severity
+from autoskillit.recipe.schema import (
+    Recipe,
+    RecipeStep,
+    StepResultCondition,
+    StepResultRoute,
+)
+from autoskillit.recipe.validator import run_semantic_rules
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+_FAKE_SKILL_NAME = "fake-review-pr"
+
+# SKILL.md where the degradation path emits the same verdict as the nominal path.
+_SKILL_MD_SHARED_VERDICT = """\
+## Critical Constraints
+
+**NEVER:**
+- Post review comments when gh is unavailable — output verdict=approved and exit 0
+
+**ALWAYS:**
+- Output verdict= on the final line
+
+## Workflow
+
+### Step 1: Find the PR
+
+If gh is unavailable or not authenticated:
+- Log "No PR found or gh unavailable — skipping review"
+- Output verdict=approved
+- Exit 0 (graceful degradation)
+
+### Step 2: Full Review
+
+Review the PR thoroughly.
+
+At the end:
+- verdict = "approved"
+"""
+
+# SKILL.md where the degradation path emits a distinct verdict (needs_human).
+_SKILL_MD_DISTINCT_VERDICT = """\
+## Critical Constraints
+
+**NEVER:**
+- Post review comments when gh is unavailable — output verdict=needs_human and exit 0
+
+**ALWAYS:**
+- Output verdict= on the final line
+
+## Workflow
+
+### Step 1: Find the PR
+
+If gh is unavailable or not authenticated:
+- Log "No PR found or gh unavailable — skipping review"
+- Output verdict=needs_human
+- Exit 0 (graceful degradation)
+
+### Step 2: Full Review
+
+Review the PR thoroughly.
+
+At the end:
+- verdict = "approved"
+"""
+
+_MANIFEST: dict = {
+    "version": "0.1.0",
+    "skills": {
+        _FAKE_SKILL_NAME: {
+            "inputs": [],
+            "outputs": [
+                {
+                    "name": "verdict",
+                    "type": "string",
+                    "allowed_values": ["approved", "needs_human", "changes_requested"],
+                }
+            ],
+        }
+    },
+}
+
+
+def _make_recipe() -> Recipe:
+    return Recipe(
+        name="test",
+        description="test",
+        kitchen_rules=["test"],
+        steps={
+            "review_step": RecipeStep(
+                tool="run_skill",
+                with_args={"skill_command": f"/autoskillit:{_FAKE_SKILL_NAME} main main"},
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            route="fix",
+                            when="${{ result.verdict }} == changes_requested",
+                        ),
+                        StepResultCondition(route="done", when="true"),
+                    ]
+                ),
+                on_failure="done",
+            ),
+            "fix": RecipeStep(
+                tool="run_skill",
+                with_args={"skill_command": "/autoskillit:resolve-review main main"},
+                on_success="done",
+                on_failure="done",
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        },
+    )
+
+
+def test_verdict_ungated_degradation_fires_when_shared_verdict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Rule fires ERROR when degradation path emits the same verdict as nominal path."""
+    skill_dir = tmp_path / "skills_extended" / _FAKE_SKILL_NAME
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(_SKILL_MD_SHARED_VERDICT)
+
+    monkeypatch.setattr(_rvd, "pkg_root", lambda: tmp_path)
+    monkeypatch.setattr(_contracts, "load_bundled_manifest", lambda: _MANIFEST)
+
+    recipe = _make_recipe()
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "verdict-ungated-degradation"]
+
+    assert len(rule_findings) >= 1, (
+        "verdict-ungated-degradation must fire when degradation path emits 'approved' "
+        f"(same as nominal path). All findings: {[f.rule for f in findings]}"
+    )
+    assert rule_findings[0].severity == Severity.ERROR
+    assert _FAKE_SKILL_NAME in rule_findings[0].message
+
+
+def test_verdict_ungated_degradation_does_not_fire_with_distinct_verdict(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Rule does NOT fire when degradation path emits a distinct verdict (needs_human)."""
+    skill_dir = tmp_path / "skills_extended" / _FAKE_SKILL_NAME
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(_SKILL_MD_DISTINCT_VERDICT)
+
+    monkeypatch.setattr(_rvd, "pkg_root", lambda: tmp_path)
+    monkeypatch.setattr(_contracts, "load_bundled_manifest", lambda: _MANIFEST)
+
+    recipe = _make_recipe()
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "verdict-ungated-degradation"]
+
+    assert rule_findings == [], (
+        "verdict-ungated-degradation must NOT fire when degradation path emits "
+        f"'needs_human' (distinct from nominal 'approved'). Got: {rule_findings}"
+    )

--- a/tests/recipe/test_rules_verdict_degradation.py
+++ b/tests/recipe/test_rules_verdict_degradation.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import autoskillit.recipe.rules.rules_verdict_degradation as _rvd
 import pytest
 
+import autoskillit.recipe._skill_helpers as _sh
 import autoskillit.recipe.contracts as _contracts
 from autoskillit.core.types import Severity
 from autoskillit.recipe.schema import (
@@ -131,11 +131,12 @@ def test_verdict_ungated_degradation_fires_when_shared_verdict(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Rule fires ERROR when degradation path emits the same verdict as nominal path."""
-    skill_dir = tmp_path / "skills_extended" / _FAKE_SKILL_NAME
+    skills_ext = tmp_path / "skills_extended"
+    skill_dir = skills_ext / _FAKE_SKILL_NAME
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(_SKILL_MD_SHARED_VERDICT)
 
-    monkeypatch.setattr(_rvd, "pkg_root", lambda: tmp_path)
+    monkeypatch.setattr(_sh, "SKILL_SEARCH_DIRS", [skills_ext])
     monkeypatch.setattr(_contracts, "load_bundled_manifest", lambda: _MANIFEST)
 
     recipe = _make_recipe()
@@ -154,11 +155,12 @@ def test_verdict_ungated_degradation_does_not_fire_with_distinct_verdict(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Rule does NOT fire when degradation path emits a distinct verdict (needs_human)."""
-    skill_dir = tmp_path / "skills_extended" / _FAKE_SKILL_NAME
+    skills_ext = tmp_path / "skills_extended"
+    skill_dir = skills_ext / _FAKE_SKILL_NAME
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(_SKILL_MD_DISTINCT_VERDICT)
 
-    monkeypatch.setattr(_rvd, "pkg_root", lambda: tmp_path)
+    monkeypatch.setattr(_sh, "SKILL_SEARCH_DIRS", [skills_ext])
     monkeypatch.setattr(_contracts, "load_bundled_manifest", lambda: _MANIFEST)
 
     recipe = _make_recipe()

--- a/tests/recipe/test_rules_verdict_degradation.py
+++ b/tests/recipe/test_rules_verdict_degradation.py
@@ -30,10 +30,10 @@ _SKILL_MD_SHARED_VERDICT = """\
 ## Critical Constraints
 
 **NEVER:**
-- Post review comments when gh is unavailable — output verdict=approved and exit 0
+- Create files outside the output directory
 
 **ALWAYS:**
-- Output verdict= on the final line
+- Output the verdict token on the final line
 
 ## Workflow
 
@@ -44,12 +44,23 @@ If gh is unavailable or not authenticated:
 - Output verdict=approved
 - Exit 0 (graceful degradation)
 
-### Step 2: Full Review
+### Step 2: Get PR Diff
+
+Fetch the diff from GitHub.
+
+### Step 3: Analyse Findings
 
 Review the PR thoroughly.
 
-At the end:
-- verdict = "approved"
+### Step 4: Determine Verdict
+
+Classify findings into categories.
+
+### Step 5: Output
+
+At the end output the verdict token:
+
+verdict=approved
 """
 
 # SKILL.md where the degradation path emits a distinct verdict (needs_human).
@@ -57,10 +68,10 @@ _SKILL_MD_DISTINCT_VERDICT = """\
 ## Critical Constraints
 
 **NEVER:**
-- Post review comments when gh is unavailable — output verdict=needs_human and exit 0
+- Create files outside the output directory
 
 **ALWAYS:**
-- Output verdict= on the final line
+- Output the verdict token on the final line
 
 ## Workflow
 
@@ -71,12 +82,23 @@ If gh is unavailable or not authenticated:
 - Output verdict=needs_human
 - Exit 0 (graceful degradation)
 
-### Step 2: Full Review
+### Step 2: Get PR Diff
+
+Fetch the diff from GitHub.
+
+### Step 3: Analyse Findings
 
 Review the PR thoroughly.
 
-At the end:
-- verdict = "approved"
+### Step 4: Determine Verdict
+
+Classify findings into categories.
+
+### Step 5: Output
+
+At the end output the verdict token:
+
+verdict=approved
 """
 
 _MANIFEST: dict = {

--- a/tests/skills/test_review_pr_verdict_guards.py
+++ b/tests/skills/test_review_pr_verdict_guards.py
@@ -127,27 +127,26 @@ AUDIT_CLAIMS_SKILL_PATH = (
 def _extract_degradation_block(text: str) -> str:
     """Extract the graceful-degradation block from a SKILL.md.
 
-    Finds the first 'unavailable' trigger line that is inside a Step section
-    (after a ``### Step`` heading), then returns text through the next step
-    heading (or 20 lines if no heading found).
+    Finds the 'unavailable' trigger line whose subsequent window contains
+    a ``verdict=`` emit, then returns text through the next step heading
+    (or 20 lines if no heading found).
     """
     lines = text.splitlines()
-    in_step = False
-    start = None
-    end = len(lines)
+    trigger_re = re.compile(r"unavailable|graceful.{0,20}degrada", re.IGNORECASE)
+    heading_re = re.compile(r"^#{1,3}\s+Step\s+\d")
+    verdict_re = re.compile(r"\bverdict\s*=\s*\w+")
     for i, line in enumerate(lines):
-        if re.search(r"^#{1,3}\s+Step\s+\d", line):
-            in_step = True
-        if in_step and re.search(r"unavailable|graceful.{0,20}degrada", line, re.IGNORECASE):
-            start = i
-            break
-    if start is None:
-        return ""
-    for i in range(start + 1, min(len(lines), start + 20)):
-        if re.search(r"^#{1,3}\s+Step\s+\d", lines[i]):
-            end = i
-            break
-    return "\n".join(lines[start:end])
+        if not trigger_re.search(line):
+            continue
+        end = min(len(lines), i + 20)
+        for j in range(i + 1, end):
+            if heading_re.match(lines[j]):
+                end = j
+                break
+        window = "\n".join(lines[i:end])
+        if verdict_re.search(window):
+            return window
+    return ""
 
 
 def test_graceful_degradation_does_not_emit_approved() -> None:

--- a/tests/skills/test_review_pr_verdict_guards.py
+++ b/tests/skills/test_review_pr_verdict_guards.py
@@ -106,6 +106,88 @@ def test_review_pr_own_pr_comment_retry():
     )
 
 
+REVIEW_RESEARCH_PR_SKILL_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "review-research-pr"
+    / "SKILL.md"
+)
+AUDIT_CLAIMS_SKILL_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "audit-claims"
+    / "SKILL.md"
+)
+
+
+def _extract_degradation_block(text: str) -> str:
+    """Extract the graceful-degradation block from a SKILL.md.
+
+    Returns text from the first 'unavailable' trigger line through the next
+    step heading (or 20 lines if no heading found).
+    """
+    lines = text.splitlines()
+    start = None
+    end = len(lines)
+    for i, line in enumerate(lines):
+        if re.search(r"unavailable|graceful.{0,20}degrada", line, re.IGNORECASE):
+            start = i
+            break
+    if start is None:
+        return ""
+    for i in range(start + 1, min(len(lines), start + 20)):
+        if re.search(r"^#{1,3}\s+Step\s+\d", lines[i]):
+            end = i
+            break
+    return "\n".join(lines[start:end])
+
+
+def test_graceful_degradation_does_not_emit_approved() -> None:
+    """review-pr degradation block must not emit verdict=approved."""
+    text = _skill_text()
+    block = _extract_degradation_block(text)
+    assert block, "Could not find graceful degradation block in review-pr/SKILL.md"
+    assert "verdict=approved" not in block and "verdict = approved" not in block, (
+        "review-pr/SKILL.md must not emit verdict=approved on the graceful-degradation path. "
+        "Use verdict=needs_human instead to distinguish zero-validation exits from real reviews."
+    )
+    assert "verdict=needs_human" in block or "verdict = needs_human" in block, (
+        "review-pr/SKILL.md graceful-degradation block must emit verdict=needs_human."
+    )
+
+
+def test_review_research_pr_graceful_degradation_does_not_emit_approved() -> None:
+    """review-research-pr degradation block must not emit verdict=approved."""
+    text = REVIEW_RESEARCH_PR_SKILL_PATH.read_text()
+    block = _extract_degradation_block(text)
+    assert block, "Could not find graceful degradation block in review-research-pr/SKILL.md"
+    assert "verdict=approved" not in block and "verdict = approved" not in block, (
+        "review-research-pr/SKILL.md must not emit verdict=approved on the graceful-degradation "
+        "path. Use verdict=needs_human instead."
+    )
+    assert "verdict=needs_human" in block or "verdict = needs_human" in block, (
+        "review-research-pr/SKILL.md graceful-degradation block must emit verdict=needs_human."
+    )
+
+
+def test_audit_claims_graceful_degradation_does_not_emit_approved() -> None:
+    """audit-claims degradation block must not emit verdict=approved."""
+    text = AUDIT_CLAIMS_SKILL_PATH.read_text()
+    block = _extract_degradation_block(text)
+    assert block, "Could not find graceful degradation block in audit-claims/SKILL.md"
+    assert "verdict=approved" not in block and "verdict = approved" not in block, (
+        "audit-claims/SKILL.md must not emit verdict=approved on the graceful-degradation path. "
+        "Use verdict=needs_human instead."
+    )
+    assert "verdict=needs_human" in block or "verdict = needs_human" in block, (
+        "audit-claims/SKILL.md graceful-degradation block must emit verdict=needs_human."
+    )
+
+
 def test_contract_yamls_include_approved_with_comments() -> None:
     """All 3 contract YAML files must include approved_with_comments in
     expected_output_patterns and pattern_examples for the review-pr contract."""

--- a/tests/skills/test_review_pr_verdict_guards.py
+++ b/tests/skills/test_review_pr_verdict_guards.py
@@ -127,14 +127,18 @@ AUDIT_CLAIMS_SKILL_PATH = (
 def _extract_degradation_block(text: str) -> str:
     """Extract the graceful-degradation block from a SKILL.md.
 
-    Returns text from the first 'unavailable' trigger line through the next
-    step heading (or 20 lines if no heading found).
+    Finds the first 'unavailable' trigger line that is inside a Step section
+    (after a ``### Step`` heading), then returns text through the next step
+    heading (or 20 lines if no heading found).
     """
     lines = text.splitlines()
+    in_step = False
     start = None
     end = len(lines)
     for i, line in enumerate(lines):
-        if re.search(r"unavailable|graceful.{0,20}degrada", line, re.IGNORECASE):
+        if re.search(r"^#{1,3}\s+Step\s+\d", line):
+            in_step = True
+        if in_step and re.search(r"unavailable|graceful.{0,20}degrada", line, re.IGNORECASE):
             start = i
             break
     if start is None:

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -309,6 +309,22 @@ def test_local_round_exempt_verdicts_constant_exists() -> None:
     assert "approved" not in LOCAL_ROUND_EXEMPT_VERDICTS
 
 
+def test_needs_human_exempt_from_local_rounds() -> None:
+    """needs_human must be exempt from local_review_rounds re-review."""
+    result = check_review_loop(
+        pr_number="42",
+        current_iteration="0",
+        max_iterations="6",
+        previous_verdict="needs_human",
+        local_review_rounds="2",
+    )
+    assert result["had_blocking"] == "false", (
+        "needs_human must yield had_blocking=false regardless of local_review_rounds "
+        "because it indicates review was skipped (graceful degradation) and "
+        "re-review would be pointless."
+    )
+
+
 # ---------------------------------------------------------------------------
 # T_SU_LI1–T_SU_LI5: check_loop_iteration tests (generic loop iteration guard)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The review-pr skill (and two siblings: review-research-pr, audit-claims) emits `verdict=approved` when GitHub is unreachable — a zero-validation approval that flows through the pipeline to CI/merge. This is a day-one design decision (commit `e084e71c`) that has recurred 8+ times because prior fixes addressed downstream routing but never the root: graceful degradation should not emit the same success token as a real review. The architectural weakness is that the contract and enforcement systems have no concept of "proof of work" — a verdict token is structurally valid regardless of whether the skill performed any actual validation.

The immunity plan introduces three layers of defense:

1. **Distinct degradation verdict** — `verdict=needs_human` replaces `verdict=approved` on all graceful-degradation paths, making zero-validation approval structurally impossible at the SKILL.md instruction level.
2. **New semantic rule `verdict-ungated-degradation`** — a static recipe-time rule that scans SKILL.md files of verdict-emitting skills for graceful-degradation phrases and errors if the degradation path emits a verdict in `allowed_values` that is also used by the nominal (work-performed) path. This makes the bug class detectable at `task test-all` time for any future skill.
3. **Contract negative examples** — adds negative examples to `skill_contracts.yaml` for review-pr (verdict=approved without gate token) and adds `BRANCH_ARG_SKILLS` category to `skill_cmd_guard.py` with contract test parity.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260606-103426-508221/.autoskillit/temp/rectify/rectify_verdict_graceful_degradation_immunity_2026-06-06_190000.md`

Closes #3871

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate* | opus | 1 | 35 | 8.0k | 446.7k | 84.0k | 25 | 65.3k | 7m 33s |
| rectify* | opus[1m] | 1 | 55 | 23.9k | 1.7M | 131.2k | 48 | 109.1k | 18m 47s |
| review_approach* | sonnet | 1 | 1.1k | 5.7k | 220.3k | 48.5k | 15 | 30.1k | 3m 51s |
| dry_walkthrough* | opus | 1 | 53 | 15.2k | 2.0M | 96.8k | 57 | 74.6k | 9m 18s |
| implement* | sonnet | 1 | 702 | 61.1k | 10.3M | 161.4k | 223 | 140.5k | 18m 25s |
| audit_impl* | sonnet | 1 | 1.6k | 7.2k | 210.7k | 44.4k | 15 | 39.5k | 2m 52s |
| prepare_pr* | MiniMax-M3 | 1 | 48.1k | 2.5k | 216.3k | 49.8k | 15 | 0 | 1m 2s |
| compose_pr* | MiniMax-M3 | 1 | 37.5k | 1.3k | 186.1k | 38.8k | 13 | 0 | 43s |
| review_pr* | sonnet | 1 | 164 | 32.0k | 1.3M | 109.0k | 49 | 88.4k | 8m 42s |
| resolve_review* | opus | 1 | 38 | 9.3k | 1.4M | 91.7k | 43 | 70.1k | 6m 30s |
| **Total** | | | 89.3k | 166.2k | 18.0M | 161.4k | | 617.6k | 1h 17m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 614 | 16726.1 | 228.9 | 99.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 7 | 204997.0 | 10013.6 | 1328.4 |
| **Total** | **621** | 29065.1 | 994.5 | 267.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus | 3 | 126 | 32.5k | 3.9M | 210.0k | 23m 22s |
| opus[1m] | 1 | 55 | 23.9k | 1.7M | 109.1k | 18m 47s |
| sonnet | 4 | 3.6k | 106.0k | 12.0M | 298.5k | 33m 52s |
| MiniMax-M3 | 2 | 85.6k | 3.8k | 402.4k | 0 | 1m 44s |