### PR TITLE
Rectify: Recipe cmd Shell-Expansion Suppression and Backend Config Completeness

### DIFF
--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -19,8 +19,10 @@ from autoskillit.execution.anomaly_detection import (
 )
 from autoskillit.execution.backends import (
     BACKEND_REGISTRY,
+    CODEX_MCP_REQUIRED_KEYS,
     CODEX_MCP_STARTUP_TIMEOUT_SEC,
     CODEX_MCP_TOOL_TIMEOUT_FLOOR,
+    CODEX_TOOL_OUTPUT_TOKEN_LIMIT,
     ClaudeCodeBackend,
     CodexBackend,
     _is_autoskillit_hook_entry,
@@ -222,8 +224,10 @@ __all__ = [
     "start_linux_tracing",
     # backends
     "BACKEND_REGISTRY",
+    "CODEX_MCP_REQUIRED_KEYS",
     "CODEX_MCP_STARTUP_TIMEOUT_SEC",
     "CODEX_MCP_TOOL_TIMEOUT_FLOOR",
+    "CODEX_TOOL_OUTPUT_TOKEN_LIMIT",
     "ClaudeCodeBackend",
     "CodexBackend",
     "_is_autoskillit_hook_entry",

--- a/src/autoskillit/execution/backends/__init__.py
+++ b/src/autoskillit/execution/backends/__init__.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from autoskillit.core import CodingAgentBackend
 
 from ._codex_config import (
+    CODEX_MCP_REQUIRED_KEYS,
     CODEX_MCP_STARTUP_TIMEOUT_SEC,
     CODEX_MCP_TOOL_TIMEOUT_FLOOR,
+    CODEX_TOOL_OUTPUT_TOKEN_LIMIT,
     _is_autoskillit_registered,
     _read_codex_config,
     _serialize_toml,
@@ -76,6 +78,8 @@ __all__ = [
     "CodexStreamParser",
     "CODEX_MCP_STARTUP_TIMEOUT_SEC",
     "CODEX_MCP_TOOL_TIMEOUT_FLOOR",
+    "CODEX_MCP_REQUIRED_KEYS",
+    "CODEX_TOOL_OUTPUT_TOKEN_LIMIT",
     "NON_VARIADIC_CODEX_FLAGS",
     "VARIADIC_CODEX_FLAGS",
     "_is_autoskillit_registered",

--- a/src/autoskillit/execution/backends/_codex_config.py
+++ b/src/autoskillit/execution/backends/_codex_config.py
@@ -23,6 +23,18 @@ CODEX_MCP_TOOL_TIMEOUT_FLOOR: float = 14364.0
 
 CODEX_MCP_STARTUP_TIMEOUT_SEC: float = 30.0
 
+# Per-tool response size budget for Codex MCP tools. Sufficient for current
+# `open_kitchen` response sizes with 2x headroom.
+CODEX_TOOL_OUTPUT_TOKEN_LIMIT: int = 50_000
+
+# Keys that must be present in the autoskillit MCP server entry for the Codex
+# backend. Validated against the entry dict actually written by
+# `ensure_codex_mcp_registered` via the arch test
+# `test_required_keys_coverage` in `tests/execution/backends/test_codex_config.py`.
+CODEX_MCP_REQUIRED_KEYS: frozenset[str] = frozenset(
+    {"command", "env_vars", "startup_timeout_sec", "tool_timeout_sec"}
+)
+
 logger = get_logger()
 
 
@@ -219,7 +231,32 @@ def _is_autoskillit_registered(
         return False
     if entry.get("startup_timeout_sec") != CODEX_MCP_STARTUP_TIMEOUT_SEC:
         return False
+    if config.get("tool_output_token_limit", 0) < CODEX_TOOL_OUTPUT_TOKEN_LIMIT:
+        return False
     return True
+
+
+def _ensure_top_level_key(path: Path, *, key: str, value: int) -> None:
+    """Insert `key = value` at the top of a TOML file if not already present.
+
+    `safe_upsert_section` only writes `[section]` blocks; it cannot write bare
+    top-level scalars. This helper handles the bare-scalar case for the
+    corrupt-file path where the entire config needs text-level edits.
+    """
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    pattern = _re.compile(rf"^\s*{_re.escape(key)}\s*=", _re.MULTILINE)
+    if pattern.search(existing):
+        return
+    line = f"{key} = {value}\n"
+    lines = existing.splitlines(keepends=True)
+    insert_at = 0
+    for i, ln in enumerate(lines):
+        if ln.lstrip().startswith("["):
+            insert_at = i
+            break
+        insert_at = i + 1
+    new_lines = lines[:insert_at] + [line] + lines[insert_at:]
+    atomic_write(path, "".join(new_lines))
 
 
 def ensure_codex_mcp_registered(
@@ -252,6 +289,11 @@ def ensure_codex_mcp_registered(
     if result.is_corrupt:
         section_text = _serialize_mcp_autoskillit_section(entry)
         safe_upsert_section(config_path, "[mcp_servers.autoskillit]", section_text)
+        _ensure_top_level_key(
+            config_path,
+            key="tool_output_token_limit",
+            value=CODEX_TOOL_OUTPUT_TOKEN_LIMIT,
+        )
         return True
     else:
         config = result.data
@@ -262,5 +304,6 @@ def ensure_codex_mcp_registered(
         ):
             return False
         config.setdefault("mcp_servers", {})["autoskillit"] = entry
+        config.setdefault("tool_output_token_limit", CODEX_TOOL_OUTPUT_TOKEN_LIMIT)
         _write_codex_config(config_path, config, source=result)
         return True

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -24,7 +24,7 @@ See each subdirectory's CLAUDE.md for details.
 | `rules_bypass.py` | Rules for `skip_when_false` bypass routing contracts and `hidden-input-ref-in-template` detection |
 | `rules_callable_scope.py` | Enforces scoped directory args for file-discovering callables |
 | `rules_clone.py` | Clone/push dataflow rules: missing remote URL, local-strategy capture |
-| `rules_cmd.py` | `run_cmd` echo-capture alignment; git remote command detection; bare git rebase without conflict routing detection; path-typed capture non-empty file guard detection |
+| `rules_cmd.py` | `run_cmd` echo-capture alignment; git remote command detection; bare git rebase without conflict routing detection; path-typed capture non-empty file guard detection; single-quoted shell expansion suppression detection |
 | `rules_contracts.py` | Skill contract completeness rules |
 | `rules_failure_verdict_bypass.py` | Detects bypass routes from verdict-gated steps reaching success stop terminals |
 | `rules_features.py` | Feature-gated tool/skill reference validation |

--- a/src/autoskillit/recipe/rules/rules_cmd.py
+++ b/src/autoskillit/recipe/rules/rules_cmd.py
@@ -20,6 +20,12 @@ _RAW_RESULT_FIELDS = {"stdout", "stderr", "exit_code"}
 # re-discovering a path that should have been captured by an upstream step.
 _FIND_HEURISTIC_RE = re.compile(r"\bfind\b.+\|\s*sort\b.+\|\s*(tail|head)\b")
 
+# Matches a single-quoted region containing $() — bash treats $() as literal text
+# inside single quotes, so command substitution silently fails. We only flag $( )
+# because ${{ ... }} is recipe ingredient syntax (not bash) and backticks are often
+# intentional literal text in commit messages or doc strings.
+_SINGLE_QUOTE_EXPANSION_RE = re.compile(r"'[^']*\$\([^']*'")
+
 
 @semantic_rule(
     name="run-cmd-emit-alignment",
@@ -321,6 +327,39 @@ def _check_run_cmd_path_capture_nonempty_guard(ctx: ValidationContext) -> list[R
                         "does not contain a 'test -s' or '[ -s' non-empty "
                         'file guard. Add `test -s "$FILE" &&` before the '
                         "echo statement to prevent emitting a 0-byte file path."
+                    ),
+                )
+            )
+    return findings
+
+
+@semantic_rule(
+    name="run-cmd-single-quote-expansion",
+    description=(
+        "run_cmd step contains $(...) command substitution inside a single-quoted "
+        "region where bash will treat it as literal text. Use double quotes."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_run_cmd_single_quote_expansion(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    for name, step in ctx.recipe.steps.items():
+        if step.tool != "run_cmd":
+            continue
+        cmd = (step.with_args or {}).get("cmd", "")
+        if not isinstance(cmd, str):
+            continue
+        for m in _SINGLE_QUOTE_EXPANSION_RE.finditer(cmd):
+            findings.append(
+                RuleFinding(
+                    rule="run-cmd-single-quote-expansion",
+                    severity=Severity.ERROR,
+                    step_name=name,
+                    message=(
+                        f"Step '{name}' has $(...) command substitution inside single "
+                        f"quotes: {m.group()!r}. Single quotes suppress shell expansion — "
+                        "the $(...) is treated as literal text. Use double quotes or "
+                        "leave unquoted."
                     ),
                 )
             )

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -253,7 +253,7 @@
     "create_impl_worktree": {
       "tool": "run_cmd",
       "with": {
-        "cmd": "bash {{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh 'impl-${{ context.issue_number }}-$(date +%Y%m%d-%H%M%S)' '{{AUTOSKILLIT_TEMP}}'",
+        "cmd": "bash {{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh \"impl-${{ context.issue_number }}-$(date +%Y%m%d-%H%M%S)\" \"{{AUTOSKILLIT_TEMP}}\"",
         "cwd": "${{ context.work_dir }}",
         "step_name": "create_impl_worktree"
       },

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -256,7 +256,7 @@ steps:
   create_impl_worktree:
     tool: run_cmd
     with:
-      cmd: "bash {{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh 'impl-${{ context.issue_number }}-$(date +%Y%m%d-%H%M%S)' '{{AUTOSKILLIT_TEMP}}'"
+      cmd: "bash {{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh \"impl-${{ context.issue_number }}-$(date +%Y%m%d-%H%M%S)\" \"{{AUTOSKILLIT_TEMP}}\""
       cwd: "${{ context.work_dir }}"
       step_name: "create_impl_worktree"
     capture:

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -278,7 +278,7 @@
     "create_impl_worktree": {
       "tool": "run_cmd",
       "with": {
-        "cmd": "bash {{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh 'impl-${{ context.issue_number }}-$(date +%Y%m%d-%H%M%S)' '{{AUTOSKILLIT_TEMP}}'",
+        "cmd": "bash {{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh \"impl-${{ context.issue_number }}-$(date +%Y%m%d-%H%M%S)\" \"{{AUTOSKILLIT_TEMP}}\"",
         "cwd": "${{ context.work_dir }}",
         "step_name": "create_impl_worktree"
       },

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -298,8 +298,7 @@ steps:
   create_impl_worktree:
     tool: run_cmd
     with:
-      cmd: "bash {{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh 'impl-${{ context.issue_number
-        }}-$(date +%Y%m%d-%H%M%S)' '{{AUTOSKILLIT_TEMP}}'"
+      cmd: "bash {{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh \"impl-${{ context.issue_number }}-$(date +%Y%m%d-%H%M%S)\" \"{{AUTOSKILLIT_TEMP}}\""
       cwd: ${{ context.work_dir }}
       step_name: create_impl_worktree
     capture:

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -307,7 +307,7 @@
     "create_impl_worktree": {
       "tool": "run_cmd",
       "with": {
-        "cmd": "bash {{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh 'impl-${{ context.issue_number }}-$(date +%Y%m%d-%H%M%S)' '{{AUTOSKILLIT_TEMP}}'",
+        "cmd": "bash {{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh \"impl-${{ context.issue_number }}-$(date +%Y%m%d-%H%M%S)\" \"{{AUTOSKILLIT_TEMP}}\"",
         "cwd": "${{ context.work_dir }}",
         "step_name": "create_impl_worktree"
       },

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -323,8 +323,7 @@ steps:
   create_impl_worktree:
     tool: run_cmd
     with:
-      cmd: "bash {{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh 'impl-${{ context.issue_number
-        }}-$(date +%Y%m%d-%H%M%S)' '{{AUTOSKILLIT_TEMP}}'"
+      cmd: "bash {{AUTOSKILLIT_SCRIPTS}}/create_impl_worktree.sh \"impl-${{ context.issue_number }}-$(date +%Y%m%d-%H%M%S)\" \"{{AUTOSKILLIT_TEMP}}\""
       cwd: ${{ context.work_dir }}
       step_name: create_impl_worktree
     capture:

--- a/tests/cli/test_doctor_backend_guards.py
+++ b/tests/cli/test_doctor_backend_guards.py
@@ -192,6 +192,7 @@ class TestCheckMcpServerRegisteredCodexBackend:
         from autoskillit.execution import (
             CODEX_MCP_STARTUP_TIMEOUT_SEC,
             CODEX_MCP_TOOL_TIMEOUT_FLOOR,
+            CODEX_TOOL_OUTPUT_TOKEN_LIMIT,
         )
         from autoskillit.execution.backends.codex import CodexBackend
 
@@ -201,6 +202,7 @@ class TestCheckMcpServerRegisteredCodexBackend:
             f'"{v}"' for v in sorted(CODEX_MCP_ENV_FORWARD_VARS - {HEADLESS_AUTO_GATE_ENV_VAR})
         )
         (codex_dir / "config.toml").write_text(
+            f"tool_output_token_limit = {CODEX_TOOL_OUTPUT_TOKEN_LIMIT}\n"
             f'[mcp_servers.autoskillit]\ncommand = "autoskillit"\n'
             f"env_vars = [{env_vars_str}]\n"
             f"startup_timeout_sec = {CODEX_MCP_STARTUP_TIMEOUT_SEC}\n"

--- a/tests/cli/test_doctor_codex_mcp.py
+++ b/tests/cli/test_doctor_codex_mcp.py
@@ -13,6 +13,7 @@ from autoskillit.core import ReadResult, Severity
 from autoskillit.execution.backends._codex_config import (
     CODEX_MCP_STARTUP_TIMEOUT_SEC,
     CODEX_MCP_TOOL_TIMEOUT_FLOOR,
+    CODEX_TOOL_OUTPUT_TOKEN_LIMIT,
 )
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
@@ -38,7 +39,8 @@ class TestCheckMcpServerRegisteredCodexBranch:
                             "startup_timeout_sec": CODEX_MCP_STARTUP_TIMEOUT_SEC,
                             "tool_timeout_sec": CODEX_MCP_TOOL_TIMEOUT_FLOOR,
                         }
-                    }
+                    },
+                    "tool_output_token_limit": CODEX_TOOL_OUTPUT_TOKEN_LIMIT,
                 }
             ),
         )

--- a/tests/execution/backends/test_backend_registry.py
+++ b/tests/execution/backends/test_backend_registry.py
@@ -41,8 +41,10 @@ class TestBackendRegistry:
         expected = {
             "BACKEND_REGISTRY",
             "CODEX_EXEC_FLAGS",
+            "CODEX_MCP_REQUIRED_KEYS",
             "CODEX_MCP_STARTUP_TIMEOUT_SEC",
             "CODEX_MCP_TOOL_TIMEOUT_FLOOR",
+            "CODEX_TOOL_OUTPUT_TOKEN_LIMIT",
             "CODEX_TOP_LEVEL_ONLY_FLAGS",
             "ClaudeCodeBackend",
             "ClaudeEnvPolicy",

--- a/tests/execution/backends/test_codex_config.py
+++ b/tests/execution/backends/test_codex_config.py
@@ -8,8 +8,10 @@ import pytest
 from autoskillit.core import CODEX_MCP_ENV_FORWARD_VARS, HEADLESS_AUTO_GATE_ENV_VAR
 from autoskillit.execution.backends import ensure_codex_mcp_registered
 from autoskillit.execution.backends._codex_config import (
+    CODEX_MCP_REQUIRED_KEYS,
     CODEX_MCP_STARTUP_TIMEOUT_SEC,
     CODEX_MCP_TOOL_TIMEOUT_FLOOR,
+    CODEX_TOOL_OUTPUT_TOKEN_LIMIT,
     _is_autoskillit_registered,
     _read_codex_config,
     _serialize_toml,
@@ -226,7 +228,8 @@ class TestIsAutoskillitRegistered:
                     "startup_timeout_sec": CODEX_MCP_STARTUP_TIMEOUT_SEC,
                     "tool_timeout_sec": CODEX_MCP_TOOL_TIMEOUT_FLOOR,
                 }
-            }
+            },
+            "tool_output_token_limit": CODEX_TOOL_OUTPUT_TOKEN_LIMIT,
         }
         assert _is_autoskillit_registered(config, headless_auto_gate=False) is True
 
@@ -239,7 +242,8 @@ class TestIsAutoskillitRegistered:
                     "startup_timeout_sec": CODEX_MCP_STARTUP_TIMEOUT_SEC,
                     "tool_timeout_sec": CODEX_MCP_TOOL_TIMEOUT_FLOOR,
                 }
-            }
+            },
+            "tool_output_token_limit": CODEX_TOOL_OUTPUT_TOKEN_LIMIT,
         }
         assert _is_autoskillit_registered(config, headless_auto_gate=True) is True
 
@@ -253,7 +257,8 @@ class TestIsAutoskillitRegistered:
                     "tool_timeout_sec": CODEX_MCP_TOOL_TIMEOUT_FLOOR,
                     "extra_field": 42,
                 }
-            }
+            },
+            "tool_output_token_limit": CODEX_TOOL_OUTPUT_TOKEN_LIMIT,
         }
         assert _is_autoskillit_registered(config, headless_auto_gate=False) is True
 
@@ -299,6 +304,35 @@ class TestIsAutoskillitRegistered:
                 f"Should reject config missing {var}"
             )
 
+    def test_missing_tool_output_token_limit_returns_false(self):
+        """Must return False when top-level tool_output_token_limit is missing."""
+        config = {
+            "mcp_servers": {
+                "autoskillit": {
+                    "command": "autoskillit",
+                    "env_vars": sorted(CODEX_MCP_ENV_FORWARD_VARS),
+                    "startup_timeout_sec": CODEX_MCP_STARTUP_TIMEOUT_SEC,
+                    "tool_timeout_sec": CODEX_MCP_TOOL_TIMEOUT_FLOOR,
+                }
+            }
+        }
+        assert _is_autoskillit_registered(config, headless_auto_gate=True) is False
+
+    def test_low_tool_output_token_limit_returns_false(self):
+        """Must return False when tool_output_token_limit is below the floor."""
+        config = {
+            "mcp_servers": {
+                "autoskillit": {
+                    "command": "autoskillit",
+                    "env_vars": sorted(CODEX_MCP_ENV_FORWARD_VARS),
+                    "startup_timeout_sec": CODEX_MCP_STARTUP_TIMEOUT_SEC,
+                    "tool_timeout_sec": CODEX_MCP_TOOL_TIMEOUT_FLOOR,
+                }
+            },
+            "tool_output_token_limit": CODEX_TOOL_OUTPUT_TOKEN_LIMIT - 1,
+        }
+        assert _is_autoskillit_registered(config, headless_auto_gate=True) is False
+
 
 class TestEnsureCodexMcpRegistered:
     def test_first_call_returns_true_and_writes(self, tmp_path):
@@ -311,6 +345,17 @@ class TestEnsureCodexMcpRegistered:
         assert "AUTOSKILLIT_HEADLESS" in entry["env_vars"]
         assert entry["startup_timeout_sec"] == CODEX_MCP_STARTUP_TIMEOUT_SEC
         assert entry["tool_timeout_sec"] == CODEX_MCP_TOOL_TIMEOUT_FLOOR
+
+    def test_tool_output_token_limit_written_to_top_level(self, tmp_path):
+        """ensure_codex_mcp_registered must set tool_output_token_limit at the top level."""
+        p = tmp_path / "config.toml"
+        ensure_codex_mcp_registered(config_path=p)
+        config = _read_codex_config(p).data
+        assert "tool_output_token_limit" in config
+        assert config["tool_output_token_limit"] >= 50_000
+        assert "tool_output_token_limit" not in config["mcp_servers"]["autoskillit"], (
+            "tool_output_token_limit is a Codex global key, not a server-entry key"
+        )
 
     def test_headless_auto_gate_true_includes_auto_gate_env(self, tmp_path):
         p = tmp_path / "config.toml"
@@ -468,6 +513,35 @@ class TestDestructiveOverwritePrevention:
         assert result.data["mcp_servers"]["other"]["command"] == "other"
         assert "autoskillit" in result.data["mcp_servers"]
 
+    def test_corrupt_file_path_writes_tool_output_token_limit(self, tmp_path):
+        """The corrupt-file path must also insert tool_output_token_limit at the top level."""
+        p = tmp_path / "config.toml"
+        p.write_text("not valid toml = =", encoding="utf-8")
+        ensure_codex_mcp_registered(config_path=p)
+        content = p.read_text(encoding="utf-8")
+        assert f"tool_output_token_limit = {CODEX_TOOL_OUTPUT_TOKEN_LIMIT}" in content
+        assert "[mcp_servers.autoskillit]" in content
+
+
+class TestRequiredKeysCoverage:
+    """The CODEX_MCP_REQUIRED_KEYS spec must match the keys actually written by
+    ensure_codex_mcp_registered. This is an arch test — every entry key must
+    be declared in the spec, and every spec key must be present in the entry."""
+
+    def test_required_keys_coverage(self, tmp_path):
+        p = tmp_path / "config.toml"
+        ensure_codex_mcp_registered(config_path=p)
+        config = _read_codex_config(p).data
+        entry = config["mcp_servers"]["autoskillit"]
+        actual_keys = set(entry.keys())
+        assert actual_keys >= CODEX_MCP_REQUIRED_KEYS, (
+            f"Entry is missing required keys: {CODEX_MCP_REQUIRED_KEYS - actual_keys}"
+        )
+        assert actual_keys == CODEX_MCP_REQUIRED_KEYS, (
+            f"Entry has keys not declared in CODEX_MCP_REQUIRED_KEYS: "
+            f"{actual_keys - CODEX_MCP_REQUIRED_KEYS}"
+        )
+
 
 class TestConfigEnvBoundary:
     def test_codex_mcp_config_contains_no_static_private_vars(self, tmp_path):
@@ -505,7 +579,8 @@ class TestConfigEnvBoundary:
                     "startup_timeout_sec": CODEX_MCP_STARTUP_TIMEOUT_SEC,
                     "tool_timeout_sec": CODEX_MCP_TOOL_TIMEOUT_FLOOR,
                 }
-            }
+            },
+            "tool_output_token_limit": CODEX_TOOL_OUTPUT_TOKEN_LIMIT,
         }
         assert _is_autoskillit_registered(config, headless_auto_gate=True) is True
 
@@ -656,7 +731,8 @@ class TestIsRegisteredRequiresAllForwardVars:
                     "startup_timeout_sec": CODEX_MCP_STARTUP_TIMEOUT_SEC,
                     "tool_timeout_sec": CODEX_MCP_TOOL_TIMEOUT_FLOOR,
                 }
-            }
+            },
+            "tool_output_token_limit": CODEX_TOOL_OUTPUT_TOKEN_LIMIT,
         }
 
     def test_all_forward_vars_present_is_registered(self) -> None:

--- a/tests/recipe/test_bundled_recipes_pipeline_structure.py
+++ b/tests/recipe/test_bundled_recipes_pipeline_structure.py
@@ -1134,3 +1134,45 @@ class TestWorktreeCreationAtOrchestratorLevel:
         assert "context.worktree_path" in cwd, (
             f"implement step cwd must reference context.worktree_path, got {cwd!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Recipe cmd quoting — bundled recipes must not have shell expansion
+# inside single-quoted regions (run-cmd-single-quote-expansion rule).
+# ---------------------------------------------------------------------------
+
+
+class TestNoSingleQuotedShellExpansionInBundledRecipes:
+    """All bundled recipes must avoid shell expansion inside single quotes."""
+
+    @pytest.fixture(scope="class")
+    def recipes(self):
+        from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+        recipes_dir = builtin_recipes_dir()
+        return {
+            yaml_path.name: load_recipe(yaml_path)
+            for yaml_path in sorted(recipes_dir.glob("*.yaml"))
+        }
+
+    def test_no_run_cmd_step_uses_single_quoted_expansion(self, recipes) -> None:
+        import re as _re
+
+        # Match $(...) inside single quotes — bash suppresses command substitution
+        # in single quotes, so the substitution would silently fail. We don't flag
+        # ${{ ... }} (recipe ingredient syntax) or backticks (often intentional
+        # literal text in commit messages / doc strings).
+        single_quote_expansion_re = _re.compile(r"'[^']*\$\([^']*'")
+        offenders: list[tuple[str, str, str]] = []
+        for recipe_name, recipe in recipes.items():
+            for step_name, step in recipe.steps.items():
+                if step.tool != "run_cmd":
+                    continue
+                cmd = (step.with_args or {}).get("cmd", "")
+                if not isinstance(cmd, str):
+                    continue
+                for m in single_quote_expansion_re.finditer(cmd):
+                    offenders.append((recipe_name, step_name, m.group()))
+        assert not offenders, (
+            f"Bundled recipes have $(...) command substitution inside single quotes: {offenders}"
+        )

--- a/tests/recipe/test_bundled_recipes_pipeline_structure.py
+++ b/tests/recipe/test_bundled_recipes_pipeline_structure.py
@@ -1156,13 +1156,8 @@ class TestNoSingleQuotedShellExpansionInBundledRecipes:
         }
 
     def test_no_run_cmd_step_uses_single_quoted_expansion(self, recipes) -> None:
-        import re as _re
+        from autoskillit.recipe.rules.rules_cmd import _SINGLE_QUOTE_EXPANSION_RE
 
-        # Match $(...) inside single quotes — bash suppresses command substitution
-        # in single quotes, so the substitution would silently fail. We don't flag
-        # ${{ ... }} (recipe ingredient syntax) or backticks (often intentional
-        # literal text in commit messages / doc strings).
-        single_quote_expansion_re = _re.compile(r"'[^']*\$\([^']*'")
         offenders: list[tuple[str, str, str]] = []
         for recipe_name, recipe in recipes.items():
             for step_name, step in recipe.steps.items():
@@ -1171,7 +1166,7 @@ class TestNoSingleQuotedShellExpansionInBundledRecipes:
                 cmd = (step.with_args or {}).get("cmd", "")
                 if not isinstance(cmd, str):
                     continue
-                for m in single_quote_expansion_re.finditer(cmd):
+                for m in _SINGLE_QUOTE_EXPANSION_RE.finditer(cmd):
                     offenders.append((recipe_name, step_name, m.group()))
         assert not offenders, (
             f"Bundled recipes have $(...) command substitution inside single quotes: {offenders}"

--- a/tests/recipe/test_rules_cmd.py
+++ b/tests/recipe/test_rules_cmd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from autoskillit.core import Severity
 from autoskillit.recipe.validator import run_semantic_rules
 from tests.recipe.conftest import _make_workflow
 
@@ -546,7 +547,7 @@ def test_run_cmd_path_capture_without_guard_flagged():
     codes = [f.rule for f in findings]
     assert "run-cmd-path-capture-requires-nonempty-guard" in codes
     finding = next(f for f in findings if f.rule == "run-cmd-path-capture-requires-nonempty-guard")
-    assert finding.severity.value == "warning"
+    assert finding.severity == Severity.WARNING
 
 
 def test_run_cmd_path_capture_with_guard_passes():
@@ -617,7 +618,7 @@ def test_single_quote_expansion_rule_fires_on_dollar_paren():
     codes = [f.rule for f in findings]
     assert "run-cmd-single-quote-expansion" in codes
     finding = next(f for f in findings if f.rule == "run-cmd-single-quote-expansion")
-    assert finding.severity.value == "error"
+    assert finding.severity == Severity.ERROR
     assert "step_a" in finding.step_name
     assert "$(date +%s)" in finding.message
 

--- a/tests/recipe/test_rules_cmd.py
+++ b/tests/recipe/test_rules_cmd.py
@@ -595,3 +595,103 @@ def test_run_cmd_path_capture_bracket_guard_passes():
     )
     findings = run_semantic_rules(recipe)
     assert all(f.rule != "run-cmd-path-capture-requires-nonempty-guard" for f in findings)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# run-cmd-single-quote-expansion
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_single_quote_expansion_rule_fires_on_dollar_paren():
+    """run_cmd with $(...) inside single quotes → ERROR finding."""
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": "bash script.sh 'arg-$(date +%s)'"},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    codes = [f.rule for f in findings]
+    assert "run-cmd-single-quote-expansion" in codes
+    finding = next(f for f in findings if f.rule == "run-cmd-single-quote-expansion")
+    assert finding.severity.value == "error"
+    assert "step_a" in finding.step_name
+    assert "$(date +%s)" in finding.message
+
+
+def test_single_quote_expansion_rule_passes_on_double_quoted_expansion():
+    """run_cmd with $(...) inside double quotes → no finding (expansion works)."""
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": 'bash script.sh "arg-$(date +%s)"'},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "run-cmd-single-quote-expansion" for f in findings)
+
+
+def test_single_quote_expansion_rule_passes_on_unquoted_expansion():
+    """run_cmd with $(...) unquoted → no finding (expansion works)."""
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": "bash script.sh arg-$(date +%s)"},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "run-cmd-single-quote-expansion" for f in findings)
+
+
+def test_single_quote_expansion_rule_passes_on_plain_single_quotes():
+    """run_cmd with single quotes but no expansion → no finding."""
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": "echo 'hello world'"},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "run-cmd-single-quote-expansion" for f in findings)
+
+
+def test_single_quote_expansion_rule_passes_on_recipe_ingredient_syntax():
+    """Recipe ${{...}} ingredient syntax inside single quotes is fine."""
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": "echo '${{ context.foo }}'"},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "run-cmd-single-quote-expansion" for f in findings)
+
+
+def test_single_quote_expansion_rule_passes_on_top_level_assignment():
+    """run_cmd with top-level $(...) (not inside single quotes) → no finding."""
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": "REMOTE=$(git remote get-url upstream)"},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "run-cmd-single-quote-expansion" for f in findings)


### PR DESCRIPTION
## Summary

Two classes of architectural weakness were discovered:

1. **Recipe `cmd:` fields can silently suppress shell expansion** — Single-quoted regions containing `$(...)` command substitution pass through YAML parsing, recipe loading, ingredient substitution, and `run_cmd` execution without any validation detecting that bash will treat the expansion as literal text. The semantic rule system in `rules_cmd.py` has 7 existing rules for `run_cmd` steps but none inspect quoting interactions with shell expansion.

2. **Backend config registration is structurally incomplete** — `ensure_codex_mcp_registered()` writes 4 keys to `~/.codex/config.toml` but omits `tool_output_token_limit`, which controls Codex's per-tool response size budget. The idempotency check `_is_autoskillit_registered()` doesn't verify this key either, so stale configs missing it are never flagged for rewrite. The Claude Code-specific `MAX_MCP_OUTPUT_TOKENS` mechanism and `anthropic/maxResultSizeChars` annotation are irrelevant to Codex — they are separate, non-portable mechanisms.

**Part A covers:** The recipe `cmd` quoting immunity (semantic rule + fix + tests) and the Codex config completeness immunity (`tool_output_token_limit` + idempotency check + tests). Part B will cover MCP response size observability (`content_size_chars` in `open_kitchen` response, truncation-risk detection, recipe content size reduction).

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260606-172055-086510/.autoskillit/temp/rectify/rectify_recipe_cmd_quoting_and_codex_config_completeness_2026-06-06_172055.md`

Closes #3881

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 7.4k | 23.0k | 3.0M | 126.9k | 71 | 104.8k | 33m 8s |
| review_approach* | sonnet | 1 | 7.1k | 6.6k | 198.2k | 52.5k | 15 | 56.6k | 6m 22s |
| dry_walkthrough* | opus | 2 | 79 | 16.1k | 1.8M | 122.3k | 68 | 156.5k | 11m 42s |
| audit_impl* | sonnet | 2 | 737 | 27.0k | 825.3k | 73.0k | 52 | 78.2k | 12m 54s |
| make_plan* | sonnet | 1 | 127 | 6.7k | 814.3k | 71.2k | 33 | 51.1k | 2m 21s |
| prepare_pr* | MiniMax-M3 | 1 | 44.8k | 3.9k | 263.2k | 50.1k | 20 | 0 | 1m 26s |
| compose_pr* | MiniMax-M3 | 1 | 35.9k | 2.0k | 190.0k | 39.3k | 14 | 0 | 53s |
| review_pr* | sonnet | 1 | 124 | 40.8k | 1.1M | 110.4k | 51 | 89.7k | 9m 15s |
| resolve_review* | opus[1m] | 1 | 45 | 6.3k | 1.2M | 80.6k | 39 | 59.4k | 5m 25s |
| **Total** | | | 96.4k | 132.3k | 9.4M | 126.9k | | 596.4k | 1h 23m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 9 | 135821.4 | 6600.0 | 701.0 |
| **Total** | **9** | 1044031.8 | 66263.9 | 14703.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 2 | 7.4k | 29.3k | 4.2M | 164.2k | 38m 33s |
| sonnet | 4 | 8.1k | 81.1k | 2.9M | 275.7k | 30m 53s |
| opus | 1 | 79 | 16.1k | 1.8M | 156.5k | 11m 42s |
| MiniMax-M3 | 2 | 80.8k | 5.9k | 453.2k | 0 | 2m 18s |