### PR TITLE
[FIX] Planner Lifecycle Registry Category Immunity

### DIFF
--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -6,7 +6,12 @@ from __future__ import annotations
 
 from autoskillit.planner.compiler import compile_plan
 from autoskillit.planner.consolidation import consolidate_wps
-from autoskillit.planner.lifecycle import load_lifecycle_registry, record_lifecycle_event
+from autoskillit.planner.lifecycle import (
+    LIFECYCLE_CATEGORY_DEFAULTS,
+    LifecycleCategory,
+    load_lifecycle_registry,
+    record_lifecycle_event,
+)
 from autoskillit.planner.manifests import (
     build_phase_assignment_manifest,
     build_phase_wp_manifest,
@@ -95,4 +100,6 @@ __all__ = [
     "DiscoveryResult",
     "load_lifecycle_registry",
     "record_lifecycle_event",
+    "LifecycleCategory",
+    "LIFECYCLE_CATEGORY_DEFAULTS",
 ]

--- a/src/autoskillit/planner/consolidation.py
+++ b/src/autoskillit/planner/consolidation.py
@@ -12,7 +12,11 @@ import regex as re
 from autoskillit.core import atomic_write, write_versioned_json
 from autoskillit.planner._dag_ops import break_cycles_greedy_fas, filter_self_references
 from autoskillit.planner._sort_utils import _natural_sort_key
-from autoskillit.planner.lifecycle import load_lifecycle_registry, record_lifecycle_event
+from autoskillit.planner.lifecycle import (
+    LifecycleCategory,
+    load_lifecycle_registry,
+    record_lifecycle_event,
+)
 from autoskillit.planner.schema import validate_wp_result
 
 _ASSIGNMENT_RE = re.compile(r"^(P\d+-A\d+)-")
@@ -344,7 +348,7 @@ def consolidate_wps(
                 for absorbed_id in non_primary_sources
                 if absorbed_id in source_to_merged
             }
-            record_lifecycle_event(planner_path, "absorbed", absorbed_data)
+            record_lifecycle_event(planner_path, LifecycleCategory.ABSORBED, absorbed_data)
 
         # Delete voided WP result files
         for voided_id in voided_wp_ids:

--- a/src/autoskillit/planner/lifecycle.py
+++ b/src/autoskillit/planner/lifecycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -13,25 +14,46 @@ _REGISTRY_FILENAME = "lifecycle_registry.json"
 _LEGACY_FILENAME = "absorption_registry.json"
 
 
-def record_lifecycle_event(planner_dir: Path, key: str, data: list[str] | dict[str, Any]) -> None:
+class LifecycleCategory(StrEnum):
+    VOIDED_PHASES = "voided_phases"
+    VOIDED_ASSIGNMENTS = "voided_assignments"
+    ABSORBED = "absorbed"
+    VOIDED_WPS = "voided_wps"
+    ARCHIVED_STUBS = "archived_stubs"
+
+
+LIFECYCLE_CATEGORY_DEFAULTS: dict[LifecycleCategory, list | dict] = {
+    LifecycleCategory.VOIDED_PHASES: [],
+    LifecycleCategory.VOIDED_ASSIGNMENTS: [],
+    LifecycleCategory.ABSORBED: {},
+    LifecycleCategory.VOIDED_WPS: {},
+    LifecycleCategory.ARCHIVED_STUBS: {},
+}
+
+for _cat in LifecycleCategory:
+    if _cat not in LIFECYCLE_CATEGORY_DEFAULTS:
+        raise AssertionError(
+            f"LifecycleCategory.{_cat.name} missing from LIFECYCLE_CATEGORY_DEFAULTS"
+        )
+del _cat
+
+
+def record_lifecycle_event(
+    planner_dir: Path, key: LifecycleCategory, data: list[str] | dict[str, Any]
+) -> None:
     wp_dir = planner_dir / "work_packages"
     wp_dir.mkdir(parents=True, exist_ok=True)
     registry_path = wp_dir / _REGISTRY_FILENAME
 
     existing: dict[str, Any] = {
-        "voided_phases": [],
-        "voided_assignments": [],
-        "absorbed": {},
-        "voided_wps": {},
+        cat.value: type(LIFECYCLE_CATEGORY_DEFAULTS[cat])() for cat in LifecycleCategory
     }
     if registry_path.exists():
         loaded = read_versioned_json(registry_path, LIFECYCLE_REGISTRY_VERSION)
         if loaded:
             existing = {
-                "voided_phases": loaded.get("voided_phases", []),
-                "voided_assignments": loaded.get("voided_assignments", []),
-                "absorbed": loaded.get("absorbed", {}),
-                "voided_wps": loaded.get("voided_wps", {}),
+                cat.value: loaded.get(cat.value, type(LIFECYCLE_CATEGORY_DEFAULTS[cat])())
+                for cat in LifecycleCategory
             }
         else:
             logger.warning(
@@ -40,14 +62,15 @@ def record_lifecycle_event(planner_dir: Path, key: str, data: list[str] | dict[s
                 hint="file exists but could not be parsed; merging with blank default",
             )
 
+    key_str = str(key)
     if isinstance(data, list):
-        current = existing.get(key, [])
+        current = existing.get(key_str, [])
         merged = list(dict.fromkeys(current + data))
-        existing[key] = merged
+        existing[key_str] = merged
     elif isinstance(data, dict):
-        current = existing.get(key, {})
+        current = existing.get(key_str, {})
         current.update(data)
-        existing[key] = current
+        existing[key_str] = current
 
     write_versioned_json(registry_path, existing, schema_version=LIFECYCLE_REGISTRY_VERSION)
 
@@ -57,10 +80,7 @@ def load_lifecycle_registry(planner_dir: Path) -> dict[str, Any]:
     registry_path = wp_dir / _REGISTRY_FILENAME
 
     defaults: dict[str, Any] = {
-        "voided_phases": [],
-        "voided_assignments": [],
-        "absorbed": {},
-        "voided_wps": {},
+        cat.value: type(LIFECYCLE_CATEGORY_DEFAULTS[cat])() for cat in LifecycleCategory
     }
 
     if registry_path.exists():

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -10,7 +10,11 @@ from typing import TypedDict
 
 from autoskillit.core import atomic_write, get_logger, read_versioned_json, write_versioned_json
 from autoskillit.planner._sort_utils import _natural_sort_key
-from autoskillit.planner.lifecycle import load_lifecycle_registry, record_lifecycle_event
+from autoskillit.planner.lifecycle import (
+    LifecycleCategory,
+    load_lifecycle_registry,
+    record_lifecycle_event,
+)
 from autoskillit.planner.schema import (
     ASSIGN_ID_RE,
     ASSIGN_RESULT_FILE_RE,
@@ -361,7 +365,7 @@ def expand_assignments(
 
     voided_phase_ids = [phase["id"] for phase in phases if not phase.get("assignments_preview")]
     if voided_phase_ids:
-        record_lifecycle_event(Path(output_dir), "voided_phases", voided_phase_ids)
+        record_lifecycle_event(Path(output_dir), LifecycleCategory.VOIDED_PHASES, voided_phase_ids)
 
     sentinel_dir = _ensure_sentinel_dir(assign_dir, "assign_sentinels")
     manifest = {
@@ -559,7 +563,7 @@ def reconcile_wp_files(planner_dir: str) -> dict[str, str]:
     if moved_ids:
         record_lifecycle_event(
             planner_path,
-            "archived_stubs",
+            LifecycleCategory.ARCHIVED_STUBS,
             {oid: {"reason": "elaboration_failed_orphan"} for oid in moved_ids},
         )
     logger.info("reconcile_wp_files", archived_count=len(moved_ids))

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -8,7 +8,7 @@ from typing import Any
 import regex as re
 
 from autoskillit.core import get_logger, write_versioned_json
-from autoskillit.planner.lifecycle import record_lifecycle_event
+from autoskillit.planner.lifecycle import LifecycleCategory, record_lifecycle_event
 from autoskillit.planner.schema import (
     ASSIGN_RESULT_FILE_RE,
     PHASE_RESULT_FILE_RE,
@@ -457,7 +457,7 @@ def merge_refined_assignments(
 
     voided_ids = [a["id"] for a in all_assignments if not a.get("proposed_work_packages")]
     if voided_ids:
-        record_lifecycle_event(Path(planner_dir), "voided_assignments", voided_ids)
+        record_lifecycle_event(Path(planner_dir), LifecycleCategory.VOIDED_ASSIGNMENTS, voided_ids)
 
     output_path = Path(planner_dir) / "refined_assignments.json"
     write_versioned_json(output_path, {"assignments": all_assignments}, schema_version=1)

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -197,6 +197,14 @@ def _check_assignment_completeness(
                 voided_wp_pairs.add((pn, an))
             except ValueError:
                 logger.warning("malformed_voided_wp_id", voided_wp_id=voided_id)
+    archived_stub_pairs: set[tuple[int, int]] = set()
+    if lifecycle_registry and isinstance(lifecycle_registry.get("archived_stubs"), dict):
+        for archived_id in lifecycle_registry["archived_stubs"]:
+            try:
+                pn, an = parse_planner_id(archived_id)[:2]
+                archived_stub_pairs.add((pn, an))
+            except ValueError:
+                logger.warning("malformed_archived_stub_id", archived_stub_id=archived_id)
     for assign_id, assign in assignment_results.items():
         if assign_id in voided_assign_ids:
             continue
@@ -204,6 +212,8 @@ def _check_assignment_completeness(
         if pair in absorbed_pairs:
             continue
         if pair in voided_wp_pairs:
+            continue
+        if pair in archived_stub_pairs:
             continue
         if pair not in wp_pairs:
             findings.append(
@@ -221,10 +231,12 @@ def _check_dep_references(
     lifecycle_registry: dict[str, Any] | None = None,
 ) -> list[ValidationFinding]:
     voided_wp_ids = set((lifecycle_registry or {}).get("voided_wps", {}).keys())
+    archived_stub_ids = set((lifecycle_registry or {}).get("archived_stubs", {}).keys())
+    exempt_wp_ids = voided_wp_ids | archived_stub_ids
     findings: list[ValidationFinding] = []
     for wp_id, wp in wp_results.items():
         for dep in wp.get("depends_on", []):
-            if dep not in wp_results and dep not in voided_wp_ids:
+            if dep not in wp_results and dep not in exempt_wp_ids:
                 findings.append(
                     {
                         "message": f"WP {wp_id} depends on unknown WP {dep}",

--- a/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
@@ -195,7 +195,7 @@ Collect all `subsumption_pairs` from validated L0 responses. For each pair:
 3. Remove the subsumed WP from the output WP list
 4. Update all `depends_on` references: any WP that depended on the subsumed WP should instead depend on the consumer WP
 5. Write voided_wps entry to `$4/work_packages/lifecycle_registry.json`:
-   Read existing registry (or create with defaults `{"voided_phases": [], "voided_assignments": [], "absorbed": {}, "voided_wps": {}}`).
+   Read existing registry (or create with defaults `{"voided_phases": [], "voided_assignments": [], "absorbed": {}, "voided_wps": {}, "archived_stubs": {}}`).
    Add to `voided_wps`: `{subsumed_id: {"merged_into": consumer_id, "reason": reason}}`.
    Write back with `schema_version: 1`.
 6. Log: `WP SUBSUMED: {subsumed_id} → {consumer_id} ({reason})`

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -168,11 +168,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils/_eval.py", 318),
     ("src/autoskillit/smoke_utils/_eval.py", 483),
     # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)
-    ("src/autoskillit/planner/consolidation.py", 333),
+    ("src/autoskillit/planner/consolidation.py", 337),
     # planner/consolidation.py — broken_cycle_edges.json (list payload; AST scanner catches it)
-    ("src/autoskillit/planner/consolidation.py", 357),
+    ("src/autoskillit/planner/consolidation.py", 361),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
-    ("src/autoskillit/planner/manifests.py", 299),
+    ("src/autoskillit/planner/manifests.py", 303),
     # _cmd_rpc_issues.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
     ("src/autoskillit/recipe/_cmd_rpc_issues.py", 77),
 }

--- a/tests/planner/CLAUDE.md
+++ b/tests/planner/CLAUDE.md
@@ -16,6 +16,7 @@ Planner manifest, validation, compilation, and merge tests.
 | `test_dag_ops.py` | Tests for _dag_ops: topological_sort, find_sccs, break_cycles_greedy_fas, filter_self_references |
 | `test_dag_ops_lazy_import.py` | Regression guard: verifies networkx is not eagerly imported at module level in _dag_ops |
 | `test_elaborate_assignments_contract.py` | Contract conformance tests for planner-elaborate-assignments skill |
+| `test_lifecycle.py` | LifecycleCategory enum, record_lifecycle_event multi-write preservation, archived_stubs exemption tests |
 | `test_elaborate_wps_contract.py` | Contract conformance tests for planner-elaborate-wps skill |
 | `test_manifests_builders.py` | build_phase_assignment_manifest and build_phase_wp_manifest |
 | `test_manifests_finalize.py` | finalize_wp_manifest and collect_tier_result_files |

--- a/tests/planner/test_consolidation_writeback.py
+++ b/tests/planner/test_consolidation_writeback.py
@@ -424,11 +424,15 @@ def test_consolidate_wps_wp_index_in_work_packages(tmp_path: Path) -> None:
 
 def test_lifecycle_registry_includes_voided_wps(tmp_path: Path) -> None:
     """voided_wps key is supported by lifecycle registry read/write."""
-    from autoskillit.planner.lifecycle import load_lifecycle_registry, record_lifecycle_event
+    from autoskillit.planner.lifecycle import (
+        LifecycleCategory,
+        load_lifecycle_registry,
+        record_lifecycle_event,
+    )
 
     record_lifecycle_event(
         tmp_path,
-        "voided_wps",
+        LifecycleCategory.VOIDED_WPS,
         {"P1-A2-WP1": {"merged_into": "P1-A1-WP1", "reason": "subsumed"}},
     )
     registry = load_lifecycle_registry(tmp_path)
@@ -452,11 +456,11 @@ def test_consolidate_wps_deletes_voided_wp_result_files(tmp_path: Path) -> None:
     write_json(wp_dir / "P1-A2-WP1_result.json", make_wp_result("P1-A2-WP1"))
 
     # Record voided_wps in lifecycle registry
-    from autoskillit.planner.lifecycle import record_lifecycle_event
+    from autoskillit.planner.lifecycle import LifecycleCategory, record_lifecycle_event
 
     record_lifecycle_event(
         tmp_path,
-        "voided_wps",
+        LifecycleCategory.VOIDED_WPS,
         {"P1-A2-WP1": {"merged_into": "P1-A1-WP1", "reason": "subsumed"}},
     )
 

--- a/tests/planner/test_lifecycle.py
+++ b/tests/planner/test_lifecycle.py
@@ -1,0 +1,91 @@
+"""Tests for autoskillit.planner.lifecycle — category enum immunity and registry behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
+
+
+def test_lifecycle_category_enum_exhaustive() -> None:
+    """Importing lifecycle module does not raise — every enum member is in defaults."""
+    from autoskillit.planner.lifecycle import (  # noqa: F401
+        LIFECYCLE_CATEGORY_DEFAULTS,
+        LifecycleCategory,
+    )
+
+
+def test_record_lifecycle_event_preserves_all_categories(tmp_path: Path) -> None:
+    """Multi-write round-trip preserves all category data (regression for the data-loss bug)."""
+    from autoskillit.planner.lifecycle import (
+        LifecycleCategory,
+        load_lifecycle_registry,
+        record_lifecycle_event,
+    )
+
+    record_lifecycle_event(
+        tmp_path,
+        LifecycleCategory.ARCHIVED_STUBS,
+        {"P1-A1-WP1": {"reason": "elaboration_failed_orphan"}},
+    )
+    record_lifecycle_event(
+        tmp_path,
+        LifecycleCategory.VOIDED_WPS,
+        {"P2-A1-WP1": {"merged_into": "P2-A1-WP2", "reason": "duplicate"}},
+    )
+
+    registry = load_lifecycle_registry(tmp_path)
+    assert "archived_stubs" in registry
+    assert registry["archived_stubs"]["P1-A1-WP1"]["reason"] == "elaboration_failed_orphan"
+    assert "voided_wps" in registry
+    assert registry["voided_wps"]["P2-A1-WP1"]["merged_into"] == "P2-A1-WP2"
+
+
+def test_check_assignment_completeness_exempts_archived_stubs() -> None:
+    """Assignment is exempt when an archived_stubs WP maps to its (phase, assignment) pair."""
+    from autoskillit.planner.validation import _check_assignment_completeness
+
+    assignment_results = {
+        "P1-A1": {"phase_number": 1, "assignment_number": 1},
+    }
+    wp_results: dict = {}
+    lifecycle_registry = {
+        "archived_stubs": {"P1-A1-WP1": {"reason": "elaboration_failed_orphan"}},
+        "voided_phases": [],
+        "voided_assignments": [],
+        "absorbed": {},
+        "voided_wps": {},
+    }
+
+    findings = _check_assignment_completeness(assignment_results, wp_results, lifecycle_registry)
+    assert not any(f["check"] == "assignment_completeness" for f in findings)
+
+
+def test_check_dep_references_exempts_archived_stubs() -> None:
+    """dep_references check exempts deps in archived_stubs (same as voided_wps)."""
+    from autoskillit.planner.validation import _check_dep_references
+
+    wp_results = {
+        "P1-A1-WP1": {"id": "P1-A1-WP1", "depends_on": ["P1-A2-WP1"]},
+    }
+    lifecycle_registry = {
+        "archived_stubs": {"P1-A2-WP1": {"reason": "elaboration_failed_orphan"}},
+        "voided_phases": [],
+        "voided_assignments": [],
+        "absorbed": {},
+        "voided_wps": {},
+    }
+
+    findings = _check_dep_references(wp_results, lifecycle_registry)
+    assert not any(f["check"] == "dep_references" for f in findings)
+
+
+def test_load_lifecycle_registry_defaults_cover_all_categories(tmp_path: Path) -> None:
+    """load_lifecycle_registry returns a dict with all category keys even when no file exists."""
+    from autoskillit.planner.lifecycle import LifecycleCategory, load_lifecycle_registry
+
+    registry = load_lifecycle_registry(tmp_path / "nonexistent")
+    for cat in LifecycleCategory:
+        assert cat.value in registry, f"{cat.value} missing from defaults"

--- a/tests/planner/test_planner_api.py
+++ b/tests/planner/test_planner_api.py
@@ -62,6 +62,8 @@ def test_planner_all_exports() -> None:
         "load_lifecycle_registry",
         "reconcile_wp_files",
         "record_lifecycle_event",
+        "LifecycleCategory",
+        "LIFECYCLE_CATEGORY_DEFAULTS",
     }
 
 

--- a/tests/planner/test_validation_checks.py
+++ b/tests/planner/test_validation_checks.py
@@ -420,7 +420,7 @@ def test_check_assignment_completeness_all_wps_voided(tmp_path: Path) -> None:
 
 def test_validate_plan_with_voided_wps_passes(tmp_path: Path) -> None:
     """Full validate_plan passes when voided WPs are properly registered."""
-    from autoskillit.planner.lifecycle import record_lifecycle_event
+    from autoskillit.planner.lifecycle import LifecycleCategory, record_lifecycle_event
 
     # Create minimal output structure using proper helpers
     phases_dir = tmp_path / "phases"
@@ -441,7 +441,7 @@ def test_validate_plan_with_voided_wps_passes(tmp_path: Path) -> None:
     # Void the second WP
     record_lifecycle_event(
         tmp_path,
-        "voided_wps",
+        LifecycleCategory.VOIDED_WPS,
         {"P1-A2-WP1": {"merged_into": "P1-A1-WP1", "reason": "subsumed"}},
     )
     # Delete its result file


### PR DESCRIPTION
## Summary

The planner lifecycle registry (`lifecycle_registry.json`) uses magic string keys with no authoritative type definition. When `archived_stubs` was added as a new lifecycle category (PR #3801), consumers (validator functions) and the registry read-modify-write loop (`record_lifecycle_event`) were never updated. The architectural solution introduces a `LifecycleCategory` StrEnum as the single source of truth with an import-time completeness assertion — the same pattern used successfully for `IssueLabelState`/`LABEL_LIFECYCLE_REGISTRY` in `_type_constants_features.py`. This makes it structurally impossible to add a lifecycle category without updating the consumer registry.

## Requirements

### REQ-FIX-1: Add `archived_stubs` exemption to assignment completeness check

Add an `archived_stubs` pair-extraction block to `_check_assignment_completeness` following the identical pattern used for `absorbed` (lines 184–191) and `voided_wps` (lines 192–199). Extract `(phase_num, assign_num)` pairs from `lifecycle_registry["archived_stubs"]` keys and add them to an exemption set checked before emitting the error. ~10 line change.

### REQ-FIX-2: Add `archived_stubs` exemption to dep references check

Add `archived_stubs` WP IDs to the exemption set in `_check_dep_references` (`validation.py:223`). Currently only `voided_wps` keys are exempted. Archived stub WP IDs should also be treated as valid dangling references.

### REQ-FIX-3: Add `archived_stubs` to lifecycle registry defaults and re-read whitelist

Three locations need updating in `lifecycle.py`:
- `record_lifecycle_event` initial defaults (lines 21–26): add `"archived_stubs": {}`
- `record_lifecycle_event` re-read reconstruction (lines 30–35): add `"archived_stubs": loaded.get("archived_stubs", {})`
- `load_lifecycle_registry` defaults (lines 59–64): add `"archived_stubs": {}`

The re-read reconstruction at lines 30–35 is critical — without it, any subsequent lifecycle event write silently drops existing `archived_stubs` data.

### REQ-FIX-4: Test coverage

Add tests verifying that:
- Assignments whose only WPs appear in `archived_stubs` do not produce `assignment_completeness` errors
- WP IDs in `archived_stubs` do not produce `dep_references` errors when referenced in `depends_on`
- `record_lifecycle_event` preserves `archived_stubs` when writing other lifecycle events

Note: the existing `test_validate_plan_ignores_archived_stubs` (`test_validation_core.py:252`) is vacuous for assignment completeness — it creates no assignment result file for the archived WP's parent assignment, so the check never fires. New tests must include the assignment result file to exercise the actual code path.

### REQ-FIX-5 (optional): Belt-and-suspenders — record to `voided_assignments`

When `reconcile_wp_files()` archives ALL WPs for an assignment, additionally record that assignment ID in `voided_assignments`. Note: this requires a non-trivial addition — `reconcile_wp_files()` currently has no assignment-level mapping and would need to consult `wp_manifest.json` or assignment result files to determine assignment membership. Consider implementing only if REQ-FIX-1 alone proves insufficient.

Closes #3845

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260607-131055-562412/.autoskillit/temp/rectify/rectify_planner-lifecycle-category-immunity_2026-06-07_131500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 55 | 15.9k | 1.2M | 95.0k | 41 | 100.9k | 16m 46s |
| review_approach* | opus[1m] | 1 | 3.0k | 5.0k | 228.2k | 52.1k | 10 | 33.2k | 5m 15s |
| dry_walkthrough* | opus | 1 | 43 | 10.0k | 931.5k | 86.2k | 44 | 86.4k | 6m 25s |
| audit_impl* | opus[1m] | 1 | 36 | 13.0k | 416.3k | 69.0k | 19 | 48.2k | 6m 22s |
| prepare_pr* | MiniMax-M3 | 1 | 45.1k | 3.5k | 313.8k | 50.2k | 18 | 0 | 1m 17s |
| compose_pr* | MiniMax-M3 | 1 | 43.2k | 1.9k | 290.7k | 46.2k | 14 | 0 | 1m 4s |
| review_pr* | opus[1m] | 3 | 99 | 89.3k | 2.1M | 94.9k | 97 | 194.9k | 23m 1s |
| **Total** | | | 91.5k | 138.7k | 5.4M | 95.0k | | 463.6k | 1h 0m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 4 | 3.2k | 123.3k | 3.9M | 377.2k | 51m 26s |
| opus | 1 | 43 | 10.0k | 931.5k | 86.4k | 6m 25s |
| MiniMax-M3 | 2 | 88.2k | 5.4k | 604.5k | 0 | 2m 21s |