### PR TITLE
[FIX] Rectify: Git Metadata Write Capability Detection Gap

### DIFF
--- a/src/autoskillit/core/types/_type_constants_registries.py
+++ b/src/autoskillit/core/types/_type_constants_registries.py
@@ -340,7 +340,10 @@ SKILL_CAPABILITY_REGISTRY: dict[str, SkillCapabilityDef] = {
         codex_status="fix-required",
     ),
     "git_metadata_write": SkillCapabilityDef(
-        description="Requires .git/ metadata write access (git worktree add, git checkout -b)",
+        description=(
+            "Requires .git/ metadata write access (git commit, git rebase, "
+            "git worktree add, git checkout -b)"
+        ),
         codex_status="not-applicable",
     ),
 }

--- a/src/autoskillit/skills_extended/generate-report/SKILL.md
+++ b/src/autoskillit/skills_extended/generate-report/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: generate-report
 categories: [research]
-uses_capabilities: [agent_model, cross_skill_ref]
+uses_capabilities: [agent_model, cross_skill_ref, git_metadata_write]
 description: Synthesize experiment results into a structured research report in the research/ folder. Supports --inconclusive flag.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: make-plan
-uses_capabilities: [agent_model, agent_subagent, cross_skill_ref]
+uses_capabilities: [agent_model, agent_subagent, cross_skill_ref, git_metadata_write]
 activate_deps: [arch-lens, write-recipe]
 description: Planning executor. ALWAYS invoke this skill when instructed to create, devise, or write an implementation plan. Do not explore the codebase or draft a plan directly — use this skill first to load the planning workflow.
 hooks:

--- a/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: resolve-claims-review
 categories: [research]
-uses_capabilities: [agent_model]
+uses_capabilities: [agent_model, git_metadata_write]
 description: >
   Fetch claim findings from audit-claims, run citation-aware intent validation
   (ACCEPT/REJECT/DISCUSS), apply targeted citation fixes, escalate findings

--- a/src/autoskillit/skills_extended/resolve-failures/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-failures/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: resolve-failures
-uses_capabilities: [cross_skill_ref, run_skill, test_check]
+uses_capabilities: [cross_skill_ref, git_metadata_write, run_skill, test_check]
 description: Failure resolution executor. ALWAYS invoke this skill when instructed to fix test failures in a worktree. Do not read test output or edit code directly — use this skill first to load the failure resolution workflow.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/resolve-merge-conflicts/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-merge-conflicts/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: resolve-merge-conflicts
 categories: [github]
+uses_capabilities: [git_metadata_write]
 description: >
   Goal-aware resolution of rebase conflicts when merging a conflict-resolution worktree
   back into the integration branch. Analyzes the intent of each side of a conflict,

--- a/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: resolve-research-review
 categories: [research]
-uses_capabilities: [agent_model]
+uses_capabilities: [agent_model, git_metadata_write]
 description: >
   Fetch PR review comments from review-research-pr, run research-aware intent
   validation (ACCEPT/REJECT/DISCUSS), apply targeted fixes, escalate unrerunnable

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: resolve-review
 categories: [github]
-uses_capabilities: [agent_model, cross_skill_ref, run_skill, test_check]
+uses_capabilities: [agent_model, cross_skill_ref, git_metadata_write, run_skill, test_check]
 description: Fetch PR review comments, run intent validation (ACCEPT/REJECT/DISCUSS) before applying fixes, and post inline replies. MCP-only — used exclusively by recipe orchestration via run_skill after review_pr reports changes_requested or needs_human verdict.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/retry-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/retry-worktree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: retry-worktree
-uses_capabilities: [agent_model, cross_skill_ref]
+uses_capabilities: [agent_model, cross_skill_ref, git_metadata_write]
 description: Worktree retry executor. ALWAYS invoke this skill when instructed to continue or retry an implementation in an existing worktree. Do not resume editing files directly — use this skill first to load the retry workflow.
 hooks:
   PreToolUse:

--- a/tests/arch/test_skill_backend_annotations.py
+++ b/tests/arch/test_skill_backend_annotations.py
@@ -26,7 +26,9 @@ _CAPABILITY_PATTERNS: dict[str, list[re.Pattern[str]]] = {
     "test_check": [re.compile(r"\btest_check\b")],
     "claude_dir": [re.compile(r"\.claude/")],
     "git_metadata_write": [
-        re.compile(r"create_impl_worktree\.sh|git worktree add\b[ \t]+\S|git checkout -b")
+        re.compile(r"create_impl_worktree\.sh|git worktree add\b[ \t]+\S|git checkout -b"),
+        re.compile(r"git\s+(?:-C\s+\S+\s+)?commit\s+-m"),
+        re.compile(r'\bgit\s+(?:-C\s+\S+\s+)?rebase\s+(?:--\w|[$"\{])'),
     ],
 }
 

--- a/tests/skills/test_skill_commit_discipline.py
+++ b/tests/skills/test_skill_commit_discipline.py
@@ -13,6 +13,8 @@ from pathlib import Path
 import pytest
 
 from autoskillit.core.paths import pkg_root
+from autoskillit.workspace.skills import _read_skill_frontmatter
+from tests.arch._helpers import _strip_frontmatter
 
 pytestmark = [pytest.mark.small]
 
@@ -61,4 +63,21 @@ def test_skill_commit_prohibits_amend(skill_dir: Path) -> None:
         f"Skill {skill_dir.name!r} contains 'git commit' instructions but does not "
         "explicitly prohibit '--amend' or require new commits. "
         "Add 'do NOT use --amend' or 'always create new commits' near each commit instruction."
+    )
+
+
+@pytest.mark.parametrize("skill_dir", _SKILL_DIRS, ids=lambda d: d.name)
+def test_git_commit_skills_declare_metadata_write(skill_dir: Path) -> None:
+    """Skills with 'git commit -m' instructions must declare git_metadata_write."""
+    content = (skill_dir / "SKILL.md").read_text()
+    body = _strip_frontmatter(content)
+    if not _GIT_COMMIT_INSTRUCTION_RE.search(body):
+        return
+    fm = _read_skill_frontmatter(skill_dir / "SKILL.md")
+    caps = set(fm.get("uses_capabilities", []))
+    assert "git_metadata_write" in caps, (
+        f"Skill {skill_dir.name!r} contains 'git commit -m' instructions but does not "
+        "declare 'git_metadata_write' in uses_capabilities. "
+        "Any skill that commits in a worktree must declare this capability "
+        "to prevent dispatch to backends where .git/ metadata is read-only."
     )


### PR DESCRIPTION
## Summary

The `git_metadata_write` capability detection pattern in `test_skill_backend_annotations.py` only matches worktree-creation commands (`git worktree add`, `git checkout -b`, `create_impl_worktree.sh`) but not downstream git metadata writes (`git commit`, `git rebase`). Eight skills perform these operations without declaring `git_metadata_write`, allowing dispatch to the Codex backend where `.git/worktrees/<name>/` is outside the sandbox's writable scope. The fix expands the detection regex to cover all git metadata write operations, making the existing bidirectional enforcement test catch this entire class of undeclared capability. Additionally, the capability description must be updated to reflect the broader scope.

Closes #3888

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260607-163912-844523/.autoskillit/temp/rectify/rectify_git_metadata_write_capability_detection_2026-06-07_170500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 6.4k | 28.5k | 4.7M | 139.6k | 112 | 233.8k | 34m 14s |
| review_approach* | opus[1m] | 1 | 1.4k | 5.5k | 213.0k | 45.6k | 12 | 28.0k | 3m 21s |
| dry_walkthrough* | opus | 1 | 36 | 11.4k | 510.3k | 81.8k | 24 | 59.6k | 7m 22s |
| audit_impl* | opus[1m] | 1 | 33 | 10.5k | 214.9k | 44.7k | 15 | 34.5k | 5m 4s |
| prepare_pr* | MiniMax-M3 | 1 | 42.2k | 1.4k | 210.5k | 45.5k | 15 | 0 | 46s |
| compose_pr* | MiniMax-M3 | 1 | 36.4k | 1.1k | 231.0k | 39.4k | 12 | 0 | 47s |
| review_pr* | opus[1m] | 2 | 54 | 39.2k | 901.4k | 74.5k | 60 | 100.4k | 9m 51s |
| resolve_review* | opus[1m] | 1 | 33 | 5.5k | 877.9k | 67.4k | 30 | 45.6k | 5m 32s |
| **Total** | | | 86.7k | 103.0k | 7.9M | 139.6k | | 502.0k | 1h 7m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 5 | 8.0k | 89.1k | 7.0M | 442.4k | 58m 4s |
| opus | 1 | 36 | 11.4k | 510.3k | 59.6k | 7m 22s |
| MiniMax-M3 | 2 | 78.6k | 2.5k | 441.5k | 0 | 1m 33s |