### PR TITLE
Rectify: Merge Gate Diagnosis Context Loss

### DIFF
--- a/src/autoskillit/recipe/rules/rules_merge_context.py
+++ b/src/autoskillit/recipe/rules/rules_merge_context.py
@@ -47,6 +47,9 @@ def _find_diagnose_merge_gate_step(
 ) -> tuple[str, RecipeStep] | None:
     """BFS from start to find the first run_python step calling diagnose_merge_gate.
 
+    Stops traversal through any merge_worktree step that already captures
+    result.failed_step, since that step re-establishes context independently.
+
     Returns (step_name, step) or None.
     """
     visited: set[str] = {start}
@@ -62,6 +65,10 @@ def _find_diagnose_merge_gate_step(
                 callable_val = str(step.with_args.get("callable", ""))
                 if callable_val == "autoskillit.smoke_utils.diagnose_merge_gate":
                     return name, step
+            if step.tool == "merge_worktree" and any(
+                "failed_step" in v.from_ for v in (step.capture or {}).values()
+            ):
+                continue
             next_frontier |= ctx.step_graph.get(name, set()) - visited
         frontier = next_frontier
     return None

--- a/src/autoskillit/recipe/rules/rules_merge_context.py
+++ b/src/autoskillit/recipe/rules/rules_merge_context.py
@@ -42,6 +42,31 @@ def _find_resolve_failures_step(
     return None
 
 
+def _find_diagnose_merge_gate_step(
+    start: str, ctx: ValidationContext
+) -> tuple[str, RecipeStep] | None:
+    """BFS from start to find the first run_python step calling diagnose_merge_gate.
+
+    Returns (step_name, step) or None.
+    """
+    visited: set[str] = {start}
+    frontier: set[str] = ctx.step_graph.get(start, set()) - visited
+    while frontier:
+        visited |= frontier
+        next_frontier: set[str] = set()
+        for name in frontier:
+            step = ctx.recipe.steps.get(name)
+            if step is None:
+                continue
+            if step.tool == "run_python":
+                callable_val = str(step.with_args.get("callable", ""))
+                if callable_val == "autoskillit.smoke_utils.diagnose_merge_gate":
+                    return name, step
+            next_frontier |= ctx.step_graph.get(name, set()) - visited
+        frontier = next_frontier
+    return None
+
+
 @semantic_rule(
     name="merge-test-gate-context-not-forwarded",
     description=(
@@ -123,5 +148,70 @@ def _check_merge_test_gate_context_not_forwarded(
                         ),
                     )
                 )
+
+    return findings
+
+
+@semantic_rule(
+    name="merge-failed-step-not-captured",
+    description=(
+        "A merge_worktree step routes on result.failed_step to a step chain that "
+        "reaches a run_python step calling autoskillit.smoke_utils.diagnose_merge_gate, "
+        "but the merge_worktree capture block does not include a field capturing "
+        "result.failed_step. Without this capture, diagnose_merge_gate receives no "
+        "failed_step argument and falls through to failure_type=test, misclassifying "
+        "pre-test failures (dirty_tree, rebase, etc.) as test failures and creating an "
+        "unwinnable retry loop."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_merge_failed_step_not_captured(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "merge_worktree":
+            continue
+        if not step.on_result or not step.on_result.conditions:
+            continue
+
+        failed_step_routes: set[str] = set()
+        for cond in step.on_result.conditions:
+            if cond.when is None:
+                continue
+            m = _FAILED_STEP_PATTERN.search(cond.when)
+            if m:
+                failed_step_routes.add(cond.route)
+
+        if not failed_step_routes:
+            continue
+
+        has_failed_step_capture = any(
+            "failed_step" in v.from_ for v in (step.capture or {}).values()
+        )
+        if has_failed_step_capture:
+            continue
+
+        for route_target in failed_step_routes:
+            result = _find_diagnose_merge_gate_step(route_target, ctx)
+            if result is None:
+                continue
+            dg_step_name, _ = result
+            findings.append(
+                RuleFinding(
+                    rule="merge-failed-step-not-captured",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"merge_worktree step '{step_name}' routes on result.failed_step "
+                        f"to a chain that reaches diagnose_merge_gate step "
+                        f"'{dg_step_name}', but its capture block is missing "
+                        f"result.failed_step. Add "
+                        f"'merge_failed_step: ${{{{ result.failed_step }}}}' to capture "
+                        f"and pass 'failed_step: ${{{{ context.merge_failed_step }}}}' "
+                        f"to diagnose_merge_gate so pre-test failures (dirty_tree, rebase, "
+                        f"etc.) are classified as failure_type=pre_test."
+                    ),
+                )
+            )
 
     return findings

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -3158,6 +3158,9 @@ callable_contracts:
     - name: output_dir
       type: string
       required: false
+    - name: failed_step
+      type: string
+      required: false
     outputs:
     - name: diagnosis_path
       type: string

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -350,7 +350,8 @@
         "test_stdout": "${{ context.merge_test_stdout }}",
         "test_stderr": "${{ context.merge_test_stderr }}",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate",
-        "work_dir": "${{ context.work_dir }}"
+        "work_dir": "${{ context.work_dir }}",
+        "failed_step": "${{ context.merge_failed_step }}"
       },
       "capture": {
         "merge_gate_diagnosis_path": "${{ result.diagnosis_path }}",
@@ -360,7 +361,8 @@
       "on_failure": "merge_gate_fix",
       "optional_context_refs": [
         "merge_test_stdout",
-        "merge_test_stderr"
+        "merge_test_stderr",
+        "merge_failed_step"
       ],
       "note": "Writes a structured diagnosis file from merge gate test output, mirroring diagnose-ci format. Routes to merge_gate_fix on both success and failure — merge_gate_fix proceeds without context if diagnosis fails. Uses distinct context keys (merge_gate_*) to avoid collision with ci_watch/diagnose_ci context variables from the CI path.\n"
     },
@@ -507,7 +509,8 @@
         "cleanup_succeeded": "${{ result.cleanup_succeeded }}",
         "worktree_path": "${{ result.worktree_path }}",
         "merge_test_stdout": "${{ result.test_stdout }}",
-        "merge_test_stderr": "${{ result.test_stderr }}"
+        "merge_test_stderr": "${{ result.test_stderr }}",
+        "merge_failed_step": "${{ result.failed_step }}"
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -337,6 +337,7 @@ steps:
       test_stderr: "${{ context.merge_test_stderr }}"
       output_dir: "{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate"
       work_dir: "${{ context.work_dir }}"
+      failed_step: "${{ context.merge_failed_step }}"
     capture:
       merge_gate_diagnosis_path: "${{ result.diagnosis_path }}"
       merge_gate_ci_conclusion: "${{ result.ci_conclusion }}"
@@ -345,6 +346,7 @@ steps:
     optional_context_refs:
     - merge_test_stdout
     - merge_test_stderr
+    - merge_failed_step
     note: >
       Writes a structured diagnosis file from merge gate test output,
       mirroring diagnose-ci format. Routes to merge_gate_fix on both success and
@@ -483,6 +485,7 @@ steps:
       worktree_path: "${{ result.worktree_path }}"
       merge_test_stdout: "${{ result.test_stdout }}"
       merge_test_stderr: "${{ result.test_stderr }}"
+      merge_failed_step: "${{ result.failed_step }}"
     on_result:
     - when: "result.failed_step == 'dirty_tree'"
       route: check_merge_fix_loop

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -418,7 +418,8 @@
         "test_stdout": "${{ context.merge_test_stdout }}",
         "test_stderr": "${{ context.merge_test_stderr }}",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate",
-        "work_dir": "${{ context.work_dir }}"
+        "work_dir": "${{ context.work_dir }}",
+        "failed_step": "${{ context.merge_failed_step }}"
       },
       "capture": {
         "merge_gate_diagnosis_path": "${{ result.diagnosis_path }}",
@@ -428,7 +429,8 @@
       "on_failure": "merge_gate_fix",
       "optional_context_refs": [
         "merge_test_stdout",
-        "merge_test_stderr"
+        "merge_test_stderr",
+        "merge_failed_step"
       ],
       "note": "Writes a structured diagnosis file from merge gate test output, mirroring diagnose-ci format. Routes to fix on both success and failure — fix proceeds without context if diagnosis fails. Uses distinct context keys (merge_gate_*) to avoid collision with ci_watch/diagnose_ci context variables from the CI path.\n"
     },
@@ -575,7 +577,8 @@
         "cleanup_succeeded": "${{ result.cleanup_succeeded }}",
         "worktree_path": "${{ result.worktree_path }}",
         "merge_test_stdout": "${{ result.test_stdout }}",
-        "merge_test_stderr": "${{ result.test_stderr }}"
+        "merge_test_stderr": "${{ result.test_stderr }}",
+        "merge_failed_step": "${{ result.failed_step }}"
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -415,6 +415,7 @@ steps:
       test_stderr: ${{ context.merge_test_stderr }}
       output_dir: '{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate'
       work_dir: ${{ context.work_dir }}
+      failed_step: ${{ context.merge_failed_step }}
     capture:
       merge_gate_diagnosis_path: ${{ result.diagnosis_path }}
       merge_gate_ci_conclusion: ${{ result.ci_conclusion }}
@@ -423,6 +424,7 @@ steps:
     optional_context_refs:
     - merge_test_stdout
     - merge_test_stderr
+    - merge_failed_step
     note: >
       Writes a structured diagnosis file from merge gate test output,
       mirroring diagnose-ci format. Routes to fix on both success and
@@ -561,6 +563,7 @@ steps:
       worktree_path: ${{ result.worktree_path }}
       merge_test_stdout: ${{ result.test_stdout }}
       merge_test_stderr: ${{ result.test_stderr }}
+      merge_failed_step: ${{ result.failed_step }}
     on_result:
     - when: result.failed_step == 'dirty_tree'
       route: check_merge_fix_loop

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -450,7 +450,8 @@
         "test_stdout": "${{ context.merge_test_stdout }}",
         "test_stderr": "${{ context.merge_test_stderr }}",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate",
-        "work_dir": "${{ context.work_dir }}"
+        "work_dir": "${{ context.work_dir }}",
+        "failed_step": "${{ context.merge_failed_step }}"
       },
       "capture": {
         "merge_gate_diagnosis_path": "${{ result.diagnosis_path }}",
@@ -460,7 +461,8 @@
       "on_failure": "merge_gate_assess",
       "optional_context_refs": [
         "merge_test_stdout",
-        "merge_test_stderr"
+        "merge_test_stderr",
+        "merge_failed_step"
       ],
       "note": "Writes a structured diagnosis file from merge gate test output, mirroring diagnose-ci format. Routes to assess on both success and failure — assess proceeds without context if diagnosis fails. Uses distinct context keys (merge_gate_*) to avoid collision with ci_watch/diagnose_ci context variables from the CI path.\n"
     },
@@ -932,7 +934,8 @@
         "cleanup_succeeded": "${{ result.cleanup_succeeded }}",
         "worktree_path": "${{ result.worktree_path }}",
         "merge_test_stdout": "${{ result.test_stdout }}",
-        "merge_test_stderr": "${{ result.test_stderr }}"
+        "merge_test_stderr": "${{ result.test_stderr }}",
+        "merge_failed_step": "${{ result.failed_step }}"
       },
       "on_result": [
         {

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -443,6 +443,7 @@ steps:
       test_stderr: ${{ context.merge_test_stderr }}
       output_dir: '{{AUTOSKILLIT_TEMP}}/diagnose-merge-gate'
       work_dir: ${{ context.work_dir }}
+      failed_step: ${{ context.merge_failed_step }}
     capture:
       merge_gate_diagnosis_path: ${{ result.diagnosis_path }}
       merge_gate_ci_conclusion: ${{ result.ci_conclusion }}
@@ -451,6 +452,7 @@ steps:
     optional_context_refs:
     - merge_test_stdout
     - merge_test_stderr
+    - merge_failed_step
     note: >
       Writes a structured diagnosis file from merge gate test output,
       mirroring diagnose-ci format. Routes to assess on both success and
@@ -843,6 +845,7 @@ steps:
       worktree_path: ${{ result.worktree_path }}
       merge_test_stdout: ${{ result.test_stdout }}
       merge_test_stderr: ${{ result.test_stderr }}
+      merge_failed_step: ${{ result.failed_step }}
     on_result:
     - when: result.failed_step == 'dirty_tree'
       route: check_merge_fix_loop

--- a/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
+++ b/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
@@ -12,9 +12,31 @@ _ENV_ERROR_RE = re.compile(
     r"ModuleNotFoundError|ImportError|FileNotFoundError|No such file", re.IGNORECASE
 )
 
+_PRE_TEST_STEPS = frozenset(
+    {
+        "dirty_tree",
+        "dirty_main_repo",
+        "rebase",
+        "path_validation",
+        "protected_branch",
+        "branch_detection",
+        "fetch",
+        "pre_rebase_check",
+        "merge_commits_detected",
+        "generated_file_cleanup",
+        "editable_install_guard",
+        "embedded_worktree",
+        "ref_coherence",
+        "merge",
+    }
+)
+_TEST_STEPS = frozenset({"test_gate", "post_rebase_test_gate"})
 
-def _classify_subtype(test_stdout: str, test_stderr: str) -> str:
+
+def _classify_test_subtype(test_stdout: str, test_stderr: str) -> str:
     combined = f"{test_stdout}\n{test_stderr}"
+    if not combined.strip():
+        return "no_test_output"
     if _TIMEOUT_RE.search(combined):
         return "timing_race"
     if _ENV_ERROR_RE.search(combined):
@@ -33,6 +55,7 @@ def diagnose_merge_gate(
     test_stdout: str = "",
     test_stderr: str = "",
     output_dir: str = "",
+    failed_step: str = "",
     **_kwargs: object,
 ) -> dict[str, str]:
     """Write a structured merge gate failure diagnosis file and return its path.
@@ -40,9 +63,23 @@ def diagnose_merge_gate(
     Called by run_python from the diagnose_merge_gate step in remediation.yaml,
     implementation.yaml, and implementation-groups.yaml. Parses merge gate test
     output and writes a diagnosis file in the same format as diagnose-ci output.
+
+    When `failed_step` is provided (e.g. "dirty_tree", "test_gate"), the
+    classification is routed to the pre-test or test path explicitly. Without
+    it, the legacy behavior of classifying from output content alone is used.
     """
-    subtype = _classify_subtype(test_stdout, test_stderr)
-    failed_tests = _extract_failed_tests(test_stdout, test_stderr)
+    if failed_step in _PRE_TEST_STEPS:
+        failure_type = "pre_test"
+        subtype = failed_step
+        failed_tests: list[str] = []
+    elif failed_step in _TEST_STEPS:
+        failure_type = "test"
+        subtype = _classify_test_subtype(test_stdout, test_stderr)
+        failed_tests = _extract_failed_tests(test_stdout, test_stderr)
+    else:
+        failure_type = "test"
+        subtype = _classify_test_subtype(test_stdout, test_stderr)
+        failed_tests = _extract_failed_tests(test_stdout, test_stderr)
 
     if not output_dir or not Path(output_dir).is_absolute():
         raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
@@ -56,13 +93,14 @@ def diagnose_merge_gate(
     content = (
         "# Merge Gate Test Failure Diagnosis\n\n"
         "## Classification\n"
-        "failure_type = test\n"
+        f"failure_type = {failure_type}\n"
         f"failure_subtype = {subtype}\n\n"
         "## Failed Tests\n"
         f"{failed_section}\n\n"
         "## Log Excerpt\n"
         f"```\n{log_excerpt}\n```\n\n"
         "## Structured Output\n"
+        f"failure_type = {failure_type}\n"
         f"failure_subtype = {subtype}\n"
     )
 

--- a/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
+++ b/src/autoskillit/smoke_utils/_merge_gate_diagnosis.py
@@ -76,6 +76,10 @@ def diagnose_merge_gate(
         failure_type = "test"
         subtype = _classify_test_subtype(test_stdout, test_stderr)
         failed_tests = _extract_failed_tests(test_stdout, test_stderr)
+    elif failed_step:
+        failure_type = "test"
+        subtype = "unrecognized_step"
+        failed_tests = []
     else:
         failure_type = "test"
         subtype = _classify_test_subtype(test_stdout, test_stderr)

--- a/tests/recipe/test_rules_merge_context_forward.py
+++ b/tests/recipe/test_rules_merge_context_forward.py
@@ -350,3 +350,151 @@ def test_rule_does_not_fire_for_fixed_recipes(recipe_name: str) -> None:
     findings = run_semantic_rules(recipe)
     flagged = [f for f in findings if f.rule == "merge-test-gate-context-not-forwarded"]
     assert len(flagged) == 0
+
+
+def _diagnose_on_result_conditions() -> list[StepResultCondition]:
+    return [
+        StepResultCondition(when="result.failed_step == 'dirty_tree'", route="check_loop"),
+        StepResultCondition(when="result.failed_step == 'test_gate'", route="check_loop"),
+        StepResultCondition(when=None, route="done"),
+    ]
+
+
+def test_merge_step_missing_failed_step_capture_fires_error() -> None:
+    """merge routes on result.failed_step to a chain reaching diagnose_merge_gate, but
+    capture is missing result.failed_step → ERROR.
+    """
+    recipe = _make_recipe(
+        {
+            "merge": RecipeStep(
+                tool="merge_worktree",
+                with_args={"worktree_path": "${{ context.worktree_path }}", "base_branch": "main"},
+                capture={
+                    "cleanup_succeeded": "${{ result.cleanup_succeeded }}",
+                    "worktree_path": "${{ result.worktree_path }}",
+                    "merge_test_stdout": "${{ result.test_stdout }}",
+                    "merge_test_stderr": "${{ result.test_stderr }}",
+                    # merge_failed_step is absent — should trigger the rule
+                },
+                on_result=StepResultRoute(conditions=_diagnose_on_result_conditions()),
+                on_failure="escalate",
+            ),
+            "check_loop": RecipeStep(
+                tool="run_python",
+                with_args={
+                    "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                    "current_iteration": "${{ context.merge_fix_count }}",
+                    "max_iterations": "3",
+                },
+                capture={"merge_fix_count": "${{ result.next_iteration }}"},
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            when="${{ result.max_exceeded }} == true", route="escalate"
+                        ),
+                        StepResultCondition(when=None, route="diagnose_merge_gate"),
+                    ]
+                ),
+                on_failure="escalate",
+            ),
+            "diagnose_merge_gate": RecipeStep(
+                tool="run_python",
+                with_args={
+                    "callable": "autoskillit.smoke_utils.diagnose_merge_gate",
+                    "test_stdout": "${{ context.merge_test_stdout }}",
+                    "test_stderr": "${{ context.merge_test_stderr }}",
+                    "output_dir": "/tmp/diagnose-merge-gate",
+                    "failed_step": "${{ context.merge_failed_step }}",
+                },
+                capture={
+                    "merge_gate_diagnosis_path": "${{ result.diagnosis_path }}",
+                },
+                on_success="done",
+                on_failure="escalate",
+            ),
+            "done": RecipeStep(action="stop", with_args={}, message="done"),
+            "escalate": RecipeStep(action="stop", with_args={}, message="escalate"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "merge-failed-step-not-captured"]
+    assert len(flagged) >= 1
+    assert all(f.severity == Severity.ERROR for f in flagged)
+    assert any("merge_failed_step" in f.message for f in flagged)
+
+
+def test_merge_step_with_failed_step_capture_is_clean() -> None:
+    """merge captures result.failed_step → rule does not fire."""
+    recipe = _make_recipe(
+        {
+            "merge": RecipeStep(
+                tool="merge_worktree",
+                with_args={"worktree_path": "${{ context.worktree_path }}", "base_branch": "main"},
+                capture={
+                    "cleanup_succeeded": "${{ result.cleanup_succeeded }}",
+                    "worktree_path": "${{ result.worktree_path }}",
+                    "merge_test_stdout": "${{ result.test_stdout }}",
+                    "merge_test_stderr": "${{ result.test_stderr }}",
+                    "merge_failed_step": "${{ result.failed_step }}",
+                },
+                on_result=StepResultRoute(conditions=_diagnose_on_result_conditions()),
+                on_failure="escalate",
+            ),
+            "check_loop": RecipeStep(
+                tool="run_python",
+                with_args={
+                    "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                    "current_iteration": "${{ context.merge_fix_count }}",
+                    "max_iterations": "3",
+                },
+                capture={"merge_fix_count": "${{ result.next_iteration }}"},
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            when="${{ result.max_exceeded }} == true", route="escalate"
+                        ),
+                        StepResultCondition(when=None, route="diagnose_merge_gate"),
+                    ]
+                ),
+                on_failure="escalate",
+            ),
+            "diagnose_merge_gate": RecipeStep(
+                tool="run_python",
+                with_args={
+                    "callable": "autoskillit.smoke_utils.diagnose_merge_gate",
+                    "test_stdout": "${{ context.merge_test_stdout }}",
+                    "test_stderr": "${{ context.merge_test_stderr }}",
+                    "output_dir": "/tmp/diagnose-merge-gate",
+                    "failed_step": "${{ context.merge_failed_step }}",
+                },
+                capture={
+                    "merge_gate_diagnosis_path": "${{ result.diagnosis_path }}",
+                },
+                on_success="done",
+                on_failure="escalate",
+            ),
+            "done": RecipeStep(action="stop", with_args={}, message="done"),
+            "escalate": RecipeStep(action="stop", with_args={}, message="escalate"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "merge-failed-step-not-captured"]
+    assert not flagged
+
+
+@pytest.mark.parametrize(
+    "recipe_name",
+    ["remediation.yaml", "implementation.yaml", "implementation-groups.yaml"],
+)
+def test_merge_failed_step_rule_does_not_fire_for_fixed_recipes(recipe_name: str) -> None:
+    """Post recipe fix: merge-failed-step-not-captured rule does not fire on the three
+    pipeline recipes (they all capture merge_failed_step and pass it through).
+    """
+    from autoskillit.core import pkg_root
+    from autoskillit.recipe.io import load_recipe
+
+    recipe_path = pkg_root() / "recipes" / recipe_name
+    recipe = load_recipe(recipe_path)
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "merge-failed-step-not-captured"]
+    assert len(flagged) == 0

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -2378,6 +2378,60 @@ def test_diagnose_merge_gate_extracts_failure_subtype(tmp_path: object) -> None:
     assert "failure_subtype = timing_race" in content_t
 
 
+def test_diagnose_merge_gate_dirty_tree_step(tmp_path: object) -> None:
+    """When failed_step is dirty_tree, subtype must be dirty_tree not unknown."""
+    from pathlib import Path
+
+    from autoskillit.smoke_utils._merge_gate_diagnosis import diagnose_merge_gate
+
+    output_dir = tmp_path  # type: ignore[union-attr]
+    result = diagnose_merge_gate(
+        test_stdout="",
+        test_stderr="",
+        output_dir=str(output_dir),
+        failed_step="dirty_tree",
+    )
+    content = Path(result["diagnosis_path"]).read_text()
+    assert "failure_subtype = dirty_tree" in content
+    assert "failure_type = pre_test" in content
+
+
+def test_diagnose_merge_gate_test_gate_empty_output(tmp_path: object) -> None:
+    """test_gate with empty output means collection failed, not unknown."""
+    from pathlib import Path
+
+    from autoskillit.smoke_utils._merge_gate_diagnosis import diagnose_merge_gate
+
+    output_dir = tmp_path  # type: ignore[union-attr]
+    result = diagnose_merge_gate(
+        test_stdout="",
+        test_stderr="",
+        output_dir=str(output_dir),
+        failed_step="test_gate",
+    )
+    content = Path(result["diagnosis_path"]).read_text()
+    assert "failure_subtype = no_test_output" in content
+    assert "failure_type = test" in content
+
+
+def test_diagnose_merge_gate_test_gate_with_output(tmp_path: object) -> None:
+    """test_gate with FAILED lines still classifies as deterministic."""
+    from pathlib import Path
+
+    from autoskillit.smoke_utils._merge_gate_diagnosis import diagnose_merge_gate
+
+    output_dir = tmp_path  # type: ignore[union-attr]
+    result = diagnose_merge_gate(
+        test_stdout="FAILED tests/test_x.py::test_y",
+        test_stderr="",
+        output_dir=str(output_dir),
+        failed_step="test_gate",
+    )
+    content = Path(result["diagnosis_path"]).read_text()
+    assert "failure_subtype = deterministic" in content
+    assert "failure_type = test" in content
+
+
 def test_diagnose_merge_gate_handles_empty_output(tmp_path: object) -> None:
     """callable with empty/absent test output returns graceful fallback."""
     from pathlib import Path
@@ -2389,7 +2443,8 @@ def test_diagnose_merge_gate_handles_empty_output(tmp_path: object) -> None:
     diag_path = Path(result["diagnosis_path"])
     assert diag_path.exists()
     content = diag_path.read_text()
-    assert "failure_subtype = unknown" in content
+    assert "failure_subtype = no_test_output" in content
+    assert "failure_type = test" in content
 
 
 def test_diagnose_merge_gate_returns_ci_conclusion_failure(tmp_path: object) -> None:


### PR DESCRIPTION
## Summary

`diagnose_merge_gate` classifies failure subtype from test output strings alone, with no knowledge of which `merge_worktree` failure step triggered the diagnosis. When called after a `dirty_tree` failure (where no tests ran), it receives empty strings, falls through to `failure_subtype = unknown`, and hardcodes `failure_type = test`. This misleads `resolve-failures` into treating a worktree-hygiene problem as a flaky test, creating an unwinnable loop.

The architectural weakness: **the recipe routing layer consumes `failed_step` for branching but never captures it into context**, so downstream classification functions must re-derive failure category from output content — an inherently lossy operation when some failure modes produce no output.

The immunity approach: make `diagnose_merge_gate` accept the failure step as a typed parameter, capture it in recipe context, add a semantic rule to enforce capture, and use exhaustive dispatch so that pre-test failures are correctly classified without consulting empty test output.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260607-163912-937216/.autoskillit/temp/rectify/rectify_merge_gate_diagnosis_context_loss_2026-06-07_164500.md`

Closes #3890

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 63 | 19.4k | 1.3M | 105.0k | 41 | 82.8k | 18m 55s |
| review_approach* | sonnet | 1 | 62 | 9.7k | 258.1k | 59.5k | 19 | 43.5k | 9m 38s |
| dry_walkthrough* | opus | 1 | 40 | 11.9k | 1.1M | 140.1k | 48 | 187.3k | 7m 10s |
| audit_impl* | sonnet | 1 | 68 | 18.3k | 297.2k | 49.3k | 25 | 47.2k | 5m 58s |
| prepare_pr* | MiniMax-M3 | 1 | 43.2k | 3.6k | 209.5k | 47.3k | 15 | 0 | 1m 16s |
| compose_pr* | MiniMax-M3 | 1 | 41.4k | 1.6k | 233.5k | 43.5k | 17 | 0 | 51s |
| review_pr* | sonnet | 1 | 156 | 32.3k | 1.1M | 92.0k | 47 | 71.2k | 7m 57s |
| resolve_review* | opus[1m] | 1 | 37 | 5.2k | 1.0M | 59.3k | 32 | 37.3k | 5m 43s |
| **Total** | | | 85.0k | 101.9k | 5.6M | 140.1k | | 469.3k | 57m 29s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 255834.5 | 9323.5 | 1304.8 |
| **Total** | **4** | 1393641.0 | 117330.2 | 25478.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 2 | 100 | 24.6k | 2.4M | 120.1k | 24m 38s |
| sonnet | 3 | 286 | 60.3k | 1.7M | 161.9k | 23m 34s |
| opus | 1 | 40 | 11.9k | 1.1M | 187.3k | 7m 10s |
| MiniMax-M3 | 2 | 84.5k | 5.2k | 443.0k | 0 | 2m 6s |