### PR TITLE
Rectify: Callable Verdict Routing Immunity

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -305,14 +305,14 @@ tasks:
         if [[ -f ".git" ]]; then
           echo "Worktree detected — creating isolated venv"
           uv venv --clear .venv
-          uv pip install -e '.[dev]' --python .venv/bin/python
+          uv sync --frozen --all-extras
         elif [[ -d ".venv" ]]; then
           echo "Main directory — installing into existing venv"
-          uv pip install -e '.[dev]' --python .venv/bin/python
+          uv sync --frozen --all-extras
         else
           echo "Main directory — creating venv and installing"
           uv venv --clear .venv
-          uv pip install -e '.[dev]' --python .venv/bin/python
+          uv sync --frozen --all-extras
         fi
         echo "Done: $(.venv/bin/python --version)"
         if command -v pre-commit >/dev/null 2>&1; then

--- a/src/autoskillit/recipe/_contracts_manifest.py
+++ b/src/autoskillit/recipe/_contracts_manifest.py
@@ -54,7 +54,12 @@ def get_skill_contract(skill_name: str, manifest: dict[str, Any]) -> SkillContra
         for inp in skill_data.get("inputs", [])
     ]
     outputs = [
-        SkillOutput(name=out["name"], type=out["type"]) for out in skill_data.get("outputs", [])
+        SkillOutput(
+            name=out["name"],
+            type=out["type"],
+            allowed_values=out.get("allowed_values", []),
+        )
+        for out in skill_data.get("outputs", [])
     ]
     patterns = skill_data.get("expected_output_patterns", [])
     examples = skill_data.get("pattern_examples", [])
@@ -138,7 +143,14 @@ def get_callable_contract(
         )
         for inp in entry.get("inputs", [])
     ]
-    outputs = [SkillOutput(name=out["name"], type=out["type"]) for out in entry.get("outputs", [])]
+    outputs = [
+        SkillOutput(
+            name=out["name"],
+            type=out["type"],
+            allowed_values=out.get("allowed_values", []),
+        )
+        for out in entry.get("outputs", [])
+    ]
     return SkillContract(inputs=inputs, outputs=outputs)
 
 

--- a/src/autoskillit/recipe/_contracts_types.py
+++ b/src/autoskillit/recipe/_contracts_types.py
@@ -25,6 +25,7 @@ class SkillInput:
 class SkillOutput:
     name: str
     type: str
+    allowed_values: list[str] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass(frozen=True, slots=True)

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -8,7 +8,7 @@ Semantic validation rule modules for recipe analysis (46 flat rule files + 4 sub
 |---|---|---|
 | `campaign/` | 5 rules | Campaign capture, deps, dispatch, flow, ingredients |
 | `ci/` | 4 rules | CI config hygiene, conflict, guards, merge queue |
-| `dataflow/` | 4 rules | Dataflow capture, callable, handoff, multipart |
+| `dataflow/` | 4 rules | Dataflow capture, callable, handoff, multipart, callable verdict routing completeness |
 | `graph/` | 4 rules | Graph cycles, output, review, routes |
 
 See each subdirectory's CLAUDE.md for details.

--- a/src/autoskillit/recipe/rules/dataflow/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/dataflow/CLAUDE.md
@@ -8,7 +8,7 @@ Dataflow semantic rule modules (4 rule files).
 |------|---------|
 | `__init__.py` | Docstring-only — rules register via `@semantic_rule` decorator on import |
 | `rules_dataflow.py` | Capture key validation, dead output, weak constraint |
-| `rules_dataflow_callable.py` | Callable contract validation, signature mismatch, context gap, work_dir arg misplacement |
+| `rules_dataflow_callable.py` | Callable contract validation, signature mismatch, context gap, work_dir arg misplacement, callable verdict routing completeness |
 | `rules_dataflow_handoff.py` | Implicit handoff, uncaptured consumer, merge cleanup, stale ref |
 | `rules_dataflow_multipart.py` | Multi-part recipe iteration notes validation |
 

--- a/src/autoskillit/recipe/rules/dataflow/rules_dataflow_callable.py
+++ b/src/autoskillit/recipe/rules/dataflow/rules_dataflow_callable.py
@@ -383,8 +383,8 @@ def _check_callable_verdict_requires_on_result(ctx: ValidationContext) -> list[R
                     message=(
                         f"Step '{step_name}' calls '{callable_path}' which declares "
                         f"output '{output.name}' with allowed_values "
-                        f"{output.allowed_values!r}, but the step uses scalar "
-                        f"on_success/on_failure routing. Replace with an on_result "
+                        f"{output.allowed_values!r}, but the step is missing "
+                        f"on_result routing. Replace with an on_result "
                         f"block that dispatches on each allowed value."
                     ),
                 )

--- a/src/autoskillit/recipe/rules/dataflow/rules_dataflow_callable.py
+++ b/src/autoskillit/recipe/rules/dataflow/rules_dataflow_callable.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib
 import inspect
 
+import regex as re
+
 from autoskillit.core import RUN_PYTHON_SENTINEL_KEYS, SKILL_TOOLS, Severity, get_logger
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.contracts import (
@@ -15,6 +17,18 @@ from autoskillit.recipe.contracts import (
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 logger = get_logger(__name__)
+
+
+def _is_callable_explicit_condition(when: str | None, value: str) -> bool:
+    """Return True iff the `when` predicate explicitly references the given value.
+
+    A `when` of None or "true" is treated as a catch-all and is NOT explicit
+    for any specific value — this mirrors the run_skill rule logic in
+    rules_verdict.py:25-31.
+    """
+    if when is None or when.strip() == "true":
+        return False
+    return bool(re.search(rf"\b{re.escape(value)}\b", when))
 
 
 def _get_provided_args(with_args: dict) -> set[str]:
@@ -265,6 +279,104 @@ def _check_work_dir_arg_misplacement(ctx: ValidationContext) -> list[RuleFinding
                         f"Step '{step_name}' has work_dir inside args but "
                         f"'{callable_path}' does not accept a work_dir parameter. "
                         f"Move work_dir to the top-level with: block for path anchoring."
+                    ),
+                )
+            )
+    return findings
+
+
+@semantic_rule(
+    name="unrouted-callable-verdict",
+    description=(
+        "run_python steps with on_result must explicitly route every allowed value "
+        "declared in the callable contract — unrouted values cause the recipe to "
+        "deadlock at runtime when a multi-valued verdict (e.g. "
+        "regression_detected, failed) has no matching condition"
+    ),
+    severity=Severity.ERROR,
+)
+def _check_unrouted_callable_verdict(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    manifest = load_bundled_manifest()
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_python":
+            continue
+        if step.on_result is None:
+            continue
+        callable_path = step.with_args.get("callable", "")
+        if not callable_path:
+            continue
+        contract = get_callable_contract(callable_path, manifest)
+        if contract is None:
+            continue
+        conditions = step.on_result.conditions
+        for output in contract.outputs:
+            if not output.allowed_values:
+                continue
+            unrouted = [
+                v
+                for v in output.allowed_values
+                if not any(_is_callable_explicit_condition(cond.when, v) for cond in conditions)
+            ]
+            for v in unrouted:
+                findings.append(
+                    RuleFinding(
+                        rule="unrouted-callable-verdict",
+                        severity=Severity.ERROR,
+                        step_name=step_name,
+                        message=(
+                            f"Step '{step_name}' has callable "
+                            f"'{callable_path}' which declares output "
+                            f"'{output.name}' with allowed_values including "
+                            f"{v!r}, but the on_result block has no condition "
+                            f"explicitly routing that value. Add a per-value "
+                            f"when: \"${{{{ result.{output.name} }}}} == '{v}'\" "
+                            f"condition or remove the value from allowed_values."
+                        ),
+                    )
+                )
+    return findings
+
+
+@semantic_rule(
+    name="callable-verdict-requires-on-result",
+    description=(
+        "run_python steps whose callable contract declares any output with "
+        "allowed_values must use on_result routing — on_success/on_failure cannot "
+        "distinguish multi-valued verdicts and will deadlock on values like "
+        "regression_detected or failed"
+    ),
+    severity=Severity.ERROR,
+)
+def _check_callable_verdict_requires_on_result(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    manifest = load_bundled_manifest()
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_python":
+            continue
+        if step.on_result is not None:
+            continue
+        callable_path = step.with_args.get("callable", "")
+        if not callable_path:
+            continue
+        contract = get_callable_contract(callable_path, manifest)
+        if contract is None:
+            continue
+        verdict_outputs = [out for out in contract.outputs if out.allowed_values]
+        if not verdict_outputs:
+            continue
+        for output in verdict_outputs:
+            findings.append(
+                RuleFinding(
+                    rule="callable-verdict-requires-on-result",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"Step '{step_name}' calls '{callable_path}' which declares "
+                        f"output '{output.name}' with allowed_values "
+                        f"{output.allowed_values!r}, but the step uses scalar "
+                        f"on_success/on_failure routing. Replace with an on_result "
+                        f"block that dispatches on each allowed value."
                     ),
                 )
             )

--- a/src/autoskillit/recipe/rules/dataflow/rules_dataflow_callable.py
+++ b/src/autoskillit/recipe/rules/dataflow/rules_dataflow_callable.py
@@ -31,6 +31,11 @@ def _is_callable_explicit_condition(when: str | None, value: str) -> bool:
     return bool(re.search(rf"\b{re.escape(value)}\b", when))
 
 
+def _has_catch_all(conditions: list) -> bool:
+    """Return True if the conditions list includes a catch-all arm (no `when`)."""
+    return any(cond.when is None or cond.when.strip() == "true" for cond in conditions)
+
+
 def _get_provided_args(with_args: dict) -> set[str]:
     _nested = with_args.get("args")
     nested_args: set[str] = set(_nested.keys()) if isinstance(_nested, dict) else set()
@@ -318,6 +323,10 @@ def _check_unrouted_callable_verdict(ctx: ValidationContext) -> list[RuleFinding
                 for v in output.allowed_values
                 if not any(_is_callable_explicit_condition(cond.when, v) for cond in conditions)
             ]
+            if not unrouted:
+                continue
+            if _has_catch_all(conditions):
+                continue
             for v in unrouted:
                 findings.append(
                     RuleFinding(

--- a/src/autoskillit/recipe/rules/rules_contracts.py
+++ b/src/autoskillit/recipe/rules/rules_contracts.py
@@ -440,8 +440,10 @@ def _check_result_field_drift(ctx: ValidationContext) -> list[RuleFinding]:
 def _check_example_covers_all_allowed_values(ctx: ValidationContext) -> list[RuleFinding]:
     """Error when any allowed_value has no corresponding pattern_examples entry.
 
-    Reads allowed_values from the raw manifest dict (not SkillContract, which does not
-    promote allowed_values into SkillOutput). An example 'covers' a value when the
+    Reads allowed_values from the raw manifest dict (not SkillContract — although
+    SkillOutput now carries allowed_values for both skill and callable contracts,
+    this rule continues to read from the manifest dict to keep pattern_examples
+    lookup local to the same data source). An example 'covers' a value when the
     example text contains a match for '{output_name}\\s*=\\s*{re.escape(value)}'.
     """
     findings: list[RuleFinding] = []

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2884,6 +2884,16 @@ callable_contracts:
     outputs:
     - name: committed
       type: str
+      allowed_values: ["false", "true", "regression_detected"]
+  autoskillit.recipe._cmd_rpc.main_repo_guard:
+    inputs:
+    - name: clone_path
+      type: str
+      required: true
+    outputs:
+    - name: cleaned
+      type: str
+      allowed_values: ["false", "true", "force", "failed"]
   autoskillit.recipe._cmd_rpc.review_path_rebase:
     inputs:
     - name: work_dir

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -485,7 +485,15 @@
         "worktree_path": "${{ context.worktree_path }}",
         "base_branch": "${{ inputs.base_branch }}"
       },
-      "on_success": "main_repo_guard",
+      "on_result": [
+        {
+          "when": "${{ result.committed }} == 'regression_detected'",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "main_repo_guard"
+        }
+      ],
       "on_failure": "main_repo_guard",
       "note": "Belt-and-suspenders guard: auto-commits any uncommitted changes before merge. Catches dirty state from context-exhausted skills, cascading pre-commit auto-fixes, or any other source. Routes to main_repo_guard to handle dirty main repo state.\n"
     },
@@ -495,7 +503,15 @@
         "callable": "autoskillit.recipe._cmd_rpc.main_repo_guard",
         "clone_path": "${{ context.work_dir }}"
       },
-      "on_success": "merge",
+      "on_result": [
+        {
+          "when": "${{ result.cleaned }} == 'failed'",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "merge"
+        }
+      ],
       "on_failure": "merge",
       "note": "Stashes uncommitted changes in the main repo before merge. Catches dirty state from infrastructure-terminated sessions that left artifacts in the clone. Routes to merge on both success and failure (merge's dirty_main_repo gate handles persistent issues).\n"
     },

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -456,7 +456,7 @@ steps:
       worktree_path: "${{ context.worktree_path }}"
       base_branch: "${{ inputs.base_branch }}"
     on_result:
-    - when: "${{ result.committed }} == 'regression_detected'"
+    - when: ${{ result.committed }} == 'regression_detected'
       route: release_issue_failure
     - route: main_repo_guard
     on_failure: main_repo_guard
@@ -471,7 +471,7 @@ steps:
       callable: "autoskillit.recipe._cmd_rpc.main_repo_guard"
       clone_path: "${{ context.work_dir }}"
     on_result:
-    - when: "${{ result.cleaned }} == 'failed'"
+    - when: ${{ result.cleaned }} == 'failed'
       route: release_issue_failure
     - route: merge
     on_failure: merge

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -455,7 +455,10 @@ steps:
       callable: "autoskillit.recipe._cmd_rpc.commit_guard"
       worktree_path: "${{ context.worktree_path }}"
       base_branch: "${{ inputs.base_branch }}"
-    on_success: main_repo_guard
+    on_result:
+    - when: "${{ result.committed }} == 'regression_detected'"
+      route: release_issue_failure
+    - route: main_repo_guard
     on_failure: main_repo_guard
     note: >
       Belt-and-suspenders guard: auto-commits any uncommitted changes before merge.
@@ -467,7 +470,10 @@ steps:
     with:
       callable: "autoskillit.recipe._cmd_rpc.main_repo_guard"
       clone_path: "${{ context.work_dir }}"
-    on_success: merge
+    on_result:
+    - when: "${{ result.cleaned }} == 'failed'"
+      route: release_issue_failure
+    - route: merge
     on_failure: merge
     note: >
       Stashes uncommitted changes in the main repo before merge. Catches dirty state

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -553,7 +553,15 @@
         "worktree_path": "${{ context.worktree_path }}",
         "base_branch": "${{ inputs.base_branch }}"
       },
-      "on_success": "main_repo_guard",
+      "on_result": [
+        {
+          "when": "${{ result.committed }} == 'regression_detected'",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "main_repo_guard"
+        }
+      ],
       "on_failure": "main_repo_guard",
       "note": "Belt-and-suspenders guard: auto-commits any uncommitted changes before merge. Catches dirty state from context-exhausted skills, cascading pre-commit auto-fixes, or any other source. Routes to main_repo_guard to handle dirty main repo state.\n"
     },
@@ -563,7 +571,15 @@
         "callable": "autoskillit.recipe._cmd_rpc.main_repo_guard",
         "clone_path": "${{ context.work_dir }}"
       },
-      "on_success": "merge",
+      "on_result": [
+        {
+          "when": "${{ result.cleaned }} == 'failed'",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "merge"
+        }
+      ],
       "on_failure": "merge",
       "note": "Stashes uncommitted changes in the main repo before merge. Catches dirty state from infrastructure-terminated sessions that left artifacts in the clone. Routes to merge on both success and failure (merge's dirty_main_repo gate handles persistent issues).\n"
     },

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -532,7 +532,10 @@ steps:
       callable: autoskillit.recipe._cmd_rpc.commit_guard
       worktree_path: ${{ context.worktree_path }}
       base_branch: ${{ inputs.base_branch }}
-    on_success: main_repo_guard
+    on_result:
+    - when: ${{ result.committed }} == 'regression_detected'
+      route: release_issue_failure
+    - route: main_repo_guard
     on_failure: main_repo_guard
     note: 'Belt-and-suspenders guard: auto-commits any uncommitted changes before
       merge. Catches dirty state from context-exhausted skills, cascading pre-commit
@@ -545,7 +548,10 @@ steps:
     with:
       callable: autoskillit.recipe._cmd_rpc.main_repo_guard
       clone_path: ${{ context.work_dir }}
-    on_success: merge
+    on_result:
+    - when: ${{ result.cleaned }} == 'failed'
+      route: release_issue_failure
+    - route: merge
     on_failure: merge
     note: 'Stashes uncommitted changes in the main repo before merge. Catches dirty
       state from infrastructure-terminated sessions that left artifacts in the clone.

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -636,7 +636,15 @@
         "worktree_path": "${{ context.implementation_ref }}",
         "base_branch": "${{ inputs.base_branch }}"
       },
-      "on_success": "pre_remediation_merge",
+      "on_result": [
+        {
+          "when": "${{ result.committed }} == 'regression_detected'",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "pre_remediation_merge"
+        }
+      ],
       "on_failure": "pre_remediation_merge"
     },
     "main_repo_guard_pre_remediation": {
@@ -645,7 +653,15 @@
         "callable": "autoskillit.recipe._cmd_rpc.main_repo_guard",
         "clone_path": "${{ context.work_dir }}"
       },
-      "on_success": "pre_remediation_merge",
+      "on_result": [
+        {
+          "when": "${{ result.cleaned }} == 'failed'",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "pre_remediation_merge"
+        }
+      ],
       "on_failure": "pre_remediation_merge"
     },
     "assess": {
@@ -910,7 +926,15 @@
         "worktree_path": "${{ context.implementation_ref }}",
         "base_branch": "${{ inputs.base_branch }}"
       },
-      "on_success": "main_repo_guard",
+      "on_result": [
+        {
+          "when": "${{ result.committed }} == 'regression_detected'",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "main_repo_guard"
+        }
+      ],
       "on_failure": "main_repo_guard",
       "note": "Belt-and-suspenders guard: auto-commits any uncommitted changes before merge. Catches dirty state from context-exhausted skills, cascading pre-commit auto-fixes, or any other source. Routes to main_repo_guard to handle dirty main repo state.\n"
     },
@@ -920,7 +944,15 @@
         "callable": "autoskillit.recipe._cmd_rpc.main_repo_guard",
         "clone_path": "${{ context.work_dir }}"
       },
-      "on_success": "merge",
+      "on_result": [
+        {
+          "when": "${{ result.cleaned }} == 'failed'",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "merge"
+        }
+      ],
       "on_failure": "merge",
       "note": "Stashes uncommitted changes in the main repo before merge. Catches dirty state from infrastructure-terminated sessions that left artifacts in the clone. Routes to merge on both success and failure (merge's dirty_main_repo gate handles persistent issues).\n"
     },

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -599,14 +599,20 @@ steps:
       callable: autoskillit.recipe._cmd_rpc.commit_guard
       worktree_path: ${{ context.implementation_ref }}
       base_branch: ${{ inputs.base_branch }}
-    on_success: pre_remediation_merge
+    on_result:
+    - when: ${{ result.committed }} == 'regression_detected'
+      route: release_issue_failure
+    - route: pre_remediation_merge
     on_failure: pre_remediation_merge
   main_repo_guard_pre_remediation:
     tool: run_python
     with:
       callable: autoskillit.recipe._cmd_rpc.main_repo_guard
       clone_path: ${{ context.work_dir }}
-    on_success: pre_remediation_merge
+    on_result:
+    - when: ${{ result.cleaned }} == 'failed'
+      route: release_issue_failure
+    - route: pre_remediation_merge
     on_failure: pre_remediation_merge
 
   assess:
@@ -814,7 +820,10 @@ steps:
       callable: autoskillit.recipe._cmd_rpc.commit_guard
       worktree_path: ${{ context.implementation_ref }}
       base_branch: ${{ inputs.base_branch }}
-    on_success: main_repo_guard
+    on_result:
+    - when: ${{ result.committed }} == 'regression_detected'
+      route: release_issue_failure
+    - route: main_repo_guard
     on_failure: main_repo_guard
     note: 'Belt-and-suspenders guard: auto-commits any uncommitted changes before
       merge. Catches dirty state from context-exhausted skills, cascading pre-commit
@@ -827,7 +836,10 @@ steps:
     with:
       callable: autoskillit.recipe._cmd_rpc.main_repo_guard
       clone_path: ${{ context.work_dir }}
-    on_success: merge
+    on_result:
+    - when: ${{ result.cleaned }} == 'failed'
+      route: release_issue_failure
+    - route: merge
     on_failure: merge
     note: 'Stashes uncommitted changes in the main repo before merge. Catches dirty
       state from infrastructure-terminated sessions that left artifacts in the clone.

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -28,6 +28,8 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_bundled_recipes_research_design.py` | Tests for research-design bundled recipe structure |
 | `test_bundled_recipes_review_pr.py` | Tests for review-pr bundled recipe structure |
 | `test_callable_contracts.py` | Contract tests for run_python callable inputs and outputs |
+| `test_contracts_types.py` | Tests for the SkillOutput dataclass — allowed_values field for callable verdict routing |
+| `test_contracts_manifest.py` | Tests for get_skill_contract and get_callable_contract allowed_values promotion from YAML |
 | `test_campaign_loader.py` | Tests for campaign recipe loading |
 | `test_create_worktree_functional.py` | Functional tests for scripts/recipe/create_worktree.sh — actually executes the script against real git repos |
 | `test_deep_staleness.py` | Tests for deep staleness detection — rule file mtime scan and session-type bypass for fleet sessions |
@@ -135,6 +137,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_rules_dataflow_handoff.py` | Tests for dataflow handoff semantic validation rule |
 | `test_rules_dataflow_merge.py` | Tests for dataflow merge semantic validation rule |
 | `test_rules_dataflow_nullable.py` | Tests for dataflow nullable semantic validation rule |
+| `test_rules_dataflow_callable.py` | Tests for unrouted-callable-verdict and callable-verdict-requires-on-result semantic rules |
 | `test_rules_work_dir_misplacement.py` | Tests for work-dir-arg-misplacement semantic rule: flags run_python steps with work_dir in args for callables that don't accept it |
 | `test_rules_dedup.py` | Tests for dedup semantic validation rule |
 | `test_rules_features.py` | Tests for features semantic validation rule |

--- a/tests/recipe/test_contracts_manifest.py
+++ b/tests/recipe/test_contracts_manifest.py
@@ -1,0 +1,96 @@
+"""Tests for the contracts manifest loaders (get_skill_contract, get_callable_contract).
+
+Verifies that `allowed_values` declared on output entries in skill_contracts.yaml
+is promoted into the resulting SkillOutput — both for run_skill contracts and
+run_python callable contracts (recipe-routing-deadlock immunity, #3889).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.recipe._contracts_manifest import (
+    get_callable_contract,
+    get_skill_contract,
+    load_bundled_manifest,
+)
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def test_get_callable_contract_promotes_allowed_values_for_commit_guard() -> None:
+    """get_callable_contract must parse `allowed_values` from YAML into SkillOutput."""
+    contract = get_callable_contract("autoskillit.recipe._cmd_rpc.commit_guard")
+    assert contract is not None, (
+        "commit_guard must be declared under callable_contracts in skill_contracts.yaml"
+    )
+    committed = next((o for o in contract.outputs if o.name == "committed"), None)
+    assert committed is not None, "commit_guard contract must declare a 'committed' output"
+    assert committed.allowed_values == ["false", "true", "regression_detected"]
+
+
+def test_get_callable_contract_promotes_allowed_values_for_main_repo_guard() -> None:
+    """get_callable_contract must parse `allowed_values` for main_repo_guard (new contract)."""
+    contract = get_callable_contract("autoskillit.recipe._cmd_rpc.main_repo_guard")
+    assert contract is not None, (
+        "main_repo_guard must be declared under callable_contracts in skill_contracts.yaml"
+    )
+    cleaned = next((o for o in contract.outputs if o.name == "cleaned"), None)
+    assert cleaned is not None, "main_repo_guard contract must declare a 'cleaned' output"
+    assert cleaned.allowed_values == ["false", "true", "force", "failed"]
+
+
+def test_get_callable_contract_defaults_allowed_values_to_empty_list() -> None:
+    """When a callable contract output has no `allowed_values` in YAML, defaults to []."""
+    contract = get_callable_contract("autoskillit.recipe._cmd_rpc.review_path_rebase")
+    assert contract is not None
+    status = next((o for o in contract.outputs if o.name == "status"), None)
+    assert status is not None
+    assert status.allowed_values == []
+
+
+def test_get_skill_contract_promotes_allowed_values_when_declared() -> None:
+    """get_skill_contract must promote `allowed_values` from YAML into SkillOutput.
+
+    Verifies the path is wired up symmetrically to get_callable_contract — adding
+    allowed_values to a skill's output entry must surface on the resulting SkillOutput.
+    """
+    manifest = load_bundled_manifest()
+    # Find any skill with allowed_values declared on an output
+    skills = manifest.get("skills", {})
+    target_skill: str | None = None
+    target_output: dict | None = None
+    for skill_name, skill_data in skills.items():
+        for out in skill_data.get("outputs", []):
+            if "allowed_values" in out:
+                target_skill = skill_name
+                target_output = out
+                break
+        if target_skill is not None:
+            break
+    if target_skill is None or target_output is None:
+        pytest.skip(
+            "No bundled skill currently declares allowed_values on an output — "
+            "this test guards the loader path so future additions are safe."
+        )
+    contract = get_skill_contract(target_skill, manifest)
+    assert contract is not None
+    out = next((o for o in contract.outputs if o.name == target_output["name"]), None)
+    assert out is not None
+    assert out.allowed_values == target_output["allowed_values"]
+
+
+def test_get_skill_contract_defaults_allowed_values_to_empty_list() -> None:
+    """get_skill_contract must default `allowed_values` to [] when not declared in YAML."""
+    manifest = load_bundled_manifest()
+    # Pick a skill that has outputs but none with allowed_values
+    skills = manifest.get("skills", {})
+    for skill_name, skill_data in skills.items():
+        outputs = skill_data.get("outputs", [])
+        if outputs and not any("allowed_values" in o for o in outputs):
+            contract = get_skill_contract(skill_name, manifest)
+            assert contract is not None
+            for o in contract.outputs:
+                assert o.allowed_values == []
+            return
+    pytest.skip("No suitable skill found for default-empty assertion")

--- a/tests/recipe/test_contracts_types.py
+++ b/tests/recipe/test_contracts_types.py
@@ -1,0 +1,38 @@
+"""Tests for the SkillOutput contract dataclass.
+
+Verifies that SkillOutput carries the optional allowed_values field that the
+callable verdict routing rules depend on (recipe-routing-deadlock immunity, #3889).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.recipe._contracts_types import SkillOutput
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def test_skill_output_accepts_allowed_values_kwarg() -> None:
+    """SkillOutput must accept an `allowed_values` keyword argument and store it."""
+    output = SkillOutput(
+        name="committed",
+        type="str",
+        allowed_values=["false", "true", "regression_detected"],
+    )
+    assert output.name == "committed"
+    assert output.type == "str"
+    assert output.allowed_values == ["false", "true", "regression_detected"]
+
+
+def test_skill_output_allowed_values_defaults_to_empty_list() -> None:
+    """SkillOutput must default `allowed_values` to an empty list (backward compat)."""
+    output = SkillOutput(name="verdict", type="str")
+    assert output.allowed_values == []
+
+
+def test_skill_output_preserves_order_of_allowed_values() -> None:
+    """SkillOutput must preserve the order of allowed_values as supplied."""
+    expected = ["z", "a", "m", "b"]
+    output = SkillOutput(name="x", type="str", allowed_values=expected)
+    assert output.allowed_values == expected

--- a/tests/recipe/test_rules_dataflow_callable.py
+++ b/tests/recipe/test_rules_dataflow_callable.py
@@ -1,0 +1,234 @@
+"""Tests for the unrouted-callable-verdict and callable-verdict-requires-on-result
+semantic rules (recipe-routing-deadlock immunity, #3889).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from autoskillit.core.types import Severity
+from autoskillit.recipe.contracts import load_bundled_manifest
+from autoskillit.recipe.registry import run_semantic_rules
+from autoskillit.recipe.rules.dataflow import rules_dataflow_callable as _r
+from autoskillit.recipe.schema import Recipe, RecipeStep, StepResultCondition, StepResultRoute
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:
+    return Recipe(
+        name="test-callable-verdict-routing",
+        description="Test recipe for callable verdict routing rules.",
+        version="0.1.0",
+        kitchen_rules=["test"],
+        steps=steps,
+    )
+
+
+def _callable_manifest(contract: dict[str, Any]) -> dict[str, Any]:
+    """Build a minimal manifest containing exactly one callable_contracts entry."""
+    return {"callable_contracts": {"autoskillit.test.fake_callable": contract}}
+
+
+def test_unrouted_callable_verdict_fires_when_value_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rule fires ERROR when an allowed_value on a callable output is unrouted in on_result."""
+    manifest = _callable_manifest(
+        {
+            "inputs": [{"name": "worktree_path", "type": "str", "required": True}],
+            "outputs": [
+                {
+                    "name": "committed",
+                    "type": "str",
+                    "allowed_values": ["a", "b", "c"],
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(_r, "load_bundled_manifest", lambda: manifest)
+
+    step = RecipeStep(
+        tool="run_python",
+        with_args={
+            "callable": "autoskillit.test.fake_callable",
+            "worktree_path": "/tmp",
+        },
+        on_result=StepResultRoute(
+            conditions=[
+                StepResultCondition(
+                    when="${{ result.committed }} == 'a'",
+                    route="next_step",
+                ),
+                StepResultCondition(
+                    when="${{ result.committed }} == 'b'",
+                    route="next_step",
+                ),
+                # Missing 'c' — should fire.
+                StepResultCondition(route="next_step"),
+            ]
+        ),
+    )
+    recipe = _make_recipe(
+        {
+            "guard": step,
+            "next_step": RecipeStep(action="stop", message="ok"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    unrouted = [f for f in findings if f.rule == "unrouted-callable-verdict"]
+    assert len(unrouted) == 1
+    assert unrouted[0].severity == Severity.ERROR
+    assert unrouted[0].step_name == "guard"
+    assert "'c'" in unrouted[0].message
+
+
+def test_unrouted_callable_verdict_passes_when_all_values_routed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rule produces no findings when every allowed_value has an explicit on_result condition."""
+    manifest = _callable_manifest(
+        {
+            "inputs": [{"name": "worktree_path", "type": "str", "required": True}],
+            "outputs": [
+                {
+                    "name": "committed",
+                    "type": "str",
+                    "allowed_values": ["a", "b", "c"],
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(_r, "load_bundled_manifest", lambda: manifest)
+
+    step = RecipeStep(
+        tool="run_python",
+        with_args={
+            "callable": "autoskillit.test.fake_callable",
+            "worktree_path": "/tmp",
+        },
+        on_result=StepResultRoute(
+            conditions=[
+                StepResultCondition(
+                    when="${{ result.committed }} == 'a'",
+                    route="next_step",
+                ),
+                StepResultCondition(
+                    when="${{ result.committed }} == 'b'",
+                    route="next_step",
+                ),
+                StepResultCondition(
+                    when="${{ result.committed }} == 'c'",
+                    route="next_step",
+                ),
+            ]
+        ),
+    )
+    recipe = _make_recipe(
+        {
+            "guard": step,
+            "next_step": RecipeStep(action="stop", message="ok"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    unrouted = [f for f in findings if f.rule == "unrouted-callable-verdict"]
+    assert unrouted == []
+
+
+def test_callable_verdict_requires_on_result_fires_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rule fires ERROR when a callable with allowed_values uses scalar on_success/on_failure."""
+    manifest = _callable_manifest(
+        {
+            "inputs": [{"name": "worktree_path", "type": "str", "required": True}],
+            "outputs": [
+                {
+                    "name": "committed",
+                    "type": "str",
+                    "allowed_values": ["false", "true", "regression_detected"],
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(_r, "load_bundled_manifest", lambda: manifest)
+
+    step = RecipeStep(
+        tool="run_python",
+        with_args={
+            "callable": "autoskillit.test.fake_callable",
+            "worktree_path": "/tmp",
+        },
+        on_success="next_step",
+        on_failure="next_step",
+    )
+    recipe = _make_recipe(
+        {
+            "guard": step,
+            "next_step": RecipeStep(action="stop", message="ok"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    requires = [f for f in findings if f.rule == "callable-verdict-requires-on-result"]
+    assert len(requires) == 1
+    assert requires[0].severity == Severity.ERROR
+    assert requires[0].step_name == "guard"
+    assert "regression_detected" in requires[0].message
+
+
+def test_callable_verdict_requires_on_result_passes_when_no_allowed_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rule produces no findings when the callable contract has no allowed_values outputs."""
+    manifest = _callable_manifest(
+        {
+            "inputs": [{"name": "worktree_path", "type": "str", "required": True}],
+            "outputs": [{"name": "status", "type": "str"}],
+        }
+    )
+    monkeypatch.setattr(_r, "load_bundled_manifest", lambda: manifest)
+
+    step = RecipeStep(
+        tool="run_python",
+        with_args={
+            "callable": "autoskillit.test.fake_callable",
+            "worktree_path": "/tmp",
+        },
+        on_success="next_step",
+        on_failure="next_step",
+    )
+    recipe = _make_recipe(
+        {
+            "guard": step,
+            "next_step": RecipeStep(action="stop", message="ok"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    requires = [f for f in findings if f.rule == "callable-verdict-requires-on-result"]
+    assert requires == []
+
+
+def test_real_callable_contract_uses_real_manifest() -> None:
+    """Sanity check: the real bundled manifest surfaces allowed_values for the new contracts.
+
+    This guards the contract manifest itself: a regression that strips the new
+    contracts (or breaks the loader) would surface here.
+    """
+    manifest = load_bundled_manifest()
+    callables = manifest.get("callable_contracts", {})
+
+    commit_guard = callables.get("autoskillit.recipe._cmd_rpc.commit_guard")
+    assert commit_guard is not None
+    committed_out = next((o for o in commit_guard["outputs"] if o["name"] == "committed"), None)
+    assert committed_out is not None
+    assert "allowed_values" in committed_out, (
+        "commit_guard contract must declare allowed_values for the regression_detected immunity"
+    )
+
+    main_repo_guard = callables.get("autoskillit.recipe._cmd_rpc.main_repo_guard")
+    assert main_repo_guard is not None, "main_repo_guard must be in callable_contracts"
+    cleaned_out = next((o for o in main_repo_guard["outputs"] if o["name"] == "cleaned"), None)
+    assert cleaned_out is not None
+    assert "allowed_values" in cleaned_out

--- a/tests/recipe/test_rules_dataflow_callable.py
+++ b/tests/recipe/test_rules_dataflow_callable.py
@@ -32,10 +32,10 @@ def _callable_manifest(contract: dict[str, Any]) -> dict[str, Any]:
     return {"callable_contracts": {"autoskillit.test.fake_callable": contract}}
 
 
-def test_unrouted_callable_verdict_fires_when_value_missing(
+def test_unrouted_callable_verdict_fires_when_value_missing_no_catch_all(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Rule fires ERROR when an allowed_value on a callable output is unrouted in on_result."""
+    """Rule fires ERROR when an allowed_value is unrouted and there is no catch-all arm."""
     manifest = _callable_manifest(
         {
             "inputs": [{"name": "worktree_path", "type": "str", "required": True}],
@@ -66,8 +66,7 @@ def test_unrouted_callable_verdict_fires_when_value_missing(
                     when="${{ result.committed }} == 'b'",
                     route="next_step",
                 ),
-                # Missing 'c' — should fire.
-                StepResultCondition(route="next_step"),
+                # No catch-all and no explicit condition for 'c' — should fire.
             ]
         ),
     )
@@ -83,6 +82,53 @@ def test_unrouted_callable_verdict_fires_when_value_missing(
     assert unrouted[0].severity == Severity.ERROR
     assert unrouted[0].step_name == "guard"
     assert "'c'" in unrouted[0].message
+
+
+def test_unrouted_callable_verdict_tolerates_catch_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rule does NOT fire when unrouted values are covered by a catch-all arm."""
+    manifest = _callable_manifest(
+        {
+            "inputs": [{"name": "worktree_path", "type": "str", "required": True}],
+            "outputs": [
+                {
+                    "name": "committed",
+                    "type": "str",
+                    "allowed_values": ["a", "b", "c"],
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(_r, "load_bundled_manifest", lambda: manifest)
+
+    step = RecipeStep(
+        tool="run_python",
+        with_args={
+            "callable": "autoskillit.test.fake_callable",
+            "worktree_path": "/tmp",
+        },
+        on_result=StepResultRoute(
+            conditions=[
+                StepResultCondition(
+                    when="${{ result.committed }} == 'a'",
+                    route="error_step",
+                ),
+                # 'b' and 'c' fall through to catch-all — acceptable.
+                StepResultCondition(route="next_step"),
+            ]
+        ),
+    )
+    recipe = _make_recipe(
+        {
+            "guard": step,
+            "next_step": RecipeStep(action="stop", message="ok"),
+            "error_step": RecipeStep(action="stop", message="error"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    unrouted = [f for f in findings if f.rule == "unrouted-callable-verdict"]
+    assert unrouted == []
 
 
 def test_unrouted_callable_verdict_passes_when_all_values_routed(


### PR DESCRIPTION
## Summary

The recipe routing system has a structural blind spot: `run_python` callable steps that return multi-valued verdict fields (like `commit_guard` returning `"false"`, `"true"`, or `"regression_detected"`) have no mechanism to declare, validate, or enforce routing coverage for those values. The existing verdict routing validation (`rules_verdict.py`) applies exclusively to `run_skill` steps. This creates unwinnable loops when a callable returns a verdict that the recipe doesn't route, causing the pipeline to proceed down a path that always fails (e.g., `merge_worktree` hitting `dirty_tree` because `commit_guard` returned `regression_detected` but didn't actually commit).

The architectural fix extends the existing `allowed_values` contract mechanism — already proven for `run_skill` steps and `merge_worktree` tool outputs — to `run_python` callable contracts. Two new semantic rules then enforce routing coverage at validation time, making this class of bug a build-time error rather than a runtime deadlock.

Closes #3889

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260607-163955-984211/.autoskillit/temp/rectify/rectify_callable_verdict_routing_immunity_2026-06-07_170800.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 66 | 23.3k | 1.9M | 133.6k | 53 | 113.1k | 17m 38s |
| review_approach* | sonnet | 1 | 1.2k | 5.6k | 193.2k | 46.6k | 15 | 49.6k | 2m 55s |
| dry_walkthrough* | opus | 2 | 81 | 17.0k | 2.1M | 88.4k | 91 | 90.4k | 8m 53s |
| audit_impl* | sonnet | 2 | 146 | 20.0k | 677.3k | 68.9k | 41 | 72.5k | 11m 19s |
| make_plan* | sonnet | 1 | 87 | 3.7k | 392.9k | 48.9k | 23 | 28.6k | 1m 21s |
| prepare_pr* | MiniMax-M3 | 1 | 43.9k | 2.0k | 159.5k | 47.6k | 12 | 0 | 1m 5s |
| compose_pr* | MiniMax-M3 | 1 | 35.6k | 1.3k | 149.4k | 38.5k | 11 | 0 | 40s |
| review_pr* | sonnet | 1 | 174 | 33.8k | 1.3M | 100.7k | 52 | 80.0k | 8m 2s |
| resolve_review* | opus[1m] | 1 | 43 | 5.9k | 1.5M | 67.9k | 49 | 46.5k | 6m 0s |
| **Total** | | | 81.3k | 112.5k | 8.4M | 133.6k | | 480.7k | 57m 58s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 190445.9 | 5811.9 | 735.1 |
| **Total** | **8** | 1049003.5 | 60092.2 | 14063.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 2 | 109 | 29.2k | 3.4M | 159.6k | 23m 38s |
| sonnet | 4 | 1.6k | 63.1k | 2.6M | 230.8k | 23m 40s |
| opus | 1 | 81 | 17.0k | 2.1M | 90.4k | 8m 53s |
| MiniMax-M3 | 2 | 79.5k | 3.3k | 308.9k | 0 | 1m 45s |