### PR TITLE
Document Missing ToolContext Protocol-Typed Fields

### DIFF
--- a/src/autoskillit/pipeline/context.py
+++ b/src/autoskillit/pipeline/context.py
@@ -91,6 +91,24 @@ class ToolContext:
     github_client:        GitHubFetcher — fetches GitHub issue content
     ci_watcher:           CIWatcher — watches GitHub Actions CI runs
     merge_queue_watcher:  MergeQueueWatcher — polls GitHub merge queue for a PR
+    github_api_log:       GitHubApiLog — session-scoped GitHub API request accumulator.
+    background:           BackgroundSupervisor — supervised async background task execution.
+                          Auto-initialized to DefaultBackgroundSupervisor when None.
+    output_pattern_resolver: OutputPatternResolver — resolves expected output patterns from
+                          a skill command.
+    write_expected_resolver: WriteExpectedResolver — resolves write-expectation metadata
+                          from skill contracts.
+    read_only_resolver:   ReadOnlyResolver — resolves whether a skill is read-only from
+                          skill contracts.
+    input_contract_resolver: InputContractResolver — resolves input contract specs from
+                          skill contracts.
+    completion_required_resolver: CompletionRequiredResolver — resolves whether a skill
+                          requires the completion marker.
+    quota_refresh_task:   QuotaRefreshTask — cancellable handle for the kitchen-scoped
+                          quota refresh background task.
+    fleet_lock:           FleetLock — semaphore-style guard for concurrent fleet dispatch.
+    build_protected_campaign_ids: CampaignProtector — resolves campaign IDs exempt from
+                          log retention purge.
     session_skill_manager: SessionSkillManager — manages per-session ephemeral skill dirs
     skill_resolver:       SkillResolver — resolves skill names to source tier
     kitchen_id:           UUID string assigned when open_kitchen fires; scopes token telemetry

--- a/src/autoskillit/server/CLAUDE.md
+++ b/src/autoskillit/server/CLAUDE.md
@@ -9,7 +9,7 @@ Sub-package: tools/ (see tools/CLAUDE.md).
 |------|---------|
 | `__init__.py` | Re-exports `mcp`, `ToolContext`, `make_context`; disables all `ALL_VISIBILITY_TAGS` at import |
 | `_editable_guard.py` | Pre-deletion editable install guard for `perform_merge()` — scans site-packages for PEP 610 direct_url.json links into the worktree |
-| `_factory.py` | Composition root — `make_context()` is the sole legal instantiation point for all 23 service contracts |
+| `_factory.py` | Composition root — `make_context()` is the sole legal instantiation point for all 24 service contracts |
 | `_guards.py` | Orchestration-level gate functions for MCP tool access control |
 | `_lifespan.py` | FastMCP lifespan context manager — deferred startup (recovery, audit loading, stale cleanup, drift check) |
 | `_misc.py` | Quota, hook-config, triage, and miscellaneous server utilities; re-exports selected execution/workspace symbols for tools |

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -1,5 +1,5 @@
 """Composition Root: make_context() is the only location that legally instantiates
-all 23 service contracts simultaneously.
+all 24 service contracts simultaneously.
 
 server/ is IL-3 — the only layer permitted to import from both IL-1 (pipeline/)
 and IL-2 (recipe/, migration/) at the same time. This module is the canonical
@@ -170,7 +170,7 @@ def make_context(
     fleet_lock: FleetLock | None = None,
     project_dir: Path | None = None,
 ) -> ToolContext:
-    """Create a fully-wired ToolContext with all 23 service fields populated.
+    """Create a fully-wired ToolContext with all 24 service fields populated.
 
     This is the Composition Root — the only location that should instantiate
     all concrete service implementations simultaneously. Uses a three-step

--- a/tests/pipeline/test_context.py
+++ b/tests/pipeline/test_context.py
@@ -415,3 +415,57 @@ def test_tool_context_has_input_contract_resolver_field() -> None:
         f"input_contract_resolver type hint {hints['input_contract_resolver']} "
         f"does not include InputContractResolver Protocol"
     )
+
+
+def test_toolcontext_protocol_fields_documented_in_docstring() -> None:
+    """Every protocol-typed field on ToolContext must appear in the Fields docstring."""
+    import inspect
+    from typing import Union, get_args, get_origin, get_type_hints
+
+    from autoskillit.pipeline.context import ToolContext
+
+    hints = get_type_hints(ToolContext)
+    docstring = inspect.getdoc(ToolContext) or ""
+
+    # Extract field names mentioned in the docstring Fields section
+    lines = docstring.split("\n")
+    fields_start = None
+    for i, line in enumerate(lines):
+        if line.strip() == "Fields":
+            fields_start = i + 2  # skip the "------" underline
+            break
+    assert fields_start is not None, "ToolContext docstring missing Fields section"
+
+    documented = set()
+    for line in lines[fields_start:]:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if ":" in stripped and not stripped.startswith(" "):
+            field_name = stripped.split(":")[0].strip()
+            documented.add(field_name)
+
+    # Find all protocol-typed fields (those importing from core.types)
+    protocol_module_prefixes = ("autoskillit.core.types.",)
+
+    def _is_protocol_type(annotation) -> bool:
+        """Check if an annotation references a Protocol from core.types."""
+        if get_origin(annotation) is Union:
+            for arg in get_args(annotation):
+                if arg is type(None):
+                    continue
+                if _is_protocol_type(arg):
+                    return True
+            return False
+        return hasattr(annotation, "__module__") and any(
+            annotation.__module__.startswith(p) for p in protocol_module_prefixes
+        )
+
+    protocol_fields = []
+    for f in dataclasses.fields(ToolContext):
+        ann = hints.get(f.name)
+        if ann is not None and _is_protocol_type(ann):
+            protocol_fields.append(f.name)
+
+    missing = sorted(set(protocol_fields) - documented)
+    assert not missing, f"Protocol-typed fields missing from ToolContext docstring: {missing}"

--- a/tests/pipeline/test_context.py
+++ b/tests/pipeline/test_context.py
@@ -432,7 +432,11 @@ def test_toolcontext_protocol_fields_documented_in_docstring() -> None:
     fields_start = None
     for i, line in enumerate(lines):
         if line.strip() == "Fields":
-            fields_start = i + 2  # skip the "------" underline
+            for j in range(i + 1, len(lines)):
+                candidate = lines[j].strip()
+                if candidate and not all(c == "-" for c in candidate):
+                    fields_start = j
+                    break
             break
     assert fields_start is not None, "ToolContext docstring missing Fields section"
 

--- a/tests/pipeline/test_context.py
+++ b/tests/pipeline/test_context.py
@@ -445,7 +445,7 @@ def test_toolcontext_protocol_fields_documented_in_docstring() -> None:
         stripped = line.strip()
         if not stripped:
             continue
-        if ":" in stripped and not stripped.startswith(" "):
+        if ":" in stripped and not line.startswith(" "):
             field_name = stripped.split(":")[0].strip()
             documented.add(field_name)
 


### PR DESCRIPTION
## Summary

Add docstring entries for the 10 undocumented protocol-typed service fields on `ToolContext` (lines 68–116 of `pipeline/context.py`), fix 3 stale hardcoded service-field counts in `server/_factory.py` and `server/CLAUDE.md`, and add an architectural test enforcing that every protocol-typed field is documented in the docstring going forward.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260607-214120-720004/.autoskillit/temp/make-plan/document_missing_toolcontext_protocol_fields_plan_2026-06-07_215200.md`

Closes #3769

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 60 | 7.2k | 846.5k | 69.0k | 31 | 49.8k | 6m 57s |
| verify* | sonnet | 1 | 92 | 15.2k | 507.7k | 58.8k | 29 | 37.2k | 5m 15s |
| implement* | MiniMax-M3 | 1 | 66.4k | 11.6k | 1.1M | 73.7k | 46 | 0 | 4m 28s |
| audit_impl* | sonnet | 1 | 1.7k | 7.2k | 167.9k | 41.2k | 14 | 26.0k | 3m 30s |
| prepare_pr* | MiniMax-M3 | 1 | 39.4k | 1.7k | 157.2k | 42.2k | 12 | 0 | 59s |
| compose_pr* | MiniMax-M3 | 1 | 37.1k | 1.2k | 187.8k | 39.3k | 14 | 0 | 39s |
| **Total** | | | 144.8k | 44.2k | 2.9M | 73.7k | | 113.0k | 21m 49s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 78 | 13512.9 | 0.0 | 149.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **78** | 37447.7 | 1448.4 | 566.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 60 | 7.2k | 846.5k | 49.8k | 6m 57s |
| sonnet | 2 | 1.8k | 22.4k | 675.5k | 63.2k | 8m 46s |
| MiniMax-M3 | 3 | 142.9k | 14.5k | 1.4M | 0 | 6m 6s |