### PR TITLE
Implementation Plan: Fix Logger Initialization Deviations in Three Modules

### DIFF
--- a/src/autoskillit/execution/backends/_codex_config.py
+++ b/src/autoskillit/execution/backends/_codex_config.py
@@ -35,7 +35,7 @@ CODEX_MCP_REQUIRED_KEYS: frozenset[str] = frozenset(
     {"command", "env_vars", "startup_timeout_sec", "tool_timeout_sec"}
 )
 
-logger = get_logger()
+logger = get_logger(__name__)
 
 
 def _format_toml_value(v: Any) -> str:

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -69,7 +69,7 @@ from autoskillit.execution.backends._cmd_builder import CmdBuilder
 from autoskillit.execution.process import _marker_is_standalone
 from autoskillit.execution.session import parse_session_result
 
-log = logging.getLogger(__name__)  # noqa: TID251
+log = logging.getLogger(__name__)  # noqa: TID251 — stdlib fallback: used before configure_logging(); structlog proxy would emit to stderr via import-time WriteLoggerFactory
 
 __all__ = [
     "ClaudeCodeBackend",

--- a/src/autoskillit/execution/process/_process_pty.py
+++ b/src/autoskillit/execution/process/_process_pty.py
@@ -6,9 +6,9 @@ import shlex
 import shutil
 import sys
 
-import structlog
+from autoskillit.core import get_logger
 
-logger = structlog.get_logger()
+logger = get_logger(__name__)
 
 
 def pty_wrap_command(cmd: list[str]) -> list[str]:

--- a/src/autoskillit/fleet/sidecar.py
+++ b/src/autoskillit/fleet/sidecar.py
@@ -9,7 +9,7 @@ from typing import Literal, NamedTuple
 
 from autoskillit.core import ensure_project_temp, get_logger
 
-logger = get_logger()
+logger = get_logger(__name__)
 
 
 class SidecarReadStatus(StrEnum):


### PR DESCRIPTION
## Summary

Fix four confirmed logger initialization deviations from the validated cohesion audit (F-C3-01):

1. **`execution/process/_process_pty.py:11`** — Replace `structlog.get_logger()` with `get_logger(__name__)` from `autoskillit.core`, eliminating both the direct structlog import and the missing module-name binding.
2. **`execution/backends/_codex_config.py:38`** — Add `__name__` argument to existing `get_logger()` call.
3. **`fleet/sidecar.py:12`** — Add `__name__` argument to existing `get_logger()` call.
4. **`execution/backends/claude.py:72`** — Add rationale comment to the existing `# noqa: TID251` suppression explaining why stdlib `logging.getLogger` is used instead of the structlog wrapper.

Closes #3770

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260607-223738-023290/.autoskillit/temp/make-plan/fix_logger_initialization_deviations_plan_2026-06-07_224600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 72 | 9.1k | 1.2M | 88.3k | 45 | 66.6k | 11m 45s |
| verify* | sonnet | 1 | 60 | 5.7k | 265.4k | 47.8k | 19 | 26.1k | 2m 49s |
| implement* | MiniMax-M3 | 1 | 50.2k | 3.7k | 536.8k | 51.5k | 35 | 0 | 2m 42s |
| audit_impl* | sonnet | 1 | 1.4k | 4.2k | 166.0k | 39.5k | 14 | 22.6k | 2m 23s |
| prepare_pr* | MiniMax-M3 | 1 | 39.4k | 2.3k | 157.3k | 42.8k | 14 | 0 | 1m 2s |
| compose_pr* | MiniMax-M3 | 1 | 35.6k | 2.7k | 229.9k | 39.8k | 16 | 0 | 1m 11s |
| review_pr* | sonnet | 3 | 446 | 32.0k | 2.5M | 58.5k | 123 | 104.9k | 9m 55s |
| **Total** | | | 127.2k | 59.7k | 5.0M | 88.3k | | 220.3k | 31m 49s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 10 | 53675.9 | 0.0 | 373.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **10** | 500203.3 | 22033.5 | 5967.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 72 | 9.1k | 1.2M | 66.6k | 11m 45s |
| sonnet | 3 | 1.9k | 41.9k | 2.9M | 153.7k | 15m 8s |
| MiniMax-M3 | 3 | 125.3k | 8.7k | 923.9k | 0 | 4m 55s |