### PR TITLE
[FIX] Context-Blind Capability Scanner Immunity

### DIFF
--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: make-plan
-uses_capabilities: [agent_model, agent_subagent, cross_skill_ref, git_metadata_write]
+uses_capabilities: [agent_model, agent_subagent, cross_skill_ref]
 activate_deps: [arch-lens, write-recipe]
 description: Planning executor. ALWAYS invoke this skill when instructed to create, devise, or write an implementation plan. Do not explore the codebase or draft a plan directly — use this skill first to load the planning workflow.
 hooks:

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -112,6 +112,8 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_codex_env_forward_bridge.py` | Cross-layer bridge: CODEX_MCP_ENV_FORWARD_VARS ↔ cmd builders ↔ capabilities parity |
 | `test_codex_timeout_coherence.py` | Cross-system timeout hierarchy: Codex MCP tool_timeout_sec must exceed max session duration |
 | `test_skill_search_dir_symmetry.py` | Suppression-delivery symmetry invariants for project-local skill search dirs |
+| `test_doc_fence_filter.py` | Unit and functional tests for `_strip_doc_fenced_blocks` section-aware code fence filter |
+| `test_capability_scanner_fence_immunity.py` | AST regression guard: capability scanners must import and call `_strip_doc_fenced_blocks` |
 
 ## Architecture Notes
 

--- a/tests/arch/_helpers.py
+++ b/tests/arch/_helpers.py
@@ -462,6 +462,52 @@ def _strip_frontmatter(content: str) -> str:
     return m.group(2) if m else content
 
 
+_STEP_HEADING_RE = _stdlib_re.compile(r"(?:Step\s+\d|^\d+[\.\):\s])")
+
+
+def _strip_doc_fenced_blocks(body: str) -> str:
+    """Strip fenced code blocks from non-step documentation sections.
+
+    Preserves code fence content under numbered step headings
+    (### Step N, #### N.N) since those contain executable instructions.
+    Strips fence content under all other headings to prevent false
+    capability detection from illustrative documentation examples.
+
+    Inline backtick spans are NOT stripped — they appear in prose
+    descriptions of genuine capabilities (e.g., resolve-failures).
+    """
+    lines = body.split("\n")
+    result: list[str] = []
+    in_step_section = False
+    in_fence = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped.startswith("#") and not in_fence:
+            heading_text = stripped.lstrip("#").strip()
+            in_step_section = bool(_STEP_HEADING_RE.match(heading_text))
+
+        if stripped.startswith("```"):
+            if not in_fence:
+                in_fence = True
+                if not in_step_section:
+                    continue
+            else:
+                in_fence = False
+                if not in_step_section:
+                    continue
+            result.append(line)
+            continue
+
+        if in_fence and not in_step_section:
+            continue
+
+        result.append(line)
+
+    return "\n".join(result)
+
+
 def _iter_skill_dirs() -> Iterator[tuple[str, Path]]:
     from autoskillit.core import paths
 

--- a/tests/arch/test_capability_scanner_fence_immunity.py
+++ b/tests/arch/test_capability_scanner_fence_immunity.py
@@ -1,0 +1,40 @@
+"""AST regression guard: capability scanners must import and call _strip_doc_fenced_blocks."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+_SCANNER_PATHS = (
+    "tests/arch/test_skill_backend_annotations.py",
+    "tests/skills/test_skill_commit_discipline.py",
+    "tests/arch/test_skill_backend_annotation_accuracy.py",
+)
+
+
+def _file_has_import_and_call(path: Path) -> bool:
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    has_import = False
+    has_call = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            names = [alias.name for alias in node.names]
+            if "_strip_doc_fenced_blocks" in names:
+                has_import = True
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name) and node.func.id == "_strip_doc_fenced_blocks":
+                has_call = True
+    return has_import and has_call
+
+
+def test_capability_scanners_use_doc_fence_filter():
+    for rel_path in _SCANNER_PATHS:
+        full_path = Path(__file__).resolve().parent.parent.parent / rel_path
+        assert _file_has_import_and_call(full_path), (
+            f"{rel_path} must import and call _strip_doc_fenced_blocks from tests.arch._helpers"
+        )

--- a/tests/arch/test_doc_fence_filter.py
+++ b/tests/arch/test_doc_fence_filter.py
@@ -1,0 +1,68 @@
+"""Unit and functional tests for _strip_doc_fenced_blocks section-aware code fence filter."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.arch._helpers import _strip_doc_fenced_blocks
+from tests.arch.test_skill_backend_annotations import _detect_capabilities
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+def test_strips_fence_in_doc_section():
+    body = "## Requirements\n```\ngit commit -m 'example'\n```\n"
+    assert "git commit" not in _strip_doc_fenced_blocks(body)
+
+
+def test_keeps_fence_in_step_section():
+    body = "### Step 1: Commit\n```bash\ngit commit -m 'real'\n```\n"
+    assert "git commit" in _strip_doc_fenced_blocks(body)
+
+
+def test_keeps_fence_in_substep_section():
+    body = "#### 4.2 — Continue rebase\n```bash\ngit rebase --continue\n```\n"
+    assert "git rebase" in _strip_doc_fenced_blocks(body)
+
+
+def test_preserves_inline_code():
+    body = "## Docs\nUse `git commit -m` to commit.\n"
+    assert "git commit" in _strip_doc_fenced_blocks(body)
+
+
+def test_preserves_prose_outside_fences():
+    body = "## Docs\nAlways run git commit -m for changes.\n"
+    assert "git commit" in _strip_doc_fenced_blocks(body)
+
+
+def test_step_decimal_heading_recognized():
+    body = "### Step 0.5: Commit\n```\ngit commit -m 'msg'\n```\n"
+    assert "git commit" in _strip_doc_fenced_blocks(body)
+
+
+def test_numbered_non_step_heading_treated_as_step():
+    body = "### 1. Component Diagrams\n```\ngit commit -m 'x'\n```\n"
+    assert "git commit" in _strip_doc_fenced_blocks(body)
+
+
+def test_step_2a_heading_recognized():
+    body = "### Step 2a: Read CI Context\n```\ngit commit -m 'x'\n```\n"
+    assert "git commit" in _strip_doc_fenced_blocks(body)
+
+
+def test_detect_capabilities_ignores_doc_fence_git_commit():
+    body = (
+        "## Conflict-Resolution Plan Requirements\n"
+        "**ALWAYS use linear approaches:**\n"
+        "```\n"
+        'git commit -m "feat: apply changes"\n'
+        "```\n"
+    )
+    detected = _detect_capabilities(body, "test-skill")
+    assert "git_metadata_write" not in detected
+
+
+def test_detect_capabilities_finds_step_fence_git_commit():
+    body = '### Step 4: Apply Fixes\n```bash\ngit commit -m "fix: resolve issue"\n```\n'
+    detected = _detect_capabilities(body, "test-skill")
+    assert "git_metadata_write" in detected

--- a/tests/arch/test_skill_backend_annotation_accuracy.py
+++ b/tests/arch/test_skill_backend_annotation_accuracy.py
@@ -9,7 +9,7 @@ import pytest
 from autoskillit.core import paths
 from autoskillit.core.types._type_constants_registries import SKILL_CAPABILITY_REGISTRY
 from autoskillit.workspace.skills import _read_skill_frontmatter
-from tests.arch._helpers import _strip_frontmatter
+from tests.arch._helpers import _strip_doc_fenced_blocks, _strip_frontmatter
 
 pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 
@@ -20,10 +20,11 @@ _GENUINE_CLAUDE_CODE_PATTERNS: tuple[re.Pattern[str], ...] = (
 
 
 def _has_genuine_claude_code_dependency(body: str, skill_name: str) -> bool:
+    filtered = _strip_doc_fenced_blocks(body)
     for pat in _GENUINE_CLAUDE_CODE_PATTERNS:
-        if pat.search(body):
+        if pat.search(filtered):
             return True
-    for line in body.splitlines():
+    for line in filtered.splitlines():
         stripped = line.strip()
         if not stripped or stripped.startswith("#") or stripped.startswith("|"):
             continue

--- a/tests/arch/test_skill_backend_annotations.py
+++ b/tests/arch/test_skill_backend_annotations.py
@@ -14,7 +14,7 @@ import pytest
 
 from autoskillit.core.types._type_constants_registries import SKILL_CAPABILITY_REGISTRY
 from autoskillit.workspace.skills import _read_skill_frontmatter
-from tests.arch._helpers import _iter_skill_dirs, _strip_frontmatter
+from tests.arch._helpers import _iter_skill_dirs, _strip_doc_fenced_blocks, _strip_frontmatter
 
 pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 
@@ -34,13 +34,14 @@ _CAPABILITY_PATTERNS: dict[str, list[re.Pattern[str]]] = {
 
 
 def _detect_capabilities(body: str, skill_name: str) -> set[str]:
+    filtered = _strip_doc_fenced_blocks(body)
     detected: set[str] = set()
     for cap_name, patterns in _CAPABILITY_PATTERNS.items():
         for pat in patterns:
-            if pat.search(body):
+            if pat.search(filtered):
                 detected.add(cap_name)
                 break
-    for line in body.splitlines():
+    for line in filtered.splitlines():
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
             continue

--- a/tests/skills/CLAUDE.md
+++ b/tests/skills/CLAUDE.md
@@ -70,6 +70,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 | `test_skill_body_cleanliness.py` | Assert that no SKILL.md body references %%ORDER_UP%% |
 | `test_skill_md_path_brace_consistency.py` | Structural guard: no SKILL.md may use single-brace {AUTOSKILLIT_TEMP} — must use double-brace {{AUTOSKILLIT_TEMP}} |
 | `test_skill_commit_discipline.py` | Prohibition tests: skills with git commit instructions must explicitly forbid --amend |
+| `test_make_plan_capability_accuracy.py` | Semantic guard: make-plan must not declare git_metadata_write capability |
 | `test_skill_compliance.py` | SKILL.md compliance tests: structural invariants for skill composition safety |
 | `test_skill_genericization.py` | Verify skill SKILL.md files contain no project-specific AutoSkillit internals |
 | `test_skill_md_spawn_syntax.py` | Regression guard: SKILL.md subagent spawn instructions must use unambiguous Agent(model="sonnet") syntax (issue #3367) |

--- a/tests/skills/test_make_plan_capability_accuracy.py
+++ b/tests/skills/test_make_plan_capability_accuracy.py
@@ -1,0 +1,16 @@
+"""Semantic guard: make-plan must not declare git_metadata_write capability."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core.paths import pkg_root
+from autoskillit.workspace.skills import _read_skill_frontmatter
+
+pytestmark = [pytest.mark.small]
+
+
+def test_make_plan_does_not_declare_git_metadata_write():
+    fm = _read_skill_frontmatter(pkg_root() / "skills_extended" / "make-plan" / "SKILL.md")
+    caps = set(fm.get("uses_capabilities", []))
+    assert "git_metadata_write" not in caps

--- a/tests/skills/test_skill_commit_discipline.py
+++ b/tests/skills/test_skill_commit_discipline.py
@@ -14,7 +14,7 @@ import pytest
 
 from autoskillit.core.paths import pkg_root
 from autoskillit.workspace.skills import _read_skill_frontmatter
-from tests.arch._helpers import _strip_frontmatter
+from tests.arch._helpers import _strip_doc_fenced_blocks, _strip_frontmatter
 
 pytestmark = [pytest.mark.small]
 
@@ -52,12 +52,13 @@ def test_skill_commit_prohibits_amend(skill_dir: Path) -> None:
     new commits.  Skills with no commit instructions (or only descriptive mentions without
     -m flag) are considered low-risk and pass."""
     text = (skill_dir / "SKILL.md").read_text()
+    scan_text = _strip_doc_fenced_blocks(_strip_frontmatter(text))
 
-    if not _GIT_COMMIT_INSTRUCTION_RE.search(text):
+    if not _GIT_COMMIT_INSTRUCTION_RE.search(scan_text):
         return
 
-    has_prohibition = bool(_AMEND_PROHIBITION_RE.search(text))
-    has_new_commit_language = bool(_NEW_COMMIT_RE.search(text))
+    has_prohibition = bool(_AMEND_PROHIBITION_RE.search(scan_text))
+    has_new_commit_language = bool(_NEW_COMMIT_RE.search(scan_text))
 
     assert has_prohibition or has_new_commit_language, (
         f"Skill {skill_dir.name!r} contains 'git commit' instructions but does not "
@@ -70,7 +71,7 @@ def test_skill_commit_prohibits_amend(skill_dir: Path) -> None:
 def test_git_commit_skills_declare_metadata_write(skill_dir: Path) -> None:
     """Skills with 'git commit -m' instructions must declare git_metadata_write."""
     content = (skill_dir / "SKILL.md").read_text()
-    body = _strip_frontmatter(content)
+    body = _strip_doc_fenced_blocks(_strip_frontmatter(content))
     if not _GIT_COMMIT_INSTRUCTION_RE.search(body):
         return
     fm = _read_skill_frontmatter(skill_dir / "SKILL.md")


### PR DESCRIPTION
## Summary

Three independent arch test scanners use context-blind regex to detect capabilities in SKILL.md files. They match patterns inside fenced code blocks that are documentation examples, producing false capability declarations. The `make-plan` skill was falsely given `git_metadata_write`, blocking it from the Codex backend. The architectural fix introduces a section-aware code fence filter — `_strip_doc_fenced_blocks()` — that strips fenced code content from documentation sections while preserving it under numbered step headings where executable instructions live. A regression guard prevents future scanners from omitting this preprocessing.

## Requirements

`make-plan` is incorrectly blocked from running on the Codex backend due to a false `git_metadata_write` capability declaration. This causes any recipe pipeline running on a Codex session to fail immediately at the first `run_skill(make-plan)` step with a `RuntimeError`. The pipeline aborts mid-execution — `bootstrap_clone`, `claim_and_resolve_issue`, and `create_and_publish_branch` all succeed (MCP tool calls are backend-agnostic), but the first skill invocation hard-fails.

### Root Cause
1. **False capability declaration in `make-plan/SKILL.md`** — line 3 declares `git_metadata_write` but `make-plan` does not perform any git write operations.
2. **Context-unaware arch test scanners** — two independent scanners (`_detect_capabilities()` and `test_git_commit_skills_declare_metadata_write`) apply regex against full post-frontmatter body without code-fence or context awareness. Both match `git commit -m` inside a fenced code block in a documentation section.
3. **Capability-to-backend derivation chain** — `git_metadata_write` has `codex_status="not-applicable"`, causing `SkillInfo.backend_requirements` to include `claude-code` only.

### Acceptance Criteria
- [ ] `make-plan` runs successfully when `session backend is 'codex'` (no `RuntimeError`)
- [ ] `task test-all` passes — including `test_forward_check_capabilities_declared`, `test_git_commit_skills_declare_metadata_write`, `test_skill_commit_prohibits_amend`, `test_codex_backend_fires_for_git_metadata_skills`
- [ ] `make-plan/SKILL.md` `uses_capabilities` no longer includes `git_metadata_write`
- [ ] No pattern from `_CAPABILITY_PATTERNS["git_metadata_write"]` matches the rewritten SKILL.md body
- [ ] `_detect_capabilities()` scanner can distinguish documentation examples from executable directives
- [ ] No other skill's capability annotation changes (all 10 genuine `git_metadata_write` skills remain annotated)

Closes #3897

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260607-221608-731094/.autoskillit/temp/rectify/rectify_context_blind_capability_scanner_immunity_2026-06-07_223000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 30.8k | 797 | 7.0M | 140.1k | 81 | 351.4k | 31m 34s |
| review_approach* | opus[1m] | 1 | 5.4k | 5.4k | 243.7k | 60.1k | 11 | 41.5k | 7m 35s |
| dry_walkthrough* | opus | 1 | 37 | 13.0k | 523.9k | 76.2k | 27 | 54.0k | 6m 17s |
| audit_impl* | opus[1m] | 1 | 925 | 8.6k | 258.5k | 47.2k | 17 | 35.1k | 3m 17s |
| prepare_pr* | MiniMax-M3 | 1 | 46.0k | 2.5k | 360.2k | 49.9k | 16 | 0 | 1m 13s |
| compose_pr* | MiniMax-M3 | 1 | 39.5k | 1.6k | 151.7k | 39.9k | 12 | 0 | 46s |
| review_pr* | opus[1m] | 1 | 27 | 31.4k | 496.6k | 85.8k | 31 | 64.0k | 7m 7s |
| resolve_review* | opus[1m] | 1 | 29 | 5.0k | 604.4k | 61.0k | 27 | 39.3k | 2m 16s |
| diagnose_ci* | MiniMax-M3 | 1 | 36.9k | 861 | 224.1k | 38.2k | 12 | 0 | 49s |
| resolve_ci* | opus[1m] | 1 | 8.2k | 2.8k | 474.6k | 52.3k | 24 | 30.1k | 4m 36s |
| **Total** | | | 167.8k | 72.1k | 10.4M | 140.1k | | 615.3k | 1h 5m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 45.3k | 54.0k | 9.1M | 561.4k | 56m 27s |
| opus | 1 | 37 | 13.0k | 523.9k | 54.0k | 6m 17s |
| MiniMax-M3 | 3 | 122.4k | 5.0k | 736.0k | 0 | 2m 47s |