### PR TITLE
Implementation Plan: Standardize recipe_version Field Across Recipe YAMLs

### DIFF
--- a/src/autoskillit/cli/_validate.py
+++ b/src/autoskillit/cli/_validate.py
@@ -19,7 +19,7 @@ from autoskillit.recipe import (
 
 validate_app = App(name="validate", help="Validation commands.")
 
-EXPECTED_SCHEMA_VERSION = "1.0"
+EXPECTED_SCHEMA_VERSION = "1.0.0"
 
 
 @dataclass

--- a/src/autoskillit/recipe/_registry_utils.py
+++ b/src/autoskillit/recipe/_registry_utils.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Final
 
+EXPECTED_SCHEMA_VERSION: Final = "1.0.0"
 _MISSING_MTIME: float = -1.0
 
 

--- a/src/autoskillit/recipe/experiment_type_registry.py
+++ b/src/autoskillit/recipe/experiment_type_registry.py
@@ -137,12 +137,12 @@ def load_all_experiment_types(
         user_dir = Path(project_dir) / ".autoskillit" / "experiment-types"
         user_types = _load_types_from_dir(user_dir)
         for spec in user_types.values():
-            if spec.schema_version and spec.schema_version != "1.0":
+            if spec.schema_version and spec.schema_version != "1.0.0":
                 logger.warning(
                     "User experiment type has schema_version mismatch; loading continues",
                     type_name=spec.name,
                     schema_version=spec.schema_version,
-                    expected_schema_version="1.0",
+                    expected_schema_version="1.0.0",
                 )
         types.update(user_types)
 

--- a/src/autoskillit/recipe/experiment_type_registry.py
+++ b/src/autoskillit/recipe/experiment_type_registry.py
@@ -7,7 +7,12 @@ from pathlib import Path
 from typing import Any
 
 from autoskillit.core import get_logger, load_yaml, pkg_root
-from autoskillit.recipe._registry_utils import _MISSING_MTIME, dir_mtime, parse_int_field
+from autoskillit.recipe._registry_utils import (
+    _MISSING_MTIME,
+    EXPECTED_SCHEMA_VERSION,
+    dir_mtime,
+    parse_int_field,
+)
 
 logger = get_logger(__name__)
 
@@ -137,12 +142,12 @@ def load_all_experiment_types(
         user_dir = Path(project_dir) / ".autoskillit" / "experiment-types"
         user_types = _load_types_from_dir(user_dir)
         for spec in user_types.values():
-            if spec.schema_version and spec.schema_version != "1.0.0":
+            if spec.schema_version and spec.schema_version != EXPECTED_SCHEMA_VERSION:
                 logger.warning(
                     "User experiment type has schema_version mismatch; loading continues",
                     type_name=spec.name,
                     schema_version=spec.schema_version,
-                    expected_schema_version="1.0.0",
+                    expected_schema_version=EXPECTED_SCHEMA_VERSION,
                 )
         types.update(user_types)
 

--- a/src/autoskillit/recipe/methodology_tradition_registry.py
+++ b/src/autoskillit/recipe/methodology_tradition_registry.py
@@ -7,7 +7,12 @@ from pathlib import Path
 from typing import Any
 
 from autoskillit.core import get_logger, load_yaml, pkg_root
-from autoskillit.recipe._registry_utils import _MISSING_MTIME, dir_mtime, parse_int_field
+from autoskillit.recipe._registry_utils import (
+    _MISSING_MTIME,
+    EXPECTED_SCHEMA_VERSION,
+    dir_mtime,
+    parse_int_field,
+)
 
 logger = get_logger(__name__)
 
@@ -243,12 +248,12 @@ def load_all_methodology_traditions(
         user_dir = Path(project_dir) / ".autoskillit" / "methodology-traditions"
         user_traditions = _load_traditions_from_dir(user_dir)
         for spec in user_traditions.values():
-            if spec.schema_version and spec.schema_version != "1.0.0":
+            if spec.schema_version and spec.schema_version != EXPECTED_SCHEMA_VERSION:
                 logger.warning(
                     "User methodology tradition has schema_version mismatch; loading continues",
                     tradition_name=spec.name,
                     schema_version=spec.schema_version,
-                    expected_schema_version="1.0.0",
+                    expected_schema_version=EXPECTED_SCHEMA_VERSION,
                 )
         traditions.update(user_traditions)
 

--- a/src/autoskillit/recipe/methodology_tradition_registry.py
+++ b/src/autoskillit/recipe/methodology_tradition_registry.py
@@ -243,12 +243,12 @@ def load_all_methodology_traditions(
         user_dir = Path(project_dir) / ".autoskillit" / "methodology-traditions"
         user_traditions = _load_traditions_from_dir(user_dir)
         for spec in user_traditions.values():
-            if spec.schema_version and spec.schema_version != "1.0":
+            if spec.schema_version and spec.schema_version != "1.0.0":
                 logger.warning(
                     "User methodology tradition has schema_version mismatch; loading continues",
                     tradition_name=spec.name,
                     schema_version=spec.schema_version,
-                    expected_schema_version="1.0",
+                    expected_schema_version="1.0.0",
                 )
         traditions.update(user_traditions)
 

--- a/src/autoskillit/recipes/experiment-types/benchmark.json
+++ b/src/autoskillit/recipes/experiment-types/benchmark.json
@@ -1,6 +1,6 @@
 {
   "name": "benchmark",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 3,
   "is_fallback": false,
   "classification_triggers": [

--- a/src/autoskillit/recipes/experiment-types/benchmark.yaml
+++ b/src/autoskillit/recipes/experiment-types/benchmark.yaml
@@ -1,5 +1,5 @@
 name: benchmark
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 3
 is_fallback: false
 classification_triggers:

--- a/src/autoskillit/recipes/experiment-types/causal_inference.json
+++ b/src/autoskillit/recipes/experiment-types/causal_inference.json
@@ -1,6 +1,6 @@
 {
   "name": "causal_inference",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 1,
   "is_fallback": false,
   "classification_triggers": [

--- a/src/autoskillit/recipes/experiment-types/causal_inference.yaml
+++ b/src/autoskillit/recipes/experiment-types/causal_inference.yaml
@@ -1,5 +1,5 @@
 name: causal_inference
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 1
 is_fallback: false
 classification_triggers:

--- a/src/autoskillit/recipes/experiment-types/configuration_study.json
+++ b/src/autoskillit/recipes/experiment-types/configuration_study.json
@@ -1,6 +1,6 @@
 {
   "name": "configuration_study",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 5,
   "is_fallback": false,
   "classification_triggers": [

--- a/src/autoskillit/recipes/experiment-types/configuration_study.yaml
+++ b/src/autoskillit/recipes/experiment-types/configuration_study.yaml
@@ -1,5 +1,5 @@
 name: configuration_study
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 5
 is_fallback: false
 classification_triggers:

--- a/src/autoskillit/recipes/experiment-types/evidence_synthesis.json
+++ b/src/autoskillit/recipes/experiment-types/evidence_synthesis.json
@@ -1,6 +1,6 @@
 {
   "name": "evidence_synthesis",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 2,
   "is_fallback": false,
   "classification_triggers": [

--- a/src/autoskillit/recipes/experiment-types/evidence_synthesis.yaml
+++ b/src/autoskillit/recipes/experiment-types/evidence_synthesis.yaml
@@ -1,5 +1,5 @@
 name: evidence_synthesis
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 2
 is_fallback: false
 classification_triggers:

--- a/src/autoskillit/recipes/experiment-types/exploratory.json
+++ b/src/autoskillit/recipes/experiment-types/exploratory.json
@@ -1,6 +1,6 @@
 {
   "name": "exploratory",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 999,
   "is_fallback": true,
   "classification_triggers": [

--- a/src/autoskillit/recipes/experiment-types/exploratory.yaml
+++ b/src/autoskillit/recipes/experiment-types/exploratory.yaml
@@ -1,5 +1,5 @@
 name: exploratory
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 999
 is_fallback: true
 classification_triggers:

--- a/src/autoskillit/recipes/experiment-types/factorial_design.json
+++ b/src/autoskillit/recipes/experiment-types/factorial_design.json
@@ -1,6 +1,6 @@
 {
   "name": "factorial_design",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 4,
   "is_fallback": false,
   "classification_triggers": [

--- a/src/autoskillit/recipes/experiment-types/factorial_design.yaml
+++ b/src/autoskillit/recipes/experiment-types/factorial_design.yaml
@@ -1,5 +1,5 @@
 name: factorial_design
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 4
 is_fallback: false
 classification_triggers:

--- a/src/autoskillit/recipes/experiment-types/instrument_validation.json
+++ b/src/autoskillit/recipes/experiment-types/instrument_validation.json
@@ -1,6 +1,6 @@
 {
   "name": "instrument_validation",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 7,
   "is_fallback": false,
   "classification_triggers": [

--- a/src/autoskillit/recipes/experiment-types/instrument_validation.yaml
+++ b/src/autoskillit/recipes/experiment-types/instrument_validation.yaml
@@ -1,5 +1,5 @@
 name: instrument_validation
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 7
 is_fallback: false
 classification_triggers:

--- a/src/autoskillit/recipes/experiment-types/observational_correlational.json
+++ b/src/autoskillit/recipes/experiment-types/observational_correlational.json
@@ -1,6 +1,6 @@
 {
   "name": "observational_correlational",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 10,
   "is_fallback": false,
   "classification_triggers": [

--- a/src/autoskillit/recipes/experiment-types/observational_correlational.yaml
+++ b/src/autoskillit/recipes/experiment-types/observational_correlational.yaml
@@ -1,5 +1,5 @@
 name: observational_correlational
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 10
 is_fallback: false
 classification_triggers:

--- a/src/autoskillit/recipes/experiment-types/qualitative_interpretive.json
+++ b/src/autoskillit/recipes/experiment-types/qualitative_interpretive.json
@@ -1,6 +1,6 @@
 {
   "name": "qualitative_interpretive",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 11,
   "is_fallback": false,
   "classification_triggers": [

--- a/src/autoskillit/recipes/experiment-types/qualitative_interpretive.yaml
+++ b/src/autoskillit/recipes/experiment-types/qualitative_interpretive.yaml
@@ -1,5 +1,5 @@
 name: qualitative_interpretive
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 11
 is_fallback: false
 classification_triggers:

--- a/src/autoskillit/recipes/experiment-types/robustness_audit.json
+++ b/src/autoskillit/recipes/experiment-types/robustness_audit.json
@@ -1,6 +1,6 @@
 {
   "name": "robustness_audit",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 8,
   "is_fallback": false,
   "classification_triggers": [

--- a/src/autoskillit/recipes/experiment-types/robustness_audit.yaml
+++ b/src/autoskillit/recipes/experiment-types/robustness_audit.yaml
@@ -1,5 +1,5 @@
 name: robustness_audit
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 8
 is_fallback: false
 classification_triggers:

--- a/src/autoskillit/recipes/experiment-types/simulation_modeling.json
+++ b/src/autoskillit/recipes/experiment-types/simulation_modeling.json
@@ -1,6 +1,6 @@
 {
   "name": "simulation_modeling",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 6,
   "is_fallback": false,
   "classification_triggers": [

--- a/src/autoskillit/recipes/experiment-types/simulation_modeling.yaml
+++ b/src/autoskillit/recipes/experiment-types/simulation_modeling.yaml
@@ -1,5 +1,5 @@
 name: simulation_modeling
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 6
 is_fallback: false
 classification_triggers:

--- a/src/autoskillit/recipes/experiment-types/single_subject.json
+++ b/src/autoskillit/recipes/experiment-types/single_subject.json
@@ -1,6 +1,6 @@
 {
   "name": "single_subject",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 9,
   "is_fallback": false,
   "classification_triggers": [

--- a/src/autoskillit/recipes/experiment-types/single_subject.yaml
+++ b/src/autoskillit/recipes/experiment-types/single_subject.yaml
@@ -1,5 +1,5 @@
 name: single_subject
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 9
 is_fallback: false
 classification_triggers:

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -3,7 +3,7 @@ description: Plan, implement, test, and merge a task end-to-end
 summary: bootstrap_clone > (claim_and_resolve?) > (create_and_publish?) > make-plan
   > (review-approach?) > dry-walkthrough > implement > test > merge (per plan part)
   > (audit-impl?) > (open_pr?) > push > cleanup
-recipe_version: 1.0.0
+recipe_version: "1.0.0"
 requires_packs:
 - github
 - ci

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -7,7 +7,7 @@ summary: 'clone > setup_remote > analyze_prs > create_batch_branch > [loop per P
   > check_mergeability > (resolve_integration_conflicts > force_push_after_rebase)?
   > review_pr_integration > (resolve_review_integration > re_push_review_integration)?
   > ci_watch_pr > cleanup'
-recipe_version: 1.0.0
+recipe_version: "1.0.0"
 requires_packs:
 - github
 - ci

--- a/src/autoskillit/recipes/methodology-traditions/_disambiguation.json
+++ b/src/autoskillit/recipes/methodology-traditions/_disambiguation.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "disambiguation_rules": [
     {
       "name": "prisma_dominance",

--- a/src/autoskillit/recipes/methodology-traditions/_disambiguation.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/_disambiguation.yaml
@@ -1,4 +1,4 @@
-schema_version: "1.0"
+schema_version: "1.0.0"
 
 disambiguation_rules:
   - name: prisma_dominance

--- a/src/autoskillit/recipes/methodology-traditions/_ml_sub_area_folding.json
+++ b/src/autoskillit/recipes/methodology-traditions/_ml_sub_area_folding.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "ml_sub_area_folding": [
     {
       "sub_area": "foundation_models",

--- a/src/autoskillit/recipes/methodology-traditions/_ml_sub_area_folding.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/_ml_sub_area_folding.yaml
@@ -1,4 +1,4 @@
-schema_version: "1.0"
+schema_version: "1.0.0"
 
 ml_sub_area_folding:
   - sub_area: foundation_models

--- a/src/autoskillit/recipes/methodology-traditions/animal_preclinical.json
+++ b/src/autoskillit/recipes/methodology-traditions/animal_preclinical.json
@@ -1,6 +1,6 @@
 {
   "name": "animal_preclinical",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 10,
   "display_name": "Animal Preclinical Study",
   "canonical_guideline": {

--- a/src/autoskillit/recipes/methodology-traditions/animal_preclinical.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/animal_preclinical.yaml
@@ -1,5 +1,5 @@
 name: animal_preclinical
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 10
 display_name: "Animal Preclinical Study"
 canonical_guideline:

--- a/src/autoskillit/recipes/methodology-traditions/controlled_intervention.json
+++ b/src/autoskillit/recipes/methodology-traditions/controlled_intervention.json
@@ -1,6 +1,6 @@
 {
   "name": "controlled_intervention",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 1,
   "display_name": "Controlled Intervention (Randomized Trial)",
   "canonical_guideline": {

--- a/src/autoskillit/recipes/methodology-traditions/controlled_intervention.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/controlled_intervention.yaml
@@ -1,5 +1,5 @@
 name: controlled_intervention
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 1
 display_name: "Controlled Intervention (Randomized Trial)"
 canonical_guideline:

--- a/src/autoskillit/recipes/methodology-traditions/diagnostic_accuracy.json
+++ b/src/autoskillit/recipes/methodology-traditions/diagnostic_accuracy.json
@@ -1,6 +1,6 @@
 {
   "name": "diagnostic_accuracy",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 4,
   "display_name": "Diagnostic Accuracy Study",
   "canonical_guideline": {

--- a/src/autoskillit/recipes/methodology-traditions/diagnostic_accuracy.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/diagnostic_accuracy.yaml
@@ -1,5 +1,5 @@
 name: diagnostic_accuracy
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 4
 display_name: "Diagnostic Accuracy Study"
 canonical_guideline:

--- a/src/autoskillit/recipes/methodology-traditions/economic_evaluation.json
+++ b/src/autoskillit/recipes/methodology-traditions/economic_evaluation.json
@@ -1,6 +1,6 @@
 {
   "name": "economic_evaluation",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 9,
   "display_name": "Economic Evaluation",
   "canonical_guideline": {

--- a/src/autoskillit/recipes/methodology-traditions/economic_evaluation.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/economic_evaluation.yaml
@@ -1,5 +1,5 @@
 name: economic_evaluation
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 9
 display_name: "Economic Evaluation"
 canonical_guideline:

--- a/src/autoskillit/recipes/methodology-traditions/measurement_instrument_validation_tradition.json
+++ b/src/autoskillit/recipes/methodology-traditions/measurement_instrument_validation_tradition.json
@@ -1,6 +1,6 @@
 {
   "name": "measurement_instrument_validation_tradition",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 7,
   "display_name": "Measurement Instrument Validation",
   "canonical_guideline": {

--- a/src/autoskillit/recipes/methodology-traditions/measurement_instrument_validation_tradition.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/measurement_instrument_validation_tradition.yaml
@@ -1,5 +1,5 @@
 name: measurement_instrument_validation_tradition
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 7
 display_name: "Measurement Instrument Validation"
 canonical_guideline:

--- a/src/autoskillit/recipes/methodology-traditions/method_comparison_benchmarking.json
+++ b/src/autoskillit/recipes/methodology-traditions/method_comparison_benchmarking.json
@@ -1,6 +1,6 @@
 {
   "name": "method_comparison_benchmarking",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 12,
   "display_name": "Method Comparison and Benchmarking",
   "canonical_guideline": {

--- a/src/autoskillit/recipes/methodology-traditions/method_comparison_benchmarking.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/method_comparison_benchmarking.yaml
@@ -1,5 +1,5 @@
 name: method_comparison_benchmarking
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 12
 display_name: "Method Comparison and Benchmarking"
 canonical_guideline:

--- a/src/autoskillit/recipes/methodology-traditions/observational_correlational.json
+++ b/src/autoskillit/recipes/methodology-traditions/observational_correlational.json
@@ -1,6 +1,6 @@
 {
   "name": "observational_correlational",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 3,
   "display_name": "Observational Correlational Study",
   "canonical_guideline": {

--- a/src/autoskillit/recipes/methodology-traditions/observational_correlational.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/observational_correlational.yaml
@@ -1,5 +1,5 @@
 name: observational_correlational
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 3
 display_name: "Observational Correlational Study"
 canonical_guideline:

--- a/src/autoskillit/recipes/methodology-traditions/prediction_model_validation.json
+++ b/src/autoskillit/recipes/methodology-traditions/prediction_model_validation.json
@@ -1,6 +1,6 @@
 {
   "name": "prediction_model_validation",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 5,
   "display_name": "Prediction Model Validation",
   "canonical_guideline": {

--- a/src/autoskillit/recipes/methodology-traditions/prediction_model_validation.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/prediction_model_validation.yaml
@@ -1,5 +1,5 @@
 name: prediction_model_validation
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 5
 display_name: "Prediction Model Validation"
 canonical_guideline:

--- a/src/autoskillit/recipes/methodology-traditions/qualitative_interpretive_tradition.json
+++ b/src/autoskillit/recipes/methodology-traditions/qualitative_interpretive_tradition.json
@@ -1,6 +1,6 @@
 {
   "name": "qualitative_interpretive_tradition",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 11,
   "display_name": "Qualitative Interpretive Research",
   "canonical_guideline": {

--- a/src/autoskillit/recipes/methodology-traditions/qualitative_interpretive_tradition.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/qualitative_interpretive_tradition.yaml
@@ -1,5 +1,5 @@
 name: qualitative_interpretive_tradition
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 11
 display_name: "Qualitative Interpretive Research"
 canonical_guideline:

--- a/src/autoskillit/recipes/methodology-traditions/quality_improvement.json
+++ b/src/autoskillit/recipes/methodology-traditions/quality_improvement.json
@@ -1,6 +1,6 @@
 {
   "name": "quality_improvement",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 8,
   "display_name": "Quality Improvement and Patient Safety",
   "canonical_guideline": {

--- a/src/autoskillit/recipes/methodology-traditions/quality_improvement.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/quality_improvement.yaml
@@ -1,5 +1,5 @@
 name: quality_improvement
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 8
 display_name: "Quality Improvement and Patient Safety"
 canonical_guideline:

--- a/src/autoskillit/recipes/methodology-traditions/simulation_modeling_tradition.json
+++ b/src/autoskillit/recipes/methodology-traditions/simulation_modeling_tradition.json
@@ -1,6 +1,6 @@
 {
   "name": "simulation_modeling_tradition",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 6,
   "display_name": "Simulation and Modeling (ABM/Computational)",
   "canonical_guideline": {

--- a/src/autoskillit/recipes/methodology-traditions/simulation_modeling_tradition.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/simulation_modeling_tradition.yaml
@@ -1,5 +1,5 @@
 name: simulation_modeling_tradition
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 6
 display_name: "Simulation and Modeling (ABM/Computational)"
 canonical_guideline:

--- a/src/autoskillit/recipes/methodology-traditions/systematic_synthesis.json
+++ b/src/autoskillit/recipes/methodology-traditions/systematic_synthesis.json
@@ -1,6 +1,6 @@
 {
   "name": "systematic_synthesis",
-  "schema_version": "1.0",
+  "schema_version": "1.0.0",
   "priority": 2,
   "display_name": "Systematic Synthesis (Meta-Analysis)",
   "canonical_guideline": {

--- a/src/autoskillit/recipes/methodology-traditions/systematic_synthesis.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/systematic_synthesis.yaml
@@ -1,5 +1,5 @@
 name: systematic_synthesis
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 2
 display_name: "Systematic Synthesis (Meta-Analysis)"
 canonical_guideline:

--- a/src/autoskillit/recipes/planner.json
+++ b/src/autoskillit/recipes/planner.json
@@ -1,6 +1,6 @@
 {
   "name": "planner",
-  "recipe_version": "2",
+  "recipe_version": "2.0.0",
   "description": "Progressive decomposition: phases, assignments, work packages\n",
   "summary": "init > analyze > [domain?] > gen-phases > parallel-phases > parallel-assignments > sequential-wps > reconcile > validate/refine > compile",
   "requires_packs": [

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -1,5 +1,5 @@
 name: planner
-recipe_version: "2"
+recipe_version: "2.0.0"
 description: |
   Progressive decomposition: phases, assignments, work packages
 summary: "init > analyze > [domain?] > gen-phases > parallel-phases > parallel-assignments > sequential-wps > reconcile > validate/refine > compile"

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -3,7 +3,7 @@ description: Investigate a bug, plan a fix, open a PR
 summary: bootstrap_clone > (claim_and_resolve?) > (create_and_publish?) > investigate
   > rectify > dry-walkthrough > implement > test > merge (per plan part) > (audit-impl?)
   > (open_pr?) > push > cleanup
-recipe_version: 1.0.0
+recipe_version: "1.0.0"
 requires_packs:
 - github
 - ci

--- a/src/autoskillit/recipes/sub-recipes/research.json
+++ b/src/autoskillit/recipes/sub-recipes/research.json
@@ -2,6 +2,7 @@
   "name": "research",
   "description": "Research sub-recipe: gather context, analyze findings, and produce a structured research report for the parent recipe.\n",
   "summary": "gather → analyze → report",
+  "recipe_version": "1.0.0",
   "ingredients": {
     "source_dir": {
       "description": "Source repository (inherited from parent recipe context)",

--- a/src/autoskillit/recipes/sub-recipes/research.yaml
+++ b/src/autoskillit/recipes/sub-recipes/research.yaml
@@ -3,6 +3,7 @@ description: >
   Research sub-recipe: gather context, analyze findings, and produce a
   structured research report for the parent recipe.
 summary: gather → analyze → report
+recipe_version: "1.0.0"
 
 ingredients:
   source_dir:

--- a/tests/cli/test_validate_registries.py
+++ b/tests/cli/test_validate_registries.py
@@ -23,7 +23,7 @@ def _write_yaml(tmp_path: Path, registry_type: str, filename: str, content: str)
 
 VALID_EXPERIMENT_TYPE = """\
 name: my-test-type
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 1
 classification_triggers:
   - trigger_alpha
@@ -49,7 +49,7 @@ l1_severity:
 VALID_METHODOLOGY_TRADITION = """\
 name: my-test-tradition
 display_name: My Test Tradition
-schema_version: "1.0"
+schema_version: "1.0.0"
 priority: 1
 canonical_guideline:
   title: Test Guideline
@@ -118,7 +118,7 @@ class TestValidateRegistries:
         """Schema-version mismatch produces ⚠ warning and exits 0."""
         monkeypatch.chdir(tmp_path)
         yaml_content = VALID_EXPERIMENT_TYPE.replace(
-            'schema_version: "1.0"', 'schema_version: "0.9"'
+            'schema_version: "1.0.0"', 'schema_version: "0.9"'
         )
         _write_yaml(tmp_path, "experiment-types", "warn_type.yaml", yaml_content)
 
@@ -126,7 +126,7 @@ class TestValidateRegistries:
         out = capsys.readouterr().out
         assert "⚠" in out
         assert "schema_version" in out
-        assert "expected '1.0'" in out
+        assert "expected '1.0.0'" in out
 
     # T_VAL_3: Missing 'name' field produces ✗ error and exit 1
     def test_missing_name_error(
@@ -324,7 +324,7 @@ class TestValidateRegistries:
         """Exit code 0 when only warnings (no errors)."""
         monkeypatch.chdir(tmp_path)
         yaml_content = VALID_EXPERIMENT_TYPE.replace(
-            'schema_version: "1.0"', 'schema_version: "0.9"'
+            'schema_version: "1.0.0"', 'schema_version: "0.9"'
         )
         _write_yaml(tmp_path, "experiment-types", "warn_only.yaml", yaml_content)
 
@@ -343,7 +343,9 @@ class TestValidateRegistries:
         """Summary line includes correct counts."""
         monkeypatch.chdir(tmp_path)
         _write_yaml(tmp_path, "experiment-types", "valid_type.yaml", VALID_EXPERIMENT_TYPE)
-        yaml_warn = VALID_EXPERIMENT_TYPE.replace('schema_version: "1.0"', 'schema_version: "0.9"')
+        yaml_warn = VALID_EXPERIMENT_TYPE.replace(
+            'schema_version: "1.0.0"', 'schema_version: "0.9"'
+        )
         _write_yaml(tmp_path, "experiment-types", "warn_type.yaml", yaml_warn)
         yaml_err = VALID_EXPERIMENT_TYPE.replace("name: my-test-type\n", "")
         _write_yaml(tmp_path, "experiment-types", "error_type.yaml", yaml_err)

--- a/tests/recipe/test_experiment_type_registry.py
+++ b/tests/recipe/test_experiment_type_registry.py
@@ -305,10 +305,10 @@ def test_no_citation_markers_in_yaml_files() -> None:
 
 
 def test_all_types_have_schema_version() -> None:
-    """Every bundled type has schema_version == '1.0'."""
+    """Every bundled type has schema_version == '1.0.0'."""
     types = load_all_experiment_types()
     for spec in types:
-        assert spec.schema_version == "1.0", (
+        assert spec.schema_version == "1.0.0", (
             f"{spec.name}: schema_version = {spec.schema_version!r}"
         )
 
@@ -438,7 +438,7 @@ def test_new_type_full_schema_valid(type_name: str) -> None:
         assert weight in VALID_WEIGHT_VALUES, f"{type_name}.{dim} = {weight!r}"
     assert isinstance(spec.classification_triggers, list)
     assert len(spec.classification_triggers) >= 1
-    assert spec.schema_version == "1.0"
+    assert spec.schema_version == "1.0.0"
     assert spec.is_fallback is False
     non_fallback_count = sum(1 for s in types if not s.is_fallback)
     assert 1 <= spec.priority <= non_fallback_count
@@ -537,7 +537,7 @@ def test_user_types_interleave_by_priority(tmp_path: Path) -> None:
 
 
 def test_schema_mismatch_warns(tmp_path: Path) -> None:
-    """A user type with schema_version != '1.0' triggers a WARNING but still loads."""
+    """A user type with schema_version != '1.0.0' triggers a WARNING but still loads."""
     import structlog.testing
 
     user_dir = tmp_path / ".autoskillit" / "experiment-types"

--- a/tests/recipe/test_io_schema_fields.py
+++ b/tests/recipe/test_io_schema_fields.py
@@ -6,10 +6,13 @@ import hashlib
 from pathlib import Path
 
 import pytest
+import regex as re
 
 from autoskillit.core.types import CaptureEntrySpec, RecipeSource
 from autoskillit.recipe.io import (
+    RECIPE_SCAN_DIRS,
     builtin_recipes_dir,
+    builtin_sub_recipes_dir,
     list_recipes,
     load_recipe,
 )
@@ -238,15 +241,6 @@ class TestRecipeVersionField:
 
     def test_all_bundled_recipes_have_semver_recipe_version(self):
         """Every bundled recipe with recipe_version uses X.Y.Z semver format."""
-        import regex as re
-
-        from autoskillit.recipe.io import (
-            RECIPE_SCAN_DIRS,
-            builtin_recipes_dir,
-            builtin_sub_recipes_dir,
-            load_recipe,
-        )
-
         semver_re = re.compile(r"^\d+\.\d+\.\d+$")
         base = builtin_recipes_dir()
         yaml_paths: list[Path] = []

--- a/tests/recipe/test_io_schema_fields.py
+++ b/tests/recipe/test_io_schema_fields.py
@@ -236,6 +236,35 @@ class TestRecipeVersionField:
         with pytest.raises(ValueError, match="recipe_version must be a quoted string"):
             load_recipe(p)
 
+    def test_all_bundled_recipes_have_semver_recipe_version(self):
+        """Every bundled recipe with recipe_version uses X.Y.Z semver format."""
+        import regex as re
+
+        from autoskillit.recipe.io import (
+            RECIPE_SCAN_DIRS,
+            builtin_recipes_dir,
+            builtin_sub_recipes_dir,
+            load_recipe,
+        )
+
+        semver_re = re.compile(r"^\d+\.\d+\.\d+$")
+        base = builtin_recipes_dir()
+        yaml_paths: list[Path] = []
+        for scan_dir in RECIPE_SCAN_DIRS:
+            scan_path = base / scan_dir if scan_dir != "." else base
+            if scan_path.is_dir():
+                yaml_paths.extend(sorted(scan_path.glob("*.yaml")))
+        sub_dir = builtin_sub_recipes_dir()
+        if sub_dir.is_dir():
+            yaml_paths.extend(sorted(sub_dir.glob("*.yaml")))
+        for yaml_path in yaml_paths:
+            recipe = load_recipe(yaml_path)
+            if recipe.recipe_version is not None:
+                assert semver_re.match(recipe.recipe_version), (
+                    f"{yaml_path.name}: recipe_version {recipe.recipe_version!r} "
+                    f"is not in X.Y.Z semver format"
+                )
+
 
 class TestContentHash:
     def test_load_recipe_sets_content_hash(self, tmp_path):

--- a/tests/recipe/test_methodology_tradition_registry.py
+++ b/tests/recipe/test_methodology_tradition_registry.py
@@ -68,7 +68,7 @@ def test_each_tradition_has_required_fields() -> None:
 def test_all_traditions_have_schema_version_1_0() -> None:
     traditions = load_all_methodology_traditions()
     for spec in traditions:
-        assert spec.schema_version == "1.0", (
+        assert spec.schema_version == "1.0.0", (
             f"{spec.name}: schema_version = {spec.schema_version!r}"
         )
 
@@ -115,7 +115,7 @@ def test_user_override_replaces_bundled(tmp_path: Path) -> None:
         yaml.dump(
             {
                 "name": "controlled_intervention",
-                "schema_version": "1.0",
+                "schema_version": "1.0.0",
                 "priority": 1,
                 "display_name": "My Custom RCT",
                 "canonical_guideline": {
@@ -145,7 +145,7 @@ def test_user_new_tradition_is_added(tmp_path: Path) -> None:
         yaml.dump(
             {
                 "name": "my_new_tradition",
-                "schema_version": "1.0",
+                "schema_version": "1.0.0",
                 "priority": 99,
                 "display_name": "My New Tradition",
                 "canonical_guideline": {
@@ -263,7 +263,7 @@ def test_detection_keywords_are_distinct() -> None:
 
 _MINIMAL_TRADITION_YAML = {
     "name": "test_tradition",
-    "schema_version": "1.0",
+    "schema_version": "1.0.0",
     "priority": 99,
     "display_name": "Test Tradition",
     "canonical_guideline": {
@@ -281,7 +281,7 @@ _MINIMAL_TRADITION_YAML = {
 
 _MINIMAL_TRADITION_YAML_2 = {
     "name": "test_tradition_2",
-    "schema_version": "1.0",
+    "schema_version": "1.0.0",
     "priority": 99,
     "display_name": "Test Tradition 2",
     "canonical_guideline": {

--- a/tests/skills/test_vis_lens_methodology_norms.py
+++ b/tests/skills/test_vis_lens_methodology_norms.py
@@ -323,7 +323,7 @@ def test_tradition_schema_valid(tradition_name: str) -> None:
     assert isinstance(spec, MethodologyTraditionSpec)
     assert spec.name == tradition_name
     assert spec.display_name, "display_name must be non-empty"
-    assert spec.schema_version == "1.0"
+    assert spec.schema_version == "1.0.0"
     assert isinstance(spec.priority, int) and spec.priority >= 1
     assert len(spec.detection_keywords) >= 2, "need >= 2 detection keywords for matching"
     assert isinstance(spec.mandatory_figures, list)


### PR DESCRIPTION
## Summary

Standardize the `recipe_version` field across all bundled recipe YAML files to use quoted semver format (`"X.Y.Z"`), fix `schema_version` values in experiment-type and methodology-tradition YAMLs from `"1.0"` to `"1.0.0"` (three-component semver), update all three registry/validation modules that compare against the expected version, update the CLI `validate registries` command constant, regenerate compiled JSON siblings, and add a structural test enforcing semver consistency going forward.

The `schema_version` key name is intentionally preserved for experiment-type and methodology-tradition files — these are not recipes (they're `ExperimentTypeSpec` and `MethodologyTraditionSpec` parsed by separate registries) and renaming to `recipe_version` would be semantically misleading.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260608-005324-730329/.autoskillit/temp/make-plan/standardize_recipe_version_plan_2026-06-08_010500.md`

Closes #3772

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 6.0k | 25.3k | 2.4M | 118.3k | 68 | 101.1k | 14m 22s |
| verify* | sonnet | 1 | 84 | 7.1k | 436.2k | 52.7k | 26 | 31.1k | 3m 46s |
| implement* | MiniMax-M3 | 1 | 94.5k | 13.5k | 3.5M | 91.5k | 148 | 0 | 9m 47s |
| fix* | sonnet | 1 | 134 | 3.5k | 756.4k | 57.3k | 36 | 35.7k | 6m 22s |
| audit_impl* | sonnet | 1 | 46 | 8.2k | 170.0k | 43.5k | 16 | 31.6k | 4m 36s |
| prepare_pr* | MiniMax-M3 | 1 | 45.7k | 4.4k | 206.7k | 50.0k | 15 | 0 | 2m 4s |
| compose_pr* | MiniMax-M3 | 1 | 36.3k | 1.2k | 151.4k | 39.3k | 12 | 0 | 58s |
| review_pr* | sonnet | 1 | 100 | 20.6k | 711.0k | 90.3k | 36 | 69.6k | 4m 56s |
| resolve_review* | sonnet | 1 | 313 | 17.3k | 2.6M | 87.6k | 98 | 66.4k | 8m 3s |
| **Total** | | | 183.2k | 101.1k | 10.9M | 118.3k | | 335.4k | 54m 57s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 187 | 18668.5 | 0.0 | 72.0 |
| fix | 2 | 378191.0 | 17854.5 | 1727.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 36 | 70928.5 | 1843.8 | 480.9 |
| **Total** | **225** | 48396.9 | 1490.9 | 449.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 6.0k | 25.3k | 2.4M | 101.1k | 14m 22s |
| sonnet | 5 | 677 | 56.6k | 4.6M | 234.3k | 27m 45s |
| MiniMax-M3 | 3 | 176.5k | 19.1k | 3.8M | 0 | 12m 50s |