### PR TITLE
Implementation Plan: Add Missing pytest.mark.feature("fleet") Markers to Four Fleet Test Files

### DIFF
--- a/tests/arch/test_feature_markers.py
+++ b/tests/arch/test_feature_markers.py
@@ -34,9 +34,13 @@ _FLEET_CROSS_DIR_FILES: frozenset[Path] = frozenset(
         _TESTS_ROOT / "server" / "test_tools_dispatch.py",
         _TESTS_ROOT / "server" / "test_tools_dispatch_validation.py",
         _TESTS_ROOT / "server" / "test_tools_dispatch_params.py",
+        _TESTS_ROOT / "server" / "test_tools_config.py",
+        _TESTS_ROOT / "server" / "test_claim_liveness.py",
+        _TESTS_ROOT / "server" / "test_tools_dispatch_split.py",
         _TESTS_ROOT / "cli" / "test_food_truck_prompt.py",
         _TESTS_ROOT / "cli" / "test_l3_orchestrator_prompt.py",
         _TESTS_ROOT / "cli" / "test_reap.py",
+        _TESTS_ROOT / "integration" / "test_fleet_concurrency.py",
     ]
 )
 

--- a/tests/integration/test_fleet_concurrency.py
+++ b/tests/integration/test_fleet_concurrency.py
@@ -15,7 +15,7 @@ from autoskillit.fleet import (
     write_initial_state,
 )
 
-pytestmark = [pytest.mark.medium]
+pytestmark = [pytest.mark.medium, pytest.mark.feature("fleet")]
 
 # -------------------------------------------------------------------
 # Cross-caller concurrency test (requires cli layer)

--- a/tests/server/test_claim_liveness.py
+++ b/tests/server/test_claim_liveness.py
@@ -11,7 +11,7 @@ from autoskillit.fleet import DispatchRecord, DispatchStatus
 from autoskillit.server.tools.tools_issue_composite import claim_and_resolve_issue
 from autoskillit.server.tools.tools_issue_labels import claim_issue
 
-pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small, pytest.mark.feature("fleet")]
 
 _ISSUE_URL = "https://github.com/owner/repo/issues/42"
 _CLAIM_MODULE = "autoskillit.server.tools._claim_helpers"

--- a/tests/server/test_tools_config.py
+++ b/tests/server/test_tools_config.py
@@ -10,7 +10,7 @@ from autoskillit.config import AutomationConfig
 from autoskillit.fleet._semaphore import FleetSemaphore
 from tests.server.conftest import _make_mock_ctx
 
-pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small, pytest.mark.feature("fleet")]
 
 
 _HOOK_CONFIG_RELPATH = (".autoskillit", "temp", ".hook_config.json")

--- a/tests/server/test_tools_dispatch_split.py
+++ b/tests/server/test_tools_dispatch_split.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small, pytest.mark.feature("fleet")]
 
 
 def test_dispatch_tool_importable():


### PR DESCRIPTION
## Summary

Four fleet-specific test files are missing the `pytest.mark.feature("fleet")` module-level marker and are not enrolled in the `_FLEET_CROSS_DIR_FILES` registry in `tests/arch/test_feature_markers.py`. This plan adds the marker to each file's `pytestmark` list and registers all four in the cross-directory enrollment set so the existing enforcement test `test_fleet_test_files_carry_feature_marker` passes for these files.

**Target files:**
1. `tests/server/test_tools_config.py` — tests `configure_fleet`/`configure_order` MCP tools
2. `tests/server/test_claim_liveness.py` — tests fleet liveness-aware claim behavior
3. `tests/server/test_tools_dispatch_split.py` — structural guard for dispatch tool split imports
4. `tests/integration/test_fleet_concurrency.py` — cross-layer fleet concurrency tests

Closes #3774

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260608-021147-425719/.autoskillit/temp/make-plan/add_missing_fleet_markers_plan_2026-06-08_021200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 60 | 8.2k | 857.3k | 76.4k | 33 | 77.3k | 8m 12s |
| verify* | sonnet | 1 | 3.9k | 6.0k | 229.6k | 55.7k | 17 | 34.2k | 4m 39s |
| implement* | MiniMax-M3 | 1 | 62.7k | 4.1k | 893.0k | 62.6k | 39 | 0 | 3m 46s |
| audit_impl* | sonnet | 1 | 36 | 4.7k | 129.4k | 40.1k | 12 | 23.1k | 1m 47s |
| prepare_pr* | MiniMax-M3 | 1 | 42.1k | 2.3k | 115.5k | 43.7k | 11 | 0 | 1m 8s |
| compose_pr* | MiniMax-M3 | 1 | 35.0k | 1.2k | 149.3k | 38.2k | 12 | 0 | 58s |
| review_pr* | sonnet | 3 | 366 | 53.5k | 2.1M | 66.1k | 123 | 130.8k | 12m 8s |
| **Total** | | | 144.2k | 80.0k | 4.5M | 76.4k | | 265.4k | 32m 40s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 12 | 74418.9 | 0.0 | 337.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **12** | 373999.4 | 22117.2 | 6668.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 60 | 8.2k | 857.3k | 77.3k | 8m 12s |
| sonnet | 3 | 4.3k | 64.3k | 2.5M | 188.1k | 18m 35s |
| MiniMax-M3 | 3 | 139.8k | 7.5k | 1.2M | 0 | 5m 52s |