### PR TITLE
Rectify: MCP Tool Context Parameter Forwarding and Merge Queue Recovery Routing

### DIFF
--- a/src/autoskillit/planner/AGENTS.md
+++ b/src/autoskillit/planner/AGENTS.md
@@ -18,6 +18,6 @@ IL-1 progressive resolution planner — phases, work packages, manifest generati
 | `lifecycle.py` | `record_lifecycle_event`, `load_lifecycle_registry` — unified lifecycle provenance for voided/absorbed entities |
 
 ## Architecture Notes
-import from `server/` or `recipe/`. `validation.py` performs a DAG cycle check before any
+The planner layer must not import from `server/` or `recipe/`. `validation.py` performs a DAG cycle check before any
 compilation proceeds. `consolidation.py` runs as a post-pass after all elaboration phases
 complete.

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -4,6 +4,7 @@ Re-export facade. Implementation: _cmd_rpc_guards.py, _cmd_rpc_merge.py, _cmd_rp
 """
 
 from autoskillit.recipe._cmd_rpc_guards import (  # noqa: F401
+    check_dropped_ci_loop,
     check_dropped_healthy_loop,
     check_eject_limit,
     commit_guard,

--- a/src/autoskillit/recipe/_cmd_rpc_guards.py
+++ b/src/autoskillit/recipe/_cmd_rpc_guards.py
@@ -76,7 +76,10 @@ def check_dropped_ci_loop(
     the route escalates to ``diagnose_ci`` (``DROPPED_CI_LIMIT_EXCEEDED``) — the
     merge-group CI keeps failing, so a re-enqueue is unlikely to help.
     """
-    max_drops = max_drops or "2"
+    try:
+        limit = int(max_drops) if max_drops else 2
+    except ValueError:
+        limit = 2
     path = Path(counter_file)
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
@@ -85,7 +88,7 @@ def check_dropped_ci_loop(
         count = 0
     count += 1
     atomic_write(path, str(count))
-    status = "DROPPED_CI_LIMIT_EXCEEDED" if count >= int(max_drops) else "DROPPED_CI_OK"
+    status = "DROPPED_CI_LIMIT_EXCEEDED" if count >= limit else "DROPPED_CI_OK"
     return {"status": status, "count": str(count)}
 
 

--- a/src/autoskillit/recipe/_cmd_rpc_guards.py
+++ b/src/autoskillit/recipe/_cmd_rpc_guards.py
@@ -85,7 +85,7 @@ def check_dropped_ci_loop(
         count = 0
     count += 1
     atomic_write(path, str(count))
-    status = "DROPPED_CI_LIMIT_EXCEEDED" if count > int(max_drops) else "DROPPED_CI_OK"
+    status = "DROPPED_CI_LIMIT_EXCEEDED" if count >= int(max_drops) else "DROPPED_CI_OK"
     return {"status": status, "count": str(count)}
 
 

--- a/src/autoskillit/recipe/_cmd_rpc_guards.py
+++ b/src/autoskillit/recipe/_cmd_rpc_guards.py
@@ -65,6 +65,30 @@ def check_dropped_healthy_loop(
     return {"status": status, "count": str(count)}
 
 
+def check_dropped_ci_loop(
+    counter_file: str,
+    max_drops: str = "2",
+) -> dict[str, str]:
+    """Increment dropped-merge-group-CI counter; return DROPPED_CI_OK or DROPPED_CI_LIMIT_EXCEEDED.
+
+    Mirrors ``check_dropped_healthy_loop`` for the ``dropped_merge_group_ci`` branch.
+    On the first drop, the recipe re-enqueues (``DROPPED_CI_OK``). After the cap,
+    the route escalates to ``diagnose_ci`` (``DROPPED_CI_LIMIT_EXCEEDED``) — the
+    merge-group CI keeps failing, so a re-enqueue is unlikely to help.
+    """
+    max_drops = max_drops or "2"
+    path = Path(counter_file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        count = int(path.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        count = 0
+    count += 1
+    atomic_write(path, str(count))
+    status = "DROPPED_CI_LIMIT_EXCEEDED" if count > int(max_drops) else "DROPPED_CI_OK"
+    return {"status": status, "count": str(count)}
+
+
 def main_repo_guard(clone_path: str) -> dict[str, str]:
     """Stash dirty state from the main repo before merge.
 

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -240,6 +240,78 @@ _TOOL_PARAMS: dict[str, frozenset[str]] = {
 }
 
 
+# Registry of context variables that are captured upstream and MUST be forwarded
+# to any tool step that accepts them. Each entry maps a tool name to the set of
+# context-param names that the tool relies on. When a recipe captures one of
+# these variables and a downstream step calls the corresponding tool, the step
+# must reference the variable in its `with:` block — silently defaulting would
+# change tool behavior (e.g., enqueue strategy on a repo where auto-merge is off).
+_TOOL_CONTEXT_PARAMS: dict[str, frozenset[str]] = {
+    "wait_for_merge_queue": frozenset({"auto_merge_available"}),
+    "enqueue_pr": frozenset({"auto_merge_available"}),
+}
+
+
+@semantic_rule(
+    name="context-param-not-forwarded",
+    description=(
+        "Tool step omits a context variable that the tool depends on — recipes must "
+        "forward context parameters explicitly so the tool receives the upstream "
+        "capture value (e.g., auto_merge_available)"
+    ),
+    severity=Severity.ERROR,
+)
+def _check_context_param_not_forwarded(ctx: ValidationContext) -> list[RuleFinding]:
+    """Fire when a tool step omits a known context parameter that the tool depends on.
+
+    The ``_TOOL_CONTEXT_PARAMS`` registry declares which tool-params must be
+    forwarded when the corresponding context variable has been captured
+    upstream. Without this rule, a step calling ``wait_for_merge_queue`` could
+    silently omit ``auto_merge_available`` from its ``with:`` block, falling
+    back to the tool's default (typically ``True``) — even on repos where the
+    upstream ``check_repo_merge_state`` capture indicated auto-merge is
+    disabled. The watcher's internal re-enqueue logic would then attempt
+    ``enablePullRequestAutoMerge`` and fail. See PR #3901.
+    """
+    captured_context: set[str] = set()
+    for step in ctx.recipe.steps.values():
+        if step.capture:
+            captured_context.update(step.capture.keys())
+        if step.capture_list:
+            captured_context.update(step.capture_list.keys())
+
+    if not captured_context:
+        return []
+
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool is None or step.tool not in _TOOL_CONTEXT_PARAMS:
+            continue
+        required_params = _TOOL_CONTEXT_PARAMS[step.tool]
+        for param in required_params:
+            if param not in captured_context:
+                continue
+            with_value = (step.with_args or {}).get(param, "")
+            if f"context.{param}" in with_value:
+                continue
+            findings.append(
+                RuleFinding(
+                    rule="context-param-not-forwarded",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"Step {step_name!r} calls tool {step.tool!r} but does not "
+                        f"forward the upstream-captured context variable {param!r}. "
+                        f"Add {param}: ${{{{ context.{param} }}}} to the with: block. "
+                        f"Omitting this param causes the tool to use its default "
+                        f"value, which may not match the captured context "
+                        f"(e.g., auto_merge_available for repos with auto-merge disabled)."
+                    ),
+                )
+            )
+    return findings
+
+
 @semantic_rule(
     name="constant-step-with-args",
     description="constant step must not have with args — there is no tool to receive them",

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -291,7 +291,7 @@ def _check_context_param_not_forwarded(ctx: ValidationContext) -> list[RuleFindi
         for param in required_params:
             if param not in captured_context:
                 continue
-            with_value = (step.with_args or {}).get(param, "")
+            with_value = str((step.with_args or {}).get(param, ""))
             if f"context.{param}" in with_value:
                 continue
             findings.append(

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -38,6 +38,12 @@ skills:
     - name: ci_failed_jobs
       type: string
       required: false
+    - name: workflow
+      type: string
+      required: false
+    - name: event
+      type: string
+      required: false
     outputs:
     - name: diagnosis_path
       type: file_path
@@ -2873,6 +2879,19 @@ callable_contracts:
       type: str
     - name: count
       type: str
+  autoskillit.recipe._cmd_rpc.check_dropped_ci_loop:
+    inputs:
+    - name: counter_file
+      type: str
+      required: true
+    - name: max_drops
+      type: str
+      required: false
+    outputs:
+    - name: status
+      type: str
+    - name: count
+      type: str
   autoskillit.recipe._cmd_rpc.commit_guard:
     inputs:
     - name: worktree_path
@@ -3271,3 +3290,26 @@ tool_output_contracts:
           - timed_out
           - no_runs
           - action_required
+  wait_for_merge_queue:
+    result_field: pr_state
+    fields:
+      pr_state:
+        type: str
+        allowed_values:
+          - merged
+          - ejected_ci_failure
+          - dropped_merge_group_ci
+          - dropped_healthy
+          - ejected
+          - stalled
+          - timeout
+          - not_enrolled
+          - error
+        terminal_values:
+          - error
+          - ejected_ci_failure
+        recoverable_values:
+          - dropped_merge_group_ci
+          - dropped_healthy
+          - ejected
+          - stalled

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -1649,6 +1649,7 @@
         "target_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
+        "auto_merge_available": "${{ context.auto_merge_available }}",
         "timeout_seconds": 60,
         "poll_interval": 10,
         "max_merge_group_drops": 1
@@ -1701,6 +1702,7 @@
         "timeout_seconds": 900,
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
+        "auto_merge_available": "${{ context.auto_merge_available }}",
         "max_merge_group_drops": 1
       },
       "capture": {
@@ -1717,7 +1719,7 @@
         },
         {
           "when": "${{ result.pr_state }} == dropped_merge_group_ci",
-          "route": "diagnose_ci"
+          "route": "check_dropped_ci_loop"
         },
         {
           "when": "${{ result.pr_state }} == not_enrolled",
@@ -1745,7 +1747,7 @@
       ],
       "on_failure": "register_clone_unconfirmed",
       "skip_when_false": "inputs.open_pr",
-      "note": "Waits up to 15 minutes for the PR to merge through the queue. merged → release_issue_success to transition issue state then register_clone_success. ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix this). not_enrolled → release_issue_failure (enrollment failed; repo configuration error). ejected → conflict fix cycle then re-enter. stalled → lightweight re-enrollment via enqueue_pr. timeout → register_clone_unconfirmed (release claim without staged label; merge unconfirmed).\n"
+      "note": "Waits up to 15 minutes for the PR to merge through the queue. merged → release_issue_success to transition issue state then register_clone_success. ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix this). dropped_merge_group_ci → check_dropped_ci_loop (re-enqueue on first drop, escalate to diagnose_ci after the cap is exceeded). not_enrolled → release_issue_failure (enrollment failed; repo configuration error). ejected → conflict fix cycle then re-enter. stalled → lightweight re-enrollment via enqueue_pr. timeout → register_clone_unconfirmed (release claim without staged label; merge unconfirmed).\n"
     },
     "reenroll_stalled_pr": {
       "tool": "enqueue_pr",
@@ -1820,7 +1822,26 @@
         }
       ],
       "on_failure": "release_issue_failure",
-      "note": "Circuit breaker for the dropped_healthy re-enrollment loop. After 2 consecutive unexplained drops with healthy PR-branch CI, escalates to release_issue_failure instead of looping. Matches the check_eject_limit pattern used for the ejected path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed directly to diagnose_ci and never reaches this step.\n"
+      "note": "Circuit breaker for the dropped_healthy re-enrollment loop. After 2 consecutive unexplained drops with healthy PR-branch CI, escalates to release_issue_failure instead of looping. Matches the check_eject_limit pattern used for the ejected path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed through check_dropped_ci_loop instead and never reaches this step.\n"
+    },
+    "check_dropped_ci_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.recipe._cmd_rpc.check_dropped_ci_loop",
+        "counter_file": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_ci_count",
+        "max_drops": "2"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.status }} == DROPPED_CI_LIMIT_EXCEEDED",
+          "route": "diagnose_ci"
+        },
+        {
+          "route": "reenter_merge_queue_cheap"
+        }
+      ],
+      "on_failure": "diagnose_ci",
+      "note": "Circuit breaker for the dropped_merge_group_ci re-enrollment loop. Tracks merge-group-CI drop count in a file-based counter. On the first drop, re-enqueues via reenter_merge_queue_cheap (transient CI failure is often self-healing). After 2 consecutive drops, escalates to diagnose_ci — the merge-group CI is persistently failing, so a re-enqueue is unlikely to help. Mirrors the check_dropped_healthy_loop pattern for the dropped_healthy branch.\n"
     },
     "queue_ejected_fix": {
       "tool": "run_python",
@@ -1907,6 +1928,7 @@
         "pr_number": "${{ context.pr_number }}",
         "target_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "auto_merge_available": "${{ context.auto_merge_available }}",
         "timeout_seconds": "60",
         "max_merge_group_drops": "1"
       },

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -1490,6 +1490,7 @@ steps:
       target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
+      auto_merge_available: "${{ context.auto_merge_available }}"
       timeout_seconds: 60
       poll_interval: 10
       max_merge_group_drops: 1
@@ -1531,6 +1532,7 @@ steps:
       timeout_seconds: 900
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
+      auto_merge_available: "${{ context.auto_merge_available }}"
       max_merge_group_drops: 1
     capture:
       queue_pr_state: "${{ result.pr_state }}"
@@ -1540,7 +1542,7 @@ steps:
     - when: "${{ result.pr_state }} == ejected_ci_failure"
       route: diagnose_ci
     - when: "${{ result.pr_state }} == dropped_merge_group_ci"
-      route: diagnose_ci
+      route: check_dropped_ci_loop
     - when: "${{ result.pr_state }} == not_enrolled"
       route: release_issue_failure
     - when: "${{ result.pr_state }} == dropped_healthy"
@@ -1558,6 +1560,8 @@ steps:
       Waits up to 15 minutes for the PR to merge through the queue.
       merged → release_issue_success to transition issue state then register_clone_success.
       ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix this).
+      dropped_merge_group_ci → check_dropped_ci_loop (re-enqueue on first drop,
+      escalate to diagnose_ci after the cap is exceeded).
       not_enrolled → release_issue_failure (enrollment failed; repo configuration error).
       ejected → conflict fix cycle then re-enter.
       stalled → lightweight re-enrollment via enqueue_pr.
@@ -1626,7 +1630,26 @@ steps:
       unexplained drops with healthy PR-branch CI, escalates to release_issue_failure
       instead of looping. Matches the check_eject_limit pattern used for the ejected
       path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed
-      directly to diagnose_ci and never reaches this step.
+      through check_dropped_ci_loop instead and never reaches this step.
+
+  check_dropped_ci_loop:
+    tool: run_python
+    with:
+      callable: "autoskillit.recipe._cmd_rpc.check_dropped_ci_loop"
+      counter_file: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_ci_count"
+      max_drops: "2"
+    on_result:
+    - when: "${{ result.status }} == DROPPED_CI_LIMIT_EXCEEDED"
+      route: diagnose_ci
+    - route: reenter_merge_queue_cheap
+    on_failure: diagnose_ci
+    note: >
+      Circuit breaker for the dropped_merge_group_ci re-enrollment loop. Tracks
+      merge-group-CI drop count in a file-based counter. On the first drop, re-enqueues
+      via reenter_merge_queue_cheap (transient CI failure is often self-healing).
+      After 2 consecutive drops, escalates to diagnose_ci — the merge-group CI is
+      persistently failing, so a re-enqueue is unlikely to help. Mirrors the
+      check_dropped_healthy_loop pattern for the dropped_healthy branch.
 
   queue_ejected_fix:
     tool: run_python
@@ -1699,6 +1722,7 @@ steps:
       pr_number: "${{ context.pr_number }}"
       target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
+      auto_merge_available: "${{ context.auto_merge_available }}"
       timeout_seconds: "60"
       max_merge_group_drops: "1"
     on_result:

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -1613,6 +1613,7 @@
         "target_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
+        "auto_merge_available": "${{ context.auto_merge_available }}",
         "timeout_seconds": 60,
         "poll_interval": 10,
         "max_merge_group_drops": 1
@@ -1665,6 +1666,7 @@
         "timeout_seconds": 900,
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
+        "auto_merge_available": "${{ context.auto_merge_available }}",
         "max_merge_group_drops": 1
       },
       "capture": {
@@ -1681,7 +1683,7 @@
         },
         {
           "when": "${{ result.pr_state }} == dropped_merge_group_ci",
-          "route": "diagnose_ci"
+          "route": "check_dropped_ci_loop"
         },
         {
           "when": "${{ result.pr_state }} == not_enrolled",
@@ -1709,7 +1711,7 @@
       ],
       "on_failure": "register_clone_unconfirmed",
       "skip_when_false": "inputs.open_pr",
-      "note": "Waits up to 15 minutes for the PR to merge through the queue. merged → release_issue_success to transition issue state then register_clone_success. ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix this). not_enrolled → release_issue_failure (enrollment failed; repo configuration error). ejected → conflict fix cycle then re-enter. stalled → lightweight re-enrollment via enqueue_pr. timeout → register_clone_unconfirmed (release claim without staged label; merge unconfirmed).\n"
+      "note": "Waits up to 15 minutes for the PR to merge through the queue. merged → release_issue_success to transition issue state then register_clone_success. ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix this). dropped_merge_group_ci → check_dropped_ci_loop (re-enqueue on first drop, escalate to diagnose_ci after the cap is exceeded). not_enrolled → release_issue_failure (enrollment failed; repo configuration error). ejected → conflict fix cycle then re-enter. stalled → lightweight re-enrollment via enqueue_pr. timeout → register_clone_unconfirmed (release claim without staged label; merge unconfirmed).\n"
     },
     "reenroll_stalled_pr": {
       "tool": "enqueue_pr",
@@ -1784,7 +1786,26 @@
         }
       ],
       "on_failure": "release_issue_failure",
-      "note": "Circuit breaker for the dropped_healthy re-enrollment loop. After 2 consecutive unexplained drops with healthy PR-branch CI, escalates to release_issue_failure instead of looping. Matches the check_eject_limit pattern used for the ejected path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed directly to diagnose_ci and never reaches this step.\n"
+      "note": "Circuit breaker for the dropped_healthy re-enrollment loop. After 2 consecutive unexplained drops with healthy PR-branch CI, escalates to release_issue_failure instead of looping. Matches the check_eject_limit pattern used for the ejected path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed through check_dropped_ci_loop instead and never reaches this step.\n"
+    },
+    "check_dropped_ci_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.recipe._cmd_rpc.check_dropped_ci_loop",
+        "counter_file": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_ci_count",
+        "max_drops": "2"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.status }} == DROPPED_CI_LIMIT_EXCEEDED",
+          "route": "diagnose_ci"
+        },
+        {
+          "route": "reenter_merge_queue_cheap"
+        }
+      ],
+      "on_failure": "diagnose_ci",
+      "note": "Circuit breaker for the dropped_merge_group_ci re-enrollment loop. Tracks merge-group-CI drop count in a file-based counter. On the first drop, re-enqueues via reenter_merge_queue_cheap (transient CI failure is often self-healing). After 2 consecutive drops, escalates to diagnose_ci — the merge-group CI is persistently failing, so a re-enqueue is unlikely to help. Mirrors the check_dropped_healthy_loop pattern for the dropped_healthy branch.\n"
     },
     "queue_ejected_fix": {
       "tool": "run_python",
@@ -1871,6 +1892,7 @@
         "pr_number": "${{ context.pr_number }}",
         "target_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "auto_merge_available": "${{ context.auto_merge_available }}",
         "timeout_seconds": "60",
         "max_merge_group_drops": "1"
       },

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1488,6 +1488,7 @@ steps:
       target_branch: ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
+      auto_merge_available: ${{ context.auto_merge_available }}
       timeout_seconds: 60
       poll_interval: 10
       max_merge_group_drops: 1
@@ -1528,6 +1529,7 @@ steps:
       timeout_seconds: 900
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
+      auto_merge_available: ${{ context.auto_merge_available }}
       max_merge_group_drops: 1
     capture:
       queue_pr_state: ${{ result.pr_state }}
@@ -1537,7 +1539,7 @@ steps:
     - when: ${{ result.pr_state }} == ejected_ci_failure
       route: diagnose_ci
     - when: ${{ result.pr_state }} == dropped_merge_group_ci
-      route: diagnose_ci
+      route: check_dropped_ci_loop
     - when: ${{ result.pr_state }} == not_enrolled
       route: release_issue_failure
     - when: ${{ result.pr_state }} == dropped_healthy
@@ -1554,9 +1556,11 @@ steps:
     note: 'Waits up to 15 minutes for the PR to merge through the queue. merged →
       release_issue_success to transition issue state then register_clone_success.
       ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix
-      this). not_enrolled → release_issue_failure (enrollment failed; repo configuration
-      error). ejected → conflict fix cycle then re-enter. stalled → lightweight re-enrollment
-      via enqueue_pr. timeout → register_clone_unconfirmed (release claim without
+      this). dropped_merge_group_ci → check_dropped_ci_loop (re-enqueue on first
+      drop, escalate to diagnose_ci after the cap is exceeded). not_enrolled →
+      release_issue_failure (enrollment failed; repo configuration error). ejected
+      → conflict fix cycle then re-enter. stalled → lightweight re-enrollment via
+      enqueue_pr. timeout → register_clone_unconfirmed (release claim without
       staged label; merge unconfirmed).
 
       '
@@ -1620,8 +1624,27 @@ steps:
     note: 'Circuit breaker for the dropped_healthy re-enrollment loop. After 2 consecutive
       unexplained drops with healthy PR-branch CI, escalates to release_issue_failure
       instead of looping. Matches the check_eject_limit pattern used for the ejected
-      path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed directly
-      to diagnose_ci and never reaches this step.
+      path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed through
+      check_dropped_ci_loop instead and never reaches this step.
+
+      '
+  check_dropped_ci_loop:
+    tool: run_python
+    with:
+      callable: autoskillit.recipe._cmd_rpc.check_dropped_ci_loop
+      counter_file: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_ci_count
+      max_drops: '2'
+    on_result:
+    - when: ${{ result.status }} == DROPPED_CI_LIMIT_EXCEEDED
+      route: diagnose_ci
+    - route: reenter_merge_queue_cheap
+    on_failure: diagnose_ci
+    note: 'Circuit breaker for the dropped_merge_group_ci re-enrollment loop. Tracks
+      merge-group-CI drop count in a file-based counter. On the first drop, re-enqueues
+      via reenter_merge_queue_cheap (transient CI failure is often self-healing).
+      After 2 consecutive drops, escalates to diagnose_ci — the merge-group CI is
+      persistently failing, so a re-enqueue is unlikely to help. Mirrors the
+      check_dropped_healthy_loop pattern for the dropped_healthy branch.
 
       '
   queue_ejected_fix:
@@ -1694,6 +1717,7 @@ steps:
       pr_number: ${{ context.pr_number }}
       target_branch: ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
+      auto_merge_available: ${{ context.auto_merge_available }}
       timeout_seconds: '60'
       max_merge_group_drops: '1'
     on_result:

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -311,6 +311,7 @@
         "timeout_seconds": 900,
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
+        "auto_merge_available": "${{ context.auto_merge_available }}",
         "max_merge_group_drops": 1
       },
       "capture": {
@@ -507,6 +508,7 @@
         "pr_number": "${{ context.current_pr_number }}",
         "target_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "auto_merge_available": "${{ context.auto_merge_available }}",
         "timeout_seconds": "60",
         "max_merge_group_drops": "1"
       },
@@ -615,6 +617,7 @@
         "target_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
+        "auto_merge_available": "${{ context.auto_merge_available }}",
         "timeout_seconds": 60,
         "poll_interval": 10,
         "max_merge_group_drops": 1

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -365,6 +365,7 @@ steps:
       timeout_seconds: 900
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
+      auto_merge_available: ${{ context.auto_merge_available }}
       max_merge_group_drops: 1
     capture:
       queue_pr_state: ${{ result.pr_state }}
@@ -522,6 +523,7 @@ steps:
       pr_number: ${{ context.current_pr_number }}
       target_branch: ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
+      auto_merge_available: ${{ context.auto_merge_available }}
       timeout_seconds: '60'
       max_merge_group_drops: '1'
     on_result:
@@ -599,6 +601,7 @@ steps:
       target_branch: ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
+      auto_merge_available: ${{ context.auto_merge_available }}
       timeout_seconds: 60
       poll_interval: 10
       max_merge_group_drops: 1

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -1747,6 +1747,7 @@
         "target_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
+        "auto_merge_available": "${{ context.auto_merge_available }}",
         "timeout_seconds": 60,
         "poll_interval": 10,
         "max_merge_group_drops": 1
@@ -1799,6 +1800,7 @@
         "timeout_seconds": 900,
         "cwd": "${{ context.work_dir }}",
         "remote_url": "${{ context.remote_url }}",
+        "auto_merge_available": "${{ context.auto_merge_available }}",
         "max_merge_group_drops": 1
       },
       "capture": {
@@ -1815,7 +1817,7 @@
         },
         {
           "when": "${{ result.pr_state }} == dropped_merge_group_ci",
-          "route": "diagnose_ci"
+          "route": "check_dropped_ci_loop"
         },
         {
           "when": "${{ result.pr_state }} == not_enrolled",
@@ -1843,7 +1845,7 @@
       ],
       "on_failure": "register_clone_unconfirmed",
       "skip_when_false": "inputs.open_pr",
-      "note": "Waits up to 15 minutes for the PR to merge through the queue. merged → release_issue_success to apply staged label, then register_clone_success. release_issue_success is optional with skip_when_false: inputs.issue_url — when issue_url is absent the step is silently skipped and pipeline continues to register_clone_success. ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix this). not_enrolled → release_issue_failure (enrollment failed; repo configuration error). ejected → conflict fix cycle then re-enter. stalled → lightweight re-enrollment via enqueue_pr. timeout → register_clone_unconfirmed (release claim without staged label; merge unconfirmed).\n"
+      "note": "Waits up to 15 minutes for the PR to merge through the queue. merged → release_issue_success to apply staged label, then register_clone_success. release_issue_success is optional with skip_when_false: inputs.issue_url — when issue_url is absent the step is silently skipped and pipeline continues to register_clone_success. ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix this). dropped_merge_group_ci → check_dropped_ci_loop (re-enqueue on first drop, escalate to diagnose_ci after the cap is exceeded). not_enrolled → release_issue_failure (enrollment failed; repo configuration error). ejected → conflict fix cycle then re-enter. stalled → lightweight re-enrollment via enqueue_pr. timeout → register_clone_unconfirmed (release claim without staged label; merge unconfirmed).\n"
     },
     "reenroll_stalled_pr": {
       "tool": "enqueue_pr",
@@ -1918,7 +1920,26 @@
         }
       ],
       "on_failure": "release_issue_failure",
-      "note": "Circuit breaker for the dropped_healthy re-enrollment loop. After 2 consecutive unexplained drops with healthy PR-branch CI, escalates to release_issue_failure instead of looping. Matches the check_eject_limit pattern used for the ejected path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed directly to diagnose_ci and never reaches this step.\n"
+      "note": "Circuit breaker for the dropped_healthy re-enrollment loop. After 2 consecutive unexplained drops with healthy PR-branch CI, escalates to release_issue_failure instead of looping. Matches the check_eject_limit pattern used for the ejected path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed through check_dropped_ci_loop instead and never reaches this step.\n"
+    },
+    "check_dropped_ci_loop": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.recipe._cmd_rpc.check_dropped_ci_loop",
+        "counter_file": "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_ci_count",
+        "max_drops": "2"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.status }} == DROPPED_CI_LIMIT_EXCEEDED",
+          "route": "diagnose_ci"
+        },
+        {
+          "route": "reenter_merge_queue_cheap"
+        }
+      ],
+      "on_failure": "diagnose_ci",
+      "note": "Circuit breaker for the dropped_merge_group_ci re-enrollment loop. Tracks merge-group-CI drop count in a file-based counter. On the first drop, re-enqueues via reenter_merge_queue_cheap (transient CI failure is often self-healing). After 2 consecutive drops, escalates to diagnose_ci — the merge-group CI is persistently failing, so a re-enqueue is unlikely to help. Mirrors the check_dropped_healthy_loop pattern for the dropped_healthy branch.\n"
     },
     "queue_ejected_fix": {
       "tool": "run_python",
@@ -2005,6 +2026,7 @@
         "pr_number": "${{ context.pr_number }}",
         "target_branch": "${{ inputs.base_branch }}",
         "cwd": "${{ context.work_dir }}",
+        "auto_merge_available": "${{ context.auto_merge_available }}",
         "timeout_seconds": "60",
         "max_merge_group_drops": "1"
       },

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1580,6 +1580,7 @@ steps:
       target_branch: ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
+      auto_merge_available: ${{ context.auto_merge_available }}
       timeout_seconds: 60
       poll_interval: 10
       max_merge_group_drops: 1
@@ -1620,6 +1621,7 @@ steps:
       timeout_seconds: 900
       cwd: ${{ context.work_dir }}
       remote_url: ${{ context.remote_url }}
+      auto_merge_available: ${{ context.auto_merge_available }}
       max_merge_group_drops: 1
     capture:
       queue_pr_state: ${{ result.pr_state }}
@@ -1629,7 +1631,7 @@ steps:
     - when: ${{ result.pr_state }} == ejected_ci_failure
       route: diagnose_ci
     - when: ${{ result.pr_state }} == dropped_merge_group_ci
-      route: diagnose_ci
+      route: check_dropped_ci_loop
     - when: ${{ result.pr_state }} == not_enrolled
       route: release_issue_failure
     - when: ${{ result.pr_state }} == dropped_healthy
@@ -1648,9 +1650,11 @@ steps:
       is optional with skip_when_false: inputs.issue_url — when issue_url is absent
       the step is silently skipped and pipeline continues to register_clone_success.
       ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix
-      this). not_enrolled → release_issue_failure (enrollment failed; repo configuration
-      error). ejected → conflict fix cycle then re-enter. stalled → lightweight re-enrollment
-      via enqueue_pr. timeout → register_clone_unconfirmed (release claim without
+      this). dropped_merge_group_ci → check_dropped_ci_loop (re-enqueue on first
+      drop, escalate to diagnose_ci after the cap is exceeded). not_enrolled →
+      release_issue_failure (enrollment failed; repo configuration error). ejected
+      → conflict fix cycle then re-enter. stalled → lightweight re-enrollment via
+      enqueue_pr. timeout → register_clone_unconfirmed (release claim without
       staged label; merge unconfirmed).
 
       '
@@ -1714,8 +1718,27 @@ steps:
     note: 'Circuit breaker for the dropped_healthy re-enrollment loop. After 2 consecutive
       unexplained drops with healthy PR-branch CI, escalates to release_issue_failure
       instead of looping. Matches the check_eject_limit pattern used for the ejected
-      path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed directly
-      to diagnose_ci and never reaches this step.
+      path. DROPPED_MERGE_GROUP_CI (confirmed merge-group CI failure) is routed through
+      check_dropped_ci_loop instead and never reaches this step.
+
+      '
+  check_dropped_ci_loop:
+    tool: run_python
+    with:
+      callable: autoskillit.recipe._cmd_rpc.check_dropped_ci_loop
+      counter_file: ${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_ci_count
+      max_drops: '2'
+    on_result:
+    - when: ${{ result.status }} == DROPPED_CI_LIMIT_EXCEEDED
+      route: diagnose_ci
+    - route: reenter_merge_queue_cheap
+    on_failure: diagnose_ci
+    note: 'Circuit breaker for the dropped_merge_group_ci re-enrollment loop. Tracks
+      merge-group-CI drop count in a file-based counter. On the first drop, re-enqueues
+      via reenter_merge_queue_cheap (transient CI failure is often self-healing).
+      After 2 consecutive drops, escalates to diagnose_ci — the merge-group CI is
+      persistently failing, so a re-enqueue is unlikely to help. Mirrors the
+      check_dropped_healthy_loop pattern for the dropped_healthy branch.
 
       '
   queue_ejected_fix:
@@ -1788,6 +1811,7 @@ steps:
       pr_number: ${{ context.pr_number }}
       target_branch: ${{ inputs.base_branch }}
       cwd: ${{ context.work_dir }}
+      auto_merge_available: ${{ context.auto_merge_available }}
       timeout_seconds: '60'
       max_merge_group_drops: '1'
     on_result:

--- a/tests/recipe/AGENTS.md
+++ b/tests/recipe/AGENTS.md
@@ -134,6 +134,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_rules_commit_guard_regression_route.py` | Tests for `commit-guard-regression-route-missing` semantic validation rule |
 | `test_rules_conditional_push.py` | Tests for conditional_push semantic validation rule |
 | `test_rules_contracts.py` | Tests for contracts semantic validation rule |
+| `test_rules_context_param_forwarding.py` | Tests for context-param-not-forwarded semantic validation rule — guards `_TOOL_CONTEXT_PARAMS` registry forwarding invariant for `auto_merge_available` and other upstream-captured context variables consumed by tool steps (PR #3901 regression guard) |
 | `test_rules_dataflow_capture.py` | Tests for dataflow capture semantic validation rule |
 | `test_rules_dataflow_handoff.py` | Tests for dataflow handoff semantic validation rule |
 | `test_rules_dataflow_merge.py` | Tests for dataflow merge semantic validation rule |

--- a/tests/recipe/test_merge_prs_queue_common.py
+++ b/tests/recipe/test_merge_prs_queue_common.py
@@ -929,22 +929,37 @@ def test_unbounded_cycle_fires_for_unguarded_dropped_merge_group_ci_branch(any_r
     for step in recipe.steps.values():
         if step.tool == "wait_for_merge_queue" and step.with_args:
             step.with_args.pop("max_merge_group_drops", None)
-    # Remove the run_python guard step so the dropped_merge_group_ci arm routes
-    # directly to diagnose_ci, and rewire the wait_for_queue condition to
-    # point to a bare re-enqueue target.
-    for step in list(recipe.steps.values()):
-        if step.tool == "wait_for_merge_queue" and step.on_result is not None:
-            step.on_result = copy.deepcopy(step.on_result)
-            for cond in step.on_result.conditions:
-                if cond.when and "dropped_merge_group_ci" in cond.when:
-                    cond.route = "reenter_merge_queue_cheap"
-        if step.tool == "run_python" and step.on_result is not None:
-            callable_val = (step.with_args or {}).get("callable", "")
-            if "check_dropped_ci_loop" in str(callable_val):
-                # Disable this guard by routing both arms to a re-enqueue target.
-                step.on_result = copy.deepcopy(step.on_result)
-                for cond in step.on_result.conditions:
-                    cond.route = "reenter_merge_queue_cheap"
+    # Remove the run_python guard step entirely and insert a bare passthrough
+    # step that routes back to the wait_for_merge_queue step.  The passthrough
+    # is NOT run_python and NOT enqueue_pr, so the unbounded-cycle per-branch
+    # analysis won't suppress it — the BFS will reach the MQ step and fire.
+    from autoskillit.recipe.schema import RecipeStep
+
+    guard_step_names = [
+        name
+        for name, step in recipe.steps.items()
+        if step.tool == "run_python"
+        and "check_dropped_ci_loop" in str((step.with_args or {}).get("callable", ""))
+    ]
+    for name in guard_step_names:
+        del recipe.steps[name]
+    passthrough_name = "_test_dmgci_passthrough"
+    mq_step_names = [
+        name
+        for name, step in recipe.steps.items()
+        if step.tool == "wait_for_merge_queue" and step.on_result is not None
+    ]
+    for step_name in mq_step_names:
+        step = recipe.steps[step_name]
+        step.on_result = copy.deepcopy(step.on_result)
+        for cond in step.on_result.conditions:
+            if cond.when and "dropped_merge_group_ci" in cond.when:
+                cond.route = passthrough_name
+        recipe.steps[passthrough_name] = RecipeStep(
+            name=passthrough_name,
+            action="route",
+            on_success=step_name,
+        )
 
     findings = run_semantic_rules(recipe)
     cycle_findings = [f for f in findings if f.rule == "unbounded-cycle"]

--- a/tests/recipe/test_merge_prs_queue_common.py
+++ b/tests/recipe/test_merge_prs_queue_common.py
@@ -634,6 +634,41 @@ def test_wait_for_queue_routing_covers_every_pr_state(recipe_fixture, request) -
 
 
 # ---------------------------------------------------------------------------
+# Context-param forwarding invariant — every wait_for_merge_queue must
+# forward context.auto_merge_available (Bug A regression guard from PR #3901).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("recipe_fixture", QUEUE_RECIPES)
+def test_wait_for_merge_queue_steps_forward_auto_merge_available(recipe_fixture, request) -> None:
+    """Every wait_for_merge_queue step must forward context.auto_merge_available.
+
+    Without this forwarding, the watcher's internal re-enqueue path uses its
+    default (typically ``True``) for ``auto_merge_available`` — which is wrong
+    on repos where ``check_repo_merge_state`` captured ``auto_merge_available=false``.
+    See PR #3901.
+    """
+    recipe = request.getfixturevalue(recipe_fixture)
+    mq_steps = {
+        name: step for name, step in recipe.steps.items() if step.tool == "wait_for_merge_queue"
+    }
+    assert mq_steps, f"{recipe_fixture}: no wait_for_merge_queue steps found"
+
+    for step_name, step in mq_steps.items():
+        with_args = step.with_args or {}
+        assert "auto_merge_available" in with_args, (
+            f"{recipe_fixture}: {step_name} (wait_for_merge_queue) is missing "
+            f"auto_merge_available in its with: block — recipes must forward "
+            f"context.auto_merge_available so the watcher uses the captured value."
+        )
+        value = with_args["auto_merge_available"]
+        assert "context.auto_merge_available" in value, (
+            f"{recipe_fixture}: {step_name}.auto_merge_available must reference "
+            f"{{{{ context.auto_merge_available }}}}, got: {value!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Auto-discovery structural guards
 # ---------------------------------------------------------------------------
 
@@ -882,8 +917,9 @@ class TestMergePrsPreEnqueueCiGate:
 
 
 def test_unbounded_cycle_fires_for_unguarded_dropped_merge_group_ci_branch(any_recipe) -> None:
-    """unbounded-cycle must fire ERROR for the dropped_merge_group_ci → diagnose_ci path
-    when max_merge_group_drops is absent (no watcher-internal guard)."""
+    """unbounded-cycle must fire ERROR for the dropped_merge_group_ci branch
+    when BOTH the watcher-internal guard (max_merge_group_drops) AND the
+    run_python loop guard step are absent (double-removal test)."""
     import copy
 
     from autoskillit.core.types import Severity
@@ -893,6 +929,22 @@ def test_unbounded_cycle_fires_for_unguarded_dropped_merge_group_ci_branch(any_r
     for step in recipe.steps.values():
         if step.tool == "wait_for_merge_queue" and step.with_args:
             step.with_args.pop("max_merge_group_drops", None)
+    # Remove the run_python guard step so the dropped_merge_group_ci arm routes
+    # directly to diagnose_ci, and rewire the wait_for_queue condition to
+    # point to a bare re-enqueue target.
+    for step in list(recipe.steps.values()):
+        if step.tool == "wait_for_merge_queue" and step.on_result is not None:
+            step.on_result = copy.deepcopy(step.on_result)
+            for cond in step.on_result.conditions:
+                if cond.when and "dropped_merge_group_ci" in cond.when:
+                    cond.route = "reenter_merge_queue_cheap"
+        if step.tool == "run_python" and step.on_result is not None:
+            callable_val = (step.with_args or {}).get("callable", "")
+            if "check_dropped_ci_loop" in str(callable_val):
+                # Disable this guard by routing both arms to a re-enqueue target.
+                step.on_result = copy.deepcopy(step.on_result)
+                for cond in step.on_result.conditions:
+                    cond.route = "reenter_merge_queue_cheap"
 
     findings = run_semantic_rules(recipe)
     cycle_findings = [f for f in findings if f.rule == "unbounded-cycle"]
@@ -909,7 +961,9 @@ def test_unbounded_cycle_fires_for_unguarded_dropped_merge_group_ci_branch(any_r
 
 
 def test_unbounded_cycle_suppressed_when_dropped_merge_group_ci_has_guard(any_recipe) -> None:
-    """unbounded-cycle must NOT fire for dropped_merge_group_ci when max_merge_group_drops >= 1."""
+    """unbounded-cycle must NOT fire for dropped_merge_group_ci when EITHER
+    the watcher-internal guard (max_merge_group_drops >= 1) OR the run_python
+    loop guard step (check_dropped_ci_loop) is present."""
     from autoskillit.core.types import Severity
     from autoskillit.recipe.validator import run_semantic_rules
 
@@ -934,13 +988,15 @@ def test_unbounded_cycle_suppressed_when_dropped_merge_group_ci_has_guard(any_re
     ]
     assert not dmgci_error_findings, (
         f"unbounded-cycle must NOT fire ERROR for guarded dropped_merge_group_ci branch in "
-        f"{any_recipe.name} (max_merge_group_drops >= 1); got: "
+        f"{any_recipe.name}; got: "
         f"{[(f.step_name, f.message[:80]) for f in dmgci_error_findings]}"
     )
 
 
 def test_dropped_merge_group_ci_reenqueue_guard_fires_without_guard(any_recipe) -> None:
-    """Semantic rule I9 must fire ERROR when max_merge_group_drops is absent."""
+    """Semantic rule I9 must fire ERROR when BOTH the watcher-internal guard
+    (max_merge_group_drops) AND the run_python loop guard step are absent
+    (double-removal test)."""
     import copy
 
     from autoskillit.core.types import Severity
@@ -950,6 +1006,18 @@ def test_dropped_merge_group_ci_reenqueue_guard_fires_without_guard(any_recipe) 
     for step in recipe.steps.values():
         if step.tool == "wait_for_merge_queue" and step.with_args:
             step.with_args.pop("max_merge_group_drops", None)
+    for step in list(recipe.steps.values()):
+        if step.tool == "wait_for_merge_queue" and step.on_result is not None:
+            step.on_result = copy.deepcopy(step.on_result)
+            for cond in step.on_result.conditions:
+                if cond.when and "dropped_merge_group_ci" in cond.when:
+                    cond.route = "reenter_merge_queue_cheap"
+        if step.tool == "run_python" and step.on_result is not None:
+            callable_val = (step.with_args or {}).get("callable", "")
+            if "check_dropped_ci_loop" in str(callable_val):
+                step.on_result = copy.deepcopy(step.on_result)
+                for cond in step.on_result.conditions:
+                    cond.route = "reenter_merge_queue_cheap"
 
     findings = run_semantic_rules(recipe)
     i9_findings = [
@@ -958,25 +1026,28 @@ def test_dropped_merge_group_ci_reenqueue_guard_fires_without_guard(any_recipe) 
         if f.rule == "dropped-merge-group-ci-unguarded-reenqueue-loop"
         and f.severity == Severity.ERROR
     ]
-    assert i9_findings, (
-        f"Rule I9 must fire ERROR for unguarded dropped_merge_group_ci in {recipe.name}"
-    )
+    assert i9_findings, f"Rule I9 must fire ERROR when both guards absent in {recipe.name}"
 
 
 def test_dropped_merge_group_ci_reenqueue_guard_suppressed_with_guard(any_recipe) -> None:
-    """Semantic rule I9 must NOT fire when max_merge_group_drops >= 1."""
+    """Semantic rule I9 must NOT fire when EITHER the watcher-internal guard
+    (max_merge_group_drops >= 1) OR the run_python loop guard step is present."""
     from autoskillit.recipe.validator import run_semantic_rules
 
-    mq_steps_with_guard = [
-        s
-        for s in any_recipe.steps.values()
-        if s.tool == "wait_for_merge_queue"
+    has_watcher_guard = any(
+        s.tool == "wait_for_merge_queue"
         and s.with_args
         and int(s.with_args.get("max_merge_group_drops", 0)) >= 1
-    ]
-    assert mq_steps_with_guard, (
-        f"Precondition: {any_recipe.name} must have at least one wait_for_merge_queue step "
-        f"with max_merge_group_drops >= 1 for this test to be meaningful"
+        for s in any_recipe.steps.values()
+    )
+    has_rp_guard = any(
+        s.tool == "run_python"
+        and "check_dropped_ci_loop" in str((s.with_args or {}).get("callable", ""))
+        for s in any_recipe.steps.values()
+    )
+    assert has_watcher_guard or has_rp_guard, (
+        f"Precondition: {any_recipe.name} must have at least one guard "
+        f"(max_merge_group_drops >= 1 or a check_dropped_ci_loop step)"
     )
 
     findings = run_semantic_rules(any_recipe)

--- a/tests/recipe/test_rules_context_param_forwarding.py
+++ b/tests/recipe/test_rules_context_param_forwarding.py
@@ -1,0 +1,139 @@
+"""Tests for the context-param-not-forwarded semantic rule.
+
+The ``_TOOL_CONTEXT_PARAMS`` registry in ``rules_tools.py`` declares which
+context variables must be forwarded to specific tool steps when they are
+captured upstream. This rule is the structural guard that prevented the
+PR #3901 bug — without it, a recipe could silently omit ``auto_merge_available``
+from a ``wait_for_merge_queue`` step and the watcher would default to
+``enablePullRequestAutoMerge`` on repos where auto-merge is disabled.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import Severity
+from autoskillit.recipe.registry import run_semantic_rules
+from tests.recipe.conftest import _make_workflow
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def test_context_param_not_forwarded_fires_for_wait_for_merge_queue() -> None:
+    """A wait_for_merge_queue step that omits auto_merge_available fires ERROR."""
+    recipe = _make_workflow(
+        {
+            "check_repo_merge_state": {
+                "tool": "check_repo_merge_state",
+                "with": {"branch": "main"},
+                "capture": {"auto_merge_available": "${{ result.auto_merge_available }}"},
+            },
+            "wait": {
+                "tool": "wait_for_merge_queue",
+                "with": {
+                    "pr_number": "${{ context.pr_number }}",
+                    "target_branch": "main",
+                    "cwd": "/tmp",
+                },
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "done"},
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    findings = [f for f in findings if f.rule == "context-param-not-forwarded"]
+    assert findings, (
+        "Expected context-param-not-forwarded finding for wait_for_merge_queue "
+        "step that omits auto_merge_available"
+    )
+    assert all(f.severity == Severity.ERROR for f in findings)
+    assert any("auto_merge_available" in f.message and "wait" in f.step_name for f in findings)
+
+
+def test_context_param_forwarded_suppresses_rule() -> None:
+    """Forwarding auto_merge_available via ${{ context.auto_merge_available }} suppresses the rule.
+
+    The rule's check is satisfied when the with: value contains
+    ``context.auto_merge_available`` — even a plain string interpolation
+    counts. Recipes don't need to re-format the value.
+    """
+    recipe = _make_workflow(
+        {
+            "check_repo_merge_state": {
+                "tool": "check_repo_merge_state",
+                "with": {"branch": "main"},
+                "capture": {"auto_merge_available": "${{ result.auto_merge_available }}"},
+            },
+            "wait": {
+                "tool": "wait_for_merge_queue",
+                "with": {
+                    "pr_number": "${{ context.pr_number }}",
+                    "target_branch": "main",
+                    "cwd": "/tmp",
+                    "auto_merge_available": "${{ context.auto_merge_available }}",
+                },
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "done"},
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    findings = [f for f in findings if f.rule == "context-param-not-forwarded"]
+    assert not findings, (
+        "Forwarding auto_merge_available must suppress the rule; got: "
+        f"{[(f.step_name, f.message) for f in findings]}"
+    )
+
+
+def test_context_param_not_forwarded_fires_for_enqueue_pr() -> None:
+    """An enqueue_pr step that omits auto_merge_available fires ERROR."""
+    recipe = _make_workflow(
+        {
+            "check_repo_merge_state": {
+                "tool": "check_repo_merge_state",
+                "with": {"branch": "main"},
+                "capture": {"auto_merge_available": "${{ result.auto_merge_available }}"},
+            },
+            "enqueue": {
+                "tool": "enqueue_pr",
+                "with": {
+                    "pr_number": "${{ context.pr_number }}",
+                    "target_branch": "main",
+                    "cwd": "/tmp",
+                },
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "done"},
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    findings = [f for f in findings if f.rule == "context-param-not-forwarded"]
+    assert findings, (
+        "Expected context-param-not-forwarded for enqueue_pr omitting auto_merge_available"
+    )
+    assert any(f.step_name == "enqueue" for f in findings)
+
+
+def test_context_param_irrelevant_tool_does_not_fire() -> None:
+    """A step calling a tool that does NOT consume auto_merge_available must not fire the rule."""
+    recipe = _make_workflow(
+        {
+            "check_repo_merge_state": {
+                "tool": "check_repo_merge_state",
+                "with": {"branch": "main"},
+                "capture": {"auto_merge_available": "${{ result.auto_merge_available }}"},
+            },
+            "wait_ci": {
+                "tool": "wait_for_ci",
+                "with": {"branch": "main", "auto_trigger": "true"},
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "done"},
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    findings = [f for f in findings if f.rule == "context-param-not-forwarded"]
+    assert not findings, (
+        "wait_for_ci does not consume auto_merge_available; the rule must not fire. "
+        f"Got: {[(f.step_name, f.message) for f in findings]}"
+    )

--- a/tests/recipe/test_rules_tools.py
+++ b/tests/recipe/test_rules_tools.py
@@ -865,3 +865,43 @@ def test_mixed_cwd_rule_does_not_fire_on_single_cwd() -> None:
     findings = run_semantic_rules(recipe)
     matched = [f for f in findings if f.rule == "mixed-cwd-without-scoping-key"]
     assert not matched, "Single-cwd recipes must not trigger the rule"
+
+
+# ---------------------------------------------------------------------------
+# tool_output_contracts: wait_for_merge_queue → pr_state
+# ---------------------------------------------------------------------------
+
+
+def test_wait_for_merge_queue_has_tool_output_contract() -> None:
+    """wait_for_merge_queue must declare a tool_output_contract on pr_state.
+
+    The contract drives the ``on-result-missing-tool-output-value`` rule which
+    validates routing completeness for the recoverable values (dropped_merge_group_ci,
+    dropped_healthy, ejected, stalled). Without this contract the rule cannot
+    detect missing routing arms.
+    """
+    from autoskillit.core import PRState
+    from autoskillit.recipe.contracts import get_tool_output_contract, load_bundled_manifest
+
+    manifest = load_bundled_manifest()
+    contract = get_tool_output_contract("wait_for_merge_queue", manifest)
+    assert contract is not None, "wait_for_merge_queue must declare a tool_output_contract"
+    assert contract.result_field == "pr_state"
+
+    field_spec = contract.fields["pr_state"]
+    expected_allowed = {s.value for s in PRState}
+    assert set(field_spec.allowed_values) == expected_allowed, (
+        f"pr_state.allowed_values must cover every PRState value; "
+        f"missing: {expected_allowed - set(field_spec.allowed_values)}"
+    )
+
+    expected_recoverable = {
+        "dropped_merge_group_ci",
+        "dropped_healthy",
+        "ejected",
+        "stalled",
+    }
+    assert expected_recoverable.issubset(field_spec.recoverable_values), (
+        f"pr_state.recoverable_values must include {expected_recoverable}; "
+        f"got: {set(field_spec.recoverable_values)}"
+    )


### PR DESCRIPTION
## Summary

Two compounding bugs caused PR #3901 to fail despite passing CI: (1) the recipe omits `auto_merge_available` from all 12 `wait_for_merge_queue` steps across 4 recipes, causing the watcher's internal re-enrollment to use `enablePullRequestAutoMerge` instead of `enqueuePullRequest` on repos where auto-merge is disabled, and (2) no recipe routing path exists to re-enqueue a PR after a transient merge-group CI failure when PR-branch CI is green. Both bugs stem from structural gaps in the recipe validation engine: no semantic rule enforces that context variables captured upstream are forwarded to all tool steps that consume them, and no `tool_output_contracts` entry exists for `wait_for_merge_queue` to enable routing completeness checks.

The immunity plan adds a new `context-param-not-forwarded` semantic rule backed by a `_TOOL_CONTEXT_PARAMS` registry, a `tool_output_contracts` entry for `wait_for_merge_queue`, a recipe-level circuit-breaker guard for transient merge-group drops, and fixes all 12 affected call sites.

## Requirements

### REQ-MQ-A: Forward `auto_merge_available` to `wait_for_merge_queue` recipe steps

Add `auto_merge_available: ${{ context.auto_merge_available }}` to both the `wait_for_queue` step (line 1531) and the `verify_queue_enrollment` step (line 1493) in `implementation.yaml`. This is a one-line addition per step, following the existing pattern used by `enqueue_to_queue` (line 1472) and `reenroll_stalled_pr` (line 1569). The watcher code's internal parameter forwarding is already correct — only the recipe caller needs updating. An alternative defense-in-depth approach would be to have the watcher re-query `fetch_repo_merge_state()` during internal re-enrollment (all required data — `owner`, `repo_name`, `target_branch` — is already in scope at line 326), but the recipe fix is simpler and matches established patterns.

### REQ-MQ-B: Add re-enqueue routing for transient merge-group failures (with circuit breaker)

When `diagnose_ci` returns `no_failure` after a `dropped_merge_group_ci`, the recipe should route to re-enrollment rather than to `resolve_ci`. This **must include a file-counter circuit breaker** analogous to `check_dropped_healthy_loop` (which uses `$AUTOSKILLIT_TEMP/dropped_healthy_count`), capped at 1-2 recipe-level iterations. Without a circuit breaker, a persistent merge-group-only failure (e.g., a test that only fails in merge-group context) would create an unbounded recipe-level loop — `max_merge_group_drops` only guards within a single `wait_for_merge_queue` call and does not stack with recipe-level retries.

### REQ-MQ-C: Enhance `diagnose-ci` to check merge-group event runs

The skill only queried `gh run list --limit 1` without filtering by event type, finding the green `pull_request` run and missing the failed `merge_group` run entirely. Passing the originating context (e.g., `event_type=merge_group`) would let it find the actual failure and produce a more accurate diagnosis.

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

Closes #3906

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260608-072112-566541/.autoskillit/temp/rectify/rectify_mq_context_forwarding_and_recovery_routing_2026-06-08_072112.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 9.6k | 25.0k | 3.0M | 135.4k | 66 | 143.1k | 22m 13s |
| review_approach* | sonnet | 1 | 52 | 6.9k | 222.9k | 49.1k | 17 | 31.7k | 3m 57s |
| dry_walkthrough* | opus | 1 | 51 | 17.1k | 2.2M | 115.7k | 70 | 115.8k | 8m 20s |
| audit_impl* | sonnet | 1 | 685 | 13.0k | 373.7k | 66.9k | 31 | 58.2k | 13m 2s |
| prepare_pr* | MiniMax-M3 | 1 | 47.2k | 3.7k | 212.5k | 51.6k | 17 | 0 | 1m 25s |
| compose_pr* | MiniMax-M3 | 1 | 36.2k | 1.9k | 151.5k | 39.6k | 12 | 0 | 53s |
| review_pr* | sonnet | 2 | 308 | 52.5k | 2.3M | 111.5k | 94 | 146.0k | 14m 54s |
| resolve_review* | opus[1m] | 2 | 88 | 20.0k | 2.1M | 74.0k | 75 | 127.5k | 12m 33s |
| resolve_pre_review_conflicts* | opus[1m] | 1 | 40 | 5.5k | 1.3M | 70.2k | 40 | 47.9k | 2m 18s |
| **Total** | | | 94.3k | 145.6k | 11.7M | 135.4k | | 670.2k | 1h 19m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 13 | 159016.3 | 9807.8 | 1538.3 |
| resolve_pre_review_conflicts | 6357 | 198.7 | 7.5 | 0.9 |
| **Total** | **6370** | 1834.9 | 105.2 | 22.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 3 | 9.8k | 50.5k | 6.3M | 318.4k | 37m 6s |
| sonnet | 3 | 1.0k | 72.4k | 2.9M | 235.9k | 31m 55s |
| opus | 1 | 51 | 17.1k | 2.2M | 115.8k | 8m 20s |
| MiniMax-M3 | 2 | 83.4k | 5.6k | 363.9k | 0 | 2m 18s |