### PR TITLE
Implementation Plan: Seal CodexEventType with ITEM_UPDATED member

### DIFF
--- a/src/autoskillit/core/types/_type_enums.py
+++ b/src/autoskillit/core/types/_type_enums.py
@@ -538,6 +538,7 @@ class CodexEventType(StrEnum):
     SESSION_META = "session_meta"
     TURN_STARTED = "turn.started"
     ITEM_STARTED = "item.started"
+    ITEM_UPDATED = "item.updated"
     ITEM_COMPLETED = "item.completed"
     TURN_COMPLETED = "turn.completed"
     TURN_FAILED = "turn.failed"

--- a/src/autoskillit/execution/backends/_codex_parse.py
+++ b/src/autoskillit/execution/backends/_codex_parse.py
@@ -61,7 +61,11 @@ def _scan_codex_ndjson(stdout: str) -> _CodexParseAccumulator:
             acc.session_id = obj.get("thread_id", "")
         elif event_type == CodexEventType.SESSION_META:
             acc.session_id = obj.get("payload", {}).get("id", "")
-        elif event_type in (CodexEventType.TURN_STARTED, CodexEventType.ITEM_STARTED):
+        elif event_type in (
+            CodexEventType.TURN_STARTED,
+            CodexEventType.ITEM_STARTED,
+            CodexEventType.ITEM_UPDATED,
+        ):
             continue
         elif event_type == CodexEventType.ITEM_COMPLETED:
             item = obj.get("item", {})
@@ -349,6 +353,13 @@ class CodexStreamParser:
                     item_type="",
                     raw=obj,
                 ),
+            )
+
+        if event_type == CodexEventType.ITEM_UPDATED:
+            return SessionEvent(
+                kind=BackendEventKind.IGNORED,
+                is_terminal=False,
+                has_marker=False,
             )
 
         logger.warning("codex_ndjson_unknown_event_type", type=obj.get("type", ""))

--- a/tests/execution/backends/test_codex_stream_parser.py
+++ b/tests/execution/backends/test_codex_stream_parser.py
@@ -9,6 +9,7 @@ from autoskillit.core import (
     BackendEventKind,
     CanonicalTokenUsage,
     CodexEventData,
+    CodexEventType,
     CodexItemType,
     StreamParser,
 )
@@ -559,5 +560,48 @@ class TestCodexParserUnrecognizedTypeWarning:
             parser.parse_line(line)
         assert any(
             log["event"] == "codex_ndjson_unknown_item_type" and log["log_level"] == "warning"
+            for log in cap
+        )
+
+
+class TestCodexParserItemUpdated:
+    def test_item_updated_enum_value(self) -> None:
+        assert CodexEventType.ITEM_UPDATED.value == "item.updated"
+
+    def test_item_updated_from_ndjson(self) -> None:
+        result = CodexEventType.from_ndjson("item.updated")
+        assert result == CodexEventType.ITEM_UPDATED
+        assert result != CodexEventType.UNKNOWN
+
+    def test_scan_ndjson_silently_discards_item_updated(self) -> None:
+        line = json.dumps({"type": "item.updated"})
+        with structlog.testing.capture_logs() as cap:
+            acc = _scan_codex_ndjson(line)
+        assert not acc.agent_messages
+        assert not acc.command_executions
+        assert not acc.mcp_tool_calls
+        assert not acc.file_changes
+        assert acc.session_id == ""
+        assert acc.success is False
+        assert not any(log["event"] == "codex_ndjson_unknown_event_type" for log in cap)
+
+    def test_parse_line_item_updated_yields_ignored_no_warning(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps({"type": "item.updated"})
+        with structlog.testing.capture_logs() as cap:
+            event = parser.parse_line(line)
+        assert event is not None
+        assert event.kind == BackendEventKind.IGNORED
+        assert event.is_terminal is False
+        assert event.has_marker is False
+        assert not any(log["event"] == "codex_ndjson_unknown_event_type" for log in cap)
+
+    def test_unknown_event_type_still_warns_after_item_updated_guard(self) -> None:
+        parser = CodexStreamParser()
+        line = json.dumps({"type": "brand_new_unknown_event"})
+        with structlog.testing.capture_logs() as cap:
+            parser.parse_line(line)
+        assert any(
+            log["event"] == "codex_ndjson_unknown_event_type" and log["log_level"] == "warning"
             for log in cap
         )


### PR DESCRIPTION
## Summary

Add `CodexEventType.ITEM_UPDATED = 'item.updated'` to the enum and route it to silent discard in both `_scan_codex_ndjson` (via tuple extension) and `CodexStreamParser.parse_line` (via dedicated guard block before the warning fallthrough), preventing `item.updated` NDJSON lines from reaching the UNKNOWN warning path.

Three files are modified:
- `src/autoskillit/core/types/_type_enums.py` — new enum member
- `src/autoskillit/execution/backends/_codex_parse.py` — two routing changes
- `tests/execution/backends/test_codex_stream_parser.py` — five new tests

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260608-113709-896380/.autoskillit/temp/make-plan/seal_codexeventtype_item_updated_plan_2026-06-08_120000.md`

Closes #3916

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 670 | 15.8k | 993.7k | 94.3k | 36 | 72.7k | 9m 46s |
| verify* | sonnet | 1 | 1.6k | 10.1k | 397.9k | 58.2k | 25 | 36.6k | 4m 42s |
| implement* | MiniMax-M3 | 1 | 66.0k | 4.6k | 880.3k | 68.7k | 48 | 0 | 2m 29s |
| audit_impl* | sonnet | 1 | 1.8k | 5.0k | 165.4k | 39.0k | 13 | 24.2k | 2m 9s |
| prepare_pr* | MiniMax-M3 | 1 | 46.2k | 2.3k | 163.7k | 47.7k | 13 | 0 | 1m 4s |
| compose_pr* | MiniMax-M3 | 1 | 37.2k | 1.4k | 185.9k | 38.5k | 12 | 0 | 49s |
| review_pr* | sonnet | 3 | 374 | 39.1k | 2.1M | 61.9k | 113 | 115.0k | 10m 38s |
| **Total** | | | 153.8k | 78.3k | 4.9M | 94.3k | | 248.6k | 31m 38s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 58 | 15178.2 | 0.0 | 80.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **58** | 84475.7 | 4285.7 | 1349.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 670 | 15.8k | 993.7k | 72.7k | 9m 46s |
| sonnet | 3 | 3.8k | 54.1k | 2.7M | 175.8k | 17m 29s |
| MiniMax-M3 | 3 | 149.3k | 8.4k | 1.2M | 0 | 4m 22s |