### PR TITLE
Implementation Plan: Introduce CODEX_FIXTURE_MIN_VERSION Constant and Canary Test

### DIFF
--- a/tests/execution/backends/test_codex_fixtures.py
+++ b/tests/execution/backends/test_codex_fixtures.py
@@ -8,8 +8,10 @@ import pytest
 
 from autoskillit.core.types._type_enums import CodexEventType
 from autoskillit.execution.backends._codex_parse import _scan_codex_ndjson
+from autoskillit.execution.backends.codex import CodexBackend
 from autoskillit.execution.process import _marker_is_standalone
 from tests.fixtures.codex import (
+    CODEX_FIXTURE_MIN_VERSION,
     CODEX_SCHEMA_VERSION,
     HAPPY_PATH_SINGLE_TURN,
     HAPPY_PATH_V0136,
@@ -56,7 +58,7 @@ class TestCodexFixturePackage:
             assert fixture_path(name).is_file()
 
     def test_all_exports_count(self) -> None:
-        assert len(CODEX_ALL) == 9
+        assert len(CODEX_ALL) == 10
 
 
 class TestCodexFixtureValidity:
@@ -273,3 +275,8 @@ class TestCodexFixturesParseWithBackend:
         assert acc.success is True
         assert acc.session_id == "thread_v0136_marker"
         assert len(acc.agent_messages) > 0
+
+
+class TestCodexFixtureVersionTracking:
+    def test_min_version_matches_backend_capability(self) -> None:
+        assert CODEX_FIXTURE_MIN_VERSION == CodexBackend().capabilities.min_version

--- a/tests/fixtures/codex/__init__.py
+++ b/tests/fixtures/codex/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 CODEX_SCHEMA_VERSION: int = 2
+CODEX_FIXTURE_MIN_VERSION: str = "0.130.0"
 
 HAPPY_PATH_SINGLE_TURN: str = "happy_path_single_turn_v0133.ndjson"
 HAPPY_PATH_V0136: str = "happy_path_v0136.ndjson"
@@ -21,6 +22,7 @@ def fixture_path(name: str) -> Path:
 
 
 __all__ = [
+    "CODEX_FIXTURE_MIN_VERSION",
     "CODEX_SCHEMA_VERSION",
     "HAPPY_PATH_SINGLE_TURN",
     "HAPPY_PATH_V0136",


### PR DESCRIPTION
## Summary

Add a `CODEX_FIXTURE_MIN_VERSION` string constant to the Codex fixture package (`tests/fixtures/codex/__init__.py`) recording the Codex CLI version at fixture capture time (`"0.130.0"`), and add a forcing-function test in `tests/execution/backends/test_codex_fixtures.py` that asserts this constant equals `CodexBackend().capabilities.min_version`. This creates a canary that breaks whenever the backend's min_version is bumped without updating the fixture constant.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260608-122410-672729/.autoskillit/temp/make-plan/codex_fixture_min_version_plan_2026-06-08_122900.md`

Closes #3917

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 46 | 4.9k | 537.0k | 64.0k | 23 | 44.5k | 3m 2s |
| verify* | sonnet | 1 | 2.6k | 5.8k | 274.1k | 51.6k | 18 | 30.1k | 4m 8s |
| implement* | MiniMax-M3 | 1 | 62.9k | 4.6k | 830.3k | 61.5k | 50 | 0 | 2m 34s |
| audit_impl* | sonnet | 1 | 965 | 4.3k | 165.8k | 39.1k | 15 | 21.8k | 2m 12s |
| prepare_pr* | MiniMax-M3 | 1 | 42.7k | 3.0k | 160.4k | 45.4k | 15 | 0 | 1m 18s |
| compose_pr* | MiniMax-M3 | 1 | 34.8k | 1.4k | 150.1k | 38.4k | 12 | 0 | 57s |
| review_pr* | sonnet | 1 | 180 | 16.4k | 1.1M | 63.4k | 50 | 42.2k | 4m 30s |
| resolve_review* | sonnet | 1 | 141 | 7.2k | 832.4k | 57.9k | 42 | 36.6k | 3m 25s |
| **Total** | | | 144.3k | 47.6k | 4.0M | 64.0k | | 175.3k | 22m 9s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 11 | 75482.7 | 0.0 | 422.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **11** | 367694.4 | 15932.1 | 4330.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 46 | 4.9k | 537.0k | 44.5k | 3m 2s |
| sonnet | 4 | 3.9k | 33.7k | 2.4M | 130.7k | 14m 17s |
| MiniMax-M3 | 3 | 140.4k | 9.0k | 1.1M | 0 | 4m 49s |