### PR TITLE
Implementation Plan: Add TestCodexCanaryEventTypes Canary Test

### DIFF
--- a/tests/execution/backends/test_codex_fixtures.py
+++ b/tests/execution/backends/test_codex_fixtures.py
@@ -280,3 +280,15 @@ class TestCodexFixturesParseWithBackend:
 class TestCodexFixtureVersionTracking:
     def test_min_version_matches_backend_capability(self) -> None:
         assert CODEX_FIXTURE_MIN_VERSION == CodexBackend().capabilities.min_version
+
+
+class TestCodexCanaryEventTypes:
+    @pytest.mark.parametrize("name", ALL_FIXTURE_NAMES, ids=ALL_FIXTURE_NAMES)
+    def test_no_unknown_event_types(self, name: str) -> None:
+        events = _load_events(name)
+        for event in events:
+            raw_type = event.get("type", "")
+            result = CodexEventType.from_ndjson(raw_type)
+            assert result is not CodexEventType.UNKNOWN, (
+                f"Fixture {name!r} contains unknown event type: {raw_type!r}"
+            )


### PR DESCRIPTION
## Summary

Add a `TestCodexCanaryEventTypes` test class to `tests/execution/backends/test_codex_fixtures.py` with a single parametrized method that asserts every NDJSON event in all 7 Codex fixture files resolves to a known `CodexEventType` member (not `UNKNOWN`). This provides a canary that breaks immediately if a new event type appears in committed fixtures without a corresponding enum entry.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260608-125758-187777/.autoskillit/temp/make-plan/codex_canary_event_types_plan_2026-06-08_130500.md`

Closes #3918

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.8k | 4.2k | 457.9k | 59.9k | 19 | 40.0k | 2m 35s |
| verify* | sonnet | 1 | 78 | 6.5k | 409.8k | 61.8k | 25 | 40.1k | 3m 29s |
| implement* | MiniMax-M3 | 1 | 52.1k | 2.0k | 610.1k | 52.6k | 24 | 0 | 1m 57s |
| audit_impl* | sonnet | 1 | 44 | 2.6k | 165.9k | 39.2k | 12 | 20.0k | 1m 35s |
| prepare_pr* | MiniMax-M3 | 1 | 42.4k | 2.0k | 152.1k | 42.2k | 11 | 0 | 1m 6s |
| compose_pr* | MiniMax-M3 | 1 | 37.1k | 1.1k | 147.0k | 38.0k | 12 | 0 | 40s |
| review_pr* | sonnet | 3 | 374 | 25.7k | 2.0M | 54.3k | 120 | 96.4k | 7m 55s |
| **Total** | | | 133.9k | 44.1k | 4.0M | 61.8k | | 196.5k | 19m 21s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 12 | 50840.6 | 0.0 | 163.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **12** | 331123.8 | 16377.9 | 3672.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.8k | 4.2k | 457.9k | 40.0k | 2m 35s |
| sonnet | 3 | 496 | 34.8k | 2.6M | 156.5k | 13m 1s |
| MiniMax-M3 | 3 | 131.6k | 5.0k | 909.2k | 0 | 3m 44s |