### PR TITLE
Implementation Plan: Introduce CI-enforced Structural Tests for BackendCapabilities Drift and Session-Type Typo Prevention

### DIFF
--- a/tests/arch/AGENTS.md
+++ b/tests/arch/AGENTS.md
@@ -115,6 +115,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_skill_search_dir_symmetry.py` | Suppression-delivery symmetry invariants for project-local skill search dirs |
 | `test_doc_fence_filter.py` | Unit and functional tests for `_strip_doc_fenced_blocks` section-aware code fence filter |
 | `test_capability_scanner_fence_immunity.py` | AST regression guard: capability scanners must import and call `_strip_doc_fenced_blocks` |
+| `test_backend_stdlib_boundaries.py` | Stdlib-boundary equality tests: write_guard fallback frozenset ↔ CLAUDE_CODE_CAPABILITIES, session type hook string literals ↔ SessionType enum |
 
 ## Architecture Notes
 

--- a/tests/arch/test_backend_stdlib_boundaries.py
+++ b/tests/arch/test_backend_stdlib_boundaries.py
@@ -1,0 +1,215 @@
+"""Stdlib-boundary equality tests for unguarded parallel registries.
+
+These tests guard against silent drift between:
+1. The fallback frozenset in `write_guard.py`'s `effective_tool_names` IfExp
+   and the canonical `CLAUDE_CODE_CAPABILITIES.write_guard_tool_names` constant.
+2. String literals compared against `AUTOSKILLIT_SESSION_TYPE` in hook scripts
+   and the canonical `SessionType` StrEnum values.
+
+Hook scripts are standalone stdlib-only subprocesses and cannot import from
+`autoskillit.*` at runtime, so we parse them via `ast` rather than importing.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+def test_write_guard_fallback_matches_claude_code_capabilities() -> None:
+    from autoskillit.core import CLAUDE_CODE_CAPABILITIES, pkg_root
+
+    wg_path = pkg_root() / "hooks" / "guards" / "write_guard.py"
+    tree = ast.parse(wg_path.read_text())
+
+    ann_assign = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "effective_tool_names"
+        ):
+            ann_assign = node
+            break
+
+    if ann_assign is None:
+        pytest.fail(
+            "effective_tool_names AnnAssign not found in write_guard.py — "
+            "file may have been restructured"
+        )
+
+    if not isinstance(ann_assign.value, ast.IfExp):
+        pytest.fail(
+            "effective_tool_names value is not an IfExp — "
+            "expected a ternary expression with a frozenset fallback"
+        )
+
+    orelse = ann_assign.value.orelse
+    if not (
+        isinstance(orelse, ast.Call)
+        and len(orelse.args) == 1
+        and isinstance(orelse.args[0], ast.Set)
+    ):
+        pytest.fail(
+            "effective_tool_names IfExp orelse is not a frozenset({...}) call — "
+            "expected frozenset with a single Set argument"
+        )
+
+    fallback = frozenset(
+        elt.value
+        for elt in orelse.args[0].elts
+        if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+    )
+
+    expected = CLAUDE_CODE_CAPABILITIES.write_guard_tool_names
+    assert fallback == expected, (
+        f"write_guard.py fallback frozenset {sorted(fallback)} does not match "
+        f"CLAUDE_CODE_CAPABILITIES.write_guard_tool_names {sorted(expected)}"
+    )
+
+
+class _SessionTypeStringVisitor(ast.NodeVisitor):
+    """Collects string literals compared against AUTOSKILLIT_SESSION_TYPE values.
+
+    Two-pass scoped visitor: first discovers which variables hold session type
+    values (from os.environ.get reads), then only collects strings from Compare
+    nodes involving those variables and from SESSION_TYPE-named frozenset constants.
+    """
+
+    def __init__(self) -> None:
+        self.found: set[str] = set()
+        self._session_type_vars: set[str] = set()
+
+    def visit_Module(self, node: ast.Module) -> None:
+        self._discover_session_type_vars(node)
+        self.generic_visit(node)
+
+    def _discover_session_type_vars(self, module: ast.Module) -> None:
+        assigns: list[tuple[str, ast.expr]] = []
+        for node in ast.walk(module):
+            if (
+                isinstance(node, ast.Assign)
+                and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+            ):
+                assigns.append((node.targets[0].id, node.value))
+
+        for name, value in assigns:
+            if self._is_session_type_env_read(value):
+                self._session_type_vars.add(name)
+
+        for name, value in assigns:
+            if name not in self._session_type_vars and self._derives_from_known_var(value):
+                self._session_type_vars.add(name)
+
+    @staticmethod
+    def _is_session_type_env_read(node: ast.expr) -> bool:
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == "AUTOSKILLIT_SESSION_TYPE"
+        ):
+            return True
+        return False
+
+    def _derives_from_known_var(self, node: ast.expr) -> bool:
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in self._session_type_vars
+        ):
+            return True
+        return False
+
+    def _involves_session_type(self, node: ast.Compare) -> bool:
+        for n in (node.left, *node.comparators):
+            if isinstance(n, ast.Name) and n.id in self._session_type_vars:
+                return True
+            if self._is_session_type_env_read(n):
+                return True
+        return False
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        if self._involves_session_type(node):
+            for val in (node.left, *node.comparators):
+                if isinstance(val, ast.Constant) and isinstance(val.value, str):
+                    self.found.add(val.value)
+                elif isinstance(val, (ast.Tuple, ast.Set)):
+                    for elt in val.elts:
+                        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                            self.found.add(elt.value)
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if (
+            len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and "SESSION_TYPE" in node.targets[0].id.upper()
+        ):
+            self._collect_frozenset_strings(node.value)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if (
+            isinstance(node.target, ast.Name)
+            and "SESSION_TYPE" in node.target.id.upper()
+            and node.value is not None
+        ):
+            self._collect_frozenset_strings(node.value)
+        self.generic_visit(node)
+
+    def _collect_frozenset_strings(self, value: ast.expr) -> None:
+        if (
+            isinstance(value, ast.Call)
+            and isinstance(value.func, ast.Name)
+            and value.func.id == "frozenset"
+            and len(value.args) == 1
+            and isinstance(value.args[0], ast.Set)
+        ):
+            for elt in value.args[0].elts:
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                    self.found.add(elt.value)
+
+
+def test_session_type_hook_strings_match_enum() -> None:
+    from autoskillit.core import pkg_root
+    from autoskillit.core.types._type_enums import SessionType
+
+    hooks_root = pkg_root() / "hooks"
+    found_literals: set[str] = set()
+
+    for py_file in sorted(hooks_root.rglob("*.py")):
+        try:
+            source = py_file.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        if "AUTOSKILLIT_SESSION_TYPE" not in source:
+            continue
+
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+
+        visitor = _SessionTypeStringVisitor()
+        visitor.visit(tree)
+        found_literals |= visitor.found
+
+    assert found_literals, (
+        "No session type string literals found in any hook file — scanner may need updating"
+    )
+
+    valid_values = {m.value for m in SessionType}
+    unrecognized = found_literals - valid_values
+    assert not unrecognized, (
+        f"Unrecognized session type literals in hook files: {sorted(unrecognized)}. "
+        f"Valid SessionType values: {sorted(valid_values)}"
+    )

--- a/tests/arch/test_backend_stdlib_boundaries.py
+++ b/tests/arch/test_backend_stdlib_boundaries.py
@@ -74,9 +74,10 @@ def test_write_guard_fallback_matches_claude_code_capabilities() -> None:
 class _SessionTypeStringVisitor(ast.NodeVisitor):
     """Collects string literals compared against AUTOSKILLIT_SESSION_TYPE values.
 
-    Two-pass scoped visitor: first discovers which variables hold session type
-    values (from os.environ.get reads), then only collects strings from Compare
-    nodes involving those variables and from SESSION_TYPE-named frozenset constants.
+    Fixed-point scoped visitor: first discovers which variables hold session type
+    values (from os.environ.get reads), then propagates through derived assignments
+    until convergence, then collects strings from Compare nodes and SESSION_TYPE
+    frozenset constants involving those variables.
     """
 
     def __init__(self) -> None:
@@ -101,9 +102,12 @@ class _SessionTypeStringVisitor(ast.NodeVisitor):
             if self._is_session_type_env_read(value):
                 self._session_type_vars.add(name)
 
-        for name, value in assigns:
-            if name not in self._session_type_vars and self._derives_from_known_var(value):
-                self._session_type_vars.add(name)
+        prev_size = -1
+        while len(self._session_type_vars) > prev_size:
+            prev_size = len(self._session_type_vars)
+            for name, value in assigns:
+                if name not in self._session_type_vars and self._derives_from_known_var(value):
+                    self._session_type_vars.add(name)
 
     @staticmethod
     def _is_session_type_env_read(node: ast.expr) -> bool:

--- a/tests/arch/test_backend_stdlib_boundaries.py
+++ b/tests/arch/test_backend_stdlib_boundaries.py
@@ -217,3 +217,8 @@ def test_session_type_hook_strings_match_enum() -> None:
         f"Unrecognized session type literals in hook files: {sorted(unrecognized)}. "
         f"Valid SessionType values: {sorted(valid_values)}"
     )
+    missing = valid_values - found_literals
+    assert not missing, (
+        f"SessionType values not referenced in any hook file: {sorted(missing)}. "
+        "A hook may have been refactored to a pattern the scanner no longer recognises."
+    )


### PR DESCRIPTION
## Summary

Create `tests/arch/test_backend_stdlib_boundaries.py` with two AST-based structural tests:
1. `test_write_guard_fallback_matches_claude_code_capabilities` — parses `write_guard.py` via AST to extract the `effective_tool_names` fallback frozenset and asserts it equals `CLAUDE_CODE_CAPABILITIES.write_guard_tool_names`, preventing silent drift between the two parallel registries.
2. `test_session_type_hook_strings_match_enum` — scans all `.py` files under `hooks/` for string literals compared against `AUTOSKILLIT_SESSION_TYPE` (across three syntactic patterns) and asserts the union is a subset of `SessionType` enum values, preventing typo-based session-tier bugs.

Additionally update `tests/arch/AGENTS.md` to register the new test file (required by `test_tests_sub_claude_md_covers_all_py_files` completeness guard).

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260608-145234-526272/.autoskillit/temp/make-plan/t4_p2_a4_wp1_backend_stdlib_boundaries_plan_2026-06-08_145600.md`

Closes #3921

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 102 | 25.6k | 1.9M | 91.8k | 69 | 115.2k | 15m 9s |
| verify* | sonnet | 1 | 60 | 9.2k | 289.8k | 55.9k | 21 | 34.2k | 4m 13s |
| implement* | MiniMax-M3 | 1 | 71.1k | 6.8k | 1.9M | 68.8k | 69 | 0 | 9m 20s |
| audit_impl* | sonnet | 1 | 335 | 6.9k | 350.3k | 48.0k | 27 | 27.1k | 3m 34s |
| prepare_pr* | MiniMax-M3 | 1 | 45.8k | 3.1k | 166.8k | 47.9k | 12 | 0 | 1m 18s |
| compose_pr* | MiniMax-M3 | 1 | 37.1k | 2.0k | 149.6k | 39.0k | 12 | 0 | 59s |
| review_pr* | sonnet | 2 | 268 | 74.3k | 1.8M | 90.9k | 101 | 133.0k | 15m 16s |
| resolve_review* | sonnet | 1 | 325 | 18.3k | 3.0M | 98.2k | 89 | 77.4k | 8m 5s |
| **Total** | | | 155.0k | 146.2k | 9.6M | 98.2k | | 386.9k | 57m 56s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 216 | 8588.5 | 0.0 | 31.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 21 | 144026.0 | 3687.9 | 871.9 |
| **Total** | **237** | 40301.3 | 1632.4 | 616.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 102 | 25.6k | 1.9M | 115.2k | 15m 9s |
| sonnet | 4 | 988 | 108.7k | 5.4M | 271.7k | 31m 8s |
| MiniMax-M3 | 3 | 154.0k | 11.9k | 2.2M | 0 | 11m 37s |