### PR TITLE
Implementation Plan: Make ClaudeSessionLocator and CodexSessionLocator Nominally Subclass SessionLocator and Resolve codex_home Protocol Drift

### DIFF
--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -41,6 +41,7 @@ from autoskillit.core import (
     ResumeSpec,
     SessionCheckpoint,
     SessionEvent,
+    SessionLocator,
     SkillSessionConfig,
     ValidatedAddDir,
     YAMLError,
@@ -93,7 +94,7 @@ class ClaudeEnvPolicy:
 
 
 @dataclass(frozen=True, slots=True)
-class ClaudeSessionLocator:
+class ClaudeSessionLocator(SessionLocator):
     def locate_session(self, session_id: str) -> Path | None:
         if not session_id or session_id.startswith(("no_session_", "crashed_")):
             return None

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -46,6 +46,7 @@ from autoskillit.core import (
     PluginSource,
     ResumeSpec,
     SessionCheckpoint,
+    SessionLocator,
     SkillSessionConfig,
     ValidatedAddDir,
     atomic_write,
@@ -237,8 +238,10 @@ _SESSION_START_TYPES: frozenset[str] = frozenset(
 
 
 @dataclass(frozen=True, slots=True)
-class CodexSessionLocator:
-    def locate_session(self, session_id: str, codex_home: Path | None = None) -> Path | None:
+class CodexSessionLocator(SessionLocator):
+    codex_home: Path | None = None
+
+    def locate_session(self, session_id: str) -> Path | None:
         if not session_id or session_id.startswith(("no_session_", "crashed_")):
             return None
 
@@ -247,8 +250,8 @@ class CodexSessionLocator:
         #    ephemeral CODEX_HOME may be cleaned up by the time we search
         candidates.append(default_log_dir() / "codex-sessions")
         # 2. Explicit codex_home or CODEX_HOME env var
-        if codex_home is not None:
-            candidates.append(codex_home / "sessions")
+        if self.codex_home is not None:
+            candidates.append(self.codex_home / "sessions")
         else:
             env_home = os.environ.get("CODEX_HOME")
             if env_home:

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -971,12 +971,15 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "for fabricated skill name rejection add defense-in-depth checks",
     ),
     "execution/backends/codex.py": (
-        1031,
+        1034,
         "REQ-CNST-010-E9: Codex backend — skill_sigil capability threading adds multi-line "
         "keyword args to _ensure_skill_prefix call sites and _has_prefix guard; "
         "write_guard_tool_names env injection adds 7 lines to _codex_exec_extras; "
         "session_meta NDJSON support and process_name_aliases add ~8 lines; "
-        "explicit plugin_install_capable + supports_context_window_suffix kwargs for arch guard",
+        "explicit plugin_install_capable + supports_context_window_suffix kwargs for arch guard; "
+        "CodexSessionLocator nominally subclasses SessionLocator Protocol with codex_home "
+        "promoted from locate_session parameter to frozen dataclass field (3 net lines: "
+        "field declaration, blank line between field and method, SessionLocator in import block)",
     ),
 }
 

--- a/tests/contracts/test_backend_compliance.py
+++ b/tests/contracts/test_backend_compliance.py
@@ -96,6 +96,13 @@ class TestBackendCompliance:
         for cls in BACKEND_REGISTRY.values():
             assert isinstance(cls().session_locator(), SessionLocator)
 
+    def test_locator_classes_nominally_subclass_session_locator(self):
+        from autoskillit.core import SessionLocator
+        from autoskillit.execution.backends import ClaudeSessionLocator, CodexSessionLocator
+
+        assert SessionLocator in ClaudeSessionLocator.__mro__
+        assert SessionLocator in CodexSessionLocator.__mro__
+
     def test_all_backends_capabilities_is_backend_capabilities(self):
         from autoskillit.core import BackendCapabilities
         from autoskillit.execution.backends import BACKEND_REGISTRY

--- a/tests/execution/AGENTS.md
+++ b/tests/execution/AGENTS.md
@@ -146,7 +146,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_backend_registry.py` | Tests for backend registry |
 | `test_codex_backend.py` | Tests for CodexFlags, CodexBackend protocol conformance, headless/resume command builders, skill session cmd config adapter, food truck cmd builder |
 | `test_codex_interactive.py` | Parametrized structural validation of CodexBackend.build_interactive_cmd — resume variants, model, system_prompt suppression, add_dirs |
-| `test_codex_session_locator.py` | Tests for CodexSessionLocator: locate_session walk, read_session decompression, env/codex_home priority, protocol conformance |
+| `test_codex_session_locator.py` | Tests for CodexSessionLocator: locate_session walk, read_session decompression, codex_home constructor-field priority over env var, protocol conformance |
 | `test_codex_env_policy.py` | Tests for CodexEnvPolicy three-layer scrub |
 | `test_codex_mcp_registration.py` | Tests for ensure_codex_mcp_registered: file creation, TOML fields, idempotency, foreign section preservation, dir creation |
 | `test_codex_stream_parser.py` | Full test suite for CodexStreamParser: happy-path, item parsing, degradation, fixture-driven integration, protocol conformance |

--- a/tests/execution/backends/test_codex_session_locator.py
+++ b/tests/execution/backends/test_codex_session_locator.py
@@ -34,8 +34,8 @@ class TestCodexSessionLocator:
         session_dir = tmp_path / "sessions" / "2026" / "05" / "26"
         session_dir.mkdir(parents=True)
         rollout = _make_rollout(session_dir, "tid_abc123")
-        locator = CodexSessionLocator()
-        result = locator.locate_session("tid_abc123", codex_home=tmp_path)
+        locator = CodexSessionLocator(codex_home=tmp_path)
+        result = locator.locate_session("tid_abc123")
         assert result == rollout
 
     def test_locate_session_skips_non_matching_thread_id(self, tmp_path: Path) -> None:
@@ -98,8 +98,8 @@ class TestCodexSessionLocator:
         assert locator.locate_session("crashed_xyz789") is None
 
     def test_locate_session_returns_none_when_sessions_dir_absent(self, tmp_path: Path) -> None:
-        locator = CodexSessionLocator()
-        result = locator.locate_session("any_id", codex_home=tmp_path)
+        locator = CodexSessionLocator(codex_home=tmp_path)
+        result = locator.locate_session("any_id")
         assert result is None
 
     def test_codex_home_priority_over_env_var(
@@ -119,8 +119,8 @@ class TestCodexSessionLocator:
 
         monkeypatch.setenv("CODEX_HOME", str(env_path))
 
-        locator = CodexSessionLocator()
-        result = locator.locate_session("tid_priority", codex_home=param_path)
+        locator = CodexSessionLocator(codex_home=param_path)
+        result = locator.locate_session("tid_priority")
 
         assert result == rollout
 
@@ -200,6 +200,6 @@ class TestCodexSessionLocator:
         session_dir = tmp_path / "sessions" / "2026" / "05" / "26"
         session_dir.mkdir(parents=True)
         rollout = _make_rollout(session_dir, "tid_meta", fmt="session_meta")
-        locator = CodexSessionLocator()
-        result = locator.locate_session("tid_meta", codex_home=tmp_path)
+        locator = CodexSessionLocator(codex_home=tmp_path)
+        result = locator.locate_session("tid_meta")
         assert result == rollout


### PR DESCRIPTION
## Summary

Add `SessionLocator` as an explicit base class to both `ClaudeSessionLocator` and `CodexSessionLocator`, and resolve the Protocol drift where `CodexSessionLocator.locate_session` accepts an extra `codex_home` parameter not declared in the `SessionLocator` Protocol. The `codex_home` parameter becomes a dataclass field on `CodexSessionLocator`, and the 4 test call sites that pass `codex_home=` to `locate_session` are converted to pass it at construction time instead.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-3922-20260609-073203-264932/.autoskillit/temp/make-plan/impl_3922_sessionlocator_subclass_plan_2026-06-09_073600.md`

Closes #3922

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 2.9k | 8.7k | 1.1M | 89.2k | 37 | 89.8k | 8m 21s |
| verify* | sonnet | 1 | 102 | 11.0k | 634.0k | 66.9k | 38 | 45.2k | 4m 39s |
| implement* | MiniMax-M3 | 1 | 2.2M | 13.6k | 0 | 0 | 105 | 0 | 9m 0s |
| audit_impl* | sonnet | 1 | 44 | 7.8k | 169.4k | 42.5k | 15 | 28.5k | 3m 39s |
| prepare_pr* | MiniMax-M3 | 1 | 241.7k | 2.6k | 0 | 0 | 17 | 0 | 1m 15s |
| compose_pr* | MiniMax-M3 | 1 | 221.3k | 912 | 0 | 0 | 11 | 0 | 47s |
| review_pr* | sonnet | 3 | 416 | 81.6k | 2.5M | 77.3k | 127 | 161.7k | 18m 28s |
| **Total** | | | 2.7M | 126.2k | 4.4M | 89.2k | | 325.2k | 46m 12s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 46 | 0.0 | 0.0 | 295.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **46** | 95202.7 | 7070.0 | 2743.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.9k | 8.7k | 1.1M | 89.8k | 8m 21s |
| sonnet | 3 | 562 | 100.4k | 3.3M | 235.4k | 26m 47s |
| MiniMax-M3 | 3 | 2.7M | 17.1k | 0 | 0 | 11m 3s |