### PR TITLE
Implementation Plan: T4-P4-A1-WP1 BackendContractBase ABC Mixin

### DIFF
--- a/tests/execution/backends/test_backend_contract_base.py
+++ b/tests/execution/backends/test_backend_contract_base.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import abc
+import dataclasses
+
+import pytest
+
+from autoskillit.core import BackendCapabilities, CodingAgentBackend
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class BackendContractBase(abc.ABC):
+    @abc.abstractmethod
+    def make_backend(self) -> CodingAgentBackend: ...
+
+    def _require_capability(self, cap: str) -> None:
+        valid = {f.name for f in dataclasses.fields(BackendCapabilities)}
+        if cap not in valid:
+            raise AttributeError(
+                f"{cap!r} is not a field of BackendCapabilities; valid fields: {sorted(valid)}"
+            )
+        if not getattr(self.make_backend().capabilities, cap):
+            pytest.skip(f"{cap!r} not supported by this backend")

--- a/tests/execution/backends/test_backend_contract_base_verify.py
+++ b/tests/execution/backends/test_backend_contract_base_verify.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import ast
-import inspect
+import typing
 from pathlib import Path
 
 import pytest
@@ -49,7 +49,7 @@ class TestBackendContractBaseStructure:
         assert getattr(BackendContractBase.make_backend, "__isabstractmethod__", False)
 
     def test_make_backend_return_annotation(self) -> None:
-        hints = inspect.get_type_hints(BackendContractBase.make_backend)
+        hints = typing.get_type_hints(BackendContractBase.make_backend)
         assert hints["return"] is CodingAgentBackend
 
     def test_pytest_does_not_collect_mixin(self) -> None:

--- a/tests/execution/backends/test_backend_contract_base_verify.py
+++ b/tests/execution/backends/test_backend_contract_base_verify.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core import BackendCapabilities, CodingAgentBackend
+from tests.execution.backends.test_backend_contract_base import BackendContractBase
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+MIXIN_SOURCE = Path(__file__).parent / "test_backend_contract_base.py"
+
+
+class _StubBackend:
+    """Minimal stub satisfying CodingAgentBackend.capabilities for testing."""
+
+    def __init__(self, capabilities: BackendCapabilities) -> None:
+        self._caps = capabilities
+
+    @property
+    def name(self) -> str:
+        return "stub"
+
+    @property
+    def capabilities(self) -> BackendCapabilities:
+        return self._caps
+
+
+class ConcreteContract(BackendContractBase):
+    """Concrete subclass for testing the ABC mixin."""
+
+    def __init__(self, caps: BackendCapabilities | None = None) -> None:
+        self._caps = caps or BackendCapabilities()
+
+    def make_backend(self) -> CodingAgentBackend:
+        return _StubBackend(self._caps)  # type: ignore[return-value]
+
+
+class TestBackendContractBaseStructure:
+    def test_mixin_is_importable_and_is_abc(self) -> None:
+        import abc
+
+        assert issubclass(BackendContractBase, abc.ABC)
+
+    def test_make_backend_is_abstract(self) -> None:
+        assert getattr(BackendContractBase.make_backend, "__isabstractmethod__", False)
+
+    def test_make_backend_return_annotation(self) -> None:
+        hints = inspect.get_type_hints(BackendContractBase.make_backend)
+        assert hints["return"] is CodingAgentBackend
+
+    def test_pytest_does_not_collect_mixin(self) -> None:
+        assert not BackendContractBase.__name__.startswith("Test")
+
+    def test_pytestmark_correct(self) -> None:
+        import tests.execution.backends.test_backend_contract_base as mod
+
+        assert mod.pytestmark == [
+            pytest.mark.layer("execution"),
+            pytest.mark.small,
+        ]
+
+    def test_no_test_functions_in_mixin_file(self) -> None:
+        tree = ast.parse(MIXIN_SOURCE.read_text())
+        test_funcs = [
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name.startswith("test_")
+        ]
+        assert test_funcs == [], f"Found test functions: {test_funcs}"
+
+    def test_no_autouse_fixture_in_mixin_file(self) -> None:
+        source = MIXIN_SOURCE.read_text()
+        assert "autouse" not in source
+
+    def test_no_headless_exclusive_vars_import(self) -> None:
+        tree = ast.parse(MIXIN_SOURCE.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                source_text = ast.get_source_segment(MIXIN_SOURCE.read_text(), node)
+                assert "_HEADLESS_EXCLUSIVE_VARS" not in (source_text or "")
+
+
+class TestRequireCapability:
+    def test_raises_on_unknown_field(self) -> None:
+        contract = ConcreteContract()
+        with pytest.raises(AttributeError, match="nonexistent_field"):
+            contract._require_capability("nonexistent_field")
+
+    def test_skips_when_capability_is_false(self) -> None:
+        contract = ConcreteContract(BackendCapabilities(channel_b_capable=False))
+        with pytest.raises(pytest.skip.Exception):
+            contract._require_capability("channel_b_capable")
+
+    def test_does_not_skip_when_capability_is_true(self) -> None:
+        contract = ConcreteContract(BackendCapabilities(supports_tool_list_changed=True))
+        result = contract._require_capability("supports_tool_list_changed")
+        assert result is None

--- a/tests/execution/backends/test_backend_contract_base_verify.py
+++ b/tests/execution/backends/test_backend_contract_base_verify.py
@@ -73,8 +73,13 @@ class TestBackendContractBaseStructure:
         assert test_funcs == [], f"Found test functions: {test_funcs}"
 
     def test_no_autouse_fixture_in_mixin_file(self) -> None:
-        source = MIXIN_SOURCE.read_text()
-        assert "autouse" not in source
+        tree = ast.parse(MIXIN_SOURCE.read_text())
+        autouse_nodes = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.keyword) and node.arg == "autouse"
+        ]
+        assert autouse_nodes == [], "Found autouse keyword argument in mixin file"
 
     def test_no_headless_exclusive_vars_import(self) -> None:
         tree = ast.parse(MIXIN_SOURCE.read_text())


### PR DESCRIPTION
## Summary

Create `tests/execution/backends/test_backend_contract_base.py` containing a `BackendContractBase` ABC mixin that future conformance test classes (P4-A2 through P4-A4) will inherit. The mixin provides an abstract `make_backend()` factory method and a `_require_capability()` skip gate that validates capability field names via `dataclasses.fields(BackendCapabilities)` before checking the bool value.

The verification tests live in a separate file `tests/execution/backends/test_backend_contract_base_verify.py` to keep the mixin file free of `test_*` functions and ensure pytest does not collect it as a test class.

Closes #3935

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-3935-20260609-083029-026107/.autoskillit/temp/make-plan/t4_p4_a1_wp1_backend_contract_base_plan_2026-06-09_090000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 46 | 6.7k | 555.8k | 67.1k | 21 | 49.4k | 3m 30s |
| verify* | sonnet | 1 | 2.3k | 8.5k | 272.5k | 51.3k | 20 | 29.7k | 3m 31s |
| implement* | MiniMax-M3 | 1 | 588.8k | 4.4k | 0 | 0 | 32 | 0 | 3m 4s |
| fix* | sonnet | 1 | 142 | 5.1k | 797.5k | 58.5k | 45 | 36.8k | 3m 4s |
| audit_impl* | sonnet | 1 | 44 | 7.8k | 168.7k | 41.6k | 15 | 28.1k | 3m 4s |
| prepare_pr* | MiniMax-M3 | 1 | 198.6k | 1.8k | 0 | 0 | 11 | 0 | 1m 10s |
| compose_pr* | MiniMax-M3 | 1 | 313.7k | 2.0k | 0 | 0 | 18 | 0 | 1m 20s |
| review_pr* | sonnet | 1 | 156 | 27.1k | 1.1M | 85.3k | 50 | 64.1k | 7m 13s |
| resolve_review* | sonnet | 1 | 141 | 8.2k | 930.0k | 67.2k | 44 | 45.9k | 4m 25s |
| resolve_pre_review_conflicts* | sonnet | 1 | 92 | 3.0k | 415.5k | 43.6k | 25 | 22.0k | 1m 4s |
| **Total** | | | 1.1M | 74.7k | 4.3M | 85.3k | | 275.9k | 31m 29s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 125 | 0.0 | 0.0 | 35.2 |
| fix | 4 | 199386.8 | 9209.5 | 1280.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 9 | 103335.2 | 5102.8 | 908.8 |
| resolve_pre_review_conflicts | 0 | — | — | — |
| **Total** | **138** | 31023.2 | 1999.4 | 541.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 46 | 6.7k | 555.8k | 49.4k | 3m 30s |
| sonnet | 6 | 2.8k | 59.8k | 3.7M | 226.6k | 22m 23s |
| MiniMax-M3 | 3 | 1.1M | 8.2k | 0 | 0 | 5m 35s |