### PR TITLE
Implementation Plan: T4-P3-A3-WP1 Extend SessionLocator Protocol with project_log_dir

### DIFF
--- a/src/autoskillit/core/types/_type_protocols_backend.py
+++ b/src/autoskillit/core/types/_type_protocols_backend.py
@@ -67,6 +67,8 @@ class SessionLocator(Protocol):
 
     def locate_session(self, session_id: str) -> Path | None: ...
 
+    def project_log_dir(self, cwd: str) -> Path: ...
+
 
 @runtime_checkable
 class CodingAgentBackend(Protocol):

--- a/src/autoskillit/core/types/_type_protocols_backend.py
+++ b/src/autoskillit/core/types/_type_protocols_backend.py
@@ -67,7 +67,13 @@ class SessionLocator(Protocol):
 
     def locate_session(self, session_id: str) -> Path | None: ...
 
-    def project_log_dir(self, cwd: str) -> Path: ...
+    def project_log_dir(self, cwd: str) -> Path:
+        """Return the log directory for the given project.
+
+        ``cwd`` is a hint — implementations MAY ignore it when the backend
+        uses a global session store rather than per-project directories.
+        """
+        ...
 
 
 @runtime_checkable

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -46,6 +46,7 @@ from autoskillit.core import (
     ValidatedAddDir,
     YAMLError,
     build_agent_env,
+    claude_code_project_dir,
     extract_skill_name,
     fast_loads,
     load_yaml,
@@ -108,6 +109,9 @@ class ClaudeSessionLocator(SessionLocator):
             if candidate.exists():
                 return candidate
         return None
+
+    def project_log_dir(self, cwd: str) -> Path:
+        return claude_code_project_dir(cwd)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -365,6 +365,9 @@ class CodexSessionLocator(SessionLocator):
                 result.append(obj)
         return result
 
+    def project_log_dir(self, cwd: str) -> Path:
+        return default_log_dir() / "codex-sessions"
+
 
 def _validate_codex_config() -> list[str]:
     """Run codex doctor --json and check config.load status."""

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -365,7 +365,7 @@ class CodexSessionLocator(SessionLocator):
                 result.append(obj)
         return result
 
-    def project_log_dir(self, cwd: str) -> Path:
+    def project_log_dir(self, cwd: str) -> Path:  # cwd unused; Codex uses a global session store
         return default_log_dir() / "codex-sessions"
 
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -971,7 +971,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "for fabricated skill name rejection add defense-in-depth checks",
     ),
     "execution/backends/codex.py": (
-        1034,
+        1037,
         "REQ-CNST-010-E9: Codex backend — skill_sigil capability threading adds multi-line "
         "keyword args to _ensure_skill_prefix call sites and _has_prefix guard; "
         "write_guard_tool_names env injection adds 7 lines to _codex_exec_extras; "
@@ -979,7 +979,8 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "explicit plugin_install_capable + supports_context_window_suffix kwargs for arch guard; "
         "CodexSessionLocator nominally subclasses SessionLocator Protocol with codex_home "
         "promoted from locate_session parameter to frozen dataclass field (3 net lines: "
-        "field declaration, blank line between field and method, SessionLocator in import block)",
+        "field declaration, blank line between field and method, SessionLocator in import block)"
+        "; project_log_dir method added to CodexSessionLocator (+3 net lines)",
     ),
 }
 

--- a/tests/contracts/test_backend_compliance.py
+++ b/tests/contracts/test_backend_compliance.py
@@ -103,6 +103,19 @@ class TestBackendCompliance:
         assert SessionLocator in ClaudeSessionLocator.__mro__
         assert SessionLocator in CodexSessionLocator.__mro__
 
+    def test_all_backends_project_log_dir_returns_path(self):
+        from pathlib import Path
+
+        from autoskillit.execution.backends import BACKEND_REGISTRY
+        from autoskillit.execution.backends.codex import CodexBackend  # noqa: F401
+
+        for cls in BACKEND_REGISTRY.values():
+            locator = cls().session_locator()
+            result = locator.project_log_dir("/tmp")
+            assert isinstance(result, Path), (
+                f"{type(locator).__name__}.project_log_dir must return Path"
+            )
+
     def test_all_backends_capabilities_is_backend_capabilities(self):
         from autoskillit.core import BackendCapabilities
         from autoskillit.execution.backends import BACKEND_REGISTRY

--- a/tests/core/test_backend_protocols.py
+++ b/tests/core/test_backend_protocols.py
@@ -48,6 +48,12 @@ def test_coding_agent_backend_has_setup_session_dir_method():
     assert callable(getattr(CodingAgentBackend, "setup_session_dir", None))
 
 
+def test_session_locator_has_project_log_dir_method():
+    from autoskillit.core import SessionLocator
+
+    assert callable(getattr(SessionLocator, "project_log_dir", None))
+
+
 def test_no_autoskillit_imports_in_protocols_backend():
     from autoskillit.core import paths
 

--- a/tests/execution/backends/test_claude_session_locator.py
+++ b/tests/execution/backends/test_claude_session_locator.py
@@ -75,11 +75,3 @@ class TestClaudeSessionLocator:
         locator = ClaudeSessionLocator()
         result = locator.project_log_dir("/some/project/path")
         assert result == fake_home / ".claude" / "projects" / "-some-project-path"
-
-    def test_project_log_dir_return_type_is_path(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        locator = ClaudeSessionLocator()
-        result = locator.project_log_dir("/any/cwd")
-        assert isinstance(result, Path)

--- a/tests/execution/backends/test_claude_session_locator.py
+++ b/tests/execution/backends/test_claude_session_locator.py
@@ -65,3 +65,21 @@ class TestClaudeSessionLocator:
         locator = ClaudeSessionLocator()
         with pytest.raises((FrozenInstanceError, TypeError)):
             locator.some_attr = "value"  # type: ignore[misc]
+
+    def test_project_log_dir_returns_claude_project_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        fake_home = tmp_path / "homedir"
+        fake_home.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        locator = ClaudeSessionLocator()
+        result = locator.project_log_dir("/some/project/path")
+        assert result == fake_home / ".claude" / "projects" / "-some-project-path"
+
+    def test_project_log_dir_return_type_is_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        locator = ClaudeSessionLocator()
+        result = locator.project_log_dir("/any/cwd")
+        assert isinstance(result, Path)

--- a/tests/execution/backends/test_codex_session_locator.py
+++ b/tests/execution/backends/test_codex_session_locator.py
@@ -203,3 +203,31 @@ class TestCodexSessionLocator:
         locator = CodexSessionLocator(codex_home=tmp_path)
         result = locator.locate_session("tid_meta")
         assert result == rollout
+
+    def test_project_log_dir_returns_codex_sessions_subdir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.default_log_dir", lambda: tmp_path / "logs"
+        )
+        locator = CodexSessionLocator()
+        result = locator.project_log_dir("/any/cwd")
+        assert result == tmp_path / "logs" / "codex-sessions"
+
+    def test_project_log_dir_ignores_cwd_argument(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.default_log_dir", lambda: tmp_path / "logs"
+        )
+        locator = CodexSessionLocator()
+        assert locator.project_log_dir("/path/a") == locator.project_log_dir("/path/b")
+
+    def test_project_log_dir_return_type_is_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "autoskillit.execution.backends.codex.default_log_dir", lambda: tmp_path / "logs"
+        )
+        locator = CodexSessionLocator()
+        assert isinstance(locator.project_log_dir("/x"), Path)

--- a/tests/execution/backends/test_codex_session_locator.py
+++ b/tests/execution/backends/test_codex_session_locator.py
@@ -222,12 +222,3 @@ class TestCodexSessionLocator:
         )
         locator = CodexSessionLocator()
         assert locator.project_log_dir("/path/a") == locator.project_log_dir("/path/b")
-
-    def test_project_log_dir_return_type_is_path(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(
-            "autoskillit.execution.backends.codex.default_log_dir", lambda: tmp_path / "logs"
-        )
-        locator = CodexSessionLocator()
-        assert isinstance(locator.project_log_dir("/x"), Path)


### PR DESCRIPTION
## Summary

Add a `project_log_dir(cwd: str) -> Path` method stub to the `SessionLocator` Protocol and implement it on both `ClaudeSessionLocator` (delegates to `claude_code_project_dir`) and `CodexSessionLocator` (returns `default_log_dir() / 'codex-sessions'`). This extends the protocol so downstream consumers can resolve backend-specific project log directories through a uniform interface.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-3923-20260609-095340-040702/.autoskillit/temp/make-plan/t4_p3_a3_wp1_extend_sessionlocator_protocol_plan_2026-06-09_095700.md`

Closes #3923

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 64 | 13.4k | 1.4M | 97.0k | 46 | 78.9k | 9m 16s |
| verify* | sonnet | 1 | 62 | 6.2k | 282.6k | 52.4k | 24 | 30.7k | 4m 36s |
| implement* | MiniMax-M3 | 1 | 2.8M | 10.6k | 0 | 0 | 76 | 0 | 5m 44s |
| audit_impl* | sonnet | 1 | 366 | 6.5k | 210.2k | 43.3k | 17 | 28.1k | 2m 54s |
| prepare_pr* | MiniMax-M3 | 1 | 275.0k | 1.8k | 0 | 0 | 14 | 0 | 49s |
| compose_pr* | MiniMax-M3 | 1 | 222.5k | 1.4k | 0 | 0 | 12 | 0 | 41s |
| review_pr* | sonnet | 1 | 118 | 24.3k | 705.5k | 73.5k | 35 | 52.8k | 5m 48s |
| resolve_review* | sonnet | 1 | 151 | 13.8k | 1.1M | 81.1k | 54 | 60.0k | 6m 37s |
| **Total** | | | 3.3M | 78.1k | 3.7M | 97.0k | | 250.5k | 36m 28s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 79 | 0.0 | 0.0 | 134.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 27 | 41423.8 | 2221.0 | 512.8 |
| **Total** | **106** | 34749.3 | 2362.9 | 736.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 64 | 13.4k | 1.4M | 78.9k | 9m 16s |
| sonnet | 4 | 697 | 50.9k | 2.3M | 171.6k | 19m 56s |
| MiniMax-M3 | 3 | 3.3M | 13.8k | 0 | 0 | 7m 14s |