### PR TITLE
Implementation Plan: Backend-Conditional Routing — gate_backend_write Step

### DIFF
--- a/src/autoskillit/recipe/rules/rules_backend_compat.py
+++ b/src/autoskillit/recipe/rules/rules_backend_compat.py
@@ -54,6 +54,8 @@ def _check_backend_incompatible_skill(ctx: ValidationContext) -> list[RuleFindin
                 if cap_def and _GIT_METADATA_WRITE_CAP in uses_caps
                 else ""
             )
+            is_guarded = bool(step.skip_when_false or step.skip_when_true or step.optional)
+            effective_severity = Severity.WARNING if is_guarded else Severity.ERROR
             findings.append(
                 make_finding(
                     rule_name="backend-incompatible-skill",
@@ -63,6 +65,7 @@ def _check_backend_incompatible_skill(ctx: ValidationContext) -> list[RuleFindin
                         f"{sorted(skill_info.backend_requirements)} but recipe targets "
                         f"backend '{ctx.backend_name}'.{git_detail}"
                     ),
+                    severity=effective_severity,
                 )
             )
     return findings

--- a/src/autoskillit/recipe/rules/rules_inputs.py
+++ b/src/autoskillit/recipe/rules/rules_inputs.py
@@ -508,6 +508,7 @@ _KNOWN_CONFIG_AUTHORITY_KEYS: frozenset[str] = frozenset(
         "post_run_diagnostics",
         "is_fleet_dispatch",
         "dispatch_id",
+        "backend_supports_git_write",
     }
 )
 

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2645,6 +2645,14 @@ callable_contracts:
     outputs:
     - name: merge_queue_data_path
       type: file_path
+  autoskillit.smoke_utils.gate_backend_write:
+    inputs:
+    - name: backend_supports_git_write
+      type: str
+      required: false
+    outputs:
+    - name: backend_capable
+      type: str
   autoskillit.planner.validate_plan:
     inputs:
     - name: output_dir

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -285,7 +285,7 @@
       },
       "retries": 0,
       "on_context_limit": "retry_worktree",
-      "on_success": "test",
+      "on_success": "gate_backend_write",
       "on_failure": "release_issue_failure",
       "optional": true,
       "skip_when_false": "inputs.backend_supports_git_write",
@@ -319,6 +319,23 @@
       "on_failure": "release_issue_failure",
       "optional": true,
       "skip_when_false": "inputs.backend_supports_git_write"
+    },
+    "gate_backend_write": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.gate_backend_write",
+        "backend_supports_git_write": "${{ inputs.backend_supports_git_write }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.backend_capable }} == false",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "test"
+        }
+      ],
+      "on_failure": "release_issue_failure"
     },
     "test": {
       "tool": "test_check",

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -45,6 +45,12 @@
       "description": "Generate architecture lens diagrams for the PR",
       "default": "false"
     },
+    "backend_supports_git_write": {
+      "description": "Whether the session backend supports .git/ metadata writes (git commit, rebase, worktree add). Resolved from backend capabilities at load time.",
+      "default": "true",
+      "hidden": true,
+      "authority": "config"
+    },
     "auto_merge": {
       "description": "Automatically merge the PR after required checks pass — via merge queue when available, direct merge otherwise",
       "default": "true"
@@ -281,6 +287,8 @@
       "on_context_limit": "retry_worktree",
       "on_success": "test",
       "on_failure": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "note": "Extracts worktree_path from result for use in subsequent steps."
     },
     "retry_worktree": {
@@ -308,7 +316,9 @@
       ],
       "on_context_limit": "test",
       "on_exhausted": "release_issue_failure",
-      "on_failure": "release_issue_failure"
+      "on_failure": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write"
     },
     "test": {
       "tool": "test_check",
@@ -617,6 +627,8 @@
       "on_failure": "release_issue_failure",
       "on_context_limit": "release_issue_failure",
       "on_rate_limit": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "optional_context_refs": [
         "merge_gate_ci_conclusion",
         "merge_gate_diagnosis_path"
@@ -689,6 +701,8 @@
       "on_failure": "release_issue_failure",
       "on_context_limit": "release_issue_failure",
       "on_rate_limit": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "optional_context_refs": [
         "merge_gate_ci_conclusion",
         "merge_gate_diagnosis_path"
@@ -752,7 +766,9 @@
       "on_failure": "release_issue_failure",
       "on_context_limit": "release_issue_failure",
       "retries": 1,
-      "on_exhausted": "release_issue_failure"
+      "on_exhausted": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write"
     },
     "inter_part_push": {
       "tool": "push_to_remote",
@@ -1080,6 +1096,8 @@
         }
       ],
       "on_failure": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "optional_context_refs": [
         "review_mode"
       ],
@@ -1129,7 +1147,9 @@
       "on_failure": "release_issue_failure",
       "on_context_limit": "release_issue_failure",
       "retries": 1,
-      "on_exhausted": "release_issue_failure"
+      "on_exhausted": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write"
     },
     "re_push_review": {
       "tool": "push_to_remote",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -32,6 +32,11 @@ ingredients:
   arch_lenses:
     description: Generate architecture lens diagrams for the PR
     default: "false"
+  backend_supports_git_write:
+    description: Whether the session backend supports .git/ metadata writes (git commit, rebase, worktree add). Resolved from backend capabilities at load time.
+    default: 'true'
+    hidden: true
+    authority: config
   auto_merge:
     description: >-
       Automatically merge the PR after required checks pass —
@@ -280,6 +285,8 @@ steps:
     on_context_limit: retry_worktree
     on_success: test
     on_failure: release_issue_failure
+    optional: true
+    skip_when_false: "inputs.backend_supports_git_write"
     note: "Extracts worktree_path from result for use in subsequent steps."
 
   retry_worktree:
@@ -301,6 +308,8 @@ steps:
     on_context_limit: test
     on_exhausted: release_issue_failure
     on_failure: release_issue_failure
+    optional: true
+    skip_when_false: "inputs.backend_supports_git_write"
 
   test:
     tool: test_check
@@ -563,6 +572,8 @@ steps:
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     on_rate_limit: release_issue_failure
+    optional: true
+    skip_when_false: "inputs.backend_supports_git_write"
     optional_context_refs:
     - merge_gate_ci_conclusion
     - merge_gate_diagnosis_path
@@ -614,6 +625,8 @@ steps:
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     on_rate_limit: release_issue_failure
+    optional: true
+    skip_when_false: "inputs.backend_supports_git_write"
     optional_context_refs:
     - merge_gate_ci_conclusion
     - merge_gate_diagnosis_path
@@ -667,6 +680,8 @@ steps:
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
+    optional: true
+    skip_when_false: "inputs.backend_supports_git_write"
 
   inter_part_push:
     tool: push_to_remote
@@ -961,6 +976,8 @@ steps:
     - when: "${{ result.verdict }} == 'ci_only_failure'"
       route: release_issue_failure
     on_failure: release_issue_failure
+    optional: true
+    skip_when_false: "inputs.backend_supports_git_write"
     optional_context_refs:
     - review_mode
     note: >
@@ -1003,6 +1020,8 @@ steps:
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
+    optional: true
+    skip_when_false: "inputs.backend_supports_git_write"
   re_push_review:
     tool: push_to_remote
     with:

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -283,7 +283,7 @@ steps:
       worktree_path: "${{ result.worktree_path }}"
     retries: 0
     on_context_limit: retry_worktree
-    on_success: test
+    on_success: gate_backend_write
     on_failure: release_issue_failure
     optional: true
     skip_when_false: "inputs.backend_supports_git_write"
@@ -310,6 +310,17 @@ steps:
     on_failure: release_issue_failure
     optional: true
     skip_when_false: "inputs.backend_supports_git_write"
+
+  gate_backend_write:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.gate_backend_write"
+      backend_supports_git_write: "${{ inputs.backend_supports_git_write }}"
+    on_result:
+    - when: "${{ result.backend_capable }} == false"
+      route: release_issue_failure
+    - route: test
+    on_failure: release_issue_failure
 
   test:
     tool: test_check

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -45,6 +45,12 @@
       "description": "Generate architecture lens diagrams for the PR",
       "default": "false"
     },
+    "backend_supports_git_write": {
+      "description": "Whether the session backend supports .git/ metadata writes (git commit, rebase, worktree add). Resolved from backend capabilities at load time.",
+      "default": "true",
+      "hidden": true,
+      "authority": "config"
+    },
     "auto_merge": {
       "description": "Automatically merge the PR after required checks pass — via merge queue when available, direct merge otherwise",
       "default": "true"
@@ -307,6 +313,8 @@
       "on_context_limit": "retry_worktree",
       "on_success": "check_changes",
       "on_failure": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "note": "Extracts worktree_path from result for use in subsequent steps."
     },
     "retry_worktree": {
@@ -339,7 +347,9 @@
       ],
       "on_context_limit": "check_changes",
       "on_exhausted": "release_issue_failure",
-      "on_failure": "release_issue_failure"
+      "on_failure": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write"
     },
     "check_changes": {
       "tool": "run_python",
@@ -717,6 +727,8 @@
       "on_failure": "release_issue_failure",
       "on_context_limit": "release_issue_failure",
       "on_rate_limit": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "optional_context_refs": [
         "merge_gate_ci_conclusion",
         "merge_gate_diagnosis_path"
@@ -790,6 +802,8 @@
       "on_failure": "release_issue_failure",
       "on_context_limit": "release_issue_failure",
       "on_rate_limit": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "optional_context_refs": [
         "merge_gate_ci_conclusion",
         "merge_gate_diagnosis_path"
@@ -853,7 +867,9 @@
       "on_failure": "release_issue_failure",
       "on_context_limit": "release_issue_failure",
       "retries": 1,
-      "on_exhausted": "release_issue_failure"
+      "on_exhausted": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write"
     },
     "inter_part_push": {
       "tool": "push_to_remote",
@@ -1173,6 +1189,8 @@
         }
       ],
       "on_failure": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "optional_context_refs": [
         "review_mode"
       ],
@@ -1222,7 +1240,9 @@
       "on_failure": "release_issue_failure",
       "on_context_limit": "release_issue_failure",
       "retries": 1,
-      "on_exhausted": "release_issue_failure"
+      "on_exhausted": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write"
     },
     "re_push_review": {
       "tool": "push_to_remote",

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -311,7 +311,7 @@
       },
       "retries": 0,
       "on_context_limit": "retry_worktree",
-      "on_success": "check_changes",
+      "on_success": "gate_backend_write",
       "on_failure": "release_issue_failure",
       "optional": true,
       "skip_when_false": "inputs.backend_supports_git_write",
@@ -350,6 +350,23 @@
       "on_failure": "release_issue_failure",
       "optional": true,
       "skip_when_false": "inputs.backend_supports_git_write"
+    },
+    "gate_backend_write": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.gate_backend_write",
+        "backend_supports_git_write": "${{ inputs.backend_supports_git_write }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.backend_capable }} == false",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "check_changes"
+        }
+      ],
+      "on_failure": "release_issue_failure"
     },
     "check_changes": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -37,6 +37,11 @@ ingredients:
   arch_lenses:
     description: Generate architecture lens diagrams for the PR
     default: 'false'
+  backend_supports_git_write:
+    description: Whether the session backend supports .git/ metadata writes (git commit, rebase, worktree add). Resolved from backend capabilities at load time.
+    default: 'true'
+    hidden: true
+    authority: config
   auto_merge:
     description: Automatically merge the PR after required checks pass — via merge
       queue when available, direct merge otherwise
@@ -324,6 +329,8 @@ steps:
     on_context_limit: retry_worktree
     on_success: check_changes
     on_failure: release_issue_failure
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
     note: Extracts worktree_path from result for use in subsequent steps.
   retry_worktree:
     tool: run_skill
@@ -349,6 +356,8 @@ steps:
     on_context_limit: check_changes
     on_exhausted: release_issue_failure
     on_failure: release_issue_failure
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
   check_changes:
     tool: run_python
     with:
@@ -669,6 +678,8 @@ steps:
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     on_rate_limit: release_issue_failure
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
     optional_context_refs:
     - merge_gate_ci_conclusion
     - merge_gate_diagnosis_path
@@ -723,6 +734,8 @@ steps:
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     on_rate_limit: release_issue_failure
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
     optional_context_refs:
     - merge_gate_ci_conclusion
     - merge_gate_diagnosis_path
@@ -774,6 +787,8 @@ steps:
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
   inter_part_push:
     tool: push_to_remote
     with:
@@ -1069,6 +1084,8 @@ steps:
     - when: ${{ result.verdict }} == 'ci_only_failure'
       route: release_issue_failure
     on_failure: release_issue_failure
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
     optional_context_refs:
     - review_mode
     note: 'Runs when review_pr reports issues (verdict=changes_requested). The clone
@@ -1111,6 +1128,8 @@ steps:
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
   re_push_review:
     tool: push_to_remote
     with:

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -327,7 +327,7 @@ steps:
       has_implementation_progress: ${{ result.has_implementation_progress }}
     retries: 0
     on_context_limit: retry_worktree
-    on_success: check_changes
+    on_success: gate_backend_write
     on_failure: release_issue_failure
     optional: true
     skip_when_false: inputs.backend_supports_git_write
@@ -358,6 +358,16 @@ steps:
     on_failure: release_issue_failure
     optional: true
     skip_when_false: inputs.backend_supports_git_write
+  gate_backend_write:
+    tool: run_python
+    with:
+      callable: autoskillit.smoke_utils.gate_backend_write
+      backend_supports_git_write: ${{ inputs.backend_supports_git_write }}
+    on_result:
+    - when: ${{ result.backend_capable }} == false
+      route: release_issue_failure
+    - route: check_changes
+    on_failure: release_issue_failure
   check_changes:
     tool: run_python
     with:

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -57,6 +57,12 @@
       "description": "Generate architecture lens diagrams for the PR",
       "default": "false"
     },
+    "backend_supports_git_write": {
+      "description": "Whether the session backend supports .git/ metadata writes (git commit, rebase, worktree add). Resolved from backend capabilities at load time.",
+      "default": "true",
+      "hidden": true,
+      "authority": "config"
+    },
     "auto_merge": {
       "description": "Automatically merge the PR after required checks pass — via merge queue when available, direct merge otherwise",
       "default": "true"
@@ -338,7 +344,9 @@
       "retries": 0,
       "on_context_limit": "retry_worktree",
       "on_success": "check_changes",
-      "on_failure": "release_issue_failure"
+      "on_failure": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write"
     },
     "retry_worktree": {
       "tool": "run_skill",
@@ -372,7 +380,9 @@
       ],
       "on_context_limit": "check_changes",
       "on_exhausted": "release_issue_failure",
-      "on_failure": "release_issue_failure"
+      "on_failure": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write"
     },
     "check_changes": {
       "tool": "run_python",
@@ -708,6 +718,8 @@
       "on_rate_limit": "release_issue_failure",
       "on_failure": "release_issue_failure",
       "on_exhausted": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "optional_context_refs": [
         "merge_gate_ci_conclusion",
         "merge_gate_diagnosis_path"
@@ -781,6 +793,8 @@
       "on_rate_limit": "release_issue_failure",
       "on_failure": "release_issue_failure",
       "on_exhausted": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "optional_context_refs": [
         "merge_gate_ci_conclusion",
         "merge_gate_diagnosis_path"
@@ -844,7 +858,9 @@
       "on_failure": "release_issue_failure",
       "on_context_limit": "release_issue_failure",
       "retries": 1,
-      "on_exhausted": "release_issue_failure"
+      "on_exhausted": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write"
     },
     "audit_impl": {
       "tool": "run_skill",
@@ -1310,6 +1326,8 @@
         }
       ],
       "on_failure": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "note": "Runs when review_pr reports issues (verdict=changes_requested). The clone (context.work_dir) has the feature branch (context.merge_target) checked out. resolve-review fetches inline and summary review comments via the GitHub API, applies fixes for each actionable finding (critical + warning severity), and commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/ flake_suspected all route to pre_review_rebase (fetch+rebase before push); ci_only_failure escalates to release_issue_failure.\n",
       "optional_context_refs": [
         "review_mode"
@@ -1359,7 +1377,9 @@
       "on_failure": "release_issue_failure",
       "on_context_limit": "release_issue_failure",
       "retries": 1,
-      "on_exhausted": "release_issue_failure"
+      "on_exhausted": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write"
     },
     "re_push_review": {
       "tool": "push_to_remote",

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -343,7 +343,7 @@
       },
       "retries": 0,
       "on_context_limit": "retry_worktree",
-      "on_success": "check_changes",
+      "on_success": "gate_backend_write",
       "on_failure": "release_issue_failure",
       "optional": true,
       "skip_when_false": "inputs.backend_supports_git_write"
@@ -383,6 +383,23 @@
       "on_failure": "release_issue_failure",
       "optional": true,
       "skip_when_false": "inputs.backend_supports_git_write"
+    },
+    "gate_backend_write": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.gate_backend_write",
+        "backend_supports_git_write": "${{ inputs.backend_supports_git_write }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.backend_capable }} == false",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "check_changes"
+        }
+      ],
+      "on_failure": "release_issue_failure"
     },
     "check_changes": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -70,6 +70,11 @@ ingredients:
   arch_lenses:
     description: Generate architecture lens diagrams for the PR
     default: 'false'
+  backend_supports_git_write:
+    description: Whether the session backend supports .git/ metadata writes (git commit, rebase, worktree add). Resolved from backend capabilities at load time.
+    default: 'true'
+    hidden: true
+    authority: config
   auto_merge:
     description: Automatically merge the PR after required checks pass — via merge
       queue when available, direct merge otherwise
@@ -358,6 +363,8 @@ steps:
     on_context_limit: retry_worktree
     on_success: check_changes
     on_failure: release_issue_failure
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
   retry_worktree:
     tool: run_skill
     model: ''
@@ -384,6 +391,8 @@ steps:
     on_context_limit: check_changes
     on_exhausted: release_issue_failure
     on_failure: release_issue_failure
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
   check_changes:
     tool: run_python
     with:
@@ -653,6 +662,8 @@ steps:
     on_rate_limit: release_issue_failure
     on_failure: release_issue_failure
     on_exhausted: release_issue_failure
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
     optional_context_refs:
     - merge_gate_ci_conclusion
     - merge_gate_diagnosis_path
@@ -706,6 +717,8 @@ steps:
     on_rate_limit: release_issue_failure
     on_failure: release_issue_failure
     on_exhausted: release_issue_failure
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
     optional_context_refs:
     - merge_gate_ci_conclusion
     - merge_gate_diagnosis_path
@@ -757,6 +770,8 @@ steps:
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
   audit_impl:
     tool: run_skill
     model: ''
@@ -1174,6 +1189,8 @@ steps:
     - when: ${{ result.verdict }} == 'ci_only_failure'
       route: release_issue_failure
     on_failure: release_issue_failure
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
     note: 'Runs when review_pr reports issues (verdict=changes_requested). The clone
       (context.work_dir) has the feature branch (context.merge_target) checked out.
       resolve-review fetches inline and summary review comments via the GitHub API,
@@ -1216,6 +1233,8 @@ steps:
     on_context_limit: release_issue_failure
     retries: 1
     on_exhausted: release_issue_failure
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
   re_push_review:
     tool: push_to_remote
     with:

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -361,7 +361,7 @@ steps:
       has_implementation_progress: ${{ result.has_implementation_progress }}
     retries: 0
     on_context_limit: retry_worktree
-    on_success: check_changes
+    on_success: gate_backend_write
     on_failure: release_issue_failure
     optional: true
     skip_when_false: inputs.backend_supports_git_write
@@ -393,6 +393,16 @@ steps:
     on_failure: release_issue_failure
     optional: true
     skip_when_false: inputs.backend_supports_git_write
+  gate_backend_write:
+    tool: run_python
+    with:
+      callable: autoskillit.smoke_utils.gate_backend_write
+      backend_supports_git_write: ${{ inputs.backend_supports_git_write }}
+    on_result:
+    - when: ${{ result.backend_capable }} == false
+      route: release_issue_failure
+    - route: check_changes
+    on_failure: release_issue_failure
   check_changes:
     tool: run_python
     with:

--- a/src/autoskillit/server/tools/_auto_overrides.py
+++ b/src/autoskillit/server/tools/_auto_overrides.py
@@ -1,0 +1,26 @@
+"""Server-authoritative ingredient override helpers.
+
+Shared between sibling tool modules (tools_kitchen, tools_recipe) that need
+to inject runtime-derived values into recipe ingredient overrides. Each
+helper returns a plain dict suitable for merging into the
+``ingredient_overrides`` keyword of ``load_and_validate``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from autoskillit.core import CodingAgentBackend
+
+
+def _backend_capability_overrides(backend: CodingAgentBackend | None) -> dict[str, str]:
+    """Return ingredient overrides derived from backend capabilities.
+
+    The ``backend_supports_git_write`` ingredient is resolved from the active
+    backend's ``git_metadata_writable`` capability. A ``None`` backend is
+    treated as writable (safe default for test/dev contexts where no backend
+    is wired).
+    """
+    git_writable = backend is None or backend.capabilities.git_metadata_writable
+    return {"backend_supports_git_write": "true" if git_writable else "false"}

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -56,6 +56,7 @@ from autoskillit.server._misc import (
     strip_ingredients_only_keys,
 )
 from autoskillit.server._notify import track_response_size
+from autoskillit.server.tools._auto_overrides import _backend_capability_overrides
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
@@ -374,12 +375,13 @@ def get_recipe(name: str) -> str:
 
     _defaults = resolve_ingredient_defaults(ctx.project_dir)
     _config_layer = build_config_authoritative_layer(_defaults)
+    _backend_overrides = _backend_capability_overrides(ctx.backend)
     try:
         result = ctx.recipes.load_and_validate(
             name,
             ctx.project_dir,
             resolved_defaults=_defaults,
-            ingredient_overrides=_config_layer,
+            ingredient_overrides={**_backend_overrides, **_config_layer},
             backend_name=ctx.backend.name if ctx.backend else None,
         )
     except ProcessStaleError:
@@ -532,6 +534,7 @@ async def open_kitchen(
                 "kitchen_id": tool_ctx.kitchen_id,
                 "diagnostics_log_dir": str(resolve_log_dir(tool_ctx.config.linux_tracing.log_dir)),
             }
+            _session_overrides.update(_backend_capability_overrides(tool_ctx.backend))
             _config_layer = build_config_authoritative_layer(_defaults)
             _merged_overrides = {**_session_overrides, **(overrides or {}), **_config_layer}
             # Runtime enum check: output_mode must be validated before recipe loading

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -21,6 +21,7 @@ from autoskillit.server._misc import (
 )
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._state import _get_ctx_or_none
+from autoskillit.server.tools._auto_overrides import _backend_capability_overrides
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
@@ -211,6 +212,7 @@ async def load_recipe(
                 "kitchen_id": tool_ctx.kitchen_id,
                 "diagnostics_log_dir": str(resolve_log_dir(tool_ctx.config.linux_tracing.log_dir)),
             }
+            _session_overrides.update(_backend_capability_overrides(tool_ctx.backend))
             _config_layer = build_config_authoritative_layer(_defaults)
             _merged_overrides = {**_session_overrides, **(overrides or {}), **_config_layer}
             result = tool_ctx.recipes.load_and_validate(

--- a/src/autoskillit/smoke_utils/AGENTS.md
+++ b/src/autoskillit/smoke_utils/AGENTS.md
@@ -6,7 +6,7 @@ Utility callables for smoke-test pipeline `run_python` steps (decomposed from mo
 
 | File | Purpose |
 |------|---------|
-| `__init__.py` | Re-export facade — 27 public names via `__all__` |
+| `__init__.py` | Re-export facade — 28 public names via `__all__` |
 | `_helpers.py` | Shared JSON loading helpers (`_load_json`, `try_load_json`) |
 | `_merge_gate_diagnosis.py` | Merge gate test failure diagnosis file writer |
 | `_review.py` | PR diff annotation, review loop guards, diff context enrichment, dimension selection, verdict aggregation |

--- a/src/autoskillit/smoke_utils/__init__.py
+++ b/src/autoskillit/smoke_utils/__init__.py
@@ -19,6 +19,7 @@ from autoskillit.smoke_utils._git import (
     compute_domain_partitions,
     detect_zero_changes,
     fetch_merge_queue_data,
+    gate_backend_write,
 )
 from autoskillit.smoke_utils._helpers import try_load_json
 from autoskillit.smoke_utils._merge_gate_diagnosis import diagnose_merge_gate
@@ -57,6 +58,7 @@ __all__ = [
     "diagnose_merge_gate",
     "enrich_diff_context",
     "fetch_merge_queue_data",
+    "gate_backend_write",
     "init_counter",
     "parse_agent_eval_manifests",
     "parse_eval_manifests",

--- a/src/autoskillit/smoke_utils/_git.py
+++ b/src/autoskillit/smoke_utils/_git.py
@@ -210,3 +210,9 @@ def close_issue_already_done(issue_url: str) -> dict[str, str]:
         timeout=60,
     )
     return {"closed": "true"}
+
+
+def gate_backend_write(backend_supports_git_write: str = "true") -> dict[str, str]:
+    if str(backend_supports_git_write).lower() in ("false", "0", "no", ""):
+        return {"backend_capable": "false"}
+    return {"backend_capable": "true"}

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -873,7 +873,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "pipeline": 12,
         "fleet": 22,  # REQ-CNST-003-E9: _dispatch_reaper.py; +_sidecar_synthesis.py; +_reset.py
         "recipe/rules": 50,  # +commit_guard_regression_route +rules_model
-        "server/tools": 25,  # _auto_overrides.py + _cancellation_shield.py + tools_fleet_reset.py
+        "server/tools": 26,  # _auto_overrides.py + _cancellation_shield.py + tools_fleet_reset.py
         "hooks/guards": 32,  # +fleet_claim_guard, +reset_resume_gate, +recipe_read_guard
     }
     violations: list[str] = []
@@ -959,10 +959,11 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "co-located with the execution engine that calls them",
     ),
     "tools_kitchen.py": (
-        1107,
+        1110,
         "REQ-CNST-010-E7: kitchen tool handlers — open_kitchen and lock_ingredients require "
         "inline validation helpers (_check_override_keys, _build_ingredient_key_suggestions) "
-        "for ingredient key validation; splitting would cross import-layer boundaries",
+        "for ingredient key validation; splitting would cross import-layer boundaries; "
+        "backend capability override injection in get_recipe adds 3 lines",
     ),
     "tools_execution.py": (
         1060,

--- a/tests/contracts/test_zero_change_circuit_breaker_contracts.py
+++ b/tests/contracts/test_zero_change_circuit_breaker_contracts.py
@@ -18,11 +18,18 @@ def _load(name: str) -> dict:
 
 
 def test_implementation_recipe_has_change_check_after_implement() -> None:
-    """implement step must route on_success to check_changes, not directly to test."""
+    """implement must route on_success to gate_backend_write, which routes to check_changes."""
     data = _load("implementation")
     implement_step = data["steps"]["implement"]
-    assert implement_step.get("on_success") == "check_changes", (
-        f"implement.on_success must be 'check_changes', got {implement_step.get('on_success')!r}"
+    assert implement_step.get("on_success") == "gate_backend_write", (
+        f"got {implement_step.get('on_success')!r}"
+    )
+
+    gate_step = data["steps"]["gate_backend_write"]
+    gate_on_result = gate_step.get("on_result", [])
+    gate_routes = [r.get("route") for r in gate_on_result if not r.get("when")]
+    assert "check_changes" in gate_routes, (
+        f"gate_backend_write catch-all must route to check_changes, got: {gate_on_result}"
     )
 
 
@@ -60,8 +67,8 @@ def test_remediation_recipe_has_same_circuit_breaker() -> None:
     data = _load("remediation")
 
     implement_step = data["steps"]["implement"]
-    assert implement_step.get("on_success") == "check_changes", (
-        f"remediation implement.on_success must be 'check_changes', "
+    assert implement_step.get("on_success") == "gate_backend_write", (
+        f"remediation implement.on_success must be 'gate_backend_write', "
         f"got {implement_step.get('on_success')!r}"
     )
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -119,11 +119,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 87),
     # tools_kitchen.py — hook config, quota guard, git_ops_policy, ingredient locks overlay
-    ("src/autoskillit/server/tools/tools_kitchen.py", 138),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 157),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 191),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 832),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 892),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 139),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 158),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 192),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 835),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 895),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict

--- a/tests/recipe/test_hidden_ingredients.py
+++ b/tests/recipe/test_hidden_ingredients.py
@@ -1333,3 +1333,30 @@ steps:
         ingredient_overrides={"task": "some task"},
     )
     assert "${{ inputs.task }}" in result["content"]
+
+
+@pytest.mark.parametrize("recipe_name", ["implementation", "remediation", "implementation-groups"])
+def test_prune_redirects_implement_to_gate_backend_write(recipe_name: str) -> None:
+    from autoskillit.recipe._recipe_composition import _prune_skipped_steps
+    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+    recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+    pruned, resolutions = _prune_skipped_steps(
+        recipe, ingredient_overrides={"backend_supports_git_write": "false"}
+    )
+    assert "implement" not in pruned.steps
+    assert resolutions["implement"] is False
+    assert "gate_backend_write" in pruned.steps
+    assert pruned.steps["create_impl_worktree"].on_success == "gate_backend_write"
+
+
+@pytest.mark.parametrize("recipe_name", ["implementation", "remediation", "implementation-groups"])
+def test_gate_backend_write_has_failure_route(recipe_name: str) -> None:
+    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+    recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+    step = recipe.steps["gate_backend_write"]
+    assert step.tool == "run_python"
+    assert step.on_result is not None
+    failure_routes = [c.route for c in step.on_result.conditions if c.when and "false" in c.when]
+    assert "release_issue_failure" in failure_routes

--- a/tests/recipe/test_rules_backend_compat.py
+++ b/tests/recipe/test_rules_backend_compat.py
@@ -60,7 +60,7 @@ class TestBackendIncompatibleSkillRule:
         findings = run_semantic_rules(ctx)
         compat_findings = [f for f in findings if f.rule == "backend-incompatible-skill"]
         assert len(compat_findings) == 1
-        assert compat_findings[0].severity == Severity.WARNING
+        assert compat_findings[0].severity == Severity.ERROR
         assert "investigate" in compat_findings[0].message
         assert "codex" in compat_findings[0].message
 
@@ -171,7 +171,7 @@ class TestBackendNameThreadingAPI:
         suggestions = result.get("suggestions", [])
         compat_findings = [f for f in suggestions if f.get("rule") == "backend-incompatible-skill"]
         assert len(compat_findings) == 1
-        assert compat_findings[0]["severity"] == "warning"
+        assert compat_findings[0]["severity"] == "error"
 
     def test_validate_from_path_threads_backend_name(self, tmp_path):
         from autoskillit.recipe._api_listing import validate_from_path
@@ -187,7 +187,7 @@ class TestBackendNameThreadingAPI:
         findings = result.get("findings", [])
         compat_findings = [f for f in findings if f.get("rule") == "backend-incompatible-skill"]
         assert len(compat_findings) == 1
-        assert compat_findings[0]["severity"] == "warning"
+        assert compat_findings[0]["severity"] == "error"
 
     def test_cache_key_varies_by_backend_name(self, tmp_path, monkeypatch):
         import autoskillit.recipe._api as api_mod
@@ -245,7 +245,36 @@ class TestBundledRecipeBackendCompat:
             f"Expected at least 1 backend-incompatible-skill finding for {recipe_name} "
             f"on codex backend (implement step uses git_metadata_write skill)"
         )
-        assert any("implement" in f.step_name for f in compat_findings)
+        step_names = {f.step_name for f in compat_findings}
+        expected_steps = {
+            "implement",
+            "retry_worktree",
+            "fix",
+            "merge_gate_fix",
+            "rebase_conflict_fix",
+            "resolve_review",
+            "resolve_pre_review_conflicts",
+        }
+        recipe_aware_expected = expected_steps - {"assess", "merge_gate_assess"}
+        if recipe_name == "remediation":
+            recipe_aware_expected = (expected_steps - {"fix", "merge_gate_fix"}) | {
+                "assess",
+                "merge_gate_assess",
+            }
+        missing = recipe_aware_expected - step_names
+        assert not missing, (
+            f"Expected findings for steps {missing} in {recipe_name} on codex backend, "
+            f"got findings for: {step_names}"
+        )
+        guarded_steps = {
+            name for name in step_names if recipe.steps[name].skip_when_false is not None
+        }
+        for f in compat_findings:
+            if f.step_name in guarded_steps:
+                assert f.severity == Severity.WARNING, (
+                    f"Step {f.step_name!r} has skip_when_false guard; expected WARNING, "
+                    f"got {f.severity}"
+                )
 
     def test_claude_code_backend_no_findings(self, recipe_name) -> None:
         from autoskillit.recipe._analysis import make_validation_context
@@ -267,3 +296,175 @@ class TestBundledRecipeBackendCompat:
             f"No backend-incompatible-skill findings expected for {recipe_name} "
             f"on claude-code backend, got: {compat_findings}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Severity promotion — guarded steps remain WARNING, unguarded escalate to ERROR
+# ---------------------------------------------------------------------------
+
+
+def _make_guarded_recipe(skip_when_false: str | None = None, optional: bool = False) -> Recipe:
+    step: RecipeStep
+    if skip_when_false is not None:
+        step = RecipeStep(
+            tool="run_skill",
+            with_args={"skill_command": "/investigate something", "cwd": "/tmp"},
+            skip_when_false=skip_when_false,
+            optional=optional,
+        )
+    elif optional:
+        step = RecipeStep(
+            tool="run_skill",
+            with_args={"skill_command": "/investigate something", "cwd": "/tmp"},
+            optional=True,
+        )
+    else:
+        step = RecipeStep(
+            tool="run_skill",
+            with_args={"skill_command": "/investigate something", "cwd": "/tmp"},
+        )
+    return Recipe(name="test-recipe", description="test", steps={"run-skill-step": step})
+
+
+class TestSeverityPromotion:
+    """Unguarded backend-incompatible steps fire ERROR; guarded ones fire WARNING."""
+
+    def test_unguarded_incompatible_step_fires_error(self) -> None:
+        recipe = _make_guarded_recipe(skip_when_false=None, optional=False)
+        resolver = _mock_resolver(_make_skill_info())
+        ctx = make_validation_context(
+            recipe,
+            backend_name="codex",
+            skill_resolver=resolver,
+            available_skills=frozenset({"investigate"}),
+        )
+        findings = run_semantic_rules(ctx)
+        compat = [f for f in findings if f.rule == "backend-incompatible-skill"]
+        assert len(compat) == 1
+        assert compat[0].severity == Severity.ERROR
+
+    def test_guarded_incompatible_step_fires_warning(self) -> None:
+        recipe = _make_guarded_recipe(skip_when_false="inputs.some_guard", optional=False)
+        resolver = _mock_resolver(_make_skill_info())
+        ctx = make_validation_context(
+            recipe,
+            backend_name="codex",
+            skill_resolver=resolver,
+            available_skills=frozenset({"investigate"}),
+        )
+        findings = run_semantic_rules(ctx)
+        compat = [f for f in findings if f.rule == "backend-incompatible-skill"]
+        assert len(compat) == 1
+        assert compat[0].severity == Severity.WARNING
+
+    def test_optional_incompatible_step_fires_warning(self) -> None:
+        recipe = _make_guarded_recipe(skip_when_false=None, optional=True)
+        resolver = _mock_resolver(_make_skill_info())
+        ctx = make_validation_context(
+            recipe,
+            backend_name="codex",
+            skill_resolver=resolver,
+            available_skills=frozenset({"investigate"}),
+        )
+        findings = run_semantic_rules(ctx)
+        compat = [f for f in findings if f.rule == "backend-incompatible-skill"]
+        assert len(compat) == 1
+        assert compat[0].severity == Severity.WARNING
+
+    def test_skip_when_true_incompatible_step_fires_warning(self) -> None:
+        step = RecipeStep(
+            tool="run_skill",
+            with_args={"skill_command": "/investigate something", "cwd": "/tmp"},
+            skip_when_true="inputs.some_flag",
+        )
+        recipe = Recipe(
+            name="test-recipe",
+            description="test",
+            steps={"run-skill-step": step},
+        )
+        resolver = _mock_resolver(_make_skill_info())
+        ctx = make_validation_context(
+            recipe,
+            backend_name="codex",
+            skill_resolver=resolver,
+            available_skills=frozenset({"investigate"}),
+        )
+        findings = run_semantic_rules(ctx)
+        compat = [f for f in findings if f.rule == "backend-incompatible-skill"]
+        assert len(compat) == 1
+        assert compat[0].severity == Severity.WARNING
+
+
+# ---------------------------------------------------------------------------
+# Bundled recipe ingredient declaration tests
+# ---------------------------------------------------------------------------
+
+
+class TestBundledRecipeIngredientDeclaration:
+    """Bundled recipes declare backend_supports_git_write as hidden config-authoritative."""
+
+    @pytest.fixture(
+        scope="class",
+        params=["implementation", "implementation-groups", "remediation"],
+        ids=lambda x: x,
+    )
+    def recipe_name(self, request: pytest.FixtureRequest) -> str:
+        return request.param
+
+    def test_bundled_recipes_declare_backend_supports_git_write(self, recipe_name) -> None:
+        from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+        recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+        assert "backend_supports_git_write" in recipe.ingredients, (
+            f"Recipe {recipe_name!r} must declare 'backend_supports_git_write' ingredient"
+        )
+        ing = recipe.ingredients["backend_supports_git_write"]
+        assert ing.hidden is True, f"backend_supports_git_write must be hidden in {recipe_name}"
+        assert ing.authority == "config", (
+            f"backend_supports_git_write must be authority=config in {recipe_name}"
+        )
+        assert ing.default == "true", (
+            f"backend_supports_git_write default must be 'true' in {recipe_name}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bundled recipe step guard tests
+# ---------------------------------------------------------------------------
+
+
+class TestBundledRecipeStepGuards:
+    """Every git_metadata_write step in bundled recipes has a skip_when_false guard."""
+
+    @pytest.fixture(
+        scope="class",
+        params=["implementation", "implementation-groups", "remediation"],
+        ids=lambda x: x,
+    )
+    def recipe_name(self, request: pytest.FixtureRequest) -> str:
+        return request.param
+
+    def test_git_metadata_write_steps_have_skip_guard(self, recipe_name) -> None:
+        from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+        from autoskillit.workspace.skills import DefaultSkillResolver
+
+        recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+        resolver = DefaultSkillResolver()
+        for step_name, step in recipe.steps.items():
+            if step.tool != "run_skill":
+                continue
+            skill_cmd = step.with_args.get("skill_command", "")
+            if not skill_cmd or not skill_cmd.startswith("/"):
+                continue
+            skill_info = resolver.resolve(skill_cmd.split()[0].lstrip("/"))
+            if skill_info is None:
+                continue
+            if (
+                not skill_info.uses_capabilities
+                or "git_metadata_write" not in skill_info.uses_capabilities
+            ):
+                continue
+            assert step.skip_when_false is not None, (
+                f"Step {step_name!r} in {recipe_name!r} dispatches git_metadata_write skill "
+                f"'{skill_info.name}' but has no skip_when_false guard"
+            )

--- a/tests/server/AGENTS.md
+++ b/tests/server/AGENTS.md
@@ -130,6 +130,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_tools_agents.py` | Tests for agent pack registry, MCP resources, and `unlock_agent_pack` |
 | `test_track_response_size.py` | Tests for the track_response_size decorator in autoskillit.server._notify |
 | `test_wire_compat.py` | Wire compatibility tests |
+| `test_backend_ingredient_injection.py` | Tests for backend_capability_overrides injection via open_kitchen, load_recipe, and get_recipe resource |
 
 | `test_tools_git_branch_isolation.py` | Integration tests for create_and_publish_branch with clone-isolated origin topology |
 | `test_tools_observability_scope.py` | Tests for bound_contextvars exception scope completeness: exception-path coverage, AST structural guard, any() assertion ban |

--- a/tests/server/_helpers.py
+++ b/tests/server/_helpers.py
@@ -80,7 +80,7 @@ _PATCHED_DEFAULTS = {
     "dispatch_id": "test-dispatch-999",
 }
 
-_SERVER_ONLY_KEYS = frozenset({"kitchen_id", "diagnostics_log_dir"})
+_SERVER_ONLY_KEYS = frozenset({"kitchen_id", "diagnostics_log_dir", "backend_supports_git_write"})
 
 _MINIMAL_SCRIPT_YAML = """\
 name: test-script

--- a/tests/server/test_backend_ingredient_injection.py
+++ b/tests/server/test_backend_ingredient_injection.py
@@ -1,0 +1,292 @@
+"""Tests for backend_capability_overrides injection in recipe-loading entry points.
+
+Verifies that ``backend_supports_git_write`` is correctly derived from
+``ToolContext.backend.capabilities.git_metadata_writable`` and injected into
+``ingredient_overrides`` by open_kitchen, load_recipe, and the recipe://
+resource handler.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from autoskillit.core import CodingAgentBackend
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+def _make_backend_with_capability(git_writable: bool) -> CodingAgentBackend:
+    """Return a MagicMock that quacks like CodingAgentBackend with the given capability."""
+    backend = MagicMock(spec=CodingAgentBackend)
+    backend.name = "claude-code" if git_writable else "codex"
+    backend.capabilities = SimpleNamespace(
+        git_metadata_writable=git_writable,
+        supports_tool_list_changed=True,
+    )
+    return backend
+
+
+# ---------------------------------------------------------------------------
+# _backend_capability_overrides unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestBackendCapabilityOverrides:
+    def test_none_backend_returns_true(self) -> None:
+        from autoskillit.server.tools._auto_overrides import _backend_capability_overrides
+
+        assert _backend_capability_overrides(None) == {"backend_supports_git_write": "true"}
+
+    def test_git_writable_backend_returns_true(self) -> None:
+        from autoskillit.server.tools._auto_overrides import _backend_capability_overrides
+
+        backend = _make_backend_with_capability(True)
+        assert _backend_capability_overrides(backend) == {"backend_supports_git_write": "true"}
+
+    def test_non_writable_backend_returns_false(self) -> None:
+        from autoskillit.server.tools._auto_overrides import _backend_capability_overrides
+
+        backend = _make_backend_with_capability(False)
+        assert _backend_capability_overrides(backend) == {"backend_supports_git_write": "false"}
+
+
+# ---------------------------------------------------------------------------
+# open_kitchen injection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestOpenKitchenInjection:
+    async def test_codex_backend_injects_false(self, tmp_path) -> None:
+        from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+        mock_ctx = MagicMock()
+        mock_ctx.kitchen_id = "test-kitchen"
+        mock_ctx.config.linux_tracing.log_dir = ""
+        mock_ctx.config.migration.suppressed = []
+        mock_ctx.config.features = {}
+        mock_ctx.config.experimental_enabled = False
+        mock_ctx.backend = _make_backend_with_capability(False)
+        mock_ctx.recipes = MagicMock()
+        mock_ctx.recipes.load_and_validate.return_value = {
+            "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+            "valid": True,
+            "suggestions": [],
+            "ingredients_table": None,
+        }
+        mock_ctx.recipes.find.return_value = None
+        mock_ctx.temp_dir = tmp_path
+
+        with patch(
+            "autoskillit.server.tools.tools_kitchen._get_ctx",
+            return_value=mock_ctx,
+        ):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen.resolve_ingredient_defaults",
+                return_value={},
+            ):
+                with patch(
+                    "autoskillit.server.tools.tools_kitchen._open_kitchen_handler",
+                    new=AsyncMock(return_value=None),
+                ):
+                    with patch(
+                        "autoskillit.server.tools.tools_kitchen._apply_triage_gate",
+                        new=AsyncMock(side_effect=lambda r, *a, **kw: r),
+                    ):
+                        with patch(
+                            "autoskillit.server.tools.tools_kitchen._redisable_subsets",
+                            new=AsyncMock(return_value=None),
+                        ):
+                            await open_kitchen(name="demo")
+
+        call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
+        overrides = call_kwargs["ingredient_overrides"]
+        assert overrides.get("backend_supports_git_write") == "false"
+
+    async def test_claude_code_backend_injects_true(self, tmp_path) -> None:
+        from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+        mock_ctx = MagicMock()
+        mock_ctx.kitchen_id = "test-kitchen"
+        mock_ctx.config.linux_tracing.log_dir = ""
+        mock_ctx.config.migration.suppressed = []
+        mock_ctx.config.features = {}
+        mock_ctx.config.experimental_enabled = False
+        mock_ctx.backend = _make_backend_with_capability(True)
+        mock_ctx.recipes = MagicMock()
+        mock_ctx.recipes.load_and_validate.return_value = {
+            "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+            "valid": True,
+            "suggestions": [],
+            "ingredients_table": None,
+        }
+        mock_ctx.recipes.find.return_value = None
+        mock_ctx.temp_dir = tmp_path
+
+        with patch(
+            "autoskillit.server.tools.tools_kitchen._get_ctx",
+            return_value=mock_ctx,
+        ):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen.resolve_ingredient_defaults",
+                return_value={},
+            ):
+                with patch(
+                    "autoskillit.server.tools.tools_kitchen._open_kitchen_handler",
+                    new=AsyncMock(return_value=None),
+                ):
+                    with patch(
+                        "autoskillit.server.tools.tools_kitchen._apply_triage_gate",
+                        new=AsyncMock(side_effect=lambda r, *a, **kw: r),
+                    ):
+                        with patch(
+                            "autoskillit.server.tools.tools_kitchen._redisable_subsets",
+                            new=AsyncMock(return_value=None),
+                        ):
+                            await open_kitchen(name="demo")
+
+        call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
+        overrides = call_kwargs["ingredient_overrides"]
+        assert overrides.get("backend_supports_git_write") == "true"
+
+
+# ---------------------------------------------------------------------------
+# load_recipe injection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestLoadRecipeInjection:
+    async def test_codex_backend_injects_false(self, tmp_path) -> None:
+        from autoskillit.server.tools.tools_recipe import load_recipe
+
+        mock_ctx = MagicMock()
+        mock_ctx.kitchen_id = "test-kitchen"
+        mock_ctx.config.linux_tracing.log_dir = ""
+        mock_ctx.config.migration.suppressed = []
+        mock_ctx.config.workspace.temp_dir = ".autoskillit/temp"
+        mock_ctx.backend = _make_backend_with_capability(False)
+        mock_ctx.recipes = MagicMock()
+        mock_ctx.recipes.load_and_validate.return_value = {
+            "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+            "valid": True,
+            "suggestions": [],
+        }
+        mock_ctx.recipes.find.return_value = None
+        mock_ctx.temp_dir = tmp_path
+
+        with patch(
+            "autoskillit.server.tools.tools_recipe._get_ctx_or_none",
+            return_value=mock_ctx,
+        ):
+            with patch(
+                "autoskillit.server.tools.tools_recipe.resolve_ingredient_defaults",
+                return_value={},
+            ):
+                with patch(
+                    "autoskillit.server.tools.tools_recipe._apply_triage_gate",
+                    new=AsyncMock(side_effect=lambda r, *a, **kw: r),
+                ):
+                    await load_recipe(name="demo")
+
+        call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
+        overrides = call_kwargs["ingredient_overrides"]
+        assert overrides.get("backend_supports_git_write") == "false"
+
+    async def test_claude_code_backend_injects_true(self, tmp_path) -> None:
+        from autoskillit.server.tools.tools_recipe import load_recipe
+
+        mock_ctx = MagicMock()
+        mock_ctx.kitchen_id = "test-kitchen"
+        mock_ctx.config.linux_tracing.log_dir = ""
+        mock_ctx.config.migration.suppressed = []
+        mock_ctx.config.workspace.temp_dir = ".autoskillit/temp"
+        mock_ctx.backend = _make_backend_with_capability(True)
+        mock_ctx.recipes = MagicMock()
+        mock_ctx.recipes.load_and_validate.return_value = {
+            "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+            "valid": True,
+            "suggestions": [],
+        }
+        mock_ctx.recipes.find.return_value = None
+        mock_ctx.temp_dir = tmp_path
+
+        with patch(
+            "autoskillit.server.tools.tools_recipe._get_ctx_or_none",
+            return_value=mock_ctx,
+        ):
+            with patch(
+                "autoskillit.server.tools.tools_recipe.resolve_ingredient_defaults",
+                return_value={},
+            ):
+                with patch(
+                    "autoskillit.server.tools.tools_recipe._apply_triage_gate",
+                    new=AsyncMock(side_effect=lambda r, *a, **kw: r),
+                ):
+                    await load_recipe(name="demo")
+
+        call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
+        overrides = call_kwargs["ingredient_overrides"]
+        assert overrides.get("backend_supports_git_write") == "true"
+
+
+# ---------------------------------------------------------------------------
+# get_recipe resource injection
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecipeResourceInjection:
+    def test_codex_backend_injects_false(self, tmp_path) -> None:
+        from autoskillit.server.tools.tools_kitchen import get_recipe
+
+        mock_ctx = MagicMock()
+        mock_ctx.project_dir = tmp_path
+        mock_ctx.backend = _make_backend_with_capability(False)
+        mock_ctx.recipes = MagicMock()
+        mock_ctx.recipes.find.return_value = MagicMock(path=tmp_path / "demo.yaml")
+        mock_ctx.recipes.load_and_validate.return_value = {
+            "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+        }
+
+        with patch(
+            "autoskillit.server.tools.tools_kitchen._get_ctx_or_none",
+            return_value=mock_ctx,
+        ):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen.resolve_ingredient_defaults",
+                return_value={},
+            ):
+                get_recipe("demo")
+
+        call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
+        overrides = call_kwargs["ingredient_overrides"]
+        assert overrides.get("backend_supports_git_write") == "false"
+
+    def test_claude_code_backend_injects_true(self, tmp_path) -> None:
+        from autoskillit.server.tools.tools_kitchen import get_recipe
+
+        mock_ctx = MagicMock()
+        mock_ctx.project_dir = tmp_path
+        mock_ctx.backend = _make_backend_with_capability(True)
+        mock_ctx.recipes = MagicMock()
+        mock_ctx.recipes.find.return_value = MagicMock(path=tmp_path / "demo.yaml")
+        mock_ctx.recipes.load_and_validate.return_value = {
+            "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+        }
+
+        with patch(
+            "autoskillit.server.tools.tools_kitchen._get_ctx_or_none",
+            return_value=mock_ctx,
+        ):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen.resolve_ingredient_defaults",
+                return_value={},
+            ):
+                get_recipe("demo")
+
+        call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
+        overrides = call_kwargs["ingredient_overrides"]
+        assert overrides.get("backend_supports_git_write") == "true"

--- a/tests/server/test_backend_ingredient_injection.py
+++ b/tests/server/test_backend_ingredient_injection.py
@@ -80,27 +80,32 @@ class TestOpenKitchenInjection:
         mock_ctx.recipes.find.return_value = None
         mock_ctx.temp_dir = tmp_path
 
-        with patch(
-            "autoskillit.server.tools.tools_kitchen._get_ctx",
-            return_value=mock_ctx,
-        ):
-            with patch(
-                "autoskillit.server.tools.tools_kitchen.resolve_ingredient_defaults",
+        mock_mcp_ctx = AsyncMock()
+        mock_mcp_ctx.enable_components = AsyncMock()
+
+        with (
+            patch(
+                "autoskillit.server.tools.tools_kitchen._require_orchestrator_exact",
+                return_value=None,
+            ),
+            patch(
+                "autoskillit.server.tools.tools_kitchen._open_kitchen_handler",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("autoskillit.server._get_ctx", return_value=mock_ctx),
+            patch(
+                "autoskillit.config.resolve_ingredient_defaults",
                 return_value={},
-            ):
-                with patch(
-                    "autoskillit.server.tools.tools_kitchen._open_kitchen_handler",
-                    new=AsyncMock(return_value=None),
-                ):
-                    with patch(
-                        "autoskillit.server.tools.tools_kitchen._apply_triage_gate",
-                        new=AsyncMock(side_effect=lambda r, *a, **kw: r),
-                    ):
-                        with patch(
-                            "autoskillit.server.tools.tools_kitchen._redisable_subsets",
-                            new=AsyncMock(return_value=None),
-                        ):
-                            await open_kitchen(name="demo")
+            ),
+            patch(
+                "autoskillit.server._misc._apply_triage_gate",
+                new_callable=AsyncMock,
+                side_effect=lambda r, *a, **kw: r,
+            ),
+            patch("autoskillit.server.tools.tools_kitchen.__version__", "0.0.0"),
+        ):
+            await open_kitchen(name="demo", ctx=mock_mcp_ctx)
 
         call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
         overrides = call_kwargs["ingredient_overrides"]
@@ -126,27 +131,32 @@ class TestOpenKitchenInjection:
         mock_ctx.recipes.find.return_value = None
         mock_ctx.temp_dir = tmp_path
 
-        with patch(
-            "autoskillit.server.tools.tools_kitchen._get_ctx",
-            return_value=mock_ctx,
-        ):
-            with patch(
-                "autoskillit.server.tools.tools_kitchen.resolve_ingredient_defaults",
+        mock_mcp_ctx = AsyncMock()
+        mock_mcp_ctx.enable_components = AsyncMock()
+
+        with (
+            patch(
+                "autoskillit.server.tools.tools_kitchen._require_orchestrator_exact",
+                return_value=None,
+            ),
+            patch(
+                "autoskillit.server.tools.tools_kitchen._open_kitchen_handler",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("autoskillit.server._get_ctx", return_value=mock_ctx),
+            patch(
+                "autoskillit.config.resolve_ingredient_defaults",
                 return_value={},
-            ):
-                with patch(
-                    "autoskillit.server.tools.tools_kitchen._open_kitchen_handler",
-                    new=AsyncMock(return_value=None),
-                ):
-                    with patch(
-                        "autoskillit.server.tools.tools_kitchen._apply_triage_gate",
-                        new=AsyncMock(side_effect=lambda r, *a, **kw: r),
-                    ):
-                        with patch(
-                            "autoskillit.server.tools.tools_kitchen._redisable_subsets",
-                            new=AsyncMock(return_value=None),
-                        ):
-                            await open_kitchen(name="demo")
+            ),
+            patch(
+                "autoskillit.server._misc._apply_triage_gate",
+                new_callable=AsyncMock,
+                side_effect=lambda r, *a, **kw: r,
+            ),
+            patch("autoskillit.server.tools.tools_kitchen.__version__", "0.0.0"),
+        ):
+            await open_kitchen(name="demo", ctx=mock_mcp_ctx)
 
         call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
         overrides = call_kwargs["ingredient_overrides"]
@@ -178,19 +188,26 @@ class TestLoadRecipeInjection:
         mock_ctx.recipes.find.return_value = None
         mock_ctx.temp_dir = tmp_path
 
-        with patch(
-            "autoskillit.server.tools.tools_recipe._get_ctx_or_none",
-            return_value=mock_ctx,
-        ):
-            with patch(
-                "autoskillit.server.tools.tools_recipe.resolve_ingredient_defaults",
+        with (
+            patch(
+                "autoskillit.server.tools.tools_recipe._require_enabled",
+                return_value=None,
+            ),
+            patch(
+                "autoskillit.server.tools.tools_recipe._get_ctx_or_none",
+                return_value=mock_ctx,
+            ),
+            patch(
+                "autoskillit.config.resolve_ingredient_defaults",
                 return_value={},
-            ):
-                with patch(
-                    "autoskillit.server.tools.tools_recipe._apply_triage_gate",
-                    new=AsyncMock(side_effect=lambda r, *a, **kw: r),
-                ):
-                    await load_recipe(name="demo")
+            ),
+            patch(
+                "autoskillit.server._misc._apply_triage_gate",
+                new_callable=AsyncMock,
+                side_effect=lambda r, *a, **kw: r,
+            ),
+        ):
+            await load_recipe(name="demo")
 
         call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
         overrides = call_kwargs["ingredient_overrides"]
@@ -214,19 +231,26 @@ class TestLoadRecipeInjection:
         mock_ctx.recipes.find.return_value = None
         mock_ctx.temp_dir = tmp_path
 
-        with patch(
-            "autoskillit.server.tools.tools_recipe._get_ctx_or_none",
-            return_value=mock_ctx,
-        ):
-            with patch(
-                "autoskillit.server.tools.tools_recipe.resolve_ingredient_defaults",
+        with (
+            patch(
+                "autoskillit.server.tools.tools_recipe._require_enabled",
+                return_value=None,
+            ),
+            patch(
+                "autoskillit.server.tools.tools_recipe._get_ctx_or_none",
+                return_value=mock_ctx,
+            ),
+            patch(
+                "autoskillit.config.resolve_ingredient_defaults",
                 return_value={},
-            ):
-                with patch(
-                    "autoskillit.server.tools.tools_recipe._apply_triage_gate",
-                    new=AsyncMock(side_effect=lambda r, *a, **kw: r),
-                ):
-                    await load_recipe(name="demo")
+            ),
+            patch(
+                "autoskillit.server._misc._apply_triage_gate",
+                new_callable=AsyncMock,
+                side_effect=lambda r, *a, **kw: r,
+            ),
+        ):
+            await load_recipe(name="demo")
 
         call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
         overrides = call_kwargs["ingredient_overrides"]
@@ -251,15 +275,17 @@ class TestGetRecipeResourceInjection:
             "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
         }
 
-        with patch(
-            "autoskillit.server.tools.tools_kitchen._get_ctx_or_none",
-            return_value=mock_ctx,
-        ):
-            with patch(
-                "autoskillit.server.tools.tools_kitchen.resolve_ingredient_defaults",
+        with (
+            patch(
+                "autoskillit.server._state._get_ctx_or_none",
+                return_value=mock_ctx,
+            ),
+            patch(
+                "autoskillit.config.resolve_ingredient_defaults",
                 return_value={},
-            ):
-                get_recipe("demo")
+            ),
+        ):
+            get_recipe("demo")
 
         call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
         overrides = call_kwargs["ingredient_overrides"]
@@ -277,15 +303,17 @@ class TestGetRecipeResourceInjection:
             "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
         }
 
-        with patch(
-            "autoskillit.server.tools.tools_kitchen._get_ctx_or_none",
-            return_value=mock_ctx,
-        ):
-            with patch(
-                "autoskillit.server.tools.tools_kitchen.resolve_ingredient_defaults",
+        with (
+            patch(
+                "autoskillit.server._state._get_ctx_or_none",
+                return_value=mock_ctx,
+            ),
+            patch(
+                "autoskillit.config.resolve_ingredient_defaults",
                 return_value={},
-            ):
-                get_recipe("demo")
+            ),
+        ):
+            get_recipe("demo")
 
         call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
         overrides = call_kwargs["ingredient_overrides"]

--- a/tests/server/test_tools_kitchen_gate_features.py
+++ b/tests/server/test_tools_kitchen_gate_features.py
@@ -408,7 +408,7 @@ def test_recipe_resource_returns_composed_content():
         "test-recipe",
         mock_ctx.project_dir,
         resolved_defaults={},
-        ingredient_overrides={},
+        ingredient_overrides={"backend_supports_git_write": "true"},
         backend_name=None,
     )
     assert result == ("name: test-recipe\nsteps:\n  stop:\n    action: stop\n    message: done\n")

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -22,6 +22,7 @@ from autoskillit.smoke_utils import (
     compile_eval_scorecard,
     consolidate_health_reports,
     enrich_diff_context,
+    gate_backend_write,
     parse_agent_eval_manifests,
     parse_eval_manifests,
     patch_pr_token_summary,
@@ -2613,7 +2614,7 @@ def test_diagnose_merge_gate_rejects_empty_output_dir() -> None:
 
 
 def test_smoke_utils_all_exports_complete() -> None:
-    """smoke_utils.__all__ must list all 27 public names."""
+    """smoke_utils.__all__ must list all 28 public names."""
     import autoskillit.smoke_utils as su
 
     expected = {
@@ -2634,6 +2635,7 @@ def test_smoke_utils_all_exports_complete() -> None:
         "diagnose_merge_gate",
         "enrich_diff_context",
         "fetch_merge_queue_data",
+        "gate_backend_write",
         "init_counter",
         "LOCAL_ROUND_EXEMPT_VERDICTS",
         "parse_agent_eval_manifests",
@@ -2668,6 +2670,7 @@ def test_smoke_utils_all_exports_complete() -> None:
         "diagnose_merge_gate",
         "enrich_diff_context",
         "fetch_merge_queue_data",
+        "gate_backend_write",
         "init_counter",
         "parse_agent_eval_manifests",
         "parse_eval_manifests",
@@ -3234,3 +3237,35 @@ def test_detect_zero_changes_clean_repo(tmp_path: Path) -> None:
     assert result["has_changes"] == "false"
     assert result["commit_count"] == "0"
     assert result["has_uncommitted_changes"] == "false"
+
+
+# T_GBW1-T_GBW3
+def test_gate_backend_write_true() -> None:
+    """Returns {"backend_capable": "true"} when backend_supports_git_write is "true"."""
+    assert gate_backend_write("true") == {"backend_capable": "true"}
+
+
+def test_gate_backend_write_TRUE_case_insensitive() -> None:
+    """Returns {"backend_capable": "true"} for uppercase TRUE."""
+    assert gate_backend_write("TRUE") == {"backend_capable": "true"}
+
+
+def test_gate_backend_write_default() -> None:
+    """Returns {"backend_capable": "true"} when no argument provided."""
+    assert gate_backend_write() == {"backend_capable": "true"}
+
+
+# T_GBW4-T_GBW6
+def test_gate_backend_write_false() -> None:
+    """Returns {"backend_capable": "false"} when backend_supports_git_write is "false"."""
+    assert gate_backend_write("false") == {"backend_capable": "false"}
+
+
+def test_gate_backend_write_zero() -> None:
+    """Returns {"backend_capable": "false"} for "0"."""
+    assert gate_backend_write("0") == {"backend_capable": "false"}
+
+
+def test_gate_backend_write_empty() -> None:
+    """Returns {"backend_capable": "false"} for empty string."""
+    assert gate_backend_write("") == {"backend_capable": "false"}


### PR DESCRIPTION
## Summary

Add a `gate_backend_write` run_python gate step to `implementation.yaml`, `remediation.yaml`, and `implementation-groups.yaml` that provides graceful degradation when `backend_supports_git_write=false`. When `implement` is pruned by `_prune_skipped_steps`, incoming routes redirect to `gate_backend_write`, which detects the backend limitation and routes to `release_issue_failure` instead of the misleading `close_issue_no_changes → done_no_changes` (success=true) terminal.

The remediation's originally proposed solution (`backend_limit_reached` as `action: stop` with `on_success: release_issue_failure`) is invalid — it violates the `stop-step-has-no-routing` rule and creates dangling routes. The correct design positions a `run_python` gate step as `implement`'s `on_success` target, reading the `backend_supports_git_write` ingredient server-side and returning a routing verdict: pass through to `check_changes`/`test` when writes are supported, or route to `release_issue_failure` when they are not.

Closes #3954

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260609-093724-632091/.autoskillit/temp/make-plan/backend_limit_gate_plan_2026-06-09_110500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 8 | 5.7k | 72.4k | 7.5M | 106.6k | 264 | 576.5k | 50m 6s |
| verify* | sonnet | 8 | 4.6k | 64.9k | 2.8M | 66.9k | 195 | 252.3k | 30m 13s |
| implement* | MiniMax-M3 | 8 | 13.0M | 64.5k | 0 | 0 | 527 | 0 | 42m 28s |
| audit_impl* | sonnet | 8 | 5.0k | 51.9k | 1.7M | 52.5k | 132 | 209.7k | 24m 23s |
| prepare_pr* | MiniMax-M3 | 5 | 1.2M | 10.1k | 0 | 0 | 66 | 0 | 5m 20s |
| compose_pr* | MiniMax-M3 | 5 | 1.3M | 7.0k | 0 | 0 | 76 | 0 | 4m 37s |
| review_pr* | sonnet | 8 | 1.2k | 183.6k | 7.5M | 85.3k | 349 | 407.9k | 46m 36s |
| dispatch:14228e37-6829-4706-bce4-6acddd0d2a6c* | sonnet | 1 | 362 | 14.5k | 3.4M | 88.9k | 93 | 89.1k | 1h 1m |
| fix* | sonnet | 3 | 442 | 21.5k | 2.5M | 64.0k | 145 | 116.8k | 11m 31s |
| resolve_review* | sonnet | 5 | 723 | 41.4k | 4.8M | 81.1k | 219 | 236.5k | 21m 23s |
| resolve_pre_review_conflicts* | sonnet | 3 | 252 | 7.0k | 1.1M | 43.6k | 67 | 65.0k | 2m 47s |
| dispatch:acab5783-adac-4fd8-bd85-edf32daa7272* | sonnet | 1 | 370 | 14.8k | 3.6M | 89.4k | 98 | 65.1k | 50m 0s |
| dispatch:1aa8335d-e94f-45ab-bf1a-b90798b1e9c6* | sonnet | 1 | 322 | 10.1k | 3.0M | 85.7k | 99 | 61.3k | 37m 7s |
| dispatch:960b5d6b-7b36-46b8-997c-efdd91262c90* | sonnet | 1 | 346 | 14.3k | 3.2M | 87.4k | 86 | 151.1k | 57m 38s |
| dispatch:f3edfafb-4bb3-49e6-88d4-a7aeb6626cc5* | sonnet | 2 | 476 | 17.6k | 4.8M | 103.9k | 127 | 168.0k | 1h 49m |
| dispatch:f7822216-f4ba-4c89-965e-4f1c1bb360d4* | sonnet | 1 | 282 | 13.5k | 2.6M | 89.8k | 77 | 65.4k | 39m 43s |
| **Total** | | | 15.6M | 609.2k | 48.6M | 106.6k | | 2.5M | 9h 54m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 461 | 0.0 | 0.0 | 140.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| dispatch:14228e37-6829-4706-bce4-6acddd0d2a6c | 0 | — | — | — |
| fix | 24 | 105704.7 | 4867.9 | 896.5 |
| resolve_review | 38 | 126457.6 | 6223.8 | 1089.9 |
| resolve_pre_review_conflicts | 0 | — | — | — |
| dispatch:acab5783-adac-4fd8-bd85-edf32daa7272 | 52 | 68577.2 | 1251.8 | 283.8 |
| dispatch:1aa8335d-e94f-45ab-bf1a-b90798b1e9c6 | 136 | 22055.9 | 450.9 | 74.4 |
| dispatch:960b5d6b-7b36-46b8-997c-efdd91262c90 | 72 | 44313.8 | 2098.0 | 199.2 |
| dispatch:f3edfafb-4bb3-49e6-88d4-a7aeb6626cc5 | 74 | 65163.9 | 2269.9 | 238.4 |
| dispatch:f7822216-f4ba-4c89-965e-4f1c1bb360d4 | 0 | — | — | — |
| **Total** | **857** | 56714.2 | 2876.1 | 710.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 5.7k | 72.4k | 7.5M | 576.5k | 50m 6s |
| sonnet | 12 | 14.5k | 455.2k | 41.1M | 1.9M | 8h 12m |
| MiniMax-M3 | 3 | 15.6M | 81.6k | 0 | 0 | 52m 26s |