### PR TITLE
Implementation Plan: T4-P3-A4-WP1 Extend SessionLocator Protocol with session_log_path

### DIFF
--- a/src/autoskillit/core/types/_type_protocols_backend.py
+++ b/src/autoskillit/core/types/_type_protocols_backend.py
@@ -75,6 +75,8 @@ class SessionLocator(Protocol):
         """
         ...
 
+    def session_log_path(self, cwd: str, session_id: str) -> Path | None: ...
+
 
 @runtime_checkable
 class CodingAgentBackend(Protocol):

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -46,6 +46,7 @@ from autoskillit.core import (
     ValidatedAddDir,
     YAMLError,
     build_agent_env,
+    claude_code_log_path,
     claude_code_project_dir,
     extract_skill_name,
     fast_loads,
@@ -112,6 +113,9 @@ class ClaudeSessionLocator(SessionLocator):
 
     def project_log_dir(self, cwd: str) -> Path:
         return claude_code_project_dir(cwd)
+
+    def session_log_path(self, cwd: str, session_id: str) -> Path | None:
+        return claude_code_log_path(cwd, session_id)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -366,8 +366,6 @@ class CodexSessionLocator(SessionLocator):
         return result
 
     def session_log_path(self, cwd: str, session_id: str) -> Path | None:
-        if not session_id or session_id.startswith(("no_session_", "crashed_")):
-            return None
         return None
 
     def project_log_dir(self, cwd: str) -> Path:  # cwd unused; Codex uses a global session store

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -365,6 +365,11 @@ class CodexSessionLocator(SessionLocator):
                 result.append(obj)
         return result
 
+    def session_log_path(self, cwd: str, session_id: str) -> Path | None:
+        if not session_id or session_id.startswith(("no_session_", "crashed_")):
+            return None
+        return None
+
     def project_log_dir(self, cwd: str) -> Path:  # cwd unused; Codex uses a global session store
         return default_log_dir() / "codex-sessions"
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -971,7 +971,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "for fabricated skill name rejection add defense-in-depth checks",
     ),
     "execution/backends/codex.py": (
-        1037,
+        1042,
         "REQ-CNST-010-E9: Codex backend — skill_sigil capability threading adds multi-line "
         "keyword args to _ensure_skill_prefix call sites and _has_prefix guard; "
         "write_guard_tool_names env injection adds 7 lines to _codex_exec_extras; "
@@ -980,7 +980,8 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "CodexSessionLocator nominally subclasses SessionLocator Protocol with codex_home "
         "promoted from locate_session parameter to frozen dataclass field (3 net lines: "
         "field declaration, blank line between field and method, SessionLocator in import block)"
-        "; project_log_dir method added to CodexSessionLocator (+3 net lines)",
+        "; project_log_dir method added to CodexSessionLocator (+3 net lines)"
+        "; session_log_path method added to CodexSessionLocator (+5 net lines)",
     ),
 }
 

--- a/tests/contracts/test_backend_compliance.py
+++ b/tests/contracts/test_backend_compliance.py
@@ -116,6 +116,28 @@ class TestBackendCompliance:
                 f"{type(locator).__name__}.project_log_dir must return Path"
             )
 
+    def test_all_backends_session_locator_has_session_log_path(self):
+        from pathlib import Path
+
+        from autoskillit.execution.backends import BACKEND_REGISTRY
+        from autoskillit.execution.backends.claude import ClaudeSessionLocator
+        from autoskillit.execution.backends.codex import CodexBackend  # noqa: F401
+
+        for cls in BACKEND_REGISTRY.values():
+            locator = cls().session_locator()
+            result_sentinel = locator.session_log_path("/tmp", "")
+            assert result_sentinel is None, (
+                f"{type(locator).__name__}.session_log_path must return None for empty session_id"
+            )
+            result_valid = locator.session_log_path("/tmp", "abc123")
+            assert result_valid is None or isinstance(result_valid, Path), (
+                f"{type(locator).__name__}.session_log_path must return Path or None"
+            )
+            if isinstance(locator, ClaudeSessionLocator):
+                assert isinstance(result_valid, Path), (
+                    "ClaudeSessionLocator.session_log_path must return Path for valid session_id"
+                )
+
     def test_all_backends_capabilities_is_backend_capabilities(self):
         from autoskillit.core import BackendCapabilities
         from autoskillit.execution.backends import BACKEND_REGISTRY

--- a/tests/core/test_backend_protocols.py
+++ b/tests/core/test_backend_protocols.py
@@ -54,6 +54,12 @@ def test_session_locator_has_project_log_dir_method():
     assert callable(getattr(SessionLocator, "project_log_dir", None))
 
 
+def test_session_locator_has_session_log_path_method():
+    from autoskillit.core import SessionLocator
+
+    assert callable(getattr(SessionLocator, "session_log_path", None))
+
+
 def test_no_autoskillit_imports_in_protocols_backend():
     from autoskillit.core import paths
 


### PR DESCRIPTION
## Summary

Add a `session_log_path(cwd, session_id) -> Path | None` method to the `SessionLocator` protocol, implement it on `ClaudeSessionLocator` (delegating to the existing `claude_code_log_path` utility) and `CodexSessionLocator` (returning `None` unconditionally since Codex log paths use a different discovery mechanism), and add compliance tests that verify all registered backends satisfy the new contract.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-3924-20260609-131106-806462/.autoskillit/temp/make-plan/t4_p3_a4_wp1_extend_sessionlocator_session_log_path_plan_2026-06-09_131500.md`

Closes #3924

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 2.1k | 15.6k | 1.1M | 98.4k | 40 | 79.7k | 9m 13s |
| verify* | sonnet | 1 | 62 | 15.3k | 286.9k | 60.7k | 21 | 39.1k | 5m 41s |
| implement* | MiniMax-M3 | 1 | 1.8M | 9.6k | 0 | 0 | 91 | 0 | 5m 25s |
| audit_impl* | sonnet | 1 | 1.2k | 5.3k | 208.4k | 41.9k | 16 | 24.4k | 2m 59s |
| prepare_pr* | MiniMax-M3 | 1 | 196.5k | 1.7k | 0 | 0 | 11 | 0 | 51s |
| compose_pr* | MiniMax-M3 | 1 | 222.0k | 1.2k | 0 | 0 | 14 | 0 | 43s |
| **Total** | | | 2.3M | 48.8k | 1.6M | 98.4k | | 143.2k | 24m 55s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 44 | 0.0 | 0.0 | 218.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **44** | 37255.6 | 3254.6 | 1109.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.1k | 15.6k | 1.1M | 79.7k | 9m 13s |
| sonnet | 2 | 1.3k | 20.7k | 495.3k | 63.5k | 8m 41s |
| MiniMax-M3 | 3 | 2.3M | 12.6k | 0 | 0 | 7m 0s |