### PR TITLE
fix: strengthen core/__init__.pyi re-export signature fidelity tests

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -107,6 +107,19 @@ def test_core_pyi_uses_as_form():
                 )
 
 
+def test_claude_code_path_functions_signature_fidelity():
+    import inspect
+
+    from autoskillit.core import claude_code_log_path, claude_code_project_dir
+
+    sig_proj = inspect.signature(claude_code_project_dir)
+    assert list(sig_proj.parameters.keys()) == ["cwd"]
+
+    sig_log = inspect.signature(claude_code_log_path)
+    assert list(sig_log.parameters.keys()) == ["cwd", "session_id"]
+    assert sig_log.return_annotation is not inspect.Parameter.empty
+
+
 def test_closure_walk_does_not_detect_lazy_init():
     import sys
     from pathlib import Path

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -125,6 +125,7 @@ def test_claude_code_path_functions_signature_fidelity():
     hints = typing.get_type_hints(claude_code_log_path)
     ret = hints.get("return")
     args = typing.get_args(ret)
+    assert args, f"Expected a generic/union return annotation, got {ret!r}"
     assert type(None) in args, f"Expected NoneType in return annotation, got {ret!r}"
 
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -121,8 +121,11 @@ def test_claude_code_path_functions_signature_fidelity():
     assert ann is not inspect.Parameter.empty
     import typing
 
-    args = typing.get_args(ann)
-    assert type(None) in args, f"Expected NoneType in return annotation, got {ann!r}"
+    # get_type_hints() resolves string annotations (from __future__ import annotations)
+    hints = typing.get_type_hints(claude_code_log_path)
+    ret = hints.get("return")
+    args = typing.get_args(ret)
+    assert type(None) in args, f"Expected NoneType in return annotation, got {ret!r}"
 
 
 def test_closure_walk_does_not_detect_lazy_init():

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -117,7 +117,12 @@ def test_claude_code_path_functions_signature_fidelity():
 
     sig_log = inspect.signature(claude_code_log_path)
     assert list(sig_log.parameters.keys()) == ["cwd", "session_id"]
-    assert sig_log.return_annotation is not inspect.Parameter.empty
+    ann = sig_log.return_annotation
+    assert ann is not inspect.Parameter.empty
+    import typing
+
+    args = typing.get_args(ann)
+    assert type(None) in args, f"Expected NoneType in return annotation, got {ann!r}"
 
 
 def test_closure_walk_does_not_detect_lazy_init():


### PR DESCRIPTION
## Summary

Verify that `core/__init__.pyi` accurately re-exports `claude_code_log_path` and `claude_code_project_dir` from `core/paths.py`, that `lazy.attach_stub()` drives lazy loading in `core/__init__.py`, and that no changes are needed post-migration. Write a targeted test confirming both functions are importable from `autoskillit.core` with correct signatures, then produce the verification report as the deliverable.

Remediate two audit findings from the initial T4-P3-A14-WP1 implementation: (1) strengthen the `test_claude_code_path_functions_signature_fidelity` test to verify that `claude_code_log_path`'s return annotation includes `None` (i.e., `Path | None`), not merely that an annotation exists; (2) write the verification report deliverable at `.autoskillit/temp/verification_report_t4_p3_a14_wp1.md`.

Closes #3934

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/impl-3934-20260609-123245-700310/.autoskillit/temp/make-plan/t4_p3_a14_wp1_confirm_core_init_pyi_re_exports_plan_2026-06-09_123600.md`
- `/home/talon/projects/autoskillit-runs/impl-3934-20260609-123245-700310/.autoskillit/temp/make-plan/t4_p3_a14_wp1_remediation_plan_2026-06-09_125300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 482 | 10.2k | 1.1M | 60.6k | 43 | 78.9k | 6m 7s |
| verify* | sonnet | 2 | 128 | 9.6k | 557.5k | 47.2k | 43 | 46.0k | 4m 44s |
| implement* | MiniMax-M3 | 2 | 1.6M | 9.1k | 0 | 0 | 89 | 0 | 7m 52s |
| audit_impl* | sonnet | 2 | 2.0k | 16.1k | 614.2k | 52.5k | 42 | 55.5k | 6m 41s |
| fix* | sonnet | 1 | 150 | 8.0k | 832.4k | 58.5k | 53 | 37.7k | 3m 54s |
| dispatch:f7822216-f4ba-4c89-965e-4f1c1bb360d4* | sonnet | 1 | 282 | 13.5k | 2.6M | 89.8k | 77 | 65.4k | 39m 43s |
| prepare_pr* | sonnet | 1 | 52 | 4.6k | 213.4k | 43.0k | 15 | 22.9k | 1m 26s |
| compose_pr* | sonnet | 1 | 51 | 3.5k | 194.8k | 37.5k | 14 | 15.8k | 1m 8s |
| review_pr* | sonnet | 3 | 316 | 32.7k | 1.7M | 57.5k | 105 | 104.1k | 9m 49s |
| resolve_review* | sonnet | 1 | 213 | 8.3k | 1.3M | 63.1k | 55 | 41.7k | 3m 37s |
| resolve_pre_review_conflicts* | sonnet | 1 | 92 | 3.5k | 414.2k | 43.0k | 24 | 21.4k | 1m 12s |
| **Total** | | | 1.6M | 119.1k | 9.6M | 89.8k | | 489.5k | 1h 26m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 20 | 0.0 | 0.0 | 456.2 |
| audit_impl | 0 | — | — | — |
| fix | 7 | 118921.0 | 5386.7 | 1148.3 |
| dispatch:f7822216-f4ba-4c89-965e-4f1c1bb360d4 | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 1 | 1342540.0 | 41729.0 | 8264.0 |
| resolve_pre_review_conflicts | 918 | 451.2 | 23.3 | 3.8 |
| **Total** | **946** | 10140.4 | 517.5 | 125.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 482 | 10.2k | 1.1M | 78.9k | 6m 7s |
| sonnet | 9 | 3.3k | 99.8k | 8.5M | 410.6k | 1h 12m |
| MiniMax-M3 | 1 | 1.6M | 9.1k | 0 | 0 | 7m 52s |