### PR TITLE
Rectify: Headless Side-Effect Leakage — Partial Result Propagation on Failure

### DIFF
--- a/src/autoskillit/server/tools/tools_issue_headless.py
+++ b/src/autoskillit/server/tools/tools_issue_headless.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
+import regex as re
 import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
@@ -36,12 +37,31 @@ _BLOCK_PARSE_ERRORS: frozenset[str] = frozenset(
     {"no result block found", "result block contained invalid JSON"}
 )
 
+# Canonical 7 fields of the headless error envelope. extra_fields cannot overwrite
+# any of these — see _build_headless_error_response for the contract.
+_CANONICAL_KEYS: frozenset[str] = frozenset(
+    {"success", "status", "error", "session_id", "stderr", "subtype", "exit_code"}
+)
+
+# Regex for partial-issue-data extraction: a GitHub issue URL anywhere in the
+# session's full text output. Used to recover evidence of side effects that
+# already happened (gh issue create) even when the structured output block is
+# missing or malformed.
+_ISSUE_URL_RE: re.Pattern[str] = re.compile(
+    r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/issues/(\d+)"
+)
+
+# Regex for partial-enrich-data extraction: matches "Enriched issue #NNN" prose
+# emitted by the enrich-issues skill before its structured output block.
+_ENRICHED_ISSUE_RE: re.Pattern[str] = re.compile(r"Enriched issue #(\d+)")
+
 
 def _build_headless_error_response(
     result: SkillResult,
     *,
     error: str,
     status: str = "failed",
+    extra_fields: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Canonical error response for tools that invoke headless sessions.
 
@@ -49,8 +69,13 @@ def _build_headless_error_response(
     builder. Do not hand-roll error dicts — that pattern caused silent omission of
     diagnostic fields (issue #384). Adding a field here propagates to all paths
     automatically.
+
+    Callers may pass ``extra_fields`` to attach partial-result evidence (e.g.,
+    ``partial_issue_url`` when a headless session created an issue but failed to
+    emit a parseable result block). ``extra_fields`` is filtered against
+    ``_CANONICAL_KEYS`` — it cannot overwrite any of the 7 canonical fields.
     """
-    return {
+    resp: dict[str, Any] = {
         "success": False,
         "status": status,
         "error": error,
@@ -59,6 +84,9 @@ def _build_headless_error_response(
         "subtype": result.subtype or "",
         "exit_code": result.exit_code if result.exit_code is not None else -1,
     }
+    if extra_fields:
+        resp.update({k: v for k, v in extra_fields.items() if k not in _CANONICAL_KEYS})
+    return resp
 
 
 def _retry_reason_to_error(result: SkillResult) -> str:
@@ -73,6 +101,76 @@ def _retry_reason_to_error(result: SkillResult) -> str:
     ):
         return result.retry_reason.value
     return result.subtype or "skill session failed"
+
+
+def _extract_partial_issue_data(result_text: str) -> dict[str, Any]:
+    """Mine a failed session's full text output for evidence of a created issue.
+
+    The prepare-issue skill creates a GitHub issue at Step 5, then applies
+    classification/labels/requirements on later steps. If the session fails mid-
+    execution (CONTRACT_RECOVERY, drain race, malformed block), the caller needs
+    to know which issue was created so it does not re-create it.
+
+    Strategy:
+      1. Try _parse_prepare_result to find a successfully-parsed block; if the
+         block parsed, return its issue_url/issue_number as partial fields.
+      2. If the block is present but JSON is malformed, the issue may still
+         have been created — search the full text for a GitHub issue URL via
+         _ISSUE_URL_RE and return the FIRST match.
+      3. If no URL is found anywhere, return an empty dict (no partial data).
+    """
+    if not result_text:
+        return {}
+
+    parsed = _parse_prepare_result(result_text)
+    if "error" not in parsed and (parsed.get("issue_url") or parsed.get("issue_number")):
+        out: dict[str, Any] = {}
+        if "issue_url" in parsed:
+            out["partial_issue_url"] = parsed["issue_url"]
+        if "issue_number" in parsed:
+            out["partial_issue_number"] = parsed["issue_number"]
+        return out
+
+    m = _ISSUE_URL_RE.search(result_text)
+    if m:
+        number = int(m.group(1))
+        url = m.group(0)
+        return {"partial_issue_url": url, "partial_issue_number": number}
+    return {}
+
+
+def _extract_partial_enrich_data(result_text: str) -> dict[str, Any]:
+    """Mine a failed session's full text output for evidence of enriched issues.
+
+    The enrich-issues skill edits issues in batches; if it fails mid-batch
+    (CONTRACT_RECOVERY, drain race, malformed block), the caller needs to know
+    which issues were already enriched so it does not re-edit them.
+
+    Strategy:
+      1. Try _parse_enrich_result; if the block parsed, return its 'enriched'
+         list as partial_issues_enriched.
+      2. If the block is absent or malformed, search the full text for
+         "Enriched issue #NNN" patterns and return the matched issue numbers
+         (in document order, deduplicated).
+      3. If no matches, return an empty dict (no partial data).
+    """
+    if not result_text:
+        return {}
+
+    parsed = _parse_enrich_result(result_text)
+    if "error" not in parsed and parsed.get("enriched"):
+        return {"partial_issues_enriched": list(parsed["enriched"])}
+
+    seen: set[int] = set()
+    ordered: list[int] = []
+    for m in _ENRICHED_ISSUE_RE.finditer(result_text):
+        n = int(m.group(1))
+        if n not in seen:
+            seen.add(n)
+            ordered.append(n)
+    if ordered:
+        return {"partial_issues_enriched": ordered}
+    return {}
 
 
 def _without_success_key(d: dict[str, Any]) -> dict[str, Any]:
@@ -224,8 +322,11 @@ async def prepare_issue(
             )
 
             if not result.success:
+                extra = _extract_partial_issue_data(result.result) if result.result else {}
                 return json.dumps(
-                    _build_headless_error_response(result, error=_retry_reason_to_error(result))
+                    _build_headless_error_response(
+                        result, error=_retry_reason_to_error(result), extra_fields=extra
+                    )
                 )
 
             if result.result is None or not result.result.strip():
@@ -242,7 +343,12 @@ async def prepare_issue(
             # The sentinel errors from _parse_prepare_result signal a block-extraction failure —
             # these are not the same as skill-internal errors embedded in a valid block.
             if parsed.get("error") in _BLOCK_PARSE_ERRORS:
-                return json.dumps(_build_headless_error_response(result, error=parsed["error"]))
+                extra = _extract_partial_issue_data(result.result)
+                return json.dumps(
+                    _build_headless_error_response(
+                        result, error=parsed["error"], extra_fields=extra
+                    )
+                )
 
             # Block parsed successfully. result.success=True is the authoritative signal —
             # the parsed block's "success" field (if any) must not overwrite it.
@@ -334,8 +440,11 @@ async def enrich_issues(
             )
 
             if not result.success:
+                extra = _extract_partial_enrich_data(result.result) if result.result else {}
                 return json.dumps(
-                    _build_headless_error_response(result, error=_retry_reason_to_error(result))
+                    _build_headless_error_response(
+                        result, error=_retry_reason_to_error(result), extra_fields=extra
+                    )
                 )
 
             if result.result is None or not result.result.strip():
@@ -348,7 +457,12 @@ async def enrich_issues(
 
             parsed = _parse_enrich_result(result.result)
             if parsed.get("error") in _BLOCK_PARSE_ERRORS:
-                return json.dumps(_build_headless_error_response(result, error=parsed["error"]))
+                extra = _extract_partial_enrich_data(result.result)
+                return json.dumps(
+                    _build_headless_error_response(
+                        result, error=parsed["error"], extra_fields=extra
+                    )
+                )
 
             return json.dumps(
                 {

--- a/tests/execution/headless/test_headless_recovery.py
+++ b/tests/execution/headless/test_headless_recovery.py
@@ -155,7 +155,8 @@ class TestNudgePtyMode:
         )
 
 
-def test_nudge_skips_for_block_delimiter_patterns() -> None:
+@pytest.mark.anyio
+async def test_nudge_skips_for_block_delimiter_patterns(tmp_path: Path) -> None:
     """Block-delimited patterns (---{name}---) are not path-capture, so hints=[].
 
     _is_path_capture_pattern returns None for block delimiters (no path-capture token
@@ -164,7 +165,12 @@ def test_nudge_skips_for_block_delimiter_patterns() -> None:
     short-circuits to None when hints=[]) cannot recover block-delimited skills — the
     caller always falls through to the failure path.
     """
-    from autoskillit.execution.headless._headless_recovery import _extract_missing_token_hints
+    from autoskillit.execution.headless._headless_recovery import (
+        _attempt_contract_nudge,
+        _extract_missing_token_hints,
+    )
+    from tests.execution.conftest import _mock_backend
+    from tests.fakes import MockSubprocessRunner
 
     result_parser = Mock()
     parsed_session = Mock()
@@ -180,3 +186,40 @@ def test_nudge_skips_for_block_delimiter_patterns() -> None:
     )
 
     assert hints == []
+
+    # Verify _attempt_contract_nudge short-circuits to None when hints is empty
+    skill_result = SkillResult(
+        success=False,
+        result="",
+        session_id="test-session",
+        subtype="empty_output",
+        is_error=False,
+        exit_code=0,
+        needs_retry=True,
+        retry_reason=RetryReason.CONTRACT_RECOVERY,
+        stderr="",
+        kill_reason=KillReason.NATURAL_EXIT,
+        evidence=WriteEvidence.none_observed(),
+    )
+    subprocess_result = SubprocessResult(
+        returncode=0,
+        stdout="",
+        stderr="",
+        termination=TerminationReason.NATURAL_EXIT,
+        pid=0,
+    )
+    backend = _mock_backend(pty_required=False, session_resume_capable=True)
+    runner = MockSubprocessRunner()
+
+    nudge_result = await _attempt_contract_nudge(
+        skill_result=skill_result,
+        subprocess_result=subprocess_result,
+        expected_output_patterns=["---prepare-issue-result---"],
+        completion_marker="%%NUDGE_DONE%%",
+        cwd=str(tmp_path),
+        runner=runner,
+        backend=backend,
+        result_parser=result_parser,
+    )
+
+    assert nudge_result is None

--- a/tests/execution/headless/test_headless_recovery.py
+++ b/tests/execution/headless/test_headless_recovery.py
@@ -223,4 +223,4 @@ async def test_nudge_skips_for_block_delimiter_patterns(tmp_path: Path) -> None:
     )
 
     assert nudge_result is None
-    result_parser.parse_stdout.assert_not_called()
+    assert result_parser.parse_stdout.call_count == 2

--- a/tests/execution/headless/test_headless_recovery.py
+++ b/tests/execution/headless/test_headless_recovery.py
@@ -223,3 +223,4 @@ async def test_nudge_skips_for_block_delimiter_patterns(tmp_path: Path) -> None:
     )
 
     assert nudge_result is None
+    result_parser.parse_stdout.assert_not_called()

--- a/tests/execution/headless/test_headless_recovery.py
+++ b/tests/execution/headless/test_headless_recovery.py
@@ -153,3 +153,30 @@ class TestNudgePtyMode:
             f"Expected last_pty_mode=False when pty_override=False, "
             f"got {mock_runner.last_pty_mode!r}"
         )
+
+
+def test_nudge_skips_for_block_delimiter_patterns() -> None:
+    """Block-delimited patterns (---{name}---) are not path-capture, so hints=[].
+
+    _is_path_capture_pattern returns None for block delimiters (no path-capture token
+    in the pattern, no '=' after the token). The for-loop in _extract_missing_token_hints
+    skips such patterns, leaving hints empty. This means _attempt_contract_nudge (which
+    short-circuits to None when hints=[]) cannot recover block-delimited skills — the
+    caller always falls through to the failure path.
+    """
+    from autoskillit.execution.headless._headless_recovery import _extract_missing_token_hints
+
+    result_parser = Mock()
+    parsed_session = Mock()
+    parsed_session.output = "irrelevant output text"
+    parsed_session.raw = {"tool_uses": []}
+    result_parser.parse_stdout.return_value = parsed_session
+
+    hints = _extract_missing_token_hints(
+        stdout="",
+        expected_output_patterns=["---prepare-issue-result---"],
+        result_parser=result_parser,
+        write_tool_names=frozenset({"Write", "Edit"}),
+    )
+
+    assert hints == []

--- a/tests/server/test_tools_integrations.py
+++ b/tests/server/test_tools_integrations.py
@@ -641,6 +641,30 @@ class TestEnrichIssuesTool:
         assert response["stderr"] == "Warning: contract stale"
         assert response["session_id"] == "enrich-123"
 
+    @pytest.mark.anyio
+    async def test_enrich_issues_contract_recovery_includes_partial_enriched(
+        self, tool_ctx_kitchen_open
+    ):
+        """CONTRACT_RECOVERY with enriched issue numbers → partial_issues_enriched propagated."""
+        mock_executor = AsyncMock()
+        mock_executor.run.return_value = SkillResult(
+            success=False,
+            result=(
+                "Enriched issue #100.\nEnriched issue #101.\nFailed on issue #102 (timeout)..."
+            ),
+            session_id="enrich-partial",
+            subtype="contract_recovery",
+            is_error=True,
+            exit_code=0,
+            needs_retry=False,
+            retry_reason=RetryReason.CONTRACT_RECOVERY,
+            stderr="",
+        )
+        tool_ctx_kitchen_open.executor = mock_executor
+        response = json.loads(await enrich_issues())
+        assert response["success"] is False
+        assert response["partial_issues_enriched"] == [100, 101]
+
 
 _REQUIRED_FAILURE_KEYS = frozenset(
     {"success", "error", "session_id", "stderr", "subtype", "exit_code"}
@@ -767,6 +791,69 @@ async def test_headless_tool_failure_paths_include_all_diagnostic_fields(
     assert response["success"] is False
     assert response["stderr"] == skill_result_kwargs["stderr"]
     assert response["session_id"] == skill_result_kwargs["session_id"]
+
+
+@pytest.mark.anyio
+async def test_prepare_issue_contract_recovery_propagates_partial_url(
+    tool_ctx_kitchen_open,
+):
+    """CONTRACT_RECOVERY: prepare_issue surfaces partial_issue_url alongside canonical fields."""
+    mock_executor = AsyncMock()
+    mock_executor.run.return_value = SkillResult(
+        success=False,
+        result="Created issue\nhttps://github.com/owner/repo/issues/42\nNow labeling...",
+        session_id="s-contract",
+        stderr="e-contract",
+        subtype="contract_recovery",
+        is_error=True,
+        exit_code=0,
+        needs_retry=False,
+        retry_reason=RetryReason.CONTRACT_RECOVERY,
+    )
+    tool_ctx_kitchen_open.executor = mock_executor
+
+    response = json.loads(await prepare_issue("Title", "Body"))
+    # Canonical contract preserved.
+    missing = _REQUIRED_FAILURE_KEYS - set(response.keys())
+    assert not missing, f"missing failure response keys: {missing}"
+    assert response["success"] is False
+    # Partial-result propagation.
+    assert response["partial_issue_url"] == "https://github.com/owner/repo/issues/42"
+    assert response["partial_issue_number"] == 42
+
+
+@pytest.mark.anyio
+async def test_prepare_issue_block_parse_error_propagates_partial_url(
+    tool_ctx_kitchen_open,
+):
+    """Block-parse-error path: prepare_issue surfaces partial_issue_url from result text."""
+    mock_executor = AsyncMock()
+    mock_executor.run.return_value = SkillResult(
+        success=True,
+        result=(
+            "Created https://github.com/owner/repo/issues/42\n"
+            "---prepare-issue-result---\n"
+            "{bad json\n"
+            "---/prepare-issue-result---"
+        ),
+        session_id="s-parse",
+        stderr="e-parse",
+        subtype="success",
+        is_error=False,
+        exit_code=0,
+        needs_retry=False,
+        retry_reason=RetryReason.NONE,
+    )
+    tool_ctx_kitchen_open.executor = mock_executor
+
+    response = json.loads(await prepare_issue("Title", "Body"))
+    # Canonical contract preserved.
+    missing = _REQUIRED_FAILURE_KEYS - set(response.keys())
+    assert not missing, f"missing failure response keys: {missing}"
+    assert response["success"] is False
+    # Partial-result propagation.
+    assert response["partial_issue_url"] == "https://github.com/owner/repo/issues/42"
+    assert response["partial_issue_number"] == 42
 
 
 class TestGetPrReviews:

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -71,6 +71,65 @@ def test_build_headless_error_response_fields() -> None:
     assert resp["exit_code"] == 1
 
 
+def test_build_headless_error_response_propagates_extra_fields() -> None:
+    """extra_fields merges partial-result data without overwriting the canonical 7 fields."""
+    result = _make_skill_result(
+        success=False,
+        retry_reason=RetryReason.CONTRACT_RECOVERY,
+        session_id="abc",
+        subtype="contract_recovery",
+    )
+    resp = _build_headless_error_response(
+        result,
+        error="contract_recovery",
+        extra_fields={
+            "partial_issue_url": "https://github.com/owner/repo/issues/42",
+            "partial_issue_number": 42,
+        },
+    )
+    assert resp["partial_issue_url"] == "https://github.com/owner/repo/issues/42"
+    assert resp["partial_issue_number"] == 42
+    # Canonical 7 fields remain intact.
+    assert resp["success"] is False
+    assert resp["status"] == "failed"
+    assert resp["error"] == "contract_recovery"
+    assert resp["session_id"] == "abc"
+    assert resp["stderr"] == ""
+    assert resp["subtype"] == "contract_recovery"
+    assert resp["exit_code"] == 0
+
+
+def test_build_headless_error_response_extra_fields_cannot_override_canonical() -> None:
+    """extra_fields cannot overwrite any of the 7 canonical keys (defense in depth)."""
+    result = _make_skill_result(
+        success=False,
+        session_id="real-session",
+        subtype="timeout",
+        exit_code=1,
+        stderr="real stderr",
+    )
+    resp = _build_headless_error_response(
+        result,
+        error="real error",
+        extra_fields={
+            "error": "injected",
+            "session_id": "spoofed",
+            "stderr": "injected stderr",
+            "subtype": "injected subtype",
+            "exit_code": 999,
+            "status": "spoofed",
+            "success": True,
+        },
+    )
+    assert resp["error"] == "real error"
+    assert resp["session_id"] == "real-session"
+    assert resp["stderr"] == "real stderr"
+    assert resp["subtype"] == "timeout"
+    assert resp["exit_code"] == 1
+    assert resp["status"] == "failed"
+    assert resp["success"] is False
+
+
 def test_retry_reason_to_error_uses_enum_value() -> None:
     """Non-NONE RetryReason → returns its .value string."""
     result = _make_skill_result(success=False, retry_reason=RetryReason.STALE)
@@ -221,6 +280,46 @@ async def test_prepare_issue_block_parse_error(tool_ctx_kitchen_open) -> None:
     result = json.loads(await prepare_issue("Title", "Body"))
     assert result["success"] is False
     assert result["error"] == "no result block found"
+
+
+@pytest.mark.anyio
+async def test_prepare_issue_contract_recovery_includes_partial_issue_url(
+    tool_ctx_kitchen_open,
+) -> None:
+    """CONTRACT_RECOVERY with URL in result.result → partial_issue_url propagated to caller."""
+    skill_result = _make_skill_result(
+        success=False,
+        retry_reason=RetryReason.CONTRACT_RECOVERY,
+        result=(
+            "I created the issue.\n\n"
+            "issue_url = https://github.com/owner/repo/issues/42\n\n"
+            "Now applying labels..."
+        ),
+    )
+    tool_ctx_kitchen_open.executor = AsyncMock()
+    tool_ctx_kitchen_open.executor.run = AsyncMock(return_value=skill_result)
+
+    result = json.loads(await prepare_issue("Title", "Body"))
+    assert result["success"] is False
+    assert result["partial_issue_url"] == "https://github.com/owner/repo/issues/42"
+    assert result["partial_issue_number"] == 42
+
+
+@pytest.mark.anyio
+async def test_prepare_issue_failure_without_issue_url_has_no_partial_fields(
+    tool_ctx_kitchen_open,
+) -> None:
+    """Generic failure (no URL anywhere in result.result) → no partial_issue_* fields."""
+    skill_result = _make_skill_result(
+        success=False, result="Session timed out before any side effect"
+    )
+    tool_ctx_kitchen_open.executor = AsyncMock()
+    tool_ctx_kitchen_open.executor.run = AsyncMock(return_value=skill_result)
+
+    result = json.loads(await prepare_issue("Title", "Body"))
+    assert result["success"] is False
+    assert "partial_issue_url" not in result
+    assert "partial_issue_number" not in result
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

When `prepare_issue` or `enrich_issues` headless sessions complete but fail output extraction (`contract_recovery`), the failure response from `_build_headless_error_response` drops all evidence of external side effects (GitHub issue creation, issue body edits) that already occurred inside the session. The caller sees `{success: false}` with no `issue_url` or `issue_number`, leading to duplicate issue creation.

The architectural weakness is that `_build_headless_error_response` is a sealed 7-field response that ignores `SkillResult.result` (the model's full text output, which contains the side-effect evidence). The fix propagates partial results through the canonical error builder via an `extra_fields` parameter, and adds extraction logic at each tool's failure path to mine `SkillResult.result` for evidence of completed side effects.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260609-151422-543443/.autoskillit/temp/rectify/rectify_headless_side_effect_leakage_2026-06-09_151422.md`

Closes #3959

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->