### PR TITLE
Rectify: Ingredient Authority Enforcement Gap — Config-Authority Keys Without Enforcement Backing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,7 +292,6 @@ forbidden_modules = [
 # so no cycle is introduced.
 ignore_imports = [
     "autoskillit.recipe.rules.rules_contracts -> autoskillit.planner",
-    "autoskillit.recipe.rules.rules_inputs -> autoskillit.config",
 ]
 
 # IL-007 | Lens: module-dependency | DS-001
@@ -308,12 +307,6 @@ forbidden_modules = [
     "autoskillit.server",
     "autoskillit.cli",
     "autoskillit.report",
-]
-# EXCEPTION: rules_inputs imports config to derive _KNOWN_CONFIG_AUTHORITY_KEYS
-# from the capability registries. migration → recipe → rules_inputs → config is
-# transitive only; migration/ itself does not use config types.
-ignore_imports = [
-    "autoskillit.recipe.rules.rules_inputs -> autoskillit.config",
 ]
 
 # IL-008 | Lens: module-dependency | DS-001

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -309,6 +309,12 @@ forbidden_modules = [
     "autoskillit.cli",
     "autoskillit.report",
 ]
+# EXCEPTION: rules_inputs imports config to derive _KNOWN_CONFIG_AUTHORITY_KEYS
+# from the capability registries. migration → recipe → rules_inputs → config is
+# transitive only; migration/ itself does not use config types.
+ignore_imports = [
+    "autoskillit.recipe.rules.rules_inputs -> autoskillit.config",
+]
 
 # IL-008 | Lens: module-dependency | DS-001
 # Rationale: The six IL-1 peers (config, pipeline, execution, workspace, report,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,6 +292,7 @@ forbidden_modules = [
 # so no cycle is introduced.
 ignore_imports = [
     "autoskillit.recipe.rules.rules_contracts -> autoskillit.planner",
+    "autoskillit.recipe.rules.rules_inputs -> autoskillit.config",
 ]
 
 # IL-007 | Lens: module-dependency | DS-001

--- a/src/autoskillit/config/__init__.py
+++ b/src/autoskillit/config/__init__.py
@@ -9,6 +9,7 @@ from autoskillit.config._config_dataclasses import (
     _MAX_CONCURRENT_DISPATCHES as _MAX_CONCURRENT_DISPATCHES,
 )
 from autoskillit.config.ingredient_defaults import (
+    BACKEND_CAPABILITY_INGREDIENTS,
     SERVER_AUTHORITATIVE_INGREDIENTS,
     apply_config_authoritative_overrides,
     build_config_authoritative_layer,
@@ -94,6 +95,7 @@ __all__ = [
     "iter_display_categories",
     "load_config",
     "resolve_ingredient_defaults",
+    "BACKEND_CAPABILITY_INGREDIENTS",
     "SERVER_AUTHORITATIVE_INGREDIENTS",
     "apply_config_authoritative_overrides",
     "build_config_authoritative_layer",

--- a/src/autoskillit/config/ingredient_defaults.py
+++ b/src/autoskillit/config/ingredient_defaults.py
@@ -125,6 +125,12 @@ SERVER_AUTHORITATIVE_INGREDIENTS: frozenset[str] = CONFIG_AUTHORITY_KEYS - {
     "backend_supports_git_write",
 }
 
+BACKEND_CAPABILITY_INGREDIENTS: frozenset[str] = frozenset(
+    {
+        "backend_supports_git_write",
+    }
+)
+
 
 def resolve_ingredient_defaults(project_dir: Path) -> dict[str, str]:
     """Resolve auto-detect ingredient values from the project environment."""
@@ -175,6 +181,8 @@ def apply_config_authoritative_overrides(
     effective_ingredients: dict[str, str],
     recipe_ingredients: Mapping[str, _HasAuthority],
     project_dir: Path,
+    *,
+    capability_overrides: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """Prevent LLM-supplied values from winning for config-authoritative keys at fleet dispatch."""
     config_keys = [
@@ -190,6 +198,8 @@ def apply_config_authoritative_overrides(
     for key in config_keys:
         if key in resolved:
             result[key] = resolved[key]
+        elif capability_overrides and key in capability_overrides:
+            result[key] = capability_overrides[key]
         else:
             logger.warning(
                 "config-authority key %r not found in resolved defaults — "

--- a/src/autoskillit/config/ingredient_defaults.py
+++ b/src/autoskillit/config/ingredient_defaults.py
@@ -199,6 +199,8 @@ def apply_config_authoritative_overrides(
         if key in resolved:
             result[key] = resolved[key]
         elif capability_overrides and key in capability_overrides:
+            # Fallback: only reached when resolve_ingredient_defaults() has no value for
+            # this key. Adding a key to resolve_ingredient_defaults shadows this branch.
             result[key] = capability_overrides[key]
         else:
             logger.warning(

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -116,7 +116,7 @@ def _build_capability_overrides(backend: Any) -> dict[str, str]:
 
     Mirrors ``_backend_capability_overrides`` in ``server.tools._auto_overrides``
     but is inlined here because fleet/ (IL-2) cannot import from server/ (IL-3).
-    A structural test asserts the key set matches ``BACKEND_CAPABILITY_INGREDIENTS``.
+    A structural test asserts every ``BACKEND_CAPABILITY_INGREDIENTS`` key is covered.
     """
     _backend_writable = backend is None or backend.capabilities.git_metadata_writable
     return {"backend_supports_git_write": "true" if _backend_writable else "false"}

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -111,6 +111,17 @@ def resolve_dispatch_timeout(
     return float(default_timeout_sec)
 
 
+def _build_capability_overrides(backend: Any) -> dict[str, str]:
+    """Compute capability-derived ingredient overrides for a backend.
+
+    Mirrors ``_backend_capability_overrides`` in ``server.tools._auto_overrides``
+    but is inlined here because fleet/ (IL-2) cannot import from server/ (IL-3).
+    A structural test asserts the key set matches ``BACKEND_CAPABILITY_INGREDIENTS``.
+    """
+    _backend_writable = backend is None or backend.capabilities.git_metadata_writable
+    return {"backend_supports_git_write": "true" if _backend_writable else "false"}
+
+
 def _write_pid(
     state_path: Path,
     dispatch_name: str,
@@ -407,8 +418,12 @@ async def _run_dispatch(
         apply_config_authoritative_overrides,
     )
 
+    _capability_overrides = _build_capability_overrides(tool_ctx.backend)
     effective_ingredients = apply_config_authoritative_overrides(
-        effective_ingredients, full_recipe.ingredients, tool_ctx.project_dir
+        effective_ingredients,
+        full_recipe.ingredients,
+        tool_ctx.project_dir,
+        capability_overrides=_capability_overrides,
     )
 
     effective_name = dispatch_name or recipe

--- a/src/autoskillit/recipe/rules/rules_inputs.py
+++ b/src/autoskillit/recipe/rules/rules_inputs.py
@@ -503,8 +503,8 @@ def _check_ingredient_condition_value_domain(
 @semantic_rule(
     name="config-authority-requires-resolve-source",
     description=(
-        "Ingredients with authority='config' must use a key resolvable"
-        " by resolve_ingredient_defaults"
+        "Ingredients with authority='config' must use a key resolvable by "
+        "resolve_ingredient_defaults() or a registered backend-capability key"
     ),
     severity=Severity.ERROR,
 )
@@ -518,11 +518,13 @@ def _check_config_authority_requires_resolve_source(ctx: ValidationContext) -> l
                 make_finding(
                     rule_name="config-authority-requires-resolve-source",
                     step_name="(top-level)",
-                    message=f"Ingredient {name!r} declares authority='config' but is not a key "
-                    f"returned by resolve_ingredient_defaults(). "
-                    f"Known config-authoritative keys: "
-                    f"{sorted(CONFIG_AUTHORITY_KEYS)}. "
-                    "Remove the authority field or use a supported key.",
+                    message=(
+                        f"Ingredient {name!r} declares authority='config' but is not a recognized "
+                        f"config-authoritative key. Known keys come from "
+                        f"SERVER_AUTHORITATIVE_INGREDIENTS, BACKEND_CAPABILITY_INGREDIENTS, "
+                        f"or source_dir: {sorted(CONFIG_AUTHORITY_KEYS)}. "
+                        f"Add the key to the appropriate registry in ingredient_defaults.py."
+                    ),
                 )
             )
         elif getattr(ing, "required", False) and getattr(ing, "default", None) is None:

--- a/src/autoskillit/server/tools/_auto_overrides.py
+++ b/src/autoskillit/server/tools/_auto_overrides.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from autoskillit.config import BACKEND_CAPABILITY_INGREDIENTS
+
 if TYPE_CHECKING:
     from autoskillit.core import CodingAgentBackend
 
@@ -24,3 +26,16 @@ def _backend_capability_overrides(backend: CodingAgentBackend | None) -> dict[st
     """
     git_writable = backend is None or backend.capabilities.git_metadata_writable
     return {"backend_supports_git_write": "true" if git_writable else "false"}
+
+
+def _promote_capability_keys(
+    config_layer: dict[str, str], session_overrides: dict[str, str]
+) -> None:
+    """Promote backend capability keys from session overrides into the config layer.
+
+    This ensures capability-derived values win the merge even when user-supplied
+    overrides would otherwise clobber them.  Mutates ``config_layer`` in place.
+    """
+    for key in BACKEND_CAPABILITY_INGREDIENTS:
+        if key in session_overrides:
+            config_layer[key] = session_overrides[key]

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -17,7 +17,6 @@ from fastmcp.dependencies import CurrentContext
 
 from autoskillit import __version__
 from autoskillit.config import (
-    BACKEND_CAPABILITY_INGREDIENTS,
     SERVER_AUTHORITATIVE_INGREDIENTS,
     build_config_authoritative_layer,
     iter_display_categories,
@@ -57,7 +56,10 @@ from autoskillit.server._misc import (
     strip_ingredients_only_keys,
 )
 from autoskillit.server._notify import track_response_size
-from autoskillit.server.tools._auto_overrides import _backend_capability_overrides
+from autoskillit.server.tools._auto_overrides import (
+    _backend_capability_overrides,
+    _promote_capability_keys,
+)
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
@@ -537,9 +539,7 @@ async def open_kitchen(
             }
             _session_overrides.update(_backend_capability_overrides(tool_ctx.backend))
             _config_layer = build_config_authoritative_layer(_defaults)
-            for _cap_key in BACKEND_CAPABILITY_INGREDIENTS:
-                if _cap_key in _session_overrides:
-                    _config_layer[_cap_key] = _session_overrides[_cap_key]
+            _promote_capability_keys(_config_layer, _session_overrides)
             _merged_overrides = {**_session_overrides, **(overrides or {}), **_config_layer}
             # Runtime enum check: output_mode must be validated before recipe loading
             if name == "research":

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -17,6 +17,7 @@ from fastmcp.dependencies import CurrentContext
 
 from autoskillit import __version__
 from autoskillit.config import (
+    BACKEND_CAPABILITY_INGREDIENTS,
     SERVER_AUTHORITATIVE_INGREDIENTS,
     build_config_authoritative_layer,
     iter_display_categories,
@@ -536,6 +537,9 @@ async def open_kitchen(
             }
             _session_overrides.update(_backend_capability_overrides(tool_ctx.backend))
             _config_layer = build_config_authoritative_layer(_defaults)
+            for _cap_key in BACKEND_CAPABILITY_INGREDIENTS:
+                if _cap_key in _session_overrides:
+                    _config_layer[_cap_key] = _session_overrides[_cap_key]
             _merged_overrides = {**_session_overrides, **(overrides or {}), **_config_layer}
             # Runtime enum check: output_mode must be validated before recipe loading
             if name == "research":

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -10,7 +10,6 @@ from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
 from autoskillit.config import (
-    BACKEND_CAPABILITY_INGREDIENTS,
     build_config_authoritative_layer,
     resolve_ingredient_defaults,
 )
@@ -25,7 +24,10 @@ from autoskillit.server._misc import (
 )
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._state import _get_ctx_or_none
-from autoskillit.server.tools._auto_overrides import _backend_capability_overrides
+from autoskillit.server.tools._auto_overrides import (
+    _backend_capability_overrides,
+    _promote_capability_keys,
+)
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 
 logger = get_logger(__name__)
@@ -218,9 +220,7 @@ async def load_recipe(
             }
             _session_overrides.update(_backend_capability_overrides(tool_ctx.backend))
             _config_layer = build_config_authoritative_layer(_defaults)
-            for _cap_key in BACKEND_CAPABILITY_INGREDIENTS:
-                if _cap_key in _session_overrides:
-                    _config_layer[_cap_key] = _session_overrides[_cap_key]
+            _promote_capability_keys(_config_layer, _session_overrides)
             _merged_overrides = {**_session_overrides, **(overrides or {}), **_config_layer}
             result = tool_ctx.recipes.load_and_validate(
                 name,

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -9,7 +9,11 @@ import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit.config import build_config_authoritative_layer, resolve_ingredient_defaults
+from autoskillit.config import (
+    BACKEND_CAPABILITY_INGREDIENTS,
+    build_config_authoritative_layer,
+    resolve_ingredient_defaults,
+)
 from autoskillit.core import get_logger, temp_dir_display_str
 from autoskillit.pipeline import GATED_TOOLS, UNGATED_TOOLS  # noqa: F401
 from autoskillit.server import mcp
@@ -214,6 +218,9 @@ async def load_recipe(
             }
             _session_overrides.update(_backend_capability_overrides(tool_ctx.backend))
             _config_layer = build_config_authoritative_layer(_defaults)
+            for _cap_key in BACKEND_CAPABILITY_INGREDIENTS:
+                if _cap_key in _session_overrides:
+                    _config_layer[_cap_key] = _session_overrides[_cap_key]
             _merged_overrides = {**_session_overrides, **(overrides or {}), **_config_layer}
             result = tool_ctx.recipes.load_and_validate(
                 name,

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -613,6 +613,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "execution",
             "fleet",
             "pipeline",
+            "recipe",
             "workspace",
             "server",
             "cli",

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -1423,7 +1423,8 @@ _TEST_LAYER_ALLOWLIST: dict[str, frozenset[str]] = {
     # workspace tests
     "tests/workspace/test_clone_ci_contract.py": frozenset({"autoskillit.execution"}),
     "tests/workspace/test_skills.py": frozenset({"autoskillit.config"}),
-    # recipe tests — recipe layer is IL-2 and may use workspace (IL-1 sibling)
+    # recipe tests — recipe layer is IL-2 and may use workspace (IL-1 sibling) or config (IL-1)
+    "tests/recipe/test_rules_inputs.py": frozenset({"autoskillit.config"}),
     "tests/recipe/test_contracts.py": frozenset({"autoskillit.workspace"}),
     "tests/recipe/test_rules_skill_content.py": frozenset({"autoskillit.workspace"}),
     "tests/recipe/test_rules_backend_compat.py": frozenset({"autoskillit.workspace"}),

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -962,11 +962,11 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "co-located with the execution engine that calls them",
     ),
     "tools_kitchen.py": (
-        1110,
+        1115,
         "REQ-CNST-010-E7: kitchen tool handlers — open_kitchen and lock_ingredients require "
         "inline validation helpers (_check_override_keys, _build_ingredient_key_suggestions) "
         "for ingredient key validation; splitting would cross import-layer boundaries; "
-        "backend capability override injection in get_recipe adds 3 lines",
+        "backend capability promotion delegated to _promote_capability_keys in _auto_overrides",
     ),
     "tools_execution.py": (
         1060,

--- a/tests/config/test_helpers.py
+++ b/tests/config/test_helpers.py
@@ -215,3 +215,59 @@ def test_config_authority_keys_superset_of_server_authoritative() -> None:
         "source_dir",
         "backend_supports_git_write",
     }
+
+
+def test_apply_config_authoritative_overrides_capability_key_overrides_caller(tmp_path):
+    """Capability key registered in BACKEND_CAPABILITY_INGREDIENTS must be overridden by
+    capability_overrides, not the caller-supplied value."""
+    from autoskillit.config import apply_config_authoritative_overrides
+    from autoskillit.recipe.schema import RecipeIngredient
+
+    recipe_ingredients = {
+        "backend_supports_git_write": RecipeIngredient(
+            description="Capability flag", authority="config"
+        ),
+    }
+
+    with patch(
+        "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
+        return_value={},
+    ):
+        result = apply_config_authoritative_overrides(
+            {"backend_supports_git_write": "true"},
+            recipe_ingredients,
+            tmp_path,
+            capability_overrides={"backend_supports_git_write": "false"},
+        )
+
+    assert result["backend_supports_git_write"] == "false"
+
+
+def test_apply_config_authoritative_overrides_unknown_key_warns_and_retains(tmp_path):
+    """A config-authority key not in any registry (truly unknown) must trigger the
+    warning-and-retain path, not the capability override path."""
+    import structlog.testing
+
+    from autoskillit.config import apply_config_authoritative_overrides
+    from autoskillit.recipe.schema import RecipeIngredient
+
+    recipe_ingredients = {
+        "totally_unknown_key": RecipeIngredient(description="Unknown", authority="config"),
+    }
+
+    with (
+        patch(
+            "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
+            return_value={},
+        ),
+        structlog.testing.capture_logs() as cap_logs,
+    ):
+        result = apply_config_authoritative_overrides(
+            {"totally_unknown_key": "caller-value"},
+            recipe_ingredients,
+            tmp_path,
+            capability_overrides={"backend_supports_git_write": "false"},
+        )
+
+    assert result["totally_unknown_key"] == "caller-value"
+    assert any("config-authority key" in e.get("event", "") for e in cap_logs)

--- a/tests/config/test_helpers.py
+++ b/tests/config/test_helpers.py
@@ -220,13 +220,12 @@ def test_config_authority_keys_superset_of_server_authoritative() -> None:
 def test_apply_config_authoritative_overrides_capability_key_overrides_caller(tmp_path):
     """Capability key registered in BACKEND_CAPABILITY_INGREDIENTS must be overridden by
     capability_overrides, not the caller-supplied value."""
+    from types import SimpleNamespace
+
     from autoskillit.config import apply_config_authoritative_overrides
-    from autoskillit.recipe.schema import RecipeIngredient
 
     recipe_ingredients = {
-        "backend_supports_git_write": RecipeIngredient(
-            description="Capability flag", authority="config"
-        ),
+        "backend_supports_git_write": SimpleNamespace(authority="config"),
     }
 
     with patch(
@@ -246,13 +245,14 @@ def test_apply_config_authoritative_overrides_capability_key_overrides_caller(tm
 def test_apply_config_authoritative_overrides_unknown_key_warns_and_retains(tmp_path):
     """A config-authority key not in any registry (truly unknown) must trigger the
     warning-and-retain path, not the capability override path."""
+    from types import SimpleNamespace
+
     import structlog.testing
 
     from autoskillit.config import apply_config_authoritative_overrides
-    from autoskillit.recipe.schema import RecipeIngredient
 
     recipe_ingredients = {
-        "totally_unknown_key": RecipeIngredient(description="Unknown", authority="config"),
+        "totally_unknown_key": SimpleNamespace(authority="config"),
     }
 
     with (

--- a/tests/fleet/test_dispatch_ingredient_validation.py
+++ b/tests/fleet/test_dispatch_ingredient_validation.py
@@ -427,8 +427,9 @@ class TestConfigAuthoritativeIngredientInjection:
     async def test_config_authoritative_key_absent_from_defaults_retains_caller_value(
         self, tool_ctx
     ):
-        """When a config-authority key is absent from resolved defaults, the caller-supplied
-        value is retained and a warning is logged."""
+        """When a config-authority key is absent from resolved defaults AND not in
+        BACKEND_CAPABILITY_INGREDIENTS, the caller-supplied value is retained and a
+        warning is logged."""
         from unittest.mock import patch
 
         import structlog.testing
@@ -442,8 +443,8 @@ class TestConfigAuthoritativeIngredientInjection:
                 description="test",
                 kind=RecipeKind.STANDARD,
                 ingredients={
-                    "base_branch": RecipeIngredient(
-                        description="Merge target", default="", authority="config"
+                    "truly_unknown_key": RecipeIngredient(
+                        description="Truly absent", default="", authority="config"
                     )
                 },
             ),
@@ -459,13 +460,13 @@ class TestConfigAuthoritativeIngredientInjection:
         with structlog.testing.capture_logs() as cap_logs:
             with patch(
                 "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
-                return_value={},  # base_branch absent — simulates resolver not returning the key
+                return_value={},  # key absent from all registries
             ):
                 await execute_dispatch(
                     tool_ctx=tool_ctx,
                     recipe="test-recipe",
                     task="t",
-                    ingredients={"base_branch": "caller-supplied"},
+                    ingredients={"truly_unknown_key": "caller-supplied"},
                     dispatch_name=None,
                     timeout_sec=None,
                     prompt_builder=_capture_prompt_builder,
@@ -473,8 +474,75 @@ class TestConfigAuthoritativeIngredientInjection:
                     quota_refresher=_noop_quota_refresher,
                 )
 
-        assert captured["ingredients"]["base_branch"] == "caller-supplied"
+        assert captured["ingredients"]["truly_unknown_key"] == "caller-supplied"
         assert any(
             e.get("log_level") == "warning" and "config-authority key" in e.get("event", "")
             for e in cap_logs
         )
+
+    @pytest.mark.anyio
+    async def test_non_writable_backend_forces_git_write_false_at_dispatch(self, tool_ctx):
+        """When tool_ctx.backend has git_metadata_writable=False, the dispatched
+        ingredients must contain backend_supports_git_write='false', regardless of
+        LLM-supplied ingredients."""
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeKind
+
+        _setup_config_authority_recipe(
+            tool_ctx,
+            Recipe(
+                name="test-recipe",
+                description="test",
+                kind=RecipeKind.STANDARD,
+                ingredients={
+                    "backend_supports_git_write": RecipeIngredient(
+                        description="Capability", default="true", authority="config"
+                    )
+                },
+            ),
+        )
+        captured: dict = {}
+
+        def _capture_prompt_builder(**kwargs):
+            captured.update(kwargs)
+            return "prompt"
+
+        tool_ctx.backend = SimpleNamespace(
+            capabilities=SimpleNamespace(git_metadata_writable=False)
+        )
+
+        from autoskillit.fleet._api import execute_dispatch
+
+        with patch(
+            "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
+            return_value={},
+        ):
+            await execute_dispatch(
+                tool_ctx=tool_ctx,
+                recipe="test-recipe",
+                task="t",
+                ingredients={"backend_supports_git_write": "true"},
+                dispatch_name=None,
+                timeout_sec=None,
+                prompt_builder=_capture_prompt_builder,
+                quota_checker=_no_sleep_quota_checker,
+                quota_refresher=_noop_quota_refresher,
+            )
+
+        assert captured["ingredients"]["backend_supports_git_write"] == "false"
+
+
+def test_capability_overrides_dict_covers_registry_keys():
+    """Structural test: every key in BACKEND_CAPABILITY_INGREDIENTS must appear in the
+    capability_overrides dict that fleet dispatch passes to apply_config_authoritative_overrides.
+    Adding a key to the registry without dispatch-site enforcement fails this test."""
+    from autoskillit.config import BACKEND_CAPABILITY_INGREDIENTS
+    from autoskillit.fleet._api import _build_capability_overrides
+
+    capability_overrides = _build_capability_overrides(backend=None)
+    missing = BACKEND_CAPABILITY_INGREDIENTS - set(capability_overrides)
+    assert not missing, (
+        f"Capability registry keys missing from dispatch capability_overrides: {missing}"
+    )

--- a/tests/fleet/test_dispatch_ingredient_validation.py
+++ b/tests/fleet/test_dispatch_ingredient_validation.py
@@ -510,7 +510,8 @@ class TestConfigAuthoritativeIngredientInjection:
             return "prompt"
 
         tool_ctx.backend = SimpleNamespace(
-            capabilities=SimpleNamespace(git_metadata_writable=False)
+            name="test-backend",
+            capabilities=SimpleNamespace(git_metadata_writable=False),
         )
 
         from autoskillit.fleet._api import execute_dispatch

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -119,11 +119,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 87),
     # tools_kitchen.py — hook config, quota guard, git_ops_policy, ingredient locks overlay
-    ("src/autoskillit/server/tools/tools_kitchen.py", 139),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 158),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 192),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 835),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 895),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 142),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 161),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 195),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 839),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 899),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict

--- a/tests/recipe/test_rules_inputs.py
+++ b/tests/recipe/test_rules_inputs.py
@@ -455,14 +455,14 @@ def test_unreachable_steps_first_step_clean() -> None:
 
 
 def test_known_config_authority_keys_derived_from_registries():
-    """_KNOWN_CONFIG_AUTHORITY_KEYS must equal the union of the registries
+    """CONFIG_AUTHORITY_KEYS must equal the union of the registries
     plus source_dir. Drift between registries is a CI failure."""
     from autoskillit.config import BACKEND_CAPABILITY_INGREDIENTS, SERVER_AUTHORITATIVE_INGREDIENTS
-    from autoskillit.recipe.rules import rules_inputs
+    from autoskillit.core import CONFIG_AUTHORITY_KEYS
 
     expected = (
         SERVER_AUTHORITATIVE_INGREDIENTS
         | BACKEND_CAPABILITY_INGREDIENTS
         | frozenset({"source_dir"})
     )
-    assert rules_inputs._KNOWN_CONFIG_AUTHORITY_KEYS == expected
+    assert CONFIG_AUTHORITY_KEYS == expected

--- a/tests/recipe/test_rules_inputs.py
+++ b/tests/recipe/test_rules_inputs.py
@@ -452,3 +452,17 @@ def test_unreachable_steps_first_step_clean() -> None:
     findings = run_semantic_rules(wf)
     unreachable = [f for f in findings if f.rule == "unreachable-step"]
     assert unreachable == []
+
+
+def test_known_config_authority_keys_derived_from_registries():
+    """_KNOWN_CONFIG_AUTHORITY_KEYS must equal the union of the registries
+    plus source_dir. Drift between registries is a CI failure."""
+    from autoskillit.config import BACKEND_CAPABILITY_INGREDIENTS, SERVER_AUTHORITATIVE_INGREDIENTS
+    from autoskillit.recipe.rules import rules_inputs
+
+    expected = (
+        SERVER_AUTHORITATIVE_INGREDIENTS
+        | BACKEND_CAPABILITY_INGREDIENTS
+        | frozenset({"source_dir"})
+    )
+    assert rules_inputs._KNOWN_CONFIG_AUTHORITY_KEYS == expected

--- a/tests/server/test_backend_ingredient_injection.py
+++ b/tests/server/test_backend_ingredient_injection.py
@@ -318,3 +318,132 @@ class TestGetRecipeResourceInjection:
         call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
         overrides = call_kwargs["ingredient_overrides"]
         assert overrides.get("backend_supports_git_write") == "true"
+
+
+# ---------------------------------------------------------------------------
+# Merge-order: capability keys must win over caller-supplied overrides
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestOpenKitchenMergeOrderCapabilityWins:
+    async def test_caller_override_clobbered_by_capability_detection(self, tmp_path) -> None:
+        """When overrides={'backend_supports_git_write': 'true'} is passed but the backend
+        is non-writable, the merged result must contain 'false' — the backend capability
+        wins over caller overrides."""
+        from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+        mock_ctx = MagicMock()
+        mock_ctx.kitchen_id = "test-kitchen"
+        mock_ctx.config.linux_tracing.log_dir = ""
+        mock_ctx.config.migration.suppressed = []
+        mock_ctx.config.features = {}
+        mock_ctx.config.experimental_enabled = False
+        mock_ctx.backend = _make_backend_with_capability(False)
+        mock_ctx.recipes = MagicMock()
+        mock_ctx.recipes.load_and_validate.return_value = {
+            "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+            "valid": True,
+            "suggestions": [],
+            "ingredients_table": None,
+        }
+        mock_ctx.recipes.find.return_value = None
+        mock_ctx.temp_dir = tmp_path
+
+        mock_mcp_ctx = AsyncMock()
+        mock_mcp_ctx.enable_components = AsyncMock()
+
+        with (
+            patch(
+                "autoskillit.server.tools.tools_kitchen._require_orchestrator_exact",
+                return_value=None,
+            ),
+            patch(
+                "autoskillit.server.tools.tools_kitchen._open_kitchen_handler",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("autoskillit.server._get_ctx", return_value=mock_ctx),
+            patch(
+                "autoskillit.config.resolve_ingredient_defaults",
+                return_value={},
+            ),
+            patch(
+                "autoskillit.server._misc._apply_triage_gate",
+                new_callable=AsyncMock,
+                side_effect=lambda r, *a, **kw: r,
+            ),
+            patch("autoskillit.server.tools.tools_kitchen.__version__", "0.0.0"),
+        ):
+            await open_kitchen(
+                name="demo",
+                overrides={"backend_supports_git_write": "true"},
+                ctx=mock_mcp_ctx,
+            )
+
+        call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
+        overrides = call_kwargs["ingredient_overrides"]
+        assert overrides.get("backend_supports_git_write") == "false"
+
+
+@pytest.mark.anyio
+class TestLoadRecipeMergeOrderCapabilityWins:
+    async def test_caller_override_clobbered_by_capability_detection(self, tmp_path) -> None:
+        """load_recipe must also promote backend-capability keys to the winning layer."""
+        from autoskillit.server.tools.tools_recipe import load_recipe
+
+        mock_ctx = MagicMock()
+        mock_ctx.kitchen_id = "test-kitchen"
+        mock_ctx.config.linux_tracing.log_dir = ""
+        mock_ctx.config.migration.suppressed = []
+        mock_ctx.config.workspace.temp_dir = ".autoskillit/temp"
+        mock_ctx.backend = _make_backend_with_capability(False)
+        mock_ctx.recipes = MagicMock()
+        mock_ctx.recipes.load_and_validate.return_value = {
+            "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+            "valid": True,
+            "suggestions": [],
+        }
+        mock_ctx.recipes.find.return_value = None
+        mock_ctx.temp_dir = tmp_path
+
+        with (
+            patch(
+                "autoskillit.server.tools.tools_recipe._require_enabled",
+                return_value=None,
+            ),
+            patch(
+                "autoskillit.server.tools.tools_recipe._get_ctx_or_none",
+                return_value=mock_ctx,
+            ),
+            patch(
+                "autoskillit.config.resolve_ingredient_defaults",
+                return_value={},
+            ),
+            patch(
+                "autoskillit.server._misc._apply_triage_gate",
+                new_callable=AsyncMock,
+                side_effect=lambda r, *a, **kw: r,
+            ),
+        ):
+            await load_recipe(name="demo", overrides={"backend_supports_git_write": "true"})
+
+        call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
+        overrides = call_kwargs["ingredient_overrides"]
+        assert overrides.get("backend_supports_git_write") == "false"
+
+
+# ---------------------------------------------------------------------------
+# Capability registry coverage: helper output matches IL-1 registry
+# ---------------------------------------------------------------------------
+
+
+def test_backend_capability_overrides_matches_registry():
+    """The set of keys returned by _backend_capability_overrides must equal
+    BACKEND_CAPABILITY_INGREDIENTS. Drift between IL-3 helper and IL-1 registry
+    is a CI failure."""
+    from autoskillit.config import BACKEND_CAPABILITY_INGREDIENTS
+    from autoskillit.server.tools._auto_overrides import _backend_capability_overrides
+
+    result = _backend_capability_overrides(backend=None)
+    assert set(result) == BACKEND_CAPABILITY_INGREDIENTS


### PR DESCRIPTION
## Summary

The `authority=config` contract on recipe ingredients is not structurally enforced. The contract promises that config-authority keys are system-controlled and cannot be overridden by LLM-supplied values, but enforcement is split across two independent mechanisms (`resolve_ingredient_defaults()` at IL-1 and `_backend_capability_overrides()` at IL-3) with no shared registry. A new `authority=config` ingredient can be declared in a recipe YAML and whitelisted in the validation rule (`_KNOWN_CONFIG_AUTHORITY_KEYS`) without any corresponding enforcement code — and the only runtime signal is a warning log that retains the caller-supplied value.

The architectural immunity proposed here introduces a **capability-override resolver registry** in `ingredient_defaults.py` (IL-1) and **derives the validation whitelist programmatically** from the registry, making it impossible to declare a config-authority key in a recipe without first registering an enforcement resolver.

## Requirements

**REQ-FLEET-001:** `apply_config_authoritative_overrides()` must accept an optional `capability_overrides` parameter that provides values for config-authority keys not resolvable from project config/environment.

**REQ-FLEET-002:** `_run_dispatch` in `fleet/_api.py` must compute `backend_supports_git_write` from `tool_ctx.backend.capabilities.git_metadata_writable` and pass it as a capability override.

**REQ-FLEET-003:** When `tool_ctx.backend` is `None`, `backend_supports_git_write` must default to `"true"` (matching `_backend_capability_overrides()` behavior).

**REQ-FLEET-004:** The capability override must be applied after config-resolved values, ensuring backend-derived values take precedence over the "caller-supplied value retained" fallback.

**REQ-FLEET-005:** Existing call sites of `apply_config_authoritative_overrides()` (without `capability_overrides`) must continue to work unchanged (parameter is optional with `None` default).

**REQ-FLEET-006:** No import-linter contracts may be violated — the `fleet/` → `config/` import already has an IL-009 exception, and no `fleet/` → `server/` import is introduced.

Closes #3971

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260609-170414-020282/.autoskillit/temp/rectify/rectify_ingredient_authority_enforcement_2026-06-09_170414.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| review_pr* | opus[1m] | 1 | 1.3k | 31.8k | 447.5k | 89.2k | 30 | 72.8k | 9m 30s |
| resolve_review* | opus[1m] | 1 | 34 | 5.6k | 936.8k | 66.1k | 36 | 44.8k | 5m 14s |
| resolve_pre_review_conflicts* | opus[1m] | 1 | 45 | 9.3k | 1.7M | 79.0k | 56 | 57.2k | 3m 35s |
| diagnose_ci* | opus[1m] | 1 | 28 | 2.5k | 350.0k | 39.3k | 14 | 17.9k | 1m 15s |
| resolve_ci* | opus[1m] | 1 | 47 | 7.0k | 1.1M | 70.2k | 44 | 46.9k | 6m 43s |
| **Total** | | | 1.5k | 56.3k | 4.6M | 89.2k | | 239.6k | 26m 19s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 234202.5 | 11195.8 | 1407.5 |
| resolve_pre_review_conflicts | 780 | 2222.9 | 73.3 | 11.9 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 13 | 88259.9 | 3606.9 | 539.4 |
| **Total** | **797** | 5791.2 | 300.6 | 70.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 5 | 1.5k | 56.3k | 4.6M | 239.6k | 26m 19s |