### PR TITLE
Implementation Plan: Eliminate all claude_code_project_dir() and claude_code_log_path() call sites from fleet/_api.py via Protocol dispatch

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -677,7 +677,10 @@ async def _run_dispatch(
 
     marker_dir: Path | None = None
     if _locator is not None:
-        marker_dir = _locator.project_log_dir(str(tool_ctx.project_dir))
+        try:
+            marker_dir = _locator.project_log_dir(str(tool_ctx.project_dir))
+        except OSError:
+            pass
 
     from autoskillit.core import execution_marker  # noqa: PLC0415
 
@@ -864,9 +867,12 @@ async def _run_dispatch(
             dispatch_sidecar_path, tool_ctx.github_client, issue_url=_issue_urls_raw
         )
 
-    project_log_dir = (
-        str(_locator.project_log_dir(str(tool_ctx.project_dir))) if _locator is not None else ""
-    )
+    project_log_dir = ""
+    if _locator is not None:
+        try:
+            project_log_dir = str(_locator.project_log_dir(str(tool_ctx.project_dir)))
+        except OSError:
+            logger.warning("project_log_dir_unavailable", exc_info=True)
 
     if (
         resume_session_id

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -19,8 +19,6 @@ from autoskillit.core import (
     SessionCheckpoint,  # noqa: F401, TC001
     SkillResult,
     atomic_write,
-    claude_code_log_path,
-    claude_code_project_dir,
     get_logger,
     truncate_text,
 )
@@ -548,8 +546,14 @@ async def _run_dispatch(
     if quota_result.get("should_sleep"):
         await asyncio.sleep(quota_result.get("sleep_seconds", 0))
 
+    _locator = tool_ctx.backend.session_locator() if tool_ctx.backend is not None else None
+
     if resume_session_id:
-        _primary_jsonl = claude_code_log_path(str(tool_ctx.project_dir), resume_session_id)
+        _primary_jsonl = (
+            _locator.session_log_path(str(tool_ctx.project_dir), resume_session_id)
+            if _locator is not None
+            else None
+        )
         if _primary_jsonl is None or not _primary_jsonl.exists():
             logger.warning(
                 "resume_jsonl_missing",
@@ -558,8 +562,10 @@ async def _run_dispatch(
             )
             _fallback_session_id = prior_session_chain[-1] if prior_session_chain else ""
             if _fallback_session_id:
-                _fallback_jsonl = claude_code_log_path(
-                    str(tool_ctx.project_dir), _fallback_session_id
+                _fallback_jsonl = (
+                    _locator.session_log_path(str(tool_ctx.project_dir), _fallback_session_id)
+                    if _locator is not None
+                    else None
                 )
                 if _fallback_jsonl is not None and _fallback_jsonl.exists():
                     logger.info(
@@ -581,7 +587,11 @@ async def _run_dispatch(
 
     resume_line_offset = 0
     if resume_session_id:
-        _resume_jsonl = claude_code_log_path(str(tool_ctx.project_dir), resume_session_id)
+        _resume_jsonl = (
+            _locator.session_log_path(str(tool_ctx.project_dir), resume_session_id)
+            if _locator is not None
+            else None
+        )
         if _resume_jsonl is not None and _resume_jsonl.exists():
             resume_line_offset = len(_resume_jsonl.read_text(encoding="utf-8").splitlines())
 
@@ -666,10 +676,8 @@ async def _run_dispatch(
         )
 
     marker_dir: Path | None = None
-    try:
-        marker_dir = claude_code_project_dir(str(tool_ctx.project_dir))
-    except OSError:
-        pass
+    if _locator is not None:
+        marker_dir = _locator.project_log_dir(str(tool_ctx.project_dir))
 
     from autoskillit.core import execution_marker  # noqa: PLC0415
 
@@ -781,11 +789,19 @@ async def _run_dispatch(
             extended_chain.append(prior_dispatched_session_id)
 
         for sid in extended_chain:
-            path = claude_code_log_path(str(tool_ctx.project_dir), sid)
+            path = (
+                _locator.session_log_path(str(tool_ctx.project_dir), sid)
+                if _locator is not None
+                else None
+            )
             if path is not None:
                 additional_jsonl_paths.append(path)
 
-        jsonl_path = claude_code_log_path(str(tool_ctx.project_dir), skill_result.session_id or "")
+        jsonl_path = (
+            _locator.session_log_path(str(tool_ctx.project_dir), skill_result.session_id or "")
+            if _locator is not None
+            else None
+        )
         if resume_line_offset and skill_result.session_id and resume_session_id:
             if skill_result.session_id != resume_session_id:
                 logger.warning(
@@ -848,11 +864,9 @@ async def _run_dispatch(
             dispatch_sidecar_path, tool_ctx.github_client, issue_url=_issue_urls_raw
         )
 
-    try:
-        project_log_dir = str(claude_code_project_dir(str(tool_ctx.project_dir)))
-    except OSError:
-        logger.warning("failed to resolve project log dir", exc_info=True)
-        project_log_dir = ""
+    project_log_dir = (
+        str(_locator.project_log_dir(str(tool_ctx.project_dir))) if _locator is not None else ""
+    )
 
     if (
         resume_session_id

--- a/tests/fleet/_helpers.py
+++ b/tests/fleet/_helpers.py
@@ -162,7 +162,7 @@ def _make_completed_clean(success: bool, reason: str = ""):
     )
 
 
-_SENTINEL = object()
+_SENTINEL: Any = object()
 
 
 def _mock_backend_with_locator(
@@ -181,6 +181,8 @@ def _mock_backend_with_locator(
         mock_locator.session_log_path.side_effect = session_log_path_side_effect
     elif session_log_path is not _SENTINEL:
         mock_locator.session_log_path.return_value = session_log_path
+    else:
+        mock_locator.session_log_path.return_value = None
     mock_backend = Mock()
     mock_backend.session_locator.return_value = mock_locator
     return mock_backend

--- a/tests/fleet/_helpers.py
+++ b/tests/fleet/_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 from autoskillit.core.types._type_constants_registries import PACK_REGISTRY, TOOL_SUBSET_TAGS
@@ -53,7 +54,6 @@ async def _noop_quota_refresher(config, **kwargs) -> None:
 
 
 def _make_recipe_info(name: str = "test-recipe", path_prefix: str = "/fake/"):
-    from pathlib import Path
 
     from autoskillit.recipe.schema import RecipeInfo, RecipeSource
 
@@ -160,3 +160,27 @@ def _make_completed_clean(success: bool, reason: str = ""):
         parse_error=None,
         source="stdout",
     )
+
+
+_SENTINEL = object()
+
+
+def _mock_backend_with_locator(
+    *,
+    project_log_dir: Path | None = None,
+    session_log_path: Path | None = _SENTINEL,
+    session_log_path_side_effect=None,
+):
+    """Build a mock backend with configured session_locator for dispatch tests."""
+    from unittest.mock import Mock
+
+    mock_locator = Mock()
+    if project_log_dir is not None:
+        mock_locator.project_log_dir.return_value = project_log_dir
+    if session_log_path_side_effect is not None:
+        mock_locator.session_log_path.side_effect = session_log_path_side_effect
+    elif session_log_path is not _SENTINEL:
+        mock_locator.session_log_path.return_value = session_log_path
+    mock_backend = Mock()
+    mock_backend.session_locator.return_value = mock_locator
+    return mock_backend

--- a/tests/fleet/_helpers.py
+++ b/tests/fleet/_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -169,7 +170,7 @@ def _mock_backend_with_locator(
     *,
     project_log_dir: Path | None = None,
     session_log_path: Path | None = _SENTINEL,
-    session_log_path_side_effect=None,
+    session_log_path_side_effect: Callable[..., Path | None] | None = None,
 ):
     """Build a mock backend with configured session_locator for dispatch tests."""
     from unittest.mock import Mock

--- a/tests/fleet/test_api.py
+++ b/tests/fleet/test_api.py
@@ -15,7 +15,7 @@ from autoskillit.fleet import (
     _write_pid,
     write_initial_state,
 )
-from tests.fleet._helpers import _setup_dispatch
+from tests.fleet._helpers import _mock_backend_with_locator, _setup_dispatch
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
 
@@ -380,10 +380,7 @@ class TestDispatchMarkerLifecycle:
         _setup_dispatch(tool_ctx, monkeypatch)
         marker_dir = tmp_path / "markers"
         marker_dir.mkdir()
-        monkeypatch.setattr(
-            "autoskillit.fleet._api.claude_code_project_dir",
-            lambda cwd: marker_dir,
-        )
+        tool_ctx.backend = _mock_backend_with_locator(project_log_dir=marker_dir)
 
         await _run(tool_ctx)
 
@@ -396,12 +393,9 @@ class TestDispatchMarkerLifecycle:
     async def test_run_dispatch_continues_when_marker_dir_unavailable(
         self, tool_ctx, monkeypatch
     ) -> None:
-        """execute_dispatch succeeds even when claude_code_project_dir raises OSError."""
+        """execute_dispatch succeeds even when backend's session_locator is unavailable."""
         _setup_dispatch(tool_ctx, monkeypatch)
-        monkeypatch.setattr(
-            "autoskillit.fleet._api.claude_code_project_dir",
-            lambda cwd: (_ for _ in ()).throw(OSError("no project dir")),
-        )
+        tool_ctx.backend = None
 
         result = await _run(tool_ctx)
 
@@ -416,10 +410,7 @@ class TestDispatchMarkerLifecycle:
         _setup_dispatch(tool_ctx, monkeypatch)
         marker_dir = tmp_path / "markers"
         marker_dir.mkdir()
-        monkeypatch.setattr(
-            "autoskillit.fleet._api.claude_code_project_dir",
-            lambda cwd: marker_dir,
-        )
+        tool_ctx.backend = _mock_backend_with_locator(project_log_dir=marker_dir)
 
         await _run(tool_ctx)
 
@@ -436,10 +427,7 @@ class TestDispatchMarkerLifecycle:
         _setup_dispatch(tool_ctx, monkeypatch)
         marker_dir = tmp_path / "markers"
         marker_dir.mkdir()
-        monkeypatch.setattr(
-            "autoskillit.fleet._api.claude_code_project_dir",
-            lambda cwd: marker_dir,
-        )
+        tool_ctx.backend = _mock_backend_with_locator(project_log_dir=marker_dir)
 
         original_dispatch_food_truck = tool_ctx.executor.dispatch_food_truck
 
@@ -465,10 +453,7 @@ class TestDispatchMarkerLifecycle:
         _setup_dispatch(tool_ctx, monkeypatch)
         marker_dir = tmp_path / "markers"
         marker_dir.mkdir()
-        monkeypatch.setattr(
-            "autoskillit.fleet._api.claude_code_project_dir",
-            lambda cwd: marker_dir,
-        )
+        tool_ctx.backend = _mock_backend_with_locator(project_log_dir=marker_dir)
 
         marker_seen: list[bool] = []
         original_dispatch = tool_ctx.executor.dispatch_food_truck
@@ -493,10 +478,7 @@ class TestDispatchMarkerLifecycle:
         _setup_dispatch(tool_ctx, monkeypatch)
         marker_dir = tmp_path / "markers"
         marker_dir.mkdir()
-        monkeypatch.setattr(
-            "autoskillit.fleet._api.claude_code_project_dir",
-            lambda cwd: marker_dir,
-        )
+        tool_ctx.backend = _mock_backend_with_locator(project_log_dir=marker_dir)
 
         captured_json: list[dict] = []
 

--- a/tests/fleet/test_api_dispatch_marker.py
+++ b/tests/fleet/test_api_dispatch_marker.py
@@ -13,7 +13,12 @@ from autoskillit.core import SkillResult
 from autoskillit.core._execution_marker import _touch_marker
 from autoskillit.core.types._type_enums import RetryReason
 from autoskillit.fleet._api import _run_dispatch
-from tests.fleet._helpers import _no_sleep_quota_checker, _noop_quota_refresher, _setup_dispatch
+from tests.fleet._helpers import (
+    _mock_backend_with_locator,
+    _no_sleep_quota_checker,
+    _noop_quota_refresher,
+    _setup_dispatch,
+)
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.medium, pytest.mark.feature("fleet")]
 
@@ -23,10 +28,7 @@ async def test_marker_created_before_dispatch(tool_ctx, monkeypatch, tmp_path: P
     _setup_dispatch(tool_ctx, monkeypatch)
     marker_dir = tmp_path / "marker_dir"
     marker_dir.mkdir(parents=True, exist_ok=True)
-    monkeypatch.setattr(
-        "autoskillit.fleet._api.claude_code_project_dir",
-        lambda _cwd: marker_dir,
-    )
+    tool_ctx.backend = _mock_backend_with_locator(project_log_dir=marker_dir)
 
     async def _asserting_dispatch(**_kw):
         found = list(marker_dir.glob("*-in-progress-*.marker"))
@@ -54,10 +56,7 @@ async def test_marker_deleted_after_success(tool_ctx, monkeypatch, tmp_path: Pat
     _setup_dispatch(tool_ctx, monkeypatch)
     marker_dir = tmp_path / "claude"
     marker_dir.mkdir(parents=True, exist_ok=True)
-    monkeypatch.setattr(
-        "autoskillit.fleet._api.claude_code_project_dir",
-        lambda _cwd: marker_dir,
-    )
+    tool_ctx.backend = _mock_backend_with_locator(project_log_dir=marker_dir)
 
     await _run_dispatch(
         tool_ctx=tool_ctx,
@@ -80,10 +79,7 @@ async def test_marker_deleted_after_exception(tool_ctx, monkeypatch, tmp_path: P
     _setup_dispatch(tool_ctx, monkeypatch)
     marker_dir = tmp_path / "claude"
     marker_dir.mkdir(parents=True, exist_ok=True)
-    monkeypatch.setattr(
-        "autoskillit.fleet._api.claude_code_project_dir",
-        lambda _cwd: marker_dir,
-    )
+    tool_ctx.backend = _mock_backend_with_locator(project_log_dir=marker_dir)
 
     async def _raise_runtime_error(**_kw):
         raise RuntimeError("boom")
@@ -134,13 +130,7 @@ async def test_marker_not_written_when_cwd_unavailable(
 ) -> None:
     _setup_dispatch(tool_ctx, monkeypatch)
 
-    def _raise_oserror(_cwd: str) -> Path:
-        raise OSError("simulated failure")
-
-    monkeypatch.setattr(
-        "autoskillit.fleet._api.claude_code_project_dir",
-        _raise_oserror,
-    )
+    tool_ctx.backend = None
 
     await _run_dispatch(
         tool_ctx=tool_ctx,

--- a/tests/fleet/test_dispatch_ingredient_validation.py
+++ b/tests/fleet/test_dispatch_ingredient_validation.py
@@ -509,9 +509,15 @@ class TestConfigAuthoritativeIngredientInjection:
             captured.update(kwargs)
             return "prompt"
 
+        from unittest.mock import Mock as _Mock
+
+        _mock_locator = _Mock()
+        _mock_locator.project_log_dir.return_value = None
+        _mock_locator.session_log_path.return_value = None
         tool_ctx.backend = SimpleNamespace(
             name="test-backend",
             capabilities=SimpleNamespace(git_metadata_writable=False),
+            session_locator=lambda: _mock_locator,
         )
 
         from autoskillit.fleet._api import execute_dispatch

--- a/tests/fleet/test_dispatch_ingredient_validation.py
+++ b/tests/fleet/test_dispatch_ingredient_validation.py
@@ -6,6 +6,7 @@ import pytest
 
 from tests.fleet._helpers import (
     _make_recipe_info,
+    _mock_backend_with_locator,
     _no_sleep_quota_checker,
     _noop_quota_refresher,
     _run,
@@ -509,16 +510,10 @@ class TestConfigAuthoritativeIngredientInjection:
             captured.update(kwargs)
             return "prompt"
 
-        from unittest.mock import Mock as _Mock
-
-        _mock_locator = _Mock()
-        _mock_locator.project_log_dir.return_value = None
-        _mock_locator.session_log_path.return_value = None
-        tool_ctx.backend = SimpleNamespace(
-            name="test-backend",
-            capabilities=SimpleNamespace(git_metadata_writable=False),
-            session_locator=lambda: _mock_locator,
-        )
+        _mock_backend = _mock_backend_with_locator(project_log_dir=None, session_log_path=None)
+        _mock_backend.name = "test-backend"
+        _mock_backend.capabilities = SimpleNamespace(git_metadata_writable=False)
+        tool_ctx.backend = _mock_backend
 
         from autoskillit.fleet._api import execute_dispatch
 

--- a/tests/fleet/test_dispatch_state_handle.py
+++ b/tests/fleet/test_dispatch_state_handle.py
@@ -63,6 +63,7 @@ class TestResumeWithoutPriorDispatchId:
         from autoskillit.core.types import CaptureEntrySpec
         from autoskillit.fleet.result_parser import L3ParseResult
         from tests.fleet._helpers import (
+            _mock_backend_with_locator,
             _no_sleep_quota_checker,
             _noop_quota_refresher,
             _setup_dispatch,
@@ -71,7 +72,9 @@ class TestResumeWithoutPriorDispatchId:
         _setup_dispatch(tool_ctx, monkeypatch)
         jsonl_file = tmp_path / "sess-123.jsonl"
         jsonl_file.touch()
-        monkeypatch.setattr("autoskillit.fleet._api.claude_code_log_path", lambda *_: jsonl_file)
+        tool_ctx.backend = _mock_backend_with_locator(
+            project_log_dir=tmp_path, session_log_path=jsonl_file
+        )
 
         mock_parsed = L3ParseResult(
             outcome="completed_clean",
@@ -276,6 +279,7 @@ class TestSessionChainAccumulatesAcrossResume:
         from autoskillit.fleet._api import _run_dispatch
         from autoskillit.fleet.state import read_state
         from tests.fleet._helpers import (
+            _mock_backend_with_locator,
             _no_sleep_quota_checker,
             _noop_quota_refresher,
             _setup_dispatch,
@@ -284,7 +288,9 @@ class TestSessionChainAccumulatesAcrossResume:
         _setup_dispatch(tool_ctx, monkeypatch)
         jsonl_file = tmp_path / "sess-resume-1.jsonl"
         jsonl_file.touch()
-        monkeypatch.setattr("autoskillit.fleet._api.claude_code_log_path", lambda *_: jsonl_file)
+        tool_ctx.backend = _mock_backend_with_locator(
+            project_log_dir=tmp_path, session_log_path=jsonl_file
+        )
 
         dispatches_dir = tool_ctx.temp_dir / "dispatches"
         campaign_id = tool_ctx.kitchen_id

--- a/tests/fleet/test_fleet_e2e.py
+++ b/tests/fleet/test_fleet_e2e.py
@@ -1032,12 +1032,11 @@ async def test_end_to_end_resumable_dispatch_uses_resume_flag(
     rt.configure_shim("success")
     jsonl_file = tmp_path / "test-session-id.jsonl"
     jsonl_file.touch()
-    from unittest.mock import Mock as _Mock
+    from tests.fleet._helpers import _mock_backend_with_locator as _mlh
 
-    _mock_locator = _Mock()
-    _mock_locator.session_log_path.return_value = jsonl_file
-    _mock_locator.project_log_dir.return_value = tmp_path
-    spy_backend.session_locator.return_value = _mock_locator
+    spy_backend.session_locator.return_value = _mlh(
+        project_log_dir=tmp_path, session_log_path=jsonl_file
+    ).session_locator.return_value
 
     await execute_dispatch(
         tool_ctx=rt.tool_ctx,

--- a/tests/fleet/test_fleet_e2e.py
+++ b/tests/fleet/test_fleet_e2e.py
@@ -1032,7 +1032,12 @@ async def test_end_to_end_resumable_dispatch_uses_resume_flag(
     rt.configure_shim("success")
     jsonl_file = tmp_path / "test-session-id.jsonl"
     jsonl_file.touch()
-    monkeypatch.setattr("autoskillit.fleet._api.claude_code_log_path", lambda *_: jsonl_file)
+    from unittest.mock import Mock as _Mock
+
+    _mock_locator = _Mock()
+    _mock_locator.session_log_path.return_value = jsonl_file
+    _mock_locator.project_log_dir.return_value = tmp_path
+    spy_backend.session_locator.return_value = _mock_locator
 
     await execute_dispatch(
         tool_ctx=rt.tool_ctx,

--- a/tests/fleet/test_helpers_exports.py
+++ b/tests/fleet/test_helpers_exports.py
@@ -66,3 +66,10 @@ def test_make_completed_clean_exported_from_fleet_helpers():
     result = _make_completed_clean(success=True)
     assert result.outcome == "completed_clean"
     assert result.payload == {"success": True}
+
+
+def test_mock_backend_with_locator_exported_from_fleet_helpers():
+    from tests.fleet._helpers import _mock_backend_with_locator
+
+    backend = _mock_backend_with_locator(project_log_dir=None)
+    assert backend.session_locator() is not None

--- a/tests/fleet/test_resume_preflight.py
+++ b/tests/fleet/test_resume_preflight.py
@@ -9,6 +9,7 @@ import structlog.testing
 
 from tests.fleet._helpers import (
     _make_no_sentinel,
+    _mock_backend_with_locator,
     _no_sleep_quota_checker,
     _noop_quota_refresher,
     _setup_dispatch,
@@ -39,9 +40,8 @@ class TestResumeJSONLPreflight:
             [DispatchRecord(name="test-recipe")],
         )
 
-        monkeypatch.setattr(
-            "autoskillit.fleet._api.claude_code_log_path",
-            lambda *_: None,
+        tool_ctx.backend = _mock_backend_with_locator(
+            project_log_dir=tmp_path, session_log_path=None
         )
 
         result = await execute_dispatch(
@@ -71,9 +71,8 @@ class TestResumeJSONLPreflight:
         jsonl_file.touch()
 
         _setup_dispatch(tool_ctx, monkeypatch)
-        monkeypatch.setattr(
-            "autoskillit.fleet._api.claude_code_log_path",
-            lambda *_: jsonl_file,
+        tool_ctx.backend = _mock_backend_with_locator(
+            project_log_dir=tmp_path, session_log_path=jsonl_file
         )
         monkeypatch.setattr(
             "autoskillit.fleet._api.parse_l3_result_block",
@@ -131,14 +130,17 @@ class TestResumeJSONLPreflight:
         chain_jsonl = tmp_path / "chain.jsonl"
         chain_jsonl.touch()
 
-        def _mock_log_path(_cwd: str, session_id: str) -> Path | None:
+        def _mock_session_log_path(_cwd: str, session_id: str) -> Path | None:
             if session_id == "nonexistent-primary":
                 return tmp_path / "nonexistent.jsonl"
             if session_id == "chain-session-id":
                 return chain_jsonl
             return None
 
-        monkeypatch.setattr("autoskillit.fleet._api.claude_code_log_path", _mock_log_path)
+        tool_ctx.backend = _mock_backend_with_locator(
+            project_log_dir=tmp_path,
+            session_log_path_side_effect=_mock_session_log_path,
+        )
         monkeypatch.setattr(
             "autoskillit.fleet._api.parse_l3_result_block",
             lambda **_: _make_no_sentinel(),
@@ -184,9 +186,8 @@ class TestSessionChainContinuity:
             )
         )
 
-        monkeypatch.setattr(
-            "autoskillit.fleet._api.claude_code_log_path",
-            lambda *_: jsonl_file,
+        tool_ctx.backend = _mock_backend_with_locator(
+            project_log_dir=tmp_path, session_log_path=jsonl_file
         )
         monkeypatch.setattr(
             "autoskillit.fleet._api.parse_l3_result_block",
@@ -280,7 +281,9 @@ class TestResumeSuccessGuard:
 
         jsonl_file = tmp_path / "session.jsonl"
         jsonl_file.touch()
-        monkeypatch.setattr("autoskillit.fleet._api.claude_code_log_path", lambda *_: jsonl_file)
+        tool_ctx.backend = _mock_backend_with_locator(
+            project_log_dir=tmp_path, session_log_path=jsonl_file
+        )
         monkeypatch.setattr(
             "autoskillit.fleet._api.parse_l3_result_block",
             lambda **_: _make_no_sentinel(),
@@ -332,7 +335,9 @@ class TestResumeSuccessGuard:
 
         jsonl_file = tmp_path / "session.jsonl"
         jsonl_file.touch()
-        monkeypatch.setattr("autoskillit.fleet._api.claude_code_log_path", lambda *_: jsonl_file)
+        tool_ctx.backend = _mock_backend_with_locator(
+            project_log_dir=tmp_path, session_log_path=jsonl_file
+        )
         monkeypatch.setattr(
             "autoskillit.fleet._api.parse_l3_result_block",
             lambda **_: _make_no_sentinel(),
@@ -375,7 +380,9 @@ class TestResumeSuccessGuard:
 
         jsonl_file = tmp_path / "session.jsonl"
         jsonl_file.touch()
-        monkeypatch.setattr("autoskillit.fleet._api.claude_code_log_path", lambda *_: jsonl_file)
+        tool_ctx.backend = _mock_backend_with_locator(
+            project_log_dir=tmp_path, session_log_path=jsonl_file
+        )
         monkeypatch.setattr(
             "autoskillit.fleet._api.parse_l3_result_block",
             lambda **_: _make_no_sentinel(),

--- a/tests/server/test_tools_dispatch_params.py
+++ b/tests/server/test_tools_dispatch_params.py
@@ -6,6 +6,7 @@ import pytest
 
 from autoskillit.fleet import FleetSemaphore
 from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+from tests.fleet._helpers import _mock_backend_with_locator
 from tests.server._helpers import (
     _make_recipe_info,
     _make_standard_recipe,
@@ -35,7 +36,10 @@ async def test_dispatch_food_truck_tool_passes_resume_session_id_to_executor(
     tool_ctx_kitchen_open.executor = executor
     jsonl_file = tmp_path / "sess-resume-123.jsonl"
     jsonl_file.touch()
-    monkeypatch.setattr("autoskillit.fleet._api.claude_code_log_path", lambda *_: jsonl_file)
+    tool_ctx_kitchen_open.backend = _mock_backend_with_locator(
+        project_log_dir=tmp_path,
+        session_log_path=jsonl_file,
+    )
 
     await dispatch_food_truck(
         recipe="test-recipe",
@@ -65,7 +69,10 @@ async def test_dispatch_food_truck_tool_passes_resume_message_to_executor(
     tool_ctx_kitchen_open.executor = executor
     jsonl_file = tmp_path / "sess-resume-123.jsonl"
     jsonl_file.touch()
-    monkeypatch.setattr("autoskillit.fleet._api.claude_code_log_path", lambda *_: jsonl_file)
+    tool_ctx_kitchen_open.backend = _mock_backend_with_locator(
+        project_log_dir=tmp_path,
+        session_log_path=jsonl_file,
+    )
 
     await dispatch_food_truck(
         recipe="test-recipe",


### PR DESCRIPTION
## Summary

Migrate 7 call sites in `src/autoskillit/fleet/_api.py` from direct `claude_code_project_dir()` / `claude_code_log_path()` utility calls to Protocol-dispatched `tool_ctx.backend.session_locator()` calls. Remove the two now-unused imports. Update all 22 monkeypatches across 6 test files that target the removed module-level names: `test_api_dispatch_marker.py` (4), `test_resume_preflight.py` (7), `test_api.py` (6), `test_fleet_e2e.py` (1), `test_dispatch_state_handle.py` (2), and `test_tools_dispatch_params.py` (2). Add a shared mock-backend helper and its export guard test.

Closes #3925

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260609-203406-584889/.autoskillit/temp/make-plan/wp1_eliminate_claude_code_project_dir_log_path_plan_2026-06-09_203700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 65 | 24.9k | 1.5M | 115.6k | 56 | 122.9k | 11m 9s |
| verify* | sonnet | 1 | 150 | 22.8k | 1.1M | 80.1k | 46 | 80.3k | 11m 16s |
| implement* | MiniMax-M3 | 1 | 5.1M | 23.4k | 0 | 0 | 173 | 0 | 8m 42s |
| fix* | sonnet | 1 | 272 | 17.1k | 2.1M | 83.8k | 79 | 62.2k | 8m 19s |
| audit_impl* | sonnet | 1 | 62 | 13.3k | 260.1k | 50.1k | 20 | 44.8k | 6m 28s |
| prepare_pr* | MiniMax-M3 | 1 | 212.5k | 3.1k | 0 | 0 | 15 | 0 | 1m 6s |
| compose_pr* | MiniMax-M3 | 1 | 186.2k | 1.7k | 0 | 0 | 12 | 0 | 46s |
| review_pr* | sonnet | 1 | 180 | 38.8k | 1.4M | 98.7k | 54 | 77.9k | 8m 47s |
| resolve_review* | sonnet | 1 | 309 | 20.4k | 2.7M | 90.5k | 98 | 91.4k | 9m 7s |
| **Total** | | | 5.5M | 165.5k | 9.0M | 115.6k | | 479.7k | 1h 5m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 208 | 0.0 | 0.0 | 112.6 |
| fix | 10 | 208014.9 | 6223.6 | 1711.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 41 | 65172.2 | 2229.8 | 497.7 |
| **Total** | **259** | 34924.2 | 1852.0 | 639.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 65 | 24.9k | 1.5M | 122.9k | 11m 9s |
| sonnet | 5 | 973 | 112.4k | 7.6M | 356.8k | 43m 59s |
| MiniMax-M3 | 3 | 5.5M | 28.2k | 0 | 0 | 10m 34s |