### PR TITLE
Implementation Plan: Eliminate claude_code_project_dir() call in run_skill() via Protocol dispatch

### DIFF
--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -26,7 +26,6 @@ from autoskillit.core import (
     SkillResult,
     ValidatedAddDir,
     WriteBehaviorSpec,
-    claude_code_project_dir,
     execution_marker,
     extract_skill_name,
     find_caller_session_id,
@@ -914,11 +913,11 @@ async def run_skill(
             _sn_token = _current_step_name.set(_canonical_step_name(step_name))
             _oid_token = _current_order_id.set(effective_order_id)
 
-            _marker_dir: Path | None = None
-            try:
-                _marker_dir = claude_code_project_dir(str(tool_ctx.project_dir))
-            except OSError:
-                pass
+            _marker_dir: Path | None = (
+                tool_ctx.backend.session_locator().project_log_dir(str(tool_ctx.project_dir))
+                if tool_ctx.backend is not None
+                else None
+            )
             _orchestrator_sid = find_caller_session_id(project_dir=tool_ctx.project_dir)
 
             _start = time.monotonic()

--- a/tests/server/test_tools_execution_command.py
+++ b/tests/server/test_tools_execution_command.py
@@ -12,6 +12,7 @@ from autoskillit.config import (
     AutomationConfig,
     RunSkillConfig,
 )
+from autoskillit.core.claude_conventions import ClaudeDirectoryConventions
 from autoskillit.execution.commands import _inject_completion_directive
 from autoskillit.execution.headless import _session_log_dir
 from autoskillit.server.tools.tools_execution import run_skill
@@ -272,6 +273,10 @@ class TestRunSkillExecutionMarker:
         mock_locator.project_log_dir.return_value = controlled_path
         mock_backend = Mock()
         mock_backend.session_locator.return_value = mock_locator
+        mock_backend.name = "claude-code"
+        mock_backend.conventions.skills_subdir = ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
+        mock_backend.capabilities.mcp_config_capable = False
+        mock_backend.capabilities.session_dir_persistent = False
         tool_ctx_kitchen_open.backend = mock_backend
 
         captured = {}

--- a/tests/server/test_tools_execution_command.py
+++ b/tests/server/test_tools_execution_command.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -256,3 +258,58 @@ class TestRunSkillPerInvocationMarker:
         assert marker1 != marker2
         assert "%%ORDER_UP::" in marker1
         assert "%%ORDER_UP::" in marker2
+
+
+class TestRunSkillExecutionMarker:
+    """Execution marker directory routes through backend session locator."""
+
+    @pytest.mark.anyio
+    async def test_marker_dir_routes_through_session_locator(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
+        mock_locator = Mock()
+        controlled_path = Path("/controlled/marker/dir")
+        mock_locator.project_log_dir.return_value = controlled_path
+        mock_backend = Mock()
+        mock_backend.session_locator.return_value = mock_locator
+        tool_ctx_kitchen_open.backend = mock_backend
+
+        captured = {}
+
+        @contextlib.asynccontextmanager
+        async def _capture_marker(marker_dir, *args, **kwargs):
+            captured["marker_dir"] = marker_dir
+            yield
+
+        monkeypatch.setattr(
+            "autoskillit.server.tools.tools_execution.execution_marker",
+            _capture_marker,
+        )
+
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, _SUCCESS_JSON, ""))
+        await run_skill("/investigate test", "/tmp")
+
+        assert captured["marker_dir"] == controlled_path
+
+    @pytest.mark.anyio
+    async def test_marker_dir_none_when_backend_is_none(self, tool_ctx_kitchen_open, monkeypatch):
+        tool_ctx_kitchen_open.backend = None
+
+        captured = {}
+
+        @contextlib.asynccontextmanager
+        async def _capture_marker(marker_dir, *args, **kwargs):
+            captured["marker_dir"] = marker_dir
+            yield
+
+        monkeypatch.setattr(
+            "autoskillit.server.tools.tools_execution.execution_marker",
+            _capture_marker,
+        )
+
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))
+        tool_ctx_kitchen_open.runner.push(_make_result(0, _SUCCESS_JSON, ""))
+        await run_skill("/investigate test", "/tmp")
+
+        assert captured["marker_dir"] is None

--- a/tests/server/test_tools_execution_command.py
+++ b/tests/server/test_tools_execution_command.py
@@ -277,6 +277,7 @@ class TestRunSkillExecutionMarker:
         mock_backend.conventions.skills_subdir = ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
         mock_backend.capabilities.mcp_config_capable = False
         mock_backend.capabilities.session_dir_persistent = False
+        mock_backend.validate_session_layout.return_value = []
         tool_ctx_kitchen_open.backend = mock_backend
 
         captured = {}


### PR DESCRIPTION
Closes #3926

## Summary

Replace the direct `claude_code_project_dir()` call at `tools_execution.py:919` with Protocol-dispatched `tool_ctx.backend.session_locator().project_log_dir()`. Remove the now-unused import. Add a `TestRunSkillExecutionMarker` test class to `test_tools_execution_command.py` proving that `_marker_dir` is routed through the backend's session locator and that `backend=None` yields `None`.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260609-215818-254397/.autoskillit/temp/make-plan/t4_p3_a6_wp1_eliminate_claude_code_project_dir_plan_2026-06-09_220600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 64 | 8.4k | 1.8M | 77.7k | 50 | 81.0k | 4m 37s |
| verify* | sonnet | 1 | 68 | 5.0k | 312.5k | 47.9k | 23 | 27.0k | 3m 8s |
| implement* | MiniMax-M3 | 1 | 876.6k | 5.2k | 0 | 0 | 45 | 0 | 3m 32s |
| fix* | sonnet | 1 | 422 | 36.0k | 4.1M | 114.5k | 123 | 93.7k | 13m 59s |
| audit_impl* | sonnet | 1 | 1.8k | 5.7k | 163.8k | 39.2k | 13 | 24.7k | 2m 26s |
| prepare_pr* | MiniMax-M3 | 1 | 227.5k | 1.6k | 0 | 0 | 13 | 0 | 52s |
| compose_pr* | MiniMax-M3 | 1 | 251.3k | 2.0k | 0 | 0 | 16 | 0 | 59s |
| review_pr* | sonnet | 3 | 406 | 42.5k | 2.3M | 62.5k | 119 | 119.9k | 12m 29s |
| resolve_review* | sonnet | 2 | 426 | 26.7k | 2.9M | 78.5k | 114 | 99.7k | 11m 42s |
| **Total** | | | 1.4M | 133.2k | 11.5M | 114.5k | | 446.0k | 53m 48s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 68 | 0.0 | 0.0 | 76.2 |
| fix | 6 | 678563.7 | 15609.3 | 6000.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **74** | 155264.8 | 6026.9 | 1800.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 64 | 8.4k | 1.8M | 81.0k | 4m 37s |
| sonnet | 5 | 3.1k | 116.0k | 9.7M | 365.0k | 43m 46s |
| MiniMax-M3 | 3 | 1.4M | 8.8k | 0 | 0 | 5m 24s |