### PR TITLE
Implementation Plan: Replace Claude-specific path computation in _headless_helpers.py with Protocol dispatch

### DIFF
--- a/src/autoskillit/execution/headless/_headless_helpers.py
+++ b/src/autoskillit/execution/headless/_headless_helpers.py
@@ -14,7 +14,6 @@ from autoskillit.core import (
     CodingAgentBackend,
     ModelIdentity,
     SkillResult,
-    claude_code_project_dir,
     get_logger,
 )
 from autoskillit.execution.backends.codex import CodexFlags
@@ -51,8 +50,8 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-def _session_log_dir(cwd: str) -> Path:
-    log_dir = claude_code_project_dir(cwd)
+def _session_log_dir(cwd: str, backend: CodingAgentBackend) -> Path:
+    log_dir = backend.session_locator().project_log_dir(cwd)
     logger.info("session_log_dir_computed", path=str(log_dir), cwd=cwd)
     if not log_dir.exists():
         logger.info("session_log_dir_precreating", path=str(log_dir), cwd=cwd)
@@ -111,7 +110,7 @@ def assert_interactive_ordering(
 def _resolve_session_log_dir(cwd: str, backend: CodingAgentBackend) -> Path | None:
     if not backend.capabilities.channel_b_capable:
         return None
-    return _session_log_dir(cwd)
+    return _session_log_dir(cwd, backend)
 
 
 def _resolve_model(

--- a/tests/execution/test_backend_dispatch.py
+++ b/tests/execution/test_backend_dispatch.py
@@ -388,5 +388,5 @@ class TestCodexLogDispatch:
             step_backend=backend,
         )
 
-        backend.session_locator.assert_not_called()
+        backend.session_locator.return_value.locate_session.assert_not_called()
         assert flush_calls[0]["codex_log_path"] is None

--- a/tests/execution/test_headless_backend_resolution.py
+++ b/tests/execution/test_headless_backend_resolution.py
@@ -39,7 +39,7 @@ class TestResolveSessionLogDir:
         minimal_ctx.backend = _mock_backend(channel_b_capable=True)
         monkeypatch.setattr(
             "autoskillit.execution.headless._headless_helpers._session_log_dir",
-            lambda cwd: Path("/fake/log/dir"),
+            lambda cwd, backend: Path("/fake/log/dir"),
         )
         result = _headless_mod._resolve_session_log_dir("/some/cwd", minimal_ctx.backend)
         assert isinstance(result, Path)

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -63,6 +63,12 @@ def _context_exhausted_session_json() -> str:
     )
 
 
+def _make_locator_backend(project_log_dir_return: Path) -> Mock:
+    backend = Mock()
+    backend.session_locator.return_value.project_log_dir.return_value = project_log_dir_return
+    return backend
+
+
 class TestSessionLogDir:
     """Unit tests for _session_log_dir — path derivation and log emission."""
 
@@ -71,81 +77,85 @@ class TestSessionLogDir:
     def test_replaces_slashes(self):
         from autoskillit.execution.headless import _session_log_dir
 
-        result = _session_log_dir("/home/user/project")
-        assert result == Path.home() / ".claude" / "projects" / "-home-user-project"
+        expected = Path.home() / ".claude" / "projects" / "-home-user-project"
+        backend = _make_locator_backend(expected)
+        result = _session_log_dir("/home/user/project", backend)
+        assert result == expected
 
     def test_replaces_underscores(self):
         from autoskillit.execution.headless import _session_log_dir
 
-        result = _session_log_dir("/home/user/my_project")
-        assert result == Path.home() / ".claude" / "projects" / "-home-user-my-project"
+        expected = Path.home() / ".claude" / "projects" / "-home-user-my-project"
+        backend = _make_locator_backend(expected)
+        result = _session_log_dir("/home/user/my_project", backend)
+        assert result == expected
 
     def test_replaces_both_slashes_and_underscores(self):
         from autoskillit.execution.headless import _session_log_dir
 
-        result = _session_log_dir("/home/user_name/my_project/sub_dir")
-        assert (
-            result == Path.home() / ".claude" / "projects" / "-home-user-name-my-project-sub-dir"
-        )
+        expected = Path.home() / ".claude" / "projects" / "-home-user-name-my-project-sub-dir"
+        backend = _make_locator_backend(expected)
+        result = _session_log_dir("/home/user_name/my_project/sub_dir", backend)
+        assert result == expected
 
     # --- log behavior (from test_server_init_gate.py TestGateTransitionLogs) ---
 
-    def test_warns_when_dir_missing(self, tmp_path, monkeypatch):
+    def test_warns_when_dir_missing(self, tmp_path):
         import structlog.testing
 
         from autoskillit.execution.headless import _session_log_dir
 
-        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+        log_dir = tmp_path / "logs" / "project-dir"
+        backend = _make_locator_backend(log_dir)
         cwd = str(tmp_path / "my-project")
         with structlog.testing.capture_logs() as logs:
-            _session_log_dir(cwd)
+            _session_log_dir(cwd, backend)
         assert any(
             e.get("event") == "session_log_dir_precreating"
             for e in logs
             if e.get("log_level") == "info"
         )
 
-    def test_no_warning_when_dir_present(self, tmp_path, monkeypatch):
+    def test_no_warning_when_dir_present(self, tmp_path):
         import structlog.testing
 
         from autoskillit.execution.headless import _session_log_dir
 
-        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
-        cwd = str(tmp_path)
-        project_hash = cwd.replace("/", "-").replace("_", "-")
-        log_dir = tmp_path / "home" / ".claude" / "projects" / project_hash
+        log_dir = tmp_path / "logs" / "project-dir"
         log_dir.mkdir(parents=True, exist_ok=True)
+        backend = _make_locator_backend(log_dir)
+        cwd = str(tmp_path)
         with structlog.testing.capture_logs() as logs:
-            _session_log_dir(cwd)
+            _session_log_dir(cwd, backend)
         assert not any(e.get("event") == "session_log_dir_missing" for e in logs)
 
-    def test_logs_path_when_dir_exists(self, tmp_path, monkeypatch):
+    def test_logs_path_when_dir_exists(self, tmp_path):
         import structlog.testing
 
         from autoskillit.execution.headless import _session_log_dir
 
-        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
-        cwd = str(tmp_path)
-        project_hash = cwd.replace("/", "-").replace("_", "-")
-        log_dir = tmp_path / "home" / ".claude" / "projects" / project_hash
+        log_dir = tmp_path / "logs" / "project-dir"
         log_dir.mkdir(parents=True, exist_ok=True)
+        backend = _make_locator_backend(log_dir)
+        cwd = str(tmp_path)
         with structlog.testing.capture_logs() as logs:
-            result = _session_log_dir(cwd)
+            result = _session_log_dir(cwd, backend)
         info_entries = [e for e in logs if e.get("log_level") == "info"]
         assert any(e.get("event") == "session_log_dir_computed" for e in info_entries)
         computed = next(e for e in info_entries if e.get("event") == "session_log_dir_computed")
         assert computed.get("path") == str(result)
         assert not any(e.get("event") == "session_log_dir_missing" for e in logs)
 
-    def test_logs_path_when_dir_missing(self, tmp_path, monkeypatch):
+    def test_logs_path_when_dir_missing(self, tmp_path):
         import structlog.testing
 
         from autoskillit.execution.headless import _session_log_dir
 
-        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+        log_dir = tmp_path / "logs" / "project-dir"
+        backend = _make_locator_backend(log_dir)
         cwd = str(tmp_path / "my-project")
         with structlog.testing.capture_logs() as logs:
-            result = _session_log_dir(cwd)
+            result = _session_log_dir(cwd, backend)
         info_entries = [e for e in logs if e.get("log_level") == "info"]
         assert any(e.get("event") == "session_log_dir_computed" for e in info_entries)
         computed = next(e for e in info_entries if e.get("event") == "session_log_dir_computed")
@@ -154,37 +164,36 @@ class TestSessionLogDir:
         assert not any(e.get("event") == "session_log_dir_missing" for e in logs)
 
     def test_headless_session_log_dir_uses_shared_util(self):
-        from autoskillit.core.paths import claude_code_project_dir
         from autoskillit.execution.headless import _session_log_dir
 
         cwd = "/home/user/project"
-        assert _session_log_dir(cwd) == claude_code_project_dir(cwd)
+        backend = _make_locator_backend(Path("/mock/log/dir"))
+        _session_log_dir(cwd, backend)
+        backend.session_locator.return_value.project_log_dir.assert_called_once_with(cwd)
 
-    def test_session_log_dir_creates_missing_directory(self, tmp_path, monkeypatch):
+    def test_session_log_dir_creates_missing_directory(self, tmp_path):
         """_session_log_dir must create the directory if absent, so Channel B
         always has a directory to poll."""
         from autoskillit.execution.headless import _session_log_dir
 
-        fake_home = tmp_path / "home"
-        fake_home.mkdir()
-        monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+        log_dir = tmp_path / "logs" / "fresh-clone-dir"
+        backend = _make_locator_backend(log_dir)
         cwd = "/some/fresh/clone/path"
-        result = _session_log_dir(cwd)
+        result = _session_log_dir(cwd, backend)
         assert result.exists()
         assert result.is_dir()
 
     def test_session_log_dir_mkdir_oserror_reraises(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from unittest.mock import Mock
-
         from autoskillit.execution.headless import _session_log_dir
 
-        monkeypatch.setattr(Path, "home", lambda: tmp_path / "nonexistent_home")
+        log_dir = tmp_path / "logs" / "some-project"
+        backend = _make_locator_backend(log_dir)
         monkeypatch.setattr(Path, "mkdir", Mock(side_effect=OSError("disk full")))
 
         with pytest.raises(OSError, match="disk full"):
-            _session_log_dir(str(tmp_path / "some_project"))
+            _session_log_dir(str(tmp_path / "some_project"), backend)
 
 
 class TestRunHeadlessCoreFilesystemWrites:
@@ -800,7 +809,6 @@ class TestRunHeadlessCore:
     async def test_run_headless_core_dispatches_through_backend_when_present(
         self, minimal_ctx, monkeypatch, tmp_path
     ):
-        from unittest.mock import Mock
 
         from autoskillit.core import CmdSpec
         from autoskillit.execution.headless import run_headless_core

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -163,11 +163,11 @@ class TestSessionLogDir:
         assert any(e.get("event") == "session_log_dir_precreating" for e in info_entries)
         assert not any(e.get("event") == "session_log_dir_missing" for e in logs)
 
-    def test_headless_session_log_dir_uses_shared_util(self):
+    def test_headless_session_log_dir_uses_shared_util(self, tmp_path):
         from autoskillit.execution.headless import _session_log_dir
 
         cwd = "/home/user/project"
-        backend = _make_locator_backend(Path("/mock/log/dir"))
+        backend = _make_locator_backend(tmp_path / "mock" / "log" / "dir")
         _session_log_dir(cwd, backend)
         backend.session_locator.return_value.project_log_dir.assert_called_once_with(cwd)
 

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -81,6 +81,9 @@ class TestSessionLogDir:
         backend = _make_locator_backend(expected)
         result = _session_log_dir("/home/user/project", backend)
         assert result == expected
+        backend.session_locator.return_value.project_log_dir.assert_called_once_with(
+            "/home/user/project"
+        )
 
     def test_replaces_underscores(self):
         from autoskillit.execution.headless import _session_log_dir
@@ -89,6 +92,9 @@ class TestSessionLogDir:
         backend = _make_locator_backend(expected)
         result = _session_log_dir("/home/user/my_project", backend)
         assert result == expected
+        backend.session_locator.return_value.project_log_dir.assert_called_once_with(
+            "/home/user/my_project"
+        )
 
     def test_replaces_both_slashes_and_underscores(self):
         from autoskillit.execution.headless import _session_log_dir
@@ -97,6 +103,9 @@ class TestSessionLogDir:
         backend = _make_locator_backend(expected)
         result = _session_log_dir("/home/user_name/my_project/sub_dir", backend)
         assert result == expected
+        backend.session_locator.return_value.project_log_dir.assert_called_once_with(
+            "/home/user_name/my_project/sub_dir"
+        )
 
     # --- log behavior (from test_server_init_gate.py TestGateTransitionLogs) ---
 
@@ -167,8 +176,10 @@ class TestSessionLogDir:
         from autoskillit.execution.headless import _session_log_dir
 
         cwd = "/home/user/project"
-        backend = _make_locator_backend(tmp_path / "mock" / "log" / "dir")
-        _session_log_dir(cwd, backend)
+        expected = tmp_path / "mock" / "log" / "dir"
+        backend = _make_locator_backend(expected)
+        result = _session_log_dir(cwd, backend)
+        assert result == expected
         backend.session_locator.return_value.project_log_dir.assert_called_once_with(cwd)
 
     def test_session_log_dir_creates_missing_directory(self, tmp_path):

--- a/tests/server/test_tools_execution_command.py
+++ b/tests/server/test_tools_execution_command.py
@@ -12,9 +12,10 @@ from autoskillit.config import (
     AutomationConfig,
     RunSkillConfig,
 )
+from autoskillit.core import BackendCapabilities
 from autoskillit.core.claude_conventions import ClaudeDirectoryConventions
 from autoskillit.execution.commands import _inject_completion_directive
-from autoskillit.execution.headless import _session_log_dir
+from autoskillit.execution.headless import _resolve_session_log_dir
 from autoskillit.server.tools.tools_execution import run_skill
 from tests.conftest import _make_result
 from tests.server.conftest import _SUCCESS_JSON
@@ -170,7 +171,9 @@ class TestRunSkillPassesSessionLogDir:
     """run_skill passes session_log_dir derived from cwd."""
 
     @pytest.mark.anyio
-    async def test_run_skill_passes_session_log_dir(self, tool_ctx_kitchen_open, tmp_path):
+    async def test_run_skill_passes_session_log_dir(
+        self, tool_ctx_kitchen_open, tmp_path, monkeypatch
+    ):
         """runner receives session_log_dir derived from cwd."""
         cfg = AutomationConfig()
         cfg.safety.require_dry_walkthrough = False
@@ -178,6 +181,16 @@ class TestRunSkillPassesSessionLogDir:
 
         cwd = str(tmp_path / "some-project")
         (tmp_path / "some-project").mkdir()
+
+        log_dir = tmp_path / "logs" / "some-project"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        tool_ctx_kitchen_open.backend.capabilities = BackendCapabilities(
+            channel_b_capable=True, write_detection_strategy="tool_names"
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.headless._headless_helpers._session_log_dir",
+            lambda cwd, backend: log_dir,
+        )
 
         tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
         tool_ctx_kitchen_open.runner.push(
@@ -191,7 +204,7 @@ class TestRunSkillPassesSessionLogDir:
         await run_skill("/investigate foo", cwd)
 
         call_kwargs = tool_ctx_kitchen_open.runner.call_args_list[-1][3]
-        expected_dir = _session_log_dir(cwd)
+        expected_dir = _resolve_session_log_dir(cwd, tool_ctx_kitchen_open.backend)
         assert call_kwargs["session_log_dir"] == expected_dir
         assert "some-project" in str(expected_dir)
 

--- a/tests/server/test_tools_execution_command.py
+++ b/tests/server/test_tools_execution_command.py
@@ -12,10 +12,8 @@ from autoskillit.config import (
     AutomationConfig,
     RunSkillConfig,
 )
-from autoskillit.core import BackendCapabilities
 from autoskillit.core.claude_conventions import ClaudeDirectoryConventions
 from autoskillit.execution.commands import _inject_completion_directive
-from autoskillit.execution.headless import _resolve_session_log_dir
 from autoskillit.server.tools.tools_execution import run_skill
 from tests.conftest import _make_result
 from tests.server.conftest import _SUCCESS_JSON
@@ -184,11 +182,8 @@ class TestRunSkillPassesSessionLogDir:
 
         log_dir = tmp_path / "logs" / "some-project"
         log_dir.mkdir(parents=True, exist_ok=True)
-        tool_ctx_kitchen_open.backend.capabilities = BackendCapabilities(
-            channel_b_capable=True, write_detection_strategy="tool_names"
-        )
         monkeypatch.setattr(
-            "autoskillit.execution.headless._headless_helpers._session_log_dir",
+            "autoskillit.execution.headless._headless_execute._resolve_session_log_dir",
             lambda cwd, backend: log_dir,
         )
 
@@ -204,9 +199,8 @@ class TestRunSkillPassesSessionLogDir:
         await run_skill("/investigate foo", cwd)
 
         call_kwargs = tool_ctx_kitchen_open.runner.call_args_list[-1][3]
-        expected_dir = _resolve_session_log_dir(cwd, tool_ctx_kitchen_open.backend)
-        assert call_kwargs["session_log_dir"] == expected_dir
-        assert "some-project" in str(expected_dir)
+        assert call_kwargs["session_log_dir"] == log_dir
+        assert "some-project" in str(log_dir)
 
 
 class TestRunSkillModel:


### PR DESCRIPTION
## Summary

Replace the direct `claude_code_project_dir(cwd)` call in `_session_log_dir` with Protocol-dispatched `backend.session_locator().project_log_dir(cwd)`. This requires adding `backend: CodingAgentBackend` to `_session_log_dir`'s signature, threading `backend` through from `_resolve_session_log_dir`, removing the `claude_code_project_dir` import, and updating all 10 tests in `test_headless_core.py`, fixing the lambda arity in `test_headless_backend_resolution.py`, and updating the server test in `test_tools_execution_command.py`.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260609-230726-907607/.autoskillit/temp/make-plan/t4_p3_a7_wp1_replace_claude_specific_path_plan_2026-06-09_231500.md`

Closes #3927

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 828 | 13.0k | 1.5M | 95.8k | 45 | 75.8k | 10m 34s |
| verify* | sonnet | 1 | 148 | 17.0k | 933.5k | 65.4k | 42 | 44.5k | 8m 45s |
| implement* | MiniMax-M3 | 1 | 1.9M | 10.2k | 0 | 0 | 52 | 0 | 4m 6s |
| fix* | sonnet | 1 | 230 | 20.4k | 1.9M | 93.4k | 77 | 141.0k | 8m 29s |
| audit_impl* | sonnet | 1 | 54 | 10.4k | 210.9k | 45.6k | 17 | 35.9k | 4m 40s |
| prepare_pr* | MiniMax-M3 | 1 | 240.4k | 2.2k | 0 | 0 | 15 | 0 | 58s |
| compose_pr* | MiniMax-M3 | 1 | 213.4k | 1.6k | 0 | 0 | 12 | 0 | 51s |
| review_pr* | sonnet | 1 | 116 | 30.0k | 831.8k | 81.5k | 48 | 52.0k | 9m 31s |
| resolve_review* | sonnet | 1 | 213 | 14.0k | 1.7M | 89.8k | 66 | 69.5k | 7m 39s |
| **Total** | | | 2.4M | 118.8k | 7.0M | 95.8k | | 418.6k | 55m 36s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 114 | 0.0 | 0.0 | 89.8 |
| fix | 18 | 104801.8 | 7832.5 | 1132.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 15 | 112751.4 | 4630.7 | 936.3 |
| **Total** | **147** | 47674.9 | 2847.9 | 808.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 828 | 13.0k | 1.5M | 75.8k | 10m 34s |
| sonnet | 5 | 761 | 91.7k | 5.6M | 342.8k | 39m 5s |
| MiniMax-M3 | 3 | 2.4M | 14.0k | 0 | 0 | 5m 56s |