### PR TITLE
[FIX] Recipe Backend Guard Gaps and Diagram Pruning Divergence

### DIFF
--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -34,6 +34,7 @@ from autoskillit.recipe.contracts import (  # noqa: E402
     validate_recipe_cards,
 )
 from autoskillit.recipe.diagrams import (  # noqa: E402
+    annotate_diagram_with_pruning,
     check_diagram_staleness,
     diagram_stale_to_suggestions,
     load_recipe_diagram,
@@ -313,6 +314,7 @@ __all__ = [
     "load_recipe_diagram",
     "check_diagram_staleness",
     "diagram_stale_to_suggestions",
+    "annotate_diagram_with_pruning",
     "builtin_sub_recipes_dir",
     "find_sub_recipe_by_name",
     "BUNDLED_EXPERIMENT_TYPES_DIR",

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -71,6 +71,7 @@ from autoskillit.recipe.contracts import (
     validate_recipe_cards,
 )
 from autoskillit.recipe.diagrams import (
+    annotate_diagram_with_pruning,
     check_diagram_staleness,
     diagram_stale_to_suggestions,
     load_recipe_diagram,
@@ -492,6 +493,9 @@ def load_and_validate(
 
     # Load pre-generated diagram
     diagram: str | None = load_recipe_diagram(name, recipes_dir)
+
+    if diagram is not None and _skip_resolutions:
+        diagram = annotate_diagram_with_pruning(diagram, _skip_resolutions)
 
     # Build pre-formatted ingredients table from active_recipe (has merged/filtered ingredients)
     _serving_recipe = active_recipe if active_recipe is not None else recipe

--- a/src/autoskillit/recipe/diagrams.py
+++ b/src/autoskillit/recipe/diagrams.py
@@ -105,3 +105,29 @@ def diagram_stale_to_suggestions(recipe_name: str) -> list[dict[str, str]]:
             ),
         }
     ]
+
+
+def annotate_diagram_with_pruning(diagram: str, skip_resolutions: dict[str, bool | None]) -> str:
+    """Append a Markdown footer listing steps pruned at serve time.
+
+    Args:
+        diagram: The raw diagram Markdown string.
+        skip_resolutions: Map of step name to its skip_when_false resolution.
+            Steps with value ``False`` are listed as pruned.
+
+    Returns:
+        The diagram with a pruning annotation footer appended, or unchanged
+        if no steps were pruned or the diagram is empty.
+    """
+    pruned = sorted(name for name, resolved in skip_resolutions.items() if resolved is False)
+    if not pruned:
+        return diagram
+    step_list = ", ".join(pruned)
+    footer = (
+        "\n\n---\n"
+        "**Steps pruned under current backend/ingredient configuration:**\n"
+        f"{step_list}\n\n"
+        "> These steps appear in the full recipe graph above but are skipped\n"
+        "> at runtime due to `skip_when_false` guards evaluating to false.\n"
+    )
+    return diagram.rstrip("\n") + footer

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -1512,6 +1512,8 @@
       "retries": 2,
       "on_exhausted": "release_issue_failure",
       "on_context_limit": "release_issue_failure",
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "on_result": [
         {
           "when": "${{ result.verdict }} == 'real_fix'",
@@ -1531,6 +1533,9 @@
         },
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
+          "route": "release_issue_failure"
+        },
+        {
           "route": "release_issue_failure"
         }
       ],
@@ -1570,6 +1575,8 @@
       "capture": {
         "conflict_escalation_required": "${{ result.escalation_required }}"
       },
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "on_result": [
         {
           "when": "${{ result.escalation_required }} == true",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -1365,6 +1365,8 @@ steps:
     retries: 2
     on_exhausted: release_issue_failure
     on_context_limit: release_issue_failure
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
     on_result:
     - when: "${{ result.verdict }} == 'real_fix'"
       route: re_push
@@ -1376,6 +1378,7 @@ steps:
       route: release_issue_failure
     - when: "${{ result.verdict }} == 'no_test_infrastructure'"
       route: release_issue_failure
+    - route: release_issue_failure
     on_failure: release_issue_failure
     note: >
       Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci
@@ -1414,6 +1417,8 @@ steps:
       step_name: resolve_pre_resolve_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
     on_result:
     - when: ${{ result.escalation_required }} == true
       route: diagnose_ci

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -2313,6 +2313,8 @@
         "verdict": "${{ result.verdict }}"
       },
       "retries": 2,
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "on_exhausted": "release_issue_failure",
       "on_context_limit": "release_issue_failure",
       "on_result": [
@@ -2376,6 +2378,8 @@
       "capture": {
         "conflict_escalation_required": "${{ result.escalation_required }}"
       },
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "on_result": [
         {
           "when": "${{ result.escalation_required }} == true",

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -739,6 +739,9 @@
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
           "route": "release_issue_failure"
+        },
+        {
+          "route": "release_issue_failure"
         }
       ],
       "on_failure": "release_issue_failure",
@@ -813,6 +816,9 @@
         },
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
+          "route": "release_issue_failure"
+        },
+        {
           "route": "release_issue_failure"
         }
       ],

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -2091,6 +2091,8 @@ steps:
     capture:
       verdict: ${{ result.verdict }}
     retries: 2
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
     on_exhausted: release_issue_failure
     on_context_limit: release_issue_failure
     on_result:
@@ -2143,6 +2145,8 @@ steps:
       step_name: resolve_pre_resolve_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
     on_result:
     - when: ${{ result.escalation_required }} == true
       route: diagnose_ci

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -685,6 +685,7 @@ steps:
       route: release_issue_failure
     - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: release_issue_failure
+    - route: release_issue_failure
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     on_rate_limit: release_issue_failure
@@ -741,6 +742,7 @@ steps:
       route: release_issue_failure
     - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: release_issue_failure
+    - route: release_issue_failure
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure
     on_rate_limit: release_issue_failure

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -2449,6 +2449,8 @@
         "verdict": "${{ result.verdict }}"
       },
       "retries": 2,
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "on_exhausted": "release_issue_failure",
       "on_context_limit": "release_issue_failure",
       "on_result": [
@@ -2512,6 +2514,8 @@
       "capture": {
         "conflict_escalation_required": "${{ result.escalation_required }}"
       },
+      "optional": true,
+      "skip_when_false": "inputs.backend_supports_git_write",
       "on_result": [
         {
           "when": "${{ result.escalation_required }} == true",

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -729,6 +729,9 @@
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
           "route": "release_issue_failure"
+        },
+        {
+          "route": "release_issue_failure"
         }
       ],
       "on_context_limit": "release_issue_failure",
@@ -803,6 +806,9 @@
         },
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
+          "route": "release_issue_failure"
+        },
+        {
           "route": "release_issue_failure"
         }
       ],

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -668,6 +668,7 @@ steps:
       route: release_issue_failure
     - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: release_issue_failure
+    - route: release_issue_failure
     on_context_limit: release_issue_failure
     on_rate_limit: release_issue_failure
     on_failure: release_issue_failure
@@ -723,6 +724,7 @@ steps:
       route: release_issue_failure
     - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: release_issue_failure
+    - route: release_issue_failure
     on_context_limit: release_issue_failure
     on_rate_limit: release_issue_failure
     on_failure: release_issue_failure

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -2197,6 +2197,8 @@ steps:
     capture:
       verdict: ${{ result.verdict }}
     retries: 2
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
     on_exhausted: release_issue_failure
     on_context_limit: release_issue_failure
     on_result:
@@ -2249,6 +2251,8 @@ steps:
       step_name: resolve_pre_resolve_conflicts
     capture:
       conflict_escalation_required: ${{ result.escalation_required }}
+    optional: true
+    skip_when_false: inputs.backend_supports_git_write
     on_result:
     - when: ${{ result.escalation_required }} == true
       route: diagnose_ci

--- a/tests/arch/test_pyright_suppression_allowlist.py
+++ b/tests/arch/test_pyright_suppression_allowlist.py
@@ -20,9 +20,9 @@ _PYRIGHT_RE = re.compile(r"#\s*pyright:\s*ignore|#.*--\s*pyright:\s*ignore")
 PRODUCTION_ALLOWLIST: dict[tuple[str, int], str] = {
     (
         "recipe/__init__.py",
-        261,
+        262,
     ): "lazy-registry: method added by _register_rule_module() side effects",
-    ("recipe/_api.py", 274): "lazy-registry: RULE_REGISTRY_HASH set by _finalize_registry()",
+    ("recipe/_api.py", 275): "lazy-registry: RULE_REGISTRY_HASH set by _finalize_registry()",
 }
 
 TEST_ALLOWLIST: dict[tuple[str, int], str] = {

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -106,13 +106,18 @@ def test_pre_merge_fix_on_context_limit_routes_to_failure(recipe_name: str) -> N
 
 @pytest.mark.parametrize("recipe_name", _PRE_MERGE_CYCLE_RECIPES)
 def test_on_result_has_catch_all(recipe_name: str) -> None:
-    """Every run_skill step with an on_result block must have a bare
-    (no-when) catch-all condition as its final entry, ensuring routing
-    is defined for unrecognized verdicts.
+    """Resolve-failures and resolve-merge-conflicts steps must have a bare
+    (no-when) catch-all as the final on_result condition, ensuring routing
+    is defined for unrecognized verdicts from these open-ended-verdict skills.
     """
+    _CATCH_ALL_REQUIRED_SKILLS = {"resolve-failures", "resolve-merge-conflicts"}
     recipe = load_recipe(_resolve_recipe_path(recipe_name))
     for step_name, step in recipe.steps.items():
         if step.tool != "run_skill":
+            continue
+        skill_cmd = step.with_args.get("skill_command", "")
+        skill = resolve_skill_name(skill_cmd)
+        if skill not in _CATCH_ALL_REQUIRED_SKILLS:
             continue
         if step.on_result is None or not step.on_result.conditions:
             continue

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -119,8 +119,10 @@ def test_on_result_has_catch_all(recipe_name: str) -> None:
         skill = resolve_skill_name(skill_cmd)
         if skill not in _CATCH_ALL_REQUIRED_SKILLS:
             continue
-        if step.on_result is None or not step.on_result.conditions:
-            continue
+        assert step.on_result is not None and step.on_result.conditions, (
+            f"{recipe_name}.{step_name}: step dispatches {skill!r} but has no "
+            f"on_result routing — unrecognized verdicts would be silently dropped"
+        )
         conditions = step.on_result.conditions
         last = conditions[-1]
         assert last.when is None, (

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -104,6 +104,26 @@ def test_pre_merge_fix_on_context_limit_routes_to_failure(recipe_name: str) -> N
     )
 
 
+@pytest.mark.parametrize("recipe_name", _PRE_MERGE_CYCLE_RECIPES)
+def test_on_result_has_catch_all(recipe_name: str) -> None:
+    """Every run_skill step with an on_result block must have a bare
+    (no-when) catch-all condition as its final entry, ensuring routing
+    is defined for unrecognized verdicts.
+    """
+    recipe = load_recipe(_resolve_recipe_path(recipe_name))
+    for step_name, step in recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        if step.on_result is None or not step.on_result.conditions:
+            continue
+        conditions = step.on_result.conditions
+        last = conditions[-1]
+        assert last.when is None, (
+            f"{recipe_name}.{step_name}: on_result final condition must be a bare "
+            f"catch-all (no `when` clause), got: {last.when!r}"
+        )
+
+
 def test_every_bundled_recipe_declares_requires_packs() -> None:
     """All top-level bundled recipes must declare a non-empty requires_packs."""
     for path in _BUNDLED_ROOT_ONLY:

--- a/tests/recipe/test_diagrams.py
+++ b/tests/recipe/test_diagrams.py
@@ -414,3 +414,45 @@ def test_generate_recipe_diagram_removed() -> None:
         "generate_recipe_diagram still exists in diagrams module. "
         "Diagram rendering must be handled by /render-recipe skill only."
     )
+
+
+# ---------------------------------------------------------------------------
+# T-PRUNE-1: diagram pruning annotation consistency
+# ---------------------------------------------------------------------------
+
+
+def test_diagram_reflects_pruning_annotations() -> None:
+    """When backend_supports_git_write is false, the served diagram includes a
+    pruning footer listing steps that were pruned, and those step names must
+    not appear as step definitions in the served content.
+    """
+    from autoskillit.recipe._api import load_and_validate
+
+    result = load_and_validate(
+        "implementation",
+        ingredient_overrides={"backend_supports_git_write": "false"},
+    )
+
+    diagram = result.get("diagram")
+    assert diagram is not None, "Diagram should not be None for bundled recipe"
+
+    assert "Steps pruned under current backend/ingredient configuration:" in diagram, (
+        "Diagram must contain a pruning annotation footer when steps are pruned. "
+        f"Got diagram:\n{diagram[-500:]}"
+    )
+
+    assert "resolve_ci" in diagram, (
+        "Pruning footer should list resolve_ci (it should be skipped under codex backend)"
+    )
+    assert "resolve_pre_resolve_conflicts" in diagram, (
+        "Pruning footer should list resolve_pre_resolve_conflicts"
+    )
+
+    content = result.get("content", "")
+    assert "resolve_ci:" not in content, (
+        "resolve_ci must be pruned from content when backend_supports_git_write is false"
+    )
+    assert "resolve_pre_resolve_conflicts:" not in content, (
+        "resolve_pre_resolve_conflicts must be pruned from content when "
+        "backend_supports_git_write is false"
+    )

--- a/tests/recipe/test_diagrams.py
+++ b/tests/recipe/test_diagrams.py
@@ -442,7 +442,7 @@ def test_diagram_reflects_pruning_annotations() -> None:
     )
 
     assert "resolve_ci" in diagram, (
-        "Pruning footer should list resolve_ci (it should be skipped under codex backend)"
+        "Pruning footer should list resolve_ci (skipped when backend_supports_git_write is false)"
     )
     assert "resolve_pre_resolve_conflicts" in diagram, (
         "Pruning footer should list resolve_pre_resolve_conflicts"

--- a/tests/recipe/test_rules_backend_compat.py
+++ b/tests/recipe/test_rules_backend_compat.py
@@ -445,18 +445,23 @@ class TestBundledRecipeStepGuards:
         return request.param
 
     def test_git_metadata_write_steps_have_skip_guard(self, recipe_name) -> None:
+        from autoskillit.core.types._type_helpers import extract_skill_name
         from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
         from autoskillit.workspace.skills import DefaultSkillResolver
 
         recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
         resolver = DefaultSkillResolver()
+        checked_count = 0
         for step_name, step in recipe.steps.items():
             if step.tool != "run_skill":
                 continue
             skill_cmd = step.with_args.get("skill_command", "")
             if not skill_cmd or not skill_cmd.startswith("/"):
                 continue
-            skill_info = resolver.resolve(skill_cmd.split()[0].lstrip("/"))
+            bare_name = extract_skill_name(skill_cmd)
+            if bare_name is None:
+                continue
+            skill_info = resolver.resolve(bare_name)
             if skill_info is None:
                 continue
             if (
@@ -468,3 +473,35 @@ class TestBundledRecipeStepGuards:
                 f"Step {step_name!r} in {recipe_name!r} dispatches git_metadata_write skill "
                 f"'{skill_info.name}' but has no skip_when_false guard"
             )
+            checked_count += 1
+        assert checked_count > 0, (
+            f"No git_metadata_write steps found in {recipe_name!r} — "
+            "test is vacuous (skill resolution may be broken)"
+        )
+
+    def test_guard_test_exercises_at_least_one_step(self, recipe_name) -> None:
+        from autoskillit.core.types._type_helpers import extract_skill_name
+        from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+        from autoskillit.workspace.skills import DefaultSkillResolver
+
+        recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+        resolver = DefaultSkillResolver()
+        count = 0
+        for step in recipe.steps.values():
+            if step.tool != "run_skill":
+                continue
+            skill_cmd = step.with_args.get("skill_command", "")
+            if not skill_cmd or not skill_cmd.startswith("/"):
+                continue
+            bare_name = extract_skill_name(skill_cmd)
+            if bare_name is None:
+                continue
+            skill_info = resolver.resolve(bare_name)
+            if skill_info is None:
+                continue
+            if "git_metadata_write" in (skill_info.uses_capabilities or []):
+                count += 1
+        assert count > 0, (
+            f"No git_metadata_write steps resolvable in {recipe_name!r} — "
+            "guard test would be vacuous (skill resolution may be broken)"
+        )

--- a/tests/recipe/test_rules_backend_compat.py
+++ b/tests/recipe/test_rules_backend_compat.py
@@ -478,30 +478,3 @@ class TestBundledRecipeStepGuards:
             f"No git_metadata_write steps found in {recipe_name!r} — "
             "test is vacuous (skill resolution may be broken)"
         )
-
-    def test_guard_test_exercises_at_least_one_step(self, recipe_name) -> None:
-        from autoskillit.core.types._type_helpers import extract_skill_name
-        from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
-        from autoskillit.workspace.skills import DefaultSkillResolver
-
-        recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
-        resolver = DefaultSkillResolver()
-        count = 0
-        for step in recipe.steps.values():
-            if step.tool != "run_skill":
-                continue
-            skill_cmd = step.with_args.get("skill_command", "")
-            if not skill_cmd or not skill_cmd.startswith("/"):
-                continue
-            bare_name = extract_skill_name(skill_cmd)
-            if bare_name is None:
-                continue
-            skill_info = resolver.resolve(bare_name)
-            if skill_info is None:
-                continue
-            if "git_metadata_write" in (skill_info.uses_capabilities or []):
-                count += 1
-        assert count > 0, (
-            f"No git_metadata_write steps resolvable in {recipe_name!r} — "
-            "guard test would be vacuous (skill resolution may be broken)"
-        )


### PR DESCRIPTION
## Summary

Two architectural weaknesses in the recipe layer allowed a codex-backend pipeline to crash:

1. **Vacuous guard test**: The test `test_git_metadata_write_steps_have_skip_guard` uses `skill_cmd.split()[0].lstrip("/")` to extract skill names, which retains the `autoskillit:` namespace prefix. `DefaultSkillResolver.resolve()` does raw directory lookup with no prefix stripping, so `resolve("autoskillit:resolve-failures")` returns `None` for every step. The loop silently `continue`s past all steps without a single assertion firing. The test passes while checking nothing.

2. **Static diagram ignores runtime pruning**: `load_and_validate()` in `_api.py` computes `_skip_resolutions` at line 406, then loads the pre-committed diagram verbatim at line 494 without consulting the pruning results. The orchestrator receives a `diagram` showing the full unpruned flow while `content` reflects the pruned recipe. On codex backends, the orchestrator drove from the diagram and attempted `resolve-failures` — a `claude-code`-only skill.

The architectural immunity approach addresses three root causes:
- **R1**: Fix the vacuous test so it uses `extract_skill_name()` (the canonical namespace-stripping function from `core/types/_type_helpers.py`) and add a non-vacuity guard.
- **R2**: Annotate the diagram at serve time with pruning information so all consumers (`open_kitchen`, `load_recipe`) receive a diagram consistent with the pruned recipe content.
- **R3**: Add `skip_when_false: inputs.backend_supports_git_write` guards to the unguarded `git_metadata_write` steps (`resolve_ci` and `resolve_pre_resolve_conflicts`) in the three bundled recipes, and add the missing `on_result` catch-all to `implementation-groups.yaml`'s `resolve_ci`.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260609-224333-762542/.autoskillit/temp/rectify/rectify_recipe_backend_guard_and_diagram_pruning_2026-06-09_224333.md`

Closes #3976

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 3 | 957 | 46.3k | 4.7M | 115.6k | 151 | 279.7k | 26m 21s |
| verify* | sonnet | 3 | 366 | 44.8k | 2.4M | 80.1k | 111 | 151.8k | 23m 9s |
| implement* | MiniMax-M3 | 3 | 7.9M | 38.8k | 0 | 0 | 270 | 0 | 16m 22s |
| fix* | sonnet | 3 | 924 | 73.5k | 8.0M | 114.5k | 279 | 296.9k | 30m 47s |
| audit_impl* | sonnet | 3 | 1.9k | 29.4k | 634.8k | 50.1k | 50 | 105.5k | 13m 35s |
| prepare_pr* | MiniMax-M3 | 3 | 680.3k | 7.0k | 0 | 0 | 43 | 0 | 2m 56s |
| compose_pr* | MiniMax-M3 | 3 | 650.9k | 5.3k | 0 | 0 | 40 | 0 | 2m 36s |
| review_pr* | sonnet | 5 | 702 | 111.3k | 4.5M | 98.7k | 221 | 249.8k | 30m 49s |
| resolve_review* | sonnet | 4 | 948 | 61.1k | 7.2M | 90.5k | 278 | 260.5k | 28m 30s |
| dispatch:d82e385d-67ec-45b4-ab18-9e708dd46ee8* | sonnet | 1 | 354 | 10.4k | 3.4M | 87.2k | 90 | 87.4k | 1h 24m |
| dispatch:c5468830-79b4-4cf5-a14f-4346b624c837* | sonnet | 1 | 450 | 14.2k | 4.5M | 96.0k | 113 | 96.2k | 1h 8m |
| dispatch:6c792aaf-f8f1-41e5-ba65-b60e2c9fd395* | sonnet | 1 | 354 | 13.5k | 3.4M | 90.0k | 89 | 117.2k | 1h 15m |
| **Total** | | | 9.2M | 455.6k | 38.8M | 115.6k | | 1.6M | 6h 43m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 390 | 0.0 | 0.0 | 99.6 |
| fix | 34 | 236410.7 | 8731.7 | 2161.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 56 | 128836.9 | 4652.7 | 1091.8 |
| dispatch:d82e385d-67ec-45b4-ab18-9e708dd46ee8 | 0 | — | — | — |
| dispatch:c5468830-79b4-4cf5-a14f-4346b624c837 | 602 | 7503.2 | 159.8 | 23.6 |
| dispatch:6c792aaf-f8f1-41e5-ba65-b60e2c9fd395 | 0 | — | — | — |
| **Total** | **1082** | 35860.9 | 1520.5 | 421.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 957 | 46.3k | 4.7M | 279.7k | 26m 21s |
| sonnet | 8 | 6.0k | 358.2k | 34.1M | 1.4M | 5h 55m |
| MiniMax-M3 | 3 | 9.2M | 51.1k | 0 | 0 | 21m 55s |