### PR TITLE
Implementation Plan: Thread session_locator into flush_session_log

### DIFF
--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -16,13 +16,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
-    from autoskillit.core import ProviderOutcome, RecipeIdentity, SessionTelemetry
+    from autoskillit.core import ProviderOutcome, RecipeIdentity, SessionLocator, SessionTelemetry
 
 
 from autoskillit.core import (
     ModelIdentity,
     atomic_write,
-    claude_code_log_path,
     default_log_dir,
     get_logger,
     iter_merged_assistant_turns,
@@ -153,6 +152,7 @@ def flush_session_log(
     max_sessions: int | None = None,
     is_resume: bool = False,
     codex_log_path: Path | None = None,
+    session_locator: SessionLocator | None = None,
     backend: Literal["claude-code", "codex"] = "claude-code",
     telemetry: SessionTelemetry,
 ) -> None:
@@ -187,7 +187,12 @@ def flush_session_log(
         cc_log = None
         cc_log_str = None
     else:
-        cc_log = claude_code_log_path(cwd, session_id)
+        from autoskillit.execution.backends.claude import (
+            ClaudeSessionLocator,
+        )  # deferred: avoids circular import via backends/claude.py
+
+        _locator = session_locator or ClaudeSessionLocator()
+        cc_log = _locator.session_log_path(cwd, session_id)
         cc_log_str = str(cc_log) if cc_log else None
 
     if cc_log and not cc_log.exists():

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -310,7 +310,9 @@ def _subagent_assistant_ndjson(
     )
 
 
-def _flush(tmp_path: Path, *, backend: str = "claude-code", **overrides) -> None:
+def _flush(
+    tmp_path: Path, *, backend: str = "claude-code", session_locator=None, **overrides
+) -> None:
     from autoskillit.core.types._type_results import ModelIdentity, ProviderOutcome
     from autoskillit.core.types._type_results_execution import (
         RecipeIdentity,
@@ -393,6 +395,7 @@ def _flush(tmp_path: Path, *, backend: str = "claude-code", **overrides) -> None
         provider_outcome=provider_outcome,
         recipe_identity=recipe_identity,
         backend=backend,
+        session_locator=session_locator,
     )
 
 

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import os
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 
@@ -27,6 +28,20 @@ from tests.execution.conftest import (
 )
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
+
+
+class _FakeLocator:
+    def __init__(self, path: Path | None) -> None:
+        self._path = path
+
+    def locate_session(self, session_id: str) -> Path | None:
+        return self._path
+
+    def project_log_dir(self, cwd: str) -> Path:
+        return Path("/fake-project-log-dir")
+
+    def session_log_path(self, cwd: str, session_id: str) -> Path | None:
+        return self._path
 
 
 def test_flush_session_log_includes_write_path_warnings_in_summary(tmp_path):
@@ -222,7 +237,7 @@ def test_flush_session_log_no_raw_stdout_on_success(tmp_path):
     assert not raw_file.exists()
 
 
-def test_flush_session_log_summary_contains_per_turn_fields(tmp_path, monkeypatch):
+def test_flush_session_log_summary_contains_per_turn_fields(tmp_path):
     cb_log = tmp_path / "s.jsonl"
     cb_log.write_text(
         json.dumps(
@@ -234,10 +249,6 @@ def test_flush_session_log_summary_contains_per_turn_fields(tmp_path, monkeypatc
         )
         + "\n"
     )
-    import autoskillit.execution.session_log as sl_mod
-
-    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
-
     flush_session_log(
         log_dir=str(tmp_path),
         cwd="/tmp",
@@ -253,6 +264,7 @@ def test_flush_session_log_summary_contains_per_turn_fields(tmp_path, monkeypatc
         telemetry=SessionTelemetry.empty(),
         provider_outcome=ProviderOutcome.none_used(),
         recipe_identity=RecipeIdentity.empty(),
+        session_locator=_FakeLocator(cb_log),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert summary["last_stop_reason"] == "end_turn"
@@ -260,7 +272,7 @@ def test_flush_session_log_summary_contains_per_turn_fields(tmp_path, monkeypatc
     assert summary["turn_timestamps"] == ["2026-04-15T07:00:00Z", "2026-04-15T07:00:05Z"]
 
 
-def test_flush_session_log_includes_no_request_id_turns(tmp_path, monkeypatch):
+def test_flush_session_log_includes_no_request_id_turns(tmp_path):
     cb_log = tmp_path / "s.jsonl"
     cb_log.write_text(
         _make_cc_jsonl_record(
@@ -275,9 +287,6 @@ def test_flush_session_log_includes_no_request_id_turns(tmp_path, monkeypatch):
         )
         + "\n"
     )
-    import autoskillit.execution.session_log as sl_mod
-
-    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
     flush_session_log(
         log_dir=str(tmp_path),
         cwd="/tmp",
@@ -292,6 +301,7 @@ def test_flush_session_log_includes_no_request_id_turns(tmp_path, monkeypatch):
         telemetry=SessionTelemetry.empty(),
         provider_outcome=ProviderOutcome.none_used(),
         recipe_identity=RecipeIdentity.empty(),
+        session_locator=_FakeLocator(cb_log),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert len(summary["turn_timestamps"]) == 2
@@ -306,7 +316,7 @@ def test_flush_session_log_includes_no_request_id_turns(tmp_path, monkeypatch):
     )
 
 
-def test_flush_session_log_all_no_rid_turns_still_recorded(tmp_path, monkeypatch):
+def test_flush_session_log_all_no_rid_turns_still_recorded(tmp_path):
     cb_log = tmp_path / "s.jsonl"
     cb_log.write_text(
         _make_cc_jsonl_record(
@@ -325,9 +335,6 @@ def test_flush_session_log_all_no_rid_turns_still_recorded(tmp_path, monkeypatch
         )
         + "\n"
     )
-    import autoskillit.execution.session_log as sl_mod
-
-    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
     flush_session_log(
         log_dir=str(tmp_path),
         cwd="/tmp",
@@ -342,6 +349,7 @@ def test_flush_session_log_all_no_rid_turns_still_recorded(tmp_path, monkeypatch
         telemetry=SessionTelemetry.empty(),
         provider_outcome=ProviderOutcome.none_used(),
         recipe_identity=RecipeIdentity.empty(),
+        session_locator=_FakeLocator(cb_log),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert len(summary["turn_timestamps"]) == 3
@@ -355,7 +363,7 @@ def test_flush_session_log_all_no_rid_turns_still_recorded(tmp_path, monkeypatch
     assert all(rid.startswith("turn-") for rid in summary["request_ids"])
 
 
-def test_channel_b_turn_count_bounded_by_channel_a(tmp_path, monkeypatch):
+def test_channel_b_turn_count_bounded_by_channel_a(tmp_path):
     cb_log = tmp_path / "s.jsonl"
     cb_log.write_text(
         _make_cc_jsonl_record(
@@ -369,9 +377,6 @@ def test_channel_b_turn_count_bounded_by_channel_a(tmp_path, monkeypatch):
         )
         + "\n"
     )
-    import autoskillit.execution.session_log as sl_mod
-
-    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
     telemetry = SessionTelemetry(
         token_usage={"input_tokens": 0, "output_tokens": 0, "turn_count": 2},
         timing_seconds=None,
@@ -395,6 +400,7 @@ def test_channel_b_turn_count_bounded_by_channel_a(tmp_path, monkeypatch):
         telemetry=telemetry,
         provider_outcome=ProviderOutcome.none_used(),
         recipe_identity=RecipeIdentity.empty(),
+        session_locator=_FakeLocator(cb_log),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     tu = json.loads((tmp_path / "sessions" / "s" / "token_usage.json").read_text())
@@ -403,7 +409,7 @@ def test_channel_b_turn_count_bounded_by_channel_a(tmp_path, monkeypatch):
     assert turn_count >= len(summary["turn_timestamps"])
 
 
-def test_parallel_lists_aligned_mixed_rid_no_rid(tmp_path, monkeypatch):
+def test_parallel_lists_aligned_mixed_rid_no_rid(tmp_path):
     cb_log = tmp_path / "s.jsonl"
     cb_log.write_text(
         _make_cc_jsonl_record(
@@ -435,9 +441,6 @@ def test_parallel_lists_aligned_mixed_rid_no_rid(tmp_path, monkeypatch):
         )
         + "\n"
     )
-    import autoskillit.execution.session_log as sl_mod
-
-    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
     flush_session_log(
         log_dir=str(tmp_path),
         cwd="/tmp",
@@ -452,6 +455,7 @@ def test_parallel_lists_aligned_mixed_rid_no_rid(tmp_path, monkeypatch):
         telemetry=SessionTelemetry.empty(),
         provider_outcome=ProviderOutcome.none_used(),
         recipe_identity=RecipeIdentity.empty(),
+        session_locator=_FakeLocator(cb_log),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert (
@@ -480,7 +484,7 @@ def test_parallel_lists_aligned_mixed_rid_no_rid(tmp_path, monkeypatch):
 # turn_tool_calls
 
 
-def test_flush_session_log_summary_contains_turn_tool_calls(tmp_path, monkeypatch):
+def test_flush_session_log_summary_contains_turn_tool_calls(tmp_path):
     cb_log = tmp_path / "s.jsonl"
     cb_log.write_text(
         json.dumps(
@@ -497,10 +501,6 @@ def test_flush_session_log_summary_contains_turn_tool_calls(tmp_path, monkeypatc
         )
         + "\n"
     )
-    import autoskillit.execution.session_log as sl_mod
-
-    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
-
     flush_session_log(
         log_dir=str(tmp_path),
         cwd="/tmp",
@@ -515,12 +515,13 @@ def test_flush_session_log_summary_contains_turn_tool_calls(tmp_path, monkeypatc
         telemetry=SessionTelemetry.empty(),
         provider_outcome=ProviderOutcome.none_used(),
         recipe_identity=RecipeIdentity.empty(),
+        session_locator=_FakeLocator(cb_log),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert summary["turn_tool_calls"] == [["ToolA", "ToolB"]]
 
 
-def test_turn_tool_calls_capped_at_8_per_turn(tmp_path, monkeypatch):
+def test_turn_tool_calls_capped_at_8_per_turn(tmp_path):
     tools = [{"type": "tool_use", "name": f"Tool{i}"} for i in range(10)]
     cb_log = tmp_path / "s.jsonl"
     cb_log.write_text(
@@ -533,9 +534,6 @@ def test_turn_tool_calls_capped_at_8_per_turn(tmp_path, monkeypatch):
         )
         + "\n"
     )
-    import autoskillit.execution.session_log as sl_mod
-
-    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
     flush_session_log(
         log_dir=str(tmp_path),
         cwd="/tmp",
@@ -550,13 +548,14 @@ def test_turn_tool_calls_capped_at_8_per_turn(tmp_path, monkeypatch):
         telemetry=SessionTelemetry.empty(),
         provider_outcome=ProviderOutcome.none_used(),
         recipe_identity=RecipeIdentity.empty(),
+        session_locator=_FakeLocator(cb_log),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert len(summary["turn_tool_calls"][0]) == 8
     assert summary["turn_tool_calls"][0] == [f"Tool{i}" for i in range(8)]
 
 
-def test_turn_tool_calls_empty_for_text_only_turn(tmp_path, monkeypatch):
+def test_turn_tool_calls_empty_for_text_only_turn(tmp_path):
     cb_log = tmp_path / "s.jsonl"
     cb_log.write_text(
         json.dumps(
@@ -568,9 +567,6 @@ def test_turn_tool_calls_empty_for_text_only_turn(tmp_path, monkeypatch):
         )
         + "\n"
     )
-    import autoskillit.execution.session_log as sl_mod
-
-    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
     flush_session_log(
         log_dir=str(tmp_path),
         cwd="/tmp",
@@ -585,12 +581,13 @@ def test_turn_tool_calls_empty_for_text_only_turn(tmp_path, monkeypatch):
         telemetry=SessionTelemetry.empty(),
         provider_outcome=ProviderOutcome.none_used(),
         recipe_identity=RecipeIdentity.empty(),
+        session_locator=_FakeLocator(cb_log),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert summary["turn_tool_calls"] == [[]]
 
 
-def test_turn_tool_calls_parallel_to_request_ids(tmp_path, monkeypatch):
+def test_turn_tool_calls_parallel_to_request_ids(tmp_path):
     records = [
         json.dumps(
             {
@@ -603,9 +600,6 @@ def test_turn_tool_calls_parallel_to_request_ids(tmp_path, monkeypatch):
     ]
     cb_log = tmp_path / "s.jsonl"
     cb_log.write_text("\n".join(records) + "\n")
-    import autoskillit.execution.session_log as sl_mod
-
-    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
     flush_session_log(
         log_dir=str(tmp_path),
         cwd="/tmp",
@@ -620,6 +614,7 @@ def test_turn_tool_calls_parallel_to_request_ids(tmp_path, monkeypatch):
         telemetry=SessionTelemetry.empty(),
         provider_outcome=ProviderOutcome.none_used(),
         recipe_identity=RecipeIdentity.empty(),
+        session_locator=_FakeLocator(cb_log),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert len(summary["turn_tool_calls"]) == len(summary["request_ids"]) == 3
@@ -630,30 +625,36 @@ def test_turn_tool_calls_parallel_to_request_ids(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_summary_includes_silent_gap_seconds(tmp_path, monkeypatch):
+def test_summary_includes_silent_gap_seconds(tmp_path):
     """silent_gap_seconds computed from cc_log mtime vs end_ts — approx 5.0s."""
-    import autoskillit.execution.session_log as sl_mod
-
     cb_log = tmp_path / "session.jsonl"
     cb_log.write_text("")
     end_ts = "2026-04-15T07:00:10+00:00"
     end_dt = datetime.fromisoformat(end_ts)
     os.utime(cb_log, (end_dt.timestamp() - 5.0,) * 2)
-    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
-    _flush(tmp_path, session_id="gap-test", end_ts=end_ts, proc_snapshots=None)
+    _flush(
+        tmp_path,
+        session_id="gap-test",
+        end_ts=end_ts,
+        proc_snapshots=None,
+        session_locator=_FakeLocator(cb_log),
+    )
     summary = json.loads((tmp_path / "sessions" / "gap-test" / "summary.json").read_text())
     assert "silent_gap_seconds" in summary
     assert summary["silent_gap_seconds"] == pytest.approx(5.0, abs=0.5)
 
 
-def test_summary_silent_gap_seconds_null_when_no_end_ts(tmp_path, monkeypatch):
+def test_summary_silent_gap_seconds_null_when_no_end_ts(tmp_path):
     """silent_gap_seconds is null when end_ts is not provided."""
-    import autoskillit.execution.session_log as sl_mod
-
     cb_log = tmp_path / "session.jsonl"
     cb_log.write_text("")
-    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
-    _flush(tmp_path, session_id="no-end-ts", end_ts="", proc_snapshots=None)
+    _flush(
+        tmp_path,
+        session_id="no-end-ts",
+        end_ts="",
+        proc_snapshots=None,
+        session_locator=_FakeLocator(cb_log),
+    )
     summary = json.loads((tmp_path / "sessions" / "no-end-ts" / "summary.json").read_text())
     assert summary["silent_gap_seconds"] is None
 
@@ -671,11 +672,8 @@ def test_summary_silent_gap_seconds_null_when_cc_log_missing(tmp_path):
     assert summary["silent_gap_seconds"] is None
 
 
-def test_flush_outcome_anomaly_included_in_anomaly_count(tmp_path, monkeypatch):
+def test_flush_outcome_anomaly_included_in_anomaly_count(tmp_path):
     """empty_result + output_tokens > 0 increments anomaly_count in summary and index."""
-    import autoskillit.execution.session_log as sl_mod
-
-    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: None)
     _flush(
         tmp_path,
         session_id="outcome-anomaly",
@@ -683,6 +681,7 @@ def test_flush_outcome_anomaly_included_in_anomaly_count(tmp_path, monkeypatch):
         success=False,
         token_usage={"output_tokens": 945, "input_tokens": 500},
         proc_snapshots=None,
+        session_locator=_FakeLocator(None),
     )
     summary = json.loads((tmp_path / "sessions" / "outcome-anomaly" / "summary.json").read_text())
     assert summary["anomaly_count"] >= 1
@@ -951,7 +950,7 @@ def test_flush_session_log_provider_used_defaults_empty_in_token_usage(tmp_path)
     assert tu["provider_used"] == ""
 
 
-def test_turn_tool_calls_merged_across_thinking_and_tool_records(tmp_path, monkeypatch):
+def test_turn_tool_calls_merged_across_thinking_and_tool_records(tmp_path):
     cb_log = tmp_path / "s.jsonl"
     cb_log.write_text(
         _make_cc_jsonl_record(
@@ -966,9 +965,6 @@ def test_turn_tool_calls_merged_across_thinking_and_tool_records(tmp_path, monke
         )
         + "\n"
     )
-    import autoskillit.execution.session_log as sl_mod
-
-    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
     flush_session_log(
         log_dir=str(tmp_path),
         cwd="/tmp",
@@ -983,13 +979,14 @@ def test_turn_tool_calls_merged_across_thinking_and_tool_records(tmp_path, monke
         telemetry=SessionTelemetry.empty(),
         provider_outcome=ProviderOutcome.none_used(),
         recipe_identity=RecipeIdentity.empty(),
+        session_locator=_FakeLocator(cb_log),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert summary["turn_tool_calls"] == [["Bash"]]
     assert summary["request_ids"] == ["req-001"]
 
 
-def test_parallel_lists_aligned_when_timestamp_missing(tmp_path, monkeypatch):
+def test_parallel_lists_aligned_when_timestamp_missing(tmp_path):
     cb_log = tmp_path / "s.jsonl"
     cb_log.write_text(
         _make_cc_jsonl_record(
@@ -1004,9 +1001,6 @@ def test_parallel_lists_aligned_when_timestamp_missing(tmp_path, monkeypatch):
         )
         + "\n"
     )
-    import autoskillit.execution.session_log as sl_mod
-
-    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
     flush_session_log(
         log_dir=str(tmp_path),
         cwd="/tmp",
@@ -1021,6 +1015,7 @@ def test_parallel_lists_aligned_when_timestamp_missing(tmp_path, monkeypatch):
         telemetry=SessionTelemetry.empty(),
         provider_outcome=ProviderOutcome.none_used(),
         recipe_identity=RecipeIdentity.empty(),
+        session_locator=_FakeLocator(cb_log),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert (
@@ -1661,7 +1656,7 @@ class TestModelAliasDriftIntegration:
         assert len(rss) == 0
 
 
-def test_flush_session_log_minimax_message_id_turn_dedup(tmp_path, monkeypatch):
+def test_flush_session_log_minimax_message_id_turn_dedup(tmp_path):
     """MiniMax-shaped JSONL (message.id, no requestId) deduplicates into correct turn count."""
     mid = "0669d3ed14adce24ccf227c37a5884d4"
     cb_log = tmp_path / "s.jsonl"
@@ -1685,9 +1680,6 @@ def test_flush_session_log_minimax_message_id_turn_dedup(tmp_path, monkeypatch):
         )
         + "\n"
     )
-    import autoskillit.execution.session_log as sl_mod
-
-    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
     flush_session_log(
         log_dir=str(tmp_path),
         cwd="/tmp",
@@ -1702,6 +1694,7 @@ def test_flush_session_log_minimax_message_id_turn_dedup(tmp_path, monkeypatch):
         telemetry=SessionTelemetry.empty(),
         provider_outcome=ProviderOutcome.none_used(),
         recipe_identity=RecipeIdentity.empty(),
+        session_locator=_FakeLocator(cb_log),
     )
     summary = json.loads(
         (tmp_path / "sessions" / "minimax-dedup-001" / "summary.json").read_text()


### PR DESCRIPTION
## Summary

Thread `session_locator: SessionLocator | None = None` into `flush_session_log` so that Claude Code log path resolution is protocol-dispatched rather than hard-wired to the `claude_code_log_path` function. When `None`, falls back to `ClaudeSessionLocator()`. Migrate all 15 monkeypatch sites in `test_session_log_fields.py` to use a `_FakeLocator` test double, and update the `_flush()` helper in `conftest.py` to forward the new parameter.

Closes #3928

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260610-075540-682859/.autoskillit/temp/make-plan/t4-p3-a8-wp1-thread-session-locator-into-flush-session-log_plan_2026-06-10_080500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 72 | 25.2k | 1.2M | 99.2k | 47 | 83.3k | 24m 42s |
| verify* | sonnet | 1 | 84 | 10.7k | 431.6k | 56.3k | 27 | 56.5k | 7m 51s |
| implement* | MiniMax-M3 | 1 | 4.5M | 16.6k | 0 | 0 | 119 | 0 | 7m 24s |
| audit_impl* | sonnet | 1 | 1.6k | 6.4k | 213.7k | 49.2k | 16 | 34.7k | 3m 39s |
| prepare_pr* | MiniMax-M3 | 1 | 193.4k | 2.4k | 0 | 0 | 14 | 0 | 1m 0s |
| compose_pr* | MiniMax-M3 | 1 | 285.6k | 1.5k | 0 | 0 | 18 | 0 | 49s |
| **Total** | | | 5.0M | 62.8k | 1.9M | 99.2k | | 174.5k | 45m 28s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 137 | 0.0 | 0.0 | 121.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **137** | 13522.5 | 1273.8 | 458.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 72 | 25.2k | 1.2M | 83.3k | 24m 42s |
| sonnet | 2 | 1.7k | 17.1k | 645.3k | 91.2k | 11m 30s |
| MiniMax-M3 | 3 | 5.0M | 20.5k | 0 | 0 | 9m 14s |