### PR TITLE
Implementation Plan: Decouple _session_picker.py from claude_code_project_dir()

### DIFF
--- a/src/autoskillit/cli/session/_session_cook.py
+++ b/src/autoskillit/cli/session/_session_cook.py
@@ -207,7 +207,8 @@ def cook(
     if isinstance(resume_spec, BareResume):
         from autoskillit.cli.session._session_picker import pick_session
 
-        selected_id = pick_session(SESSION_TYPE_COOK, project_dir)
+        _log_dir = backend.session_locator().project_log_dir(str(project_dir))
+        selected_id = pick_session(SESSION_TYPE_COOK, project_dir, _log_dir)
         if selected_id is not None:
             resume_spec = NamedResume(session_id=selected_id)
         else:

--- a/src/autoskillit/cli/session/_session_order.py
+++ b/src/autoskillit/cli/session/_session_order.py
@@ -144,10 +144,15 @@ def order(
     if _resume and recipe is None:
         from autoskillit.cli._prompts import _OPEN_KITCHEN_GREETINGS
         from autoskillit.cli.session._session_picker import pick_session as _pick_session
+        from autoskillit.config import load_config as _load_config_resume
         from autoskillit.core import BareResume, NamedResume, NoResume
+        from autoskillit.execution import get_backend as _get_backend_resume
 
         if isinstance(resume_spec, BareResume):
-            _sel = _pick_session("order", Path.cwd())
+            _cfg_resume = _load_config_resume(Path.cwd())
+            _backend_resume = _get_backend_resume(_cfg_resume.agent_backend.backend)
+            _log_dir = _backend_resume.session_locator().project_log_dir(str(Path.cwd()))
+            _sel = _pick_session("order", Path.cwd(), _log_dir)
             resume_spec = NamedResume(session_id=_sel) if _sel else NoResume()
         _launch_cook_session(
             "",

--- a/src/autoskillit/cli/session/_session_picker.py
+++ b/src/autoskillit/cli/session/_session_picker.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from autoskillit.core import claude_code_project_dir
-
 _ORDER_GREETING_PREFIXES = (
     "Today's special:",
     "Order up! Today's special:",
@@ -18,12 +16,12 @@ _ORDER_GREETING_PREFIXES = (
 )
 
 
-def pick_session(session_type: str, project_dir: Path) -> str | None:
+def pick_session(session_type: str, project_dir: Path, project_log_dir: Path) -> str | None:
     """Show filtered picker. Returns selected Claude session UUID or None (fresh start)."""
     from autoskillit.core import read_registry
 
     registry = read_registry(project_dir)
-    sessions = _load_sessions_index(project_dir)
+    sessions = _load_sessions_index(project_log_dir)
     filtered = [s for s in sessions if _classify_session(s, registry) == session_type]
 
     if not filtered:
@@ -33,9 +31,9 @@ def pick_session(session_type: str, project_dir: Path) -> str | None:
     return _run_picker(filtered, session_type, registry)
 
 
-def _load_sessions_index(project_dir: Path) -> list[dict]:
+def _load_sessions_index(project_log_dir: Path) -> list[dict]:
     """Load sessions-index.json, filtering out sidechain entries."""
-    index_path = claude_code_project_dir(str(project_dir)) / "sessions-index.json"
+    index_path = project_log_dir / "sessions-index.json"
     try:
         entries: list[dict] = json.loads(index_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -559,7 +559,7 @@ class TestCookInteractive:
         mock_mgr.init_session.return_value = fake_skills_dir
         picker_calls: list = []
 
-        def fake_pick_session(session_type: str, project_dir) -> None:
+        def fake_pick_session(session_type: str, project_dir, project_log_dir) -> None:
             picker_calls.append((session_type, project_dir))
             return None
 

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -559,7 +559,7 @@ class TestCookInteractive:
         mock_mgr.init_session.return_value = fake_skills_dir
         picker_calls: list = []
 
-        def fake_pick_session(session_type: str, project_dir, project_log_dir) -> None:
+        def fake_pick_session(session_type: str, project_dir, project_log_dir) -> str | None:
             picker_calls.append((session_type, project_dir))
             return None
 

--- a/tests/cli/test_cook_order_picker.py
+++ b/tests/cli/test_cook_order_picker.py
@@ -278,7 +278,7 @@ class TestCLIOrderPicker:
         )
         picker_calls: list = []
 
-        def fake_pick_session(session_type: str, project_dir, project_log_dir) -> None:
+        def fake_pick_session(session_type: str, project_dir, project_log_dir) -> str | None:
             picker_calls.append(session_type)
             return None
 

--- a/tests/cli/test_cook_order_picker.py
+++ b/tests/cli/test_cook_order_picker.py
@@ -278,7 +278,7 @@ class TestCLIOrderPicker:
         )
         picker_calls: list = []
 
-        def fake_pick_session(session_type: str, project_dir) -> None:
+        def fake_pick_session(session_type: str, project_dir, project_log_dir) -> None:
             picker_calls.append(session_type)
             return None
 

--- a/tests/cli/test_session_picker.py
+++ b/tests/cli/test_session_picker.py
@@ -24,18 +24,12 @@ def _make_index(tmp_path: Path, entries: list[dict]) -> Path:
     return tmp_path
 
 
-def test_pick_session_no_sessions_returns_none(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_pick_session_no_sessions_returns_none(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
     project_dir.mkdir()
     claude_dir = tmp_path / "claude-projects"
     claude_dir.mkdir()
-    monkeypatch.setattr(
-        "autoskillit.cli.session._session_picker.claude_code_project_dir",
-        lambda _: claude_dir,
-    )
-    result = pick_session("cook", project_dir)
+    result = pick_session("cook", project_dir, claude_dir)
     assert result is None
 
 
@@ -65,14 +59,10 @@ def test_pick_session_filters_cook(
     bridge_claude_session_id(project_dir, "lid-cook", "cook-uuid-1")
     bridge_claude_session_id(project_dir, "lid-order", "order-uuid-1")
 
-    monkeypatch.setattr(
-        "autoskillit.cli.session._session_picker.claude_code_project_dir",
-        lambda _: claude_dir,
-    )
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     monkeypatch.setattr("builtins.input", lambda _prompt="": "1")
 
-    result = pick_session("cook", project_dir)
+    result = pick_session("cook", project_dir, claude_dir)
     assert result == "cook-uuid-1"
 
 
@@ -100,14 +90,10 @@ def test_pick_session_filters_order(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     bridge_claude_session_id(project_dir, "lid-cook", "cook-uuid-1")
     bridge_claude_session_id(project_dir, "lid-order", "order-uuid-1")
 
-    monkeypatch.setattr(
-        "autoskillit.cli.session._session_picker.claude_code_project_dir",
-        lambda _: claude_dir,
-    )
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     monkeypatch.setattr("builtins.input", lambda _prompt="": "1")
 
-    result = pick_session("order", project_dir)
+    result = pick_session("order", project_dir, claude_dir)
     assert result == "order-uuid-1"
 
 
@@ -129,7 +115,7 @@ def test_greeting_heuristic_open_kitchen_order() -> None:
     assert result == "order"
 
 
-def test_sidechain_sessions_excluded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_sidechain_sessions_excluded(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
     project_dir.mkdir()
     claude_dir = tmp_path / "claude"
@@ -140,12 +126,7 @@ def test_sidechain_sessions_excluded(tmp_path: Path, monkeypatch: pytest.MonkeyP
     ]
     (claude_dir / "sessions-index.json").write_text(json.dumps(entries), encoding="utf-8")
 
-    monkeypatch.setattr(
-        "autoskillit.cli.session._session_picker.claude_code_project_dir",
-        lambda _: claude_dir,
-    )
-
-    result = pick_session("cook", project_dir)
+    result = pick_session("cook", project_dir, claude_dir)
     assert result is None
 
 


### PR DESCRIPTION
## Summary

Decouple `_session_picker.py` from the Claude Code-specific `claude_code_project_dir()` function by accepting `project_log_dir: Path` as a parameter on both `_load_sessions_index()` and `pick_session()`. Callers in `_session_cook.py` and `_session_order.py` compute this path via the backend's `SessionLocator.project_log_dir()` method before calling `pick_session()`. Four test monkeypatches in `test_session_picker.py` are replaced with direct parameter passing. Two additional test files (`test_cook_interactive.py`, `test_cook_order_picker.py`) with `fake_pick_session` stubs are updated to accept the new third parameter.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260610-091615-551434/.autoskillit/temp/make-plan/decouple_session_picker_plan_2026-06-10_091800.md`

Closes #3929

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 102 | 13.0k | 1.8M | 91.5k | 66 | 70.8k | 8m 23s |
| verify* | sonnet | 1 | 102 | 13.9k | 665.4k | 71.9k | 35 | 50.9k | 5m 6s |
| implement* | MiniMax-M3 | 1 | 1.2M | 8.2k | 0 | 0 | 51 | 0 | 4m 32s |
| audit_impl* | sonnet | 1 | 44 | 6.1k | 166.3k | 42.1k | 12 | 26.7k | 3m 0s |
| prepare_pr* | MiniMax-M3 | 1 | 194.1k | 2.0k | 0 | 0 | 15 | 0 | 2m 22s |
| compose_pr* | MiniMax-M3 | 1 | 175.8k | 1.1k | 0 | 0 | 12 | 0 | 42s |
| **Total** | | | 1.6M | 44.4k | 2.7M | 91.5k | | 148.4k | 24m 7s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 55 | 0.0 | 0.0 | 148.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **55** | 48211.9 | 2698.2 | 807.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 102 | 13.0k | 1.8M | 70.8k | 8m 23s |
| sonnet | 2 | 146 | 20.1k | 831.6k | 77.6k | 8m 6s |
| MiniMax-M3 | 3 | 1.6M | 11.4k | 0 | 0 | 7m 37s |