### PR TITLE
Implementation Plan: Replace vestigial OSError guard with Protocol dispatch

### DIFF
--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -31,7 +31,6 @@ from autoskillit.cli.session._session_order import _recipes_dir_for, order
 from autoskillit.core import (
     RecipeSource,
     atomic_write,
-    claude_code_project_dir,
 )
 from autoskillit.execution import _has_active_execution_marker
 
@@ -152,11 +151,11 @@ def serve(*, verbose: Annotated[bool, Parameter(name=["--verbose", "-v"])] = Fal
     try:
         backend_options = {"use_uvloop": sys.platform != "win32"}
 
-        _marker_dir: Path | None = None
-        try:
-            _marker_dir = claude_code_project_dir(str(ctx.project_dir))
-        except OSError:
-            pass
+        _marker_dir: Path | None = (
+            ctx.backend.session_locator().project_log_dir(str(ctx.project_dir))
+            if ctx.backend is not None
+            else None
+        )
 
         async def _guarded_serve() -> None:
             await serve_with_signal_guard(

--- a/tests/cli/test_app_main.py
+++ b/tests/cli/test_app_main.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -44,10 +46,6 @@ def test_serve_activity_check_uses_backend_derived_marker_dir(
     tmp_path: Path,
 ) -> None:
     """serve() must derive _marker_dir via backend.session_locator().project_log_dir()."""
-    import asyncio
-    import importlib
-    from unittest.mock import MagicMock
-
     app_module = importlib.import_module("autoskillit.cli.app")
 
     monkeypatch.chdir(tmp_path)
@@ -88,7 +86,7 @@ def test_serve_activity_check_uses_backend_derived_marker_dir(
         str(tmp_path)
     )
 
-    assert captured_activity_check, "serve_with_signal_guard was not called"
+    assert len(captured_activity_check) == 1, "serve_with_signal_guard was not called exactly once"
 
     seen_marker_dirs: list = []
     monkeypatch.setattr(

--- a/tests/cli/test_app_main.py
+++ b/tests/cli/test_app_main.py
@@ -45,7 +45,10 @@ def test_serve_activity_check_uses_backend_derived_marker_dir(
 ) -> None:
     """serve() must derive _marker_dir via backend.session_locator().project_log_dir()."""
     import asyncio
+    import importlib
     from unittest.mock import MagicMock
+
+    app_module = importlib.import_module("autoskillit.cli.app")
 
     monkeypatch.chdir(tmp_path)
 
@@ -74,7 +77,7 @@ def test_serve_activity_check_uses_backend_derived_marker_dir(
     async def fake_serve_guard(mcp_instance, *, activity_check=None, **kw):
         captured_activity_check.append(activity_check)
 
-    monkeypatch.setattr("autoskillit.cli.app.serve_with_signal_guard", fake_serve_guard)
+    monkeypatch.setattr(app_module, "serve_with_signal_guard", fake_serve_guard)
     monkeypatch.setattr("anyio.run", lambda fn, **kw: asyncio.run(fn()))
 
     from autoskillit.cli.app import serve
@@ -89,7 +92,8 @@ def test_serve_activity_check_uses_backend_derived_marker_dir(
 
     seen_marker_dirs: list = []
     monkeypatch.setattr(
-        "autoskillit.cli.app.is_server_active",
+        app_module,
+        "is_server_active",
         lambda md, fl: (seen_marker_dirs.append(md), False)[-1],
     )
 

--- a/tests/cli/test_app_main.py
+++ b/tests/cli/test_app_main.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import importlib
 import sys
+from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
 
 
 def test_main_does_not_call_app_after_update_restart(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -36,3 +37,64 @@ def test_main_does_not_call_app_after_update_restart(monkeypatch: pytest.MonkeyP
         pass
 
     assert not app_called, "app() must not be called when update path exits the process"
+
+
+def test_serve_activity_check_uses_backend_derived_marker_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """serve() must derive _marker_dir via backend.session_locator().project_log_dir()."""
+    import asyncio
+    from unittest.mock import MagicMock
+
+    monkeypatch.chdir(tmp_path)
+
+    expected_dir = tmp_path / "backend-marker"
+
+    mock_backend = MagicMock()
+    mock_backend.session_locator.return_value.project_log_dir.return_value = expected_dir
+
+    mock_ctx = MagicMock()
+    mock_ctx.project_dir = tmp_path
+    mock_ctx.backend = mock_backend
+    mock_ctx.fleet_lock = None
+
+    mock_cfg = MagicMock()
+    mock_cfg.logging.level = "INFO"
+    mock_cfg.logging.json_output = None
+    mock_cfg.safety.protected_branches = []
+
+    monkeypatch.setattr("autoskillit.config.load_config", lambda _: mock_cfg)
+    monkeypatch.setattr("autoskillit.core.configure_logging", lambda **kw: None)
+    monkeypatch.setattr("autoskillit.server.make_context", lambda *a, **kw: mock_ctx)
+    monkeypatch.setattr("autoskillit.server._initialize", lambda ctx: None)
+
+    captured_activity_check: list = []
+
+    async def fake_serve_guard(mcp_instance, *, activity_check=None, **kw):
+        captured_activity_check.append(activity_check)
+
+    monkeypatch.setattr("autoskillit.cli.app.serve_with_signal_guard", fake_serve_guard)
+    monkeypatch.setattr("anyio.run", lambda fn, **kw: asyncio.run(fn()))
+
+    from autoskillit.cli.app import serve
+
+    serve()
+
+    mock_backend.session_locator.return_value.project_log_dir.assert_called_once_with(
+        str(tmp_path)
+    )
+
+    assert captured_activity_check, "serve_with_signal_guard was not called"
+
+    seen_marker_dirs: list = []
+    monkeypatch.setattr(
+        "autoskillit.cli.app.is_server_active",
+        lambda md, fl: (seen_marker_dirs.append(md), False)[-1],
+    )
+
+    captured_activity_check[0]()
+    assert seen_marker_dirs == [expected_dir], (
+        f"activity_check should pass backend-derived marker_dir ({expected_dir}), "
+        f"got {seen_marker_dirs}"
+    )


### PR DESCRIPTION
## Summary

Replace `cli/app.py`'s direct call to `claude_code_project_dir()` (wrapped in a dead `except OSError` guard) with Protocol-dispatched `ctx.backend.session_locator().project_log_dir()`. Remove the now-unused `claude_code_project_dir` import. Add a smoke test proving the activity check lambda receives the backend-derived marker directory.

## Requirements

---
plan_id: a83ae274-34af-4772-a500-f9ac02160ced
source_commit: 8136d957cdd89772b8c1d124fb8021dd421bc4c0
---

## Goal

Replace vestigial OSError guard with Protocol dispatch and prove routing via smoke test.

## Context

- Phase: SessionLocator Protocol Fixes and Call-Site Migration (Milestone: 3-sessionlocator-protocol-fixes-and-call-site-migration)
- Assignment: P3-A10 (Migrate cli/app.py:157 to Protocol-dispatched project_log_dir)
- Depends on: P3-A3-WP1
- Depended on by: P3-A13-WP1

## Deliverables

- `app.py — OSError guard removed, Protocol dispatch added, import removed`
- `test_app_main.py — smoke test asserting activity_check uses backend-derived marker_dir`

## Technical Steps

1. Remove claude_code_project_dir from autoskillit.core import block.
2. Replace lines 155-159 with: _marker_dir = ctx.backend.session_locator().project_log_dir(...) if ctx.backend is not None else None
3. Verify _marker_dir: Path | None annotation preserved.
4. Verify is_server_active() already guards None marker_dir.
5. Add @pytest.mark.medium smoke test that monkeypatches make_context, anyio.run, and serve_with_signal_guard.

## Acceptance Criteria

- claude_code_project_dir not in app.py.
- No try/except OSError at former call site.
- RecipeSource and atomic_write still imported.
- _marker_dir: Path | None annotation preserved.
- Smoke test passes with mock backend.
- task test-check passes.

Closes #3930

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260610-100822-985723/.autoskillit/temp/make-plan/t4-p3-a10-wp1-replace-vestigial-oserror-guard_plan_2026-06-10_101500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 2.1k | 16.8k | 698.6k | 79.2k | 29 | 60.8k | 6m 52s |
| verify* | sonnet | 1 | 52 | 15.3k | 229.9k | 58.6k | 18 | 37.7k | 5m 43s |
| implement* | MiniMax-M3 | 1 | 1.1M | 5.4k | 0 | 0 | 49 | 0 | 4m 13s |
| fix* | sonnet | 1 | 134 | 8.8k | 798.9k | 67.1k | 44 | 46.1k | 4m 6s |
| audit_impl* | sonnet | 1 | 44 | 4.7k | 165.5k | 40.7k | 11 | 23.6k | 2m 33s |
| prepare_pr* | MiniMax-M3 | 2 | 420.9k | 5.3k | 0 | 0 | 28 | 0 | 2m 6s |
| compose_pr* | MiniMax-M3 | 1 | 213.8k | 1.5k | 0 | 0 | 14 | 0 | 42s |
| review_pr* | sonnet | 1 | 132 | 19.2k | 790.4k | 65.1k | 44 | 45.0k | 4m 25s |
| resolve_review* | sonnet | 1 | 245 | 21.4k | 2.1M | 92.7k | 69 | 72.6k | 9m 23s |
| **Total** | | | 1.8M | 98.5k | 4.8M | 92.7k | | 285.9k | 40m 7s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 75 | 0.0 | 0.0 | 72.4 |
| fix | 8 | 99862.4 | 5768.4 | 1098.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 262663.4 | 9071.0 | 2680.4 |
| **Total** | **91** | 52577.6 | 3141.6 | 1082.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.1k | 16.8k | 698.6k | 60.8k | 6m 52s |
| sonnet | 5 | 607 | 69.4k | 4.1M | 225.1k | 26m 13s |
| MiniMax-M3 | 3 | 1.8M | 12.2k | 0 | 0 | 7m 2s |