### PR TITLE
Implementation Plan: Keep _EXEMPT_FILES Accurate and Self-Documenting After P3 Migration

### DIFF
--- a/tests/arch/test_no_backend_name_bypass.py
+++ b/tests/arch/test_no_backend_name_bypass.py
@@ -9,15 +9,18 @@ pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 # Exempt files where backend name comparison is structurally necessary.
 _EXEMPT_FILES: frozenset[str] = frozenset(
     {
-        "execution/backends/__init__.py",  # BACKEND_REGISTRY lookup
-        "server/_factory.py",  # Feature-gated backend swap (pre-capabilities)
-        "cli/_marketplace.py",  # Marketplace — Claude Code-only install guard
-        "execution/recording.py",  # Replay setup: fmt == "codex" Compare for player selection
-        "execution/headless/_headless_result.py",  # Claude-specific result parsing
-        "core/_version_snapshot.py",  # Version snapshot — routes codex_version by backend name
-        "execution/headless/_headless_helpers.py",  # assert_headless_cmd claude -p flag check
-        "cli/session/_session_launch.py",  # Feature-gate backend-alignment fallback
-        "recipe/rules/rules_backend_compat.py",  # Backend compatibility semantic rule
+        # Pre-instantiation config guard: backend object not yet constructed
+        "server/_factory.py",
+        # Cassette format from filenames; selects api_simulator player (no backend at replay time)
+        "execution/recording.py",
+        # Claude-specific JSONL stdout format; parse_session_result() is Claude-only
+        "execution/headless/_headless_result.py",
+        # IL-0 module: cannot import BackendCapabilities (IL-1); routes version data by name
+        "core/_version_snapshot.py",
+        # Binary name check on CmdSpec subprocess argv; no backend context in assert_headless_cmd()
+        "execution/headless/_headless_helpers.py",
+        # FeatureDef.requires_backend_alignment is config-layer; no capabilities at scan time
+        "cli/session/_session_launch.py",
     }
 )
 


### PR DESCRIPTION
## Summary

Remove 3 stale entries from `_EXEMPT_FILES` in `test_no_backend_name_bypass.py` and add self-documenting inline comments to the remaining 6 entries explaining why each structural backend-name comparison is unavoidable.

The 3 entries to remove (`execution/backends/__init__.py`, `cli/_marketplace.py`, `recipe/rules/rules_backend_compat.py`) have zero AST `Compare` violations — the exemptions were either always technically incorrect (dict-key lookup, not a Compare node) or became stale after P3 migration refactored comparisons to capability checks.

The 6 remaining entries each have genuine `ast.Compare` nodes referencing backend-name literals or constants, and each has a documented reason why the comparison cannot be replaced with a `BackendCapabilities` field.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260610-112706-148380/.autoskillit/temp/make-plan/keep_exempt_files_accurate_plan_2026-06-10_113600.md`

Closes #3933

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 898 | 5.9k | 646.5k | 70.6k | 32 | 51.6k | 4m 36s |
| verify* | sonnet | 1 | 60 | 9.5k | 269.5k | 52.5k | 22 | 31.6k | 3m 49s |
| implement* | MiniMax-M3 | 1 | 774.7k | 3.3k | 0 | 0 | 34 | 0 | 7m 4s |
| audit_impl* | sonnet | 1 | 52 | 3.6k | 201.3k | 39.1k | 12 | 21.1k | 2m 3s |
| prepare_pr* | MiniMax-M3 | 1 | 228.1k | 1.9k | 0 | 0 | 16 | 0 | 45s |
| compose_pr* | MiniMax-M3 | 1 | 177.3k | 1.9k | 0 | 0 | 11 | 0 | 44s |
| review_pr* | sonnet | 1 | 100 | 13.6k | 550.2k | 58.5k | 33 | 38.2k | 3m 43s |
| resolve_review* | sonnet | 1 | 147 | 7.2k | 973.1k | 70.2k | 43 | 49.7k | 5m 0s |
| **Total** | | | 1.2M | 46.9k | 2.6M | 70.6k | | 192.1k | 27m 45s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 21 | 0.0 | 0.0 | 155.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **21** | 125740.9 | 9147.6 | 2231.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 898 | 5.9k | 646.5k | 51.6k | 4m 36s |
| sonnet | 4 | 359 | 33.9k | 2.0M | 140.5k | 14m 35s |
| MiniMax-M3 | 3 | 1.2M | 7.0k | 0 | 0 | 8m 33s |