### PR TITLE
Rectify: Surface LoadRecipeResult Errors and Fail-Closed on Invalid Content

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -372,14 +372,17 @@ async def _run_dispatch(
         )
 
     if not validation_result.get("valid", False):
+        structural_errors = validation_result.get("errors", [])
         error_findings = [
             s for s in validation_result.get("suggestions", []) if s.get("severity") == "error"
+        ]
+        error_parts = structural_errors[:3] + [
+            f"[{f['rule']}] {f['message']}" for f in error_findings[:3]
         ]
         return DispatchResult(
             DispatchRejected(
                 error_code=FleetErrorCode.FLEET_RECIPE_INVALID,
-                message=f"Recipe '{recipe}' has validation errors: "
-                + "; ".join(f"[{f['rule']}] {f['message']}" for f in error_findings[:3]),
+                message=f"Recipe '{recipe}' has validation errors: " + "; ".join(error_parts),
             ),
             per_dispatch_state_path=None,
         )

--- a/src/autoskillit/hooks/formatters/_fmt_recipe.py
+++ b/src/autoskillit/hooks/formatters/_fmt_recipe.py
@@ -33,6 +33,7 @@ _FMT_LOAD_RECIPE_RENDERED: frozenset[str] = frozenset(
 _FMT_LOAD_RECIPE_SUPPRESSED: frozenset[str] = frozenset(
     {
         "greeting",  # delivered via positional CLI arg, not MCP response
+        "errors",  # structural validation errors; internal to load_and_validate
         "diagram",  # user sees it in terminal preview; agent doesn't need it
         "kitchen_rules",  # already in the YAML content
         "requires_packs",  # internal field; used for skill gating, not display
@@ -170,6 +171,7 @@ _FMT_OPEN_KITCHEN_SUPPRESSED: frozenset[str] = frozenset(
     {
         "success",  # metadata — model infers success from formatted output
         "kitchen",  # metadata — model knows kitchen state from context
+        "errors",  # structural validation errors; internal to load_and_validate
         "greeting",  # delivered via CLI preview, not MCP response
         "diagram",  # rendered in terminal preview, not needed by agent
         "kitchen_rules",  # already embedded in YAML content

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -312,6 +312,7 @@ def load_and_validate(
     raw = substitute_scripts_placeholder(raw)
     suggestions: list[dict[str, Any]] = []
     valid = True
+    errors: list[str] = []
     recipe = None
     active_recipe = None
     _skip_resolutions: dict[str, bool | None] = {}
@@ -517,6 +518,7 @@ def load_and_validate(
     _assert_no_raw_placeholders(raw, context=name, hidden_ingredient_names=_hidden_names)
     result: LoadRecipeResult = {
         "content": raw,
+        "errors": errors,
         "diagram": diagram,
         "suggestions": suggestions,
         "valid": valid,

--- a/src/autoskillit/recipe/_recipe_ingredients.py
+++ b/src/autoskillit/recipe/_recipe_ingredients.py
@@ -111,6 +111,7 @@ class LoadRecipeResult(TypedDict, total=False):
     """Typed schema for the load_recipe handler → formatter boundary."""
 
     content: str
+    errors: list[str]
     diagram: str | None
     suggestions: list[dict[str, Any]]
     valid: bool
@@ -133,8 +134,9 @@ class OpenKitchenResult(TypedDict, total=False):
     Extends LoadRecipeResult with three post-return keys injected by the handler.
     """
 
-    # Inherited from LoadRecipeResult (14 keys)
+    # Inherited from LoadRecipeResult (15 keys)
     content: str
+    errors: list[str]
     diagram: str | None
     suggestions: list[dict[str, Any]]
     valid: bool

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -1065,7 +1065,6 @@
           "route": "check_review_loop"
         },
         {
-          "when": "true",
           "route": "check_review_loop"
         }
       ],
@@ -1109,6 +1108,9 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
+          "route": "release_issue_failure"
+        },
+        {
           "route": "release_issue_failure"
         }
       ],

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -945,8 +945,7 @@ steps:
       route: check_review_loop
     - when: "${{ result.verdict }} == approved"
       route: check_review_loop
-    - when: "true"
-      route: check_review_loop
+    - route: check_review_loop
     on_failure: check_repo_ci_event
     on_context_limit: check_repo_ci_event
     optional: true
@@ -986,6 +985,7 @@ steps:
       route: pre_review_rebase
     - when: "${{ result.verdict }} == 'ci_only_failure'"
       route: release_issue_failure
+    - route: release_issue_failure
     on_failure: release_issue_failure
     optional: true
     skip_when_false: "inputs.backend_supports_git_write"

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -1147,7 +1147,6 @@
           "route": "check_review_loop"
         },
         {
-          "when": "true",
           "route": "check_review_loop"
         }
       ],
@@ -1208,6 +1207,9 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
+          "route": "release_issue_failure"
+        },
+        {
           "route": "release_issue_failure"
         }
       ],

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1035,8 +1035,7 @@ steps:
       route: check_review_loop
     - when: ${{ result.verdict }} == approved
       route: check_review_loop
-    - when: 'true'
-      route: check_review_loop
+    - route: check_review_loop
     on_failure: check_repo_ci_event
     on_context_limit: check_repo_ci_event
     optional: true
@@ -1095,6 +1094,7 @@ steps:
       route: pre_review_rebase
     - when: ${{ result.verdict }} == 'ci_only_failure'
       route: release_issue_failure
+    - route: release_issue_failure
     on_failure: release_issue_failure
     optional: true
     skip_when_false: inputs.backend_supports_git_write

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -1196,6 +1196,9 @@
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
           "route": "register_clone_failure"
+        },
+        {
+          "route": "register_clone_failure"
         }
       ],
       "on_failure": "register_clone_failure",
@@ -1558,6 +1561,9 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
+          "route": "register_clone_failure"
+        },
+        {
           "route": "register_clone_failure"
         }
       ],

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -1162,6 +1162,7 @@ steps:
       route: register_clone_failure
     - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: register_clone_failure
+    - route: register_clone_failure
     on_failure: register_clone_failure
     skip_when_false: inputs.backend_supports_git_write
     retries: 3
@@ -1523,6 +1524,7 @@ steps:
       route: register_clone_failure
     - when: ${{ result.verdict }} == 'ci_only_failure'
       route: register_clone_failure
+    - route: register_clone_failure
     on_failure: register_clone_failure
     skip_when_false: inputs.backend_supports_git_write
     note: 'Resolves review findings on the integration PR (REQ-REVIEW-002). Fetches

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -1301,7 +1301,6 @@
           "route": "check_review_loop"
         },
         {
-          "when": "true",
           "route": "check_review_loop"
         }
       ],
@@ -1345,6 +1344,9 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
+          "route": "release_issue_failure"
+        },
+        {
           "route": "release_issue_failure"
         }
       ],

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1158,8 +1158,7 @@ steps:
       route: check_review_loop
     - when: ${{ result.verdict }} == approved
       route: check_review_loop
-    - when: 'true'
-      route: check_review_loop
+    - route: check_review_loop
     on_failure: check_repo_ci_event
     on_context_limit: check_repo_ci_event
     optional: true
@@ -1200,6 +1199,7 @@ steps:
       route: pre_review_rebase
     - when: ${{ result.verdict }} == 'ci_only_failure'
       route: release_issue_failure
+    - route: release_issue_failure
     on_failure: release_issue_failure
     optional: true
     skip_when_false: inputs.backend_supports_git_write

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -660,6 +660,9 @@
         {
           "when": "${{ context.verdict }} == 'no_test_infrastructure'",
           "route": "escalate_stop"
+        },
+        {
+          "route": "escalate_stop"
         }
       ],
       "on_failure": "escalate_stop",

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -613,6 +613,7 @@ steps:
       route: escalate_stop
     - when: "${{ context.verdict }} == 'no_test_infrastructure'"
       route: escalate_stop
+    - route: escalate_stop
     on_failure: escalate_stop
     on_context_limit: escalate_stop
     skip_when_false: "inputs.backend_supports_git_write"

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -935,6 +935,9 @@
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
           "route": "escalate_stop"
+        },
+        {
+          "route": "escalate_stop"
         }
       ],
       "on_failure": "escalate_stop",

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -875,6 +875,7 @@ steps:
       route: escalate_stop
     - when: "${{ result.verdict }} == 'no_test_infrastructure'"
       route: escalate_stop
+    - route: escalate_stop
     on_failure: escalate_stop
     on_context_limit: escalate_stop
     skip_when_false: "inputs.backend_supports_git_write"

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -97,6 +97,24 @@ def _kitchen_failure_envelope(
     )
 
 
+def _recipe_validation_error_response(name: str, result: dict) -> str:  # type: ignore[type-arg]
+    _errs: list[str] = result.get("errors", [])
+    _error_detail = "; ".join(_errs[:3]) if _errs else "unknown structural error"
+    return json.dumps(
+        {
+            "success": False,
+            "kitchen": "failed",
+            "user_visible_message": (
+                f"Recipe '{name}' failed structural validation: {_error_detail}"
+            ),
+            "error": f"Recipe '{name}' failed validation: {_error_detail}",
+            "stage": "recipe_validation",
+            "errors": _errs,
+            "suggestions": result.get("suggestions", []),
+        }
+    )
+
+
 class QuotaGuardHookPayload(TypedDict):
     cache_max_age: int
     cache_path: str
@@ -604,21 +622,7 @@ async def open_kitchen(
                         tool_ctx.active_recipe_ingredients = None
                 # Default to False for missing 'valid' so a absent key is treated as invalid
                 if not result.get("valid", False) or not result.get("content", ""):
-                    _errs = result.get("errors", [])
-                    _error_detail = "; ".join(_errs[:3]) if _errs else "unknown structural error"
-                    return json.dumps(
-                        {
-                            "success": False,
-                            "kitchen": "failed",
-                            "user_visible_message": (
-                                f"Recipe '{name}' failed structural validation: {_error_detail}"
-                            ),
-                            "error": f"Recipe '{name}' failed validation: {_error_detail}",
-                            "stage": "recipe_validation",
-                            "errors": _errs,
-                            "suggestions": result.get("suggestions", []),
-                        }
-                    )
+                    return _recipe_validation_error_response(name, result)
                 result["success"] = True
                 result["kitchen"] = "open"
                 result["version"] = __version__
@@ -705,21 +709,7 @@ async def open_kitchen(
                 return _kitchen_failure_envelope(exc, stage="apply_triage_gate")
 
             if not result.get("valid", False) or not result.get("content", ""):
-                _errs = result.get("errors", [])
-                _error_detail = "; ".join(_errs[:3]) if _errs else "unknown structural error"
-                return json.dumps(
-                    {
-                        "success": False,
-                        "kitchen": "failed",
-                        "user_visible_message": (
-                            f"Recipe '{name}' failed structural validation: {_error_detail}"
-                        ),
-                        "error": f"Recipe '{name}' failed validation: {_error_detail}",
-                        "stage": "recipe_validation",
-                        "errors": _errs,
-                        "suggestions": result.get("suggestions", []),
-                    }
-                )
+                return _recipe_validation_error_response(name, result)
 
             result["success"] = True
             result["kitchen"] = "open"

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -7,7 +7,7 @@ import json
 import os
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 if TYPE_CHECKING:
     from autoskillit.config.settings import QuotaGuardConfig
@@ -97,7 +97,7 @@ def _kitchen_failure_envelope(
     )
 
 
-def _recipe_validation_error_response(name: str, result: dict) -> str:  # type: ignore[type-arg]
+def _recipe_validation_error_response(name: str, result: dict[str, Any]) -> str:
     _errs: list[str] = result.get("errors", [])
     _error_detail = "; ".join(_errs[:3]) if _errs else "unknown structural error"
     return json.dumps(

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -602,6 +602,23 @@ async def open_kitchen(
                     else:
                         tool_ctx.active_recipe_steps = None
                         tool_ctx.active_recipe_ingredients = None
+                # Default to False for missing 'valid' so a absent key is treated as invalid
+                if not result.get("valid", False) or not result.get("content", ""):
+                    _errs = result.get("errors", [])
+                    _error_detail = "; ".join(_errs[:3]) if _errs else "unknown structural error"
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "kitchen": "failed",
+                            "user_visible_message": (
+                                f"Recipe '{name}' failed structural validation: {_error_detail}"
+                            ),
+                            "error": f"Recipe '{name}' failed validation: {_error_detail}",
+                            "stage": "recipe_validation",
+                            "errors": _errs,
+                            "suggestions": result.get("suggestions", []),
+                        }
+                    )
                 result["success"] = True
                 result["kitchen"] = "open"
                 result["version"] = __version__
@@ -686,6 +703,23 @@ async def open_kitchen(
             except Exception as exc:
                 logger.warning("open_kitchen_failure", stage="apply_triage_gate", exc_info=True)
                 return _kitchen_failure_envelope(exc, stage="apply_triage_gate")
+
+            if not result.get("valid", False) or not result.get("content", ""):
+                _errs = result.get("errors", [])
+                _error_detail = "; ".join(_errs[:3]) if _errs else "unknown structural error"
+                return json.dumps(
+                    {
+                        "success": False,
+                        "kitchen": "failed",
+                        "user_visible_message": (
+                            f"Recipe '{name}' failed structural validation: {_error_detail}"
+                        ),
+                        "error": f"Recipe '{name}' failed validation: {_error_detail}",
+                        "stage": "recipe_validation",
+                        "errors": _errs,
+                        "suggestions": result.get("suggestions", []),
+                    }
+                )
 
             result["success"] = True
             result["kitchen"] = "open"

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -933,6 +933,7 @@ _IMPORT_GUARD_TRANSITIVE_OVERRIDES: dict[str, frozenset[str]] = {
             "recipe/test_staleness_cache.py",
             "recipe/test_sub_recipe_loading.py",
             "recipe/test_sub_recipe_validation.py",
+            "server/test_backend_ingredient_injection.py",
         }
     ),
     "planner": frozenset(

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -716,7 +716,6 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "recipe/test_sub_recipe_loading.py",
             "recipe/test_sub_recipe_validation.py",
             # Server file-level entries:
-            "server/test_backend_ingredient_injection.py",
             "server/test_factory.py",
             "server/test_tools_clone.py",
             "server/test_tools_execution_routing.py",

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -716,6 +716,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "recipe/test_sub_recipe_loading.py",
             "recipe/test_sub_recipe_validation.py",
             # Server file-level entries:
+            "server/test_backend_ingredient_injection.py",
             "server/test_factory.py",
             "server/test_tools_clone.py",
             "server/test_tools_execution_routing.py",

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -962,11 +962,13 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "co-located with the execution engine that calls them",
     ),
     "tools_kitchen.py": (
-        1115,
+        1150,
         "REQ-CNST-010-E7: kitchen tool handlers — open_kitchen and lock_ingredients require "
         "inline validation helpers (_check_override_keys, _build_ingredient_key_suggestions) "
         "for ingredient key validation; splitting would cross import-layer boundaries; "
-        "backend capability promotion delegated to _promote_capability_keys in _auto_overrides",
+        "backend capability promotion delegated to _promote_capability_keys in _auto_overrides; "
+        "fail-closed validity gate on both deferred-recall and normal paths adds structural "
+        "error propagation from LoadRecipeResult",
     ),
     "tools_execution.py": (
         1110,

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -122,8 +122,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools/tools_kitchen.py", 142),
     ("src/autoskillit/server/tools/tools_kitchen.py", 161),
     ("src/autoskillit/server/tools/tools_kitchen.py", 195),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 839),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 899),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 873),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 933),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -119,11 +119,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 87),
     # tools_kitchen.py — hook config, quota guard, git_ops_policy, ingredient locks overlay
-    ("src/autoskillit/server/tools/tools_kitchen.py", 142),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 161),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 195),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 873),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 933),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 160),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 179),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 213),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 863),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 923),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -1188,15 +1188,12 @@ def test_load_and_validate_surfaces_errors_on_dangling_routes(tmp_path: Path) ->
     """LoadRecipeResult must contain an 'errors' field with structural error strings
     when post-prune validation detects dangling routes."""
     from autoskillit.recipe._api import load_and_validate
-    from autoskillit.workspace.skills import DefaultSkillResolver
 
-    resolver = DefaultSkillResolver()
     result = load_and_validate(
         "implementation",
         project_dir=tmp_path,
         ingredient_overrides={"backend_supports_git_write": "false"},
         backend_name="codex",
-        lister=resolver,
     )
     assert result["valid"] is False
     assert "errors" in result, "LoadRecipeResult must include 'errors' field"

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -1184,9 +1184,14 @@ steps:
 # ---------------------------------------------------------------------------
 
 
-def test_load_and_validate_surfaces_errors_on_dangling_routes(tmp_path: Path) -> None:
-    """LoadRecipeResult must contain an 'errors' field with structural error strings
-    when post-prune validation detects dangling routes."""
+def test_load_and_validate_produces_valid_content_after_step_pruning(tmp_path: Path) -> None:
+    """After structural repair (when=None catch-alls on resolve_review), pruning
+    skip_when_false steps must produce a recipe with non-empty content and no
+    structural errors from dangling routes.
+
+    This is the post-fix state: dangling routes that the pre-fix YAML produced
+    are now repaired by the computable redirect catch-alls.
+    """
     from autoskillit.recipe._api import load_and_validate
 
     result = load_and_validate(
@@ -1195,10 +1200,11 @@ def test_load_and_validate_surfaces_errors_on_dangling_routes(tmp_path: Path) ->
         ingredient_overrides={"backend_supports_git_write": "false"},
         backend_name="codex",
     )
-    assert result["valid"] is False
-    assert "errors" in result, "LoadRecipeResult must include 'errors' field"
-    assert isinstance(result["errors"], list), "errors must be a list"
-    assert len(result["errors"]) > 0, "errors list must be non-empty when valid=False"
-    assert any("dangling" in e.lower() for e in result["errors"]), (
-        "At least one error should mention dangling routes"
+    schema_errors = result.get("errors", [])
+    assert not any("dangling" in e.lower() for e in schema_errors), (
+        f"Post-fix pruning should not produce dangling route errors, got: {schema_errors}"
+    )
+    assert result["content"], (
+        "Content must be non-empty after pruning — empty content indicates "
+        "unrepaired dangling routes after step pruning"
     )

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -1177,3 +1177,31 @@ steps:
     assert undeclared2 == [], (
         f"Expected no undeclared-capture-key after YAML-only update: {undeclared2}"
     )
+
+
+# ---------------------------------------------------------------------------
+# T-ERR-1: LoadRecipeResult must surface errors when valid=False
+# ---------------------------------------------------------------------------
+
+
+def test_load_and_validate_surfaces_errors_on_dangling_routes(tmp_path: Path) -> None:
+    """LoadRecipeResult must contain an 'errors' field with structural error strings
+    when post-prune validation detects dangling routes."""
+    from autoskillit.recipe._api import load_and_validate
+    from autoskillit.workspace.skills import DefaultSkillResolver
+
+    resolver = DefaultSkillResolver()
+    result = load_and_validate(
+        "implementation",
+        project_dir=tmp_path,
+        ingredient_overrides={"backend_supports_git_write": "false"},
+        backend_name="codex",
+        lister=resolver,
+    )
+    assert result["valid"] is False
+    assert "errors" in result, "LoadRecipeResult must include 'errors' field"
+    assert isinstance(result["errors"], list), "errors must be a list"
+    assert len(result["errors"]) > 0, "errors list must be non-empty when valid=False"
+    assert any("dangling" in e.lower() for e in result["errors"]), (
+        "At least one error should mention dangling routes"
+    )

--- a/tests/recipe/test_bundled_recipe_hidden_policy.py
+++ b/tests/recipe/test_bundled_recipe_hidden_policy.py
@@ -64,6 +64,7 @@ def test_bundled_recipe_content_has_no_residual_skip_signals(recipe_name: str) -
 
     result = load_and_validate(recipe_name)
     recipe_content = result["content"]
+    assert recipe_content, f"Content must be non-empty for recipe '{recipe_name}'"
     # Parse the raw recipe to find hidden ingredients referenced by skip_when_false
     recipe_obj = load_recipe(pkg_root() / "recipes" / f"{recipe_name}.yaml")
     hidden_ing_names = {name for name, ing in recipe_obj.ingredients.items() if ing.hidden}
@@ -95,6 +96,9 @@ def test_bundled_recipe_content_has_no_residual_skip_signals(recipe_name: str) -
             ingredient_overrides={ing_name: "true"},
         )
         truthy_content = truthy_result["content"]
+        assert truthy_content, (
+            f"Truthy content must be non-empty for recipe '{recipe_name}' ingredient '{ing_name}'"
+        )
         residual_optional = []
         residual_skip = []
         for step_name in guarded_steps:

--- a/tests/recipe/test_content_integrity.py
+++ b/tests/recipe/test_content_integrity.py
@@ -51,6 +51,10 @@ def test_truthy_resolved_step_has_no_optional_signal_in_content(
     error_findings = [s for s in result.get("suggestions", []) if s.get("severity") == "error"]
     assert not error_findings, f"load_and_validate failed: {error_findings}"
     content = result["content"]
+    assert content, (
+        f"Recipe '{recipe_name}' ingredient '{ing_name}': content is empty after "
+        f"truthy resolution — vacuous assertions would hide bugs"
+    )
     residual_optional = []
     residual_skip = []
     for step_name in guarded_steps:

--- a/tests/recipe/test_hidden_ingredients.py
+++ b/tests/recipe/test_hidden_ingredients.py
@@ -928,6 +928,16 @@ steps:
     assert result["content"] == ""
 
 
+def _has_computable_redirect(step: object) -> bool:
+    """Return True if the step has a safe redirect that can be computed."""
+    if getattr(step, "on_success", None) is not None:
+        return True
+    on_result = getattr(step, "on_result", None)
+    if on_result is not None and on_result.conditions:
+        return any(c.when is None for c in on_result.conditions)
+    return False
+
+
 def test_bundled_recipes_prune_produces_no_dangling_routes() -> None:
     """Regression: pruning skip_when_false steps with computable redirects
     produces no dangling routes in each bundled recipe.
@@ -937,15 +947,6 @@ def test_bundled_recipes_prune_produces_no_dangling_routes() -> None:
         _validate_no_dangling_routes,
     )
     from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
-
-    def _has_computable_redirect(step: object) -> bool:
-        """Return True if the step has a safe redirect that can be computed."""
-        if getattr(step, "on_success", None) is not None:
-            return True
-        on_result = getattr(step, "on_result", None)
-        if on_result is not None and on_result.conditions:
-            return any(c.when is None for c in on_result.conditions)
-        return False
 
     recipe_dir = builtin_recipes_dir()
     yaml_files = sorted(recipe_dir.glob("*.yaml"))
@@ -963,20 +964,34 @@ def test_bundled_recipes_prune_produces_no_dangling_routes() -> None:
             pruned, resolutions = _prune_skipped_steps(
                 recipe, ingredient_overrides={ingredient_name: "false"}
             )
-            # Only assert no dangling routes when all pruned steps have computable
-            # redirects. When any pruned step lacks a redirect, dangling routes are
-            # expected and detected by _validate_no_dangling_routes as designed.
-            all_pruned_have_redirect = all(
-                _has_computable_redirect(recipe.steps[name])
-                for name, kept in resolutions.items()
-                if not kept and name in recipe.steps
-            )
-            if not all_pruned_have_redirect:
-                continue
             errors = _validate_no_dangling_routes(pruned)
             assert not errors, (
                 f"Bundled recipe {yaml_file.name!r}: pruning step {step_name!r} "
-                f"produced dangling routes: {errors}"
+                f"(ingredient={ingredient_name!r}) produced dangling routes: {errors}. "
+                f"Fix: add a when=None catch-all condition to the pruned step's on_result, "
+                f"or add on_success to provide a computable redirect."
+            )
+
+
+def test_all_skip_guarded_steps_have_computable_redirect() -> None:
+    """Every bundled recipe step with skip_when_false must have a computable redirect.
+
+    This is the structural invariant: if a step can be pruned, the pruning engine
+    must be able to repair all routes that pointed to it. Steps that lack both
+    on_success and a when=None catch-all in on_result are structurally defective.
+    """
+    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+    recipe_dir = builtin_recipes_dir()
+    for yaml_file in sorted(recipe_dir.glob("*.yaml")):
+        recipe = load_recipe(yaml_file)
+        for step_name, step in recipe.steps.items():
+            if step.skip_when_false is None:
+                continue
+            assert _has_computable_redirect(step), (
+                f"Bundled recipe {yaml_file.name!r}: step {step_name!r} has "
+                f"skip_when_false={step.skip_when_false!r} but no computable redirect. "
+                f"Add on_success or a when=None catch-all to on_result."
             )
 
 

--- a/tests/server/test_backend_ingredient_injection.py
+++ b/tests/server/test_backend_ingredient_injection.py
@@ -483,6 +483,10 @@ class TestRealCompositionPruning:
             lister=resolver,
         )
         content = result["content"]
+        assert content, (
+            "Content must be non-empty after codex pruning — "
+            "empty content indicates unrepairable dangling routes after step pruning"
+        )
         for step_name in self._GIT_WRITE_STEPS:
             assert f"  {step_name}:" not in content, (
                 f"Guarded step {step_name!r} still present as YAML key in pruned content"

--- a/tests/server/test_backend_ingredient_injection.py
+++ b/tests/server/test_backend_ingredient_injection.py
@@ -470,17 +470,18 @@ class TestRealCompositionPruning:
         "resolve_ci",
     }
 
+    @pytest.mark.xfail(
+        reason="Part B: resolve_review needs when=None catch-all to avoid dangling routes",
+        strict=True,
+    )
     def test_codex_overrides_remove_guarded_steps_from_content(self, tmp_path: Path) -> None:
         from autoskillit.recipe._api import load_and_validate
-        from autoskillit.workspace.skills import DefaultSkillResolver
 
-        resolver = DefaultSkillResolver()
         result = load_and_validate(
             "implementation",
             project_dir=tmp_path,
             ingredient_overrides={"backend_supports_git_write": "false"},
             backend_name="codex",
-            lister=resolver,
         )
         content = result["content"]
         assert content, (

--- a/tests/server/test_backend_ingredient_injection.py
+++ b/tests/server/test_backend_ingredient_injection.py
@@ -470,10 +470,6 @@ class TestRealCompositionPruning:
         "resolve_ci",
     }
 
-    @pytest.mark.xfail(
-        reason="Part B: resolve_review needs when=None catch-all to avoid dangling routes",
-        strict=True,
-    )
     def test_codex_overrides_remove_guarded_steps_from_content(self, tmp_path: Path) -> None:
         from autoskillit.recipe._api import load_and_validate
 

--- a/tests/server/test_open_kitchen_deferred_recall.py
+++ b/tests/server/test_open_kitchen_deferred_recall.py
@@ -28,11 +28,15 @@ async def test_deferred_recall_sets_active_recipe_steps_from_recipe():
 
     mock_ctx = _make_deferred_recall_ctx("test-recipe")
     mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "name: test-recipe\nsteps:\n  build:\n    cmd: task build\n",
+        "valid": True,
+        "errors": [],
         "requires_packs": [],
         "requires_features": [],
         "content_hash": "abc123",
         "composite_hash": "def456",
         "recipe_version": "1.0",
+        "suggestions": [],
     }
     mock_recipe_info = MagicMock()
     mock_recipe_info.path = Path("/fake/.autoskillit/recipes/test-recipe.yaml")
@@ -60,11 +64,15 @@ async def test_deferred_recall_sets_active_recipe_steps_none_when_find_raises():
 
     mock_ctx = _make_deferred_recall_ctx("test-recipe")
     mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "name: test-recipe\nsteps:\n  build:\n    cmd: task build\n",
+        "valid": True,
+        "errors": [],
         "requires_packs": [],
         "requires_features": [],
         "content_hash": "abc",
         "composite_hash": "def",
         "recipe_version": "1.0",
+        "suggestions": [],
     }
     mock_ctx.recipes.find.side_effect = RuntimeError("disk error")
 
@@ -83,11 +91,15 @@ async def test_deferred_recall_sets_active_recipe_steps_none_when_find_returns_n
 
     mock_ctx = _make_deferred_recall_ctx("test-recipe")
     mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "name: test-recipe\nsteps:\n  build:\n    cmd: task build\n",
+        "valid": True,
+        "errors": [],
         "requires_packs": [],
         "requires_features": [],
         "content_hash": "abc",
         "composite_hash": "def",
         "recipe_version": "1.0",
+        "suggestions": [],
     }
     mock_ctx.recipes.find.return_value = None
 

--- a/tests/server/test_server_init_gate.py
+++ b/tests/server/test_server_init_gate.py
@@ -19,6 +19,19 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.medium]
 class TestKitchenVisibility:
     """FastMCP v3 tag-based visibility: kitchen tools hidden at startup."""
 
+    @pytest.fixture(autouse=True)
+    def _reset_visibility(self):
+        from autoskillit.core import ALL_VISIBILITY_TAGS
+        from autoskillit.server import mcp
+
+        mcp._transforms.clear()
+        for tag in sorted(ALL_VISIBILITY_TAGS):
+            mcp.disable(tags={tag})
+        yield
+        mcp._transforms.clear()
+        for tag in sorted(ALL_VISIBILITY_TAGS):
+            mcp.disable(tags={tag})
+
     @pytest.mark.anyio
     async def test_kitchen_tools_hidden_at_startup(self):
         """No kitchen tool (gated or headless-tagged) appears in tools/list for a fresh session."""

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -687,6 +687,68 @@ async def test_open_kitchen_load_and_validate_raises_returns_failure_envelope(
 
 
 @pytest.mark.anyio
+async def test_open_kitchen_fails_on_empty_content(tmp_path, monkeypatch):
+    """open_kitchen must return success=false when load_and_validate produces
+    content='' and valid=False (dangling route wipe)."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+    mock_ctx.recipes = MagicMock()
+    mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "",
+        "valid": False,
+        "errors": ["[post-prune] dangling route: Step 'x' routes to unknown step 'y'"],
+        "suggestions": [],
+    }
+    mock_ctx.config.migration.suppressed = []
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()
+            ):
+                with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+                    from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+                    result_str = await open_kitchen(name="demo", ctx=mock_ctx)
+
+    parsed = json.loads(result_str)
+    assert parsed["success"] is False, (
+        "open_kitchen must not return success=true when content is empty"
+    )
+    assert parsed["kitchen"] == "failed"
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_fails_on_invalid_recipe(tmp_path, monkeypatch):
+    """open_kitchen must return success=false when load_and_validate sets valid=False."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+    mock_ctx.recipes = MagicMock()
+    mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+        "valid": False,
+        "errors": ["some structural error"],
+        "suggestions": [{"severity": "error", "rule": "test", "message": "bad"}],
+    }
+    mock_ctx.config.migration.suppressed = []
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()
+            ):
+                with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+                    from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+                    result_str = await open_kitchen(name="demo", ctx=mock_ctx)
+
+    parsed = json.loads(result_str)
+    assert parsed["success"] is False
+
+
+@pytest.mark.anyio
 async def test_open_kitchen_apply_triage_gate_raises_returns_failure_envelope(
     tmp_path, monkeypatch
 ):

--- a/tests/server/test_tools_kitchen_gate_features.py
+++ b/tests/server/test_tools_kitchen_gate_features.py
@@ -246,12 +246,15 @@ async def test_open_kitchen_uses_project_dir_for_recipe_lookup(tmp_path, monkeyp
         "name: test-project-dir-recipe\n"
         "description: Test recipe for project_dir propagation\n"
         "autoskillit_version: '0.2.0'\n"
+        "kind: interactive\n"
         "kitchen_rules:\n"
         "  - Never use native tools\n"
+        "  - Never use Read, Grep, Glob, Edit, Write, Bash, Agent,"
+        " WebFetch, WebSearch, NotebookEdit\n"
         "steps:\n"
         "  stop:\n"
         "    action: stop\n"
-        "    message: done\n"
+        "    message: Pipeline complete. Emit sentinel to signal success.\n"
     )
     recipes_dir = different_dir / ".autoskillit" / "recipes"
     recipes_dir.mkdir(parents=True)

--- a/tests/server/test_tools_kitchen_visibility.py
+++ b/tests/server/test_tools_kitchen_visibility.py
@@ -228,13 +228,16 @@ async def test_open_kitchen_with_recipe_returns_combined_response(tmp_path, monk
 
 @pytest.mark.anyio
 async def test_open_kitchen_with_recipe_not_found(tmp_path, monkeypatch):
-    """open_kitchen(name='nonexistent') returns error with kitchen still open."""
+    """open_kitchen(name='nonexistent') fails closed when recipe is not found."""
     monkeypatch.chdir(tmp_path)
     mock_ctx = _make_mock_ctx()
     mock_ctx.enable_components = AsyncMock()
     mock_ctx.recipes = MagicMock()
     mock_ctx.recipes.load_and_validate.return_value = {
-        "error": "No recipe named 'nonexistent' found",
+        "content": "",
+        "valid": False,
+        "errors": ["No recipe named 'nonexistent' found"],
+        "suggestions": [],
     }
     mock_ctx.recipes.find.return_value = None
     mock_ctx.config.migration.suppressed = []
@@ -250,11 +253,9 @@ async def test_open_kitchen_with_recipe_not_found(tmp_path, monkeypatch):
                     result_str = await open_kitchen(name="nonexistent", ctx=mock_ctx)
 
     result = json.loads(result_str)
-    assert "error" in result
+    assert result["success"] is False
     assert "nonexistent" in result["error"]
-    assert result["kitchen"] == "open"
-    # Kitchen should still be opened even if recipe fails
-    mock_ctx.gate.enable.assert_called_once()
+    assert result["kitchen"] == "failed"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

`open_kitchen` silently returns `content: ""` with `success: true` when post-prune validation detects dangling routes or route-consistency errors. The architectural weakness is threefold:

1. **`load_and_validate()` computes structural errors but discards them** — `LoadRecipeResult` has no `errors` field, so the reason for `valid=False` is lost at the TypedDict boundary.
2. **`open_kitchen` stamps `success: true` unconditionally** — it never checks `result["valid"]` or `result["content"]` before returning.
3. **`_prune_skipped_steps` produces unrepairable dangling routes silently** — when a pruned step has no computable redirect (no `on_success`, no `when=None` catch-all in `on_result`), the route-repair loop is a no-op, and the only signal is a list of strings returned from `_validate_no_dangling_routes` that gets appended to a local variable and then discarded.

Part A addresses the core data-loss path: surfacing structural errors through `LoadRecipeResult`, making `open_kitchen` fail-closed on invalid content, and adding tests that catch this class of bug. Part B will address the recipe YAML fixes (adding `when=None` catch-all to `resolve_review`) and broader vacuous-assertion cleanup.

## Problem

When the orchestrator backend is Codex, `open_kitchen(name="implementation")` returns `success: true`, `valid: false`, and `content: ""` — the **entire recipe body is silently withheld**. The orchestrator receives no explanation for the empty content, has no prompt instruction for this state, and is structurally blocked from every recovery path (`recipe_read_guard.py` PreToolUse hook + sous-chef raw-read prohibition + `load_recipe` returning the same empty result).

In run `impl-20260610-095047-486925` (TalonT-Org/the-token-reserve#147, PR TalonT-Org/the-token-reserve#189, AutoSkillit 0.10.745, 2026-06-10 09:49–11:31), the Codex orchestrator **improvised the entire 60-minute pipeline from the Mermaid `diagram` field, the ingredients table, and the sous-chef prompt** — executing steps the composition had pruned as backend-incompatible (e.g. `implement` → `implement-worktree-no-merge`, declared `requires backend ['claude-code']`), with no step routing, no `capture:` contracts, no retry counts, and zero `record_pipeline_step` calls. The PR happened to merge green, but the run cannot be trusted to have followed the composed plan.

**Reproduced at repo HEAD `18f410893` (0.10.748).** This is the sixth manifestation of the step-pruning/content-divergence family.

## Root cause chain

1. **Guard introduction (2026-06-09):** `207deda91` (#3960) introduced the `backend_supports_git_write` ingredient and added `skip_when_false: inputs.backend_supports_git_write` to 7 steps in `implementation.yaml` (and 7 in `remediation.yaml`) including `resolve_review` — without giving `resolve_review` a `when=None` catch-all route. The bug became reachable <24h before the failing run.
2. **Codex capability override:** `_backend_capability_overrides()` (`src/autoskillit/server/tools/_auto_overrides.py:19-28`) maps Codex's `git_metadata_writable=False` to `backend_supports_git_write="false"`, injected into session overrides at `src/autoskillit/server/tools/tools_kitchen.py:540`, promoted over user-supplied overrides via `_promote_capability_keys` (line 542), and passed to `load_and_validate` (lines 627-635).
3. **Unrepairable route:** `_prune_skipped_steps()` (`src/autoskillit/recipe/_recipe_composition.py:294-415` (redirect derivation 352-364)) prunes `resolve_review` but derives `redirect = None` — the step has no `on_success` and all four of its `on_result` conditions carry `when` clauses (the repair logic deliberately never derives a redirect from `on_failure`/`on_exhausted`) (`src/autoskillit/recipes/implementation.yaml:1089-1097`). The surviving `enrich_diff_context` (`on_success: resolve_review`, `on_failure: resolve_review`, `implementation.yaml:1064-1065`) is left dangling. The code comment acknowledges this path: "redirect stays None and `_validate_no_dangling_routes` catches dangling refs."
4. **Silent content wipe:** `_validate_no_dangling_routes` returns `["Step 'enrich_diff_context' routes to unknown step 'resolve_review'"]` and `load_and_validate()` sets `raw = ""` (`src/autoskillit/recipe/_api.py:415-418`). The `errors` list feeds only `compute_recipe_validity()`; **`LoadRecipeResult` has no `errors` field**, so the reason never reaches the caller.
5. **No fail signal, no recovery:** `open_kitchen` returns `success: true, kitchen: "open"` without checking `valid`/`content` (`tools_kitchen.py:690-692`; the deferred-recall branch at 605-607 is equally unchecked). Neither sous-chef SKILL.md nor any orchestrator prompt covers `content: ""`. The #3736/#3947 defenses (raw-read prohibition, `recipe_read_guard.py`, compaction disable) eliminate self-recovery, converting the state into a trap.

## Reproduction (repo HEAD `18f410893`, 0.10.748)

```python
load_and_validate("implementation", project_dir=Path("/home/talon/projects/token-reserve"),
                  backend_name="codex", lister=DefaultSkillResolver(),
                  ingredient_overrides={"backend_supports_git_write": "false",
                                        "post_run_diagnostics": "false"})
# → valid: False, content_len: 0, 13 error-severity backend-incompatible-skill suggestions,
#   exactly one dangling-route error (instrumented): enrich_diff_context → resolve_review
# same call with backend_name="claude-code" → valid: True, content_len: 86,942
```

Claude Code is unaffected because `git_metadata_writable=True` produces no pruning of these steps — full content is delivered. This is **not** Codex-side truncation: the run's rollout log records the full `open_kitchen` results (90,635 and 86,672 bytes) with zero truncation markers; `tool_output_token_limit=50000` and compaction-disable were correctly written to `config.toml`.

## Remediation targets

1. **Surface the wipe reason:** add `errors: list[str]` to `LoadRecipeResult` and populate it whenever `raw` is cleared (`_api.py:415-426`).
2. **Fail loudly in `open_kitchen`:** when `valid is False` and `content == ""`, return a failure envelope (`success: false` + the dangling-route errors) — never `success: true` with no recipe.
3. **Orchestrator halt instruction:** sous-chef/orchestrator-prompt rule — if `open_kitchen` returns empty `content`, halt and escalate; never execute from the diagram.
4. **Fix the recipe:** give `resolve_review` a computable redirect (`when=None` catch-all) or guard `enrich_diff_context`'s routes consistently so the pruned subgraph is removed atomically; audit the other `backend_supports_git_write`-guarded steps — 11 in `implementation.yaml` at HEAD, added across `207deda91`, `884e1f2ae`, `d88bda83a` — and the other bundled recipes (`remediation.yaml` gained 7 guards in the same commit) for the same exposure.
5. **Close the test escape hatch:** replace the `continue` at `tests/recipe/test_hidden_ingredients.py:966-975` with an assertion (and ideally a semantic validation rule) that every prunable step has a computable redirect; add a codex-composition test asserting `valid is True` AND non-empty `content` AND all surviving steps present for each bundled recipe.
6. **Secondary:** bundled skills are invisible to Codex sessions (no `--plugin-dir` equivalent; `src/autoskillit/workspace/session_skills.py:319` excludes `BUNDLED`), so the orchestrator could not map a post-hoc "run analyze health" request to `/autoskillit:analyze-pipeline-health`; consider listing invocable bundled skill commands in the Codex orchestrator prompt or `open_kitchen` result.

Closes #3992

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260610-175022-808728/.autoskillit/temp/rectify/rectify_silent_recipe_content_wipe_part_a_2026-06-10_180512.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 4.9k | 23.2k | 1.3M | 97.0k | 43 | 82.9k | 21m 11s |
| review_approach* | opus[1m] | 1 | 4.5k | 6.1k | 260.0k | 49.0k | 14 | 35.4k | 5m 23s |
| dry_walkthrough* | opus | 1 | 41 | 9.6k | 867.8k | 89.3k | 35 | 67.7k | 7m 33s |
| implement* | MiniMax-M3 | 1 | 3.7M | 9.0k | 0 | 0 | 79 | 0 | 7m 44s |
| audit_impl* | opus[1m] | 1 | 1.2k | 11.3k | 257.3k | 48.2k | 18 | 39.9k | 4m 33s |
| prepare_pr* | MiniMax-M3 | 1 | 284.5k | 2.9k | 0 | 0 | 12 | 0 | 1m 7s |
| compose_pr* | MiniMax-M3 | 1 | 351.0k | 1.3k | 0 | 0 | 12 | 0 | 51s |
| review_pr* | opus[1m] | 1 | 43 | 26.5k | 980.9k | 89.0k | 36 | 68.0k | 6m 17s |
| **Total** | | | 4.4M | 89.8k | 3.6M | 97.0k | | 294.0k | 54m 42s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 243 | 0.0 | 0.0 | 37.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **243** | 14903.1 | 1210.0 | 369.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 4 | 10.7k | 67.0k | 2.8M | 226.3k | 37m 26s |
| opus | 1 | 41 | 9.6k | 867.8k | 67.7k | 7m 33s |
| MiniMax-M3 | 3 | 4.4M | 13.2k | 0 | 0 | 9m 42s |