### PR TITLE
T5-P1-A2-WP1 — Ensure open_kitchen Failure Predicate Keys on JSON Field

### DIFF
--- a/src/autoskillit/cli/_prompts_orchestrator.py
+++ b/src/autoskillit/cli/_prompts_orchestrator.py
@@ -155,8 +155,8 @@ FAILURE PREDICATES — when to follow on_failure:
 - classify_fix: "error:" line present in output
 
 FAILURE PREDICATE — open_kitchen:
-  If the open_kitchen response contains `"success": false` OR does not
-  contain the substring `--- INGREDIENTS TABLE ---`:
+  If the open_kitchen response contains `"success": false` OR `"ingredients_table"`: null
+  (field absent or null in the JSON response):
     1. Extract and print the value of "user_visible_message" from the
        JSON response verbatim (fall back to the raw response text if
        parsing fails).

--- a/src/autoskillit/fleet/_prompts.py
+++ b/src/autoskillit/fleet/_prompts.py
@@ -201,8 +201,8 @@ FAILURE PREDICATES — when to follow on_failure:
 - classify_fix: "error:" line present in output
 
 FAILURE PREDICATE — open_kitchen:
-  If the open_kitchen response contains `"success": false` OR does not
-  contain the substring `--- INGREDIENTS TABLE ---`:
+  If the open_kitchen response contains `"success": false` OR `"ingredients_table"`: null
+  (field absent or null in the JSON response):
     1. Emit the sentinel block with success=false and reason="open_kitchen_failed".
     2. End the session.
 

--- a/tests/cli/test_orchestrator_prompt_contract.py
+++ b/tests/cli/test_orchestrator_prompt_contract.py
@@ -42,13 +42,13 @@ class TestOpenKitchenFailurePredicate:
         section = prompt[idx : idx + 500]
         assert "DO NOT call AskUserQuestion" in section
 
-    def test_open_kitchen_predicate_uses_substring_not_json_field_dispatch(self):
-        """Negative: the predicate block must NOT use JSON-field dispatch phrasing."""
+    def test_open_kitchen_predicate_uses_json_field_not_substring(self):
+        """The predicate block must use JSON-field check, not substring marker."""
         prompt = _get_prompt()
         idx = prompt.index("FAILURE PREDICATE — open_kitchen")
         section = prompt[idx : idx + 500]
-        assert "json.loads" not in section.lower()
-        assert "parsed[" not in section
+        assert "--- INGREDIENTS TABLE ---" not in section
+        assert "ingredients_table" in section
 
 
 class TestStep0ToolPredicateCoverage:

--- a/tests/fleet/test_food_truck_prompt.py
+++ b/tests/fleet/test_food_truck_prompt.py
@@ -157,3 +157,20 @@ def test_food_truck_prompt_no_caller_instructions_section_when_empty():
         caller_instructions="",
     )
     assert "CALLER INSTRUCTIONS" not in prompt
+
+
+def test_food_truck_open_kitchen_predicate_uses_json_field_not_substring():
+    """Food truck predicate must use JSON-field check, not substring marker."""
+    prompt = _build_food_truck_prompt(
+        recipe="test-recipe",
+        task="Test task",
+        ingredients={},
+        mcp_prefix=DIRECT_PREFIX,
+        dispatch_id="test-dispatch",
+        campaign_id="test-campaign",
+        l3_timeout_sec=300,
+    )
+    idx = prompt.index("FAILURE PREDICATE — open_kitchen")
+    section = prompt[idx : idx + 500]
+    assert "--- INGREDIENTS TABLE ---" not in section
+    assert "ingredients_table" in section


### PR DESCRIPTION
## Summary

Replace the `--- INGREDIENTS TABLE ---` substring check in the open_kitchen failure predicate with an `"ingredients_table": null` JSON field check. This change affects two prompt builders (`_build_orchestrator_prompt` in `cli/_prompts_orchestrator.py` and `_build_food_truck_prompt` in `fleet/_prompts.py`) and their corresponding test files. The substring marker is injected by a hook and is absent on Codex, causing silent failure-detection blindness on that backend. The JSON field is present in all `open_kitchen` responses regardless of backend.

Closes #3999

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260611-073832-079933/.autoskillit/temp/make-plan/T5-P1-A2-WP1-ensure-open-kitchen-predicate-json-field_plan_2026-06-11_074300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.8k | 8.4k | 1.1M | 80.4k | 38 | 59.5k | 7m 3s |
| verify* | sonnet | 1 | 86 | 8.8k | 494.2k | 65.2k | 32 | 44.3k | 3m 25s |
| implement* | MiniMax-M3 | 1 | 679.6k | 3.6k | 0 | 0 | 28 | 0 | 2m 22s |
| audit_impl* | sonnet | 1 | 44 | 4.5k | 164.1k | 39.7k | 11 | 22.8k | 2m 33s |
| prepare_pr* | MiniMax-M3 | 1 | 149.7k | 1.6k | 0 | 0 | 12 | 0 | 40s |
| compose_pr* | MiniMax-M3 | 1 | 175.6k | 1.0k | 0 | 0 | 12 | 0 | 37s |
| review_pr* | sonnet | 3 | 366 | 30.3k | 2.0M | 58.0k | 106 | 105.7k | 8m 31s |
| **Total** | | | 1.0M | 58.2k | 3.8M | 80.4k | | 232.4k | 25m 12s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 33 | 0.0 | 0.0 | 109.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **33** | 114629.8 | 7041.6 | 1764.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.8k | 8.4k | 1.1M | 59.5k | 7m 3s |
| sonnet | 3 | 496 | 43.6k | 2.6M | 172.8k | 14m 30s |
| MiniMax-M3 | 3 | 1.0M | 6.3k | 0 | 0 | 3m 39s |