### PR TITLE
Implementation Plan: Deferred-Recall Fail-Closed Validity Guard Tests

### DIFF
--- a/tests/server/AGENTS.md
+++ b/tests/server/AGENTS.md
@@ -103,7 +103,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_run_skill_pipeline_deps.py` | Tests for _check_pipeline_deps server-side pipeline dependency enforcement in run_skill |
 | `test_no_path_cwd_in_tools.py` | Regression guard: Path.cwd() must not appear in server tool handlers |
 | `test_open_kitchen_staleness.py` | Tests for ProcessStaleError propagation through open_kitchen — failure envelope with staleness context |
-| `test_open_kitchen_deferred_recall.py` | Tests for active_recipe_steps assignment in the _is_deferred_recall=True path |
+| `test_open_kitchen_deferred_recall.py` | Tests for the _is_deferred_recall=True path: active_recipe_steps and fail-closed guard |
 | `test_tools_label_validation.py` | Tests for label whitelist validation in server tool handlers |
 | `test_tools_list_recipes.py` | Tests for autoskillit server list_recipes tool |
 | `test_tools_load_recipe.py` | Tests for autoskillit server load_recipe tool |

--- a/tests/server/test_open_kitchen_deferred_recall.py
+++ b/tests/server/test_open_kitchen_deferred_recall.py
@@ -1,4 +1,4 @@
-"""Tests for active_recipe_steps assignment in the _is_deferred_recall=True path."""
+"""Tests for the _is_deferred_recall=True path: active_recipe_steps and fail-closed guard."""
 
 from __future__ import annotations
 
@@ -109,3 +109,88 @@ async def test_deferred_recall_sets_active_recipe_steps_none_when_find_returns_n
     parsed = json.loads(result)
     assert parsed["success"] is True
     assert mock_ctx.active_recipe_steps is None
+
+
+@pytest.mark.anyio
+async def test_deferred_recall_fails_closed_when_valid_false_empty_content():
+    """Guard fires when load_and_validate returns valid=False with empty content."""
+    from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+    mock_ctx = _make_deferred_recall_ctx("test-recipe")
+    mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "",
+        "valid": False,
+        "errors": ["structural error A"],
+        "requires_packs": [],
+        "requires_features": [],
+        "content_hash": "abc",
+        "composite_hash": "def",
+        "recipe_version": "1.0",
+        "suggestions": [],
+    }
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        result = await open_kitchen(name="test-recipe", ctx=mock_ctx)
+
+    parsed = json.loads(result)
+    assert parsed["success"] is False
+    assert parsed["kitchen"] == "failed"
+    assert parsed["stage"] == "recipe_validation"
+    assert parsed["errors"] == ["structural error A"]
+    assert "user_visible_message" in parsed
+
+
+@pytest.mark.anyio
+async def test_deferred_recall_fails_closed_when_valid_false_nonempty_content():
+    """Guard fires on valid=False regardless of content presence."""
+    from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+    mock_ctx = _make_deferred_recall_ctx("test-recipe")
+    mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "non-empty content",
+        "valid": False,
+        "errors": ["structural error B"],
+        "requires_packs": [],
+        "requires_features": [],
+        "content_hash": "abc",
+        "composite_hash": "def",
+        "recipe_version": "1.0",
+        "suggestions": [],
+    }
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        result = await open_kitchen(name="test-recipe", ctx=mock_ctx)
+
+    parsed = json.loads(result)
+    assert parsed["success"] is False
+    assert parsed["kitchen"] == "failed"
+    assert parsed["stage"] == "recipe_validation"
+    assert parsed["errors"] == ["structural error B"]
+    assert "user_visible_message" in parsed
+
+
+@pytest.mark.anyio
+async def test_deferred_recall_fails_closed_when_valid_missing():
+    """Guard treats absent valid key as False via result.get('valid', False)."""
+    from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+    mock_ctx = _make_deferred_recall_ctx("test-recipe")
+    mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "non-empty content",
+        "errors": [],
+        "requires_packs": [],
+        "requires_features": [],
+        "content_hash": "abc",
+        "composite_hash": "def",
+        "recipe_version": "1.0",
+        "suggestions": [],
+    }
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        result = await open_kitchen(name="test-recipe", ctx=mock_ctx)
+
+    parsed = json.loads(result)
+    assert parsed["success"] is False
+    assert parsed["kitchen"] == "failed"
+    assert parsed["stage"] == "recipe_validation"
+    assert "user_visible_message" in parsed

--- a/tests/server/test_open_kitchen_deferred_recall.py
+++ b/tests/server/test_open_kitchen_deferred_recall.py
@@ -193,4 +193,5 @@ async def test_deferred_recall_fails_closed_when_valid_missing():
     assert parsed["success"] is False
     assert parsed["kitchen"] == "failed"
     assert parsed["stage"] == "recipe_validation"
+    assert parsed["errors"] == []
     assert "user_visible_message" in parsed


### PR DESCRIPTION
## Summary

Add 3 regression test functions to `tests/server/test_open_kitchen_deferred_recall.py` covering the fail-closed validity guard on the `_is_deferred_recall=True` branch of `open_kitchen`. The guard (at `tools_kitchen.py:631`) rejects recipes when `valid` is `False` or `content` is empty, returning a structured error envelope via `_recipe_validation_error_response`. No production code changes.

Closes #4002

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260611-133942-160970/.autoskillit/temp/make-plan/t5_p1_a5_wp1_deferred_recall_fail_closed_tests_plan_2026-06-11_134500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 2.0k | 6.4k | 594.9k | 68.7k | 24 | 50.2k | 6m 29s |
| verify* | sonnet | 1 | 92 | 9.3k | 469.4k | 53.4k | 24 | 32.5k | 4m 50s |
| implement* | MiniMax-M3 | 1 | 725.2k | 5.9k | 0 | 0 | 34 | 0 | 3m 16s |
| audit_impl* | sonnet | 1 | 44 | 7.0k | 164.9k | 40.3k | 15 | 26.5k | 2m 48s |
| prepare_pr* | MiniMax-M3 | 1 | 310.6k | 2.5k | 0 | 0 | 18 | 0 | 1m 15s |
| compose_pr* | MiniMax-M3 | 1 | 175.5k | 1.1k | 0 | 0 | 12 | 0 | 40s |
| review_pr* | sonnet | 1 | 164 | 14.0k | 940.7k | 60.0k | 43 | 39.5k | 4m 17s |
| resolve_review* | sonnet | 1 | 157 | 5.5k | 909.2k | 61.9k | 44 | 87.0k | 2m 56s |
| **Total** | | | 1.2M | 51.6k | 3.1M | 68.7k | | 235.8k | 26m 35s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 89 | 0.0 | 0.0 | 65.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 1 | 909176.0 | 87046.0 | 5510.0 |
| **Total** | **90** | 34211.8 | 2619.8 | 573.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.0k | 6.4k | 594.9k | 50.2k | 6m 29s |
| sonnet | 4 | 457 | 35.8k | 2.5M | 185.5k | 14m 53s |
| MiniMax-M3 | 3 | 1.2M | 9.4k | 0 | 0 | 5m 12s |