### PR TITLE
Implementation Plan: T5-P3-A1-WP1 Recipe × Backend Composition Matrix CI Gate

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -682,6 +682,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             # recipe direct-import entries (import autoskillit.workspace at AST level):
             "recipe/test_contracts.py",
             "recipe/test_backend_reachability.py",
+            "recipe/test_recipe_backend_composition_matrix.py",
             "recipe/test_rules_backend_compat.py",
             "recipe/test_rules_skill_content.py",
             "recipe/test_rules_stamp_ownership.py",

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -1480,6 +1480,10 @@ _TEST_LAYER_ALLOWLIST: dict[str, frozenset[str]] = {
     "tests/recipe/test_backend_reachability.py": frozenset(
         {"autoskillit.server", "autoskillit.execution", "autoskillit.workspace"}
     ),
+    # composition matrix crosses the same packages as reachability — full pipeline
+    "tests/recipe/test_recipe_backend_composition_matrix.py": frozenset(
+        {"autoskillit.server", "autoskillit.execution", "autoskillit.workspace"}
+    ),
     # review loop routing integration imports root-level smoke_utils
     "tests/recipe/test_review_loop_routing_integration.py": frozenset({"autoskillit.smoke_utils"}),
     # migration tests — migration engine integrates with execution.session

--- a/tests/recipe/AGENTS.md
+++ b/tests/recipe/AGENTS.md
@@ -83,6 +83,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_planner_recipe.py` | Tests for the planner recipe structure |
 | `test_promote_to_main_wrapper.py` | Tests for the promote-to-main wrapper recipe |
 | `test_pseudocode_sync_rule.py` | Tests for the pseudocode-callable-divergence semantic rule |
+| `test_recipe_backend_composition_matrix.py` | Recipe x backend composition matrix: parametrized CI gate validating every (recipe, backend) combination with declared-unsupported and known-broken governance |
 | `test_recipe_ci_applicable_routing.py` | Structural tests for ci_applicable routing guards across all wait_for_ci chains |
 | `test_recipe_ci_contracts.py` | Cross-recipe ci_event/branch coherence and remote_url structural tests |
 | `test_recipe_ci_watch_event.py` | Tests for CI watch event in recipe steps |

--- a/tests/recipe/test_recipe_backend_composition_matrix.py
+++ b/tests/recipe/test_recipe_backend_composition_matrix.py
@@ -69,9 +69,6 @@ def _apply_marks(matrix_ids: list[tuple[str, str]]) -> list[Any]:
 
 @pytest.mark.parametrize("recipe_name,backend_name", _apply_marks(_MATRIX_IDS))
 def test_recipe_backend_matrix_cell(recipe_name: str, backend_name: str) -> None:
-    if (recipe_name, backend_name) in DECLARED_UNSUPPORTED:
-        pytest.skip(reason=UNSUPPORTED_REASONS[(recipe_name, backend_name)]["reason"])
-
     backend = get_backend(backend_name)
     result = load_and_validate(
         recipe_name,

--- a/tests/recipe/test_recipe_backend_composition_matrix.py
+++ b/tests/recipe/test_recipe_backend_composition_matrix.py
@@ -25,13 +25,16 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 _ALL_RECIPE_NAMES = sorted(all_validated_recipe_names(_PROJECT_ROOT))
 _BACKEND_NAMES = sorted(BACKEND_REGISTRY.keys())
-_MATRIX_IDS: list[tuple[str, str]] = [(r, b) for r in _ALL_RECIPE_NAMES for b in _BACKEND_NAMES]
 
 
 # -- By-design unsupported combos (skip) ------------------------------------
 DECLARED_UNSUPPORTED: frozenset[tuple[str, str]] = frozenset()
 
 UNSUPPORTED_REASONS: dict[tuple[str, str], dict[str, str]] = {}
+
+_MATRIX_IDS: list[tuple[str, str]] = [
+    (r, b) for r in _ALL_RECIPE_NAMES for b in _BACKEND_NAMES if (r, b) not in DECLARED_UNSUPPORTED
+]
 
 
 # -- Known-broken combos (xfail strict) -------------------------------------

--- a/tests/recipe/test_recipe_backend_composition_matrix.py
+++ b/tests/recipe/test_recipe_backend_composition_matrix.py
@@ -1,0 +1,138 @@
+"""Recipe x backend composition matrix -- full cross-product CI gate.
+
+Validates every bundled recipe composes validly under every registered backend.
+DECLARED_UNSUPPORTED governs by-design unsupported combos; orphan and
+collection-count meta-tests prevent skip-rot and matrix shrinkage.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from autoskillit.core import Severity
+from autoskillit.execution.backends import BACKEND_REGISTRY, get_backend
+from autoskillit.recipe._api import load_and_validate
+from autoskillit.recipe.io import all_validated_recipe_names
+from autoskillit.server.tools._auto_overrides import _backend_capability_overrides
+from autoskillit.workspace.skills import DefaultSkillResolver
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+_ALL_RECIPE_NAMES = sorted(all_validated_recipe_names(_PROJECT_ROOT))
+_BACKEND_NAMES = sorted(BACKEND_REGISTRY.keys())
+_MATRIX_IDS: list[tuple[str, str]] = [(r, b) for r in _ALL_RECIPE_NAMES for b in _BACKEND_NAMES]
+
+
+# -- By-design unsupported combos (skip) ------------------------------------
+DECLARED_UNSUPPORTED: frozenset[tuple[str, str]] = frozenset()
+
+UNSUPPORTED_REASONS: dict[tuple[str, str], dict[str, str]] = {}
+
+
+# -- Known-broken combos (xfail strict) -------------------------------------
+KNOWN_BROKEN: dict[tuple[str, str], str] = {
+    ("agent-eval", "claude-code"): (
+        "tracking: #4069 -- violates all-dispatchable-stops-have-sentinel + dead-output"
+    ),
+    ("agent-eval", "codex"): (
+        "tracking: #4069 -- violates all-dispatchable-stops-have-sentinel + dead-output"
+    ),
+    ("skill-eval", "claude-code"): (
+        "tracking: #4069 -- violates all-dispatchable-stops-have-sentinel + dead-output"
+    ),
+    ("skill-eval", "codex"): (
+        "tracking: #4069 -- violates all-dispatchable-stops-have-sentinel + dead-output"
+    ),
+}
+
+_SKILL_RESOLVER = DefaultSkillResolver()
+
+
+def _apply_marks(matrix_ids: list[tuple[str, str]]) -> list[Any]:
+    """Wrap matrix tuples in pytest.param, attaching xfail marks for KNOWN_BROKEN."""
+    params: list[Any] = []
+    for r, b in matrix_ids:
+        marks: list[Any] = []
+        if (r, b) in KNOWN_BROKEN:
+            marks.append(pytest.mark.xfail(strict=True, reason=KNOWN_BROKEN[(r, b)]))
+        params.append(pytest.param(r, b, marks=marks, id=f"{r}/{b}"))
+    return params
+
+
+@pytest.mark.parametrize("recipe_name,backend_name", _apply_marks(_MATRIX_IDS))
+def test_recipe_backend_matrix_cell(recipe_name: str, backend_name: str) -> None:
+    if (recipe_name, backend_name) in DECLARED_UNSUPPORTED:
+        pytest.skip(reason=UNSUPPORTED_REASONS[(recipe_name, backend_name)]["reason"])
+
+    backend = get_backend(backend_name)
+    result = load_and_validate(
+        recipe_name,
+        project_dir=_PROJECT_ROOT,
+        backend_name=backend_name,
+        ingredient_overrides=_backend_capability_overrides(backend),
+        lister=_SKILL_RESOLVER,
+    )
+
+    assert result["valid"] is True, (
+        f"Recipe '{recipe_name}' invalid on backend '{backend_name}': "
+        + "; ".join(
+            f"[{s.get('rule')}] {s.get('message', '')[:80]}"
+            for s in result.get("suggestions", [])
+            if s.get("severity") == Severity.ERROR
+        )
+    )
+    assert len(result.get("content", "")) > 0, (
+        f"Recipe '{recipe_name}' on backend '{backend_name}' produced empty content"
+    )
+
+    suggestions: list[dict[str, Any]] = result.get("suggestions", [])
+    dangling = [
+        s for s in suggestions if s.get("message", "").startswith("[post-prune] dangling route:")
+    ]
+    assert not dangling, (
+        f"Recipe '{recipe_name}' on backend '{backend_name}' has dangling routes: "
+        + "; ".join(s.get("message", "") for s in dangling)
+    )
+
+    backend_compat_errors = [
+        s
+        for s in suggestions
+        if s.get("rule") == "backend-incompatible-skill" and s.get("severity") == Severity.ERROR
+    ]
+    assert not backend_compat_errors, (
+        f"Recipe '{recipe_name}' on backend '{backend_name}' has "
+        f"backend-incompatible-skill errors: "
+        + "; ".join(s.get("message", "") for s in backend_compat_errors)
+    )
+
+
+def test_declared_unsupported_orphan_check() -> None:
+    """Every DECLARED_UNSUPPORTED entry must reference a live recipe and backend."""
+    recipe_names = frozenset(_ALL_RECIPE_NAMES)
+    backend_names = frozenset(BACKEND_REGISTRY.keys())
+    for recipe_name, backend_name in DECLARED_UNSUPPORTED:
+        assert recipe_name in recipe_names, (
+            f"DECLARED_UNSUPPORTED entry ({recipe_name!r}, {backend_name!r}) "
+            f"references unknown recipe {recipe_name!r}. "
+            f"Valid: {sorted(recipe_names)}"
+        )
+        assert backend_name in backend_names, (
+            f"DECLARED_UNSUPPORTED entry ({recipe_name!r}, {backend_name!r}) "
+            f"references unknown backend {backend_name!r}. "
+            f"Valid: {sorted(backend_names)}"
+        )
+
+
+def test_matrix_collection_count() -> None:
+    """Matrix size = recipes x backends - declared unsupported."""
+    expected = len(_ALL_RECIPE_NAMES) * len(_BACKEND_NAMES) - len(DECLARED_UNSUPPORTED)
+    assert len(_MATRIX_IDS) == expected, (
+        f"Matrix size mismatch: got {len(_MATRIX_IDS)}, "
+        f"expected {len(_ALL_RECIPE_NAMES)} recipes x {len(_BACKEND_NAMES)} backends "
+        f"- {len(DECLARED_UNSUPPORTED)} unsupported = {expected}"
+    )


### PR DESCRIPTION
## Summary

Add `tests/recipe/test_recipe_backend_composition_matrix.py` — a parametrized test module that validates every bundled recipe composes validly under every registered backend. The module uses:

- **Full cross-product parametrization** from live `BACKEND_REGISTRY × all_validated_recipe_names()` (currently 20 recipes × 2 backends = 40 cells)
- **`DECLARED_UNSUPPORTED` frozenset** for by-design unsupported combos (currently empty — all combos are supported)
- **`KNOWN_BROKEN` dict** for should-work-but-broken combos decorated with `xfail(strict=True)` (currently 4 cells: agent-eval and skill-eval on both backends, tracking #4069)
- **`UNSUPPORTED_REASONS` dict** mapping each `DECLARED_UNSUPPORTED` entry to `{reason, issue_ref}`
- **Orphan meta-test** preventing skip-rot (stale `DECLARED_UNSUPPORTED` entries)
- **Collection-count meta-test** preventing matrix shrinkage

Per live cell, the test calls `load_and_validate(recipe_name, project_dir=_PROJECT_ROOT, backend_name=backend_name, ingredient_overrides=_backend_capability_overrides(get_backend(backend_name)), lister=DefaultSkillResolver())` and asserts: `result['valid'] is True`, `result['content']` is non-empty, no `[post-prune] dangling route:` suggestion, no `backend-incompatible-skill` ERROR suggestion.

Closes #4008

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260611-182135-648906/.autoskillit/temp/make-plan/t5-p3-a1-wp1-recipe-backend-composition-matrix_plan_2026-06-11_182600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 85 | 23.7k | 2.0M | 101.8k | 48 | 80.3k | 30m 21s |
| verify* | sonnet | 1 | 76 | 9.3k | 394.4k | 56.6k | 23 | 35.7k | 5m 12s |
| implement* | MiniMax-M3 | 1 | 1.1M | 6.8k | 0 | 0 | 49 | 0 | 5m 37s |
| fix* | sonnet | 1 | 134 | 5.7k | 834.4k | 69.1k | 48 | 48.2k | 3m 28s |
| audit_impl* | sonnet | 1 | 1.1k | 5.3k | 240.1k | 40.1k | 17 | 23.5k | 3m 0s |
| prepare_pr* | MiniMax-M3 | 1 | 234.5k | 2.2k | 0 | 0 | 15 | 0 | 56s |
| compose_pr* | MiniMax-M3 | 1 | 251.6k | 1.7k | 0 | 0 | 15 | 0 | 59s |
| review_pr* | sonnet | 2 | 322 | 48.2k | 2.0M | 77.3k | 94 | 110.2k | 12m 6s |
| resolve_review* | sonnet | 2 | 330 | 19.9k | 2.2M | 72.7k | 93 | 94.6k | 8m 31s |
| **Total** | | | 1.6M | 122.9k | 7.7M | 101.8k | | 392.6k | 1h 10m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 140 | 0.0 | 0.0 | 48.8 |
| fix | 4 | 208595.2 | 12058.8 | 1436.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 273688.2 | 11831.0 | 2481.4 |
| **Total** | **152** | 50646.9 | 2582.6 | 808.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 85 | 23.7k | 2.0M | 80.3k | 30m 21s |
| sonnet | 5 | 1.9k | 88.5k | 5.7M | 312.3k | 32m 19s |
| MiniMax-M3 | 3 | 1.6M | 10.7k | 0 | 0 | 7m 32s |