### PR TITLE
[FIX] Dispatch-Feasibility Preflight — Claim-Before-Validate Immunity

### DIFF
--- a/src/autoskillit/hooks/formatters/_fmt_recipe.py
+++ b/src/autoskillit/hooks/formatters/_fmt_recipe.py
@@ -43,6 +43,7 @@ _FMT_LOAD_RECIPE_SUPPRESSED: frozenset[str] = frozenset(
         "recipe_version",  # internal identity metadata
         "stop_step_semantics",  # delivered via open_kitchen response Channel B; not redisplayed
         "deferred_guards",  # internal deferral metadata; not displayed to agent
+        "post_prune_step_names",  # internal preflight field; not displayed to agent
     }
 )
 
@@ -183,6 +184,7 @@ _FMT_OPEN_KITCHEN_SUPPRESSED: frozenset[str] = frozenset(
         "stop_step_semantics",  # delivered via open_kitchen Channel B
         "hook_warning",  # edge-case diagnostic; not rendered in standard path
         "deferred_guards",  # internal deferral metadata; not displayed to agent
+        "post_prune_step_names",  # internal preflight field; not displayed to agent
     }
 )
 

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -580,6 +580,8 @@ def load_and_validate(
                 )
     if _deferred_guard_list:
         result["deferred_guards"] = _deferred_guard_list
+    if active_recipe is not None:
+        result["post_prune_step_names"] = list(active_recipe.steps.keys())
 
     # Write to cache (only when recipe was found and fully processed)
     if match is not None:

--- a/src/autoskillit/recipe/_recipe_ingredients.py
+++ b/src/autoskillit/recipe/_recipe_ingredients.py
@@ -126,6 +126,7 @@ class LoadRecipeResult(TypedDict, total=False):
     composite_hash: str
     recipe_version: str | None
     deferred_guards: list[DeferredGuard]
+    post_prune_step_names: list[str]
 
 
 class OpenKitchenResult(TypedDict, total=False):
@@ -134,7 +135,7 @@ class OpenKitchenResult(TypedDict, total=False):
     Extends LoadRecipeResult with three post-return keys injected by the handler.
     """
 
-    # Inherited from LoadRecipeResult (15 keys)
+    # Inherited from LoadRecipeResult (17 keys)
     content: str
     errors: list[str]
     diagram: str | None
@@ -151,6 +152,7 @@ class OpenKitchenResult(TypedDict, total=False):
     composite_hash: str
     recipe_version: str | None
     deferred_guards: list[DeferredGuard]
+    post_prune_step_names: list[str]
     # Post-return keys injected by open_kitchen handler (4 keys)
     success: bool
     kitchen: str

--- a/src/autoskillit/server/tools/AGENTS.md
+++ b/src/autoskillit/server/tools/AGENTS.md
@@ -19,6 +19,7 @@ MCP `@mcp.tool()` handlers registered on import (20 tool modules).
 | `tools_clone.py` | `clone_repo`, `remove_clone`, `push_to_remote`, `register_clone_status`, `batch_cleanup_clones`, `bootstrap_clone` |
 | `_claim_helpers.py` | `ClaimDecision`, `_try_claim_with_liveness`, `_get_campaign_state_paths` — shared claiming logic for `claim_issue` and `claim_and_resolve_issue` |
 | `_execution_helpers.py` | `_import_and_call`, `_coerce_scalar`, `maybe_promote_work_dir`, `validate_path_arg_anchoring`, `resolve_relative_path_args` — execution helpers for `run_python` (no MCP tools) |
+| `_preflight.py` | `_check_dispatch_feasibility`, `_get_fix_required_hook_matchers`, `filter_steps_by_post_prune` — shared preflight for `open_kitchen` and `dispatch_food_truck` |
 | `tools_execution.py` | `run_cmd`, `run_python`, `run_skill` |
 | `tools_fleet_dispatch.py` | `dispatch_food_truck`, `record_gate_dispatch` |
 | `tools_fleet_reset.py` | `reset_dispatch` (full dispatch artifact cleanup) |

--- a/src/autoskillit/server/tools/_preflight.py
+++ b/src/autoskillit/server/tools/_preflight.py
@@ -108,7 +108,7 @@ def _check_dispatch_feasibility(
             "backend": backend.name,
             "escape_hatch": (
                 "Per-step provider: override with ANTHROPIC_BASE_URL set to "
-                "reroute dispatch to claude-code (which has applicable_guards)."
+                "reroute dispatch to claude-code (which enforces all fix-required hooks)."
             ),
         }
     )

--- a/src/autoskillit/server/tools/_preflight.py
+++ b/src/autoskillit/server/tools/_preflight.py
@@ -1,0 +1,114 @@
+"""Dispatch-feasibility preflight — shared by open_kitchen and dispatch_food_truck."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from autoskillit.hook_registry import HOOK_REGISTRY
+
+
+def _get_fix_required_hook_matchers(applicable_guards: frozenset[str]) -> list[str]:
+    """Return matchers of fix-required hooks not enforced by the given guard set."""
+    return [
+        h.matcher
+        for h in HOOK_REGISTRY
+        if h.codex_status == "fix-required"
+        and (
+            not h.scripts
+            or not frozenset(Path(s).stem for s in h.scripts).issubset(applicable_guards)
+        )
+    ]
+
+
+def filter_steps_by_post_prune(
+    raw_steps: dict[str, Any],
+    post_prune_step_names: list[str],
+) -> dict[str, Any]:
+    """Return only the steps whose names survived skip_when_false pruning."""
+    keep = set(post_prune_step_names)
+    return {k: v for k, v in raw_steps.items() if k in keep}
+
+
+def _check_dispatch_feasibility(
+    post_prune_step_names: list[str],
+    active_recipe_steps: dict[str, Any],
+    backend: Any | None,
+    config_providers: Any,
+) -> str | None:
+    """Fail-closed dispatch-feasibility preflight.
+
+    Evaluated at open_kitchen time (and dispatch_food_truck time) to detect
+    recipe/backend combinations where HOOK_REGISTRY has fix-required entries
+    that the current backend cannot enforce. Returns a JSON error envelope
+    string on failure, None on pass.
+    """
+    if backend is None:
+        return None
+    if not post_prune_step_names:
+        return None
+
+    run_skill_step_names: list[str] = []
+    for step_name in post_prune_step_names:
+        step = active_recipe_steps.get(step_name)
+        if step is not None and getattr(step, "tool", None) == "run_skill":
+            run_skill_step_names.append(step_name)
+
+    if not run_skill_step_names:
+        return None
+
+    from autoskillit.server._guards import _resolve_provider_profile  # circular-break
+
+    recipe_name = ""
+    feasible_step_names: list[str] = []
+    for step_name in run_skill_step_names:
+        step = active_recipe_steps.get(step_name)
+        step_provider = getattr(step, "provider", "") or ""
+        _profile_name, provider_extras = _resolve_provider_profile(
+            step_name,
+            recipe_name,
+            config_providers,
+            step_provider=step_provider,
+        )
+        if (
+            provider_extras
+            and "ANTHROPIC_BASE_URL" in provider_extras
+            and not backend.capabilities.anthropic_provider_capable
+        ):
+            continue
+        feasible_step_names.append(step_name)
+
+    if not feasible_step_names:
+        return None
+
+    fix_required_matchers = _get_fix_required_hook_matchers(
+        backend.capabilities.applicable_guards,
+    )
+    if not fix_required_matchers:
+        return None
+
+    return json.dumps(
+        {
+            "success": False,
+            "kitchen": "preflight_failed",
+            "user_visible_message": (
+                f"Cannot dispatch recipe: backend {backend.name!r} cannot enforce "
+                f"HOOK_REGISTRY fix-required entries "
+                f"[{', '.join(fix_required_matchers)}]. "
+                f"Add a per-step provider override that sets ANTHROPIC_BASE_URL "
+                f"to reroute dispatch to claude-code, which has full hook enforcement."
+            ),
+            "error": (
+                f"Dispatch infeasible on backend {backend.name!r}: "
+                f"fix-required hooks {fix_required_matchers} are not enforceable."
+            ),
+            "stage": "dispatch_feasibility_preflight",
+            "unfixable_matchers": fix_required_matchers,
+            "backend": backend.name,
+            "escape_hatch": (
+                "Per-step provider: override with ANTHROPIC_BASE_URL set to "
+                "reroute dispatch to claude-code (which has applicable_guards)."
+            ),
+        }
+    )

--- a/src/autoskillit/server/tools/_preflight.py
+++ b/src/autoskillit/server/tools/_preflight.py
@@ -36,6 +36,7 @@ def _check_dispatch_feasibility(
     active_recipe_steps: dict[str, Any],
     backend: Any | None,
     config_providers: Any,
+    recipe_name: str = "",
 ) -> str | None:
     """Fail-closed dispatch-feasibility preflight.
 
@@ -60,7 +61,6 @@ def _check_dispatch_feasibility(
 
     from autoskillit.server._guards import _resolve_provider_profile  # circular-break
 
-    recipe_name = ""
     feasible_step_names: list[str] = []
     for step_name in run_skill_step_names:
         step = active_recipe_steps.get(step_name)

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import time
 from pathlib import Path
+from typing import Any
 
 import anyio
 import regex as re
@@ -98,6 +99,105 @@ def _get_fix_required_hook_matchers(applicable_guards: frozenset[str]) -> list[s
             or not frozenset(Path(s).stem for s in h.scripts).issubset(applicable_guards)
         )
     ]
+
+
+def _check_dispatch_feasibility(
+    post_prune_step_names: list[str],
+    active_recipe_steps: dict[str, Any],
+    backend: CodingAgentBackend | None,
+    config_providers: Any,
+) -> str | None:
+    """Fail-closed dispatch-feasibility preflight.
+
+    Evaluated at open_kitchen time (and dispatch_food_truck time) to detect
+    recipe/backend combinations where HOOK_REGISTRY has fix-required entries
+    that the current backend cannot enforce. Returns a JSON error envelope
+    string on failure, None on pass.
+
+    Args:
+        post_prune_step_names: Step names surviving skip_when_false pruning.
+            Empty list (all pruned) trivially passes.
+        active_recipe_steps: Step objects keyed by name. Used to inspect
+            step.tool for each run_skill step.
+        backend: Session backend. When None, the check is skipped.
+        config_providers: ProvidersConfig used by _resolve_provider_profile
+            to determine per-step backend overrides (ANTHROPIC_BASE_URL reroute).
+
+    Returns:
+        JSON error envelope string on failure (structured for the agent to
+        surface to the user), None on pass.
+    """
+    if backend is None:
+        return None
+    if not post_prune_step_names:
+        return None
+
+    run_skill_step_names: list[str] = []
+    for step_name in post_prune_step_names:
+        step = active_recipe_steps.get(step_name)
+        if step is not None and getattr(step, "tool", None) == "run_skill":
+            run_skill_step_names.append(step_name)
+
+    if not run_skill_step_names:
+        return None
+
+    # Filter out steps whose provider profile reroutes to claude-code via
+    # ANTHROPIC_BASE_URL. Such steps dispatch to the claude-code backend,
+    # which has the full applicable_guards set and passes the check.
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    recipe_name = ""
+    feasible_step_names: list[str] = []
+    for step_name in run_skill_step_names:
+        step = active_recipe_steps.get(step_name)
+        step_provider = getattr(step, "provider", "") or ""
+        _profile_name, provider_extras = _resolve_provider_profile(
+            step_name,
+            recipe_name,
+            config_providers,
+            step_provider=step_provider,
+        )
+        if (
+            provider_extras
+            and "ANTHROPIC_BASE_URL" in provider_extras
+            and not backend.capabilities.anthropic_provider_capable
+        ):
+            continue
+        feasible_step_names.append(step_name)
+
+    if not feasible_step_names:
+        return None
+
+    fix_required_matchers = _get_fix_required_hook_matchers(
+        backend.capabilities.applicable_guards,
+    )
+    if not fix_required_matchers:
+        return None
+
+    return json.dumps(
+        {
+            "success": False,
+            "kitchen": "preflight_failed",
+            "user_visible_message": (
+                f"Cannot dispatch recipe: backend {backend.name!r} cannot enforce "
+                f"HOOK_REGISTRY fix-required entries "
+                f"[{', '.join(fix_required_matchers)}]. "
+                f"Add a per-step provider override that sets ANTHROPIC_BASE_URL "
+                f"to reroute dispatch to claude-code, which has full hook enforcement."
+            ),
+            "error": (
+                f"Dispatch infeasible on backend {backend.name!r}: "
+                f"fix-required hooks {fix_required_matchers} are not enforceable."
+            ),
+            "stage": "dispatch_feasibility_preflight",
+            "unfixable_matchers": fix_required_matchers,
+            "backend": backend.name,
+            "escape_hatch": (
+                "Per-step provider: override with ANTHROPIC_BASE_URL set to "
+                "reroute dispatch to claude-code (which has applicable_guards)."
+            ),
+        }
+    )
 
 
 def _check_backend_compat(

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -8,7 +8,6 @@ import os
 import shutil
 import time
 from pathlib import Path
-from typing import Any
 
 import anyio
 import regex as re
@@ -38,7 +37,6 @@ from autoskillit.core import (
 from autoskillit.core import current_order_id as _current_order_id
 from autoskillit.core import current_step_name as _current_step_name
 from autoskillit.core import resolve_skill_temp_dir as _resolve_skill_temp_dir
-from autoskillit.hook_registry import HOOK_REGISTRY
 from autoskillit.pipeline import canonical_step_name as _canonical_step_name
 from autoskillit.server import mcp
 from autoskillit.server._guards import (
@@ -66,6 +64,7 @@ from autoskillit.server.tools._execution_helpers import (
     resolve_relative_path_args,
     validate_path_arg_anchoring,
 )
+from autoskillit.server.tools._preflight import _get_fix_required_hook_matchers
 
 logger = get_logger(__name__)
 
@@ -86,118 +85,6 @@ def _is_backend_incompatible(skill_info: object, effective_backend: str) -> bool
     """Return True if skill's backend_requirements exclude effective_backend."""
     reqs = getattr(skill_info, "backend_requirements", None)
     return bool(reqs and effective_backend not in reqs)
-
-
-def _get_fix_required_hook_matchers(applicable_guards: frozenset[str]) -> list[str]:
-    """Return matchers of fix-required hooks not enforced by the given guard set."""
-    return [
-        h.matcher
-        for h in HOOK_REGISTRY
-        if h.codex_status == "fix-required"
-        and (
-            not h.scripts
-            or not frozenset(Path(s).stem for s in h.scripts).issubset(applicable_guards)
-        )
-    ]
-
-
-def _check_dispatch_feasibility(
-    post_prune_step_names: list[str],
-    active_recipe_steps: dict[str, Any],
-    backend: CodingAgentBackend | None,
-    config_providers: Any,
-) -> str | None:
-    """Fail-closed dispatch-feasibility preflight.
-
-    Evaluated at open_kitchen time (and dispatch_food_truck time) to detect
-    recipe/backend combinations where HOOK_REGISTRY has fix-required entries
-    that the current backend cannot enforce. Returns a JSON error envelope
-    string on failure, None on pass.
-
-    Args:
-        post_prune_step_names: Step names surviving skip_when_false pruning.
-            Empty list (all pruned) trivially passes.
-        active_recipe_steps: Step objects keyed by name. Used to inspect
-            step.tool for each run_skill step.
-        backend: Session backend. When None, the check is skipped.
-        config_providers: ProvidersConfig used by _resolve_provider_profile
-            to determine per-step backend overrides (ANTHROPIC_BASE_URL reroute).
-
-    Returns:
-        JSON error envelope string on failure (structured for the agent to
-        surface to the user), None on pass.
-    """
-    if backend is None:
-        return None
-    if not post_prune_step_names:
-        return None
-
-    run_skill_step_names: list[str] = []
-    for step_name in post_prune_step_names:
-        step = active_recipe_steps.get(step_name)
-        if step is not None and getattr(step, "tool", None) == "run_skill":
-            run_skill_step_names.append(step_name)
-
-    if not run_skill_step_names:
-        return None
-
-    # Filter out steps whose provider profile reroutes to claude-code via
-    # ANTHROPIC_BASE_URL. Such steps dispatch to the claude-code backend,
-    # which has the full applicable_guards set and passes the check.
-    from autoskillit.server._guards import _resolve_provider_profile
-
-    recipe_name = ""
-    feasible_step_names: list[str] = []
-    for step_name in run_skill_step_names:
-        step = active_recipe_steps.get(step_name)
-        step_provider = getattr(step, "provider", "") or ""
-        _profile_name, provider_extras = _resolve_provider_profile(
-            step_name,
-            recipe_name,
-            config_providers,
-            step_provider=step_provider,
-        )
-        if (
-            provider_extras
-            and "ANTHROPIC_BASE_URL" in provider_extras
-            and not backend.capabilities.anthropic_provider_capable
-        ):
-            continue
-        feasible_step_names.append(step_name)
-
-    if not feasible_step_names:
-        return None
-
-    fix_required_matchers = _get_fix_required_hook_matchers(
-        backend.capabilities.applicable_guards,
-    )
-    if not fix_required_matchers:
-        return None
-
-    return json.dumps(
-        {
-            "success": False,
-            "kitchen": "preflight_failed",
-            "user_visible_message": (
-                f"Cannot dispatch recipe: backend {backend.name!r} cannot enforce "
-                f"HOOK_REGISTRY fix-required entries "
-                f"[{', '.join(fix_required_matchers)}]. "
-                f"Add a per-step provider override that sets ANTHROPIC_BASE_URL "
-                f"to reroute dispatch to claude-code, which has full hook enforcement."
-            ),
-            "error": (
-                f"Dispatch infeasible on backend {backend.name!r}: "
-                f"fix-required hooks {fix_required_matchers} are not enforceable."
-            ),
-            "stage": "dispatch_feasibility_preflight",
-            "unfixable_matchers": fix_required_matchers,
-            "backend": backend.name,
-            "escape_hatch": (
-                "Per-step provider: override with ANTHROPIC_BASE_URL set to "
-                "reroute dispatch to claude-code (which has applicable_guards)."
-            ),
-        }
-    )
 
 
 def _check_backend_compat(

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -333,7 +333,7 @@ async def dispatch_food_truck(
             except Exception:
                 logger.warning("dispatch_food_truck_preflight_load_failed", exc_info=True)
 
-        _active_recipe_steps: dict[str, Any] = {}
+        _active_recipe_steps: dict[str, Any] | None = None
         if _fleet_load_result and tool_ctx.recipes is not None:
             try:
                 _recipe_info = tool_ctx.recipes.find(recipe, tool_ctx.project_dir)
@@ -346,7 +346,7 @@ async def dispatch_food_truck(
             except Exception:
                 logger.warning("dispatch_food_truck_preflight_recipe_load_failed", exc_info=True)
 
-        if tool_ctx.backend is not None:
+        if tool_ctx.backend is not None and _active_recipe_steps is not None:
             _preflight_err = _check_dispatch_feasibility(
                 post_prune_step_names=_fleet_load_result.get("post_prune_step_names", []),
                 active_recipe_steps=_active_recipe_steps,

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -48,7 +48,10 @@ from autoskillit.server._guards import _require_enabled, _require_fleet
 from autoskillit.server._misc import resolve_log_dir
 from autoskillit.server._notify import track_response_size
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
-from autoskillit.server.tools._preflight import _check_dispatch_feasibility
+from autoskillit.server.tools._preflight import (
+    _check_dispatch_feasibility,
+    filter_steps_by_post_prune,
+)
 
 logger = get_logger(__name__)
 
@@ -330,10 +333,23 @@ async def dispatch_food_truck(
             except Exception:
                 logger.warning("dispatch_food_truck_preflight_load_failed", exc_info=True)
 
+        _active_recipe_steps: dict[str, Any] = {}
+        if _fleet_load_result and tool_ctx.recipes is not None:
+            try:
+                _recipe_info = tool_ctx.recipes.find(recipe, tool_ctx.project_dir)
+                if _recipe_info is not None:
+                    _recipe_obj = tool_ctx.recipes.load(_recipe_info.path)
+                    _active_recipe_steps = filter_steps_by_post_prune(
+                        _recipe_obj.steps,
+                        _fleet_load_result.get("post_prune_step_names", []),
+                    )
+            except Exception:
+                logger.warning("dispatch_food_truck_preflight_recipe_load_failed", exc_info=True)
+
         if tool_ctx.backend is not None:
             _preflight_err = _check_dispatch_feasibility(
                 post_prune_step_names=_fleet_load_result.get("post_prune_step_names", []),
-                active_recipe_steps={},
+                active_recipe_steps=_active_recipe_steps,
                 backend=tool_ctx.backend,
                 config_providers=tool_ctx.config.providers,
             )

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -48,6 +48,7 @@ from autoskillit.server._guards import _require_enabled, _require_fleet
 from autoskillit.server._misc import resolve_log_dir
 from autoskillit.server._notify import track_response_size
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
+from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
 
 logger = get_logger(__name__)
 
@@ -311,6 +312,33 @@ async def dispatch_food_truck(
                     FleetErrorCode.FLEET_DISPATCH_SKIPPED,
                     "Dispatch skipped: skip_when condition evaluated to true",
                 )
+
+        # Dispatch-feasibility preflight: verify the backend can enforce
+        # all fix-required hooks for the recipe's run_skill steps before
+        # spawning a subprocess.
+        _fleet_load_result: dict[str, Any] = {}
+        if tool_ctx.recipes is not None:
+            try:
+                _fleet_load_result = tool_ctx.recipes.load_and_validate(
+                    recipe,
+                    tool_ctx.project_dir,
+                    suppressed=tool_ctx.config.migration.suppressed if tool_ctx.config else None,
+                    ingredient_overrides=ingredients,
+                    temp_dir=tool_ctx.temp_dir,
+                    backend_name=tool_ctx.backend.name if tool_ctx.backend else None,
+                )
+            except Exception:
+                logger.warning("dispatch_food_truck_preflight_load_failed", exc_info=True)
+
+        if tool_ctx.backend is not None:
+            _preflight_err = _check_dispatch_feasibility(
+                post_prune_step_names=_fleet_load_result.get("post_prune_step_names", []),
+                active_recipe_steps={},
+                backend=tool_ctx.backend,
+                config_providers=tool_ctx.config.providers,
+            )
+            if _preflight_err is not None:
+                return _preflight_err
 
         result = await execute_dispatch(
             tool_ctx=tool_ctx,

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -48,7 +48,7 @@ from autoskillit.server._guards import _require_enabled, _require_fleet
 from autoskillit.server._misc import resolve_log_dir
 from autoskillit.server._notify import track_response_size
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
-from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+from autoskillit.server.tools._preflight import _check_dispatch_feasibility
 
 logger = get_logger(__name__)
 

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -352,6 +352,7 @@ async def dispatch_food_truck(
                 active_recipe_steps=_active_recipe_steps,
                 backend=tool_ctx.backend,
                 config_providers=tool_ctx.config.providers,
+                recipe_name=recipe,
             )
             if _preflight_err is not None:
                 return _preflight_err

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -61,6 +61,7 @@ from autoskillit.server.tools._auto_overrides import (
     _promote_capability_keys,
 )
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
+from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
 
 logger = get_logger(__name__)
 
@@ -625,7 +626,10 @@ async def open_kitchen(
                         try:
                             recipe_obj = tool_ctx.recipes.load(recipe_info.path)
                             _deferred_recipe_obj = recipe_obj
-                            tool_ctx.active_recipe_steps = dict(recipe_obj.steps)
+                            _post_prune_names = set(result.get("post_prune_step_names", []))
+                            tool_ctx.active_recipe_steps = {
+                                k: v for k, v in recipe_obj.steps.items() if k in _post_prune_names
+                            }
                             tool_ctx.active_recipe_ingredients = frozenset(
                                 recipe_obj.ingredients.keys()
                             )
@@ -638,7 +642,21 @@ async def open_kitchen(
                         tool_ctx.active_recipe_ingredients = None
                 # Default to False for missing 'valid' so a absent key is treated as invalid
                 if not result.get("valid", False) or not result.get("content", ""):
+                    tool_ctx.gate.disable()
                     return _recipe_validation_error_response(name, result)
+                # Dispatch-feasibility preflight: verify the backend can enforce
+                # all fix-required hooks for the recipe's run_skill steps.
+                if tool_ctx.active_recipe_steps is not None:
+                    _preflight_err = _check_dispatch_feasibility(
+                        post_prune_step_names=result.get("post_prune_step_names", []),
+                        active_recipe_steps=tool_ctx.active_recipe_steps,
+                        backend=tool_ctx.backend,
+                        config_providers=tool_ctx.config.providers,
+                    )
+                    if _preflight_err is not None:
+                        tool_ctx.gate.disable()
+                        await ctx.disable_components(tags={"kitchen"})
+                        return _preflight_err
                 result["success"] = True
                 result["kitchen"] = "open"
                 result["version"] = __version__
@@ -708,7 +726,10 @@ async def open_kitchen(
                 try:
                     recipe_obj = tool_ctx.recipes.load(recipe_info.path)
                     _normal_recipe_obj = recipe_obj
-                    tool_ctx.active_recipe_steps = dict(recipe_obj.steps)
+                    _post_prune_names = set(result.get("post_prune_step_names", []))
+                    tool_ctx.active_recipe_steps = {
+                        k: v for k, v in recipe_obj.steps.items() if k in _post_prune_names
+                    }
                     tool_ctx.active_recipe_ingredients = frozenset(recipe_obj.ingredients.keys())
                 except Exception:
                     logger.warning("open_kitchen_recipe_steps_cache_failed", exc_info=True)
@@ -725,7 +746,22 @@ async def open_kitchen(
                 return _kitchen_failure_envelope(exc, stage="apply_triage_gate")
 
             if not result.get("valid", False) or not result.get("content", ""):
+                tool_ctx.gate.disable()
                 return _recipe_validation_error_response(name, result)
+
+            # Dispatch-feasibility preflight: verify the backend can enforce
+            # all fix-required hooks for the recipe's run_skill steps.
+            if tool_ctx.active_recipe_steps is not None:
+                _preflight_err = _check_dispatch_feasibility(
+                    post_prune_step_names=result.get("post_prune_step_names", []),
+                    active_recipe_steps=tool_ctx.active_recipe_steps,
+                    backend=tool_ctx.backend,
+                    config_providers=tool_ctx.config.providers,
+                )
+                if _preflight_err is not None:
+                    tool_ctx.gate.disable()
+                    await ctx.disable_components(tags={"kitchen"})
+                    return _preflight_err
 
             result["success"] = True
             result["kitchen"] = "open"

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -61,7 +61,10 @@ from autoskillit.server.tools._auto_overrides import (
     _promote_capability_keys,
 )
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
-from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+from autoskillit.server.tools._preflight import (
+    _check_dispatch_feasibility,
+    filter_steps_by_post_prune,
+)
 
 logger = get_logger(__name__)
 
@@ -626,10 +629,9 @@ async def open_kitchen(
                         try:
                             recipe_obj = tool_ctx.recipes.load(recipe_info.path)
                             _deferred_recipe_obj = recipe_obj
-                            _post_prune_names = set(result.get("post_prune_step_names", []))
-                            tool_ctx.active_recipe_steps = {
-                                k: v for k, v in recipe_obj.steps.items() if k in _post_prune_names
-                            }
+                            tool_ctx.active_recipe_steps = filter_steps_by_post_prune(
+                                recipe_obj.steps, result.get("post_prune_step_names", [])
+                            )
                             tool_ctx.active_recipe_ingredients = frozenset(
                                 recipe_obj.ingredients.keys()
                             )
@@ -726,10 +728,9 @@ async def open_kitchen(
                 try:
                     recipe_obj = tool_ctx.recipes.load(recipe_info.path)
                     _normal_recipe_obj = recipe_obj
-                    _post_prune_names = set(result.get("post_prune_step_names", []))
-                    tool_ctx.active_recipe_steps = {
-                        k: v for k, v in recipe_obj.steps.items() if k in _post_prune_names
-                    }
+                    tool_ctx.active_recipe_steps = filter_steps_by_post_prune(
+                        recipe_obj.steps, result.get("post_prune_step_names", [])
+                    )
                     tool_ctx.active_recipe_ingredients = frozenset(recipe_obj.ingredients.keys())
                 except Exception:
                     logger.warning("open_kitchen_recipe_steps_cache_failed", exc_info=True)

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -654,6 +654,7 @@ async def open_kitchen(
                         active_recipe_steps=tool_ctx.active_recipe_steps,
                         backend=tool_ctx.backend,
                         config_providers=tool_ctx.config.providers,
+                        recipe_name=name,
                     )
                     if _preflight_err is not None:
                         tool_ctx.gate.disable()
@@ -758,6 +759,7 @@ async def open_kitchen(
                     active_recipe_steps=tool_ctx.active_recipe_steps,
                     backend=tool_ctx.backend,
                     config_providers=tool_ctx.config.providers,
+                    recipe_name=name,
                 )
                 if _preflight_err is not None:
                     tool_ctx.gate.disable()

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -858,8 +858,9 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "hooks",
             "cli",
             "execution",
-            # server/ narrowed to 3 files
+            # server/ narrowed to 4 files
             "server/test_tools_kitchen_envelope.py",
+            "server/test_tools_kitchen_preflight.py",
             "server/test_lifespan.py",
             "server/test_run_skill_backend_compat.py",
             # infra/ narrowed to 7 files

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -861,6 +861,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             # server/ narrowed to 4 files
             "server/test_tools_kitchen_envelope.py",
             "server/test_tools_kitchen_preflight.py",
+            "server/test_tools_fleet_dispatch_preflight.py",
             "server/test_lifespan.py",
             "server/test_run_skill_backend_compat.py",
             # infra/ narrowed to 7 files

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -876,7 +876,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "pipeline": 12,
         "fleet": 22,  # REQ-CNST-003-E9: _dispatch_reaper.py; +_sidecar_synthesis.py; +_reset.py
         "recipe/rules": 51,  # +commit_guard_regression_route +rules_model +rules_gitignored_deliverable  # noqa: E501
-        "server/tools": 26,  # _auto_overrides.py + _cancellation_shield.py + tools_fleet_reset.py
+        "server/tools": 27,  # +_preflight.py (dispatch-feasibility preflight)
         "hooks/guards": 32,  # +fleet_claim_guard, +reset_resume_gate, +recipe_read_guard
     }
     violations: list[str] = []
@@ -962,13 +962,14 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "co-located with the execution engine that calls them",
     ),
     "tools_kitchen.py": (
-        1160,
+        1200,
         "REQ-CNST-010-E7: kitchen tool handlers — open_kitchen and lock_ingredients require "
         "inline validation helpers (_check_override_keys, _build_ingredient_key_suggestions) "
         "for ingredient key validation; splitting would cross import-layer boundaries; "
         "backend capability promotion delegated to _promote_capability_keys in _auto_overrides; "
         "fail-closed validity gate on both deferred-recall and normal paths adds structural "
-        "error propagation from LoadRecipeResult; get_recipe validity guard adds 9 lines",
+        "error propagation from LoadRecipeResult; get_recipe validity guard adds 9 lines; "
+        "dispatch-feasibility preflight wiring on both paths with gate-close on failure",
     ),
     "tools_execution.py": (
         1130,

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -119,11 +119,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 89),
     # tools_kitchen.py — hook config, quota guard, git_ops_policy, ingredient locks overlay
-    ("src/autoskillit/server/tools/tools_kitchen.py", 167),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 186),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 220),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 879),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 939),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 171),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 190),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 224),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 916),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 976),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -122,8 +122,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools/tools_kitchen.py", 171),
     ("src/autoskillit/server/tools/tools_kitchen.py", 190),
     ("src/autoskillit/server/tools/tools_kitchen.py", 224),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 916),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 976),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 918),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 978),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -124,6 +125,53 @@ def test_load_recipe_result_requires_packs_absent_for_standard_recipe(tmp_path):
     _setup_project_recipe(tmp_path, "test-recipe-no-rules", _RECIPE_NO_RULES)
     result = load_and_validate(name="test-recipe-no-rules", project_dir=tmp_path)
     assert "requires_packs" not in result
+
+
+# ---------------------------------------------------------------------------
+# T-POSTPRUNE-1: post_prune_step_names field in LoadRecipeResult
+# ---------------------------------------------------------------------------
+
+
+_RECIPE_WITH_SKIP_STEPS: Any = """\
+name: test-recipe-skip
+description: Recipe with skip_when_false steps for pruning
+autoskillit_version: "0.3.0"
+ingredients:
+  enable_step_a:
+    description: Toggle for step A
+    default: "true"
+  enable_step_b:
+    description: Toggle for step B
+    default: "false"
+steps:
+  step_a:
+    action: confirm
+    message: A
+    skip_when_false: inputs.enable_step_a
+  step_b:
+    action: confirm
+    message: B
+    skip_when_false: inputs.enable_step_b
+  step_c:
+    action: stop
+    message: C
+"""
+
+
+def test_load_recipe_result_has_post_prune_step_names(tmp_path):
+    """LoadRecipeResult includes post_prune_step_names reflecting surviving steps.
+
+    step_b is pruned (enable_step_b defaults to "false"); step_a and step_c survive.
+    """
+    from autoskillit.recipe._api import load_and_validate
+
+    _setup_project_recipe(tmp_path, "test-recipe-skip", _RECIPE_WITH_SKIP_STEPS)
+    result = load_and_validate(name="test-recipe-skip", project_dir=tmp_path)
+    assert "post_prune_step_names" in result, "post_prune_step_names must be in LoadRecipeResult"
+    post_prune = set(result["post_prune_step_names"])
+    assert "step_a" in post_prune
+    assert "step_c" in post_prune
+    assert "step_b" not in post_prune, "step_b should be pruned (enable_step_b=false)"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/AGENTS.md
+++ b/tests/server/AGENTS.md
@@ -91,6 +91,8 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_tools_issue_lifecycle.py` | Tests for server/tools/tools_issue_headless.py and server/tools/tools_issue_labels.py |
 | `test_tools_kitchen_cache_poison.py` | Cross-tool cache-poison regression: open_kitchen(ingredients_only=True) must not corrupt subsequent load_recipe calls for the same recipe |
 | `test_tools_kitchen_envelope.py` | Tests for tools_kitchen.py: hook drift warnings and failure envelopes |
+| `test_tools_kitchen_preflight.py` | Tests for dispatch-feasibility preflight in open_kitchen and shared _check_dispatch_feasibility function |
+| `test_tools_fleet_dispatch_preflight.py` | Tests for dispatch_food_truck preflight wiring — preflight before execute_dispatch |
 | `test_tools_kitchen_helpers.py` | Tests for tools_kitchen.py helper functions: _recipe_validation_error_response semantic-finding surfacing |
 | `test_tools_kitchen_gate.py` | Tests for tools_kitchen.py: gate toggle, review gate cleanup, kitchen_id, misc |
 | `test_tools_kitchen_gate_features.py` | Tests for tools_kitchen.py: recipe packs, quota refresh, ingredients_only, project_dir |

--- a/tests/server/test_open_kitchen_deferred_recall.py
+++ b/tests/server/test_open_kitchen_deferred_recall.py
@@ -37,6 +37,7 @@ async def test_deferred_recall_sets_active_recipe_steps_from_recipe():
         "composite_hash": "def456",
         "recipe_version": "1.0",
         "suggestions": [],
+        "post_prune_step_names": ["build", "test"],
     }
     mock_recipe_info = MagicMock()
     mock_recipe_info.path = Path("/fake/.autoskillit/recipes/test-recipe.yaml")

--- a/tests/server/test_run_skill_backend_compat.py
+++ b/tests/server/test_run_skill_backend_compat.py
@@ -205,7 +205,6 @@ class TestHookFixRequiredDispatchGate:
 
         from autoskillit.core import AGENT_BACKEND_CODEX, CodingAgentBackend
         from autoskillit.hook_registry import HookDef
-        from autoskillit.server.tools import tools_execution
         from autoskillit.server.tools.tools_execution import _check_backend_compat
 
         registry = [
@@ -215,7 +214,9 @@ class TestHookFixRequiredDispatchGate:
                 codex_status="fix-required",
             ),
         ]
-        monkeypatch.setattr(tools_execution, "HOOK_REGISTRY", registry)
+        from autoskillit.server.tools import _preflight as _preflight_mod
+
+        monkeypatch.setattr(_preflight_mod, "HOOK_REGISTRY", registry)
 
         backend = MagicMock(spec=CodingAgentBackend)
         backend.name = AGENT_BACKEND_CODEX
@@ -246,7 +247,6 @@ class TestHookFixRequiredDispatchGate:
 
         from autoskillit.core import AGENT_BACKEND_CLAUDE_CODE, CodingAgentBackend
         from autoskillit.hook_registry import HookDef
-        from autoskillit.server.tools import tools_execution
         from autoskillit.server.tools.tools_execution import _check_backend_compat
 
         registry = [
@@ -256,7 +256,9 @@ class TestHookFixRequiredDispatchGate:
                 codex_status="fix-required",
             ),
         ]
-        monkeypatch.setattr(tools_execution, "HOOK_REGISTRY", registry)
+        from autoskillit.server.tools import _preflight as _preflight_mod
+
+        monkeypatch.setattr(_preflight_mod, "HOOK_REGISTRY", registry)
 
         backend = MagicMock(spec=CodingAgentBackend)
         backend.name = AGENT_BACKEND_CLAUDE_CODE
@@ -284,7 +286,6 @@ class TestHookFixRequiredDispatchGate:
 
         from autoskillit.core import AGENT_BACKEND_CODEX, CodingAgentBackend
         from autoskillit.hook_registry import HookDef
-        from autoskillit.server.tools import tools_execution
         from autoskillit.server.tools.tools_execution import _check_backend_compat
 
         # scripts=[] means the hook has no guard scripts to check coverage against;
@@ -296,7 +297,9 @@ class TestHookFixRequiredDispatchGate:
                 codex_status="fix-required",
             ),
         ]
-        monkeypatch.setattr(tools_execution, "HOOK_REGISTRY", registry)
+        from autoskillit.server.tools import _preflight as _preflight_mod
+
+        monkeypatch.setattr(_preflight_mod, "HOOK_REGISTRY", registry)
 
         backend = MagicMock(spec=CodingAgentBackend)
         backend.name = AGENT_BACKEND_CODEX
@@ -326,14 +329,15 @@ class TestHookFixRequiredDispatchGate:
 
         from autoskillit.core import AGENT_BACKEND_CODEX, CodingAgentBackend
         from autoskillit.hook_registry import HookDef
-        from autoskillit.server.tools import tools_execution
         from autoskillit.server.tools.tools_execution import _check_backend_compat
 
         registry = [
             HookDef(matcher=r"Read|Write", codex_status="works-as-is"),
             HookDef(matcher=r"Bash", codex_status="not-applicable"),
         ]
-        monkeypatch.setattr(tools_execution, "HOOK_REGISTRY", registry)
+        from autoskillit.server.tools import _preflight as _preflight_mod
+
+        monkeypatch.setattr(_preflight_mod, "HOOK_REGISTRY", registry)
 
         backend = MagicMock(spec=CodingAgentBackend)
         backend.name = AGENT_BACKEND_CODEX
@@ -359,7 +363,6 @@ class TestHookFixRequiredDispatchGate:
 
         from autoskillit.core import AGENT_BACKEND_CODEX, CodingAgentBackend
         from autoskillit.hook_registry import HookDef
-        from autoskillit.server.tools import tools_execution
         from autoskillit.server.tools.tools_execution import _check_backend_compat
 
         registry = [
@@ -374,7 +377,9 @@ class TestHookFixRequiredDispatchGate:
                 codex_status="fix-required",
             ),
         ]
-        monkeypatch.setattr(tools_execution, "HOOK_REGISTRY", registry)
+        from autoskillit.server.tools import _preflight as _preflight_mod
+
+        monkeypatch.setattr(_preflight_mod, "HOOK_REGISTRY", registry)
 
         backend = MagicMock(spec=CodingAgentBackend)
         backend.name = AGENT_BACKEND_CODEX

--- a/tests/server/test_tools_fleet_dispatch_preflight.py
+++ b/tests/server/test_tools_fleet_dispatch_preflight.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import inspect
 
+import pytest
+
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 

--- a/tests/server/test_tools_fleet_dispatch_preflight.py
+++ b/tests/server/test_tools_fleet_dispatch_preflight.py
@@ -8,8 +8,14 @@ runs before execute_dispatch.
 from __future__ import annotations
 
 import inspect
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from autoskillit.hook_registry import HookDef
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
@@ -40,3 +46,75 @@ class TestFleetDispatchPreflightWiring:
             f"Preflight must be called before execute_dispatch "
             f"(preflight at {preflight_pos}, execute at {execute_pos})"
         )
+
+
+class TestFleetDispatchPreflightBehavioral:
+    """Behavioral tests: preflight blocks execute_dispatch on incompatible backend."""
+
+    @pytest.mark.anyio
+    async def test_execute_dispatch_not_called_on_preflight_failure(
+        self, build_ctx_open: Any
+    ) -> None:
+        """When preflight fails, execute_dispatch must not be called."""
+        from autoskillit.core import BackendCapabilities
+
+        tool_ctx = build_ctx_open()
+
+        caps = BackendCapabilities(
+            applicable_guards=frozenset(),
+            anthropic_provider_capable=False,
+        )
+        backend = MagicMock()
+        backend.name = "codex"
+        backend.capabilities = caps
+        tool_ctx.backend = backend
+
+        tool_ctx.recipes = MagicMock()
+        tool_ctx.recipes.load_and_validate.return_value = {
+            "valid": True,
+            "post_prune_step_names": ["s1"],
+        }
+        recipe_info = MagicMock()
+        recipe_info.path = Path("/fake/recipe.yaml")
+        tool_ctx.recipes.find.return_value = recipe_info
+
+        recipe_obj = MagicMock()
+        step_mock = MagicMock()
+        step_mock.tool = "run_skill"
+        step_mock.provider = ""
+        recipe_obj.steps = {"s1": step_mock}
+        tool_ctx.recipes.load.return_value = recipe_obj
+
+        synthetic = HookDef(
+            matcher=r"Read|Write|Edit",
+            scripts=["guards/synthetic_test_hook.py"],
+            codex_status="fix-required",
+            mechanism="deny",
+        )
+
+        mock_execute = AsyncMock()
+        with (
+            patch("autoskillit.server._state._ctx", tool_ctx),
+            patch("autoskillit.server.tools._preflight.HOOK_REGISTRY", [synthetic]),
+            patch(
+                "autoskillit.server.tools.tools_fleet_dispatch.execute_dispatch",
+                mock_execute,
+            ),
+            patch(
+                "autoskillit.server.tools.tools_fleet_dispatch._require_fleet",
+                lambda _name: None,
+            ),
+        ):
+            from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
+
+            ctx_mock = AsyncMock()
+            result = await dispatch_food_truck(
+                recipe="test-recipe",
+                task="test task",
+                ctx=ctx_mock,
+            )
+
+        mock_execute.assert_not_called()
+        parsed = json.loads(result)
+        assert parsed.get("stage") == "dispatch_feasibility_preflight"
+        assert parsed.get("success") is False

--- a/tests/server/test_tools_fleet_dispatch_preflight.py
+++ b/tests/server/test_tools_fleet_dispatch_preflight.py
@@ -27,7 +27,7 @@ class TestFleetDispatchPreflightWiring:
         """dispatch_food_truck source must call _check_dispatch_feasibility."""
         from autoskillit.server.tools import tools_fleet_dispatch
 
-        source = inspect.getsource(tools_fleet_dispatch)
+        source = inspect.getsource(tools_fleet_dispatch.dispatch_food_truck)
         assert "_check_dispatch_feasibility" in source, (
             "dispatch_food_truck must call _check_dispatch_feasibility"
         )
@@ -37,7 +37,7 @@ class TestFleetDispatchPreflightWiring:
         the execute_dispatch call."""
         from autoskillit.server.tools import tools_fleet_dispatch
 
-        source = inspect.getsource(tools_fleet_dispatch)
+        source = inspect.getsource(tools_fleet_dispatch.dispatch_food_truck)
         preflight_pos = source.find("_check_dispatch_feasibility")
         execute_pos = source.find("execute_dispatch(")
         assert preflight_pos > 0

--- a/tests/server/test_tools_fleet_dispatch_preflight.py
+++ b/tests/server/test_tools_fleet_dispatch_preflight.py
@@ -1,0 +1,40 @@
+"""Tests for dispatch_food_truck preflight integration.
+
+Verifies that the fleet dispatch path references the shared
+_check_dispatch_feasibility function and that the preflight
+runs before execute_dispatch.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+class TestFleetDispatchPreflightWiring:
+    """Structural tests confirming preflight is wired into dispatch_food_truck."""
+
+    def test_dispatch_food_truck_calls_preflight(self) -> None:
+        """dispatch_food_truck source must call _check_dispatch_feasibility."""
+        from autoskillit.server.tools import tools_fleet_dispatch
+
+        source = inspect.getsource(tools_fleet_dispatch)
+        assert "_check_dispatch_feasibility" in source, (
+            "dispatch_food_truck must call _check_dispatch_feasibility"
+        )
+
+    def test_preflight_called_before_execute_dispatch(self) -> None:
+        """In the source order, _check_dispatch_feasibility must appear before
+        the execute_dispatch call."""
+        from autoskillit.server.tools import tools_fleet_dispatch
+
+        source = inspect.getsource(tools_fleet_dispatch)
+        preflight_pos = source.find("_check_dispatch_feasibility")
+        execute_pos = source.find("execute_dispatch(")
+        assert preflight_pos > 0
+        assert execute_pos > 0
+        assert preflight_pos < execute_pos, (
+            f"Preflight must be called before execute_dispatch "
+            f"(preflight at {preflight_pos}, execute at {execute_pos})"
+        )

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -383,9 +383,13 @@ async def test_open_kitchen_smoke_test_renders_resolved_base_branch(monkeypatch)
                 "autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()
             ):
                 with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
-                    from autoskillit.server.tools.tools_kitchen import open_kitchen
+                    with patch(
+                        "autoskillit.server.tools.tools_kitchen._check_dispatch_feasibility",
+                        return_value=None,
+                    ):
+                        from autoskillit.server.tools.tools_kitchen import open_kitchen
 
-                    result_str = await open_kitchen(name="smoke-test", ctx=mock_ctx)
+                        result_str = await open_kitchen(name="smoke-test", ctx=mock_ctx)
 
     parsed = json.loads(result_str)
     assert parsed["success"] is True
@@ -484,13 +488,17 @@ async def test_open_kitchen_with_config_authority_ingredient(monkeypatch):
                 "autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()
             ):
                 with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
-                    from autoskillit.server.tools.tools_kitchen import open_kitchen
+                    with patch(
+                        "autoskillit.server.tools.tools_kitchen._check_dispatch_feasibility",
+                        return_value=None,
+                    ):
+                        from autoskillit.server.tools.tools_kitchen import open_kitchen
 
-                    result_str = await open_kitchen(
-                        name="smoke-test",
-                        overrides={"base_branch": "main"},
-                        ctx=mock_ctx,
-                    )
+                        result_str = await open_kitchen(
+                            name="smoke-test",
+                            overrides={"base_branch": "main"},
+                            ctx=mock_ctx,
+                        )
 
     parsed = json.loads(result_str)
     assert parsed["success"] is True

--- a/tests/server/test_tools_kitchen_preflight.py
+++ b/tests/server/test_tools_kitchen_preflight.py
@@ -205,7 +205,7 @@ class TestCheckDispatchFeasibilityUnit:
         parsed = json.loads(result)
         assert parsed.get("success") is False
         assert parsed.get("stage") == "dispatch_feasibility_preflight"
-        assert "dormancy_test_hook" in str(parsed) or "fix-required" in str(parsed)
+        assert "dormancy_test_hook" in str(parsed)
 
     def test_provider_override_excludes_step(self) -> None:
         """A run_skill step with a provider profile that sets ANTHROPIC_BASE_URL

--- a/tests/server/test_tools_kitchen_preflight.py
+++ b/tests/server/test_tools_kitchen_preflight.py
@@ -6,7 +6,7 @@ preventing irreversible side effects from side-effect tools between
 open_kitchen and the first run_skill.
 
 The preflight is implemented as `_check_dispatch_feasibility()` in
-server/tools/tools_execution.py. These tests cover both the function
+server/tools/_preflight.py. These tests cover both the function
 itself and its integration into open_kitchen and dispatch_food_truck.
 """
 
@@ -271,6 +271,35 @@ class TestCheckDispatchFeasibilityUnit:
         parsed = json.loads(result)
         assert "escape_hatch" in parsed or "ANTHROPIC_BASE_URL" in str(parsed)
 
+    def test_real_hook_registry_codex_backend(self) -> None:
+        """Exercise _check_dispatch_feasibility with the real production HOOK_REGISTRY."""
+        from autoskillit.server.tools._preflight import (
+            _check_dispatch_feasibility,
+            _get_fix_required_hook_matchers,
+        )
+
+        backend = _make_codex_backend()
+        active_steps: dict[str, Any] = {
+            "step1": _make_recipe_step("step1", tool="run_skill"),
+        }
+
+        result = _check_dispatch_feasibility(
+            post_prune_step_names=["step1"],
+            active_recipe_steps=active_steps,
+            backend=backend,
+            config_providers=_DEFAULT_PROVIDERS,
+        )
+
+        has_unenforced = bool(
+            _get_fix_required_hook_matchers(backend.capabilities.applicable_guards)
+        )
+        if has_unenforced:
+            assert result is not None
+            parsed = json.loads(result)
+            assert parsed.get("stage") == "dispatch_feasibility_preflight"
+        else:
+            assert result is None
+
 
 # ---------------------------------------------------------------------------
 # Wiring tests: confirm preflight is called from open_kitchen and dispatch_food_truck
@@ -308,3 +337,84 @@ class TestPreflightWiring:
         assert "_check_dispatch_feasibility" in source, (
             "tools_fleet_dispatch.py must reference _check_dispatch_feasibility"
         )
+
+
+# ---------------------------------------------------------------------------
+# Gate-closure tests: open_kitchen disables gate on preflight/validation failure
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightGateClosure:
+    """Tests verifying gate closure on preflight and validation failure paths."""
+
+    @pytest.mark.anyio
+    async def test_gate_closed_after_validation_failure(self, build_ctx_open: Any) -> None:
+        """open_kitchen disables the gate when load_and_validate returns valid=False."""
+        from pathlib import Path
+        from unittest.mock import AsyncMock
+
+        tool_ctx = build_ctx_open()
+        assert tool_ctx.gate.enabled is True
+
+        tool_ctx.recipes = MagicMock()
+        tool_ctx.recipes.load_and_validate.return_value = {
+            "valid": False,
+            "errors": ["synthetic failure"],
+            "content": "",
+        }
+        tool_ctx.recipes.find.return_value = MagicMock(path=Path("/fake/recipe.yaml"))
+
+        with patch("autoskillit.server._state._ctx", tool_ctx):
+            from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+            ctx_mock = AsyncMock()
+            result = await open_kitchen(name="test-recipe", ctx=ctx_mock)
+
+        assert tool_ctx.gate.enabled is False
+        parsed = json.loads(result)
+        assert parsed.get("stage") == "recipe_validation"
+
+    @pytest.mark.anyio
+    async def test_open_kitchen_preflight_blocks_and_closes_gate(
+        self, build_ctx_open: Any
+    ) -> None:
+        """open_kitchen returns preflight error and closes gate for incompatible backend."""
+        from pathlib import Path
+        from unittest.mock import AsyncMock
+
+        tool_ctx = build_ctx_open()
+        assert tool_ctx.gate.enabled is True
+
+        tool_ctx.backend = _make_codex_backend()
+        tool_ctx.recipes = MagicMock()
+        tool_ctx.recipes.load_and_validate.return_value = {
+            "valid": True,
+            "content": "steps:\n  s1:\n    tool: run_skill",
+            "post_prune_step_names": ["s1"],
+        }
+        recipe_info = MagicMock()
+        recipe_info.path = Path("/fake/recipe.yaml")
+        tool_ctx.recipes.find.return_value = recipe_info
+
+        recipe_obj = MagicMock()
+        step_mock = MagicMock()
+        step_mock.tool = "run_skill"
+        step_mock.provider = ""
+        recipe_obj.steps = {"s1": step_mock}
+        recipe_obj.ingredients = {}
+        tool_ctx.recipes.load.return_value = recipe_obj
+
+        synthetic = _make_fix_required_hook()
+        with (
+            patch("autoskillit.server._state._ctx", tool_ctx),
+            patch("autoskillit.server.tools._preflight.HOOK_REGISTRY", [synthetic]),
+        ):
+            from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+            ctx_mock = AsyncMock()
+            result = await open_kitchen(name="test-recipe", ctx=ctx_mock)
+
+        assert tool_ctx.gate.enabled is False
+        parsed = json.loads(result)
+        assert parsed.get("stage") == "dispatch_feasibility_preflight"
+        assert parsed.get("success") is False

--- a/tests/server/test_tools_kitchen_preflight.py
+++ b/tests/server/test_tools_kitchen_preflight.py
@@ -18,7 +18,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from autoskillit.config._config_dataclasses import ProvidersConfig
+
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+_DEFAULT_PROVIDERS = ProvidersConfig()
 
 
 def _make_recipe_step(name: str, tool: str | None = "run_skill", **kwargs: Any) -> MagicMock:
@@ -60,7 +64,6 @@ def _make_codex_backend() -> MagicMock:
     from autoskillit.core import BackendCapabilities
 
     caps = BackendCapabilities(
-        name="codex",
         applicable_guards=frozenset(),
         anthropic_provider_capable=False,
     )
@@ -71,12 +74,11 @@ def _make_codex_backend() -> MagicMock:
 
 
 def _make_claude_backend() -> MagicMock:
-    """Create a mock claude-code backend with applicable_guards."""
+    """Create a mock claude-code backend with applicable_guards covering the synthetic hook."""
     from autoskillit.core import AGENT_BACKEND_CLAUDE_CODE, BackendCapabilities
 
     caps = BackendCapabilities(
-        name=AGENT_BACKEND_CLAUDE_CODE,
-        applicable_guards=frozenset({"skill_load_guard"}),
+        applicable_guards=frozenset({"skill_load_guard", "synthetic_test_hook"}),
         anthropic_provider_capable=True,
     )
     backend = MagicMock()
@@ -95,7 +97,7 @@ class TestCheckDispatchFeasibilityUnit:
 
     def test_no_run_skill_steps_returns_none(self) -> None:
         """A recipe with no run_skill steps passes the preflight (1c)."""
-        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
 
         backend = _make_codex_backend()
         active_steps: dict[str, Any] = {
@@ -103,48 +105,48 @@ class TestCheckDispatchFeasibilityUnit:
             "step2": _make_recipe_step("step2", tool="run_python"),
         }
         synthetic = _make_fix_required_hook()
-        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [synthetic]):
+        with patch("autoskillit.server.tools._preflight.HOOK_REGISTRY", [synthetic]):
             result = _check_dispatch_feasibility(
                 post_prune_step_names=["step1", "step2"],
                 active_recipe_steps=active_steps,
                 backend=backend,
-                config_providers=MagicMock(),
+                config_providers=_DEFAULT_PROVIDERS,
             )
         assert result is None, f"Expected None, got: {result}"
 
     def test_compatible_backend_passes(self) -> None:
         """Backend with applicable_guards covering the fix-required hook passes (1e)."""
-        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
 
         backend = _make_claude_backend()
         active_steps: dict[str, Any] = {
             "step1": _make_recipe_step("step1", tool="run_skill"),
         }
         synthetic = _make_fix_required_hook()
-        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [synthetic]):
+        with patch("autoskillit.server.tools._preflight.HOOK_REGISTRY", [synthetic]):
             result = _check_dispatch_feasibility(
                 post_prune_step_names=["step1"],
                 active_recipe_steps=active_steps,
                 backend=backend,
-                config_providers=MagicMock(),
+                config_providers=_DEFAULT_PROVIDERS,
             )
         assert result is None, f"Expected None for compatible backend, got: {result}"
 
     def test_incompatible_backend_fails(self) -> None:
         """Backend with empty applicable_guards returns error (1b)."""
-        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
 
         backend = _make_codex_backend()
         active_steps: dict[str, Any] = {
             "step1": _make_recipe_step("step1", tool="run_skill"),
         }
         synthetic = _make_fix_required_hook()
-        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [synthetic]):
+        with patch("autoskillit.server.tools._preflight.HOOK_REGISTRY", [synthetic]):
             result = _check_dispatch_feasibility(
                 post_prune_step_names=["step1"],
                 active_recipe_steps=active_steps,
                 backend=backend,
-                config_providers=MagicMock(),
+                config_providers=_DEFAULT_PROVIDERS,
             )
         assert result is not None
         parsed = json.loads(result)
@@ -153,51 +155,51 @@ class TestCheckDispatchFeasibilityUnit:
 
     def test_empty_post_prune_names_returns_none(self) -> None:
         """An empty post-prune step list (all pruned) returns None (1d)."""
-        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
 
         backend = _make_codex_backend()
         synthetic = _make_fix_required_hook()
-        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [synthetic]):
+        with patch("autoskillit.server.tools._preflight.HOOK_REGISTRY", [synthetic]):
             result = _check_dispatch_feasibility(
                 post_prune_step_names=[],
                 active_recipe_steps={},
                 backend=backend,
-                config_providers=MagicMock(),
+                config_providers=_DEFAULT_PROVIDERS,
             )
         assert result is None
 
     def test_no_fix_required_hooks_returns_none(self) -> None:
         """A registry with no fix-required entries passes regardless of backend (1e)."""
-        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
 
         backend = _make_codex_backend()
         active_steps: dict[str, Any] = {
             "step1": _make_recipe_step("step1", tool="run_skill"),
         }
-        with patch("autoskillit.hook_registry.HOOK_REGISTRY", []):
+        with patch("autoskillit.server.tools._preflight.HOOK_REGISTRY", []):
             result = _check_dispatch_feasibility(
                 post_prune_step_names=["step1"],
                 active_recipe_steps=active_steps,
                 backend=backend,
-                config_providers=MagicMock(),
+                config_providers=_DEFAULT_PROVIDERS,
             )
         assert result is None
 
     def test_dormancy_synthetic_hook_always_blocks(self) -> None:
         """Synthetic fix-required hook permanently exercises failure path (1f)."""
-        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
 
         backend = _make_codex_backend()
         active_steps: dict[str, Any] = {
             "step1": _make_recipe_step("step1", tool="run_skill"),
         }
         dormancy = _make_dormancy_hook()
-        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [dormancy]):
+        with patch("autoskillit.server.tools._preflight.HOOK_REGISTRY", [dormancy]):
             result = _check_dispatch_feasibility(
                 post_prune_step_names=["step1"],
                 active_recipe_steps=active_steps,
                 backend=backend,
-                config_providers=MagicMock(),
+                config_providers=_DEFAULT_PROVIDERS,
             )
         assert result is not None
         parsed = json.loads(result)
@@ -208,29 +210,21 @@ class TestCheckDispatchFeasibilityUnit:
     def test_provider_override_excludes_step(self) -> None:
         """A run_skill step with a provider profile that sets ANTHROPIC_BASE_URL
         on a non-anthropic backend is excluded from the check (1h)."""
-        from autoskillit.config._config_dataclasses import (
-            ProviderProfileDef,
-            ProvidersConfig,
-        )
-        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+        from autoskillit.config._config_dataclasses import ProvidersConfig
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
 
         backend = _make_codex_backend()
         active_steps: dict[str, Any] = {
             "step1": _make_recipe_step("step1", tool="run_skill", provider="myprofile"),
         }
-        profile = ProviderProfileDef(
-            name="myprofile",
-            base_url="https://example.com",
-        )
         providers_config = ProvidersConfig(
-            profiles={"myprofile": profile},
-            resolved_profiles={"myprofile": profile},
+            profiles={"myprofile": {"base_url": "https://example.com"}},
             recipe_overrides={},
             step_overrides={},
             default_provider="myprofile",
         )
         synthetic = _make_fix_required_hook()
-        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [synthetic]):
+        with patch("autoskillit.server.tools._preflight.HOOK_REGISTRY", [synthetic]):
             result = _check_dispatch_feasibility(
                 post_prune_step_names=["step1"],
                 active_recipe_steps=active_steps,
@@ -241,37 +235,37 @@ class TestCheckDispatchFeasibilityUnit:
 
     def test_no_backend_returns_none(self) -> None:
         """When backend is None, the preflight returns None (no check possible)."""
-        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
 
         backend = None
         active_steps: dict[str, Any] = {
             "step1": _make_recipe_step("step1", tool="run_skill"),
         }
         synthetic = _make_fix_required_hook()
-        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [synthetic]):
+        with patch("autoskillit.server.tools._preflight.HOOK_REGISTRY", [synthetic]):
             result = _check_dispatch_feasibility(
                 post_prune_step_names=["step1"],
                 active_recipe_steps=active_steps,
                 backend=backend,
-                config_providers=MagicMock(),
+                config_providers=_DEFAULT_PROVIDERS,
             )
         assert result is None
 
     def test_error_includes_escape_hatch(self) -> None:
         """Preflight error envelope mentions the provider-override escape hatch."""
-        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
 
         backend = _make_codex_backend()
         active_steps: dict[str, Any] = {
             "step1": _make_recipe_step("step1", tool="run_skill"),
         }
         synthetic = _make_fix_required_hook()
-        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [synthetic]):
+        with patch("autoskillit.server.tools._preflight.HOOK_REGISTRY", [synthetic]):
             result = _check_dispatch_feasibility(
                 post_prune_step_names=["step1"],
                 active_recipe_steps=active_steps,
                 backend=backend,
-                config_providers=MagicMock(),
+                config_providers=_DEFAULT_PROVIDERS,
             )
         assert result is not None
         parsed = json.loads(result)
@@ -288,7 +282,7 @@ class TestPreflightWiring:
 
     def test_check_dispatch_feasibility_is_importable(self) -> None:
         """The shared function exists and is importable."""
-        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
 
         assert callable(_check_dispatch_feasibility)
 

--- a/tests/server/test_tools_kitchen_preflight.py
+++ b/tests/server/test_tools_kitchen_preflight.py
@@ -364,11 +364,18 @@ class TestPreflightGateClosure:
         }
         tool_ctx.recipes.find.return_value = MagicMock(path=Path("/fake/recipe.yaml"))
 
+        async def _triage_passthrough(result, *_a, **_kw):
+            return result
+
         with (
             patch("autoskillit.server._state._ctx", tool_ctx),
             patch(
                 "autoskillit.server.tools.tools_kitchen._require_orchestrator_exact",
                 return_value=None,
+            ),
+            patch(
+                "autoskillit.server.tools.tools_kitchen._apply_triage_gate",
+                side_effect=_triage_passthrough,
             ),
         ):
             from autoskillit.server.tools.tools_kitchen import open_kitchen
@@ -410,6 +417,9 @@ class TestPreflightGateClosure:
         recipe_obj.ingredients = {}
         tool_ctx.recipes.load.return_value = recipe_obj
 
+        async def _triage_passthrough(result, *_a, **_kw):
+            return result
+
         synthetic = _make_fix_required_hook()
         with (
             patch("autoskillit.server._state._ctx", tool_ctx),
@@ -417,6 +427,10 @@ class TestPreflightGateClosure:
             patch(
                 "autoskillit.server.tools.tools_kitchen._require_orchestrator_exact",
                 return_value=None,
+            ),
+            patch(
+                "autoskillit.server.tools.tools_kitchen._apply_triage_gate",
+                side_effect=_triage_passthrough,
             ),
         ):
             from autoskillit.server.tools.tools_kitchen import open_kitchen

--- a/tests/server/test_tools_kitchen_preflight.py
+++ b/tests/server/test_tools_kitchen_preflight.py
@@ -205,7 +205,7 @@ class TestCheckDispatchFeasibilityUnit:
         parsed = json.loads(result)
         assert parsed.get("success") is False
         assert parsed.get("stage") == "dispatch_feasibility_preflight"
-        assert "dormancy_test_hook" in str(parsed)
+        assert parsed.get("unfixable_matchers") == [r"Read|Write|Edit|Bash"]
 
     def test_provider_override_excludes_step(self) -> None:
         """A run_skill step with a provider profile that sets ANTHROPIC_BASE_URL

--- a/tests/server/test_tools_kitchen_preflight.py
+++ b/tests/server/test_tools_kitchen_preflight.py
@@ -1,0 +1,316 @@
+"""Tests for dispatch-feasibility preflight in open_kitchen and dispatch_food_truck.
+
+These tests verify the temporal-ordering guarantee: the gate is closed
+when a recipe's run_skill steps are infeasible for the current backend,
+preventing irreversible side effects from side-effect tools between
+open_kitchen and the first run_skill.
+
+The preflight is implemented as `_check_dispatch_feasibility()` in
+server/tools/tools_execution.py. These tests cover both the function
+itself and its integration into open_kitchen and dispatch_food_truck.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+def _make_recipe_step(name: str, tool: str | None = "run_skill", **kwargs: Any) -> MagicMock:
+    """Create a mock RecipeStep with the given tool and other attributes."""
+    step = MagicMock()
+    step.name = name
+    step.tool = tool
+    for k, v in kwargs.items():
+        setattr(step, k, v)
+    return step
+
+
+def _make_fix_required_hook() -> Any:
+    """Create a synthetic HookDef with codex_status=fix-required."""
+    from autoskillit.hook_registry import HookDef
+
+    return HookDef(
+        matcher=r"Read|Write|Edit",
+        scripts=["guards/synthetic_test_hook.py"],
+        codex_status="fix-required",
+        mechanism="deny",
+    )
+
+
+def _make_dormancy_hook() -> Any:
+    """Create a permanent dormancy-test HookDef."""
+    from autoskillit.hook_registry import HookDef
+
+    return HookDef(
+        matcher=r"Read|Write|Edit|Bash",
+        scripts=["guards/dormancy_test_hook.py"],
+        codex_status="fix-required",
+        mechanism="deny",
+    )
+
+
+def _make_codex_backend() -> MagicMock:
+    """Create a mock codex backend with empty applicable_guards."""
+    from autoskillit.core import BackendCapabilities
+
+    caps = BackendCapabilities(
+        name="codex",
+        applicable_guards=frozenset(),
+        anthropic_provider_capable=False,
+    )
+    backend = MagicMock()
+    backend.name = "codex"
+    backend.capabilities = caps
+    return backend
+
+
+def _make_claude_backend() -> MagicMock:
+    """Create a mock claude-code backend with applicable_guards."""
+    from autoskillit.core import AGENT_BACKEND_CLAUDE_CODE, BackendCapabilities
+
+    caps = BackendCapabilities(
+        name=AGENT_BACKEND_CLAUDE_CODE,
+        applicable_guards=frozenset({"skill_load_guard"}),
+        anthropic_provider_capable=True,
+    )
+    backend = MagicMock()
+    backend.name = AGENT_BACKEND_CLAUDE_CODE
+    backend.capabilities = caps
+    return backend
+
+
+# ---------------------------------------------------------------------------
+# Direct tests for _check_dispatch_feasibility (1b-1f, 1h)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDispatchFeasibilityUnit:
+    """Unit tests for the shared _check_dispatch_feasibility function."""
+
+    def test_no_run_skill_steps_returns_none(self) -> None:
+        """A recipe with no run_skill steps passes the preflight (1c)."""
+        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+
+        backend = _make_codex_backend()
+        active_steps: dict[str, Any] = {
+            "step1": _make_recipe_step("step1", tool="run_cmd"),
+            "step2": _make_recipe_step("step2", tool="run_python"),
+        }
+        synthetic = _make_fix_required_hook()
+        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [synthetic]):
+            result = _check_dispatch_feasibility(
+                post_prune_step_names=["step1", "step2"],
+                active_recipe_steps=active_steps,
+                backend=backend,
+                config_providers=MagicMock(),
+            )
+        assert result is None, f"Expected None, got: {result}"
+
+    def test_compatible_backend_passes(self) -> None:
+        """Backend with applicable_guards covering the fix-required hook passes (1e)."""
+        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+
+        backend = _make_claude_backend()
+        active_steps: dict[str, Any] = {
+            "step1": _make_recipe_step("step1", tool="run_skill"),
+        }
+        synthetic = _make_fix_required_hook()
+        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [synthetic]):
+            result = _check_dispatch_feasibility(
+                post_prune_step_names=["step1"],
+                active_recipe_steps=active_steps,
+                backend=backend,
+                config_providers=MagicMock(),
+            )
+        assert result is None, f"Expected None for compatible backend, got: {result}"
+
+    def test_incompatible_backend_fails(self) -> None:
+        """Backend with empty applicable_guards returns error (1b)."""
+        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+
+        backend = _make_codex_backend()
+        active_steps: dict[str, Any] = {
+            "step1": _make_recipe_step("step1", tool="run_skill"),
+        }
+        synthetic = _make_fix_required_hook()
+        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [synthetic]):
+            result = _check_dispatch_feasibility(
+                post_prune_step_names=["step1"],
+                active_recipe_steps=active_steps,
+                backend=backend,
+                config_providers=MagicMock(),
+            )
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed.get("stage") == "dispatch_feasibility_preflight"
+        assert parsed.get("success") is False
+
+    def test_empty_post_prune_names_returns_none(self) -> None:
+        """An empty post-prune step list (all pruned) returns None (1d)."""
+        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+
+        backend = _make_codex_backend()
+        synthetic = _make_fix_required_hook()
+        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [synthetic]):
+            result = _check_dispatch_feasibility(
+                post_prune_step_names=[],
+                active_recipe_steps={},
+                backend=backend,
+                config_providers=MagicMock(),
+            )
+        assert result is None
+
+    def test_no_fix_required_hooks_returns_none(self) -> None:
+        """A registry with no fix-required entries passes regardless of backend (1e)."""
+        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+
+        backend = _make_codex_backend()
+        active_steps: dict[str, Any] = {
+            "step1": _make_recipe_step("step1", tool="run_skill"),
+        }
+        with patch("autoskillit.hook_registry.HOOK_REGISTRY", []):
+            result = _check_dispatch_feasibility(
+                post_prune_step_names=["step1"],
+                active_recipe_steps=active_steps,
+                backend=backend,
+                config_providers=MagicMock(),
+            )
+        assert result is None
+
+    def test_dormancy_synthetic_hook_always_blocks(self) -> None:
+        """Synthetic fix-required hook permanently exercises failure path (1f)."""
+        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+
+        backend = _make_codex_backend()
+        active_steps: dict[str, Any] = {
+            "step1": _make_recipe_step("step1", tool="run_skill"),
+        }
+        dormancy = _make_dormancy_hook()
+        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [dormancy]):
+            result = _check_dispatch_feasibility(
+                post_prune_step_names=["step1"],
+                active_recipe_steps=active_steps,
+                backend=backend,
+                config_providers=MagicMock(),
+            )
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed.get("success") is False
+        assert parsed.get("stage") == "dispatch_feasibility_preflight"
+        assert "dormancy_test_hook" in str(parsed) or "fix-required" in str(parsed)
+
+    def test_provider_override_excludes_step(self) -> None:
+        """A run_skill step with a provider profile that sets ANTHROPIC_BASE_URL
+        on a non-anthropic backend is excluded from the check (1h)."""
+        from autoskillit.config._config_dataclasses import (
+            ProviderProfileDef,
+            ProvidersConfig,
+        )
+        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+
+        backend = _make_codex_backend()
+        active_steps: dict[str, Any] = {
+            "step1": _make_recipe_step("step1", tool="run_skill", provider="myprofile"),
+        }
+        profile = ProviderProfileDef(
+            name="myprofile",
+            base_url="https://example.com",
+        )
+        providers_config = ProvidersConfig(
+            profiles={"myprofile": profile},
+            resolved_profiles={"myprofile": profile},
+            recipe_overrides={},
+            step_overrides={},
+            default_provider="myprofile",
+        )
+        synthetic = _make_fix_required_hook()
+        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [synthetic]):
+            result = _check_dispatch_feasibility(
+                post_prune_step_names=["step1"],
+                active_recipe_steps=active_steps,
+                backend=backend,
+                config_providers=providers_config,
+            )
+        assert result is None, f"Provider override should exclude step from check, got: {result}"
+
+    def test_no_backend_returns_none(self) -> None:
+        """When backend is None, the preflight returns None (no check possible)."""
+        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+
+        backend = None
+        active_steps: dict[str, Any] = {
+            "step1": _make_recipe_step("step1", tool="run_skill"),
+        }
+        synthetic = _make_fix_required_hook()
+        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [synthetic]):
+            result = _check_dispatch_feasibility(
+                post_prune_step_names=["step1"],
+                active_recipe_steps=active_steps,
+                backend=backend,
+                config_providers=MagicMock(),
+            )
+        assert result is None
+
+    def test_error_includes_escape_hatch(self) -> None:
+        """Preflight error envelope mentions the provider-override escape hatch."""
+        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+
+        backend = _make_codex_backend()
+        active_steps: dict[str, Any] = {
+            "step1": _make_recipe_step("step1", tool="run_skill"),
+        }
+        synthetic = _make_fix_required_hook()
+        with patch("autoskillit.hook_registry.HOOK_REGISTRY", [synthetic]):
+            result = _check_dispatch_feasibility(
+                post_prune_step_names=["step1"],
+                active_recipe_steps=active_steps,
+                backend=backend,
+                config_providers=MagicMock(),
+            )
+        assert result is not None
+        parsed = json.loads(result)
+        assert "escape_hatch" in parsed or "ANTHROPIC_BASE_URL" in str(parsed)
+
+
+# ---------------------------------------------------------------------------
+# Wiring tests: confirm preflight is called from open_kitchen and dispatch_food_truck
+# ---------------------------------------------------------------------------
+
+
+class TestPreflightWiring:
+    """Structural tests confirming the preflight is wired into call sites."""
+
+    def test_check_dispatch_feasibility_is_importable(self) -> None:
+        """The shared function exists and is importable."""
+        from autoskillit.server.tools.tools_execution import _check_dispatch_feasibility
+
+        assert callable(_check_dispatch_feasibility)
+
+    def test_open_kitchen_module_imports_preflight(self) -> None:
+        """tools_kitchen module references _check_dispatch_feasibility."""
+        # The module should have a reference to the preflight function
+        import inspect
+
+        from autoskillit.server.tools import tools_kitchen
+
+        source = inspect.getsource(tools_kitchen)
+        assert "_check_dispatch_feasibility" in source, (
+            "tools_kitchen.py must reference _check_dispatch_feasibility"
+        )
+
+    def test_fleet_dispatch_module_imports_preflight(self) -> None:
+        """tools_fleet_dispatch module references _check_dispatch_feasibility."""
+        import inspect
+
+        from autoskillit.server.tools import tools_fleet_dispatch
+
+        source = inspect.getsource(tools_fleet_dispatch)
+        assert "_check_dispatch_feasibility" in source, (
+            "tools_fleet_dispatch.py must reference _check_dispatch_feasibility"
+        )

--- a/tests/server/test_tools_kitchen_preflight.py
+++ b/tests/server/test_tools_kitchen_preflight.py
@@ -364,7 +364,13 @@ class TestPreflightGateClosure:
         }
         tool_ctx.recipes.find.return_value = MagicMock(path=Path("/fake/recipe.yaml"))
 
-        with patch("autoskillit.server._state._ctx", tool_ctx):
+        with (
+            patch("autoskillit.server._state._ctx", tool_ctx),
+            patch(
+                "autoskillit.server.tools.tools_kitchen._require_orchestrator_exact",
+                return_value=None,
+            ),
+        ):
             from autoskillit.server.tools.tools_kitchen import open_kitchen
 
             ctx_mock = AsyncMock()
@@ -408,6 +414,10 @@ class TestPreflightGateClosure:
         with (
             patch("autoskillit.server._state._ctx", tool_ctx),
             patch("autoskillit.server.tools._preflight.HOOK_REGISTRY", [synthetic]),
+            patch(
+                "autoskillit.server.tools.tools_kitchen._require_orchestrator_exact",
+                return_value=None,
+            ),
         ):
             from autoskillit.server.tools.tools_kitchen import open_kitchen
 


### PR DESCRIPTION
## Summary

Add a dispatch-feasibility preflight in the server layer that fires at `open_kitchen` and `dispatch_food_truck` time — validating that the backend can dispatch the recipe's `run_skill` steps before any irreversible side effects (clone, branch push, issue labeling) occur. On preflight failure, the gate is closed, structurally denying all downstream side-effect tools via `_require_enabled()`. This fixes the "claim-before-validate" anti-pattern identified in production run `impl-20260611-163753-197057` where the backend-compat check fired only inside `run_skill`, after claims and branch pushes had already happened.

<details>
<summary>Individual Group Plans</summary>

### Plan 1: Rectify — Dispatch-Feasibility Preflight — Claim-Before-Validate Immunity

The backend-compatibility gate (`_check_backend_compat`) fires only inside `run_skill` — after irreversible external side effects (clone, branch push, issue labeling) have already occurred. The incompatibility is statically knowable at `open_kitchen` time from constants (`HOOK_REGISTRY`, `backend.capabilities`). The architectural weakness is that `open_kitchen` enables the gate and reveals tools before validating that the backend can dispatch the recipe's steps, and no existing test models the temporal ordering between gate-enable, side-effect tools, and the compat check.

The immunity plan addresses three layers:
1. **LoadRecipeResult extension** — expose post-prune step names from the recipe layer so the server can inspect them without duplicating parse logic.
2. **Server-layer preflight** — a `_check_dispatch_feasibility` function shared by `open_kitchen` and `dispatch_food_truck`, evaluated against post-prune steps and the real backend, with gate-close on failure.
3. **Temporal-ordering test infrastructure** — tests that assert gate state after validation failure, test with the real `HOOK_REGISTRY`, and verify that side-effect tools are structurally denied after preflight failure.

### Plan 2: Implementation — dispatch_food_truck Preflight Fix and Missing Tests

Fix the `active_recipe_steps={}` bug in `dispatch_food_truck` that renders the dispatch-feasibility preflight a no-op, and add four missing tests: gate-closure after validation failure (1a), full `open_kitchen` integration preflight (1b), real `HOOK_REGISTRY` test (1e), and behavioral fleet dispatch preflight (1g).

The root cause is that `dispatch_food_truck` calls `_check_dispatch_feasibility` with an empty dict for `active_recipe_steps`, unlike `open_kitchen` which properly loads the `Recipe` object via `recipes.find()` + `recipes.load()` and filters with `filter_steps_by_post_prune()`. The fix mirrors the `open_kitchen` pattern.

</details>

Closes #4083

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/remediation-20260611-215136-833713/.autoskillit/temp/rectify/rectify_dispatch_feasibility_preflight_2026-06-11_215136.md`
- `/home/talon/projects/autoskillit-runs/remediation-20260611-215136-833713/.autoskillit/temp/make-plan/remediation_dispatch_feasibility_preflight_plan_2026-06-11_230600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| resolve_review* | sonnet | 10 | 3.0k | 136.6k | 15.9M | 109.9k | 608 | 628.2k | 1h 6m |
| dispatch:44d3705c-3f62-459b-af5b-9678f2bbcb64* | sonnet | 1 | 114 | 3.6k | 1.2M | 94.6k | 28 | 94.9k | 23m 9s |
| plan* | opus[1m] | 10 | 9.8k | 210.3k | 14.0M | 136.8k | 432 | 818.6k | 2h 19m |
| verify* | sonnet | 10 | 4.1k | 122.6k | 4.7M | 74.1k | 255 | 427.3k | 1h 2m |
| implement* | MiniMax-M3 | 10 | 24.0M | 134.7k | 0 | 0 | 722 | 0 | 1h 11m |
| audit_impl* | sonnet | 10 | 7.0k | 83.3k | 2.2M | 50.6k | 160 | 310.9k | 48m 30s |
| prepare_pr* | MiniMax-M3 | 9 | 2.1M | 20.7k | 0 | 0 | 129 | 0 | 9m 6s |
| compose_pr* | MiniMax-M3 | 9 | 1.7M | 14.3k | 0 | 0 | 115 | 0 | 8m 6s |
| review_pr* | sonnet | 14 | 2.1k | 347.6k | 13.6M | 101.1k | 618 | 770.8k | 1h 26m |
| dispatch:0145c757-e69c-4878-929a-ba4acb07e3d1* | sonnet | 1 | 322 | 13.7k | 3.0M | 86.3k | 84 | 62.0k | 42m 39s |
| fix* | sonnet | 5 | 854 | 38.0k | 5.9M | 98.2k | 276 | 254.5k | 27m 19s |
| dispatch:341f411a-3d76-4fcf-88a3-15a64c6d7bd4* | sonnet | 1 | 354 | 10.0k | 3.4M | 86.4k | 89 | 62.0k | 1h 18m |
| dispatch:7e27c189-e656-4ec2-b528-b128157c59a8* | sonnet | 1 | 490 | 17.2k | 5.0M | 98.3k | 122 | 73.9k | 1h 26m |
| dispatch:36a96fbc-6c25-4316-a068-66f069a326ac* | sonnet | 1 | 386 | 14.1k | 3.8M | 89.9k | 102 | 65.5k | 1h 14m |
| dispatch:540912dc-04a8-4bda-b6dd-1ba4a533b68f* | sonnet | 1 | 418 | 12.6k | 4.1M | 89.9k | 106 | 65.5k | 1h 27m |
| dispatch:726982d8-8d44-4345-91ee-7c36d41bf8c0* | sonnet | 1 | 330 | 11.6k | 3.1M | 84.9k | 82 | 60.5k | 1h 10m |
| dispatch:c51e35aa-e1dc-42fd-91a6-8cadbf463f94* | sonnet | 1 | 418 | 12.6k | 4.1M | 90.7k | 107 | 66.3k | 1h 36m |
| dispatch:136d06d2-7313-45ac-b80d-f17a96a36af8* | sonnet | 1 | 322 | 10.0k | 3.0M | 83.9k | 80 | 59.5k | 1h 8m |
| dispatch:04f878e3-4291-4f0d-bae2-8cc73470181d* | sonnet | 1 | 468 | 164 | 4.1M | 81.4k | 58 | 201.6k | 1h 0m |
| **Total** | | | 27.9M | 1.2M | 91.1M | 136.8k | | 4.0M | 20h 8m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| resolve_review | 100 | 159103.9 | 6282.2 | 1366.2 |
| dispatch:44d3705c-3f62-459b-af5b-9678f2bbcb64 | 0 | — | — | — |
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 1691 | 0.0 | 0.0 | 79.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| dispatch:0145c757-e69c-4878-929a-ba4acb07e3d1 | 360 | 8363.5 | 172.2 | 38.2 |
| fix | 29 | 202454.8 | 8775.7 | 1309.2 |
| dispatch:341f411a-3d76-4fcf-88a3-15a64c6d7bd4 | 446 | 7548.5 | 139.0 | 22.5 |
| dispatch:7e27c189-e656-4ec2-b528-b128157c59a8 | 235 | 21444.0 | 314.5 | 73.2 |
| dispatch:36a96fbc-6c25-4316-a068-66f069a326ac | 0 | — | — | — |
| dispatch:540912dc-04a8-4bda-b6dd-1ba4a533b68f | 0 | — | — | — |
| dispatch:726982d8-8d44-4345-91ee-7c36d41bf8c0 | 0 | — | — | — |
| dispatch:c51e35aa-e1dc-42fd-91a6-8cadbf463f94 | 844 | 4875.8 | 78.5 | 14.9 |
| dispatch:136d06d2-7313-45ac-b80d-f17a96a36af8 | 0 | — | — | — |
| dispatch:04f878e3-4291-4f0d-bae2-8cc73470181d | 0 | — | — | — |
| **Total** | **3705** | 24594.1 | 1085.6 | 327.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| sonnet | 15 | 20.8k | 833.7k | 77.1M | 3.2M | 16h 20m |
| opus[1m] | 1 | 9.8k | 210.3k | 14.0M | 818.6k | 2h 19m |
| MiniMax-M3 | 3 | 27.9M | 169.7k | 0 | 0 | 1h 28m |