### PR TITLE
Implementation Plan: T5-P4-A1-WP1 BackendCmdBuilderBase ABC and FlagVocabulary

### DIFF
--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -37,10 +37,7 @@ from autoskillit.execution.backends import (
     sync_hooks_to_codex_config,
 )
 from autoskillit.execution.ci import DefaultCIWatcher
-from autoskillit.execution.commands import (
-    _MAX_MCP_OUTPUT_TOKENS_VALUE,  # noqa: F401
-    ClaudeHeadlessCmd,
-)
+from autoskillit.execution.commands import ClaudeHeadlessCmd
 from autoskillit.execution.db import (
     DefaultDatabaseReader,
 )

--- a/src/autoskillit/execution/backends/AGENTS.md
+++ b/src/autoskillit/execution/backends/AGENTS.md
@@ -7,6 +7,7 @@ IL-1 backend abstraction layer — concrete `CodingAgentBackend` implementations
 | File | Purpose |
 |------|---------|
 | `__init__.py` | `BACKEND_REGISTRY`, `get_backend()` factory, re-exports |
+| `_backend_cmd_builder_base.py` | `BackendCmdBuilderBase` ABC (frozen dataclass), `FlagVocabulary` NamedTuple, `SHARED_BASELINE_ENV` — canonical location for shared env-assembly keys |
 | `claude.py` | `ClaudeCodeBackend` (incl. `validate_session_layout`), `ClaudeEnvPolicy`, `ClaudeSessionLocator`, `ClaudeStreamParser`, `ClaudeResultParser` (prompt utilities moved to `_claude_prompt.py`) |
 | `_claude_prompt.py` | Prompt injection utilities, session constants (`_ensure_skill_prefix`, `_inject_completion_directive`, `_compose_resume_prompt`, etc.), shared by claude + codex + commands |
 | `codex.py` | `CodexFlags`, `CodexBackend` (incl. `validate_session_layout`, `setup_session_dir` agent TOML generation via `_generate_agent_tomls`), `CodexEnvPolicy`, `CodexSessionLocator` (parse/config moved to `_codex_parse.py` / `_codex_config.py`) |

--- a/src/autoskillit/execution/backends/_backend_cmd_builder_base.py
+++ b/src/autoskillit/execution/backends/_backend_cmd_builder_base.py
@@ -33,15 +33,11 @@ if TYPE_CHECKING:
 # Raises the Claude Code client-side MCP tool result size gate from the
 # default 25,000 tokens to 50,000, preventing open_kitchen() responses
 # from being persisted to a file instead of returned inline.
-# Canonical definition lives here; ``_claude_prompt.py`` re-exports it as a
-# legacy alias for downstream consumers.
 _MAX_MCP_OUTPUT_TOKENS_VALUE: str = "50000"
 
 
 # Baseline env vars injected into EVERY AutoSkillit-launched session. Callers
-# can override via env_extras. This is the canonical source for the two
-# always-on shared keys; ``_SESSION_BASELINE_ENV`` in ``_claude_prompt.py`` is
-# re-exported as a legacy alias. The shim ``_codex_exec_extras`` (in
+# can override via env_extras. The shim ``_codex_exec_extras`` (in
 # ``codex.py``) imports this directly for the ``include_session_baseline=True``
 # path so resume sessions do NOT inadvertently pick up ambient campaign/kitchen
 # IDs from ``os.environ`` (which ``_assemble_shared_env_extras`` would).

--- a/src/autoskillit/execution/backends/_backend_cmd_builder_base.py
+++ b/src/autoskillit/execution/backends/_backend_cmd_builder_base.py
@@ -121,12 +121,15 @@ class BackendCmdBuilderBase(ABC):
         return extras
 
     def _apply_config(self, config: SkillSessionConfig) -> dict[str, Any]:
-        """Unpack all :class:`SkillSessionConfig` fields into a plain dict.
+        """Unpack :class:`SkillSessionConfig` command-building fields into a plain dict.
 
         Separates shared fields (consumed by ``_assemble_shared_env_extras``)
         from backend-specific fields. The returned dict is the single source
         of truth that backend-specific builders can read from instead of
         accepting each field as a separate parameter.
+
+        ``backend_override`` is intentionally excluded — it is consumed upstream
+        at the headless layer before command builders are invoked.
         """
         return {
             "completion_marker": config.completion_marker,

--- a/src/autoskillit/execution/backends/_backend_cmd_builder_base.py
+++ b/src/autoskillit/execution/backends/_backend_cmd_builder_base.py
@@ -1,0 +1,160 @@
+"""Canonical location for the BackendCmdBuilderBase ABC and shared env-assembly keys.
+
+Both ``ClaudeCodeBackend`` (in ``claude.py``) and ``CodexBackend`` (in ``codex.py``)
+inherit from :class:`BackendCmdBuilderBase`. The base class owns the shared
+``_assemble_shared_env_extras`` static helper and four abstract extension points
+(``_binary``, ``_sandbox_default``, ``_env_policy``, ``_flag_vocabulary``) that
+each concrete backend implements.
+
+This module is stdlib-only plus IL-0 core imports. It is IL-1 compliant — no
+imports from ``claude.py`` or ``codex.py`` (the two concrete backends).
+"""
+
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+from autoskillit.core import (
+    CAMPAIGN_ID_ENV_VAR,
+    KITCHEN_SESSION_ID_ENV_VAR,
+    SkillSessionConfig,
+)
+
+if TYPE_CHECKING:
+    from autoskillit.core import EnvPolicy
+
+
+# Injected into every AutoSkillit-launched headless and cook session.
+# Raises the Claude Code client-side MCP tool result size gate from the
+# default 25,000 tokens to 50,000, preventing open_kitchen() responses
+# from being persisted to a file instead of returned inline.
+# Canonical definition lives here; ``_claude_prompt.py`` re-exports it as a
+# legacy alias for downstream consumers.
+_MAX_MCP_OUTPUT_TOKENS_VALUE: str = "50000"
+
+
+# Baseline env vars injected into EVERY AutoSkillit-launched session. Callers
+# can override via env_extras. This is the canonical source for the two
+# always-on shared keys; ``_SESSION_BASELINE_ENV`` in ``_claude_prompt.py`` is
+# re-exported as a legacy alias. The shim ``_codex_exec_extras`` (in
+# ``codex.py``) imports this directly for the ``include_session_baseline=True``
+# path so resume sessions do NOT inadvertently pick up ambient campaign/kitchen
+# IDs from ``os.environ`` (which ``_assemble_shared_env_extras`` would).
+SHARED_BASELINE_ENV: Mapping[str, str] = MappingProxyType(
+    {
+        "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
+        "MCP_CONNECTION_NONBLOCKING": "0",
+    }
+)
+
+
+class FlagVocabulary(NamedTuple):
+    """Per-backend CLI flag metadata used by the shared ``CmdBuilder``."""
+
+    variadic_flags: frozenset[str]
+    non_variadic_flags: frozenset[str]
+    model_flag: str
+    add_dir_flag: str
+    resume_flag: str
+    config_override_flag: str
+
+
+@dataclass(frozen=True, slots=True)
+class BackendCmdBuilderBase(ABC):
+    """Base class for backend command builders.
+
+    Owns the shared env-assembly logic that both ``ClaudeCodeBackend`` and
+    ``CodexBackend`` previously duplicated. Subclasses must implement four
+    abstract extension points that capture backend-specific behavior.
+    """
+
+    @abstractmethod
+    def _binary(self) -> str:
+        """Return the CLI binary name for this backend."""
+
+    @abstractmethod
+    def _sandbox_default(self) -> str:
+        """Return the default sandbox mode string for this backend."""
+
+    @abstractmethod
+    def _env_policy(self) -> EnvPolicy:
+        """Return the backend's :class:`EnvPolicy` instance."""
+
+    @abstractmethod
+    def _flag_vocabulary(self) -> FlagVocabulary:
+        """Return the backend's :class:`FlagVocabulary`."""
+
+    @staticmethod
+    def _assemble_shared_env_extras(
+        *,
+        write_prefix: str = "",
+        write_prefixes: tuple[str, ...] = (),
+        cwd: str = "",
+        scenario_step_name: str = "",
+    ) -> dict[str, str]:
+        """Assemble the eight shared env keys consumed by both backends.
+
+        Always-on keys (two): ``MAX_MCP_OUTPUT_TOKENS``, ``MCP_CONNECTION_NONBLOCKING``.
+
+        Conditional keys (six): ``SCENARIO_STEP_NAME``,
+        ``CAMPAIGN_ID_ENV_VAR``, ``KITCHEN_SESSION_ID_ENV_VAR``,
+        ``AUTOSKILLIT_ALLOWED_WRITE_PREFIX``, ``AUTOSKILLIT_ALLOWED_WRITE_PREFIXES``,
+        ``AUTOSKILLIT_CWD``. Each is included only when its input is non-empty
+        (campaign/kitchen IDs are also read from the ambient ``os.environ``).
+        """
+        extras: dict[str, str] = dict(SHARED_BASELINE_ENV)
+        if scenario_step_name:
+            extras["SCENARIO_STEP_NAME"] = scenario_step_name
+        campaign_id = os.environ.get(CAMPAIGN_ID_ENV_VAR)
+        if campaign_id:
+            extras[CAMPAIGN_ID_ENV_VAR] = campaign_id
+        kitchen_session_id = os.environ.get(KITCHEN_SESSION_ID_ENV_VAR)
+        if kitchen_session_id:
+            extras[KITCHEN_SESSION_ID_ENV_VAR] = kitchen_session_id
+        if write_prefix:
+            extras["AUTOSKILLIT_ALLOWED_WRITE_PREFIX"] = write_prefix
+        if write_prefixes:
+            extras["AUTOSKILLIT_ALLOWED_WRITE_PREFIXES"] = ":".join(write_prefixes)
+        if cwd:
+            extras["AUTOSKILLIT_CWD"] = cwd
+        return extras
+
+    def _apply_config(self, config: SkillSessionConfig) -> dict[str, Any]:
+        """Unpack all :class:`SkillSessionConfig` fields into a plain dict.
+
+        Separates shared fields (consumed by ``_assemble_shared_env_extras``)
+        from backend-specific fields. The returned dict is the single source
+        of truth that backend-specific builders can read from instead of
+        accepting each field as a separate parameter.
+        """
+        return {
+            "completion_marker": config.completion_marker,
+            "model": config.model,
+            "plugin_source": config.plugin_source,
+            "output_format": config.output_format,
+            "add_dirs": config.add_dirs,
+            "exit_after_stop_delay_ms": config.exit_after_stop_delay_ms,
+            "stream_idle_timeout_ms": config.stream_idle_timeout_ms,
+            "scenario_step_name": config.scenario_step_name,
+            "temp_dir_relpath": config.temp_dir_relpath,
+            "allowed_write_prefix": config.allowed_write_prefix,
+            "allowed_write_prefixes": config.allowed_write_prefixes,
+            "provider_extras": config.provider_extras,
+            "profile_name": config.profile_name,
+            "resume_session_id": config.resume_session_id,
+            "resume_checkpoint": config.resume_checkpoint,
+            "resume_message": config.resume_message,
+            "sandbox_mode": config.sandbox_mode,
+        }
+
+
+__all__ = [
+    "BackendCmdBuilderBase",
+    "FlagVocabulary",
+    "SHARED_BASELINE_ENV",
+]

--- a/src/autoskillit/execution/backends/_claude_prompt.py
+++ b/src/autoskillit/execution/backends/_claude_prompt.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass
-from types import MappingProxyType
 from typing import Any, NamedTuple
 
 from autoskillit.core import (
@@ -15,6 +14,19 @@ from autoskillit.core import (
     extract_skill_name,
     temp_dir_display_str,
 )
+from autoskillit.execution.backends._backend_cmd_builder_base import (
+    _MAX_MCP_OUTPUT_TOKENS_VALUE,
+    SHARED_BASELINE_ENV,
+)
+
+# Legacy aliases preserved for downstream consumers (claude.py, codex.py, commands.py)
+# that import these names from _claude_prompt. Canonical definitions live in
+# _backend_cmd_builder_base.py.
+_SESSION_BASELINE_ENV: Mapping[str, str] = SHARED_BASELINE_ENV
+__all__ = [
+    "_MAX_MCP_OUTPUT_TOKENS_VALUE",
+    "_SESSION_BASELINE_ENV",
+]
 
 
 def _extract_write_artifacts(tool_uses: list[dict[str, Any]]) -> list[str]:
@@ -24,23 +36,6 @@ def _extract_write_artifacts(tool_uses: list[dict[str, Any]]) -> list[str]:
         if t.get("name") in {"Write", "Edit"} and t.get("file_path")
     ]
 
-
-# Injected into every AutoSkillit-launched headless and cook session.
-# Raises the Claude Code client-side MCP tool result size gate from the
-# default 25,000 tokens to 50,000, preventing open_kitchen() responses
-# from being persisted to a file instead of returned inline.
-_MAX_MCP_OUTPUT_TOKENS_VALUE: str = "50000"
-
-# Baseline env vars injected into EVERY AutoSkillit-launched Claude session
-# (both interactive and headless). Callers can override via env_extras.
-# Analogous to IDE_ENV_ALWAYS_EXTRAS in _claude_env.py but scoped to
-# session-level concerns rather than IDE scrubbing.
-_SESSION_BASELINE_ENV: Mapping[str, str] = MappingProxyType(
-    {
-        "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
-        "MCP_CONNECTION_NONBLOCKING": "0",
-    }
-)
 
 # Non-negotiable env overrides applied to every headless subprocess launch.
 # Injected after build_agent_env() so callers cannot clobber these values via

--- a/src/autoskillit/execution/backends/_claude_prompt.py
+++ b/src/autoskillit/execution/backends/_claude_prompt.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, NamedTuple
 
@@ -14,19 +13,6 @@ from autoskillit.core import (
     extract_skill_name,
     temp_dir_display_str,
 )
-from autoskillit.execution.backends._backend_cmd_builder_base import (
-    _MAX_MCP_OUTPUT_TOKENS_VALUE,
-    SHARED_BASELINE_ENV,
-)
-
-# Legacy aliases preserved for downstream consumers (claude.py, codex.py, commands.py)
-# that import these names from _claude_prompt. Canonical definitions live in
-# _backend_cmd_builder_base.py.
-_SESSION_BASELINE_ENV: Mapping[str, str] = SHARED_BASELINE_ENV
-__all__ = [
-    "_MAX_MCP_OUTPUT_TOKENS_VALUE",
-    "_SESSION_BASELINE_ENV",
-]
 
 
 def _extract_write_artifacts(tool_uses: list[dict[str, Any]]) -> list[str]:

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -53,6 +53,7 @@ from autoskillit.core import (
     pkg_root,
 )
 from autoskillit.execution.backends._backend_cmd_builder_base import (
+    SHARED_BASELINE_ENV,
     BackendCmdBuilderBase,
     FlagVocabulary,
 )
@@ -61,7 +62,6 @@ from autoskillit.execution.backends._claude_prompt import (
     _HEADLESS_EXCLUSIVE_VARS,
     _INTERACTIVE_ENV_EXCLUSIONS,
     _PROVIDER_EXTRAS_BASE_DENYLIST,
-    _SESSION_BASELINE_ENV,
     _SKILL_SESSION_EXTRAS_DENYLIST,
     PromptBuildContext,
     _apply_output_format,
@@ -459,7 +459,7 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
             builder.variadic_pair(ClaudeFlags.ADD_DIR, str(d))
         for t in tools:
             builder.variadic_pair(ClaudeFlags.TOOLS, t)
-        merged: dict[str, str] = dict(_SESSION_BASELINE_ENV)
+        merged: dict[str, str] = dict(SHARED_BASELINE_ENV)
         if env_extras:
             merged.update(env_extras)
         interactive_base = {
@@ -498,7 +498,7 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
                 pass
             case None:
                 pass
-        merged: dict[str, str] = dict(_SESSION_BASELINE_ENV)
+        merged: dict[str, str] = dict(SHARED_BASELINE_ENV)
         if env_extras:
             merged.update(env_extras)
         env = dict(build_agent_env(base={}, extras=merged))

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -18,7 +18,6 @@ from autoskillit.core import (
     CAMPAIGN_ID_ENV_VAR,
     CLAUDE_CODE_CAPABILITIES,
     CONTEXT_EXHAUSTION_MARKER,
-    KITCHEN_SESSION_ID_ENV_VAR,
     ORCHESTRATOR_SESSION_REQUIRED_ENV,
     SESSION_TYPE_ORCHESTRATOR,
     SESSION_TYPE_SKILL,
@@ -53,11 +52,14 @@ from autoskillit.core import (
     load_yaml,
     pkg_root,
 )
+from autoskillit.execution.backends._backend_cmd_builder_base import (
+    BackendCmdBuilderBase,
+    FlagVocabulary,
+)
 from autoskillit.execution.backends._claude_prompt import (
     _HEADLESS_ENV_HARDENING,
     _HEADLESS_EXCLUSIVE_VARS,
     _INTERACTIVE_ENV_EXCLUSIONS,
-    _MAX_MCP_OUTPUT_TOKENS_VALUE,
     _PROVIDER_EXTRAS_BASE_DENYLIST,
     _SESSION_BASELINE_ENV,
     _SKILL_SESSION_EXTRAS_DENYLIST,
@@ -270,7 +272,35 @@ class ClaudeResultParser:
 
 
 @dataclass(frozen=True, slots=True)
-class ClaudeCodeBackend:
+class ClaudeCodeBackend(BackendCmdBuilderBase):
+    def _binary(self) -> str:
+        return "claude"
+
+    def _sandbox_default(self) -> str:
+        return "workspace-write"
+
+    def _env_policy(self) -> ClaudeEnvPolicy:
+        return ClaudeEnvPolicy()
+
+    def _flag_vocabulary(self) -> FlagVocabulary:
+        return FlagVocabulary(
+            variadic_flags=frozenset(
+                {ClaudeFlags.ADD_DIR, ClaudeFlags.PLUGIN_DIR, ClaudeFlags.TOOLS}
+            ),
+            non_variadic_flags=frozenset(
+                {
+                    ClaudeFlags.PRINT,
+                    ClaudeFlags.MODEL,
+                    ClaudeFlags.RESUME,
+                    ClaudeFlags.DANGEROUSLY_SKIP_PERMISSIONS,
+                }
+            ),
+            model_flag=ClaudeFlags.MODEL,
+            add_dir_flag=ClaudeFlags.ADD_DIR,
+            resume_flag=ClaudeFlags.RESUME,
+            config_override_flag="",
+        )
+
     @property
     def name(self) -> str:
         return AGENT_BACKEND_CLAUDE_CODE
@@ -600,8 +630,6 @@ class ClaudeCodeBackend:
         extras: dict[str, str] = {
             "AUTOSKILLIT_HEADLESS": "1",
             "AUTOSKILLIT_SESSION_TYPE": SESSION_TYPE_SKILL,
-            "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
-            "MCP_CONNECTION_NONBLOCKING": "0",
             AGENT_BACKEND_ENV_VAR: AGENT_BACKEND_CLAUDE_CODE,
             AGENT_BACKEND_DYNACONF_ENV_VAR: AGENT_BACKEND_CLAUDE_CODE,
             AUTOSKILLIT_APPLICABLE_GUARDS: ",".join(sorted(self.capabilities.applicable_guards)),
@@ -613,20 +641,14 @@ class ClaudeCodeBackend:
             extras["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] = str(exit_after_stop_delay_ms)
         if stream_idle_timeout_ms > 0:
             extras["CLAUDE_STREAM_IDLE_TIMEOUT_MS"] = str(stream_idle_timeout_ms)
-        if scenario_step_name:
-            extras["SCENARIO_STEP_NAME"] = scenario_step_name
-        campaign_id = os.environ.get(CAMPAIGN_ID_ENV_VAR)
-        if campaign_id:
-            extras[CAMPAIGN_ID_ENV_VAR] = campaign_id
-        kitchen_session_id = os.environ.get(KITCHEN_SESSION_ID_ENV_VAR)
-        if kitchen_session_id:
-            extras[KITCHEN_SESSION_ID_ENV_VAR] = kitchen_session_id
-        if allowed_write_prefix:
-            extras["AUTOSKILLIT_ALLOWED_WRITE_PREFIX"] = allowed_write_prefix
-        if allowed_write_prefixes:
-            extras["AUTOSKILLIT_ALLOWED_WRITE_PREFIXES"] = ":".join(allowed_write_prefixes)
-        if cwd:
-            extras["AUTOSKILLIT_CWD"] = cwd
+        extras.update(
+            self._assemble_shared_env_extras(
+                write_prefix=allowed_write_prefix,
+                write_prefixes=allowed_write_prefixes,
+                cwd=cwd,
+                scenario_step_name=scenario_step_name,
+            )
+        )
         extras["AUTOSKILLIT_SKILL_NAME"] = extract_skill_name(skill_command) or ""
         if provider_extras:
             for k, v in provider_extras.items():
@@ -705,8 +727,6 @@ class ClaudeCodeBackend:
         extras: dict[str, str] = {
             "AUTOSKILLIT_HEADLESS": "1",
             "AUTOSKILLIT_SESSION_TYPE": SESSION_TYPE_ORCHESTRATOR,
-            "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
-            "MCP_CONNECTION_NONBLOCKING": "0",
             AGENT_BACKEND_ENV_VAR: AGENT_BACKEND_CLAUDE_CODE,
             AGENT_BACKEND_DYNACONF_ENV_VAR: AGENT_BACKEND_CLAUDE_CODE,
             AUTOSKILLIT_APPLICABLE_GUARDS: ",".join(sorted(self.capabilities.applicable_guards)),
@@ -718,17 +738,15 @@ class ClaudeCodeBackend:
             extras["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] = str(exit_after_stop_delay_ms)
         if stream_idle_timeout_ms > 0:
             extras["CLAUDE_STREAM_IDLE_TIMEOUT_MS"] = str(stream_idle_timeout_ms)
-        if scenario_step_name:
-            extras["SCENARIO_STEP_NAME"] = scenario_step_name
-        kitchen_session_id = os.environ.get(KITCHEN_SESSION_ID_ENV_VAR)
-        if kitchen_session_id:
-            extras[KITCHEN_SESSION_ID_ENV_VAR] = kitchen_session_id
-        if allowed_write_prefix:
-            extras["AUTOSKILLIT_ALLOWED_WRITE_PREFIX"] = allowed_write_prefix
-        if allowed_write_prefixes:
-            extras["AUTOSKILLIT_ALLOWED_WRITE_PREFIXES"] = ":".join(allowed_write_prefixes)
-        if cwd:
-            extras["AUTOSKILLIT_CWD"] = cwd
+        extras.update(
+            self._assemble_shared_env_extras(
+                write_prefix=allowed_write_prefix,
+                write_prefixes=allowed_write_prefixes,
+                cwd=cwd,
+                scenario_step_name=scenario_step_name,
+            )
+        )
+        extras.pop(CAMPAIGN_ID_ENV_VAR, None)  # food truck does not propagate campaign ID
         if env_extras:
             for k, v in env_extras.items():
                 if k not in _PROVIDER_EXTRAS_BASE_DENYLIST:

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -21,13 +21,11 @@ from autoskillit.core import (
     AUTOSKILLIT_APPLICABLE_GUARDS,
     AUTOSKILLIT_PRIVATE_ENV_VARS,
     AUTOSKILLIT_WRITE_GUARD_TOOL_NAMES,
-    CAMPAIGN_ID_ENV_VAR,
     CODEX_EFFORT_MAPPING,
     CODEX_INTERACTIVE_REQUIRED_ENV,
     CODEX_MCP_ENV_FORWARD_VARS,
     CODEX_MODEL_ALIASES,
     FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
-    KITCHEN_SESSION_ID_ENV_VAR,
     MCP_CLIENT_BACKEND_ENV_VAR,
     ORCHESTRATOR_SESSION_REQUIRED_ENV,
     RESUME_SESSION_BASELINE_KEYS,
@@ -56,9 +54,13 @@ from autoskillit.core import (
     load_yaml,
     pkg_root,
 )
+from autoskillit.execution.backends._backend_cmd_builder_base import (
+    SHARED_BASELINE_ENV,
+    BackendCmdBuilderBase,
+    FlagVocabulary,
+)
 from autoskillit.execution.backends._claude_prompt import (
     _HEADLESS_EXCLUSIVE_VARS,
-    _MAX_MCP_OUTPUT_TOKENS_VALUE,
     _PROVIDER_EXTRAS_BASE_DENYLIST,
     _SESSION_BASELINE_ENV,
     _SKILL_SESSION_EXTRAS_DENYLIST,
@@ -182,7 +184,7 @@ def _codex_exec_extras(
 ) -> dict[str, str]:
     extras: dict[str, str] = {}
     if include_session_baseline:
-        extras.update(_SESSION_BASELINE_ENV)
+        extras.update(SHARED_BASELINE_ENV)
     extras.update(
         {
             "AUTOSKILLIT_HEADLESS": "1",
@@ -471,7 +473,26 @@ def _generate_agent_tomls(session_dir: Path) -> int:
 
 
 @dataclass(frozen=True, slots=True)
-class CodexBackend:
+class CodexBackend(BackendCmdBuilderBase):
+    def _binary(self) -> str:
+        return "codex"
+
+    def _sandbox_default(self) -> str:
+        return "workspace-write"
+
+    def _env_policy(self) -> CodexEnvPolicy:
+        return CodexEnvPolicy()
+
+    def _flag_vocabulary(self) -> FlagVocabulary:
+        return FlagVocabulary(
+            variadic_flags=VARIADIC_CODEX_FLAGS,
+            non_variadic_flags=NON_VARIADIC_CODEX_FLAGS,
+            model_flag=CodexFlags.MODEL,
+            add_dir_flag=CodexFlags.ADD_DIR,
+            resume_flag=CodexFlags.RESUME_SUBCOMMAND,
+            config_override_flag=CodexFlags.CONFIG_OVERRIDE,
+        )
+
     @property
     def name(self) -> str:
         return AGENT_BACKEND_CODEX
@@ -677,22 +698,14 @@ class CodexBackend:
             applicable_guards=self.capabilities.applicable_guards,
             write_guard_tool_names=self.capabilities.write_guard_tool_names,
         )
-        extras["MAX_MCP_OUTPUT_TOKENS"] = _MAX_MCP_OUTPUT_TOKENS_VALUE
-        extras["MCP_CONNECTION_NONBLOCKING"] = "0"
-        if scenario_step_name:
-            extras["SCENARIO_STEP_NAME"] = scenario_step_name
-        campaign_id = os.environ.get(CAMPAIGN_ID_ENV_VAR)
-        if campaign_id:
-            extras[CAMPAIGN_ID_ENV_VAR] = campaign_id
-        kitchen_session_id = os.environ.get(KITCHEN_SESSION_ID_ENV_VAR)
-        if kitchen_session_id:
-            extras[KITCHEN_SESSION_ID_ENV_VAR] = kitchen_session_id
-        if allowed_write_prefix:
-            extras["AUTOSKILLIT_ALLOWED_WRITE_PREFIX"] = allowed_write_prefix
-        if allowed_write_prefixes:
-            extras["AUTOSKILLIT_ALLOWED_WRITE_PREFIXES"] = ":".join(allowed_write_prefixes)
-        if cwd:
-            extras["AUTOSKILLIT_CWD"] = cwd
+        extras.update(
+            self._assemble_shared_env_extras(
+                write_prefix=allowed_write_prefix,
+                write_prefixes=allowed_write_prefixes,
+                cwd=cwd,
+                scenario_step_name=scenario_step_name,
+            )
+        )
         extras["AUTOSKILLIT_SKILL_NAME"] = extract_skill_name(skill_command) or ""
         if provider_extras:
             for k, v in provider_extras.items():
@@ -784,24 +797,16 @@ class CodexBackend:
             applicable_guards=self.capabilities.applicable_guards,
             write_guard_tool_names=self.capabilities.write_guard_tool_names,
         )
-        extras["MAX_MCP_OUTPUT_TOKENS"] = _MAX_MCP_OUTPUT_TOKENS_VALUE
-        extras["MCP_CONNECTION_NONBLOCKING"] = "0"
-        if scenario_step_name:
-            extras["SCENARIO_STEP_NAME"] = scenario_step_name
-        campaign_id = os.environ.get(CAMPAIGN_ID_ENV_VAR)
-        if campaign_id:
-            extras[CAMPAIGN_ID_ENV_VAR] = campaign_id
-        kitchen_session_id = os.environ.get(KITCHEN_SESSION_ID_ENV_VAR)
-        if kitchen_session_id:
-            extras[KITCHEN_SESSION_ID_ENV_VAR] = kitchen_session_id
+        extras.update(
+            self._assemble_shared_env_extras(
+                write_prefix=allowed_write_prefix,
+                write_prefixes=allowed_write_prefixes,
+                cwd=cwd,
+                scenario_step_name=scenario_step_name,
+            )
+        )
         if completion_marker:
             extras["AUTOSKILLIT_COMPLETION_MARKER"] = completion_marker
-        if allowed_write_prefix:
-            extras["AUTOSKILLIT_ALLOWED_WRITE_PREFIX"] = allowed_write_prefix
-        if allowed_write_prefixes:
-            extras["AUTOSKILLIT_ALLOWED_WRITE_PREFIXES"] = ":".join(allowed_write_prefixes)
-        if cwd:
-            extras["AUTOSKILLIT_CWD"] = cwd
         if env_extras:
             for k, v in env_extras.items():
                 if k not in _PROVIDER_EXTRAS_BASE_DENYLIST:

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -62,7 +62,6 @@ from autoskillit.execution.backends._backend_cmd_builder_base import (
 from autoskillit.execution.backends._claude_prompt import (
     _HEADLESS_EXCLUSIVE_VARS,
     _PROVIDER_EXTRAS_BASE_DENYLIST,
-    _SESSION_BASELINE_ENV,
     _SKILL_SESSION_EXTRAS_DENYLIST,
     PromptBuildContext,
     _compose_resume_prompt,
@@ -882,7 +881,7 @@ class CodexBackend(BackendCmdBuilderBase):
         for d in add_dirs:
             builder.variadic_pair(CodexFlags.ADD_DIR, str(d))
         base_env = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}
-        merged_extras: dict[str, str] = dict(_SESSION_BASELINE_ENV)
+        merged_extras: dict[str, str] = dict(SHARED_BASELINE_ENV)
         merged_extras.update(
             {
                 "AUTOSKILLIT_HEADLESS": "",

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from autoskillit.core import CmdSpec
 from autoskillit.execution.backends._claude_prompt import (
     _HEADLESS_EXCLUSIVE_VARS,  # noqa: F401 — re-export for downstream consumers
-    _MAX_MCP_OUTPUT_TOKENS_VALUE,  # noqa: F401 — re-export for downstream consumers
-    _SESSION_BASELINE_ENV,  # noqa: F401 — re-export for downstream consumers
     PromptBuildContext,  # noqa: F401 — re-export for downstream consumers
     _apply_output_format,  # noqa: F401 — re-export for downstream consumers
     _build_resume_context,  # noqa: F401 — re-export for downstream consumers

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -980,7 +980,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "dispatch gate add defense-in-depth checks",
     ),
     "execution/backends/codex.py": (
-        1065,
+        1060,
         "REQ-CNST-010-E9: Codex backend — skill_sigil capability threading adds multi-line "
         "keyword args to _ensure_skill_prefix call sites and _has_prefix guard; "
         "write_guard_tool_names env injection adds 7 lines to _codex_exec_extras; "
@@ -992,10 +992,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "; project_log_dir method added to CodexSessionLocator (+3 net lines)"
         "; session_log_path method added to CodexSessionLocator (+5 net lines)"
         "; process_idle_timeout_ms field wired through build_skill_session_cmd and "
-        "build_food_truck_cmd CmdSpec constructors (+8 net lines)"
-        "; T5-P4-A1-WP1 BackendCmdBuilderBase inheritance adds 4 extension-point methods "
-        "(~20 lines) net +8 lines after env-assembly consolidation in build_skill_session_cmd "
-        "and build_food_truck_cmd",
+        "build_food_truck_cmd CmdSpec constructors (+8 net lines)",
     ),
 }
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -980,7 +980,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "dispatch gate add defense-in-depth checks",
     ),
     "execution/backends/codex.py": (
-        1060,
+        1065,
         "REQ-CNST-010-E9: Codex backend — skill_sigil capability threading adds multi-line "
         "keyword args to _ensure_skill_prefix call sites and _has_prefix guard; "
         "write_guard_tool_names env injection adds 7 lines to _codex_exec_extras; "
@@ -992,7 +992,10 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "; project_log_dir method added to CodexSessionLocator (+3 net lines)"
         "; session_log_path method added to CodexSessionLocator (+5 net lines)"
         "; process_idle_timeout_ms field wired through build_skill_session_cmd and "
-        "build_food_truck_cmd CmdSpec constructors (+8 net lines)",
+        "build_food_truck_cmd CmdSpec constructors (+8 net lines)"
+        "; T5-P4-A1-WP1 BackendCmdBuilderBase inheritance adds 4 extension-point methods "
+        "(~20 lines) net +8 lines after env-assembly consolidation in build_skill_session_cmd "
+        "and build_food_truck_cmd",
     ),
 }
 

--- a/tests/cli/test_cook_env_scrub.py
+++ b/tests/cli/test_cook_env_scrub.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from autoskillit.execution import _MAX_MCP_OUTPUT_TOKENS_VALUE
+from autoskillit.execution.backends._backend_cmd_builder_base import SHARED_BASELINE_ENV
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
@@ -89,7 +89,7 @@ def test_launch_cook_session_env_has_max_mcp_output_tokens(
         _launch_cook_session("system prompt", initial_message="hello")
 
     env = mock_run.call_args.kwargs["env"]
-    assert env["MAX_MCP_OUTPUT_TOKENS"] == _MAX_MCP_OUTPUT_TOKENS_VALUE
+    assert env["MAX_MCP_OUTPUT_TOKENS"] == SHARED_BASELINE_ENV["MAX_MCP_OUTPUT_TOKENS"]
 
 
 def test_launch_cook_session_env_has_mcp_connection_nonblocking(
@@ -173,4 +173,4 @@ def test_cook_command_env_has_max_mcp_output_tokens(
         cook()
 
     env = mock_run.call_args.kwargs["env"]
-    assert env["MAX_MCP_OUTPUT_TOKENS"] == _MAX_MCP_OUTPUT_TOKENS_VALUE
+    assert env["MAX_MCP_OUTPUT_TOKENS"] == SHARED_BASELINE_ENV["MAX_MCP_OUTPUT_TOKENS"]

--- a/tests/execution/backends/test_backend_cmd_builder_base.py
+++ b/tests/execution/backends/test_backend_cmd_builder_base.py
@@ -1,0 +1,155 @@
+"""Tests for execution/backends/_backend_cmd_builder_base.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import (
+    CAMPAIGN_ID_ENV_VAR,
+    KITCHEN_SESSION_ID_ENV_VAR,
+    SkillSessionConfig,
+)
+from autoskillit.execution.backends import ClaudeCodeBackend, CodexBackend
+from autoskillit.execution.backends._backend_cmd_builder_base import (
+    SHARED_BASELINE_ENV,
+    BackendCmdBuilderBase,
+    FlagVocabulary,
+)
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class _ConcreteBuilder(BackendCmdBuilderBase):
+    """Minimal concrete subclass for testing _apply_config."""
+
+    def _binary(self) -> str:
+        return "test-binary"
+
+    def _sandbox_default(self) -> str:
+        return "test-sandbox"
+
+    def _env_policy(self):  # pragma: no cover - not exercised in these tests
+        return None
+
+    def _flag_vocabulary(self) -> FlagVocabulary:
+        return FlagVocabulary(
+            variadic_flags=frozenset(),
+            non_variadic_flags=frozenset(),
+            model_flag="--model",
+            add_dir_flag="--add-dir",
+            resume_flag="--resume",
+            config_override_flag="-c",
+        )
+
+
+class TestFlagVocabulary:
+    def test_fields(self) -> None:
+        fv = FlagVocabulary(
+            variadic_flags=frozenset({"--add-dir"}),
+            non_variadic_flags=frozenset({"--json"}),
+            model_flag="--model",
+            add_dir_flag="--add-dir",
+            resume_flag="--resume",
+            config_override_flag="-c",
+        )
+        assert isinstance(fv.variadic_flags, frozenset)
+        assert isinstance(fv.non_variadic_flags, frozenset)
+        assert isinstance(fv.model_flag, str)
+        assert isinstance(fv.add_dir_flag, str)
+        assert isinstance(fv.resume_flag, str)
+        assert isinstance(fv.config_override_flag, str)
+
+    def test_is_namedtuple(self) -> None:
+        assert issubclass(FlagVocabulary, tuple)
+        assert hasattr(FlagVocabulary, "_fields")
+        assert len(FlagVocabulary._fields) == 6
+
+
+class TestAssembleSharedEnvExtras:
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(CAMPAIGN_ID_ENV_VAR, "camp-123")
+        monkeypatch.setenv(KITCHEN_SESSION_ID_ENV_VAR, "kitchen-456")
+
+    def test_all_eight_keys(self) -> None:
+        result = BackendCmdBuilderBase._assemble_shared_env_extras(
+            write_prefix="/tmp/wp",
+            write_prefixes=("/tmp/a", "/tmp/b"),
+            cwd="/work",
+            scenario_step_name="step1",
+        )
+        assert result["MAX_MCP_OUTPUT_TOKENS"] == "50000"
+        assert result["MCP_CONNECTION_NONBLOCKING"] == "0"
+        assert result[CAMPAIGN_ID_ENV_VAR] == "camp-123"
+        assert result[KITCHEN_SESSION_ID_ENV_VAR] == "kitchen-456"
+        assert result["AUTOSKILLIT_ALLOWED_WRITE_PREFIX"] == "/tmp/wp"
+        assert result["AUTOSKILLIT_ALLOWED_WRITE_PREFIXES"] == "/tmp/a:/tmp/b"
+        assert result["AUTOSKILLIT_CWD"] == "/work"
+        assert result["SCENARIO_STEP_NAME"] == "step1"
+
+    def test_conditional_keys_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(CAMPAIGN_ID_ENV_VAR, raising=False)
+        monkeypatch.delenv(KITCHEN_SESSION_ID_ENV_VAR, raising=False)
+        result = BackendCmdBuilderBase._assemble_shared_env_extras()
+        assert "MAX_MCP_OUTPUT_TOKENS" in result
+        assert "MCP_CONNECTION_NONBLOCKING" in result
+        assert CAMPAIGN_ID_ENV_VAR not in result
+        assert KITCHEN_SESSION_ID_ENV_VAR not in result
+        assert "AUTOSKILLIT_ALLOWED_WRITE_PREFIX" not in result
+        assert "AUTOSKILLIT_ALLOWED_WRITE_PREFIXES" not in result
+        assert "AUTOSKILLIT_CWD" not in result
+        assert "SCENARIO_STEP_NAME" not in result
+
+
+class TestApplyConfig:
+    def test_round_trip(self) -> None:
+        config = SkillSessionConfig(
+            completion_marker="%%DONE%%",
+            model="sonnet",
+            scenario_step_name="s1",
+            allowed_write_prefix="/tmp",
+            allowed_write_prefixes=("/a", "/b"),
+            sandbox_mode="read-only",
+        )
+        result = _ConcreteBuilder()._apply_config(config)
+        assert result["completion_marker"] == "%%DONE%%"
+        assert result["model"] == "sonnet"
+        assert result["scenario_step_name"] == "s1"
+        assert result["allowed_write_prefix"] == "/tmp"
+        assert result["allowed_write_prefixes"] == ("/a", "/b")
+        assert result["sandbox_mode"] == "read-only"
+
+
+class TestSubclassRelationship:
+    def test_claude_is_subclass(self) -> None:
+        assert isinstance(ClaudeCodeBackend(), BackendCmdBuilderBase)
+
+    def test_codex_is_subclass(self) -> None:
+        assert isinstance(CodexBackend(), BackendCmdBuilderBase)
+
+
+class TestExtensionPoints:
+    def test_claude_binary(self) -> None:
+        assert ClaudeCodeBackend()._binary() == "claude"
+
+    def test_codex_binary(self) -> None:
+        assert CodexBackend()._binary() == "codex"
+
+    def test_claude_flag_vocabulary(self) -> None:
+        fv = ClaudeCodeBackend()._flag_vocabulary()
+        assert isinstance(fv, FlagVocabulary)
+        assert fv.model_flag == "--model"
+
+    def test_codex_flag_vocabulary(self) -> None:
+        fv = CodexBackend()._flag_vocabulary()
+        assert isinstance(fv, FlagVocabulary)
+        assert fv.model_flag == "--model"
+        assert fv.config_override_flag == "-c"
+
+
+class TestSharedBaselineEnv:
+    def test_exactly_two_keys(self) -> None:
+        assert set(SHARED_BASELINE_ENV.keys()) == {
+            "MAX_MCP_OUTPUT_TOKENS",
+            "MCP_CONNECTION_NONBLOCKING",
+        }

--- a/tests/execution/backends/test_backend_cmd_builder_base.py
+++ b/tests/execution/backends/test_backend_cmd_builder_base.py
@@ -52,12 +52,12 @@ class TestFlagVocabulary:
             resume_flag="--resume",
             config_override_flag="-c",
         )
-        assert isinstance(fv.variadic_flags, frozenset)
-        assert isinstance(fv.non_variadic_flags, frozenset)
-        assert isinstance(fv.model_flag, str)
-        assert isinstance(fv.add_dir_flag, str)
-        assert isinstance(fv.resume_flag, str)
-        assert isinstance(fv.config_override_flag, str)
+        assert fv.variadic_flags == frozenset({"--add-dir"})
+        assert fv.non_variadic_flags == frozenset({"--json"})
+        assert fv.model_flag == "--model"
+        assert fv.add_dir_flag == "--add-dir"
+        assert fv.resume_flag == "--resume"
+        assert fv.config_override_flag == "-c"
 
     def test_is_namedtuple(self) -> None:
         assert issubclass(FlagVocabulary, tuple)
@@ -78,6 +78,7 @@ class TestAssembleSharedEnvExtras:
             cwd="/work",
             scenario_step_name="step1",
         )
+        assert len(result) == 8
         assert result["MAX_MCP_OUTPUT_TOKENS"] == "50000"
         assert result["MCP_CONNECTION_NONBLOCKING"] == "0"
         assert result[CAMPAIGN_ID_ENV_VAR] == "camp-123"

--- a/tests/execution/backends/test_backends_split_integrity.py
+++ b/tests/execution/backends/test_backends_split_integrity.py
@@ -21,10 +21,10 @@ class TestClaudePromptModuleExists:
 
         assert callable(_inject_completion_directive)
 
-    def test__MAX_MCP_OUTPUT_TOKENS_VALUE_importable(self):
-        from autoskillit.execution.backends._claude_prompt import _MAX_MCP_OUTPUT_TOKENS_VALUE
+    def test_SHARED_BASELINE_ENV_importable_from_claude_prompt_base(self):
+        from autoskillit.execution.backends._backend_cmd_builder_base import SHARED_BASELINE_ENV
 
-        assert _MAX_MCP_OUTPUT_TOKENS_VALUE == "50000"
+        assert SHARED_BASELINE_ENV["MAX_MCP_OUTPUT_TOKENS"] == "50000"
 
 
 class TestCodexConfigModuleExists:

--- a/tests/execution/backends/test_backends_split_integrity.py
+++ b/tests/execution/backends/test_backends_split_integrity.py
@@ -76,6 +76,25 @@ class TestCodexScenarioPlayerModuleExists:
         assert callable(make_codex_scenario_player)
 
 
+class TestBackendCmdBuilderBaseModuleExists:
+    """Symbols in _backend_cmd_builder_base are importable from there."""
+
+    def test_BackendCmdBuilderBase_importable(self):
+        from autoskillit.execution.backends._backend_cmd_builder_base import BackendCmdBuilderBase
+
+        assert BackendCmdBuilderBase is not None
+
+    def test_FlagVocabulary_importable(self):
+        from autoskillit.execution.backends._backend_cmd_builder_base import FlagVocabulary
+
+        assert FlagVocabulary is not None
+
+    def test_SHARED_BASELINE_ENV_importable(self):
+        from autoskillit.execution.backends._backend_cmd_builder_base import SHARED_BASELINE_ENV
+
+        assert "MAX_MCP_OUTPUT_TOKENS" in SHARED_BASELINE_ENV
+
+
 class TestBackendsPublicAPISurfacePreserved:
     """All __all__ symbols from backends/__init__ are importable."""
 

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -467,14 +467,12 @@ class TestCodexResumeCmd:
 
     def test_resume_cmd_uses_filtered_base_env(self, monkeypatch) -> None:
         from autoskillit.core import CODEX_MCP_ENV_FORWARD_VARS
-        from autoskillit.execution.commands import (
-            _HEADLESS_EXCLUSIVE_VARS,
-            _SESSION_BASELINE_ENV,
-        )
+        from autoskillit.execution.backends._backend_cmd_builder_base import SHARED_BASELINE_ENV
+        from autoskillit.execution.commands import _HEADLESS_EXCLUSIVE_VARS
 
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "leaked")
         spec = CodexBackend().build_resume_cmd(resume_session_id="abc123", prompt="continue")
-        reinjected = frozenset(_SESSION_BASELINE_ENV.keys()) | CODEX_MCP_ENV_FORWARD_VARS
+        reinjected = frozenset(SHARED_BASELINE_ENV.keys()) | CODEX_MCP_ENV_FORWARD_VARS
         leaking = (_HEADLESS_EXCLUSIVE_VARS - reinjected) & spec.env.keys()
         assert not leaking, f"_HEADLESS_EXCLUSIVE_VARS leaked into resume env: {leaking}"
 

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -5,17 +5,14 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.core import CmdSpec
-from autoskillit.execution.commands import (
-    _MAX_MCP_OUTPUT_TOKENS_VALUE,
-    _SESSION_BASELINE_ENV,
-)
+from autoskillit.execution.backends._backend_cmd_builder_base import SHARED_BASELINE_ENV
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 def test_session_baseline_env_contains_mcp_connection_nonblocking() -> None:
-    assert "MCP_CONNECTION_NONBLOCKING" in _SESSION_BASELINE_ENV
-    assert _SESSION_BASELINE_ENV["MCP_CONNECTION_NONBLOCKING"] == "0"
+    assert "MCP_CONNECTION_NONBLOCKING" in SHARED_BASELINE_ENV
+    assert SHARED_BASELINE_ENV["MCP_CONNECTION_NONBLOCKING"] == "0"
 
 
 def test_cmdspec_importable_from_execution() -> None:
@@ -33,6 +30,6 @@ def test_cmdspec_in_execution_all() -> None:
 
 
 def test_max_mcp_output_tokens_value_is_string() -> None:
-    """_MAX_MCP_OUTPUT_TOKENS_VALUE must be a non-empty string."""
-    assert isinstance(_MAX_MCP_OUTPUT_TOKENS_VALUE, str)
-    assert _MAX_MCP_OUTPUT_TOKENS_VALUE
+    """MAX_MCP_OUTPUT_TOKENS in SHARED_BASELINE_ENV must be a non-empty string."""
+    assert isinstance(SHARED_BASELINE_ENV["MAX_MCP_OUTPUT_TOKENS"], str)
+    assert SHARED_BASELINE_ENV["MAX_MCP_OUTPUT_TOKENS"]

--- a/tests/execution/test_commands_invariants.py
+++ b/tests/execution/test_commands_invariants.py
@@ -7,12 +7,10 @@ from pathlib import Path
 import pytest
 
 from autoskillit.core import ClaudeFlags, DirectInstall, OutputFormat
+from autoskillit.execution.backends._backend_cmd_builder_base import SHARED_BASELINE_ENV
 from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.backends.codex import CodexBackend
-from autoskillit.execution.commands import (
-    _HEADLESS_EXCLUSIVE_VARS,
-    _MAX_MCP_OUTPUT_TOKENS_VALUE,
-)
+from autoskillit.execution.commands import _HEADLESS_EXCLUSIVE_VARS
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -66,7 +64,7 @@ def test_all_session_builders_inject_max_mcp_output_tokens(builder_call) -> None
     """Every session command builder must produce env with MAX_MCP_OUTPUT_TOKENS."""
     spec = builder_call()
     assert "MAX_MCP_OUTPUT_TOKENS" in spec.env
-    assert spec.env["MAX_MCP_OUTPUT_TOKENS"] == _MAX_MCP_OUTPUT_TOKENS_VALUE
+    assert spec.env["MAX_MCP_OUTPUT_TOKENS"] == SHARED_BASELINE_ENV["MAX_MCP_OUTPUT_TOKENS"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Create `BackendCmdBuilderBase` as a `@dataclass(frozen=True, slots=True)` ABC in a new module `_backend_cmd_builder_base.py` within `execution/backends/`. This ABC owns the canonical definition of the eight shared env keys that both `ClaudeCodeBackend` and `CodexBackend` currently duplicate. Both backends inherit from it. `_codex_exec_extras` is demoted to a shim that derives the two always-on shared keys from the base class without calling the full `_assemble_shared_env_extras()` (which also reads ambient env vars — not appropriate for the `include_session_baseline` path). `FlagVocabulary` NamedTuple captures per-backend CLI flag metadata.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.



Closes #4014

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260612-083826-983233/.autoskillit/temp/make-plan/t5_p4_a1_wp1_backend_cmd_builder_base_plan_2026-06-12_090000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.3k | 38.2k | 2.5M | 141.0k | 72 | 150.9k | 17m 12s |
| verify* | sonnet | 1 | 1.3k | 19.3k | 672.1k | 74.1k | 36 | 74.3k | 7m 33s |
| implement* | MiniMax-M3 | 1 | 10.5M | 29.0k | 0 | 0 | 174 | 0 | 24m 36s |
| audit_impl* | sonnet | 1 | 1.4k | 14.0k | 333.0k | 66.0k | 18 | 46.5k | 7m 46s |
| prepare_pr* | MiniMax-M3 | 1 | 211.4k | 2.6k | 0 | 0 | 13 | 0 | 1m 3s |
| compose_pr* | MiniMax-M3 | 1 | 176.9k | 1.4k | 0 | 0 | 12 | 0 | 41s |
| review_pr* | sonnet | 1 | 132 | 36.2k | 983.5k | 98.3k | 44 | 79.2k | 9m 54s |
| resolve_review* | sonnet | 1 | 613 | 46.1k | 7.6M | 137.3k | 167 | 235.5k | 19m 30s |
| **Total** | | | 10.9M | 187.0k | 12.1M | 141.0k | | 586.5k | 1h 28m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 527 | 0.0 | 0.0 | 55.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 97 | 78401.9 | 2428.3 | 475.4 |
| **Total** | **624** | 19322.5 | 939.9 | 299.6 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.3k | 38.2k | 2.5M | 150.9k | 17m 12s |
| sonnet | 4 | 3.5k | 115.7k | 9.6M | 435.6k | 44m 44s |
| MiniMax-M3 | 3 | 10.9M | 33.1k | 0 | 0 | 26m 21s |