### PR TITLE
[FIX] Double open_kitchen Context Cost — Pre-Reveal / Deferred-Recall Architectural Immunity

### DIFF
--- a/src/autoskillit/pipeline/context.py
+++ b/src/autoskillit/pipeline/context.py
@@ -168,6 +168,7 @@ class ToolContext:
     recipe_content_hash: str = field(default="")
     recipe_composite_hash: str = field(default="")
     recipe_version: str = field(default="")
+    gate_infrastructure_ready: bool = field(default=False)
     kitchen_id: str = field(default="")
     active_recipe_packs: frozenset[str] | None = field(default_factory=lambda: None)
     active_recipe_features: frozenset[str] | None = field(default_factory=lambda: None)

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -342,6 +342,7 @@ async def _pre_reveal_kitchen(ctx: Any) -> None:
     register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
     _write_hook_config()
     await _prime_quota_cache()
+    ctx.gate_infrastructure_ready = True
 
 
 async def _food_truck_auto_gate_boot(ctx: Any) -> None:

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -518,6 +518,7 @@ async def open_kitchen(
 
         _ctx_pre = _get_ctx()
         _skip_handler = _ctx_pre.gate_infrastructure_ready
+        tool_ctx = _get_ctx()
 
         if not _skip_handler:
             handler_err = await _open_kitchen_handler()
@@ -554,7 +555,7 @@ async def open_kitchen(
                     logger.warning(
                         "open_kitchen_failure", stage="enable_components", exc_info=True
                     )
-                    _get_ctx().gate_infrastructure_ready = False
+                    tool_ctx.gate_infrastructure_ready = False
                     return _kitchen_failure_envelope(exc, stage="enable_components")
 
             try:
@@ -567,7 +568,7 @@ async def open_kitchen(
                 )
             except Exception as exc:
                 logger.warning("open_kitchen_failure", stage="redisable_subsets", exc_info=True)
-                _get_ctx().gate_infrastructure_ready = False
+                tool_ctx.gate_infrastructure_ready = False
                 return _kitchen_failure_envelope(exc, stage="redisable_subsets")
 
         _is_deferred_recall = (

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -554,6 +554,7 @@ async def open_kitchen(
                     logger.warning(
                         "open_kitchen_failure", stage="enable_components", exc_info=True
                     )
+                    _get_ctx().gate_infrastructure_ready = False
                     return _kitchen_failure_envelope(exc, stage="enable_components")
 
             try:
@@ -566,6 +567,7 @@ async def open_kitchen(
                 )
             except Exception as exc:
                 logger.warning("open_kitchen_failure", stage="redisable_subsets", exc_info=True)
+                _get_ctx().gate_infrastructure_ready = False
                 return _kitchen_failure_envelope(exc, stage="redisable_subsets")
 
         _is_deferred_recall = (

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -276,6 +276,7 @@ async def _open_kitchen_handler() -> str | None:
     except Exception:
         logger.warning("open_kitchen_registry_failed", exc_info=True)
 
+    ctx.gate_infrastructure_ready = True
     return None
 
 
@@ -331,6 +332,7 @@ def _close_kitchen_handler() -> None:
     ctx.recipe_content_hash = ""
     ctx.recipe_composite_hash = ""
     ctx.recipe_version = ""
+    ctx.gate_infrastructure_ready = False
     logger.info("close_kitchen", gate_state="closed")
     if (log := ctx.github_api_log) is not None:
         orphan_usage = log.drain(ctx.kitchen_id)
@@ -515,15 +517,29 @@ async def open_kitchen(
         disabled_subsets = _get_ctx().config.subsets.disabled
 
         _ctx_pre = _get_ctx()
-        _is_deferred_recall = (
-            name is not None and _ctx_pre.gate.enabled and _ctx_pre.recipe_name == name
-        )
+        _skip_handler = _ctx_pre.gate_infrastructure_ready
 
-        if not _is_deferred_recall:
+        if not _skip_handler:
             handler_err = await _open_kitchen_handler()
             if handler_err is not None:
                 return handler_err
+        else:
+            _ctx_post = _get_ctx()
+            if _ctx_post.quota_refresh_task is None:
+                try:
+                    _ctx_post.quota_refresh_task = create_background_task(
+                        _quota_refresh_loop(
+                            _ctx_post.config.quota_guard,
+                            provider=resolve_provider(_ctx_post.config.providers.default_provider),
+                        ),
+                        label="quota_refresh_loop",
+                    )
+                except Exception:
+                    logger.warning(
+                        "open_kitchen_quota_refresh_deferred_start_failed", exc_info=True
+                    )
 
+        if not _skip_handler:
             _kctx_pre = _get_ctx()
             _skip_notify = (
                 _kctx_pre.backend is not None
@@ -551,6 +567,13 @@ async def open_kitchen(
             except Exception as exc:
                 logger.warning("open_kitchen_failure", stage="redisable_subsets", exc_info=True)
                 return _kitchen_failure_envelope(exc, stage="redisable_subsets")
+
+        _is_deferred_recall = (
+            name is not None
+            and _ctx_pre.gate.enabled
+            and _ctx_pre.recipe_name == name
+            and _ctx_pre.recipe_name != ""
+        )
 
         _forbidden_list = ", ".join(PIPELINE_FORBIDDEN_TOOLS)
         _ctx = _get_ctx()
@@ -645,6 +668,7 @@ async def open_kitchen(
                 # Default to False for missing 'valid' so a absent key is treated as invalid
                 if not result.get("valid", False) or not result.get("content", ""):
                     tool_ctx.gate.disable()
+                    tool_ctx.gate_infrastructure_ready = False
                     return _recipe_validation_error_response(name, result)
                 # Dispatch-feasibility preflight: verify the backend can enforce
                 # all fix-required hooks for the recipe's run_skill steps.
@@ -658,6 +682,7 @@ async def open_kitchen(
                     )
                     if _preflight_err is not None:
                         tool_ctx.gate.disable()
+                        tool_ctx.gate_infrastructure_ready = False
                         await ctx.disable_components(tags={"kitchen"})
                         return _preflight_err
                 result["success"] = True
@@ -680,6 +705,8 @@ async def open_kitchen(
                     )
                     if _override_warnings:
                         result["warnings"] = _override_warnings
+                if ingredients_only:
+                    result = strip_ingredients_only_keys(result)
                 return json.dumps(result)
             try:
                 result = tool_ctx.recipes.load_and_validate(
@@ -749,6 +776,7 @@ async def open_kitchen(
 
             if not result.get("valid", False) or not result.get("content", ""):
                 tool_ctx.gate.disable()
+                tool_ctx.gate_infrastructure_ready = False
                 return _recipe_validation_error_response(name, result)
 
             # Dispatch-feasibility preflight: verify the backend can enforce
@@ -763,6 +791,7 @@ async def open_kitchen(
                 )
                 if _preflight_err is not None:
                     tool_ctx.gate.disable()
+                    tool_ctx.gate_infrastructure_ready = False
                     await ctx.disable_components(tags={"kitchen"})
                     return _preflight_err
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -962,14 +962,16 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "co-located with the execution engine that calls them",
     ),
     "tools_kitchen.py": (
-        1200,
+        1250,
         "REQ-CNST-010-E7: kitchen tool handlers — open_kitchen and lock_ingredients require "
         "inline validation helpers (_check_override_keys, _build_ingredient_key_suggestions) "
         "for ingredient key validation; splitting would cross import-layer boundaries; "
         "backend capability promotion delegated to _promote_capability_keys in _auto_overrides; "
         "fail-closed validity gate on both deferred-recall and normal paths adds structural "
         "error propagation from LoadRecipeResult; get_recipe validity guard adds 9 lines; "
-        "dispatch-feasibility preflight wiring on both paths with gate-close on failure",
+        "dispatch-feasibility preflight wiring on both paths with gate-close on failure; "
+        "gate_infrastructure_ready guard restructuring adds 22 lines for handler-skip path, "
+        "quota_refresh_loop deferred start, and all four gate.disable() rollback resets",
     ),
     "tools_execution.py": (
         1130,

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -122,8 +122,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools/tools_kitchen.py", 171),
     ("src/autoskillit/server/tools/tools_kitchen.py", 190),
     ("src/autoskillit/server/tools/tools_kitchen.py", 224),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 918),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 978),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 947),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1007),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -122,8 +122,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools/tools_kitchen.py", 171),
     ("src/autoskillit/server/tools/tools_kitchen.py", 190),
     ("src/autoskillit/server/tools/tools_kitchen.py", 224),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 949),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 1009),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 950),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1010),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -122,8 +122,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools/tools_kitchen.py", 171),
     ("src/autoskillit/server/tools/tools_kitchen.py", 190),
     ("src/autoskillit/server/tools/tools_kitchen.py", 224),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 947),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 1007),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 949),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1009),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -107,6 +107,7 @@ def _make_mock_ctx() -> MagicMock:
     ctx.project_dir = Path("/fake/project")
     ctx.config.subsets.disabled = []  # REQ-VIS-008: no subsets disabled by default
     ctx.active_recipe_ingredients = None
+    ctx.gate_infrastructure_ready = False
     return ctx
 
 

--- a/tests/server/test_kitchen_lifecycle.py
+++ b/tests/server/test_kitchen_lifecycle.py
@@ -87,3 +87,38 @@ async def test_close_kitchen_removes_tracker_dir(monkeypatch, tmp_path):
         _close_kitchen_handler()
 
     assert not tracker_dir.exists()
+
+
+async def test_back_to_back_open_close_open_resets_infrastructure(monkeypatch, tmp_path):
+    """After close, gate_infrastructure_ready must be False so a re-open runs the handler."""
+    monkeypatch.chdir(tmp_path)
+
+    ctx = make_context(
+        AutomationConfig(),
+        runner=None,
+        plugin_source=DirectInstall(plugin_dir=tmp_path),
+        project_dir=tmp_path,
+    )
+    monkeypatch.setattr(_state, "_ctx", ctx)
+    monkeypatch.setattr(_state, "_startup_ready", None)
+
+    with (
+        patch("autoskillit.server.tools.tools_kitchen._prime_quota_cache", new_callable=AsyncMock),
+        patch("autoskillit.core.register_active_kitchen"),
+        patch("autoskillit.core.unregister_active_kitchen"),
+    ):
+        result1 = await _open_kitchen_handler()
+        assert result1 is None
+        assert ctx.gate_infrastructure_ready is True
+
+        _close_kitchen_handler()
+        assert ctx.gate_infrastructure_ready is False
+
+        result2 = await _open_kitchen_handler()
+        assert result2 is None
+        assert ctx.gate_infrastructure_ready is True
+
+        task = ctx.quota_refresh_task
+        await asyncio.sleep(0)
+        if task is not None:
+            assert task.cancelled() or task.done()

--- a/tests/server/test_kitchen_lifecycle.py
+++ b/tests/server/test_kitchen_lifecycle.py
@@ -110,15 +110,19 @@ async def test_back_to_back_open_close_open_resets_infrastructure(monkeypatch, t
         result1 = await _open_kitchen_handler()
         assert result1 is None
         assert ctx.gate_infrastructure_ready is True
+        first_task = ctx.quota_refresh_task
 
         _close_kitchen_handler()
         assert ctx.gate_infrastructure_ready is False
+        await asyncio.sleep(0)
+        assert first_task.cancelled() or first_task.done()
 
         result2 = await _open_kitchen_handler()
         assert result2 is None
         assert ctx.gate_infrastructure_ready is True
+        second_task = ctx.quota_refresh_task
+        assert second_task is not first_task
 
-        task = ctx.quota_refresh_task
+        _close_kitchen_handler()
         await asyncio.sleep(0)
-        if task is not None:
-            assert task.cancelled() or task.done()
+        assert second_task.cancelled() or second_task.done()

--- a/tests/server/test_lifespan_skill_boot.py
+++ b/tests/server/test_lifespan_skill_boot.py
@@ -353,6 +353,9 @@ class TestSkillAutoGateBoot:
         assert ctx.kitchen_id is not None, "kitchen_id should be set by pre-reveal path"
         assert ctx.active_recipe_packs == frozenset()
         assert ctx.active_recipe_steps == {}
+        assert ctx.gate_infrastructure_ready is True, (
+            "gate_infrastructure_ready should be True after pre-reveal"
+        )
 
     @pytest.mark.anyio
     async def test_codex_non_headless_pre_reveal_suppresses_disabled_subset(

--- a/tests/server/test_open_kitchen_deferred_recall.py
+++ b/tests/server/test_open_kitchen_deferred_recall.py
@@ -337,34 +337,6 @@ async def test_gate_rollback_resets_gate_infrastructure_ready():
 
 
 @pytest.mark.anyio
-async def test_pre_reveal_backend_does_not_support_tool_list_changed():
-    """Simulates Codex pre-reveal: gate enabled, recipe_name empty, infrastructure ready.
-    Handler must be skipped, recipe loaded normally."""
-    from autoskillit.server.tools import tools_kitchen
-
-    mock_ctx = _make_pre_revealed_ctx("test-recipe")
-    mock_recipe_info = MagicMock()
-    mock_recipe_info.path = Path("/fake/.autoskillit/recipes/test-recipe.yaml")
-    mock_ctx.recipes.find.return_value = mock_recipe_info
-    mock_recipe_obj = MagicMock()
-    mock_recipe_obj.steps = {"build": {"cmd": "task build"}}
-    mock_recipe_obj.ingredients = {"ing1": "val1"}
-    mock_ctx.recipes.load.return_value = mock_recipe_obj
-
-    with (
-        patch("autoskillit.server._get_ctx", return_value=mock_ctx),
-        patch.object(
-            tools_kitchen, "_open_kitchen_handler", new_callable=MagicMock
-        ) as mock_handler,
-    ):
-        result = await tools_kitchen.open_kitchen(name="test-recipe", ctx=mock_ctx)
-
-    mock_handler.assert_not_called()
-    parsed = json.loads(result)
-    assert parsed["success"] is True
-
-
-@pytest.mark.anyio
 async def test_cold_open_kitchen_runs_handler():
     """When gate_infrastructure_ready is False (cold state), handler must run."""
     from autoskillit.server.tools import tools_kitchen

--- a/tests/server/test_open_kitchen_deferred_recall.py
+++ b/tests/server/test_open_kitchen_deferred_recall.py
@@ -238,7 +238,7 @@ async def test_pre_reveal_then_open_does_not_re_execute_handler():
     with (
         patch("autoskillit.server._get_ctx", return_value=mock_ctx),
         patch.object(
-            tools_kitchen, "_open_kitchen_handler", new_callable=MagicMock
+            tools_kitchen, "_open_kitchen_handler", new_callable=AsyncMock
         ) as mock_handler,
     ):
         result = await tools_kitchen.open_kitchen(name="test-recipe", ctx=mock_ctx)
@@ -300,7 +300,7 @@ async def test_double_open_kitchen_no_name_does_not_re_execute_handler():
     with (
         patch("autoskillit.server._get_ctx", return_value=mock_ctx),
         patch.object(
-            tools_kitchen, "_open_kitchen_handler", new_callable=MagicMock
+            tools_kitchen, "_open_kitchen_handler", new_callable=AsyncMock
         ) as mock_handler,
     ):
         result = await tools_kitchen.open_kitchen(ctx=mock_ctx)

--- a/tests/server/test_open_kitchen_deferred_recall.py
+++ b/tests/server/test_open_kitchen_deferred_recall.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -376,7 +376,7 @@ async def test_cold_open_kitchen_runs_handler():
     with (
         patch("autoskillit.server._get_ctx", return_value=mock_ctx),
         patch.object(
-            tools_kitchen, "_open_kitchen_handler", new_callable=MagicMock
+            tools_kitchen, "_open_kitchen_handler", new_callable=AsyncMock
         ) as mock_handler,
     ):
         mock_handler.return_value = None

--- a/tests/server/test_open_kitchen_deferred_recall.py
+++ b/tests/server/test_open_kitchen_deferred_recall.py
@@ -18,6 +18,7 @@ def _make_deferred_recall_ctx(name: str) -> MagicMock:
     ctx.gate.enabled = True
     ctx.recipe_name = name
     ctx.kitchen_id = "test-kitchen"
+    ctx.gate_infrastructure_ready = True
     return ctx
 
 
@@ -196,3 +197,190 @@ async def test_deferred_recall_fails_closed_when_valid_missing():
     assert parsed["stage"] == "recipe_validation"
     assert parsed["errors"] == []
     assert "user_visible_message" in parsed
+
+
+def _make_pre_revealed_ctx(name: str) -> MagicMock:
+    ctx = _make_mock_ctx()
+    ctx.gate.enabled = True
+    ctx.recipe_name = ""
+    ctx.kitchen_id = "test-kitchen"
+    ctx.gate_infrastructure_ready = True
+    ctx.recipes.load_and_validate.return_value = {
+        "content": "name: test-recipe\nsteps:\n  build:\n    cmd: task build\n",
+        "valid": True,
+        "errors": [],
+        "requires_packs": [],
+        "requires_features": [],
+        "content_hash": "abc123",
+        "composite_hash": "def456",
+        "recipe_version": "1.0",
+        "suggestions": [],
+        "post_prune_step_names": ["build", "test"],
+    }
+    return ctx
+
+
+@pytest.mark.anyio
+async def test_pre_reveal_then_open_does_not_re_execute_handler():
+    """Pre-revealed state (gate enabled, recipe_name empty, infrastructure ready)
+    must skip _open_kitchen_handler and still load the recipe."""
+    from autoskillit.server.tools import tools_kitchen
+
+    mock_ctx = _make_pre_revealed_ctx("test-recipe")
+    mock_recipe_info = MagicMock()
+    mock_recipe_info.path = Path("/fake/.autoskillit/recipes/test-recipe.yaml")
+    mock_ctx.recipes.find.return_value = mock_recipe_info
+    mock_recipe_obj = MagicMock()
+    mock_recipe_obj.steps = {"build": {"cmd": "task build"}}
+    mock_recipe_obj.ingredients = {"ing1": "val1"}
+    mock_ctx.recipes.load.return_value = mock_recipe_obj
+
+    with (
+        patch("autoskillit.server._get_ctx", return_value=mock_ctx),
+        patch.object(
+            tools_kitchen, "_open_kitchen_handler", new_callable=MagicMock
+        ) as mock_handler,
+    ):
+        result = await tools_kitchen.open_kitchen(name="test-recipe", ctx=mock_ctx)
+
+    mock_handler.assert_not_called()
+    parsed = json.loads(result)
+    assert parsed["success"] is True
+
+
+@pytest.mark.anyio
+async def test_deferred_recall_strips_content_when_ingredients_only_true():
+    """Deferred-recall path must respect ingredients_only flag."""
+    from autoskillit.server.tools import tools_kitchen
+
+    mock_ctx = _make_deferred_recall_ctx("test-recipe")
+    mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "name: test-recipe\nsteps:\n  build:\n    cmd: task build\n",
+        "valid": True,
+        "errors": [],
+        "requires_packs": [],
+        "requires_features": [],
+        "content_hash": "abc",
+        "composite_hash": "def",
+        "recipe_version": "1.0",
+        "suggestions": [],
+        "orchestration_rules": "some rules",
+        "stop_step_semantics": "some semantics",
+    }
+    mock_recipe_info = MagicMock()
+    mock_recipe_info.path = Path("/fake/.autoskillit/recipes/test-recipe.yaml")
+    mock_ctx.recipes.find.return_value = mock_recipe_info
+    mock_recipe_obj = MagicMock()
+    mock_recipe_obj.steps = {"build": {"cmd": "task build"}}
+    mock_recipe_obj.ingredients = {"ing1": "val1"}
+    mock_ctx.recipes.load.return_value = mock_recipe_obj
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        result = await tools_kitchen.open_kitchen(
+            name="test-recipe", ingredients_only=True, ctx=mock_ctx
+        )
+
+    parsed = json.loads(result)
+    assert "content" not in parsed
+    assert "orchestration_rules" not in parsed
+    assert "stop_step_semantics" not in parsed
+
+
+@pytest.mark.anyio
+async def test_double_open_kitchen_no_name_does_not_re_execute_handler():
+    """Calling open_kitchen() with name=None while infrastructure is ready
+    must not re-run _open_kitchen_handler."""
+    from autoskillit.server.tools import tools_kitchen
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.gate.enabled = True
+    mock_ctx.gate_infrastructure_ready = True
+    mock_ctx.kitchen_id = "test-kitchen"
+
+    with (
+        patch("autoskillit.server._get_ctx", return_value=mock_ctx),
+        patch.object(
+            tools_kitchen, "_open_kitchen_handler", new_callable=MagicMock
+        ) as mock_handler,
+    ):
+        result = await tools_kitchen.open_kitchen(ctx=mock_ctx)
+
+    mock_handler.assert_not_called()
+    assert isinstance(result, str)
+
+
+@pytest.mark.anyio
+async def test_gate_rollback_resets_gate_infrastructure_ready():
+    """When recipe validation fails in deferred-recall path, gate_infrastructure_ready
+    must be reset so the next open_kitchen call re-runs the handler."""
+    from autoskillit.server.tools import tools_kitchen
+
+    mock_ctx = _make_pre_revealed_ctx("bad-recipe")
+    mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "",
+        "valid": False,
+        "errors": ["structural error"],
+        "requires_packs": [],
+        "requires_features": [],
+        "content_hash": "abc",
+        "composite_hash": "def",
+        "recipe_version": "1.0",
+        "suggestions": [],
+    }
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        result = await tools_kitchen.open_kitchen(name="bad-recipe", ctx=mock_ctx)
+
+    parsed = json.loads(result)
+    assert parsed["success"] is False
+    assert mock_ctx.gate_infrastructure_ready is False
+
+
+@pytest.mark.anyio
+async def test_pre_reveal_backend_does_not_support_tool_list_changed():
+    """Simulates Codex pre-reveal: gate enabled, recipe_name empty, infrastructure ready.
+    Handler must be skipped, recipe loaded normally."""
+    from autoskillit.server.tools import tools_kitchen
+
+    mock_ctx = _make_pre_revealed_ctx("test-recipe")
+    mock_recipe_info = MagicMock()
+    mock_recipe_info.path = Path("/fake/.autoskillit/recipes/test-recipe.yaml")
+    mock_ctx.recipes.find.return_value = mock_recipe_info
+    mock_recipe_obj = MagicMock()
+    mock_recipe_obj.steps = {"build": {"cmd": "task build"}}
+    mock_recipe_obj.ingredients = {"ing1": "val1"}
+    mock_ctx.recipes.load.return_value = mock_recipe_obj
+
+    with (
+        patch("autoskillit.server._get_ctx", return_value=mock_ctx),
+        patch.object(
+            tools_kitchen, "_open_kitchen_handler", new_callable=MagicMock
+        ) as mock_handler,
+    ):
+        result = await tools_kitchen.open_kitchen(name="test-recipe", ctx=mock_ctx)
+
+    mock_handler.assert_not_called()
+    parsed = json.loads(result)
+    assert parsed["success"] is True
+
+
+@pytest.mark.anyio
+async def test_cold_open_kitchen_runs_handler():
+    """When gate_infrastructure_ready is False (cold state), handler must run."""
+    from autoskillit.server.tools import tools_kitchen
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.gate.enabled = False
+    mock_ctx.gate_infrastructure_ready = False
+
+    with (
+        patch("autoskillit.server._get_ctx", return_value=mock_ctx),
+        patch.object(
+            tools_kitchen, "_open_kitchen_handler", new_callable=MagicMock
+        ) as mock_handler,
+    ):
+        mock_handler.return_value = None
+        result = await tools_kitchen.open_kitchen(name="test-recipe", ctx=mock_ctx)
+
+    mock_handler.assert_called_once()
+    assert isinstance(result, str)


### PR DESCRIPTION
## Summary

The `open_kitchen` MCP tool lacks a unified gate-infrastructure / content-delivery separation. When the Codex backend pre-reveals kitchen tools at lifespan boot (`_pre_reveal_kitchen`), it opens the gate and performs side effects (hook config, quota prime, registry) but does NOT set `ctx.recipe_name`. When the agent subsequently calls `open_kitchen(name="X")`, the `_is_deferred_recall` guard fails (`recipe_name == ""` != `"X"`), causing the full `_open_kitchen_handler()` to re-execute — redundantly re-opening the gate, generating a new `kitchen_id`, re-writing hook config, re-priming quota, and restarting the quota refresh loop. Then the recipe is loaded and the full ~100KB payload is returned. The pre-reveal work is wasted and the gate infrastructure is initialized twice.

Additionally, the `_is_deferred_recall` path (lines 595-683 of `tools_kitchen.py`) returns the **full** `LoadRecipeResult` including the `content` field (~72-102KB recipe YAML), with no `ingredients_only` stripping applied. This means every deferred recall re-sends the entire recipe.

The architectural weakness is that `open_kitchen` conflates three concerns into a single code path: (1) gate infrastructure setup, (2) recipe content loading, and (3) response payload assembly. The `_is_deferred_recall` flag is a boolean that either skips or runs the handler wholesale, with no intermediate state for "gate already open, just load recipe."

Closes #4089

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260612-091855-490847/.autoskillit/temp/rectify/rectify_double_open_kitchen_context_cost_2026-06-12_091855.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| resolve_review* | sonnet | 12 | 3.8k | 198.4k | 25.0M | 137.3k | 835 | 924.8k | 1h 33m |
| dispatch:44d3705c-3f62-459b-af5b-9678f2bbcb64* | sonnet | 1 | 114 | 3.6k | 1.2M | 94.6k | 28 | 94.9k | 23m 9s |
| plan* | opus[1m] | 12 | 14.6k | 260.4k | 17.6M | 141.0k | 544 | 1.0M | 2h 47m |
| verify* | sonnet | 12 | 5.6k | 155.7k | 6.5M | 74.1k | 363 | 546.0k | 1h 14m |
| implement* | MiniMax-M3 | 12 | 36.6M | 172.1k | 0 | 0 | 970 | 0 | 1h 40m |
| audit_impl* | sonnet | 12 | 8.5k | 113.5k | 2.7M | 66.0k | 195 | 396.4k | 1h 1m |
| prepare_pr* | MiniMax-M3 | 11 | 2.5M | 25.6k | 0 | 0 | 155 | 0 | 11m 4s |
| compose_pr* | MiniMax-M3 | 11 | 2.1M | 17.0k | 0 | 0 | 138 | 0 | 9m 33s |
| review_pr* | sonnet | 16 | 2.4k | 413.6k | 15.7M | 101.1k | 710 | 907.8k | 1h 43m |
| dispatch:0145c757-e69c-4878-929a-ba4acb07e3d1* | sonnet | 1 | 322 | 13.7k | 3.0M | 86.3k | 84 | 62.0k | 42m 39s |
| fix* | sonnet | 6 | 980 | 43.2k | 6.6M | 98.2k | 318 | 293.1k | 32m 54s |
| dispatch:341f411a-3d76-4fcf-88a3-15a64c6d7bd4* | sonnet | 1 | 354 | 10.0k | 3.4M | 86.4k | 89 | 62.0k | 1h 18m |
| dispatch:7e27c189-e656-4ec2-b528-b128157c59a8* | sonnet | 1 | 490 | 17.2k | 5.0M | 98.3k | 122 | 73.9k | 1h 26m |
| dispatch:36a96fbc-6c25-4316-a068-66f069a326ac* | sonnet | 1 | 386 | 14.1k | 3.8M | 89.9k | 102 | 65.5k | 1h 14m |
| dispatch:540912dc-04a8-4bda-b6dd-1ba4a533b68f* | sonnet | 1 | 418 | 12.6k | 4.1M | 89.9k | 106 | 65.5k | 1h 27m |
| dispatch:726982d8-8d44-4345-91ee-7c36d41bf8c0* | sonnet | 1 | 330 | 11.6k | 3.1M | 84.9k | 82 | 60.5k | 1h 10m |
| dispatch:c51e35aa-e1dc-42fd-91a6-8cadbf463f94* | sonnet | 1 | 418 | 12.6k | 4.1M | 90.7k | 107 | 66.3k | 1h 36m |
| dispatch:136d06d2-7313-45ac-b80d-f17a96a36af8* | sonnet | 1 | 322 | 10.0k | 3.0M | 83.9k | 80 | 59.5k | 1h 8m |
| dispatch:04f878e3-4291-4f0d-bae2-8cc73470181d* | sonnet | 1 | 468 | 164 | 4.1M | 81.4k | 58 | 201.6k | 1h 0m |
| dispatch:037f42f2-ac88-494d-b62b-2764614ba87c* | sonnet | 1 | 330 | 9.7k | 3.0M | 84.4k | 84 | 140.6k | 1h 48m |
| diagnose_ci* | MiniMax-M3 | 1 | 277.2k | 2.0k | 0 | 0 | 16 | 0 | 1m 6s |
| resolve_ci* | sonnet | 1 | 158 | 6.4k | 908.4k | 56.9k | 49 | 36.3k | 4m 1s |
| **Total** | | | 41.5M | 1.5M | 112.7M | 141.0k | | 5.1M | 24h 16m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| resolve_review | 197 | 127121.5 | 4694.2 | 1007.2 |
| dispatch:44d3705c-3f62-459b-af5b-9678f2bbcb64 | 0 | — | — | — |
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 2268 | 0.0 | 0.0 | 75.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| dispatch:0145c757-e69c-4878-929a-ba4acb07e3d1 | 360 | 8363.5 | 172.2 | 38.2 |
| fix | 36 | 182321.1 | 8141.6 | 1199.6 |
| dispatch:341f411a-3d76-4fcf-88a3-15a64c6d7bd4 | 446 | 7548.5 | 139.0 | 22.5 |
| dispatch:7e27c189-e656-4ec2-b528-b128157c59a8 | 235 | 21444.0 | 314.5 | 73.2 |
| dispatch:36a96fbc-6c25-4316-a068-66f069a326ac | 0 | — | — | — |
| dispatch:540912dc-04a8-4bda-b6dd-1ba4a533b68f | 0 | — | — | — |
| dispatch:726982d8-8d44-4345-91ee-7c36d41bf8c0 | 0 | — | — | — |
| dispatch:c51e35aa-e1dc-42fd-91a6-8cadbf463f94 | 844 | 4875.8 | 78.5 | 14.9 |
| dispatch:136d06d2-7313-45ac-b80d-f17a96a36af8 | 0 | — | — | — |
| dispatch:04f878e3-4291-4f0d-bae2-8cc73470181d | 0 | — | — | — |
| dispatch:037f42f2-ac88-494d-b62b-2764614ba87c | 0 | — | — | — |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 7 | 129768.6 | 5190.9 | 914.9 |
| **Total** | **4393** | 25656.8 | 1160.8 | 346.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| sonnet | 17 | 25.4k | 1.0M | 95.1M | 4.1M | 19h 27m |
| opus[1m] | 1 | 14.6k | 260.4k | 17.6M | 1.0M | 2h 47m |
| MiniMax-M3 | 4 | 41.5M | 216.8k | 0 | 0 | 2h 2m |