### PR TITLE
Implementation Plan: T5-P4-A2-WP2 Make build_inspector_cmd a Proper Capability-Gated Method

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -223,6 +223,7 @@ from .types import BackgroundSupervisor as BackgroundSupervisor
 from .types import BareResume as BareResume
 from .types import CampaignProtector as CampaignProtector
 from .types import CanonicalTokenUsage as CanonicalTokenUsage
+from .types import CapabilityNotSupportedError as CapabilityNotSupportedError
 from .types import CaptureEntrySpec as CaptureEntrySpec
 from .types import CaptureValueType as CaptureValueType
 from .types import CaptureValueTypeError as CaptureValueTypeError

--- a/src/autoskillit/core/types/_type_exceptions.py
+++ b/src/autoskillit/core/types/_type_exceptions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 __all__ = [
+    "CapabilityNotSupportedError",
     "RecipeLoadError",
     "ProcessStaleError",
     "RecipeNotFoundError",
@@ -19,3 +20,12 @@ class ProcessStaleError(RecipeLoadError):
 
 class RecipeNotFoundError(RecipeLoadError):
     """Named recipe could not be found in any scan directory."""
+
+
+class CapabilityNotSupportedError(Exception):
+    """Backend does not support the requested capability."""
+
+    def __init__(self, capability: str, backend_name: str) -> None:
+        self.capability = capability
+        self.backend_name = backend_name
+        super().__init__(f"{backend_name!r} does not support capability {capability!r}")

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -27,6 +27,7 @@ from autoskillit.core import (
     BackendConventions,
     BackendEventKind,
     BareResume,
+    CapabilityNotSupportedError,
     ClaudeDirectoryConventions,
     ClaudeEventData,
     ClaudeFlags,
@@ -865,4 +866,7 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
         return []
 
     def build_inspector_cmd(self, prompt: str, *, model: str = "") -> CmdSpec:
-        raise RuntimeError("build_inspector_cmd not yet implemented — lands in #3534")
+        if not self.capabilities.inspector_capable:
+            raise CapabilityNotSupportedError("inspector_capable", self.name)
+        msg = "inspector_capable is True but build_inspector_cmd has no implementation"
+        raise AssertionError(msg)

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -35,6 +35,7 @@ from autoskillit.core import (
     BackendCapabilities,
     BackendConventions,
     BareResume,
+    CapabilityNotSupportedError,
     ClaudeDirectoryConventions,
     CmdSpec,
     CodexEventType,
@@ -1054,4 +1055,7 @@ class CodexBackend(BackendCmdBuilderBase):
         return errors
 
     def build_inspector_cmd(self, prompt: str, *, model: str = "") -> CmdSpec:
-        raise RuntimeError("build_inspector_cmd not yet implemented — lands in #3534")
+        if not self.capabilities.inspector_capable:
+            raise CapabilityNotSupportedError("inspector_capable", self.name)
+        msg = "inspector_capable is True but build_inspector_cmd has no implementation"
+        raise AssertionError(msg)

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -248,7 +248,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "_type_constants_registries": frozenset(
         {"cli", "config", "core", "pipeline", "recipe", "server", "workspace"}
     ),
-    "_type_exceptions": frozenset({"core", "fleet", "recipe", "server"}),
+    "_type_exceptions": frozenset({"core", "execution", "fleet", "recipe", "server"}),
     "_type_phoropter": frozenset({"core"}),
     "_type_tradition_manifest": frozenset({"core"}),
     "_step_context": frozenset({"core", "execution", "pipeline", "server"}),

--- a/tests/arch/test_capability_consumption.py
+++ b/tests/arch/test_capability_consumption.py
@@ -44,11 +44,6 @@ _FORWARD_DECLARED: dict[str, ForwardDeclaredField] = {
         rationale="MCP env forwarding — enforcement arch test exists, awaiting src/ consumer",
         added_date=date(2026, 5, 31),
     ),
-    "inspector_capable": ForwardDeclaredField(
-        issue=3533,
-        rationale="Health Inspector capability gating — production consumer in #3574",
-        added_date=date(2026, 6, 1),
-    ),
     "required_session_files": ForwardDeclaredField(
         issue=3134,
         rationale=(

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -980,7 +980,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "dispatch gate add defense-in-depth checks",
     ),
     "execution/backends/codex.py": (
-        1060,
+        1062,
         "REQ-CNST-010-E9: Codex backend — skill_sigil capability threading adds multi-line "
         "keyword args to _ensure_skill_prefix call sites and _has_prefix guard; "
         "write_guard_tool_names env injection adds 7 lines to _codex_exec_extras; "
@@ -992,7 +992,8 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "; project_log_dir method added to CodexSessionLocator (+3 net lines)"
         "; session_log_path method added to CodexSessionLocator (+5 net lines)"
         "; process_idle_timeout_ms field wired through build_skill_session_cmd and "
-        "build_food_truck_cmd CmdSpec constructors (+8 net lines)",
+        "build_food_truck_cmd CmdSpec constructors (+8 net lines)"
+        "; CapabilityNotSupportedError capability-gate in build_inspector_cmd (+1 net line)",
     ),
 }
 

--- a/tests/execution/backends/test_backend_behavioral_contract.py
+++ b/tests/execution/backends/test_backend_behavioral_contract.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from autoskillit.core import DirectInstall
+from autoskillit.core import CapabilityNotSupportedError, DirectInstall
 from autoskillit.execution.backends import BACKEND_REGISTRY
 from autoskillit.execution.backends.codex import CodexBackend
 
@@ -21,6 +21,10 @@ CAPABILITY_METHOD_MAP: dict[str, tuple[str, dict]] = {
             "cwd": "/tmp",
             "completion_marker": "%%X%%",
         },
+    ),
+    "inspector_capable": (
+        "build_inspector_cmd",
+        {"prompt": "test prompt"},
     ),
     "session_resume_capable": (
         "build_resume_cmd",
@@ -44,9 +48,14 @@ class TestCapabilityMethodConsistency:
             except (RuntimeError, NotImplementedError) as exc:
                 pytest.fail(f"{backend_name}.{method_name}() raised {type(exc).__name__}: {exc}")
 
-    def test_inspector_capable_is_false(self, backend_name: str) -> None:
+    def test_incapable_backends_raise_capability_not_supported(self, backend_name: str) -> None:
         backend = BACKEND_REGISTRY[backend_name]()
-        assert backend.capabilities.inspector_capable is False
+        if backend.capabilities.inspector_capable:
+            pytest.skip("backend is inspector_capable")
+        with pytest.raises(CapabilityNotSupportedError) as exc_info:
+            backend.build_inspector_cmd("test prompt")
+        assert exc_info.value.capability == "inspector_capable"
+        assert exc_info.value.backend_name == backend_name
 
 
 class TestWriteDetectionStrategyRouting:

--- a/tests/execution/backends/test_coding_agent_backend_conformance.py
+++ b/tests/execution/backends/test_coding_agent_backend_conformance.py
@@ -11,6 +11,7 @@ import pytest
 from autoskillit.core import (
     BackendCapabilities,
     BackendConventions,
+    CapabilityNotSupportedError,
     CmdSpec,
     CodingAgentBackend,
     DirectInstall,
@@ -28,7 +29,6 @@ pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 NOT_YET_LIVE: frozenset[str] = frozenset(
     {
-        "inspector_capable",
         "min_version",
         "patch_format",
         "required_session_files",
@@ -276,9 +276,10 @@ class TestCodingAgentBackendConformance(BackendContractBase):
         """BackendCapabilities.inspector_capable — raises when not capable."""
         if self.backend.capabilities.inspector_capable:
             pytest.skip("backend is inspector_capable — not testing the not-capable path")
-        with pytest.raises(RuntimeError) as exc_info:
+        with pytest.raises(CapabilityNotSupportedError) as exc_info:
             self.backend.build_inspector_cmd("test prompt")
-        assert "not yet implemented" in str(exc_info.value)
+        assert exc_info.value.capability == "inspector_capable"
+        assert exc_info.value.backend_name == self.backend.name
 
     # --- Group 6: Behavioral Contracts ---
 

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -211,7 +211,7 @@ class TestModuleCascadeCore:
 
     def test_type_exceptions_cascade(self) -> None:
         assert MODULE_CASCADE_CORE["_type_exceptions"] == frozenset(
-            {"core", "fleet", "recipe", "server"}
+            {"core", "execution", "fleet", "recipe", "server"}
         )
 
     def test_step_context_cascade(self) -> None:
@@ -670,7 +670,7 @@ class TestBuildTestScopeCoreCascade:
             )
 
     def test_type_exceptions_narrow_cascade(self, tmp_path: Path) -> None:
-        """_type_exceptions → narrow cascade of 4 dirs."""
+        """_type_exceptions → narrow cascade of 5 dirs."""
         tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
         result = build_test_scope(
             changed_files={"src/autoskillit/core/types/_type_exceptions.py"},
@@ -679,12 +679,11 @@ class TestBuildTestScopeCoreCascade:
         )
         assert result is not None
         dir_names = {p.name for p in result}
-        for pkg in ["core", "fleet", "recipe", "server"]:
+        for pkg in ["core", "execution", "fleet", "recipe", "server"]:
             assert pkg in dir_names, f"_type_exceptions cascade should include {pkg}"
         for excluded in [
             "cli",
             "config",
-            "execution",
             "pipeline",
             "migration",
             "workspace",


### PR DESCRIPTION
## Summary

Replace the unchecked `RuntimeError` stubs in both `ClaudeCodeBackend.build_inspector_cmd` and `CodexBackend.build_inspector_cmd` with a proper `CapabilityNotSupportedError` that is raised only when `inspector_capable=False`. This involves:

1. Defining `CapabilityNotSupportedError(Exception)` in `core/types/_type_exceptions.py` with structured `capability` and `backend_name` fields
2. Replacing `RuntimeError` raises in both backends with `CapabilityNotSupportedError`
3. Removing `inspector_capable` from `_FORWARD_DECLARED` (it now has a production consumer)
4. Updating conformance tests to assert the new exception type
5. Adding a parametrized arch test in `test_backend_behavioral_contract.py`

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260612-102320-415368/.autoskillit/temp/make-plan/t5-p4-a2-wp2-capability-gated-build-inspector-cmd_plan_2026-06-12_103500.md`

Closes #4017

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 3.5k | 11.9k | 1.1M | 94.3k | 40 | 73.3k | 10m 33s |
| verify* | sonnet | 1 | 172 | 13.7k | 1.1M | 65.3k | 72 | 44.4k | 4m 17s |
| implement* | MiniMax-M3 | 1 | 2.0M | 8.4k | 0 | 0 | 74 | 0 | 4m 16s |
| fix* | sonnet | 1 | 126 | 5.2k | 692.4k | 59.5k | 42 | 38.6k | 5m 34s |
| audit_impl* | sonnet | 1 | 46 | 16.1k | 168.1k | 43.3k | 17 | 38.9k | 5m 34s |
| prepare_pr* | MiniMax-M3 | 1 | 196.1k | 2.3k | 0 | 0 | 13 | 0 | 55s |
| compose_pr* | MiniMax-M3 | 1 | 176.6k | 1.2k | 0 | 0 | 11 | 0 | 46s |
| review_pr* | sonnet | 1 | 156 | 29.7k | 1.0M | 78.0k | 48 | 57.9k | 6m 46s |
| resolve_review* | sonnet | 1 | 205 | 15.7k | 1.5M | 81.2k | 60 | 61.0k | 7m 53s |
| diagnose_ci* | MiniMax-M3 | 1 | 277.2k | 2.0k | 0 | 0 | 16 | 0 | 1m 6s |
| resolve_ci* | sonnet | 1 | 158 | 6.4k | 908.4k | 56.9k | 49 | 36.3k | 4m 1s |
| **Total** | | | 2.7M | 112.8k | 6.5M | 94.3k | | 350.4k | 51m 44s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 50 | 0.0 | 0.0 | 167.2 |
| fix | 7 | 98910.0 | 5514.4 | 745.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 7 | 129768.6 | 5190.9 | 914.9 |
| **Total** | **64** | 102109.6 | 5475.1 | 1762.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 3.5k | 11.9k | 1.1M | 73.3k | 10m 33s |
| sonnet | 6 | 863 | 86.9k | 5.4M | 277.1k | 34m 7s |
| MiniMax-M3 | 4 | 2.7M | 14.0k | 0 | 0 | 7m 2s |