### PR TITLE
T5-P4-A4-WP2 Eliminate Generator G6 (Dead Canonical Constant)

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -499,6 +499,11 @@ def _materialize_profile_skills(session_dir: Path) -> int:
         try:
             target.symlink_to(entry.resolve())
         except OSError:
+            logger.debug(
+                "codex_profile_skill_symlink_failed_using_copytree",
+                skill=entry.name,
+                exc_info=True,
+            )
             try:
                 shutil.copytree(entry, target)
             except OSError:

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -472,6 +472,46 @@ def _generate_agent_tomls(session_dir: Path) -> int:
     return count
 
 
+def _materialize_profile_skills(session_dir: Path) -> int:
+    """Symlink ~/.codex/skills/<name> dirs into session_dir/skills/<name>.
+
+    Scans Path.home() / ".codex" / "skills" for subdirectories containing
+    SKILL.md. Each is symlinked into session_dir/skills/<name>. Falls back
+    to shutil.copytree if symlink creation fails. Subdirectories without
+    SKILL.md are skipped. Returns the number of skills materialized.
+    """
+    profile_skills_root = Path.home() / ".codex" / "skills"
+    if not profile_skills_root.is_dir():
+        return 0
+    count = 0
+    skills_base = session_dir / "skills"
+    skills_base.mkdir(parents=True, exist_ok=True)
+    try:
+        entries = list(profile_skills_root.iterdir())
+    except OSError:
+        return 0
+    for entry in entries:
+        if not entry.is_dir() or not (entry / "SKILL.md").is_file():
+            continue
+        target = skills_base / entry.name
+        if target.exists() or target.is_symlink():
+            continue
+        try:
+            target.symlink_to(entry.resolve())
+        except OSError:
+            try:
+                shutil.copytree(entry, target)
+            except OSError:
+                logger.warning(
+                    "codex_profile_skill_copy_failed",
+                    skill=entry.name,
+                    exc_info=True,
+                )
+                continue
+        count += 1
+    return count
+
+
 @dataclass(frozen=True, slots=True)
 class CodexBackend(BackendCmdBuilderBase):
     def _binary(self) -> str:
@@ -1013,6 +1053,11 @@ class CodexBackend(BackendCmdBuilderBase):
             _generate_agent_tomls(session_dir)
         except Exception:
             logger.warning("codex_agent_toml_generation_failed", exc_info=True)
+
+        try:
+            _materialize_profile_skills(session_dir)
+        except Exception:
+            logger.warning("codex_profile_skills_materialization_failed", exc_info=True)
 
     def validate_skill_content(self, content: str) -> list[str]:
         return []

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -604,8 +604,13 @@ class DefaultSessionSkillManager:
 
         # Compute project-local overrides (REQ-OVR-001..004)
         _plsc = backend is None or backend.capabilities.project_local_skills_capable
+        _search_dirs: tuple[str, ...] | None = (
+            backend.conventions.project_local_skill_search_dirs or None
+            if backend is not None
+            else None
+        )
         overrides: frozenset[ProjectLocalOverride] = (
-            detect_project_local_overrides(project_dir)
+            detect_project_local_overrides(project_dir, search_dirs=_search_dirs)
             if project_dir is not None and _plsc
             else frozenset()
         )

--- a/src/autoskillit/workspace/skills.py
+++ b/src/autoskillit/workspace/skills.py
@@ -85,16 +85,21 @@ def _dir_mtime(path: Path) -> float:
         return 0.0
 
 
-def detect_project_local_overrides(project_dir: Path) -> frozenset[ProjectLocalOverride]:
+def detect_project_local_overrides(
+    project_dir: Path,
+    search_dirs: tuple[str, ...] | None = None,
+) -> frozenset[ProjectLocalOverride]:
     """Return project-local skill overrides with path provenance.
 
-    Scans all directories in ALL_PROJECT_LOCAL_SKILL_SEARCH_DIRS under
-    project_dir. First-match-wins: if a skill name appears under multiple
-    search dirs, only the first (by tuple order) is returned.
+    Scans all directories in `search_dirs` (or `_OVERRIDE_SEARCH_DIRS` when
+    `search_dirs is None`) under `project_dir`. First-match-wins: if a skill
+    name appears under multiple search dirs, only the first (by tuple order)
+    is returned.
     """
     overrides: set[ProjectLocalOverride] = set()
     seen: set[str] = set()
-    for subdir in _OVERRIDE_SEARCH_DIRS:
+    active = search_dirs if search_dirs is not None else _OVERRIDE_SEARCH_DIRS
+    for subdir in active:
         search_root = project_dir / subdir
         if not search_root.is_dir():
             continue

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -1469,6 +1469,10 @@ _TEST_LAYER_ALLOWLIST: dict[str, frozenset[str]] = {
     # workspace tests
     "tests/workspace/test_clone_ci_contract.py": frozenset({"autoskillit.execution"}),
     "tests/workspace/test_skills.py": frozenset({"autoskillit.config"}),
+    # project-local override tests use backend convention objects to verify scoping behavior
+    "tests/workspace/test_project_local_overrides.py": frozenset({"autoskillit.execution"}),
+    # codex session skills tests import _materialize_profile_skills from codex backend
+    "tests/workspace/test_session_skills_codex.py": frozenset({"autoskillit.execution"}),
     # recipe tests — recipe layer is IL-2 and may use workspace (IL-1 sibling) or config (IL-1)
     "tests/recipe/test_rules_inputs.py": frozenset({"autoskillit.config"}),
     "tests/recipe/test_contracts.py": frozenset({"autoskillit.workspace"}),

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -985,7 +985,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "dispatch gate add defense-in-depth checks",
     ),
     "execution/backends/codex.py": (
-        1066,
+        1109,
         "REQ-CNST-010-E9: Codex backend — skill_sigil capability threading adds multi-line "
         "keyword args to _ensure_skill_prefix call sites and _has_prefix guard; "
         "write_guard_tool_names env injection adds 7 lines to _codex_exec_extras; "
@@ -1001,7 +1001,9 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "; CapabilityNotSupportedError capability-gate in build_inspector_cmd (+1 net line); "
         "AGENT_BACKEND_ENV_VAR injection in build_interactive_cmd merged_extras (+1 net line) "
         "and build_resume_cmd _codex_exec_extras call expansion to multi-line (+2 net lines) "
-        "for T5-P4-A3-WP3 guard-hook backend dispatch",
+        "for T5-P4-A3-WP3 guard-hook backend dispatch"
+        "; _materialize_profile_skills function (~43 lines) for T5-P4-A4-WP2 profile skill "
+        "materialization into Codex session directories",
     ),
 }
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -985,7 +985,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "dispatch gate add defense-in-depth checks",
     ),
     "execution/backends/codex.py": (
-        1109,
+        1114,
         "REQ-CNST-010-E9: Codex backend — skill_sigil capability threading adds multi-line "
         "keyword args to _ensure_skill_prefix call sites and _has_prefix guard; "
         "write_guard_tool_names env injection adds 7 lines to _codex_exec_extras; "
@@ -1003,7 +1003,8 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "and build_resume_cmd _codex_exec_extras call expansion to multi-line (+2 net lines) "
         "for T5-P4-A3-WP3 guard-hook backend dispatch"
         "; _materialize_profile_skills function (~43 lines) for T5-P4-A4-WP2 profile skill "
-        "materialization into Codex session directories",
+        "materialization into Codex session directories"
+        "; debug-level symlink failure log in _materialize_profile_skills (+5 net lines)",
     ),
 }
 

--- a/tests/contracts/test_project_local_skill_delivery_contract.py
+++ b/tests/contracts/test_project_local_skill_delivery_contract.py
@@ -6,12 +6,14 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.core.types._type_backend import ALL_PROJECT_LOCAL_SKILL_SEARCH_DIRS
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 
 pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
 
 
-@pytest.mark.parametrize("search_dir", ALL_PROJECT_LOCAL_SKILL_SEARCH_DIRS)
+@pytest.mark.parametrize(
+    "search_dir", ClaudeCodeBackend().conventions.project_local_skill_search_dirs
+)
 def test_project_local_skill_delivered_from_each_search_dir(
     tmp_path: Path, search_dir: str
 ) -> None:
@@ -96,3 +98,59 @@ def test_project_dir_not_cwd_detects_overrides(tmp_path: Path) -> None:
         "override from kitchen root must be delivered even when CWD is a worktree"
     )
     assert "# KITCHEN LOCAL" in Path(delivered).read_text()
+
+
+def test_backend_scoped_delivery_excludes_foreign_search_dir(tmp_path: Path) -> None:
+    """claude-code backend must NOT deliver skills from .codex/skills/."""
+    from autoskillit.execution.backends import get_backend
+    from autoskillit.workspace.session_skills import (
+        DefaultSessionSkillManager,
+        SkillsDirectoryProvider,
+    )
+
+    project_root = tmp_path / "project"
+    foreign_skill_dir = project_root / ".codex" / "skills" / "foreign-skill"
+    foreign_skill_dir.mkdir(parents=True)
+    (foreign_skill_dir / "SKILL.md").write_text("# FOREIGN SKILL")
+
+    backend = get_backend("claude-code")
+    mgr = DefaultSessionSkillManager(SkillsDirectoryProvider(), ephemeral_root=tmp_path / "eph")
+    result = mgr.init_session(
+        "sess-foreign", cook_session=False, project_dir=project_root, backend=backend
+    )
+
+    delivered = result / ".claude" / "skills" / "foreign-skill" / "SKILL.md"
+    assert not Path(delivered).exists(), (
+        "claude-code backend must NOT deliver skills from .codex/skills/ "
+        "(not in claude-code conventions)"
+    )
+
+
+@pytest.mark.parametrize(
+    "search_dir", ClaudeCodeBackend().conventions.project_local_skill_search_dirs
+)
+def test_backend_scoped_delivery_includes_convention_dirs(tmp_path: Path, search_dir: str) -> None:
+    """claude-code backend delivers skills from each convention dir individually."""
+    from autoskillit.execution.backends import get_backend
+    from autoskillit.workspace.session_skills import (
+        DefaultSessionSkillManager,
+        SkillsDirectoryProvider,
+    )
+
+    project_root = tmp_path / "project"
+    skill_name = f"conv-skill-{search_dir.replace('/', '-').replace('.', '_')}"
+    skill_dir = project_root / search_dir / skill_name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(f"# CONVENTION SKILL from {search_dir}")
+
+    backend = get_backend("claude-code")
+    mgr = DefaultSessionSkillManager(SkillsDirectoryProvider(), ephemeral_root=tmp_path / "eph")
+    result = mgr.init_session(
+        "sess-conv", cook_session=False, project_dir=project_root, backend=backend
+    )
+
+    delivered = result / ".claude" / "skills" / skill_name / "SKILL.md"
+    assert Path(delivered).exists(), (
+        f"claude-code backend must deliver skill from convention dir {search_dir}"
+    )
+    assert "# CONVENTION SKILL" in Path(delivered).read_text()

--- a/tests/execution/backends/test_validate_session_layout.py
+++ b/tests/execution/backends/test_validate_session_layout.py
@@ -161,3 +161,36 @@ class TestCodexLayoutValidation:
         backend = CodexBackend()
         errors = backend.validate_session_layout(tmp_path)
         assert not any("sessions" in e and "symlink" in e for e in errors)
+
+    def test_codex_profile_skills_appear_in_session_dir(self, tmp_path, monkeypatch):
+        from autoskillit.execution.backends.codex import _materialize_profile_skills
+
+        fake_home = tmp_path / "fake_home"
+        profile_skill = fake_home / ".codex" / "skills" / "my-profile-skill"
+        profile_skill.mkdir(parents=True)
+        (profile_skill / "SKILL.md").write_text("# MY PROFILE SKILL")
+        # Subdir without SKILL.md should be skipped
+        (fake_home / ".codex" / "skills" / "no-skill-dir").mkdir()
+
+        session_dir = tmp_path / "session"
+        (session_dir / "skills").mkdir(parents=True)
+
+        monkeypatch.setenv("HOME", str(fake_home))
+        count = _materialize_profile_skills(session_dir)
+
+        assert count == 1
+        assert (session_dir / "skills" / "my-profile-skill" / "SKILL.md").exists()
+        assert not (session_dir / "skills" / "no-skill-dir").exists()
+
+    def test_codex_profile_skills_missing_codex_skills_dir_no_raise(self, tmp_path, monkeypatch):
+        from autoskillit.execution.backends.codex import _materialize_profile_skills
+
+        fake_home = tmp_path / "fake_home"
+        fake_home.mkdir()
+        session_dir = tmp_path / "session"
+        (session_dir / "skills").mkdir(parents=True)
+
+        monkeypatch.setenv("HOME", str(fake_home))
+        count = _materialize_profile_skills(session_dir)
+
+        assert count == 0

--- a/tests/execution/backends/test_validate_session_layout.py
+++ b/tests/execution/backends/test_validate_session_layout.py
@@ -175,7 +175,7 @@ class TestCodexLayoutValidation:
         session_dir = tmp_path / "session"
         (session_dir / "skills").mkdir(parents=True)
 
-        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
         count = _materialize_profile_skills(session_dir)
 
         assert count == 1
@@ -190,7 +190,7 @@ class TestCodexLayoutValidation:
         session_dir = tmp_path / "session"
         (session_dir / "skills").mkdir(parents=True)
 
-        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
         count = _materialize_profile_skills(session_dir)
 
         assert count == 0

--- a/tests/server/test_tools_execution_command.py
+++ b/tests/server/test_tools_execution_command.py
@@ -284,6 +284,7 @@ class TestRunSkillExecutionMarker:
         mock_backend.conventions.skills_subdir = ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR
         mock_backend.capabilities.mcp_config_capable = False
         mock_backend.capabilities.session_dir_persistent = False
+        mock_backend.capabilities.project_local_skills_capable = False
         mock_backend.validate_session_layout.return_value = []
         tool_ctx_kitchen_open.backend = mock_backend
 

--- a/tests/workspace/test_project_local_overrides.py
+++ b/tests/workspace/test_project_local_overrides.py
@@ -123,6 +123,65 @@ def test_detect_project_local_overrides_union_four_paths(tmp_path):
     )
 
 
+def test_detect_project_local_overrides_explicit_search_dirs(tmp_path):
+    """T-OVR-022: search_dirs limits detection to the supplied dirs only."""
+    from autoskillit.workspace.skills import detect_project_local_overrides
+
+    for subdir, name in [
+        (".claude/skills/claude-only", "claude-only"),
+        (".autoskillit/skills/as-only", "as-only"),
+        (".codex/skills/codex-only", "codex-only"),
+        (".agents/skills/agents-only", "agents-only"),
+    ]:
+        d = tmp_path / subdir
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(f"# {name}")
+    result = detect_project_local_overrides(
+        tmp_path, search_dirs=(".codex/skills", ".agents/skills")
+    )
+    assert override_names(result) == frozenset({"codex-only", "agents-only"})
+
+
+def test_detect_project_local_overrides_codex_backend_scoping(tmp_path):
+    """T-OVR-023: CodexBackend's convention search dirs scope detection."""
+    from autoskillit.execution.backends.codex import CodexBackend
+    from autoskillit.workspace.skills import detect_project_local_overrides
+
+    for subdir, name in [
+        (".claude/skills/claude-excluded", "claude-excluded"),
+        (".codex/skills/codex-included", "codex-included"),
+    ]:
+        d = tmp_path / subdir
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(f"# {name}")
+    result = detect_project_local_overrides(
+        tmp_path, search_dirs=CodexBackend().conventions.project_local_skill_search_dirs
+    )
+    assert override_names(result) == frozenset({"codex-included"})
+
+
+def test_detect_project_local_overrides_claude_code_backend_scoping(tmp_path):
+    """T-OVR-024: ClaudeCodeBackend's convention search dirs scope detection."""
+    from autoskillit.execution.backends.claude import ClaudeCodeBackend
+    from autoskillit.workspace.skills import detect_project_local_overrides
+
+    for subdir, name in [
+        (".claude/skills/claude-included", "claude-included"),
+        (".autoskillit/skills/as-included", "as-included"),
+        (".codex/skills/codex-excluded", "codex-excluded"),
+        (".agents/skills/agents-included", "agents-included"),
+    ]:
+        d = tmp_path / subdir
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(f"# {name}")
+    result = detect_project_local_overrides(
+        tmp_path, search_dirs=ClaudeCodeBackend().conventions.project_local_skill_search_dirs
+    )
+    assert override_names(result) == frozenset(
+        {"claude-included", "as-included", "agents-included"}
+    )
+
+
 # ---------------------------------------------------------------------------
 # T-OVR-007..011: init_session() — project_dir override filtering
 # ---------------------------------------------------------------------------

--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -112,7 +112,7 @@ def test_profile_skills_symlinked_into_session_dir(tmp_path, monkeypatch) -> Non
     session_dir = tmp_path / "session"
     (session_dir / "skills").mkdir(parents=True)
 
-    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
     count = _materialize_profile_skills(session_dir)
 
     target = session_dir / "skills" / "my-skill"
@@ -131,7 +131,7 @@ def test_missing_profile_skills_dir_does_not_raise(tmp_path, monkeypatch) -> Non
     session_dir = tmp_path / "session"
     (session_dir / "skills").mkdir(parents=True)
 
-    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
     count = _materialize_profile_skills(session_dir)
 
     assert count == 0

--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -98,3 +98,40 @@ def test_codex_init_session_raises_when_pre_launch_fails(
     mgr = make_session_skill_manager()
     with pytest.raises(RuntimeError, match="Pre-launch check failed"):
         mgr.init_session("sid", cook_session=True, backend=codex_env.backend)
+
+
+def test_profile_skills_symlinked_into_session_dir(tmp_path, monkeypatch) -> None:
+    """_materialize_profile_skills symlinks ~/.codex/skills/<name> into session_dir/skills/<name>."""  # noqa: E501
+    from autoskillit.execution.backends.codex import _materialize_profile_skills
+
+    fake_home = tmp_path / "fake_home"
+    profile_skill = fake_home / ".codex" / "skills" / "my-skill"
+    profile_skill.mkdir(parents=True)
+    (profile_skill / "SKILL.md").write_text("# MY SKILL")
+
+    session_dir = tmp_path / "session"
+    (session_dir / "skills").mkdir(parents=True)
+
+    monkeypatch.setenv("HOME", str(fake_home))
+    count = _materialize_profile_skills(session_dir)
+
+    target = session_dir / "skills" / "my-skill"
+    assert target.is_symlink() or target.is_dir()
+    assert (target / "SKILL.md").read_text() == "# MY SKILL"
+    assert count == 1
+
+
+def test_missing_profile_skills_dir_does_not_raise(tmp_path, monkeypatch) -> None:
+    """_materialize_profile_skills returns 0 when ~/.codex/skills is absent."""
+    from autoskillit.execution.backends.codex import _materialize_profile_skills
+
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+
+    session_dir = tmp_path / "session"
+    (session_dir / "skills").mkdir(parents=True)
+
+    monkeypatch.setenv("HOME", str(fake_home))
+    count = _materialize_profile_skills(session_dir)
+
+    assert count == 0


### PR DESCRIPTION
Make `BackendConventions.project_local_skill_search_dirs` the live dispatch key for project-local skill discovery by parameterizing `detect_project_local_overrides` with a `search_dirs` argument. When a backend is available, `init_session` passes its conventions' search dirs, scoping discovery to the backend's declared directories (e.g., claude-code excludes `.codex/skills`). The `_OVERRIDE_SEARCH_DIRS` identity binding is preserved as the no-backend fallback. Additionally, extract `_materialize_profile_skills` in the Codex backend to symlink `~/.codex/skills/` profile skills into session directories during `setup_session_dir`.

**Other call sites of `detect_project_local_overrides`:** Two additional call sites exist — `src/autoskillit/recipe/rules/rules_skills.py:116` and `src/autoskillit/cli/_onboarding.py:27`. Both are intentionally left without `search_dirs` (defaulting to `None` → `_OVERRIDE_SEARCH_DIRS`) because no backend is available in the recipe validation or CLI onboarding contexts. The new default-`None` parameter preserves their existing behavior.

Closes #4021

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260612-133807-351054/.autoskillit/temp/make-plan/t5_p4_a4_wp2_eliminate_generator_g6_plan_2026-06-12_140000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 52 | 30.4k | 1.2M | 125.7k | 39 | 110.9k | 15m 5s |
| verify* | sonnet | 1 | 78 | 8.1k | 407.3k | 57.1k | 30 | 36.2k | 4m 59s |
| implement* | MiniMax-M3 | 1 | 3.1M | 12.4k | 0 | 0 | 71 | 0 | 5m 36s |
| fix* | sonnet | 1 | 302 | 31.5k | 3.2M | 123.5k | 111 | 103.5k | 12m 20s |
| audit_impl* | sonnet | 1 | 697 | 11.5k | 270.6k | 59.7k | 18 | 40.0k | 8m 20s |
| prepare_pr* | MiniMax-M3 | 1 | 157.8k | 2.5k | 0 | 0 | 13 | 0 | 59s |
| compose_pr* | MiniMax-M3 | 1 | 217.2k | 2.4k | 0 | 0 | 12 | 0 | 1m 1s |
| review_pr* | sonnet | 1 | 164 | 45.3k | 1.2M | 100.7k | 47 | 80.8k | 11m 26s |
| resolve_review* | sonnet | 1 | 223 | 22.4k | 2.0M | 101.1k | 73 | 81.2k | 11m 53s |
| **Total** | | | 3.5M | 166.6k | 8.3M | 125.7k | | 452.7k | 1h 11m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 258 | 0.0 | 0.0 | 48.1 |
| fix | 19 | 169227.7 | 5445.8 | 1660.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 10 | 197061.4 | 8122.9 | 2243.0 |
| **Total** | **287** | 28993.2 | 1577.2 | 580.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 52 | 30.4k | 1.2M | 110.9k | 15m 5s |
| sonnet | 5 | 1.5k | 118.9k | 7.1M | 341.7k | 49m 0s |
| MiniMax-M3 | 3 | 3.5M | 17.3k | 0 | 0 | 7m 36s |