### PR TITLE
Implementation Plan: T5-P4-A6-WP1 Enforce the contract — remove _FORWARD_DECLARED exemption, add capability gate branch coverage

### DIFF
--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -551,7 +551,7 @@ def _build_skill_result(
     success = outcome == SessionOutcome.SUCCEEDED
     needs_retry = outcome == SessionOutcome.RETRIABLE
 
-    infra_category = classify_infra_exit(session, result)
+    infra_category = classify_infra_exit(session, result, capabilities=backend.capabilities)
     api_retry = _build_api_retry_outcome(session)
 
     # API error override: when the session failed due to an API infrastructure error

--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -9,7 +9,7 @@ import regex as re
 from autoskillit.core import CODEX_CONTEXT_EXHAUSTION_MARKER, InfraExitCategory, get_logger
 
 if TYPE_CHECKING:
-    from autoskillit.core import SubprocessResult
+    from autoskillit.core import BackendCapabilities, SubprocessResult
     from autoskillit.execution.session._session_model import ClaudeSessionResult
 
 logger = get_logger(__name__)
@@ -94,6 +94,8 @@ def is_signal_death_code(returncode: int) -> bool:
 def classify_infra_exit(
     session: ClaudeSessionResult,
     result: SubprocessResult,
+    *,
+    capabilities: BackendCapabilities | None = None,
 ) -> InfraExitCategory:
     """Classify why a headless session exited at the infrastructure level.
 
@@ -102,11 +104,19 @@ def classify_infra_exit(
     (HTTP 429) is checked before other API errors so transient rate limits are
     distinguished from structural failures and routed to on_rate_limit instead of
     on_context_limit.
+
+    When ``capabilities`` is provided, context-exhaustion detection is gated on
+    ``supports_context_exhaustion_detection``; backends that do not support
+    context-exhaustion telemetry (e.g., Claude's local session JSONL marker is
+    already authoritative) skip those checks. ``capabilities=None`` is permissive
+    and preserves the prior behavior for callers that have not yet threaded a
+    capability object through.
     """
-    if session._is_context_exhausted():
-        return InfraExitCategory.CONTEXT_EXHAUSTED
-    if _CODEX_CONTEXT_EXHAUSTION_PATTERN.search(result.stderr):
-        return InfraExitCategory.CONTEXT_EXHAUSTED
+    if capabilities is None or capabilities.supports_context_exhaustion_detection:
+        if session._is_context_exhausted():
+            return InfraExitCategory.CONTEXT_EXHAUSTED
+        if _CODEX_CONTEXT_EXHAUSTION_PATTERN.search(result.stderr):
+            return InfraExitCategory.CONTEXT_EXHAUSTED
     # Rate limit detection — must precede all API_ERROR checks (including
     # api_retry_exhausted) so 429s are classified as RATE_LIMITED even
     # when retries are exhausted.

--- a/tests/arch/test_capability_consumption.py
+++ b/tests/arch/test_capability_consumption.py
@@ -29,11 +29,6 @@ _FORWARD_DECLARED: dict[str, ForwardDeclaredField] = {
         rationale="thinking-block rendering gating",
         added_date=date(2026, 5, 31),
     ),
-    "supports_context_exhaustion_detection": ForwardDeclaredField(
-        issue=3384,
-        rationale="context exhaustion and recovery paths",
-        added_date=date(2026, 5, 31),
-    ),
     "min_version": ForwardDeclaredField(
         issue=3122,
         rationale="version validation via BackendCapabilities fields",

--- a/tests/execution/backends/test_coding_agent_backend_conformance.py
+++ b/tests/execution/backends/test_coding_agent_backend_conformance.py
@@ -351,6 +351,10 @@ class TestCodingAgentBackendConformance(BackendContractBase):
                 f" for backend {self.backend.name!r}"
             )
 
+    def test_supports_context_exhaustion_detection_is_bool(self) -> None:
+        """BackendCapabilities.supports_context_exhaustion_detection — capability is bool-typed."""
+        assert isinstance(self.backend.capabilities.supports_context_exhaustion_detection, bool)
+
 
 def test_every_capability_field_exercised_or_not_yet_live() -> None:
     fields = {f.name for f in dataclasses.fields(BackendCapabilities)}

--- a/tests/execution/backends/test_coding_agent_backend_conformance.py
+++ b/tests/execution/backends/test_coding_agent_backend_conformance.py
@@ -33,7 +33,6 @@ NOT_YET_LIVE: frozenset[str] = frozenset(
         "patch_format",
         "required_session_files",
         "session_dir_symlinks",
-        "supports_context_exhaustion_detection",
         "supports_thinking_blocks",
     }
 )

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -7,6 +7,7 @@ import json
 import pytest
 
 from autoskillit.core.types import (
+    BackendCapabilities,
     ChannelConfirmation,
     InfraExitCategory,
     SubprocessResult,
@@ -302,6 +303,42 @@ class TestCodexContextExhaustion:
         )
         result = _sr(returncode=1, stderr="")
         assert classify_infra_exit(session, result) == InfraExitCategory.RATE_LIMITED
+
+
+class TestContextExhaustionCapabilityGate:
+    """Capability gate: supports_context_exhaustion_detection controls detection."""
+
+    def test_capability_false_suppresses_context_exhausted(self):
+        """capability=False + context exhaustion signals → NOT CONTEXT_EXHAUSTED."""
+        caps = BackendCapabilities(supports_context_exhaustion_detection=False)
+        session = ClaudeSessionResult(
+            subtype="success",
+            is_error=True,
+            result="prompt is too long",
+            session_id="s1",
+            jsonl_context_exhausted=True,
+        )
+        result = _sr(returncode=1)
+        assert (
+            classify_infra_exit(session, result, capabilities=caps)
+            != InfraExitCategory.CONTEXT_EXHAUSTED
+        )
+
+    def test_capability_true_produces_context_exhausted(self):
+        """capability=True + context exhaustion signals → CONTEXT_EXHAUSTED."""
+        caps = BackendCapabilities(supports_context_exhaustion_detection=True)
+        session = ClaudeSessionResult(
+            subtype="success",
+            is_error=True,
+            result="prompt is too long",
+            session_id="s1",
+            jsonl_context_exhausted=True,
+        )
+        result = _sr(returncode=1)
+        assert (
+            classify_infra_exit(session, result, capabilities=caps)
+            == InfraExitCategory.CONTEXT_EXHAUSTED
+        )
 
 
 @pytest.mark.parametrize("category", list(InfraExitCategory))

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -7,6 +7,7 @@ import json
 import pytest
 
 from autoskillit.core.types import (
+    CODEX_CONTEXT_EXHAUSTION_MARKER,
     BackendCapabilities,
     ChannelConfirmation,
     InfraExitCategory,
@@ -335,6 +336,36 @@ class TestContextExhaustionCapabilityGate:
             jsonl_context_exhausted=True,
         )
         result = _sr(returncode=1)
+        assert (
+            classify_infra_exit(session, result, capabilities=caps)
+            == InfraExitCategory.CONTEXT_EXHAUSTED
+        )
+
+    def test_capability_false_suppresses_context_exhausted_via_stderr(self):
+        """capability=False + Codex stderr pattern → NOT CONTEXT_EXHAUSTED."""
+        caps = BackendCapabilities(supports_context_exhaustion_detection=False)
+        session = ClaudeSessionResult(
+            subtype="success",
+            is_error=True,
+            result="",
+            session_id="s1",
+        )
+        result = _sr(returncode=1, stderr=CODEX_CONTEXT_EXHAUSTION_MARKER)
+        assert (
+            classify_infra_exit(session, result, capabilities=caps)
+            != InfraExitCategory.CONTEXT_EXHAUSTED
+        )
+
+    def test_capability_true_detects_context_exhausted_via_stderr(self):
+        """capability=True + Codex stderr pattern → CONTEXT_EXHAUSTED."""
+        caps = BackendCapabilities(supports_context_exhaustion_detection=True)
+        session = ClaudeSessionResult(
+            subtype="success",
+            is_error=True,
+            result="",
+            session_id="s1",
+        )
+        result = _sr(returncode=1, stderr=CODEX_CONTEXT_EXHAUSTION_MARKER)
         assert (
             classify_infra_exit(session, result, capabilities=caps)
             == InfraExitCategory.CONTEXT_EXHAUSTED


### PR DESCRIPTION
## Summary

Add a capability gate to `classify_infra_exit` so context exhaustion detection is only applied when the backend declares `supports_context_exhaustion_detection=True`. This creates a production consumer of the `BackendCapabilities` field, allowing its removal from `_FORWARD_DECLARED`. Two new branch tests verify the gate: capability=False suppresses CONTEXT_EXHAUSTED, capability=True produces it.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260612-190625-055731/.autoskillit/temp/make-plan/t5_p4_a6_wp1_enforce_contract_plan_2026-06-12_192600.md`

Closes #4023

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.8k | 23.0k | 1.5M | 112.6k | 45 | 113.9k | 13m 22s |
| verify* | sonnet | 1 | 68 | 10.8k | 351.2k | 61.7k | 23 | 40.8k | 4m 29s |
| implement* | MiniMax-M3 | 1 | 1.4M | 6.2k | 0 | 0 | 58 | 0 | 3m 57s |
| fix* | sonnet | 1 | 134 | 6.0k | 792.8k | 64.1k | 38 | 43.2k | 5m 23s |
| audit_impl* | sonnet | 1 | 498 | 6.3k | 205.4k | 41.8k | 19 | 26.8k | 3m 31s |
| prepare_pr* | MiniMax-M3 | 1 | 188.4k | 2.4k | 0 | 0 | 11 | 0 | 46s |
| compose_pr* | MiniMax-M3 | 1 | 176.3k | 1.3k | 0 | 0 | 13 | 0 | 47s |
| review_pr* | sonnet | 1 | 140 | 27.4k | 846.6k | 74.2k | 44 | 53.9k | 5m 56s |
| resolve_review* | sonnet | 1 | 327 | 12.3k | 2.5M | 78.8k | 84 | 57.9k | 6m 53s |
| **Total** | | | 1.8M | 95.7k | 6.2M | 112.6k | | 336.5k | 45m 8s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 65 | 0.0 | 0.0 | 95.8 |
| fix | 4 | 198190.8 | 10791.0 | 1493.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 31 | 81158.6 | 1867.5 | 397.7 |
| **Total** | **100** | 61812.1 | 3365.3 | 957.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.8k | 23.0k | 1.5M | 113.9k | 13m 22s |
| sonnet | 5 | 1.2k | 62.8k | 4.7M | 222.6k | 26m 15s |
| MiniMax-M3 | 3 | 1.8M | 9.9k | 0 | 0 | 5m 30s |