### PR TITLE
feat(backends): introduce CompositeSessionLocator dispatch point

### DIFF
--- a/src/autoskillit/execution/backends/AGENTS.md
+++ b/src/autoskillit/execution/backends/AGENTS.md
@@ -8,6 +8,7 @@ IL-1 backend abstraction layer — concrete `CodingAgentBackend` implementations
 |------|---------|
 | `__init__.py` | `BACKEND_REGISTRY`, `get_backend()` factory, re-exports |
 | `_backend_cmd_builder_base.py` | `BackendCmdBuilderBase` ABC (frozen dataclass), `FlagVocabulary` NamedTuple, `SHARED_BASELINE_ENV` — canonical location for shared env-assembly keys |
+| `_composite_locator.py` | `CompositeSessionLocator` — single dispatch point iterating BACKEND_REGISTRY for session location |
 | `claude.py` | `ClaudeCodeBackend` (incl. `validate_session_layout`), `ClaudeEnvPolicy`, `ClaudeSessionLocator`, `ClaudeStreamParser`, `ClaudeResultParser` (prompt utilities moved to `_claude_prompt.py`) |
 | `_claude_prompt.py` | Prompt injection utilities, session constants (`_ensure_skill_prefix`, `_inject_completion_directive`, `_compose_resume_prompt`, etc.), shared by claude + codex + commands |
 | `codex.py` | `CodexFlags`, `CodexBackend` (incl. `validate_session_layout`, `setup_session_dir` agent TOML generation via `_generate_agent_tomls`), `CodexEnvPolicy`, `CodexSessionLocator` (parse/config moved to `_codex_parse.py` / `_codex_config.py`) |

--- a/src/autoskillit/execution/backends/__init__.py
+++ b/src/autoskillit/execution/backends/__init__.py
@@ -20,6 +20,7 @@ from ._codex_hooks import (
     sync_hooks_to_codex_config,
 )
 from ._codex_parse import CodexResultParser, CodexStreamParser
+from ._composite_locator import CompositeSessionLocator
 from .claude import (
     ClaudeCodeBackend,
     ClaudeEnvPolicy,
@@ -62,6 +63,7 @@ __all__ = [
     "BACKEND_REGISTRY",
     "CODEX_EXEC_FLAGS",
     "CODEX_TOP_LEVEL_ONLY_FLAGS",
+    "CompositeSessionLocator",
     "_is_autoskillit_hook_entry",
     "generate_codex_hooks_config",
     "sync_hooks_to_codex_config",

--- a/src/autoskillit/execution/backends/_composite_locator.py
+++ b/src/autoskillit/execution/backends/_composite_locator.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from autoskillit.core import SessionLocator
+if TYPE_CHECKING:
+    from autoskillit.core import SessionLocator
 
 
 @dataclass(frozen=True, slots=True)
-class CompositeSessionLocator(SessionLocator):
+class CompositeSessionLocator:
     def locate_session(self, session_id: str) -> Path | None:
         if not session_id or session_id.startswith(("no_session_", "crashed_")):
             return None

--- a/src/autoskillit/execution/backends/_composite_locator.py
+++ b/src/autoskillit/execution/backends/_composite_locator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,8 +15,21 @@ logger = get_logger(__name__)
 
 @dataclass(frozen=True, slots=True)
 class CompositeSessionLocator:
+    _locators: tuple[SessionLocator, ...] = field(default=(), repr=False)
+
     def locate_session(self, session_id: str) -> Path | None:
         if not session_id or session_id.startswith(("no_session_", "crashed_")):
+            return None
+        if self._locators:
+            locators: tuple[SessionLocator, ...] = self._locators
+            for locator in locators:
+                try:
+                    result = locator.locate_session(session_id)
+                except Exception:
+                    logger.debug("session_locate_failed", exc_info=True)
+                    continue
+                if result is not None:
+                    return result
             return None
         from autoskillit.execution.backends import BACKEND_REGISTRY
 

--- a/src/autoskillit/execution/backends/_composite_locator.py
+++ b/src/autoskillit/execution/backends/_composite_locator.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from autoskillit.core import SessionLocator
+
+
+@dataclass(frozen=True, slots=True)
+class CompositeSessionLocator(SessionLocator):
+    def locate_session(self, session_id: str) -> Path | None:
+        if not session_id or session_id.startswith(("no_session_", "crashed_")):
+            return None
+        from autoskillit.execution.backends import BACKEND_REGISTRY
+
+        for cls in BACKEND_REGISTRY.values():
+            result = cls().session_locator().locate_session(session_id)
+            if result is not None:
+                return result
+        return None
+
+    def project_log_dir(self, cwd: str) -> Path:
+        return self.project_log_dir_for(cwd, "claude-code")
+
+    def project_log_dir_for(self, cwd: str, backend_name: str) -> Path:
+        from autoskillit.execution.backends import BACKEND_REGISTRY
+
+        cls = BACKEND_REGISTRY.get(backend_name)
+        if cls is None:
+            valid = ", ".join(sorted(BACKEND_REGISTRY))
+            msg = f"Unknown backend {backend_name!r}. Valid names: {valid}"
+            raise ValueError(msg)
+        return cls().session_locator().project_log_dir(cwd)
+
+    def session_log_path(self, cwd: str, session_id: str) -> Path | None:
+        return self.locate_session(session_id)
+
+    def locator_for(self, backend_name: str) -> SessionLocator:
+        from autoskillit.execution.backends import BACKEND_REGISTRY
+
+        cls = BACKEND_REGISTRY.get(backend_name)
+        if cls is None:
+            valid = ", ".join(sorted(BACKEND_REGISTRY))
+            msg = f"Unknown backend {backend_name!r}. Valid names: {valid}"
+            raise ValueError(msg)
+        return cls().session_locator()

--- a/src/autoskillit/execution/backends/_composite_locator.py
+++ b/src/autoskillit/execution/backends/_composite_locator.py
@@ -4,8 +4,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from autoskillit.core import get_logger
+
 if TYPE_CHECKING:
     from autoskillit.core import SessionLocator
+
+
+logger = get_logger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -15,8 +20,12 @@ class CompositeSessionLocator:
             return None
         from autoskillit.execution.backends import BACKEND_REGISTRY
 
-        for cls in BACKEND_REGISTRY.values():
-            result = cls().session_locator().locate_session(session_id)
+        for backend_name, cls in BACKEND_REGISTRY.items():
+            try:
+                result = cls().session_locator().locate_session(session_id)
+            except Exception:
+                logger.debug("session_locate_failed", backend=backend_name, exc_info=True)
+                continue
             if result is not None:
                 return result
         return None

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -496,15 +496,6 @@ async def _execute_claude_headless(
     ):
         from autoskillit.execution.session_log import flush_session_log
 
-        _codex_log: Path | None = None
-        if not _step_backend.capabilities.channel_b_capable and skill_result.session_id:
-            try:
-                _codex_log = _step_backend.session_locator().locate_session(
-                    skill_result.session_id
-                )
-            except Exception:
-                logger.debug("codex_session_locate_failed", exc_info=True)
-
         try:
             flush_session_log(
                 log_dir=ctx.config.linux_tracing.log_dir,
@@ -574,7 +565,6 @@ async def _execute_claude_headless(
                 max_sessions=ctx.config.linux_tracing.max_sessions,
                 model_identity=model_identity,
                 is_resume=spec.is_resume,
-                codex_log_path=_codex_log,
                 backend=cast(Literal["claude-code", "codex"], _step_backend.name),
             )
         except Exception:

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -311,6 +311,7 @@ async def _execute_claude_headless(
                     max_sessions=ctx.config.linux_tracing.max_sessions,
                     model_identity=model_identity,
                     backend=cast(Literal["claude-code", "codex"], _step_backend.name),
+                    channel_b_capable=_step_backend.capabilities.channel_b_capable,
                     comm_aliases=_step_backend.capabilities.process_name_aliases,
                     telemetry=_build_error_path_telemetry(
                         ctx.github_api_log,
@@ -374,6 +375,7 @@ async def _execute_claude_headless(
                         max_sessions=ctx.config.linux_tracing.max_sessions,
                         model_identity=model_identity,
                         backend=cast(Literal["claude-code", "codex"], _step_backend.name),
+                        channel_b_capable=_step_backend.capabilities.channel_b_capable,
                         comm_aliases=_step_backend.capabilities.process_name_aliases,
                         telemetry=_build_error_path_telemetry(
                             ctx.github_api_log,
@@ -566,6 +568,7 @@ async def _execute_claude_headless(
                 model_identity=model_identity,
                 is_resume=spec.is_resume,
                 backend=cast(Literal["claude-code", "codex"], _step_backend.name),
+                channel_b_capable=_step_backend.capabilities.channel_b_capable,
             )
         except Exception:
             logger.debug("session_log_flush_failed", exc_info=True)

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -183,9 +183,7 @@ def flush_session_log(
     else:
         dir_name = f"no_session_{start_ts.replace(':', '-')}"
 
-    from autoskillit.execution.backends._composite_locator import (
-        CompositeSessionLocator,
-    )
+    from autoskillit.execution.backends import CompositeSessionLocator
 
     _codex_log_str: str | None = None
 

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -151,7 +151,6 @@ def flush_session_log(
     model_identity: ModelIdentity = ModelIdentity.unknown(),
     max_sessions: int | None = None,
     is_resume: bool = False,
-    codex_log_path: Path | None = None,
     session_locator: SessionLocator | None = None,
     backend: Literal["claude-code", "codex"] = "claude-code",
     telemetry: SessionTelemetry,
@@ -183,17 +182,30 @@ def flush_session_log(
     else:
         dir_name = f"no_session_{start_ts.replace(':', '-')}"
 
-    if codex_log_path is not None:
-        cc_log = None
-        cc_log_str = None
-    else:
-        from autoskillit.execution.backends.claude import (
-            ClaudeSessionLocator,
-        )  # deferred: avoids circular import via backends/claude.py
+    from autoskillit.execution.backends._composite_locator import (
+        CompositeSessionLocator,
+    )
 
-        _locator = session_locator or ClaudeSessionLocator()
+    _codex_log_str: str | None = None
+
+    if session_locator is not None:
+        _locator = session_locator
+    else:
+        _composite = CompositeSessionLocator()
+        _locator = _composite.locator_for(backend)
+
+    if backend == "claude-code":
         cc_log = _locator.session_log_path(cwd, session_id)
         cc_log_str = str(cc_log) if cc_log else None
+    else:
+        cc_log = None
+        cc_log_str = None
+        if session_id and not session_id.startswith(("no_session_", "crashed_")):
+            try:
+                _codex_found = _locator.locate_session(session_id)
+                _codex_log_str = str(_codex_found) if _codex_found else None
+            except Exception:
+                logger.debug("session_locate_failed", backend=backend, exc_info=True)
 
     if cc_log and not cc_log.exists():
         logger.warning("claude_code_log_not_found", path=cc_log_str, session_id=session_id)
@@ -506,7 +518,7 @@ def flush_session_log(
         "campaign_id": campaign_id,
         "dispatch_id": dispatch_id,
         "claude_code_log": cc_log_str,
-        "codex_log": str(codex_log_path) if codex_log_path else None,
+        "codex_log": _codex_log_str,
         "skill_command": skill_command,
         "success": success,
         "subtype": subtype,

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -153,6 +153,7 @@ def flush_session_log(
     is_resume: bool = False,
     session_locator: SessionLocator | None = None,
     backend: Literal["claude-code", "codex"] = "claude-code",
+    channel_b_capable: bool = True,
     telemetry: SessionTelemetry,
 ) -> None:
     """Flush session diagnostics to disk.
@@ -194,7 +195,7 @@ def flush_session_log(
         _composite = CompositeSessionLocator()
         _locator = _composite.locator_for(backend)
 
-    if backend == "claude-code":
+    if channel_b_capable:
         cc_log = _locator.session_log_path(cwd, session_id)
         cc_log_str = str(cc_log) if cc_log else None
     else:

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -878,6 +878,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "recipe/rules": 51,  # +commit_guard_regression_route +rules_model +rules_gitignored_deliverable  # noqa: E501
         "server/tools": 27,  # +_preflight.py (dispatch-feasibility preflight)
         "hooks/guards": 32,  # +fleet_claim_guard, +reset_resume_gate, +recipe_read_guard
+        "execution/backends": 11,  # +_composite_locator.py (CompositeSessionLocator)
     }
     violations: list[str] = []
     dirs_to_check: list[Path] = []

--- a/tests/execution/backends/test_backend_registry.py
+++ b/tests/execution/backends/test_backend_registry.py
@@ -47,6 +47,7 @@ class TestBackendRegistry:
             "CODEX_MCP_TOOL_TIMEOUT_FLOOR",
             "CODEX_TOOL_OUTPUT_TOKEN_LIMIT",
             "CODEX_TOP_LEVEL_ONLY_FLAGS",
+            "CompositeSessionLocator",
             "ClaudeCodeBackend",
             "ClaudeEnvPolicy",
             "ClaudeResultParser",

--- a/tests/execution/backends/test_composite_session_locator.py
+++ b/tests/execution/backends/test_composite_session_locator.py
@@ -113,7 +113,7 @@ class TestLocatorFor:
 class TestInvariants:
     def test_frozen(self):
         loc = CompositeSessionLocator()
-        with pytest.raises(FrozenInstanceError):
+        with pytest.raises((FrozenInstanceError, TypeError)):
             loc.x = 1  # type: ignore[attr-defined]
 
     def test_protocol_conformance(self):

--- a/tests/execution/backends/test_composite_session_locator.py
+++ b/tests/execution/backends/test_composite_session_locator.py
@@ -59,6 +59,28 @@ class TestLocateSession:
     def test_guards_invalid_ids(self, sid):
         assert CompositeSessionLocator().locate_session(sid) is None
 
+    def test_skips_failing_backend(self, monkeypatch):
+        class _FailLocator:
+            def locate_session(self, session_id):
+                raise RuntimeError("backend unavailable")
+
+            def project_log_dir(self, cwd):
+                return Path("/stub")
+
+            def session_log_path(self, cwd, session_id):
+                return None
+
+        hit = Path("/found/session.jsonl")
+        registry = {
+            "broken": _fake_backend(_FailLocator()),
+            "good": _fake_backend(_StubLocator(hit)),
+        }
+        import autoskillit.execution.backends as backends_mod
+
+        monkeypatch.setattr(backends_mod, "BACKEND_REGISTRY", registry)
+
+        assert CompositeSessionLocator().locate_session("sid-1") == hit
+
 
 class TestProjectLogDirFor:
     def test_dispatches_by_name(self, monkeypatch):

--- a/tests/execution/backends/test_composite_session_locator.py
+++ b/tests/execution/backends/test_composite_session_locator.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from autoskillit.core import SessionLocator
+from autoskillit.execution.backends import CompositeSessionLocator
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+def _fake_backend(locator: SessionLocator) -> type:
+    backend = Mock()
+    backend.session_locator.return_value = locator
+    cls = Mock(return_value=backend)
+    return cls
+
+
+class _StubLocator:
+    def __init__(self, locate_result: Path | None = None, log_dir: Path | None = None):
+        self._locate = locate_result
+        self._log_dir = log_dir or Path("/stub")
+
+    def locate_session(self, session_id: str) -> Path | None:
+        return self._locate
+
+    def project_log_dir(self, cwd: str) -> Path:
+        return self._log_dir
+
+    def session_log_path(self, cwd: str, session_id: str) -> Path | None:
+        return self._locate
+
+
+class TestLocateSession:
+    def test_returns_first_non_none(self, monkeypatch):
+        hit = Path("/found/session.jsonl")
+        registry = {
+            "miss": _fake_backend(_StubLocator(None)),
+            "hit": _fake_backend(_StubLocator(hit)),
+        }
+        import autoskillit.execution.backends as backends_mod
+
+        monkeypatch.setattr(backends_mod, "BACKEND_REGISTRY", registry)
+
+        assert CompositeSessionLocator().locate_session("sid-1") == hit
+
+    def test_returns_none_when_all_miss(self, monkeypatch):
+        registry = {"a": _fake_backend(_StubLocator(None))}
+        import autoskillit.execution.backends as backends_mod
+
+        monkeypatch.setattr(backends_mod, "BACKEND_REGISTRY", registry)
+
+        assert CompositeSessionLocator().locate_session("sid-1") is None
+
+    @pytest.mark.parametrize("sid", ["", "no_session_123", "crashed_456"])
+    def test_guards_invalid_ids(self, sid):
+        assert CompositeSessionLocator().locate_session(sid) is None
+
+
+class TestProjectLogDirFor:
+    def test_dispatches_by_name(self, monkeypatch):
+        expected = Path("/logs/claude")
+        registry = {"claude-code": _fake_backend(_StubLocator(log_dir=expected))}
+        import autoskillit.execution.backends as backends_mod
+
+        monkeypatch.setattr(backends_mod, "BACKEND_REGISTRY", registry)
+
+        assert CompositeSessionLocator().project_log_dir_for("/cwd", "claude-code") == expected
+
+    def test_raises_for_unknown(self, monkeypatch):
+        import autoskillit.execution.backends as backends_mod
+
+        monkeypatch.setattr(backends_mod, "BACKEND_REGISTRY", {})
+
+        with pytest.raises(ValueError, match="Unknown backend"):
+            CompositeSessionLocator().project_log_dir_for("/cwd", "unknown")
+
+
+class TestSessionLogPath:
+    def test_delegates_to_locate_session(self, monkeypatch):
+        hit = Path("/found/session.jsonl")
+        registry = {"a": _fake_backend(_StubLocator(hit))}
+        import autoskillit.execution.backends as backends_mod
+
+        monkeypatch.setattr(backends_mod, "BACKEND_REGISTRY", registry)
+
+        assert CompositeSessionLocator().session_log_path("/cwd", "sid") == hit
+
+
+class TestLocatorFor:
+    def test_returns_backend_locator(self, monkeypatch):
+        stub = _StubLocator(Path("/x"))
+        registry = {"claude-code": _fake_backend(stub)}
+        import autoskillit.execution.backends as backends_mod
+
+        monkeypatch.setattr(backends_mod, "BACKEND_REGISTRY", registry)
+
+        result = CompositeSessionLocator().locator_for("claude-code")
+        assert result is stub
+
+    def test_raises_for_unknown(self, monkeypatch):
+        import autoskillit.execution.backends as backends_mod
+
+        monkeypatch.setattr(backends_mod, "BACKEND_REGISTRY", {})
+
+        with pytest.raises(ValueError, match="Unknown backend"):
+            CompositeSessionLocator().locator_for("unknown")
+
+
+class TestInvariants:
+    def test_frozen(self):
+        loc = CompositeSessionLocator()
+        with pytest.raises(FrozenInstanceError):
+            loc.x = 1  # type: ignore[attr-defined]
+
+    def test_protocol_conformance(self):
+        assert isinstance(CompositeSessionLocator(), SessionLocator)

--- a/tests/execution/test_backend_dispatch.py
+++ b/tests/execution/test_backend_dispatch.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -339,8 +338,6 @@ class TestCodexLogDispatch:
         )
         backend = _mock_backend(channel_b_capable=False, process_name="codex")
         backend.name = "codex"
-        sentinel = Path("/sentinel/codex.jsonl")
-        backend.session_locator().locate_session.return_value = sentinel
 
         fake_runner, flush_calls = _patch_for_flush(monkeypatch, tmp_path, result)
         minimal_ctx.runner = fake_runner  # type: ignore[assignment]
@@ -355,8 +352,8 @@ class TestCodexLogDispatch:
             step_backend=backend,
         )
 
-        backend.session_locator().locate_session.assert_called_once_with("sid-1")
-        assert flush_calls[0]["codex_log_path"] == sentinel
+        assert "codex_log_path" not in flush_calls[0]
+        assert flush_calls[0]["backend"] == "codex"
 
     @pytest.mark.anyio
     async def test_channel_b_true_skips_session_locator(self, minimal_ctx, tmp_path, monkeypatch):
@@ -388,5 +385,5 @@ class TestCodexLogDispatch:
             step_backend=backend,
         )
 
-        backend.session_locator.return_value.locate_session.assert_not_called()
-        assert flush_calls[0]["codex_log_path"] is None
+        assert "codex_log_path" not in flush_calls[0]
+        assert flush_calls[0]["backend"] == "claude-code"

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -1179,6 +1179,7 @@ class TestCodexLogFields:
         flush_session_log(
             log_dir=str(tmp_path),
             backend="codex",
+            channel_b_capable=False,
             session_locator=_FakeLocator(codex_log),
             cwd="/some/worktree",
             session_id="codex-session-001",
@@ -1234,6 +1235,7 @@ class TestCodexLogFields:
         flush_session_log(
             log_dir=str(tmp_path),
             backend="codex",
+            channel_b_capable=False,
             session_locator=_FakeLocator(codex_log),
             cwd="/some/worktree",
             session_id="codex-session-002",
@@ -1263,6 +1265,7 @@ class TestCodexLogFields:
             start_ts="2026-05-26T08:00:00",
             proc_snapshots=None,
             backend="codex",
+            channel_b_capable=False,
             session_locator=_FakeLocator(None),
             telemetry=SessionTelemetry.empty(),
             provider_outcome=ProviderOutcome.none_used(),

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -1178,7 +1178,8 @@ class TestCodexLogFields:
         codex_log.write_text(event_line)
         flush_session_log(
             log_dir=str(tmp_path),
-            codex_log_path=codex_log,
+            backend="codex",
+            session_locator=_FakeLocator(codex_log),
             cwd="/some/worktree",
             session_id="codex-session-001",
             pid=12345,
@@ -1200,6 +1201,7 @@ class TestCodexLogFields:
     def test_flush_codex_log_null_when_not_provided(self, tmp_path):
         flush_session_log(
             log_dir=str(tmp_path),
+            session_locator=_FakeLocator(None),
             cwd="/some/worktree",
             session_id="cc-session-001",
             pid=12345,
@@ -1231,7 +1233,8 @@ class TestCodexLogFields:
         codex_log.write_text(event_line)
         flush_session_log(
             log_dir=str(tmp_path),
-            codex_log_path=codex_log,
+            backend="codex",
+            session_locator=_FakeLocator(codex_log),
             cwd="/some/worktree",
             session_id="codex-session-002",
             pid=12345,
@@ -1246,6 +1249,31 @@ class TestCodexLogFields:
             recipe_identity=RecipeIdentity.empty(),
         )
         assert "claude_code_log_not_found" not in caplog.text
+
+    def test_backend_codex_skips_channel_b_parsing(self, tmp_path):
+        flush_session_log(
+            log_dir=str(tmp_path),
+            cwd="/some/worktree",
+            session_id="codex-session-003",
+            pid=12345,
+            skill_command="/autoskillit:implement",
+            success=True,
+            subtype="completed",
+            exit_code=0,
+            start_ts="2026-05-26T08:00:00",
+            proc_snapshots=None,
+            backend="codex",
+            session_locator=_FakeLocator(None),
+            telemetry=SessionTelemetry.empty(),
+            provider_outcome=ProviderOutcome.none_used(),
+            recipe_identity=RecipeIdentity.empty(),
+        )
+        summary = json.loads(
+            (tmp_path / "sessions" / "codex-session-003" / "summary.json").read_text()
+        )
+        assert summary["request_ids"] == []
+        assert summary["turn_timestamps"] == []
+        assert summary["turn_tool_calls"] == []
 
 
 def test_primary_model_identifier_parent_wins_on_output_tokens():


### PR DESCRIPTION
## Summary

Introduce a `CompositeSessionLocator` in `execution/backends/_composite_locator.py` that provides a single dispatch point for session log resolution across backends, replacing the dual `codex_log_path`/`ClaudeSessionLocator` branching in `flush_session_log`. The composite iterates `BACKEND_REGISTRY` to locate sessions, supports per-backend dispatch via `locator_for(backend)`, and (remediation) wraps each backend's call in `try/except Exception` with structured debug logging so a failing backend cannot abort the scan.

<details>
<summary>Individual Group Plans</summary>

### Group 1: T5-P4-A6-WP2 Provide a single SessionLocator dispatch point
Create a `CompositeSessionLocator` in `execution/backends/_composite_locator.py` that iterates `BACKEND_REGISTRY` to locate session logs, then replace the dual `codex_log_path`/`ClaudeSessionLocator` branching in `flush_session_log` with backend-parameter-driven dispatch through this composite. Remove the `codex_log_path` parameter from `flush_session_log` and the pre-computation block from `_headless_execute.py`. Update tests to use explicit `backend=` dispatch instead of `codex_log_path=`.

### Group 2: T5-P4-A6-WP2 Remediation — Per-backend exception handling in CompositeSessionLocator.locate_session
Add per-backend `try/except Exception` with structured debug logging inside `CompositeSessionLocator.locate_session` so that if one backend's locator raises, the scan continues to the next backend rather than aborting. Add a test verifying this resilient-iteration behavior.

</details>

Closes #4024

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/impl-20260612-201007-221351/.autoskillit/temp/make-plan/t5_p4_a6_wp2_composite_session_locator_plan_2026-06-12_201500.md`
- `/home/talon/projects/autoskillit-runs/impl-20260612-201007-221351/.autoskillit/temp/make-plan/t5_p4_a6_wp2_remediation_composite_locator_plan_2026-06-12_202600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 6.5k | 58.5k | 3.1M | 136.9k | 101 | 177.1k | 24m 29s |
| verify* | sonnet | 2 | 934 | 26.5k | 701.1k | 80.8k | 47 | 88.2k | 9m 46s |
| implement* | MiniMax-M3 | 2 | 4.5M | 19.1k | 0 | 0 | 136 | 0 | 12m 53s |
| fix* | sonnet | 1 | 382 | 38.2k | 4.5M | 126.2k | 127 | 105.2k | 18m 0s |
| audit_impl* | sonnet | 2 | 1.4k | 30.4k | 722.7k | 61.9k | 46 | 90.8k | 15m 16s |
| retry_worktree* | sonnet | 1 | 68 | 1.8k | 278.1k | 42.8k | 16 | 21.9k | 2m 23s |
| prepare_pr* | MiniMax-M3 | 1 | 258.4k | 3.4k | 0 | 0 | 17 | 0 | 1m 12s |
| compose_pr* | MiniMax-M3 | 1 | 287.9k | 2.2k | 0 | 0 | 16 | 0 | 1m 0s |
| review_pr* | sonnet | 1 | 108 | 42.0k | 871.6k | 103.5k | 38 | 83.5k | 9m 56s |
| resolve_review* | sonnet | 1 | 702 | 29.9k | 2.2M | 104.7k | 77 | 84.4k | 13m 57s |
| **Total** | | | 5.1M | 252.0k | 12.3M | 136.9k | | 651.2k | 1h 48m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 288 | 0.0 | 0.0 | 66.4 |
| fix | 18 | 247544.2 | 5846.3 | 2124.1 |
| audit_impl | 0 | — | — | — |
| retry_worktree | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 19 | 114696.6 | 4441.1 | 1573.8 |
| **Total** | **325** | 37874.3 | 2003.7 | 775.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 6.5k | 58.5k | 3.1M | 177.1k | 24m 29s |
| sonnet | 6 | 3.6k | 168.8k | 9.2M | 474.1k | 1h 9m |
| MiniMax-M3 | 3 | 5.1M | 24.7k | 0 | 0 | 15m 7s |