### PR TITLE
T5-P5-A13-WP1 Make JSON Contract Card Staleness Detectable

### DIFF
--- a/tests/arch/AGENTS.md
+++ b/tests/arch/AGENTS.md
@@ -78,6 +78,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_python_no_hardcoded_temp.py` | Architectural invariant: no literal `.autoskillit/temp` outside the whitelist |
 | `test_quota_capability_isolation.py` | AST guard: quota modules must not reference BackendCapabilities fields |
 | `test_recipe_diagram_freshness.py` | Parametrized diagram freshness enforcement: bundled recipes must have non-stale diagrams; missing diagrams are xfail(strict=True) with shrink-enforcement meta-test |
+| `test_recipe_contract_freshness.py` | Parametrized JSON card freshness enforcement: contract cards must have non-stale .json companions with content parity |
 | `test_recipe_rule_registration.py` | REQ-RECIPE-001: every recipe/rules_*.py file must be imported by recipe/__init__.py |
 | `test_rule_severity_consistency.py` | AST guards: rule functions must use make_finding()/make_block_finding(); RuleFinding severity must match @semantic_rule decorator severity; _KNOWN_NON_CONFORMING_RULES entries must carry tracking comments |
 | `test_regex_guards.py` | Arch guard: keyword regexes in cmd-scanning rules must use path-safe lookbehind guards |

--- a/tests/arch/test_recipe_contract_freshness.py
+++ b/tests/arch/test_recipe_contract_freshness.py
@@ -1,0 +1,68 @@
+"""Parametrized JSON contract card freshness enforcement: contract cards must have
+non-stale .json companions with content parity, and the contract collection must
+not silently shrink.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from autoskillit.recipe.io import builtin_recipes_dir
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+_RECIPES_DIR = builtin_recipes_dir()
+_CONTRACTS_DIR = _RECIPES_DIR / "contracts"
+_CONTRACT_STEMS = (
+    sorted(p.stem for p in _CONTRACTS_DIR.glob("*.yaml")) if _CONTRACTS_DIR.is_dir() else []
+)
+
+MINIMUM_CONTRACT_COUNT = 15
+
+
+@pytest.mark.parametrize("stem", _CONTRACT_STEMS, ids=_CONTRACT_STEMS)
+def test_json_card_exists(stem: str) -> None:
+    json_path = _CONTRACTS_DIR / f"{stem}.json"
+    assert json_path.is_file(), (
+        f"Contract '{stem}' has a .yaml card but no .json companion. "
+        f"Run 'task regen-contracts' to regenerate."
+    )
+
+
+@pytest.mark.parametrize("stem", _CONTRACT_STEMS, ids=_CONTRACT_STEMS)
+def test_json_card_content_parity(stem: str) -> None:
+    yaml_path = _CONTRACTS_DIR / f"{stem}.yaml"
+    json_path = _CONTRACTS_DIR / f"{stem}.json"
+    if not json_path.is_file():
+        pytest.skip(f"JSON card missing for '{stem}' (covered by test_json_card_exists)")
+    yaml_data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    json_data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert yaml_data == json_data, (
+        f"Content mismatch between '{stem}.yaml' and '{stem}.json'. "
+        f"Run 'task regen-contracts' to regenerate."
+    )
+
+
+def test_collection_count_rot_guard() -> None:
+    assert len(_CONTRACT_STEMS) >= MINIMUM_CONTRACT_COUNT, (
+        f"Expected at least {MINIMUM_CONTRACT_COUNT} contract card YAMLs in "
+        f"{_CONTRACTS_DIR}, found {len(_CONTRACT_STEMS)}. "
+        "Is builtin_recipes_dir() resolving correctly? "
+        "Run 'task regen-contracts' to regenerate."
+    )
+
+
+def test_no_orphan_json_cards() -> None:
+    if not _CONTRACTS_DIR.is_dir():
+        pytest.skip("Contracts directory does not exist")
+    json_stems = {p.stem for p in _CONTRACTS_DIR.glob("*.json")}
+    yaml_stems = set(_CONTRACT_STEMS)
+    orphans = sorted(json_stems - yaml_stems)
+    assert not orphans, (
+        f"Found orphan JSON cards with no matching .yaml: {orphans}. "
+        f"Remove stale .json files or run 'task regen-contracts'."
+    )

--- a/tests/arch/test_recipe_contract_freshness.py
+++ b/tests/arch/test_recipe_contract_freshness.py
@@ -6,11 +6,10 @@ not silently shrink.
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
-import yaml
 
+from autoskillit.core.io import load_yaml
 from autoskillit.recipe.io import builtin_recipes_dir
 
 pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
@@ -39,7 +38,7 @@ def test_json_card_content_parity(stem: str) -> None:
     json_path = _CONTRACTS_DIR / f"{stem}.json"
     if not json_path.is_file():
         pytest.skip(f"JSON card missing for '{stem}' (covered by test_json_card_exists)")
-    yaml_data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    yaml_data = load_yaml(yaml_path)
     json_data = json.loads(json_path.read_text(encoding="utf-8"))
     assert yaml_data == json_data, (
         f"Content mismatch between '{stem}.yaml' and '{stem}.json'. "

--- a/tests/arch/test_recipe_contract_freshness.py
+++ b/tests/arch/test_recipe_contract_freshness.py
@@ -20,7 +20,14 @@ _CONTRACT_STEMS = (
     sorted(p.stem for p in _CONTRACTS_DIR.glob("*.yaml")) if _CONTRACTS_DIR.is_dir() else []
 )
 
-MINIMUM_CONTRACT_COUNT = 15
+MINIMUM_CONTRACT_COUNT = 15  # floor below current count (17 at creation); catches silent deletion
+
+
+def test_contracts_dir_exists() -> None:
+    assert _CONTRACTS_DIR.is_dir(), (
+        f"Contracts directory not found: {_CONTRACTS_DIR}. "
+        "Is builtin_recipes_dir() resolving correctly?"
+    )
 
 
 @pytest.mark.parametrize("stem", _CONTRACT_STEMS, ids=_CONTRACT_STEMS)


### PR DESCRIPTION
## Summary

Create `tests/arch/test_recipe_contract_freshness.py` — a parametrized architectural test that enforces JSON contract card freshness at CI time. The test discovers all `.yaml` contract cards under `builtin_recipes_dir() / "contracts"`, verifies each has a matching `.json` companion with content parity, guards against collection count rot (>= 15), and detects orphan JSON files. This makes contract card staleness merge-blocking alongside the existing diagram staleness enforcement in `test_recipe_diagram_freshness.py`.

**Basename note:** A file `tests/hooks/test_recipe_contract_freshness.py` already exists — it tests the pre-commit hook script (`scripts/recipe_contract_freshness.py`) and carries `layer("hooks")`. The new arch-layer file tests a different concern (CI-time JSON card parity) and the basename collision is benign: different directories, different markers, different imports, different purpose. The cascade map entry at `tests/_test_filter.py:741` correctly references the hooks file; the arch file needs no cascade entry because `arch/` is in `ALWAYS_RUN_*` sets.

Closes #4032

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260613-005940-568369/.autoskillit/temp/make-plan/t5_p5_a13_wp1_json_contract_card_freshness_plan_2026-06-13_010600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 69 | 18.8k | 1.5M | 94.9k | 59 | 77.3k | 13m 41s |
| verify* | sonnet | 1 | 2.8k | 11.6k | 324.7k | 53.5k | 25 | 32.6k | 5m 20s |
| implement* | MiniMax-M3 | 1 | 1.7M | 8.2k | 0 | 0 | 73 | 0 | 4m 20s |
| fix* | sonnet | 1 | 134 | 3.8k | 727.1k | 55.8k | 35 | 35.1k | 3m 0s |
| audit_impl* | sonnet | 1 | 1.7k | 7.6k | 163.6k | 39.0k | 11 | 26.7k | 3m 37s |
| prepare_pr* | MiniMax-M3 | 1 | 190.4k | 2.2k | 0 | 0 | 11 | 0 | 53s |
| compose_pr* | MiniMax-M3 | 1 | 177.2k | 1.2k | 0 | 0 | 12 | 0 | 46s |
| review_pr* | sonnet | 2 | 258 | 24.0k | 1.4M | 59.5k | 70 | 73.4k | 7m 5s |
| resolve_review* | sonnet | 1 | 275 | 13.6k | 2.0M | 77.8k | 78 | 56.8k | 13m 33s |
| **Total** | | | 2.0M | 91.1k | 6.1M | 94.9k | | 302.0k | 52m 19s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 69 | 0.0 | 0.0 | 119.2 |
| fix | 5 | 145425.8 | 7030.0 | 765.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 9 | 220712.1 | 6313.4 | 1510.0 |
| **Total** | **83** | 74010.3 | 3638.0 | 1097.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 69 | 18.8k | 1.5M | 77.3k | 13m 41s |
| sonnet | 5 | 5.2k | 60.7k | 4.6M | 224.7k | 32m 38s |
| MiniMax-M3 | 3 | 2.0M | 11.6k | 0 | 0 | 6m 0s |