### PR TITLE
Implementation Plan: T5-P5-A3-WP1 Server-Side Recipe-Read Prohibition & Write-Target Boundary

### DIFF
--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -6,9 +6,12 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import regex as re
+
 from autoskillit.core import (
     InputContractResolver,
     SessionType,
+    extract_bash_write_targets,
     extract_path_arg,
     extract_positional_args,
     extract_skill_name,
@@ -22,6 +25,17 @@ if TYPE_CHECKING:
     from autoskillit.config._config_dataclasses import ProviderProfileDef, ProvidersConfig
 
 logger = get_logger(__name__)
+
+
+RECIPE_READ_DENY_TRIGGER: str = "must not read recipe/skill/agent files directly"
+
+_RECIPE_READ_CMD_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"(?:\.autoskillit|src/autoskillit)/recipes/.*\.ya?ml"),
+    re.compile(r"src/autoskillit/skills(?:_extended)?/.*/SKILL\.md"),
+    re.compile(r"src/autoskillit/agents/.*\.md"),
+]
+
+_RECIPE_READ_CALLABLE_PATTERN: re.Pattern[str] = re.compile(r"^autoskillit\.recipe\.(?!_cmd_rpc)")
 
 
 def _get_ctx():  # type: ignore[return]
@@ -129,6 +143,57 @@ def _require_enabled() -> str | None:
     """
     if not _get_ctx().gate.enabled:
         return gate_error_result()
+    return None
+
+
+def _check_recipe_read_prohibition(
+    *, cmd: str | None = None, callable_name: str | None = None
+) -> str | None:
+    """Deny recipe/skill/agent file reads and recipe module callables.
+
+    Headless-only: interactive sessions bypass this guard.
+    Returns gate_error_result JSON on match, None on pass.
+    """
+    if os.environ.get("AUTOSKILLIT_HEADLESS") != "1":
+        return None
+    if cmd is not None:
+        for pattern in _RECIPE_READ_CMD_PATTERNS:
+            if pattern.search(cmd):
+                return gate_error_result(
+                    f"run_cmd {RECIPE_READ_DENY_TRIGGER}. "
+                    "Use load_recipe to recall step definitions or the Skill tool "
+                    "for skill instructions."
+                )
+    if callable_name is not None:
+        if _RECIPE_READ_CALLABLE_PATTERN.search(callable_name):
+            return gate_error_result(
+                f"run_python {RECIPE_READ_DENY_TRIGGER}. "
+                "Use load_recipe to recall step definitions."
+            )
+    return None
+
+
+def _check_write_target_boundary(
+    cmd: str, cwd: str, allowed_prefixes: tuple[str, ...]
+) -> str | None:
+    """Deny run_cmd writes outside allowed prefix directories.
+
+    Fail-open: returns None when allowed_prefixes is empty (no write scope configured).
+    Returns gate_error_result JSON when a write target falls outside all prefixes.
+    """
+    if not allowed_prefixes:
+        return None
+    targets = extract_bash_write_targets(cmd, cwd)
+    if not targets:
+        return None
+    normalized = tuple(os.path.realpath(p).rstrip("/") + "/" for p in allowed_prefixes)
+    for target in targets:
+        resolved = os.path.realpath(target)
+        if not any(resolved.startswith(pfx) for pfx in normalized):
+            return gate_error_result(
+                f"run_cmd write target {target!r} is outside allowed write prefixes: "
+                f"{', '.join(allowed_prefixes)}"
+            )
     return None
 
 

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -35,7 +35,7 @@ _RECIPE_READ_CMD_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"src/autoskillit/agents/.*\.md"),
 ]
 
-_RECIPE_READ_CALLABLE_PATTERN: re.Pattern[str] = re.compile(r"^autoskillit\.recipe\.(?!_cmd_rpc)")
+_RECIPE_READ_CALLABLE_PATTERN: re.Pattern[str] = re.compile(r"autoskillit\.recipe\.(?!_cmd_rpc)")
 
 
 def _get_ctx():  # type: ignore[return]
@@ -165,7 +165,7 @@ def _check_recipe_read_prohibition(
                     "for skill instructions."
                 )
     if callable_name is not None:
-        if _RECIPE_READ_CALLABLE_PATTERN.search(callable_name):
+        if _RECIPE_READ_CALLABLE_PATTERN.match(callable_name):
             return gate_error_result(
                 f"run_python {RECIPE_READ_DENY_TRIGGER}. "
                 "Use load_recipe to recall step definitions."

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -182,7 +182,6 @@ def _check_write_target_boundary(
     Returns gate_error_result JSON when a write target falls outside all prefixes.
     """
     if not allowed_prefixes:
-        logger.debug("write_target_boundary: no allowed_prefixes configured — fail-open")
         return None
     targets = extract_bash_write_targets(cmd, cwd)
     if not targets:

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -182,6 +182,7 @@ def _check_write_target_boundary(
     Returns gate_error_result JSON when a write target falls outside all prefixes.
     """
     if not allowed_prefixes:
+        logger.debug("write_target_boundary: no allowed_prefixes configured — fail-open")
         return None
     targets = extract_bash_write_targets(cmd, cwd)
     if not targets:

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -333,6 +333,10 @@ async def run_cmd(
         return gate
     try:
         with structlog.contextvars.bound_contextvars(tool="run_cmd", cwd=cwd):
+            if not _derive_run_cmd_write_prefixes():
+                logger.debug(
+                    "run_cmd: no write prefixes configured — write boundary guard inactive"
+                )
             logger.info("run_cmd", cmd=cmd[:80], cwd=cwd)
             await _notify(
                 ctx, "info", f"run_cmd: {cmd[:80]}", "autoskillit.run_cmd", extra={"cwd": cwd}

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -42,6 +42,8 @@ from autoskillit.server import mcp
 from autoskillit.server._guards import (
     _check_dry_walkthrough,
     _check_input_contracts,
+    _check_recipe_read_prohibition,
+    _check_write_target_boundary,
     _require_enabled,
     _require_orchestrator_or_higher,
     _validate_skill_command,
@@ -283,6 +285,22 @@ def _has_active_locks(order_id: str) -> bool:
     return any(v is False for steps in locked_steps.values() for v in steps.values())
 
 
+def _derive_run_cmd_write_prefixes() -> tuple[str, ...]:
+    """Read allowed write prefixes from environment.
+
+    Mirrors the env-var resolution logic in hooks/guards/write_guard.py:
+    AUTOSKILLIT_ALLOWED_WRITE_PREFIXES (colon-separated) takes precedence over
+    AUTOSKILLIT_ALLOWED_WRITE_PREFIX (single value).
+    """
+    multi = os.environ.get("AUTOSKILLIT_ALLOWED_WRITE_PREFIXES", "")
+    if multi:
+        return tuple(p for p in multi.split(":") if p)
+    single = os.environ.get("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "")
+    if single:
+        return (single,)
+    return ()
+
+
 @mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
 @_cancellation_shield(result_type="run_cmd")
 @track_response_size("run_cmd")
@@ -306,6 +324,11 @@ async def run_cmd(
     if (tier_gate := _require_orchestrator_or_higher("run_cmd")) is not None:
         return tier_gate
     if (gate := _require_enabled()) is not None:
+        return gate
+    if (gate := _check_recipe_read_prohibition(cmd=cmd)) is not None:
+        return gate
+    _write_pfx = _derive_run_cmd_write_prefixes()
+    if (gate := _check_write_target_boundary(cmd, cwd, _write_pfx)) is not None:
         return gate
     try:
         with structlog.contextvars.bound_contextvars(tool="run_cmd", cwd=cwd):
@@ -397,6 +420,8 @@ async def run_python(
     if (tier_gate := _require_orchestrator_or_higher("run_python")) is not None:
         return tier_gate
     if (gate := _require_enabled()) is not None:
+        return gate
+    if (gate := _check_recipe_read_prohibition(callable_name=callable)) is not None:
         return gate
     try:
         with structlog.contextvars.bound_contextvars(tool="run_python"):

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -327,8 +327,9 @@ async def run_cmd(
         return gate
     if (gate := _check_recipe_read_prohibition(cmd=cmd)) is not None:
         return gate
-    _write_pfx = _derive_run_cmd_write_prefixes()
-    if (gate := _check_write_target_boundary(cmd, cwd, _write_pfx)) is not None:
+    if (
+        gate := _check_write_target_boundary(cmd, cwd, _derive_run_cmd_write_prefixes())
+    ) is not None:
         return gate
     try:
         with structlog.contextvars.bound_contextvars(tool="run_cmd", cwd=cwd):

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -254,7 +254,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "_type_tradition_manifest": frozenset({"core"}),
     "_step_context": frozenset({"core", "execution", "pipeline", "server"}),
     "_execution_marker": frozenset({"core", "execution", "fleet", "server"}),
-    "bash_write_targets": frozenset({"core", "execution"}),
+    "bash_write_targets": frozenset({"core", "execution", "server"}),
 }
 
 # Narrow per-module cascade for execution/. Modules not listed here fall through

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -982,12 +982,13 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "; supports_quota_check bool at call sites replaces resolve_provider (+3 net lines)",
     ),
     "tools_execution.py": (
-        1130,
+        1150,
         "REQ-CNST-010-E8: execution tool handlers — run_cmd/run_python/run_skill are the "
         "three primary execution paths; fail-closed existence gate, empty-closure gate "
         "for fabricated skill name rejection, _check_backend_compat fail-closed gate "
         "with resolver-absent fallback via extract_skill_name, and fix-required hook "
-        "dispatch gate add defense-in-depth checks",
+        "dispatch gate add defense-in-depth checks; server-side recipe-read prohibition "
+        "and write-target boundary guards add defense-in-depth gate checks",
     ),
     "execution/backends/codex.py": (
         1114,

--- a/tests/hooks/test_hook_sync.py
+++ b/tests/hooks/test_hook_sync.py
@@ -100,3 +100,13 @@ def test_ingredient_lock_deny_trigger_sync():
         f"server={INGREDIENT_LOCK_DENY_PREFIX!r} vs "
         f"hook={INGREDIENT_LOCK_DENY_TRIGGER!r}"
     )
+
+
+def test_recipe_read_deny_trigger_sync():
+    """RECIPE_READ_DENY_TRIGGER must be identical in server guards and hook guard."""
+    from autoskillit.hooks.guards.recipe_read_guard import RECIPE_READ_DENY_TRIGGER as _HOOK
+    from autoskillit.server._guards import RECIPE_READ_DENY_TRIGGER as _SERVER
+
+    assert _SERVER == _HOOK, (
+        f"Recipe read deny trigger mismatch: server={_SERVER!r} vs hook={_HOOK!r}"
+    )

--- a/tests/server/AGENTS.md
+++ b/tests/server/AGENTS.md
@@ -115,6 +115,8 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_tools_recipe.py` | Tests for autoskillit server validate_recipe tool and recipe docstring contracts |
 | `test_tools_report_bug.py` | Tests for report_bug MCP tool handler and supporting helpers (_parse_fingerprint, _extract_block, _parse_prepare_result, _parse_enrich_result) |
 | `test_tools_run_cmd.py` | Tests for run_cmd and run_python MCP tool handlers |
+| `test_tools_run_cmd_invariants.py` | Server-side invariant tests for run_cmd: recipe-read prohibition and write-target boundary |
+| `test_tools_run_python_invariants.py` | Server-side invariant tests for run_python: recipe-read prohibition |
 | `test_tools_run_cmd_unit.py` | Unit tests for run_cmd: observability, timing, and headless gate enforcement |
 | `test_tools_run_python.py` | Unit tests for run_python: observability and headless gate enforcement |
 | `test_tools_run_python_cwd.py` | Tests for run_python work_dir path resolution: anchors relative output_dir to work_dir |

--- a/tests/server/test_guards_module.py
+++ b/tests/server/test_guards_module.py
@@ -30,3 +30,19 @@ def test_require_fleet_doc_mentions_l3():
     assert "L3" in doc
     assert "L1" in doc
     assert "L2" in doc
+
+
+def test_check_recipe_read_prohibition_importable():
+    from autoskillit.server._guards import _check_recipe_read_prohibition
+
+    doc = _check_recipe_read_prohibition.__doc__ or ""
+    assert "recipe" in doc.lower()
+    assert "headless" in doc.lower()
+
+
+def test_check_write_target_boundary_importable():
+    from autoskillit.server._guards import _check_write_target_boundary
+
+    doc = _check_write_target_boundary.__doc__ or ""
+    assert "write" in doc.lower()
+    assert "prefix" in doc.lower()

--- a/tests/server/test_tools_run_cmd_invariants.py
+++ b/tests/server/test_tools_run_cmd_invariants.py
@@ -19,6 +19,7 @@ class TestRecipeReadProhibitionCmd:
     @pytest.fixture(autouse=True)
     def _headless(self, monkeypatch):
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
 
     @pytest.mark.anyio
     async def test_denies_recipe_yaml_path(self, tool_ctx_kitchen_open):
@@ -82,6 +83,7 @@ class TestWriteTargetBoundaryCmd:
     @pytest.fixture(autouse=True)
     def _headless(self, monkeypatch):
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
 
     @pytest.mark.anyio
     async def test_denies_write_outside_allowed_prefix(self, tool_ctx_kitchen_open, monkeypatch):

--- a/tests/server/test_tools_run_cmd_invariants.py
+++ b/tests/server/test_tools_run_cmd_invariants.py
@@ -1,0 +1,112 @@
+"""Server-side invariant tests for run_cmd: recipe-read prohibition and write-target boundary."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from autoskillit.server._guards import RECIPE_READ_DENY_TRIGGER
+from autoskillit.server.tools.tools_execution import run_cmd
+from tests.conftest import _make_result
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+class TestRecipeReadProhibitionCmd:
+    """run_cmd denies recipe/skill/agent file access in headless sessions."""
+
+    @pytest.fixture(autouse=True)
+    def _headless(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+
+    @pytest.mark.anyio
+    async def test_denies_recipe_yaml_path(self, tool_ctx_kitchen_open):
+        result = json.loads(await run_cmd(cmd="cat .autoskillit/recipes/deploy.yaml", cwd="/tmp"))
+        assert result["success"] is False
+        assert result["subtype"] == "gate_error"
+        assert RECIPE_READ_DENY_TRIGGER in result["result"]
+
+    @pytest.mark.anyio
+    async def test_denies_src_recipe_yaml(self, tool_ctx_kitchen_open):
+        result = json.loads(await run_cmd(cmd="head src/autoskillit/recipes/base.yml", cwd="/tmp"))
+        assert result["subtype"] == "gate_error"
+
+    @pytest.mark.anyio
+    async def test_denies_skill_md_path(self, tool_ctx_kitchen_open):
+        result = json.loads(
+            await run_cmd(cmd="cat src/autoskillit/skills/open-kitchen/SKILL.md", cwd="/tmp")
+        )
+        assert result["subtype"] == "gate_error"
+
+    @pytest.mark.anyio
+    async def test_denies_skills_extended_skill_md(self, tool_ctx_kitchen_open):
+        result = json.loads(
+            await run_cmd(
+                cmd="cat src/autoskillit/skills_extended/audit-arch/SKILL.md",
+                cwd="/tmp",
+            )
+        )
+        assert result["subtype"] == "gate_error"
+
+    @pytest.mark.anyio
+    async def test_denies_agent_md_path(self, tool_ctx_kitchen_open):
+        result = json.loads(
+            await run_cmd(cmd="cat src/autoskillit/agents/explorer.md", cwd="/tmp")
+        )
+        assert result["subtype"] == "gate_error"
+
+    @pytest.mark.anyio
+    async def test_allows_benign_cmd(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "hello\n", ""))
+        result = json.loads(await run_cmd(cmd="echo hello", cwd="/tmp"))
+        assert result["success"] is True
+
+    @pytest.mark.anyio
+    async def test_allows_non_recipe_python_file(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+        result = json.loads(await run_cmd(cmd="cat src/autoskillit/core/__init__.py", cwd="/tmp"))
+        assert result["success"] is True
+
+    @pytest.mark.anyio
+    async def test_allows_in_non_headless(self, tool_ctx_kitchen_open, monkeypatch):
+        monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+        result = json.loads(await run_cmd(cmd="cat .autoskillit/recipes/deploy.yaml", cwd="/tmp"))
+        assert result["success"] is True
+
+
+class TestWriteTargetBoundaryCmd:
+    """run_cmd denies writes outside allowed prefixes; fails open when unset."""
+
+    @pytest.fixture(autouse=True)
+    def _headless(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+
+    @pytest.mark.anyio
+    async def test_denies_write_outside_allowed_prefix(self, tool_ctx_kitchen_open, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIXES", "/safe/dir")
+        result = json.loads(await run_cmd(cmd="echo x > /forbidden/file.txt", cwd="/tmp"))
+        assert result["success"] is False
+        assert result["subtype"] == "gate_error"
+        assert "outside allowed write prefixes" in result["result"]
+
+    @pytest.mark.anyio
+    async def test_allows_write_inside_prefix(self, tool_ctx_kitchen_open, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIXES", "/safe/dir")
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+        result = json.loads(await run_cmd(cmd="echo x > /safe/dir/file.txt", cwd="/tmp"))
+        assert result["success"] is True
+
+    @pytest.mark.anyio
+    async def test_allows_any_write_when_no_prefix(self, tool_ctx_kitchen_open):
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+        result = json.loads(await run_cmd(cmd="echo x > /anywhere/file.txt", cwd="/tmp"))
+        assert result["success"] is True
+
+    @pytest.mark.anyio
+    async def test_allows_read_only_cmd_with_prefix(self, tool_ctx_kitchen_open, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIXES", "/safe/dir")
+        tool_ctx_kitchen_open.runner.push(_make_result(0, "", ""))
+        result = json.loads(await run_cmd(cmd="ls /forbidden/", cwd="/tmp"))
+        assert result["success"] is True

--- a/tests/server/test_tools_run_python_invariants.py
+++ b/tests/server/test_tools_run_python_invariants.py
@@ -1,0 +1,62 @@
+"""Server-side invariant tests for run_python: recipe-read prohibition."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from autoskillit.server._guards import RECIPE_READ_DENY_TRIGGER
+from autoskillit.server.tools.tools_execution import run_python
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+class TestRecipeReadProhibitionCallable:
+    """run_python denies autoskillit.recipe.* callables in headless sessions."""
+
+    @pytest.fixture(autouse=True)
+    def _headless(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+
+    @pytest.mark.anyio
+    async def test_denies_recipe_callable(self, tool_ctx_kitchen_open):
+        result = json.loads(await run_python(callable="autoskillit.recipe.load_recipe"))
+        assert result["success"] is False
+        assert result["subtype"] == "gate_error"
+        assert RECIPE_READ_DENY_TRIGGER in result["result"]
+
+    @pytest.mark.anyio
+    async def test_denies_recipe_submodule_callable(self, tool_ctx_kitchen_open):
+        result = json.loads(await run_python(callable="autoskillit.recipe.schema.validate"))
+        assert result["subtype"] == "gate_error"
+
+    @pytest.mark.anyio
+    async def test_allows_cmd_rpc_callable(self, tool_ctx_kitchen_open, monkeypatch):
+        mock = AsyncMock(return_value={"success": True, "result": "ok"})
+        monkeypatch.setattr("autoskillit.server.tools.tools_execution._import_and_call", mock)
+        result = json.loads(await run_python(callable="autoskillit.recipe._cmd_rpc"))
+        assert result["success"] is True
+
+    @pytest.mark.anyio
+    async def test_allows_cmd_rpc_batch_callable(self, tool_ctx_kitchen_open, monkeypatch):
+        mock = AsyncMock(return_value={"success": True, "result": "ok"})
+        monkeypatch.setattr("autoskillit.server.tools.tools_execution._import_and_call", mock)
+        result = json.loads(await run_python(callable="autoskillit.recipe._cmd_rpc_batch"))
+        assert result["success"] is True
+
+    @pytest.mark.anyio
+    async def test_allows_non_recipe_callable(self, tool_ctx_kitchen_open, monkeypatch):
+        mock = AsyncMock(return_value={"success": True, "result": "ok"})
+        monkeypatch.setattr("autoskillit.server.tools.tools_execution._import_and_call", mock)
+        result = json.loads(await run_python(callable="autoskillit.core.paths.pkg_root"))
+        assert result["success"] is True
+
+    @pytest.mark.anyio
+    async def test_allows_in_non_headless(self, tool_ctx_kitchen_open, monkeypatch):
+        monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
+        mock = AsyncMock(return_value={"success": True, "result": "ok"})
+        monkeypatch.setattr("autoskillit.server.tools.tools_execution._import_and_call", mock)
+        result = json.loads(await run_python(callable="autoskillit.recipe.load_recipe"))
+        assert result["success"] is True

--- a/tests/server/test_tools_run_python_invariants.py
+++ b/tests/server/test_tools_run_python_invariants.py
@@ -19,6 +19,7 @@ class TestRecipeReadProhibitionCallable:
     @pytest.fixture(autouse=True)
     def _headless(self, monkeypatch):
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
 
     @pytest.mark.anyio
     async def test_denies_recipe_callable(self, tool_ctx_kitchen_open):


### PR DESCRIPTION
## Summary

Add server-side defense-in-depth guards to `_guards.py` that replicate the recipe-read prohibition currently enforced only by the `recipe_read_guard.py` PreToolUse hook, and add write-target boundary checking for `run_cmd`. This makes both prohibitions HARD-enforced inside the MCP tool layer, backend-agnostic (works for Claude Code, Codex, and any future backend), and independent of hook scripts.


Closes #4034

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260613-020615-380722/.autoskillit/temp/make-plan/t5-p5-a3-wp1-server-side-recipe-read-guard_plan_2026-06-13_021500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 90 | 26.9k | 3.0M | 136.8k | 77 | 116.9k | 16m 37s |
| verify* | sonnet | 1 | 1.3k | 11.3k | 476.4k | 62.4k | 26 | 41.5k | 6m 27s |
| implement* | MiniMax-M3 | 1 | 3.4M | 11.7k | 0 | 0 | 92 | 0 | 7m 3s |
| fix* | sonnet | 1 | 216 | 14.0k | 2.2M | 117.4k | 75 | 96.5k | 7m 5s |
| audit_impl* | sonnet | 1 | 54 | 12.8k | 231.0k | 60.3k | 17 | 41.0k | 7m 8s |
| prepare_pr* | MiniMax-M3 | 1 | 194.9k | 2.2k | 0 | 0 | 14 | 0 | 50s |
| compose_pr* | MiniMax-M3 | 1 | 178.7k | 2.2k | 0 | 0 | 12 | 0 | 49s |
| review_pr* | sonnet | 1 | 142 | 36.9k | 991.3k | 89.8k | 42 | 70.1k | 8m 51s |
| resolve_review* | sonnet | 1 | 327 | 24.6k | 2.8M | 104.5k | 89 | 83.7k | 10m 40s |
| **Total** | | | 3.8M | 142.5k | 9.7M | 136.8k | | 449.6k | 1h 5m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 292 | 0.0 | 0.0 | 40.0 |
| fix | 15 | 144832.0 | 6432.4 | 932.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 354473.6 | 10458.9 | 3078.0 |
| **Total** | **315** | 30927.9 | 1427.3 | 452.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 90 | 26.9k | 3.0M | 116.9k | 16m 37s |
| sonnet | 5 | 2.0k | 99.6k | 6.7M | 332.7k | 40m 12s |
| MiniMax-M3 | 3 | 3.7M | 16.0k | 0 | 0 | 8m 42s |