### PR TITLE
T5-P6-A11-WP1 Document Codex git_metadata_writable Sandbox Verification

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -584,7 +584,14 @@ class CodexBackend(BackendCmdBuilderBase):
             inspector_capable=False,
             supports_context_window_suffix=False,
             has_unguarded_filesystem_access=True,
-            git_metadata_writable=False,
+            # Codex workspace-write sandbox mounts .git/ read-only.
+            # Evidence: codex-rs/protocol/src/permissions.rs hardcodes
+            # .git in PROTECTED_METADATA_PATH_NAMES; enforced via
+            # Seatbelt (macOS) and bwrap/landlock (Linux).
+            # Consumers: _auto_overrides.py, fleet/_api.py gate on this
+            # field; rules_backend_compat.py emits ERROR for
+            # git_metadata_write skills on backends where this is False.
+            git_metadata_writable=False,  # sandbox excludes .git metadata path
             skill_sigil="$",
             session_dir_persistent=True,
         )

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -992,7 +992,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "and write-target boundary guards add defense-in-depth gate checks",
     ),
     "execution/backends/codex.py": (
-        1114,
+        1125,
         "REQ-CNST-010-E9: Codex backend — skill_sigil capability threading adds multi-line "
         "keyword args to _ensure_skill_prefix call sites and _has_prefix guard; "
         "write_guard_tool_names env injection adds 7 lines to _codex_exec_extras; "
@@ -1011,7 +1011,9 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "for T5-P4-A3-WP3 guard-hook backend dispatch"
         "; _materialize_profile_skills function (~43 lines) for T5-P4-A4-WP2 profile skill "
         "materialization into Codex session directories"
-        "; debug-level symlink failure log in _materialize_profile_skills (+5 net lines)",
+        "; debug-level symlink failure log in _materialize_profile_skills (+5 net lines)"
+        "; evidence comment above git_metadata_writable=False citing permissions.rs sandbox "
+        "protection and consumer path (+7 net lines) for T5-P6-A11-WP1",
     ),
 }
 

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -1748,3 +1748,8 @@ class TestCodexBackendSetupSessionDir:
         assert "# wp-elaborator" in body
         assert "## Tool Constraints" in body
         assert "```json" in body
+
+    def test_no_git_subdir_created(self) -> None:
+        self._write_all_source_files()
+        CodexBackend().setup_session_dir(self.session_dir)
+        assert not (self.session_dir / ".git").exists()

--- a/tests/execution/backends/test_codex_capabilities_fields.py
+++ b/tests/execution/backends/test_codex_capabilities_fields.py
@@ -29,3 +29,8 @@ class TestCodexCapabilitiesNewFields:
         from autoskillit.execution.backends.codex import CodexBackend
 
         assert CodexBackend().capabilities.default_skill_sandbox_mode == "workspace-write"
+
+    def test_git_metadata_writable(self):
+        from autoskillit.execution.backends.codex import CodexBackend
+
+        assert CodexBackend().capabilities.git_metadata_writable is False


### PR DESCRIPTION
## Summary

Add a documented, evidence-backed code comment above `git_metadata_writable=False` in `CodexBackend.capabilities` confirming that the Codex `workspace-write` sandbox protects `.git/` from writes. This is **Path A** — the existing value is correct. The Codex CLI source code (`codex-rs/protocol/src/permissions.rs`) hardcodes `.git` in `PROTECTED_METADATA_PATH_NAMES`, and the `default_read_only_subpaths_for_writable_root()` function enforces read-only access for `.git/` on all platforms (Seatbelt on macOS, bwrap/landlock on Linux). Add two tests: one asserting the capability field value, one asserting `setup_session_dir` does not create a `.git` subdirectory.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260627-010559-672793/.autoskillit/temp/make-plan/t5_p6_a11_wp1_codex_git_metadata_writable_plan_2026-06-27_013500.md`

Closes #4047

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 46 | 5.8k | 567.7k | 70.6k | 24 | 54.5k | 4m 4s |
| verify* | sonnet | 1 | 84 | 6.3k | 394.9k | 47.0k | 26 | 28.5k | 2m 48s |
| implement* | MiniMax-M3 | 1 | 72.9k | 3.5k | 863.5k | 0 | 32 | 0 | 1m 35s |
| fix* | sonnet | 1 | 142 | 5.6k | 780.1k | 58.1k | 41 | 39.6k | 3m 12s |
| audit_impl* | sonnet | 1 | 60 | 10.3k | 242.7k | 44.5k | 15 | 33.9k | 4m 41s |
| prepare_pr* | MiniMax-M3 | 1 | 40.7k | 2.1k | 109.0k | 0 | 11 | 0 | 32s |
| compose_pr* | MiniMax-M3 | 1 | 36.4k | 1.6k | 213.0k | 0 | 14 | 0 | 47s |
| review_pr* | sonnet | 2 | 226 | 26.4k | 1.2M | 62.3k | 64 | 79.6k | 6m 43s |
| **Total** | | | 150.6k | 61.7k | 4.4M | 70.6k | | 236.1k | 24m 24s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 19 | 45446.7 | 0.0 | 184.5 |
| fix | 6 | 130022.5 | 6595.2 | 935.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **25** | 174982.5 | 9442.7 | 2468.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 46 | 5.8k | 567.7k | 54.5k | 4m 4s |
| sonnet | 4 | 512 | 48.7k | 2.6M | 181.6k | 17m 26s |
| MiniMax-M3 | 3 | 150.1k | 7.3k | 1.2M | 0 | 2m 53s |