### PR TITLE
Document stderr regex branch unreachability and add turn.failed fixture-driven tests

### DIFF
--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -115,6 +115,7 @@ def classify_infra_exit(
     if capabilities is None or capabilities.supports_context_exhaustion_detection:
         if session._is_context_exhausted():
             return InfraExitCategory.CONTEXT_EXHAUSTED
+        # Codex turn.failed arrives on stdout (NDJSON); this stderr branch is non-Codex fallback.
         if _CODEX_CONTEXT_EXHAUSTION_PATTERN.search(result.stderr):
             return InfraExitCategory.CONTEXT_EXHAUSTED
     # Rate limit detection — must precede all API_ERROR checks (including

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -56,8 +56,11 @@ def _sr(
     )
 
 
-def _turn_failed_ndjson(error_message: str) -> str:
-    return json.dumps({"type": "turn.failed", "error": {"message": error_message}})
+def _turn_failed_ndjson(error_message: str, *, error_code: str = "") -> str:
+    error: dict[str, str] = {"message": error_message}
+    if error_code:
+        error["code"] = error_code
+    return json.dumps({"type": "turn.failed", "error": error})
 
 
 class TestClassifyInfraExit:
@@ -411,6 +414,47 @@ class TestCodexContextExhaustionFromTurnFailed:
         agent_result = CodexResultParser().parse_stdout(ndjson)
         adapted = _adapt_agent_result(agent_result)
         assert adapted.jsonl_context_exhausted is False
+
+    def test_turn_failed_error_code_only_classify_returns_context_exhausted(self) -> None:
+        ndjson = _turn_failed_ndjson("", error_code="context_length_exceeded")
+        agent_result = CodexResultParser().parse_stdout(ndjson)
+        adapted = _adapt_agent_result(agent_result)
+        result = _sr(returncode=1)
+        assert classify_infra_exit(adapted, result) == InfraExitCategory.CONTEXT_EXHAUSTED
+
+    def test_turn_failed_error_code_and_message_classify_returns_context_exhausted(self) -> None:
+        ndjson = _turn_failed_ndjson(
+            "The model's context length has been exceeded",
+            error_code="context_length_exceeded",
+        )
+        agent_result = CodexResultParser().parse_stdout(ndjson)
+        adapted = _adapt_agent_result(agent_result)
+        result = _sr(returncode=1)
+        assert classify_infra_exit(adapted, result) == InfraExitCategory.CONTEXT_EXHAUSTED
+
+    def test_turn_failed_message_only_classify_returns_context_exhausted(self) -> None:
+        ndjson = _turn_failed_ndjson("context_length_exceeded", error_code="")
+        agent_result = CodexResultParser().parse_stdout(ndjson)
+        adapted = _adapt_agent_result(agent_result)
+        result = _sr(returncode=1)
+        assert classify_infra_exit(adapted, result) == InfraExitCategory.CONTEXT_EXHAUSTED
+
+    def test_turn_failed_non_exhaustion_error_code_not_context_exhausted(self) -> None:
+        ndjson = _turn_failed_ndjson("Internal server error", error_code="server_error")
+        agent_result = CodexResultParser().parse_stdout(ndjson)
+        adapted = _adapt_agent_result(agent_result)
+        result = _sr(returncode=1)
+        assert classify_infra_exit(adapted, result) != InfraExitCategory.CONTEXT_EXHAUSTED
+
+    def test_stderr_non_exhaustion_not_context_exhausted(self) -> None:
+        session = ClaudeSessionResult(
+            subtype="success",
+            is_error=False,
+            result="",
+            session_id="s1",
+        )
+        result = _sr(returncode=1, stderr="some transient error")
+        assert classify_infra_exit(session, result) != InfraExitCategory.CONTEXT_EXHAUSTED
 
 
 class TestRateLimitClassification:

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -416,7 +416,9 @@ class TestCodexContextExhaustionFromTurnFailed:
         assert adapted.jsonl_context_exhausted is False
 
     def test_turn_failed_error_code_only_classify_returns_context_exhausted(self) -> None:
-        ndjson = _turn_failed_ndjson("", error_code="context_length_exceeded")
+        ndjson = _turn_failed_ndjson(
+            "Agent terminated unexpectedly", error_code="context_length_exceeded"
+        )
         agent_result = CodexResultParser().parse_stdout(ndjson)
         adapted = _adapt_agent_result(agent_result)
         result = _sr(returncode=1)
@@ -444,7 +446,7 @@ class TestCodexContextExhaustionFromTurnFailed:
         agent_result = CodexResultParser().parse_stdout(ndjson)
         adapted = _adapt_agent_result(agent_result)
         result = _sr(returncode=1)
-        assert classify_infra_exit(adapted, result) != InfraExitCategory.CONTEXT_EXHAUSTED
+        assert classify_infra_exit(adapted, result) == InfraExitCategory.API_ERROR
 
     def test_stderr_non_exhaustion_not_context_exhausted(self) -> None:
         session = ClaudeSessionResult(
@@ -454,7 +456,7 @@ class TestCodexContextExhaustionFromTurnFailed:
             session_id="s1",
         )
         result = _sr(returncode=1, stderr="some transient error")
-        assert classify_infra_exit(session, result) != InfraExitCategory.CONTEXT_EXHAUSTED
+        assert classify_infra_exit(session, result) == InfraExitCategory.COMPLETED
 
 
 class TestRateLimitClassification:


### PR DESCRIPTION
## Summary

Add a clarifying comment in `_exit_classification.py` documenting that the stderr regex branch (`_CODEX_CONTEXT_EXHAUSTION_PATTERN.search(result.stderr)`) is unreachable for Codex because `turn.failed` events arrive via stdout NDJSON, not stderr. Extend the `_turn_failed_ndjson` test helper with an optional `error_code` kwarg and add five new test methods exercising all `error.code` / `error.message` variants of `turn.failed` classification plus a stderr boundary test.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260627-014523-646887/.autoskillit/temp/make-plan/t5_p6_a14_wp1_stderr_regex_unreachable_plan_2026-06-27_015000.md`

Closes #4050

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 3.5k | 7.6k | 672.2k | 68.1k | 26 | 54.1k | 4m 17s |
| verify* | sonnet | 1 | 70 | 7.1k | 390.3k | 70.7k | 23 | 52.2k | 4m 9s |
| implement* | MiniMax-M3 | 1 | 62.7k | 6.2k | 1.3M | 0 | 68 | 0 | 2m 13s |
| audit_impl* | sonnet | 1 | 1.6k | 6.3k | 159.7k | 38.4k | 14 | 27.7k | 2m 56s |
| prepare_pr* | MiniMax-M3 | 1 | 40.1k | 1.7k | 110.1k | 0 | 11 | 0 | 38s |
| compose_pr* | MiniMax-M3 | 1 | 36.5k | 1.5k | 249.1k | 0 | 14 | 0 | 55s |
| review_pr* | sonnet | 1 | 124 | 16.4k | 731.1k | 62.2k | 37 | 43.9k | 4m 20s |
| resolve_review* | sonnet | 1 | 239 | 19.0k | 2.0M | 90.1k | 72 | 72.2k | 7m 34s |
| **Total** | | | 144.9k | 65.7k | 5.7M | 90.1k | | 250.2k | 27m 5s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 49 | 27125.6 | 0.0 | 126.1 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 255755.6 | 9028.8 | 2375.4 |
| **Total** | **57** | 99783.1 | 4388.6 | 1152.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 3.5k | 7.6k | 672.2k | 54.1k | 4m 17s |
| sonnet | 4 | 2.1k | 48.8k | 3.3M | 196.1k | 19m 1s |
| MiniMax-M3 | 3 | 139.4k | 9.3k | 1.7M | 0 | 3m 46s |