### PR TITLE
Implementation Plan: T5-P6-A7-WP1 Provide a Single Doctor Check Surfacing Four Codex Backend Graduation Criteria

### DIFF
--- a/src/autoskillit/cli/doctor/AGENTS.md
+++ b/src/autoskillit/cli/doctor/AGENTS.md
@@ -1,6 +1,6 @@
 # doctor/
 
-Diagnostic health checks for the autoskillit installation (28 checks).
+Diagnostic health checks for the autoskillit installation (33 checks).
 
 ## Files
 
@@ -15,7 +15,7 @@ Diagnostic health checks for the autoskillit installation (28 checks).
 | `_doctor_hooks.py` | Hook registration, executability, and registry drift checks |
 | `_doctor_install.py` | Install path, entry points, version drift, update dismissal checks |
 | `_doctor_mcp.py` | MCP server registration, dual registration, plugin cache checks |
-| `_doctor_runtime.py` | Quota cache schema version, claude process state, and codex version checks |
+| `_doctor_runtime.py` | Quota cache schema version, claude process state, codex version, and codex graduation checks |
 
 ## Architecture Notes
 

--- a/src/autoskillit/cli/doctor/__init__.py
+++ b/src/autoskillit/cli/doctor/__init__.py
@@ -61,6 +61,7 @@ from ._doctor_mcp import (
 )
 from ._doctor_runtime import (
     _check_claude_process_state_breakdown,
+    _check_codex_graduation,
     _check_codex_version,
     _check_quota_cache_schema,
     _check_script_binary,
@@ -212,6 +213,9 @@ def run_doctor(*, output_json: bool = False) -> None:
     results.append(
         _check_codex_mcp_timeouts(backend=_backend, run_skill=cfg.run_skill, fleet=cfg.fleet)
     )
+
+    # Check 33: Codex graduation criteria
+    results.append(_check_codex_graduation(backend=_backend))
 
     # Output
     if output_json:

--- a/src/autoskillit/cli/doctor/_doctor_runtime.py
+++ b/src/autoskillit/cli/doctor/_doctor_runtime.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import regex as re
 
 from autoskillit.core import (
-    AGENT_BACKEND_CODEX,
     CodingAgentBackend,
     Severity,
     default_log_dir,
@@ -210,6 +209,7 @@ def _check_codex_graduation(
     if backend is None or not backend.capabilities.version_check_command:
         return DoctorResult(Severity.OK, check_name, "Skipped (no codex backend)")
 
+    backend_name = backend.name
     log_root = log_dir or default_log_dir()
 
     # Criterion 1: version check
@@ -249,7 +249,7 @@ def _check_codex_graduation(
                 entry = json.loads(line)
             except (json.JSONDecodeError, ValueError):
                 continue
-            if entry.get("backend") == AGENT_BACKEND_CODEX:
+            if entry.get("backend") == backend_name:
                 smoke_status = "pass" if entry.get("success") else "fail"
                 break
     except OSError:

--- a/src/autoskillit/cli/doctor/_doctor_runtime.py
+++ b/src/autoskillit/cli/doctor/_doctor_runtime.py
@@ -223,7 +223,11 @@ def _check_codex_graduation(
         raw = json.loads(probe_path.read_text())
         entries = raw.get("entries", {}) if isinstance(raw, dict) else {}
         if entries:
-            probe_status = "pass" if any(e.get("passed") for e in entries.values()) else "fail"
+            probe_status = (
+                "pass"
+                if any(isinstance(e, dict) and e.get("passed") for e in entries.values())
+                else "fail"
+            )
     except (OSError, json.JSONDecodeError, ValueError):
         pass
 

--- a/src/autoskillit/cli/doctor/_doctor_runtime.py
+++ b/src/autoskillit/cli/doctor/_doctor_runtime.py
@@ -8,7 +8,13 @@ from pathlib import Path
 
 import regex as re
 
-from autoskillit.core import CodingAgentBackend, Severity, default_log_dir, get_logger
+from autoskillit.core import (
+    AGENT_BACKEND_CODEX,
+    CodingAgentBackend,
+    Severity,
+    default_log_dir,
+    get_logger,
+)
 from autoskillit.execution import QUOTA_CACHE_SCHEMA_VERSION
 
 from ._doctor_types import DoctorResult
@@ -243,7 +249,7 @@ def _check_codex_graduation(
                 entry = json.loads(line)
             except (json.JSONDecodeError, ValueError):
                 continue
-            if entry.get("backend") == "codex":
+            if entry.get("backend") == AGENT_BACKEND_CODEX:
                 smoke_status = "pass" if entry.get("success") else "fail"
                 break
     except OSError:

--- a/src/autoskillit/cli/doctor/_doctor_runtime.py
+++ b/src/autoskillit/cli/doctor/_doctor_runtime.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import regex as re
 
-from autoskillit.core import CodingAgentBackend, Severity, get_logger
+from autoskillit.core import CodingAgentBackend, Severity, default_log_dir, get_logger
 from autoskillit.execution import QUOTA_CACHE_SCHEMA_VERSION
 
 from ._doctor_types import DoctorResult
@@ -192,3 +192,71 @@ def _check_script_binary() -> DoctorResult:
             "script(1) present but -qefc flags unsupported — PTY wrapping may not work correctly",
         )
     return DoctorResult(Severity.OK, check_name, "script(1) available with -qefc support")
+
+
+def _check_codex_graduation(
+    *,
+    backend: CodingAgentBackend | None = None,
+    log_dir: Path | None = None,
+) -> DoctorResult:
+    check_name = "codex_graduation"
+
+    if backend is None or not backend.capabilities.version_check_command:
+        return DoctorResult(Severity.OK, check_name, "Skipped (no codex backend)")
+
+    log_root = log_dir or default_log_dir()
+
+    # Criterion 1: version check
+    version_result = _check_codex_version(backend=backend)
+    version_status = "pass" if version_result.severity == Severity.OK else "fail"
+
+    # Criterion 2: probe-harness cache
+    probe_path = log_root / "codex-probe-cache.json"
+    probe_status = "not-yet-run"
+    try:
+        raw = json.loads(probe_path.read_text())
+        entries = raw.get("entries", {}) if isinstance(raw, dict) else {}
+        if entries:
+            probe_status = "pass" if any(e.get("passed") for e in entries.values()) else "fail"
+    except (OSError, json.JSONDecodeError, ValueError):
+        pass
+
+    # Criterion 3: matrix last-run result
+    matrix_path = log_root / "codex-matrix-result.json"
+    matrix_status = "not-yet-run"
+    try:
+        matrix_raw = json.loads(matrix_path.read_text())
+        if isinstance(matrix_raw, dict) and "passed" in matrix_raw:
+            matrix_status = "pass" if matrix_raw["passed"] else "fail"
+    except (OSError, json.JSONDecodeError, ValueError):
+        pass
+
+    # Criterion 4: sessions.jsonl smoke
+    sessions_path = log_root / "sessions.jsonl"
+    smoke_status = "not-found"
+    try:
+        for line in reversed(sessions_path.read_text().splitlines()):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if entry.get("backend") == "codex":
+                smoke_status = "pass" if entry.get("success") else "fail"
+                break
+    except OSError:
+        pass
+
+    statuses = [version_status, probe_status, matrix_status, smoke_status]
+    summary = (
+        f"version={version_status} | probe={probe_status}"
+        f" | matrix={matrix_status} | smoke={smoke_status}"
+    )
+
+    if not all(s == "pass" for s in statuses):
+        pending = sum(1 for s in statuses if s != "pass")
+        summary += f" — EXPERIMENTAL hold: {pending} of 4 criteria pending"
+
+    return DoctorResult(Severity.INFO, check_name, summary)

--- a/tests/cli/AGENTS.md
+++ b/tests/cli/AGENTS.md
@@ -28,7 +28,7 @@ CLI command, subcommand, and interactive workflow tests.
 | `test_cook_order_prompt.py` | Tests: cook CLI order command — system prompt content, MCP prefix selection, ownership |
 | `test_cook_workspace.py` | Tests: cook CLI workspace init and clean commands |
 | `test_doctor.py` | Tests for CLI doctor command and related utilities |
-| `test_doctor_backend_guards.py` | Tests for doctor backend guard checks (stale MCP, MCP registered, process state) and run_doctor backend wiring |
+| `test_doctor_backend_guards.py` | Tests for doctor backend guard checks (stale MCP, MCP registered, process state, codex graduation) and run_doctor backend wiring |
 | `test_doctor_codex_mcp.py` | Tests for _check_mcp_server_registered Codex branch — monkeypatch-based, no filesystem I/O |
 | `test_doctor_fleet_checks.py` | Tests for fleet doctor checks — Group M ambient env/infra/campaign, Group N feature gates and registry |
 | `test_doctor_migration.py` | Tests for doctor quota cache schema, install classification, version consistency, and drift |

--- a/tests/cli/test_doctor_backend_guards.py
+++ b/tests/cli/test_doctor_backend_guards.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -579,3 +580,114 @@ class TestCheckCodexVersion:
         result = _check_codex_version(backend=CodexBackend())
         assert result.severity == Severity.OK
         assert "0.131.0" in result.message
+
+
+class TestCheckCodexGraduation:
+    """Tests for _check_codex_graduation doctor check (Check 33)."""
+
+    def _codex_result(self, stdout: str, returncode: int = 0, stderr: str = ""):
+        return type(
+            "CompletedProcess",
+            (),
+            {"returncode": returncode, "stdout": stdout, "stderr": stderr},
+        )()
+
+    def test_skip_for_none_backend(self) -> None:
+        from autoskillit.cli.doctor._doctor_runtime import _check_codex_graduation
+        from autoskillit.core import Severity
+
+        result = _check_codex_graduation(backend=None)
+        assert result.severity == Severity.OK
+        assert result.check == "codex_graduation"
+        assert "skipped" in result.message.lower()
+
+    def test_skip_for_non_codex_backend(self) -> None:
+        from types import SimpleNamespace
+
+        from autoskillit.cli.doctor._doctor_runtime import _check_codex_graduation
+        from autoskillit.core import Severity
+
+        stub = SimpleNamespace(capabilities=SimpleNamespace(version_check_command=""))
+        result = _check_codex_graduation(backend=stub)
+        assert result.severity == Severity.OK
+        assert "skipped" in result.message.lower()
+
+    def test_all_green_omits_hold_note(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import subprocess
+        from datetime import UTC, datetime
+
+        from autoskillit.cli.doctor._doctor_runtime import _check_codex_graduation
+        from autoskillit.core import Severity
+        from autoskillit.execution.backends.codex import CodexBackend
+
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: self._codex_result("Codex 0.130.0\n"),
+        )
+        ts = datetime.now(UTC).isoformat()
+        (tmp_path / "codex-probe-cache.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "entries": {"0.130.0": {"passed": True, "probe_timestamp": ts}},
+                }
+            )
+        )
+        (tmp_path / "codex-matrix-result.json").write_text(json.dumps({"passed": True}))
+        (tmp_path / "sessions.jsonl").write_text(
+            json.dumps({"backend": "codex", "success": True}) + "\n"
+        )
+
+        result = _check_codex_graduation(backend=CodexBackend(), log_dir=tmp_path)
+        assert result.severity == Severity.INFO
+        assert "version=pass" in result.message
+        assert "probe=pass" in result.message
+        assert "matrix=pass" in result.message
+        assert "smoke=pass" in result.message
+        assert "EXPERIMENTAL" not in result.message
+
+    def test_non_green_includes_hold_note(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import subprocess
+
+        from autoskillit.cli.doctor._doctor_runtime import _check_codex_graduation
+        from autoskillit.core import Severity
+        from autoskillit.execution.backends.codex import CodexBackend
+
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: self._codex_result("Codex 0.130.0\n"),
+        )
+        (tmp_path / "sessions.jsonl").write_text(
+            json.dumps({"backend": "codex", "success": True}) + "\n"
+        )
+
+        result = _check_codex_graduation(backend=CodexBackend(), log_dir=tmp_path)
+        assert result.severity == Severity.INFO
+        assert "not-yet-run" in result.message
+        assert "EXPERIMENTAL" in result.message
+
+    def test_absent_files_yield_not_yet_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import subprocess
+
+        from autoskillit.cli.doctor._doctor_runtime import _check_codex_graduation
+        from autoskillit.core import Severity
+        from autoskillit.execution.backends.codex import CodexBackend
+
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: self._codex_result("Codex 0.130.0\n"),
+        )
+        result = _check_codex_graduation(backend=CodexBackend(), log_dir=tmp_path)
+        assert result.severity == Severity.INFO
+        assert "probe=not-yet-run" in result.message
+        assert "matrix=not-yet-run" in result.message
+        assert "smoke=not-found" in result.message

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -238,14 +238,14 @@ def test_quota_thresholds_defaults() -> None:
 
 
 def test_doctor_check_count_is_31() -> None:
-    # 38 total = 17 numbered base + 7 lettered sub-checks (2b–2e, 4b, 7b, 7c)
+    # 39 total = 17 numbered base + 7 lettered sub-checks (2b–2e, 4b, 7b, 7c)
     # + 4 ambient env (18–21) + 2 feature (22–23) + 6 gated franchise (24–29)
-    # + 1 codex version (30) + 1 script binary (31).
+    # + 1 codex version (30) + 1 script binary (31) + 1 codex graduation (33).
     # The docs claim 17 user-visible checks; the gap is intentional (Check 2/4/7
     # split into sub-markers here but appear as single entries in docs).
     # Update both tests whenever a new doctor check is added.
     count = _count_doctor_checks()
-    assert count == 39, f"Expected 39 doctor checks; found {count}"
+    assert count == 40, f"Expected 40 doctor checks; found {count}"
 
 
 def test_bundled_recipe_count_is_15() -> None:

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -237,10 +237,11 @@ def test_quota_thresholds_defaults() -> None:
     assert long_ == pytest.approx(95.0)
 
 
-def test_doctor_check_count_is_31() -> None:
-    # 39 total = 17 numbered base + 7 lettered sub-checks (2b–2e, 4b, 7b, 7c)
+def test_doctor_check_count_is_40() -> None:
+    # 40 total = 17 numbered base + 7 lettered sub-checks (2b–2e, 4b, 7b, 7c)
     # + 4 ambient env (18–21) + 2 feature (22–23) + 6 gated franchise (24–29)
-    # + 1 codex version (30) + 1 script binary (31) + 1 codex graduation (33).
+    # + 1 codex version (30) + 1 script binary (31) + 1 MCP timeouts (32)
+    # + 1 codex graduation (33).
     # The docs claim 17 user-visible checks; the gap is intentional (Check 2/4/7
     # split into sub-markers here but appear as single entries in docs).
     # Update both tests whenever a new doctor check is added.


### PR DESCRIPTION
## Summary

Add `_check_codex_graduation` to the doctor runtime module. The function evaluates four graduation criteria for the `codex_backend` feature (version check, probe-harness cache, matrix last-run, sessions.jsonl smoke run), assembles a pipe-delimited status summary, and returns `Severity.INFO` with an EXPERIMENTAL hold note when any criterion is non-green. Register as Check 33 in `__init__.py` and add 5 test scenarios to `test_doctor_backend_guards.py`.

Note: The issue references "Check 34" but the current highest check number is 32 (Codex MCP tool_timeout_sec coherence). The next sequential number is 33. This plan uses 33 to maintain sequential ordering.

Closes #4056

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260627-064010-500578/.autoskillit/temp/make-plan/t5_p6_a7_wp1_codex_graduation_doctor_check_plan_2026-06-27_070000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.4k | 18.6k | 1.2M | 98.3k | 44 | 84.2k | 13m 7s |
| verify* | sonnet | 1 | 76 | 10.3k | 385.4k | 54.9k | 26 | 36.4k | 4m 50s |
| implement* | MiniMax-M3 | 1 | 65.3k | 8.4k | 1.6M | 0 | 67 | 0 | 3m 39s |
| fix* | sonnet | 1 | 360 | 16.5k | 2.9M | 86.7k | 108 | 68.2k | 8m 23s |
| audit_impl* | sonnet | 1 | 44 | 11.5k | 164.7k | 43.5k | 14 | 36.5k | 5m 20s |
| prepare_pr* | MiniMax-M3 | 1 | 41.2k | 2.8k | 156.3k | 0 | 13 | 0 | 42s |
| compose_pr* | MiniMax-M3 | 1 | 36.1k | 1.3k | 176.4k | 0 | 12 | 0 | 29s |
| review_pr* | sonnet | 1 | 158 | 55.9k | 1.2M | 105.8k | 48 | 88.4k | 12m 47s |
| resolve_review* | sonnet | 1 | 215 | 16.3k | 1.6M | 79.2k | 62 | 61.4k | 6m 49s |
| **Total** | | | 144.9k | 141.5k | 9.4M | 105.8k | | 375.1k | 56m 10s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 192 | 8428.7 | 0.0 | 43.8 |
| fix | 16 | 182832.3 | 4261.9 | 1032.5 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 13 | 125025.5 | 4720.8 | 1250.6 |
| **Total** | **221** | 42498.6 | 1697.4 | 640.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.4k | 18.6k | 1.2M | 84.2k | 13m 7s |
| sonnet | 5 | 853 | 110.4k | 6.3M | 290.9k | 38m 11s |
| MiniMax-M3 | 3 | 142.7k | 12.5k | 2.0M | 0 | 4m 51s |