### PR TITLE
Produce written audit record for TOML read-merge-write correctness

### DIFF
--- a/.autoskillit/temp/audit_toml_read_merge_write_2026-06-27.md
+++ b/.autoskillit/temp/audit_toml_read_merge_write_2026-06-27.md
@@ -1,0 +1,59 @@
+# TOML Read-Merge-Write Audit Record
+
+**Date:** 2026-06-27
+**Scope:** Confirm the TOML read-merge-write path in `_codex_config.py` and `_codex_hooks.py` preserves unknown configuration keys.
+**Verdict:** CORRECT — the path preserves all keys by design.
+
+## Finding 1: `_upsert_config_value` is absent
+
+`grep -r '_upsert_config_value' src/ tests/` returns zero hits. No upsert helper exists that could bypass the dict-based pipeline and overwrite keys.
+
+## Finding 2: `ensure_codex_mcp_registered` follows read-mutate-write
+
+File: `src/autoskillit/execution/backends/_codex_config.py`, lines 272–325.
+
+For valid TOML files (lines 313–325):
+1. **Read:** `_read_codex_config(config_path)` calls `tomllib.loads()` (lines 195–203); it returns a `ReadResult` wrapper — the caller unpacks the dict via `config = result.data` (line 314).
+2. **Mutate in-place:** Three targeted mutations — `config.setdefault("mcp_servers", {})["autoskillit"] = entry`, `config.setdefault("tool_output_token_limit", ...)`, `config["model_auto_compact_token_limit"] = ...` (lines 321–323). No keys are removed.
+3. **Write:** `_write_codex_config(config_path, config, source=result)` calls `atomic_write(path, _serialize_toml(data))` (line 212).
+
+The corrupt-file branch (lines 299–312) uses text-level `safe_upsert_section` / `_ensure_top_level_key` edits, which also preserve surrounding content.
+
+## Finding 3: `_serialize_toml` has no key allowlist
+
+File: `src/autoskillit/execution/backends/_codex_config.py`, lines 172–188.
+
+The function iterates `data.items()` three times: once for top-level scalars (line 174), once for top-level dicts (line 180), once for arrays-of-tables (line 183). There is no key exclusion list, no allowlist, no filtering. Every key present in the input dict is unconditionally emitted to the output string. Unknown keys are preserved by design.
+
+## Finding 4: `_format_toml_value` raises `TypeError` on unsupported types
+
+File: `src/autoskillit/execution/backends/_codex_config.py`, lines 49–69.
+
+The function handles `bool`, `str`, `int`, `float`, and `list`. The final `else` branch (lines 68–69) raises `TypeError(f"Unsupported TOML value type: {type(v).__name__}")`. There is no silent data loss — unsupported types cause an immediate, visible failure.
+
+## Finding 5: `sync_hooks_to_codex_config` follows the same pattern, touching only `hooks`
+
+File: `src/autoskillit/execution/backends/_codex_hooks.py`, lines 118–154.
+
+1. **Read:** `_read_codex_config(config_path)` (line 127).
+2. **Mutate:** `config["hooks"] = merged` (line 152) — this is the only key modified. All other top-level keys pass through untouched.
+3. **Write:** `_write_codex_config(config_path, config, source=result)` (line 153).
+
+The corrupt-file path (lines 128–133) uses `_upsert_hooks_text` for text-level block replacement, also preserving non-hook content.
+
+## Finding 6: Pre-existing coverage gap and how new tests close it
+
+File: `tests/execution/backends/test_codex_config.py`, class `TestDestructiveOverwritePrevention` (line 556).
+
+**Pre-existing tests (5):** Covered corrupt-file append behavior and one valid-TOML scenario (`test_ensure_mcp_registered_full_rewrite_on_valid_toml`) that only checked `mcp_servers.other` preservation — not arbitrary top-level scalars.
+
+**Coverage gap:** No test verified that non-MCP top-level scalar keys (e.g., `model`, `theme`, `disable_telemetry`) survive the read-mutate-write pipeline on the valid-TOML branch. A serializer regression skipping non-dict top-level keys would have gone undetected.
+
+**New tests closing the gap (3):**
+1. `test_preserves_unknown_top_level_scalars` (line 605) — fresh registration preserves `model`, `theme`, `disable_telemetry`.
+2. `test_preserves_unknown_top_level_scalars_on_re_registration` (line 620) — stale `tool_timeout_sec` forces rewrite; unknown scalars survive.
+3. `test_sync_preserves_unknown_top_level_scalars` in `tests/hooks/test_codex_hooks.py` (line 195) — `sync_hooks_to_codex_config` preserves `model`, `theme`.
+
+## Conclusion
+
+The TOML read-merge-write path is correct. Unknown keys are preserved at every stage because: (a) `_read_codex_config` returns the complete parsed dict, (b) mutation functions modify only targeted keys without removing others, and (c) `_serialize_toml` emits all dict entries with no allowlist filtering. Three new tests now provide regression coverage for this property.

--- a/tests/backend/test_codex_hooks_round_trip.py
+++ b/tests/backend/test_codex_hooks_round_trip.py
@@ -150,3 +150,16 @@ class TestSyncHooksToCodexConfig:
         assert not codex_dir.exists()
         sync_hooks_to_codex_config()
         assert codex_dir.exists()
+
+    def test_preserves_unknown_top_level_scalars(self, fake_home: Path):
+        """Unknown top-level scalar keys (model/theme) must survive a hook sync
+        round-trip via the default ~/.codex/config.toml path resolution."""
+        codex_dir = fake_home / ".codex"
+        codex_dir.mkdir(parents=True)
+        config_path = codex_dir / "config.toml"
+        config_path.write_text('model = "o3"\ntheme = "dark"\n')
+        sync_hooks_to_codex_config()
+        parsed = tomllib.loads(config_path.read_text())
+        assert parsed["model"] == "o3"
+        assert parsed["theme"] == "dark"
+        assert "hooks" in parsed

--- a/tests/execution/backends/test_codex_config.py
+++ b/tests/execution/backends/test_codex_config.py
@@ -602,6 +602,46 @@ class TestDestructiveOverwritePrevention:
         content = p.read_text(encoding="utf-8")
         assert f"model_auto_compact_token_limit = {CODEX_AUTO_COMPACT_LIMIT}" in content
 
+    def test_preserves_unknown_top_level_scalars(self, tmp_path):
+        """Unknown top-level scalar keys (model/theme/disable_telemetry) must survive
+        a fresh MCP registration round-trip through the read → mutate → write pipeline."""
+        p = tmp_path / "config.toml"
+        p.write_text(
+            'model = "o3"\ntheme = "dark"\ndisable_telemetry = true\n',
+            encoding="utf-8",
+        )
+        ensure_codex_mcp_registered(config_path=p)
+        result = _read_codex_config(p)
+        assert result.data["model"] == "o3"
+        assert result.data["theme"] == "dark"
+        assert result.data["disable_telemetry"] is True
+        assert "autoskillit" in result.data.get("mcp_servers", {})
+
+    def test_preserves_unknown_top_level_scalars_on_re_registration(self, tmp_path):
+        """Unknown top-level scalars must survive even when a stale tool_timeout_sec
+        forces a re-registration rewrite via the valid-TOML branch."""
+        p = tmp_path / "config.toml"
+        seed = (
+            'model = "o3"\n'
+            'theme = "dark"\n'
+            "\n"
+            "[mcp_servers.autoskillit]\n"
+            'command = "autoskillit"\n'
+            "tool_timeout_sec = 1\n"
+            f"startup_timeout_sec = {CODEX_MCP_STARTUP_TIMEOUT_SEC}\n"
+            "env_vars = []\n"
+        )
+        p.write_text(seed, encoding="utf-8")
+        changed = ensure_codex_mcp_registered(config_path=p)
+        assert changed is True
+        result = _read_codex_config(p)
+        assert result.data["model"] == "o3"
+        assert result.data["theme"] == "dark"
+        assert (
+            result.data["mcp_servers"]["autoskillit"]["tool_timeout_sec"]
+            == CODEX_MCP_TOOL_TIMEOUT_FLOOR
+        )
+
 
 class TestRequiredKeysCoverage:
     """The CODEX_MCP_REQUIRED_KEYS spec must match the keys actually written by

--- a/tests/hooks/test_codex_hooks.py
+++ b/tests/hooks/test_codex_hooks.py
@@ -192,6 +192,17 @@ class TestSyncHooksToCodexConfig:
         assert "[[hooks.PreToolUse]]" in content
         assert "[[hooks]]\n" not in content
 
+    def test_sync_preserves_unknown_top_level_scalars(self, tmp_path):
+        """Unknown top-level scalar keys (model/theme) must survive a hook sync
+        round-trip through the read → mutate → write pipeline."""
+        p = tmp_path / "config.toml"
+        p.write_text('model = "o3"\ntheme = "dark"\n', encoding="utf-8")
+        sync_hooks_to_codex_config(config_path=p)
+        result = _read_codex_config(p)
+        assert result.data["model"] == "o3"
+        assert result.data["theme"] == "dark"
+        assert "hooks" in result.data
+
 
 class TestHookSyncCorruptFilePreservation:
     def test_sync_hooks_preserves_corrupt_file_content(self, tmp_path):


### PR DESCRIPTION
## Summary

Produce a written audit record confirming that the TOML read-merge-write path in `_codex_config.py` and `_codex_hooks.py` is correct (unknown keys are preserved, no destructive overwrite), and add four new tests validating unknown-key preservation through `ensure_codex_mcp_registered` and `sync_hooks_to_codex_config`. The audit document at `.autoskillit/temp/audit_toml_read_merge_write_2026-06-27.md` confirms six findings about the read-merge-write path; tests verify behavior in `tests/backend/test_codex_hooks_round_trip.py`, `tests/execution/backends/test_codex_config.py`, and `tests/hooks/test_codex_hooks.py`.

<details>
<summary>Individual Group Plans</summary>

### Group 1: t5-p6-a8-wp1-audit-toml-read-merge-write_plan_2026-06-27_080000

Produce a written audit document confirming that the TOML read-merge-write path in `_codex_config.py` and `_codex_hooks.py` is correct (unknown keys are preserved, no destructive overwrite), then add four new tests validating unknown-key preservation through `ensure_codex_mcp_registered` and `sync_hooks_to_codex_config`. No production source files are modified.

### Group 2: t5-p6-a8-wp1-produce-written-audit-record_plan_2026-06-27_075138

Create the missing audit findings document at `.autoskillit/temp/audit_toml_read_merge_write_2026-06-27.md` confirming six findings about the TOML read-merge-write path in `_codex_config.py` and `_codex_hooks.py`. No source code or test changes — the tests already exist and pass. This is a documentation-only deliverable.

</details>




Closes #4057

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/impl-20260627-075138-527422/.autoskillit/temp/make-plan/t5-p6-a8-wp1-audit-toml-read-merge-write_plan_2026-06-27_080000.md`
- `/home/talon/projects/autoskillit-runs/impl-20260627-075138-527422/.autoskillit/temp/make-plan/t5-p6-a8-wp1-produce-written-audit-record_plan_2026-06-27_075138.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 2.9k | 17.8k | 1.8M | 87.3k | 60 | 105.9k | 15m 14s |
| verify* | sonnet | 2 | 200 | 26.0k | 1.1M | 60.4k | 63 | 81.9k | 10m 11s |
| implement* | MiniMax-M3 | 2 | 124.7k | 13.9k | 2.7M | 0 | 93 | 0 | 7m 7s |
| audit_impl* | sonnet | 2 | 1.2k | 20.1k | 467.4k | 49.5k | 31 | 68.2k | 10m 20s |
| prepare_pr* | MiniMax-M3 | 1 | 46.9k | 3.3k | 202.5k | 0 | 15 | 0 | 48s |
| compose_pr* | MiniMax-M3 | 1 | 36.7k | 1.7k | 140.8k | 0 | 11 | 0 | 32s |
| review_pr* | sonnet | 3 | 308 | 42.5k | 1.7M | 66.5k | 100 | 132.9k | 12m 3s |
| **Total** | | | 212.9k | 125.3k | 8.2M | 87.3k | | 388.9k | 56m 17s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 123 | 22298.0 | 0.0 | 113.0 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **123** | 66550.5 | 3161.8 | 1018.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.9k | 17.8k | 1.8M | 105.9k | 15m 14s |
| sonnet | 3 | 1.7k | 88.6k | 3.3M | 283.0k | 32m 35s |
| MiniMax-M3 | 3 | 208.3k | 18.9k | 3.1M | 0 | 8m 27s |