### PR TITLE
Implementation Plan: T5-P1-A1-WP2 Hook Deny Efficacy Probe Harness

### DIFF
--- a/tests/execution/backends/conftest.py
+++ b/tests/execution/backends/conftest.py
@@ -1,0 +1,134 @@
+"""Probe harness for PreToolUse deny-mechanism guard efficacy.
+
+Provides shared constants, registry-derived count invariants, and xdist-safe
+accumulation that ferries probe rows from workers to the controller via the
+``workeroutput`` IPC channel under the dedicated key ``"hook_probe_rows"`` —
+distinct from the root conftest's ``"filter_selected"`` / ``"filter_deselected"``
+keys, so filter-stats IPC is unaffected.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from autoskillit.hook_registry import HOOK_REGISTRY
+
+# Local mirror of _SKIP_CODEX_STATUSES from autoskillit.execution.backends._codex_hooks.
+# Defined here so the conftest has no import dependency on execution.backends (which
+# would create a tests/ -> execution/ IL cycle for the backends subdirectory).
+_SKIP_CODEX: frozenset[str] = frozenset({"fix-required", "not-applicable"})
+
+TOOL_CLASSES: dict[str, str] = {
+    "Bash": "Bash",
+    "Write": "Write",
+    "Edit": "Edit",
+    "Grep": "Grep",
+    "AskUserQuestion": "AskUserQuestion",
+    "mcp_run_skill": "mcp__autoskillit__run_skill",
+    "mcp_run_cmd": "mcp__autoskillit__run_cmd",
+    "mcp_run_python": "mcp__autoskillit__run_python",
+    "mcp_open_kitchen": "mcp__autoskillit__open_kitchen",
+    "mcp_remove_clone": "mcp__autoskillit__remove_clone",
+    "mcp_merge_worktree": "mcp__autoskillit__merge_worktree",
+    "mcp_push_to_remote": "mcp__autoskillit__push_to_remote",
+    "mcp_dispatch_food_truck": "mcp__autoskillit__dispatch_food_truck",
+    "mcp_wait_for_ci": "mcp__autoskillit__wait_for_ci",
+    "mcp_reset_dispatch": "mcp__autoskillit__reset_dispatch",
+    "apply_patch": "apply_patch",
+}
+
+SESSION_MODES: tuple[str, ...] = ("interactive", "headless-p", "subagent")
+BACKENDS: tuple[str, ...] = ("claude-code", "codex")
+
+
+def _compute_total_probe_count() -> int:
+    """Total parametrized combinations (including inert codex rows).
+
+    Mirrors the cross-product that ``_collect_probe_params()`` yields:
+    for each PreToolUse+deny hook with at least one matching tool class,
+    every (script, matching tool class, session mode, backend) tuple counts.
+    """
+    count = 0
+    for hd in HOOK_REGISTRY:
+        if hd.event_type != "PreToolUse" or hd.mechanism != "deny":
+            continue
+        matching = sum(1 for t in TOOL_CLASSES.values() if re.fullmatch(hd.matcher, t))
+        if matching == 0:
+            continue
+        count += matching * len(hd.scripts) * len(SESSION_MODES) * len(BACKENDS)
+    return count
+
+
+def _compute_expected_non_inert() -> int:
+    """Non-inert combinations only (matrix rows that get recorded).
+
+    A combination is inert when backend=="codex" AND the hook would be
+    excluded from ``generate_codex_hooks_config()`` — i.e.,
+    ``session_scope=="interactive_only"`` OR ``codex_status`` in
+    ``{"fix-required", "not-applicable"}``. This mirrors the filtering at
+    ``_codex_hooks.py:52-55``.
+    """
+    count = 0
+    for hd in HOOK_REGISTRY:
+        if hd.event_type != "PreToolUse" or hd.mechanism != "deny":
+            continue
+        matching = sum(1 for t in TOOL_CLASSES.values() if re.fullmatch(hd.matcher, t))
+        if matching == 0:
+            continue
+        for _ in hd.scripts:
+            for be in BACKENDS:
+                if be == "codex" and (
+                    hd.session_scope == "interactive_only" or hd.codex_status in _SKIP_CODEX
+                ):
+                    continue
+                count += matching * len(SESSION_MODES)
+    return count
+
+
+EXPECTED_TOTAL_PROBE_COUNT: int = _compute_total_probe_count()
+EXPECTED_NON_INERT_COMBINATIONS: int = _compute_expected_non_inert()
+
+# xdist-safe probe row accumulation -------------------------------------------------
+#
+# Each xdist worker has its own ``_probe_rows`` list (separate process). Workers
+# forward their accumulated rows to the controller via the built-in
+# ``workeroutput`` IPC channel under the key ``"hook_probe_rows"``. The
+# controller merges in ``pytest_testnodedown`` and writes the serialized
+# matrix in ``pytest_sessionfinish``.
+
+_probe_rows: list[dict] = []
+_controller_rows: list[dict] = []
+
+
+def record_probe_row(row: dict) -> None:
+    """Append a probe row to the current worker's accumulator."""
+    _probe_rows.append(row)
+
+
+def pytest_testnodedown(node, error):
+    """Controller-side: harvest rows from a finishing worker."""
+    wo = getattr(node, "workeroutput", {})
+    rows = wo.get("hook_probe_rows", [])
+    _controller_rows.extend(rows)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Worker-side: ship rows to controller; controller-side: serialize matrix."""
+    if hasattr(session.config, "workerinput"):
+        # xdist worker: send accumulated rows to controller via workeroutput IPC.
+        session.config.workeroutput["hook_probe_rows"] = _probe_rows
+        return
+    # Controller (or non-xdist run): write matrix JSON.
+    all_rows = _controller_rows or _probe_rows
+    if not all_rows:
+        return
+    project_dir = Path(__file__).resolve().parents[3]
+    out_dir = project_dir / ".autoskillit" / "temp"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "hook_deny_strength_matrix.json"
+    out_path.write_text(
+        json.dumps({"combinations": all_rows}, indent=2),
+        encoding="utf-8",
+    )

--- a/tests/execution/backends/test_hook_deny_efficacy_probe.py
+++ b/tests/execution/backends/test_hook_deny_efficacy_probe.py
@@ -1,0 +1,306 @@
+"""PreToolUse deny-mechanism guard efficacy probe harness.
+
+These probes measure guard decision outcomes conditional on hook firing. Whether the
+backend fires PreToolUse for MCP-class tools is an open question (B4v) requiring live
+CLI probes (CODEX_SMOKE_TEST-gated). The strength matrix emitted by P1-A1-WP3 consumes
+these results.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from autoskillit.execution.backends._codex_hooks import generate_codex_hooks_config
+from autoskillit.hook_registry import HOOK_REGISTRY, HOOKS_DIR
+from tests.execution.backends.conftest import (
+    _SKIP_CODEX,
+    BACKENDS,
+    EXPECTED_TOTAL_PROBE_COUNT,
+    SESSION_MODES,
+    TOOL_CLASSES,
+    record_probe_row,
+)
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
+
+
+SESSION_MODE_ENV: dict[str, dict[str, str]] = {
+    "interactive": {},
+    "headless-p": {
+        "AUTOSKILLIT_HEADLESS": "1",
+        "AUTOSKILLIT_SESSION_TYPE": "skill",
+    },
+    "subagent": {
+        "AUTOSKILLIT_HEADLESS": "1",
+        "AUTOSKILLIT_SESSION_TYPE": "skill",
+    },
+}
+
+BACKEND_ENV: dict[str, dict[str, str]] = {
+    "claude-code": {"AUTOSKILLIT_AGENT_BACKEND": "claude-code"},
+    "codex": {"AUTOSKILLIT_AGENT_BACKEND": "codex"},
+}
+
+# Contract: TOOL_CLASS_PAYLOADS.keys() == TOOL_CLASSES.keys()
+TOOL_CLASS_PAYLOADS: dict[str, dict] = {
+    "Bash": {
+        "tool_name": TOOL_CLASSES["Bash"],
+        "tool_input": {
+            "command": "pip install -e . && pytest tests/ && gh pr create && gh run download && git commit --amend",
+            "run_in_background": True,
+        },
+    },
+    "Write": {
+        "tool_name": TOOL_CLASSES["Write"],
+        "tool_input": {
+            "file_path": "/worktree/.autoskillit/phases/non-canonical-name.md",
+        },
+    },
+    "Edit": {
+        "tool_name": TOOL_CLASSES["Edit"],
+        "tool_input": {
+            "file_path": "/worktree/.autoskillit/phases/non-canonical-name.md",
+        },
+    },
+    "Grep": {
+        "tool_name": TOOL_CLASSES["Grep"],
+        "tool_input": {
+            "pattern": r"foo\|bar",
+            "path": "/worktree/src",
+        },
+    },
+    "AskUserQuestion": {
+        "tool_name": TOOL_CLASSES["AskUserQuestion"],
+        "tool_input": {
+            "question": "probe",
+        },
+    },
+    "mcp_run_skill": {
+        "tool_name": TOOL_CLASSES["mcp_run_skill"],
+        "tool_input": {
+            "skill_command": "non-slash-command",
+            "step_name": "probe-step",
+        },
+    },
+    "mcp_run_cmd": {
+        "tool_name": TOOL_CLASSES["mcp_run_cmd"],
+        "tool_input": {
+            "command": "pip install -e . && pytest tests/ && gh pr create && gh run download && git commit --amend",
+            "run_in_background": True,
+        },
+    },
+    "mcp_run_python": {
+        "tool_name": TOOL_CLASSES["mcp_run_python"],
+        "tool_input": {
+            "callable": "autoskillit.recipe.run_thing",
+        },
+    },
+    "mcp_open_kitchen": {
+        "tool_name": TOOL_CLASSES["mcp_open_kitchen"],
+        "tool_input": {},
+    },
+    "mcp_remove_clone": {
+        "tool_name": TOOL_CLASSES["mcp_remove_clone"],
+        "tool_input": {
+            "clone_path": "/nonexistent/path/that/does/not/exist",
+        },
+    },
+    "mcp_merge_worktree": {
+        "tool_name": TOOL_CLASSES["mcp_merge_worktree"],
+        "tool_input": {
+            "base_branch": "main",
+        },
+    },
+    "mcp_push_to_remote": {
+        "tool_name": TOOL_CLASSES["mcp_push_to_remote"],
+        "tool_input": {
+            "branch": "main",
+        },
+    },
+    "mcp_dispatch_food_truck": {
+        "tool_name": TOOL_CLASSES["mcp_dispatch_food_truck"],
+        "tool_input": {},
+    },
+    "mcp_wait_for_ci": {
+        "tool_name": TOOL_CLASSES["mcp_wait_for_ci"],
+        "tool_input": {},
+    },
+    "mcp_reset_dispatch": {
+        "tool_name": TOOL_CLASSES["mcp_reset_dispatch"],
+        "tool_input": {},
+    },
+    "apply_patch": {
+        "tool_name": TOOL_CLASSES["apply_patch"],
+        "tool_input": {
+            "patch": "--- a/foo\n+++ b/foo\n@@ -1 +1 @@\n-old\n+new\n",
+        },
+    },
+}
+
+# Verify the contract: TOOL_CLASS_PAYLOADS.keys() == TOOL_CLASSES.keys()
+assert set(TOOL_CLASS_PAYLOADS.keys()) == set(TOOL_CLASSES.keys()), (
+    "TOOL_CLASS_PAYLOADS keys must match TOOL_CLASSES keys exactly"
+)
+
+
+def _clean_env() -> dict[str, str]:
+    """Strip AUTOSKILLIT_* keys from the test runner's environment."""
+    return {k: v for k, v in os.environ.items() if not k.startswith("AUTOSKILLIT_")}
+
+
+def _invoke_guard(
+    script_path: Path,
+    stdin_payload: dict,
+    env_overrides: dict[str, str],
+    tmp_path: Path,
+) -> dict:
+    """Invoke a guard script as a subprocess and parse its JSON output.
+
+    Asserts exit code 0 (fail-open contract — guards must exit 0 on either decision).
+    Returns the parsed stdout JSON dict, or empty dict on empty stdout.
+    """
+    merged_env = {**_clean_env(), **env_overrides}
+    result = subprocess.run(  # noqa: S603  (intentional subprocess probe)
+        [sys.executable, str(script_path)],
+        input=json.dumps(stdin_payload),
+        env=merged_env,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        timeout=5,
+    )
+    assert result.returncode == 0, (
+        f"guard {script_path.name} exited {result.returncode}: {result.stderr}"
+    )
+    stdout = result.stdout.strip()
+    if not stdout:
+        return {}
+    return json.loads(stdout)
+
+
+def _build_payload(tool_class: str, session_mode: str) -> dict:
+    """Deep-copy the deny-triggering payload for a tool class, plus subagent fields."""
+    payload = copy.deepcopy(TOOL_CLASS_PAYLOADS[tool_class])
+    if session_mode == "subagent":
+        payload["agent_id"] = "probe-subagent-001"
+        payload["agent_type"] = "general-purpose"
+    return payload
+
+
+def _collect_probe_params() -> list[Any]:
+    """Yield pytest.param entries for every PreToolUse+deny combination.
+
+    Cross-product: (script) × (matching tool classes) × SESSION_MODES × BACKENDS.
+    Co-derivation contract: every yielded ``script`` satisfies
+    ``script in HOOK_REGISTRY[hookdef_idx].scripts``.
+    Yields ALL combinations including inert codex rows (inert check is in test body).
+    """
+    params: list[Any] = []
+    for hookdef_idx, hd in enumerate(HOOK_REGISTRY):
+        if hd.event_type != "PreToolUse" or hd.mechanism != "deny":
+            continue
+        for tc_key, tc_value in TOOL_CLASSES.items():
+            if not re.fullmatch(hd.matcher, tc_value):
+                continue
+            for script in hd.scripts:
+                for session_mode in SESSION_MODES:
+                    for backend in BACKENDS:
+                        params.append(
+                            pytest.param(
+                                hookdef_idx,
+                                script,
+                                tc_key,
+                                session_mode,
+                                backend,
+                                id=(f"{Path(script).stem}__{tc_key}__{session_mode}__{backend}"),
+                            )
+                        )
+    return params
+
+
+class TestHookDenyEfficacyProbe:
+    """Probe each deny-mechanism guard script as a subprocess across the matrix."""
+
+    @pytest.mark.parametrize(
+        "hookdef_idx, script, tool_class, session_mode, backend",
+        _collect_probe_params(),
+    )
+    def test_probe(
+        self,
+        hookdef_idx: int,
+        script: str,
+        tool_class: str,
+        session_mode: str,
+        backend: str,
+        tmp_path: Path,
+    ) -> None:
+        hookdef = HOOK_REGISTRY[hookdef_idx]
+
+        # --- Inert check for codex backend ---
+        # Mirrors generate_codex_hooks_config() at _codex_hooks.py:52-55: skip
+        # session_scope=="interactive_only" AND skip codex_status in {"fix-required", "not-applicable"}.
+        if backend == "codex":
+            if hookdef.session_scope == "interactive_only" or hookdef.codex_status in _SKIP_CODEX:
+                codex_config = generate_codex_hooks_config()
+                script_stem = Path(script).stem
+                for entries in codex_config.values():
+                    for entry in entries:
+                        for hook in entry.get("hooks", []):
+                            assert script_stem not in hook.get("command", ""), (
+                                f"{script_stem} found in codex config but should be excluded"
+                            )
+                return  # Inert — do not record to matrix
+
+        # --- Build env and payload ---
+        env = {**SESSION_MODE_ENV[session_mode], **BACKEND_ENV[backend]}
+        env["AUTOSKILLIT_ALLOWED_WRITE_PREFIXES"] = str(tmp_path)
+        env["AUTOSKILLIT_CWD"] = str(tmp_path)
+        payload = _build_payload(tool_class, session_mode)
+
+        # --- Set up minimal filesystem state where needed ---
+        (tmp_path / ".autoskillit" / "temp").mkdir(parents=True, exist_ok=True)
+
+        # --- Invoke guard ---
+        script_path = HOOKS_DIR / script
+        result = _invoke_guard(script_path, payload, env, tmp_path)
+
+        # --- Classify outcome ---
+        hook_output = result.get("hookSpecificOutput", {})
+        decision = hook_output.get("permissionDecision")
+
+        if decision == "deny":
+            strength = "hard"
+        else:
+            strength = "soft"
+
+        # --- Record to matrix ---
+        record_probe_row(
+            {
+                "tool_class": tool_class,
+                "session_mode": session_mode,
+                "backend": backend,
+                "hook": Path(script).stem,
+                "observed_decision": decision or "allow",
+                "codex_status_claimed": hookdef.codex_status,
+                "strength": strength,
+            }
+        )
+
+
+def test_probe_collection_count() -> None:
+    """Meta-test: parametrized probe count must match the registry-derived total.
+
+    Uses ``EXPECTED_TOTAL_PROBE_COUNT`` (total including inert), since
+    ``_collect_probe_params()`` yields all combinations. Adding a new
+    deny-mechanism hook automatically fails this test until the matrix adapts.
+    """
+    assert len(_collect_probe_params()) == EXPECTED_TOTAL_PROBE_COUNT

--- a/tests/execution/backends/test_hook_deny_efficacy_probe.py
+++ b/tests/execution/backends/test_hook_deny_efficacy_probe.py
@@ -55,7 +55,11 @@ TOOL_CLASS_PAYLOADS: dict[str, dict] = {
     "Bash": {
         "tool_name": TOOL_CLASSES["Bash"],
         "tool_input": {
-            "command": "pip install -e . && pytest tests/ && gh pr create && gh run download && git commit --amend",
+            "command": (
+                "pip install -e . && pytest tests/ "
+                "&& gh pr create && gh run download "
+                "&& git commit --amend"
+            ),
             "run_in_background": True,
         },
     },
@@ -94,7 +98,11 @@ TOOL_CLASS_PAYLOADS: dict[str, dict] = {
     "mcp_run_cmd": {
         "tool_name": TOOL_CLASSES["mcp_run_cmd"],
         "tool_input": {
-            "command": "pip install -e . && pytest tests/ && gh pr create && gh run download && git commit --amend",
+            "command": (
+                "pip install -e . && pytest tests/ "
+                "&& gh pr create && gh run download "
+                "&& git commit --amend"
+            ),
             "run_in_background": True,
         },
     },
@@ -247,7 +255,7 @@ class TestHookDenyEfficacyProbe:
 
         # --- Inert check for codex backend ---
         # Mirrors generate_codex_hooks_config() at _codex_hooks.py:52-55: skip
-        # session_scope=="interactive_only" AND skip codex_status in {"fix-required", "not-applicable"}.
+        # interactive_only session_scope OR codex_status in {fix-required, not-applicable}.
         if backend == "codex":
             if hookdef.session_scope == "interactive_only" or hookdef.codex_status in _SKIP_CODEX:
                 codex_config = generate_codex_hooks_config()

--- a/tests/execution/backends/test_hook_deny_efficacy_probe.py
+++ b/tests/execution/backends/test_hook_deny_efficacy_probe.py
@@ -285,7 +285,9 @@ class TestHookDenyEfficacyProbe:
         hook_output = result.get("hookSpecificOutput", {})
         decision = hook_output.get("permissionDecision")
 
-        if decision == "deny":
+        if not result:
+            strength = "none"
+        elif decision == "deny":
             strength = "hard"
         else:
             strength = "soft"

--- a/tests/execution/backends/test_hook_strength_matrix.py
+++ b/tests/execution/backends/test_hook_strength_matrix.py
@@ -54,7 +54,10 @@ def test_works_as_is_hooks_have_soft_or_better() -> None:
     rows = matrix["combinations"]
 
     works_as_is_stems: set[str] = {
-        Path(hd.scripts[0]).stem for hd in HOOK_REGISTRY if hd.codex_status == "works-as-is"
+        Path(script).stem
+        for hd in HOOK_REGISTRY
+        if hd.codex_status == "works-as-is"
+        for script in hd.scripts
     }
     seen_stems: set[str] = set()
     for row in rows:

--- a/tests/execution/backends/test_hook_strength_matrix.py
+++ b/tests/execution/backends/test_hook_strength_matrix.py
@@ -1,0 +1,78 @@
+"""Meta-tests for the PreToolUse deny-mechanism strength matrix.
+
+The matrix is written to ``.autoskillit/temp/hook_deny_strength_matrix.json``
+by the probe harness conftest once probes complete. When the JSON is absent
+(e.g., when only these meta-tests are collected), all three tests skip
+gracefully — the probe suite must be run first to populate the matrix.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autoskillit.hook_registry import HOOK_REGISTRY
+from tests.execution.backends.conftest import EXPECTED_NON_INERT_COMBINATIONS
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
+
+
+_MATRIX_PATH = (
+    Path(__file__).resolve().parents[3]
+    / ".autoskillit"
+    / "temp"
+    / "hook_deny_strength_matrix.json"
+)
+
+
+def _load_matrix() -> dict:
+    """Load the serialized strength matrix, skipping if absent."""
+    if not _MATRIX_PATH.exists():
+        pytest.skip("probe suite was not run — matrix JSON absent")
+    return json.loads(_MATRIX_PATH.read_text(encoding="utf-8"))
+
+
+def test_matrix_combination_count() -> None:
+    """The matrix must contain exactly EXPECTED_NON_INERT_COMBINATIONS rows.
+
+    Inert probes return early without calling ``record_probe_row``, so the
+    matrix holds only non-inert combinations.
+    """
+    matrix = _load_matrix()
+    assert len(matrix["combinations"]) == EXPECTED_NON_INERT_COMBINATIONS
+
+
+def test_works_as_is_hooks_have_soft_or_better() -> None:
+    """For each works-as-is hook, at least one matrix row must be soft or hard.
+
+    A "works-as-is" hook claims codex parity — its guard must produce a
+    non-inert outcome (``soft`` or ``hard``) for at least one matrix row.
+    """
+    matrix = _load_matrix()
+    rows = matrix["combinations"]
+
+    works_as_is_stems: set[str] = {
+        Path(hd.scripts[0]).stem for hd in HOOK_REGISTRY if hd.codex_status == "works-as-is"
+    }
+    seen_stems: set[str] = set()
+    for row in rows:
+        if row["hook"] in works_as_is_stems and row["strength"] in {"soft", "hard"}:
+            seen_stems.add(row["hook"])
+
+    missing = works_as_is_stems - seen_stems
+    assert not missing, f"works-as-is hooks missing soft/hard rows: {missing}"
+
+
+def test_not_applicable_hooks_appear_only_as_inert() -> None:
+    """Not-applicable hooks must be absent from the matrix (inert probes are not recorded)."""
+    matrix = _load_matrix()
+    rows = matrix["combinations"]
+
+    not_applicable_stems: set[str] = {
+        Path(hd.scripts[0]).stem for hd in HOOK_REGISTRY if hd.codex_status == "not-applicable"
+    }
+    matrix_stems: set[str] = {row["hook"] for row in rows}
+    leaked = not_applicable_stems & matrix_stems
+    assert not leaked, f"not-applicable hooks appeared in matrix: {leaked}"


### PR DESCRIPTION
## Summary

Create a deterministic, merge-blocking probe harness that exercises every PreToolUse deny-mechanism guard script across the full (tool_class × session_mode × backend) matrix. Three new files in `tests/execution/backends/`:

1. **`conftest.py`** — xdist-safe probe row accumulation via `workeroutput` IPC, matrix JSON serialization to `.autoskillit/temp/hook_deny_strength_matrix.json`, shared constants, and both `EXPECTED_TOTAL_PROBE_COUNT` and `EXPECTED_NON_INERT_COMBINATIONS` derived from `HOOK_REGISTRY`.
2. **`test_hook_deny_efficacy_probe.py`** — parametrized `TestHookDenyEfficacyProbe` class exercising each deny-mechanism guard script as a subprocess, plus a collection-count meta-test and a scope-boundary module docstring.
3. **`test_hook_strength_matrix.py`** — three meta-tests validating the serialized strength matrix: combination count, works-as-is strength floor, and not-applicable inert invariant.

Closes #3998

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260627-131941-432993/.autoskillit/temp/make-plan/T5-P1-A1-WP2_hook_deny_efficacy_probe_plan_2026-06-27_132500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 2.6k | 59.9k | 1.6M | 157.4k | 56 | 188.0k | 29m 54s |
| verify* | sonnet | 1 | 5.3k | 10.1k | 540.3k | 74.2k | 27 | 55.7k | 7m 12s |
| implement* | MiniMax-M3 | 1 | 89.7k | 19.1k | 2.9M | 0 | 97 | 0 | 8m 33s |
| audit_impl* | sonnet | 1 | 60 | 17.4k | 302.1k | 68.2k | 19 | 50.7k | 7m 54s |
| prepare_pr* | MiniMax-M3 | 1 | 47.0k | 2.5k | 154.2k | 0 | 12 | 0 | 1m 0s |
| compose_pr* | MiniMax-M3 | 1 | 35.8k | 1.6k | 141.4k | 0 | 12 | 0 | 25s |
| review_pr* | sonnet | 1 | 148 | 62.5k | 1.2M | 117.5k | 45 | 99.8k | 14m 24s |
| resolve_review* | sonnet | 1 | 231 | 15.7k | 2.0M | 90.3k | 69 | 72.7k | 10m 58s |
| **Total** | | | 180.9k | 188.9k | 8.7M | 157.4k | | 466.9k | 1h 20m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 526 | 5504.0 | 0.0 | 36.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 9 | 218722.4 | 8079.0 | 1749.4 |
| **Total** | **535** | 16323.5 | 872.7 | 353.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.6k | 59.9k | 1.6M | 188.0k | 29m 54s |
| sonnet | 4 | 5.7k | 105.8k | 4.0M | 278.9k | 40m 29s |
| MiniMax-M3 | 3 | 172.5k | 23.2k | 3.2M | 0 | 9m 59s |