### PR TITLE
Implementation Plan: T5-P3-A3-WP1 Establish Committed Fixture Foundation for B3a Deterministic Conformance

### DIFF
--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -153,6 +153,9 @@ tests/recipe/fixtures/*:
 tests/fixtures/codex/*.ndjson:
   - execution/
 
+tests/execution/backends/fixtures/codex_ndjson/*.json:
+  - execution/
+
 # Local .autoskillit/ config and state files
 .autoskillit/test-source-map.json:
   - infra/

--- a/tests/execution/backends/fixtures/codex_ndjson/__init__.py
+++ b/tests/execution/backends/fixtures/codex_ndjson/__init__.py
@@ -1,0 +1,24 @@
+"""Codex NDJSON deterministic conformance fixture schemas.
+
+Versions the sealed JSON Schema fixtures for B3a conformance testing.
+FIXTURE_SCHEMA_VERSION tracks the JSON Schema fixture format and is distinct
+from CODEX_SCHEMA_VERSION (in tests/fixtures/codex/ and core/types/) which
+versions the NDJSON session replay fixture format.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+FIXTURE_SCHEMA_VERSION: int = 1
+
+
+def fixture_schema_path(name: str) -> Path:
+    """Return the absolute path to a fixture file in this directory."""
+    return Path(__file__).parent / name
+
+
+__all__ = [
+    "FIXTURE_SCHEMA_VERSION",
+    "fixture_schema_path",
+]

--- a/tests/execution/backends/fixtures/codex_ndjson/config_toml_schema_template.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/config_toml_schema_template.json
@@ -1,0 +1,34 @@
+{
+  "_codex_mcp_required_keys": [
+    "command",
+    "env_vars",
+    "startup_timeout_sec",
+    "tool_timeout_sec"
+  ],
+  "mcp_server_entry_required_keys": {
+    "command": {
+      "expected_type": "str"
+    },
+    "env_vars": {
+      "expected_type": "list"
+    },
+    "startup_timeout_sec": {
+      "expected_type": "float"
+    },
+    "tool_timeout_sec": {
+      "expected_type": "float"
+    }
+  },
+  "top_level_keys": {
+    "model_auto_compact_token_limit": {
+      "constraint": "minimum",
+      "expected_type": "int",
+      "floor_value": 999999999
+    },
+    "tool_output_token_limit": {
+      "constraint": "minimum",
+      "expected_type": "int",
+      "floor_value": 50000
+    }
+  }
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/event_error.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_error.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "error",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/event_item_completed.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_item_completed.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "item": {
+      "properties": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "type": {
+      "const": "item.completed",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type",
+    "item"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/event_item_started.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_item_started.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "item.started",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/event_item_updated.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_item_updated.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "item.updated",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/event_session_meta.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_session_meta.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "payload": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "type": {
+      "const": "session_meta",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type",
+    "payload"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/event_thread_started.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_thread_started.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "thread_id": {
+      "type": "string"
+    },
+    "type": {
+      "const": "thread.started",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type",
+    "thread_id"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/event_turn_completed.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_turn_completed.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "turn.completed",
+      "type": "string"
+    },
+    "usage": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "type",
+    "usage"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/event_turn_failed.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_turn_failed.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "error": {
+      "oneOf": [
+        {
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "message"
+          ],
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "type": {
+      "const": "turn.failed",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type",
+    "error"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/event_turn_started.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_turn_started.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "turn.started",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/hook_event_format_snapshot.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/hook_event_format_snapshot.json
@@ -1,0 +1,296 @@
+{
+  "_registry_hash": "e2026897c0e2c46ff1b6beb448cade141294f1c7b296dad2b4cf46e61d8c646e",
+  "_staleness_note": "Regenerate in the same commit as P5-A6 (B4-hookdef-extension) when mechanism/enforcement_strength fields are added to HookDef.",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py formatters/pretty_output_hook",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__.*autoskillit.*"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py token_summary_hook",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py quota_post_hook",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py pipeline_step_post_hook",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py recipe_confirmed_post_hook",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__.*autoskillit.*__run_skill.*"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py review_gate_post_hook",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__.*autoskillit.*__(run_skill|run_python).*"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py resume_gate_post_hook",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "(mcp__.*autoskillit.*__)?dispatch_food_truck"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py lint_after_edit_hook",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "Write|Edit"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/skill_cmd_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/quota_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/skill_command_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/ingredient_lock_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/pipeline_step_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__.*autoskillit.*__run_skill.*"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/remove_clone_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__.*autoskillit.*__remove_clone"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/open_kitchen_guard",
+            "timeout": 5,
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__.*autoskillit.*__open_kitchen.*"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/branch_protection_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__.*autoskillit.*__merge_worktree"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/branch_protection_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__.*autoskillit.*__push_to_remote"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/unsafe_install_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/pr_create_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/compose_pr_body_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/planner_gh_discovery_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/artifact_download_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/git_ops_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/test_runner_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash|mcp__.*autoskillit.*__run_cmd"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/generated_file_write_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/planner_result_naming_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "Write|Edit"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/write_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "Write|Edit|Bash|mcp__.*autoskillit.*__run_cmd"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/skill_orchestration_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__.*autoskillit.*__(run_skill|run_cmd|run_python).*"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/recipe_read_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash|mcp__.*autoskillit.*__(run_cmd|run_python)"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/background_exec_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash|Agent"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/fleet_dispatch_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/resume_ownership_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/ingredient_lock_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          },
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/fleet_claim_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "(mcp__.*autoskillit.*__)?dispatch_food_truck"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/skill_load_guard",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "Read|Write|Edit|Bash|Grep|Glob"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/review_loop_gate",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__.*autoskillit.*__(wait_for_ci|enqueue_pr)"
+      },
+      {
+        "hooks": [
+          {
+            "command": "python3 SANITIZED_HOOKS_DIR/_dispatch.py guards/reset_resume_gate",
+            "trusted_hash": "SANITIZED_FOR_DETERMINISM",
+            "type": "command"
+          }
+        ],
+        "matcher": "(mcp__.*autoskillit.*__)?reset_dispatch"
+      }
+    ]
+  }
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/item_agent_message.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/item_agent_message.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "text": {
+      "type": "string"
+    },
+    "type": {
+      "const": "agent_message",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type",
+    "text"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/item_collab_tool_call.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/item_collab_tool_call.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "collab_tool_call",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/item_command_execution.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/item_command_execution.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "command_execution",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/item_file_change.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/item_file_change.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "changes": {
+      "items": {
+        "properties": {
+          "path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "path": {
+      "type": "string"
+    },
+    "type": {
+      "const": "file_change",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/item_function_call.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/item_function_call.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "function_call",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/item_mcp_tool_call.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/item_mcp_tool_call.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "mcp_tool_call",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/item_message.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/item_message.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "content": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "type": {
+      "const": "message",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type",
+    "content"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/item_reasoning.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/item_reasoning.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "reasoning",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/item_todo_list.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/item_todo_list.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "todo_list",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/item_web_search.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/item_web_search.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "web_search",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
## Summary

Create 21 committed JSON fixture files and 2 Python package init files under `tests/execution/backends/fixtures/codex_ndjson/` to seal the contract boundary between Codex CLI NDJSON output and the production parser. This includes 9 event schemas (one per non-UNKNOWN `CodexEventType`), 10 item schemas (one per non-UNKNOWN `CodexItemType`), a hook event format snapshot bound to `HOOK_REGISTRY_HASH`, and a config.toml schema template. Also updates `.autoskillit/test-filter-manifest.yaml` with a glob pattern for the new JSON fixture files. No source code or test files are modified — this WP produces only fixture data consumed by P3-A3-WP3's conformance tests.

Closes #4010

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260628-005721-828122/.autoskillit/temp/make-plan/t5-p3-a3-wp1-establish-fixture-foundation_plan_2026-06-28_010600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 1.3k | 22.1k | 1.4M | 105.1k | 40 | 86.5k | 14m 4s |
| verify* | sonnet | 1 | 68 | 7.3k | 356.6k | 58.3k | 23 | 39.8k | 4m 6s |
| implement* | MiniMax-M3 | 1 | 68.3k | 12.4k | 1.6M | 0 | 108 | 0 | 5m 29s |
| audit_impl* | sonnet | 1 | 62 | 14.3k | 250.9k | 51.9k | 19 | 47.6k | 7m 47s |
| prepare_pr* | MiniMax-M3 | 1 | 47.4k | 2.5k | 161.7k | 49.1k | 14 | 0 | 1m 32s |
| compose_pr* | MiniMax-M3 | 1 | 36.7k | 1.3k | 177.2k | 0 | 14 | 0 | 31s |
| review_pr* | sonnet | 1 | 132 | 28.1k | 941.9k | 89.0k | 56 | 71.1k | 6m 47s |
| resolve_review* | sonnet | 1 | 181 | 11.9k | 1.3M | 74.4k | 51 | 56.5k | 6m 15s |
| **Total** | | | 154.2k | 99.9k | 6.2M | 105.1k | | 301.5k | 46m 34s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 719 | 2245.0 | 0.0 | 17.2 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **719** | 8586.0 | 419.4 | 139.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 1.3k | 22.1k | 1.4M | 86.5k | 14m 4s |
| sonnet | 4 | 443 | 61.6k | 2.8M | 215.0k | 24m 56s |
| MiniMax-M3 | 3 | 152.4k | 16.2k | 2.0M | 0 | 7m 33s |