### PR TITLE
T5-P4-A2-WP1 — Eliminate noqa:F841 Silent Parameter Discards in CodexBackend

### DIFF
--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -833,7 +833,7 @@ class CodexBackend(BackendCmdBuilderBase):
     ) -> CmdSpec:
         if plugin_source is not None:
             logger.warning("codex_plugin_source_discarded", plugin_source=str(plugin_source))
-        if output_format != OutputFormat.JSON:
+        if output_format != OutputFormat.STREAM_JSON:
             logger.warning("codex_output_format_coerced")
 
         if resume_session_id:

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -696,10 +696,10 @@ class CodexBackend(BackendCmdBuilderBase):
             cfg = self._apply_config(config)
             completion_marker = cfg["completion_marker"]
             model = cfg["model"]
-            plugin_source = cfg["plugin_source"]  # noqa: F841  # no-op: Codex has no --plugin-dir equivalent
-            output_format = cfg["output_format"]  # noqa: F841  # no-op: --json is unconditional for Codex
+            plugin_source = cfg["plugin_source"]
+            output_format = cfg["output_format"]
             add_dirs = cfg["add_dirs"]
-            exit_after_stop_delay_ms = cfg["exit_after_stop_delay_ms"]  # noqa: F841  # no-op: Claude-only
+            exit_after_stop_delay_ms = cfg["exit_after_stop_delay_ms"]
             stream_idle_timeout_ms = cfg["stream_idle_timeout_ms"]
             scenario_step_name = cfg["scenario_step_name"]
             temp_dir_relpath = cfg["temp_dir_relpath"]
@@ -711,6 +711,10 @@ class CodexBackend(BackendCmdBuilderBase):
             resume_checkpoint = cfg["resume_checkpoint"]
             resume_message = cfg["resume_message"]
             sandbox_mode = cfg["sandbox_mode"]
+        if plugin_source is not None:
+            logger.warning("codex_plugin_source_discarded", plugin_source=str(plugin_source))
+        if output_format != OutputFormat.JSON:
+            logger.warning("codex_output_format_coerced")
         _has_prefix = (
             bool(profile_name)
             and skill_command.strip().startswith("/")
@@ -769,6 +773,14 @@ class CodexBackend(BackendCmdBuilderBase):
             extras["AUTOSKILLIT_COMPLETION_MARKER"] = completion_marker
         if add_dirs:
             extras["CODEX_HOME"] = add_dirs[0].path
+        if exit_after_stop_delay_ms:
+            extras.setdefault(
+                "AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(exit_after_stop_delay_ms / 1000)
+            )
+        if stream_idle_timeout_ms:
+            extras.setdefault(
+                "AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(stream_idle_timeout_ms / 1000)
+            )
 
         filtered_base = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}
         env = CodexEnvPolicy().build_env(
@@ -819,9 +831,10 @@ class CodexBackend(BackendCmdBuilderBase):
         sentinel_contract: str = "",
         resume_message: str | None = None,
     ) -> CmdSpec:
-        _plugin_source = plugin_source  # noqa: F841  # no-op: Codex has no --plugin-dir
-        _output_format = output_format  # noqa: F841  # no-op: --json is unconditional
-        _exit_ms = exit_after_stop_delay_ms  # noqa: F841  # no-op: Claude-only
+        if plugin_source is not None:
+            logger.warning("codex_plugin_source_discarded", plugin_source=str(plugin_source))
+        if output_format != OutputFormat.JSON:
+            logger.warning("codex_output_format_coerced")
 
         if resume_session_id:
             effective_prompt = _compose_resume_prompt(
@@ -864,6 +877,14 @@ class CodexBackend(BackendCmdBuilderBase):
             for k, v in env_extras.items():
                 if k not in _PROVIDER_EXTRAS_BASE_DENYLIST:
                     extras[k] = v
+        if exit_after_stop_delay_ms:
+            extras.setdefault(
+                "AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(exit_after_stop_delay_ms / 1000)
+            )
+        if stream_idle_timeout_ms:
+            extras.setdefault(
+                "AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(stream_idle_timeout_ms / 1000)
+            )
 
         filtered_base = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}
         env = CodexEnvPolicy().build_env(

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -996,7 +996,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "crash-close before executor when /dev/shm path has been reclaimed (+26 net lines)",
     ),
     "execution/backends/codex.py": (
-        1125,
+        1150,
         "REQ-CNST-010-E9: Codex backend — skill_sigil capability threading adds multi-line "
         "keyword args to _ensure_skill_prefix call sites and _has_prefix guard; "
         "write_guard_tool_names env injection adds 7 lines to _codex_exec_extras; "
@@ -1018,7 +1018,10 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "; debug-level symlink failure log in _materialize_profile_skills (+5 net lines)"
         "; evidence comment above git_metadata_writable=False citing permissions.rs sandbox "
         "protection and consumer path (+7 net lines) for T5-P6-A11-WP1"
-        "; env-assembly consolidation via _assemble_shared_env_extras (T5-P4-A1-WP2)",
+        "; env-assembly consolidation via _assemble_shared_env_extras (T5-P4-A1-WP2)"
+        "; explicit parameter dispositions for "
+        "plugin_source/output_format/exit_after_stop_delay_ms "
+        "replacing noqa:F841 silent discards (+18 net lines) for T5-P4-A2-WP1",
     ),
 }
 

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -1638,11 +1638,15 @@ class TestCodexDiscardDispositions:
         )
         assert spec.process_idle_timeout_ms == 10000
 
-    def test_zero_ms_no_idle_timeout_skill_builder(self) -> None:
+    def test_zero_ms_no_idle_timeout_skill_builder(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", raising=False)
         spec = CodexBackend().build_skill_session_cmd(**self.SKILL_BASE)
         assert "AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT" not in spec.env
 
-    def test_zero_ms_no_idle_timeout_food_truck_builder(self) -> None:
+    def test_zero_ms_no_idle_timeout_food_truck_builder(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", raising=False)
         spec = CodexBackend().build_food_truck_cmd(**self.FOOD_TRUCK_BASE)
         assert "AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT" not in spec.env
 

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -611,20 +611,17 @@ class TestCodexBuildSkillSessionCmd:
         spec2 = CodexBackend().build_skill_session_cmd(**self.BASE)
         assert "AUTOSKILLIT_COMPLETION_MARKER" not in spec2.env
 
-    def test_claude_only_params_accepted_but_ignored(self) -> None:
-        spec = CodexBackend().build_skill_session_cmd(
-            **{
-                **self.BASE,
-                "exit_after_stop_delay_ms": 5000,
-                "stream_idle_timeout_ms": 3000,
-            }
-        )
-        cmd_str = " ".join(spec.cmd)
-        assert "--output-format" not in cmd_str
-        assert "--plugin-dir" not in cmd_str
+    def test_default_params_emit_no_warnings(self) -> None:
+        with structlog.testing.capture_logs() as cap_logs:
+            spec = CodexBackend().build_skill_session_cmd(**self.BASE)
+        discard_events = [
+            e
+            for e in cap_logs
+            if e.get("event") in ("codex_plugin_source_discarded", "codex_output_format_coerced")
+        ]
+        assert discard_events == []
         assert "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY" not in spec.env
         assert "CLAUDE_STREAM_IDLE_TIMEOUT_MS" not in spec.env
-        assert spec.process_idle_timeout_ms == 3000
 
     def test_stream_idle_timeout_routed_to_cmdspec(self) -> None:
         spec = CodexBackend().build_skill_session_cmd(

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -1537,58 +1537,140 @@ class TestClaudeCodeBackendProcessIdleDefault:
 
 
 class TestCodexDiscardDispositions:
-    """Document the complete noqa:F841 discard disposition picture in codex.py.
+    """Codex builder parameter disposition contracts.
 
-    stream_idle_timeout_ms -> routed to CmdSpec.process_idle_timeout_ms (P1-A6-WP1).
-    plugin_source, output_format, exit_after_stop_delay_ms -> intentional
-    no-op discards (P2-A2 scope).
+    plugin_source -> logged warning when non-None.
+    output_format -> logged warning when != JSON.
+    exit_after_stop_delay_ms -> AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT env injection via setdefault.
+    stream_idle_timeout_ms -> routed to CmdSpec.process_idle_timeout_ms + env injection.
     """
 
-    def test_stream_idle_timeout_routed_in_skill_builder(self) -> None:
+    SKILL_BASE: dict[str, object] = {
+        "skill_command": "/test",
+        "cwd": "/work",
+        "completion_marker": "%%DONE%%",
+    }
+    FOOD_TRUCK_BASE: dict[str, object] = {
+        "orchestrator_prompt": "go",
+        "plugin_source": DirectInstall(plugin_dir=Path("/pkg")),
+        "cwd": "/work",
+        "completion_marker": "%%DONE%%",
+    }
+
+    def test_plugin_source_warning_skill_builder(self) -> None:
+        with structlog.testing.capture_logs() as cap_logs:
+            CodexBackend().build_skill_session_cmd(
+                **self.SKILL_BASE,
+                plugin_source=DirectInstall(plugin_dir=Path("/pkg")),
+            )
+        events = [e for e in cap_logs if e.get("event") == "codex_plugin_source_discarded"]
+        assert len(events) == 1
+        assert events[0]["log_level"] == "warning"
+
+    def test_plugin_source_warning_food_truck_builder(self) -> None:
+        with structlog.testing.capture_logs() as cap_logs:
+            CodexBackend().build_food_truck_cmd(**self.FOOD_TRUCK_BASE)
+        events = [e for e in cap_logs if e.get("event") == "codex_plugin_source_discarded"]
+        assert len(events) == 1
+        assert events[0]["log_level"] == "warning"
+
+    def test_output_format_warning_skill_builder(self) -> None:
+        with structlog.testing.capture_logs() as cap_logs:
+            CodexBackend().build_skill_session_cmd(
+                **self.SKILL_BASE,
+                output_format=OutputFormat.STREAM_JSON,
+            )
+        events = [e for e in cap_logs if e.get("event") == "codex_output_format_coerced"]
+        assert len(events) == 1
+        assert events[0]["log_level"] == "warning"
+
+    def test_output_format_warning_food_truck_builder(self) -> None:
+        with structlog.testing.capture_logs() as cap_logs:
+            CodexBackend().build_food_truck_cmd(
+                **self.FOOD_TRUCK_BASE,
+                output_format=OutputFormat.JSON,
+            )
+        events = [e for e in cap_logs if e.get("event") == "codex_output_format_coerced"]
+        assert len(events) == 1
+        assert events[0]["log_level"] == "warning"
+
+    def test_exit_delay_injects_idle_timeout_skill_builder(self) -> None:
         spec = CodexBackend().build_skill_session_cmd(
-            skill_command="/test",
-            cwd="/work",
-            completion_marker="%%DONE%%",
+            **self.SKILL_BASE,
+            exit_after_stop_delay_ms=5000,
+        )
+        assert spec.env["AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT"] == "5.0"
+
+    def test_exit_delay_injects_idle_timeout_food_truck_builder(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(
+            **self.FOOD_TRUCK_BASE,
+            exit_after_stop_delay_ms=5000,
+        )
+        assert spec.env["AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT"] == "5.0"
+
+    def test_stream_idle_injects_idle_timeout_skill_builder(self) -> None:
+        spec = CodexBackend().build_skill_session_cmd(
+            **self.SKILL_BASE,
+            stream_idle_timeout_ms=3000,
+        )
+        assert spec.env["AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT"] == "3.0"
+        assert spec.process_idle_timeout_ms == 3000
+
+    def test_stream_idle_injects_idle_timeout_food_truck_builder(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(
+            **self.FOOD_TRUCK_BASE,
+            stream_idle_timeout_ms=3000,
+        )
+        assert spec.env["AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT"] == "3.0"
+        assert spec.process_idle_timeout_ms == 3000
+
+    def test_stream_idle_routed_to_process_idle_skill_builder(self) -> None:
+        spec = CodexBackend().build_skill_session_cmd(
+            **self.SKILL_BASE,
             stream_idle_timeout_ms=10000,
         )
         assert spec.process_idle_timeout_ms == 10000
 
-    def test_stream_idle_timeout_routed_in_food_truck_builder(self) -> None:
+    def test_stream_idle_routed_to_process_idle_food_truck_builder(self) -> None:
         spec = CodexBackend().build_food_truck_cmd(
-            orchestrator_prompt="go",
-            plugin_source=DirectInstall(plugin_dir=Path("/pkg")),
-            cwd="/work",
-            completion_marker="%%DONE%%",
-            stream_idle_timeout_ms=20000,
+            **self.FOOD_TRUCK_BASE,
+            stream_idle_timeout_ms=10000,
         )
-        assert spec.process_idle_timeout_ms == 20000
+        assert spec.process_idle_timeout_ms == 10000
 
-    def test_exit_after_stop_delay_still_discarded(self) -> None:
+    def test_zero_ms_no_idle_timeout_skill_builder(self) -> None:
+        spec = CodexBackend().build_skill_session_cmd(**self.SKILL_BASE)
+        assert "AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT" not in spec.env
+
+    def test_zero_ms_no_idle_timeout_food_truck_builder(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(**self.FOOD_TRUCK_BASE)
+        assert "AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT" not in spec.env
+
+    def test_existing_idle_timeout_not_overwritten_skill_builder(self) -> None:
         spec = CodexBackend().build_skill_session_cmd(
-            skill_command="/test",
-            cwd="/work",
-            completion_marker="%%DONE%%",
+            **self.SKILL_BASE,
             exit_after_stop_delay_ms=5000,
+            provider_extras={"AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT": "99.0"},
         )
-        assert "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY" not in spec.env
+        assert spec.env["AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT"] == "99.0"
 
-    def test_plugin_source_still_discarded(self) -> None:
-        spec = CodexBackend().build_skill_session_cmd(
-            skill_command="/test",
-            cwd="/work",
-            completion_marker="%%DONE%%",
-            plugin_source=DirectInstall(plugin_dir=Path("/pkg")),
+    def test_existing_idle_timeout_not_overwritten_food_truck_builder(self) -> None:
+        spec = CodexBackend().build_food_truck_cmd(
+            **self.FOOD_TRUCK_BASE,
+            exit_after_stop_delay_ms=5000,
+            env_extras={"AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT": "99.0"},
         )
-        assert "--plugin-dir" not in " ".join(spec.cmd)
+        assert spec.env["AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT"] == "99.0"
 
-    def test_output_format_still_discarded(self) -> None:
-        spec = CodexBackend().build_skill_session_cmd(
-            skill_command="/test",
-            cwd="/work",
-            completion_marker="%%DONE%%",
-            output_format=OutputFormat.STREAM_JSON,
-        )
-        assert "--json" in spec.cmd
+    def test_no_warnings_on_defaults_skill_builder(self) -> None:
+        with structlog.testing.capture_logs() as cap_logs:
+            CodexBackend().build_skill_session_cmd(**self.SKILL_BASE)
+        discard_events = [
+            e
+            for e in cap_logs
+            if e.get("event") in ("codex_plugin_source_discarded", "codex_output_format_coerced")
+        ]
+        assert discard_events == []
 
 
 class TestCodexBackendSetupSessionDir:


### PR DESCRIPTION
## Summary

Remove all 6 `noqa:F841` silent parameter discards across `build_skill_session_cmd` and `build_food_truck_cmd` in `codex.py`. Each discarded parameter gets an explicit disposition: `plugin_source` and `output_format` emit structlog warnings when non-default values are passed, and `exit_after_stop_delay_ms` (plus `stream_idle_timeout_ms`) inject `AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT` into env extras via `setdefault`. Replace the old test and rewrite the `TestCodexDiscardDispositions` class to assert the new behavioral contracts.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260628-060859-170393/.autoskillit/temp/make-plan/t5_p4_a2_wp1_eliminate_noqa_f841_discards_plan_2026-06-28_061300.md`

Closes #4016

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 2.0k | 18.0k | 1.2M | 84.8k | 45 | 89.9k | 11m 47s |
| verify* | sonnet | 1 | 68 | 9.4k | 335.3k | 54.9k | 21 | 36.5k | 4m 12s |
| implement* | MiniMax-M3 | 1 | 74.7k | 12.0k | 1.8M | 0 | 73 | 0 | 10m 28s |
| fix* | sonnet | 1 | 248 | 16.6k | 2.0M | 91.2k | 77 | 72.6k | 6m 59s |
| audit_impl* | sonnet | 1 | 62 | 22.1k | 286.2k | 67.5k | 21 | 53.3k | 9m 5s |
| prepare_pr* | MiniMax-M3 | 1 | 41.9k | 1.9k | 111.0k | 0 | 11 | 0 | 30s |
| compose_pr* | MiniMax-M3 | 1 | 35.9k | 1.1k | 175.8k | 0 | 12 | 0 | 35s |
| review_pr* | sonnet | 1 | 134 | 26.9k | 886.9k | 77.2k | 36 | 59.7k | 6m 52s |
| resolve_review* | sonnet | 1 | 197 | 17.7k | 1.5M | 83.4k | 53 | 65.7k | 7m 5s |
| **Total** | | | 155.1k | 125.8k | 8.5M | 91.2k | | 377.8k | 57m 35s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 206 | 8946.3 | 0.0 | 58.4 |
| fix | 17 | 119658.8 | 4273.5 | 976.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **223** | 37902.8 | 1694.3 | 564.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.0k | 18.0k | 1.2M | 89.9k | 11m 47s |
| sonnet | 5 | 709 | 92.7k | 5.1M | 287.9k | 34m 15s |
| MiniMax-M3 | 3 | 152.5k | 15.1k | 2.1M | 0 | 11m 32s |