### PR TITLE
Implementation Plan: Make MCP Tool Timeout a First-Class RunSkillConfig Field

### DIFF
--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -104,6 +104,7 @@ class RunSkillConfig:
     idle_output_timeout: int = 1000
     max_suppression_seconds: int = 1800
     stream_idle_timeout_ms: int = 600000
+    mcp_tool_timeout_sec: float = 14364.0
 
     # Safety margin (ms) above exit_after_stop_delay_ms that
     # natural_exit_grace_seconds must cover so the drain window can absorb
@@ -111,6 +112,8 @@ class RunSkillConfig:
     _EXIT_GRACE_BUFFER_MS: ClassVar[int] = 500
 
     def __post_init__(self) -> None:
+        if self.mcp_tool_timeout_sec <= 0:
+            raise ValueError(f"mcp_tool_timeout_sec={self.mcp_tool_timeout_sec} must be > 0.")
         if self.stream_idle_timeout_ms < 0:
             raise ValueError(
                 f"stream_idle_timeout_ms={self.stream_idle_timeout_ms} must be >= 0 "

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -51,6 +51,7 @@ run_skill:
   idle_output_timeout: 1000
   max_suppression_seconds: 1800
   stream_idle_timeout_ms: 600000
+  mcp_tool_timeout_sec: 14364.0
 
 model:
   default: sonnet

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -513,7 +513,9 @@ class AutomationConfig:
         except ValueError as exc:
             raise ValueError(f"fleet config: {exc}") from exc
         _timeout_coherence_gate(result.run_skill)
-        _codex_mcp_timeout_coherence_gate(result.run_skill, result.fleet)
+        _codex_mcp_timeout_coherence_gate(
+            result.run_skill, result.fleet, tool_timeout=result.run_skill.mcp_tool_timeout_sec
+        )
         return result
 
 

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -1084,15 +1084,17 @@ async def run_skill(
                                 inspector_eligible=_in_fleet_dispatch and bool(_inspector_model),
                                 inspector_model=_inspector_model,
                             )
-                except TimeoutError:
+                except TimeoutError as exc:
                     logger.error(
                         "run_skill_mcp_tool_timeout",
                         timeout_sec=_cfg.run_skill.mcp_tool_timeout_sec,
                     )
+                    _timeout_exc = TimeoutError(
+                        f"MCP tool timeout ({_cfg.run_skill.mcp_tool_timeout_sec}s) exceeded"
+                    )
+                    _timeout_exc.__cause__ = exc
                     return SkillResult.crashed(
-                        exception=TimeoutError(
-                            f"MCP tool timeout ({_cfg.run_skill.mcp_tool_timeout_sec}s) exceeded"
-                        ),
+                        exception=_timeout_exc,
                         skill_command=resolved_command,
                         order_id=effective_order_id,
                     ).to_json()

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -1041,47 +1041,61 @@ async def run_skill(
 
             _start = time.monotonic()
             try:
-                async with execution_marker(
-                    _marker_dir,
-                    _orchestrator_sid,
-                    "run-skill",
-                ):
-                    skill_result = await tool_ctx.executor.run(
-                        resolved_command,
-                        cwd,
-                        model=effective_model,
-                        add_dirs=skill_add_dirs,
-                        step_name=step_name,
-                        kitchen_id=tool_ctx.kitchen_id,
-                        order_id=effective_order_id,
-                        expected_output_patterns=expected_output_patterns,
-                        write_behavior=write_spec,
-                        stale_threshold=float(stale_threshold)
-                        if stale_threshold is not None
-                        else None,
-                        idle_output_timeout=float(idle_output_timeout)
-                        if idle_output_timeout is not None
-                        else None,
-                        completion_marker=invocation_marker,
-                        recipe_name=tool_ctx.recipe_name,
-                        recipe_content_hash=tool_ctx.recipe_content_hash,
-                        recipe_composite_hash=tool_ctx.recipe_composite_hash,
-                        recipe_version=tool_ctx.recipe_version,
-                        allowed_write_prefix=allowed_write_prefix,
-                        allowed_write_prefixes=allowed_write_prefixes,
-                        readonly_skill=is_read_only,
-                        completion_required=completion_required,
-                        write_watch_dirs=write_watch_dirs,
-                        provider_extras=provider_extras,
-                        profile_name=profile_name_out,
-                        provider_name=profile_name_out,
-                        backend_override=backend_override,
-                        resume_session_id=resume_session_id,
-                        marker_dir=_marker_dir,
-                        caller_session_id=_orchestrator_sid,
-                        inspector_eligible=_in_fleet_dispatch and bool(_inspector_model),
-                        inspector_model=_inspector_model,
+                try:
+                    with anyio.fail_after(_cfg.run_skill.mcp_tool_timeout_sec):
+                        async with execution_marker(
+                            _marker_dir,
+                            _orchestrator_sid,
+                            "run-skill",
+                        ):
+                            skill_result = await tool_ctx.executor.run(
+                                resolved_command,
+                                cwd,
+                                model=effective_model,
+                                add_dirs=skill_add_dirs,
+                                step_name=step_name,
+                                kitchen_id=tool_ctx.kitchen_id,
+                                order_id=effective_order_id,
+                                expected_output_patterns=expected_output_patterns,
+                                write_behavior=write_spec,
+                                stale_threshold=float(stale_threshold)
+                                if stale_threshold is not None
+                                else None,
+                                idle_output_timeout=float(idle_output_timeout)
+                                if idle_output_timeout is not None
+                                else None,
+                                completion_marker=invocation_marker,
+                                recipe_name=tool_ctx.recipe_name,
+                                recipe_content_hash=tool_ctx.recipe_content_hash,
+                                recipe_composite_hash=tool_ctx.recipe_composite_hash,
+                                recipe_version=tool_ctx.recipe_version,
+                                allowed_write_prefix=allowed_write_prefix,
+                                allowed_write_prefixes=allowed_write_prefixes,
+                                readonly_skill=is_read_only,
+                                completion_required=completion_required,
+                                write_watch_dirs=write_watch_dirs,
+                                provider_extras=provider_extras,
+                                profile_name=profile_name_out,
+                                provider_name=profile_name_out,
+                                backend_override=backend_override,
+                                resume_session_id=resume_session_id,
+                                marker_dir=_marker_dir,
+                                caller_session_id=_orchestrator_sid,
+                                inspector_eligible=_in_fleet_dispatch and bool(_inspector_model),
+                                inspector_model=_inspector_model,
+                            )
+                except TimeoutError:
+                    logger.error(
+                        "run_skill_mcp_tool_timeout",
+                        timeout_sec=_cfg.run_skill.mcp_tool_timeout_sec,
                     )
+                    return SkillResult.crashed(
+                        exception=TimeoutError(
+                            f"MCP tool timeout ({_cfg.run_skill.mcp_tool_timeout_sec}s) exceeded"
+                        ),
+                        skill_command=resolved_command,
+                        order_id=effective_order_id,
+                    ).to_json()
                 if skill_result.success:
                     tool_ctx.audit.record_success(skill_command)
                     _clear_run_skill_state(tool_ctx.project_dir)

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -10,7 +10,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import anyio  # noqa: E402  (added by mcp_tool_timeout plan)
+import anyio
 
 if TYPE_CHECKING:
     from autoskillit.fleet import DispatchOutcome

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -10,6 +10,8 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import anyio  # noqa: E402  (added by mcp_tool_timeout plan)
+
 if TYPE_CHECKING:
     from autoskillit.fleet import DispatchOutcome
 
@@ -376,35 +378,47 @@ async def dispatch_food_truck(
             tool_ctx.backend is not None
             and tool_ctx.backend.capabilities.anthropic_provider_capable
         )
-        result = await execute_dispatch(
-            tool_ctx=tool_ctx,
-            recipe=recipe,
-            task=task,
-            ingredients=ingredients,
-            dispatch_name=dispatch_name,
-            timeout_sec=timeout_sec,
-            prompt_builder=_get_food_truck_prompt_builder(
-                has_unguarded_filesystem_access=(
-                    tool_ctx.backend.capabilities.has_unguarded_filesystem_access
-                    if tool_ctx.backend
-                    else False
-                ),
-            ),
-            quota_checker=lambda cfg: check_and_sleep_if_needed(
-                cfg,
-                provider="anthropic" if _supports_quota else "",
-            ),
-            quota_refresher=_refresh_quota_cache,
-            cache_invalidator=invalidate_cache,
-            capture=capture,
-            resume_session_id=resume_session_id,
-            resume_checkpoint=parsed_checkpoint,
-            idle_output_timeout=idle_output_timeout,
-            caller_session_id=caller_session_id,
-            prior_dispatch_id=prior_dispatch_id,
-            resume_message=resume_message,
-            caller_instructions=caller_instructions,
-        )
+        try:
+            with anyio.fail_after(tool_ctx.config.run_skill.mcp_tool_timeout_sec):
+                result = await execute_dispatch(
+                    tool_ctx=tool_ctx,
+                    recipe=recipe,
+                    task=task,
+                    ingredients=ingredients,
+                    dispatch_name=dispatch_name,
+                    timeout_sec=timeout_sec,
+                    prompt_builder=_get_food_truck_prompt_builder(
+                        has_unguarded_filesystem_access=(
+                            tool_ctx.backend.capabilities.has_unguarded_filesystem_access
+                            if tool_ctx.backend
+                            else False
+                        ),
+                    ),
+                    quota_checker=lambda cfg: check_and_sleep_if_needed(
+                        cfg,
+                        provider="anthropic" if _supports_quota else "",
+                    ),
+                    quota_refresher=_refresh_quota_cache,
+                    cache_invalidator=invalidate_cache,
+                    capture=capture,
+                    resume_session_id=resume_session_id,
+                    resume_checkpoint=parsed_checkpoint,
+                    idle_output_timeout=idle_output_timeout,
+                    caller_session_id=caller_session_id,
+                    prior_dispatch_id=prior_dispatch_id,
+                    resume_message=resume_message,
+                    caller_instructions=caller_instructions,
+                )
+        except TimeoutError:
+            logger.error(
+                "dispatch_food_truck_mcp_tool_timeout",
+                timeout_sec=tool_ctx.config.run_skill.mcp_tool_timeout_sec,
+            )
+            return fleet_error(
+                FleetErrorCode.FLEET_L3_TIMEOUT,
+                f"MCP tool timeout ({tool_ctx.config.run_skill.mcp_tool_timeout_sec}s) "
+                f"exceeded during dispatch",
+            )
 
         if campaign_state_path_str and isinstance(result, DispatchResult):
             _write_dispatch_to_campaign_state(

--- a/tests/config/test_defaults.py
+++ b/tests/config/test_defaults.py
@@ -96,3 +96,4 @@ class TestDefaultsSyncYamlDataclass:
         assert cfg.run_skill.natural_exit_grace_seconds == dc.natural_exit_grace_seconds
         assert cfg.run_skill.max_suppression_seconds == dc.max_suppression_seconds
         assert cfg.run_skill.completion_drain_timeout == dc.completion_drain_timeout
+        assert cfg.run_skill.mcp_tool_timeout_sec == dc.mcp_tool_timeout_sec

--- a/tests/config/test_timeout_coherence.py
+++ b/tests/config/test_timeout_coherence.py
@@ -83,3 +83,40 @@ class TestCodexMcpTimeoutCoherenceGate:
         assert any(
             "codex_mcp_tool_timeout_coherence" in entry.get("event", "") for entry in cap_logs
         )
+
+    def test_mcp_tool_timeout_rejects_non_positive(self):
+        """__post_init__ rejects mcp_tool_timeout_sec <= 0."""
+        from autoskillit.config._config_dataclasses import RunSkillConfig
+
+        with pytest.raises(ValueError, match="mcp_tool_timeout_sec"):
+            RunSkillConfig(mcp_tool_timeout_sec=0)
+        with pytest.raises(ValueError, match="mcp_tool_timeout_sec"):
+            RunSkillConfig(mcp_tool_timeout_sec=-1.0)
+
+    def test_mcp_tool_timeout_field_below_max_triggers_warning(self):
+        """Coherence gate warns when mcp_tool_timeout_sec field is below max session."""
+        from autoskillit.config._config_dataclasses import FleetConfig, RunSkillConfig
+
+        rs = RunSkillConfig(mcp_tool_timeout_sec=100.0)
+        fc = FleetConfig()
+        with structlog.testing.capture_logs() as cap_logs:
+            _codex_mcp_timeout_coherence_gate(rs, fc, tool_timeout=rs.mcp_tool_timeout_sec)
+        assert any(
+            "codex_mcp_tool_timeout_coherence" in entry.get("event", "") for entry in cap_logs
+        )
+
+    def test_mcp_tool_timeout_field_at_max_passes_cleanly(self):
+        """Coherence gate passes when mcp_tool_timeout_sec field is at or above max session."""
+        from autoskillit.config._config_dataclasses import FleetConfig, RunSkillConfig
+
+        rs = RunSkillConfig()
+        fc = FleetConfig()
+        max_session = max(fc.default_timeout_sec + fc.max_extension_seconds, rs.timeout)
+        rs_at_max = RunSkillConfig(mcp_tool_timeout_sec=float(max_session))
+        with structlog.testing.capture_logs() as cap_logs:
+            _codex_mcp_timeout_coherence_gate(
+                rs_at_max, fc, tool_timeout=rs_at_max.mcp_tool_timeout_sec
+            )
+        assert not any(
+            "codex_mcp_tool_timeout_coherence" in entry.get("event", "") for entry in cap_logs
+        )

--- a/tests/server/test_tools_dispatch_params.py
+++ b/tests/server/test_tools_dispatch_params.py
@@ -240,3 +240,36 @@ class TestDispatchFoodTruckIdleTimeout:
         executor = tool_ctx.executor
         assert executor.dispatch_calls, "dispatch_food_truck was never called"
         assert executor.dispatch_calls[0].idle_output_timeout == 0.0
+
+
+@pytest.mark.anyio
+async def test_dispatch_food_truck_returns_fleet_error_on_mcp_timeout(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+):
+    """dispatch_food_truck returns fleet_l3_timeout envelope on MCP tool TimeoutError."""
+    import json
+
+    from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
+
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+    tool_ctx_kitchen_open.fleet_lock = FleetSemaphore(max_concurrent=1)
+    repo = InMemoryRecipeRepository()
+    recipe_info = _make_recipe_info("test-recipe")
+    repo.add_recipe("test-recipe", recipe_info)
+    repo.add_full_recipe(recipe_info.path, _make_standard_recipe("test-recipe"))
+    tool_ctx_kitchen_open.recipes = repo
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+
+    async def _timeout_dispatch(*args, **kwargs):
+        raise TimeoutError("mcp_tool_timeout_sec exceeded")
+
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_fleet_dispatch.execute_dispatch",
+        _timeout_dispatch,
+    )
+
+    result_json = await dispatch_food_truck(recipe="test-recipe", task="do-work")
+    result = json.loads(result_json)
+    assert result["success"] is False
+    assert result["error"] == "fleet_l3_timeout"

--- a/tests/server/test_tools_execution_command.py
+++ b/tests/server/test_tools_execution_command.py
@@ -327,3 +327,30 @@ class TestRunSkillExecutionMarker:
         await run_skill("/investigate test", "/tmp")
 
         assert captured["marker_dir"] is None
+
+
+class TestRunSkillMcpTimeout:
+    """run_skill wraps executor.run with anyio.fail_after(mcp_tool_timeout_sec)."""
+
+    @pytest.mark.anyio
+    async def test_run_skill_returns_crashed_on_mcp_timeout(
+        self, tool_ctx_kitchen_open, monkeypatch
+    ):
+        """On TimeoutError, run_skill returns SkillResult.crashed() envelope."""
+        import json
+
+        cfg = AutomationConfig()
+        cfg.safety.require_dry_walkthrough = False
+        tool_ctx_kitchen_open.config = cfg
+
+        tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard
+
+        async def _timeout_run(*args, **kwargs):
+            raise TimeoutError("mcp_tool_timeout_sec exceeded")
+
+        monkeypatch.setattr(tool_ctx_kitchen_open.executor, "run", _timeout_run)
+
+        result_json = await run_skill("/investigate something", "/tmp")
+        result = json.loads(result_json)
+        assert result["success"] is False
+        assert result["subtype"] == "crashed"


### PR DESCRIPTION
## Summary

Add `mcp_tool_timeout_sec: float` to `RunSkillConfig` (default `14364.0`, matching `CODEX_MCP_TOOL_TIMEOUT_FLOOR`). Wire the field through the coherence gate in `settings.py`, then wrap execution calls in `tools_execution.py` and `tools_fleet_dispatch.py` with `anyio.fail_after(mcp_tool_timeout_sec)` to enforce the timeout at the MCP tool boundary. On timeout, `run_skill` returns `SkillResult.crashed()` and `dispatch_food_truck` returns `fleet_error(FLEET_L3_TIMEOUT)`.

Closes #4048

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260628-134410-508955/.autoskillit/temp/make-plan/t5_p6_a12_wp1_mcp_tool_timeout_plan_2026-06-28_140500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 3.1k | 29.5k | 2.1M | 123.1k | 67 | 110.2k | 15m 7s |
| verify* | sonnet | 1 | 1.0k | 9.8k | 405.8k | 58.6k | 29 | 40.1k | 4m 49s |
| implement* | MiniMax-M3 | 1 | 98.4k | 13.4k | 4.2M | 0 | 116 | 0 | 5m 20s |
| audit_impl* | sonnet | 1 | 44 | 13.3k | 168.2k | 46.8k | 13 | 43.3k | 5m 34s |
| prepare_pr* | MiniMax-M3 | 1 | 43.8k | 2.0k | 193.5k | 0 | 16 | 0 | 32s |
| compose_pr* | MiniMax-M3 | 1 | 36.7k | 1.9k | 142.1k | 0 | 13 | 0 | 54s |
| review_pr* | sonnet | 1 | 164 | 31.9k | 1.2M | 86.4k | 48 | 68.6k | 7m 29s |
| resolve_review* | sonnet | 1 | 213 | 14.0k | 1.5M | 72.5k | 67 | 54.0k | 8m 26s |
| **Total** | | | 183.5k | 115.8k | 9.9M | 123.1k | | 316.2k | 48m 12s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 272 | 15294.4 | 0.0 | 49.3 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 12 | 126910.7 | 4499.0 | 1168.8 |
| **Total** | **284** | 34709.8 | 1113.3 | 407.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 3.1k | 29.5k | 2.1M | 110.2k | 15m 7s |
| sonnet | 4 | 1.5k | 69.0k | 3.3M | 206.0k | 26m 19s |
| MiniMax-M3 | 3 | 178.9k | 17.3k | 4.5M | 0 | 6m 45s |