### PR TITLE
Implementation Plan: T5-P3-A3-WP3 Produce Merge-Blocking CI Tests for Codex Deterministic Conformance

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -468,6 +468,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=None,
         help="Git base ref for changed-file detection (overrides AUTOSKILLIT_TEST_BASE_REF).",
     )
+    parser.addoption(
+        "--update-fixtures",
+        action="store_true",
+        default=False,
+        help="Regenerate deterministic conformance fixtures in-place instead of asserting.",
+    )
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/tests/execution/AGENTS.md
+++ b/tests/execution/AGENTS.md
@@ -153,5 +153,6 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_codex_stream_parser.py` | Full test suite for CodexStreamParser: happy-path, item parsing, degradation, fixture-driven integration, protocol conformance |
 | `test_codex_result_parser.py` | Tests for CodexResultParser |
 | `test_codex_config.py` | Tests for TOML read/write primitives, _is_autoskillit_registered, and ensure_codex_mcp_registered |
+| `test_codex_deterministic_conformance.py` | Sealed-enum vocabulary, hook event format, and config.toml schema template conformance tests with --update-fixtures review gate |
 | `test_cmd_builder.py` | CmdBuilder ordering invariant and CmdSpec origin tests |
 | `test_coding_agent_backend_conformance.py` | Parametrized conformance tests for all CodingAgentBackend implementations via BackendContractBase |

--- a/tests/execution/backends/conftest.py
+++ b/tests/execution/backends/conftest.py
@@ -13,7 +13,16 @@ import json
 import re
 from pathlib import Path
 
+import pytest
+
 from autoskillit.hook_registry import HOOK_REGISTRY
+
+
+@pytest.fixture
+def update_fixtures(request: pytest.FixtureRequest) -> bool:
+    """Expose --update-fixtures CLI flag as a fixture."""
+    return bool(request.config.getoption("--update-fixtures"))
+
 
 # Local mirror of _SKIP_CODEX_STATUSES from autoskillit.execution.backends._codex_hooks.
 # Defined here so the conftest has no import dependency on execution.backends (which

--- a/tests/execution/backends/fixtures/codex_ndjson/event_item.completed.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_item.completed.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "item": {
+      "properties": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "type": {
+      "const": "item.completed",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type",
+    "item"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/event_item.started.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_item.started.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "item.started",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/event_item.updated.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_item.updated.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "item.updated",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/event_thread.started.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_thread.started.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "thread_id": {
+      "type": "string"
+    },
+    "type": {
+      "const": "thread.started",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type",
+    "thread_id"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/event_turn.completed.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_turn.completed.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "turn.completed",
+      "type": "string"
+    },
+    "usage": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "type",
+    "usage"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/event_turn.failed.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_turn.failed.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "error": {
+      "oneOf": [
+        {
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "message"
+          ],
+          "type": "object"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "type": {
+      "const": "turn.failed",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type",
+    "error"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/fixtures/codex_ndjson/event_turn.started.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_turn.started.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "turn.started",
+      "type": "string"
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "type": "object"
+}

--- a/tests/execution/backends/test_codex_deterministic_conformance.py
+++ b/tests/execution/backends/test_codex_deterministic_conformance.py
@@ -33,6 +33,13 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures" / "codex_ndjson"
 _NON_UNKNOWN_EVENT_TYPES = [m for m in CodexEventType if m != CodexEventType.UNKNOWN]
 _NON_UNKNOWN_ITEM_TYPES = [m for m in CodexItemType if m != CodexItemType.UNKNOWN]
 
+_MCP_KEY_EXPECTED_TYPES: dict[str, str] = {
+    "command": "str",
+    "env_vars": "list",
+    "startup_timeout_sec": "float",
+    "tool_timeout_sec": "float",
+}
+
 
 def _sanitize_hooks(hooks: dict[str, list[dict]]) -> dict[str, list[dict]]:
     """Replace machine-specific paths and hashes with deterministic placeholders."""
@@ -58,13 +65,7 @@ def _generate_config_template() -> dict:
     return {
         "_codex_mcp_required_keys": sorted(CODEX_MCP_REQUIRED_KEYS),
         "mcp_server_entry_required_keys": {
-            key: {
-                "expected_type": "str"
-                if key in ("command",)
-                else "list"
-                if key == "env_vars"
-                else "float"
-            }
+            key: {"expected_type": _MCP_KEY_EXPECTED_TYPES[key]}
             for key in sorted(CODEX_MCP_REQUIRED_KEYS)
         },
         "top_level_keys": {

--- a/tests/execution/backends/test_codex_deterministic_conformance.py
+++ b/tests/execution/backends/test_codex_deterministic_conformance.py
@@ -242,3 +242,7 @@ class TestCodexConfigTomlSchemaTemplate:
             reloaded["top_level_keys"]["tool_output_token_limit"]["floor_value"]
             == CODEX_TOOL_OUTPUT_TOKEN_LIMIT
         )
+        assert (
+            reloaded["top_level_keys"]["model_auto_compact_token_limit"]["floor_value"]
+            == CODEX_AUTO_COMPACT_LIMIT
+        )

--- a/tests/execution/backends/test_codex_deterministic_conformance.py
+++ b/tests/execution/backends/test_codex_deterministic_conformance.py
@@ -1,0 +1,243 @@
+"""Merge-blocking CI tests for Codex deterministic conformance.
+
+Seals the ``CodexEventType`` / ``CodexItemType`` vocabulary, hook event
+formats, and ``config.toml`` schema template against undetected drift.
+All tests are pure Python assertions against committed JSON fixtures —
+no live CLI, no subprocess, no network I/O.
+
+Run ``pytest --update-fixtures -n0`` to regenerate fixtures in-place
+after a deliberate vocabulary or format change.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core.types._type_enums import CodexEventType, CodexItemType
+from autoskillit.execution.backends._codex_config import (
+    CODEX_AUTO_COMPACT_LIMIT,
+    CODEX_MCP_REQUIRED_KEYS,
+    CODEX_TOOL_OUTPUT_TOKEN_LIMIT,
+)
+from autoskillit.execution.backends._codex_hooks import generate_codex_hooks_config
+from autoskillit.hook_registry import HOOK_REGISTRY_HASH, HOOKS_DIR
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "codex_ndjson"
+
+_NON_UNKNOWN_EVENT_TYPES = [m for m in CodexEventType if m != CodexEventType.UNKNOWN]
+_NON_UNKNOWN_ITEM_TYPES = [m for m in CodexItemType if m != CodexItemType.UNKNOWN]
+
+
+def _sanitize_hooks(hooks: dict[str, list[dict]]) -> dict[str, list[dict]]:
+    """Replace machine-specific paths and hashes with deterministic placeholders."""
+    raw = json.dumps(hooks, sort_keys=True)
+    raw = raw.replace(str(HOOKS_DIR), "SANITIZED_HOOKS_DIR")
+    raw = re.sub(
+        r'"trusted_hash":\s*"[a-f0-9]{64}"', '"trusted_hash": "SANITIZED_FOR_DETERMINISM"', raw
+    )
+    return json.loads(raw)
+
+
+def _assert_single_worker(request: pytest.FixtureRequest) -> None:
+    """Skip if running under xdist parallel workers."""
+    if hasattr(request.config, "workerinput"):
+        pytest.skip(
+            "--update-fixtures must be run with -n0 (single worker) "
+            "to prevent concurrent writes under xdist -n 4"
+        )
+
+
+def _generate_config_template() -> dict:
+    """Build the config.toml schema template from live constants."""
+    return {
+        "_codex_mcp_required_keys": sorted(CODEX_MCP_REQUIRED_KEYS),
+        "mcp_server_entry_required_keys": {
+            key: {
+                "expected_type": "str"
+                if key in ("command",)
+                else "list"
+                if key == "env_vars"
+                else "float"
+            }
+            for key in sorted(CODEX_MCP_REQUIRED_KEYS)
+        },
+        "top_level_keys": {
+            "tool_output_token_limit": {
+                "expected_type": "int",
+                "constraint": "minimum",
+                "floor_value": CODEX_TOOL_OUTPUT_TOKEN_LIMIT,
+            },
+            "model_auto_compact_token_limit": {
+                "expected_type": "int",
+                "constraint": "minimum",
+                "floor_value": CODEX_AUTO_COMPACT_LIMIT,
+            },
+        },
+    }
+
+
+class TestCodexEventTypeVocabulary:
+    @pytest.mark.parametrize(
+        "member",
+        _NON_UNKNOWN_EVENT_TYPES,
+        ids=[m.value for m in _NON_UNKNOWN_EVENT_TYPES],
+    )
+    def test_event_schema_exists_and_valid(self, member: CodexEventType) -> None:
+        fixture_path = FIXTURES_DIR / f"event_{member.value}.json"
+        assert fixture_path.exists(), (
+            f"Missing fixture for CodexEventType.{member.name} — "
+            f"expected {fixture_path.name}. Add the schema file or run with --update-fixtures."
+        )
+        schema = json.loads(fixture_path.read_text(encoding="utf-8"))
+        assert isinstance(schema.get("required"), list) and len(schema["required"]) > 0, (
+            f"{fixture_path.name}: 'required' must be a non-empty list"
+        )
+        assert schema.get("additionalProperties") is False, (
+            f"{fixture_path.name}: 'additionalProperties' must be false (sealed schema)"
+        )
+
+    def test_sealed_enumeration(self) -> None:
+        missing = []
+        for member in _NON_UNKNOWN_EVENT_TYPES:
+            fixture_path = FIXTURES_DIR / f"event_{member.value}.json"
+            if not fixture_path.exists():
+                missing.append(member.value)
+        assert not missing, (
+            f"Sealed enumeration violated — CodexEventType members without fixture files: "
+            f"{missing}. Add schema fixtures or remove the enum members."
+        )
+
+
+class TestCodexItemTypeVocabulary:
+    @pytest.mark.parametrize(
+        "member",
+        _NON_UNKNOWN_ITEM_TYPES,
+        ids=[m.value for m in _NON_UNKNOWN_ITEM_TYPES],
+    )
+    def test_item_schema_exists_and_valid(self, member: CodexItemType) -> None:
+        fixture_path = FIXTURES_DIR / f"item_{member.value}.json"
+        assert fixture_path.exists(), (
+            f"Missing fixture for CodexItemType.{member.name} — "
+            f"expected {fixture_path.name}. Add the schema file or run with --update-fixtures."
+        )
+        schema = json.loads(fixture_path.read_text(encoding="utf-8"))
+        assert isinstance(schema.get("required"), list) and len(schema["required"]) > 0, (
+            f"{fixture_path.name}: 'required' must be a non-empty list"
+        )
+        assert schema.get("additionalProperties") is False, (
+            f"{fixture_path.name}: 'additionalProperties' must be false (sealed schema)"
+        )
+
+    def test_sealed_enumeration(self) -> None:
+        missing = []
+        for member in _NON_UNKNOWN_ITEM_TYPES:
+            fixture_path = FIXTURES_DIR / f"item_{member.value}.json"
+            if not fixture_path.exists():
+                missing.append(member.value)
+        assert not missing, (
+            f"Sealed enumeration violated — CodexItemType members without fixture files: "
+            f"{missing}. Add schema fixtures or remove the enum members."
+        )
+
+
+class TestCodexHookEventFormatFixture:
+    _SNAPSHOT_PATH = FIXTURES_DIR / "hook_event_format_snapshot.json"
+
+    def test_hook_snapshot_matches_live_registry(self) -> None:
+        snapshot = json.loads(self._SNAPSHOT_PATH.read_text(encoding="utf-8"))
+        live_hooks = generate_codex_hooks_config()
+        sanitized_live = _sanitize_hooks(live_hooks)
+
+        assert snapshot["_registry_hash"] == HOOK_REGISTRY_HASH, (
+            f"HOOK_REGISTRY_HASH drift detected: "
+            f"fixture={snapshot['_registry_hash'][:12]}… vs live={HOOK_REGISTRY_HASH[:12]}…. "
+            f"Rerun with: pytest --update-fixtures -n0 "
+            f"tests/execution/backends/test_codex_deterministic_conformance.py"
+        )
+        assert sanitized_live == snapshot["hooks"], (
+            "Hook event format structure drift detected — "
+            "live generate_codex_hooks_config() output (sanitized) differs from snapshot. "
+            "Rerun with: pytest --update-fixtures -n0 "
+            "tests/execution/backends/test_codex_deterministic_conformance.py"
+        )
+
+    def test_update_fixtures_writes_snapshot(
+        self, update_fixtures: bool, request: pytest.FixtureRequest
+    ) -> None:
+        if not update_fixtures:
+            pytest.skip("--update-fixtures not set")
+        _assert_single_worker(request)
+
+        live_hooks = generate_codex_hooks_config()
+        sanitized_live = _sanitize_hooks(live_hooks)
+        snapshot_data = {
+            "_registry_hash": HOOK_REGISTRY_HASH,
+            "hooks": sanitized_live,
+        }
+        self._SNAPSHOT_PATH.write_text(
+            json.dumps(snapshot_data, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        reloaded = json.loads(self._SNAPSHOT_PATH.read_text(encoding="utf-8"))
+        assert reloaded["_registry_hash"] == HOOK_REGISTRY_HASH
+        assert reloaded["hooks"] == sanitized_live
+
+
+class TestCodexConfigTomlSchemaTemplate:
+    _TEMPLATE_PATH = FIXTURES_DIR / "config_toml_schema_template.json"
+
+    def test_required_keys_present(self) -> None:
+        template = json.loads(self._TEMPLATE_PATH.read_text(encoding="utf-8"))
+        fixture_keys = set(template["_codex_mcp_required_keys"])
+        assert CODEX_MCP_REQUIRED_KEYS == fixture_keys, (
+            f"CODEX_MCP_REQUIRED_KEYS drift: live={sorted(CODEX_MCP_REQUIRED_KEYS)}, "
+            f"fixture={sorted(fixture_keys)}. "
+            f"Rerun with: pytest --update-fixtures -n0 "
+            f"tests/execution/backends/test_codex_deterministic_conformance.py"
+        )
+
+    def test_pinned_constants_match(self) -> None:
+        template = json.loads(self._TEMPLATE_PATH.read_text(encoding="utf-8"))
+        top = template["top_level_keys"]
+        assert top["tool_output_token_limit"]["floor_value"] == CODEX_TOOL_OUTPUT_TOKEN_LIMIT, (
+            f"CODEX_TOOL_OUTPUT_TOKEN_LIMIT drift: "
+            f"fixture={top['tool_output_token_limit']['floor_value']} "
+            f"vs live={CODEX_TOOL_OUTPUT_TOKEN_LIMIT}"
+        )
+        assert top["model_auto_compact_token_limit"]["floor_value"] == CODEX_AUTO_COMPACT_LIMIT, (
+            f"CODEX_AUTO_COMPACT_LIMIT drift: "
+            f"fixture={top['model_auto_compact_token_limit']['floor_value']} "
+            f"vs live={CODEX_AUTO_COMPACT_LIMIT}"
+        )
+        mcp_keys = template["mcp_server_entry_required_keys"]
+        assert "startup_timeout_sec" in mcp_keys, (
+            "startup_timeout_sec missing from MCP entry template"
+        )
+        assert "tool_timeout_sec" in mcp_keys, "tool_timeout_sec missing from MCP entry template"
+
+    def test_update_fixtures_regenerates_template(
+        self, update_fixtures: bool, request: pytest.FixtureRequest
+    ) -> None:
+        if not update_fixtures:
+            pytest.skip("--update-fixtures not set")
+        _assert_single_worker(request)
+
+        template = _generate_config_template()
+        self._TEMPLATE_PATH.write_text(
+            json.dumps(template, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        reloaded = json.loads(self._TEMPLATE_PATH.read_text(encoding="utf-8"))
+        assert set(reloaded["_codex_mcp_required_keys"]) == CODEX_MCP_REQUIRED_KEYS
+        assert (
+            reloaded["top_level_keys"]["tool_output_token_limit"]["floor_value"]
+            == CODEX_TOOL_OUTPUT_TOKEN_LIMIT
+        )


### PR DESCRIPTION
## Summary

Add `tests/execution/backends/test_codex_deterministic_conformance.py` with four test classes that seal the `CodexEventType`/`CodexItemType` vocabulary, hook event formats, and config.toml schema template against undetected drift. Register `--update-fixtures` in the existing `pytest_addoption()` in `tests/conftest.py` and expose it as a pytest fixture. All tests are pure Python assertions against committed JSON fixtures — no live CLI, no subprocess, no network I/O.

Closes #4011

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260628-181308-999735/.autoskillit/temp/make-plan/t5_p3_a3_wp3_deterministic_conformance_plan_2026-06-28_181500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 56 | 16.0k | 1.4M | 103.4k | 53 | 85.0k | 12m 28s |
| verify* | sonnet | 1 | 92 | 12.2k | 513.0k | 58.1k | 28 | 39.6k | 6m 32s |
| implement* | MiniMax-M3 | 1 | 70.2k | 8.8k | 1.3M | 0 | 62 | 0 | 3m 19s |
| fix* | sonnet | 1 | 150 | 8.5k | 898.8k | 66.6k | 45 | 48.0k | 8m 21s |
| audit_impl* | sonnet | 1 | 52 | 18.9k | 221.1k | 52.8k | 16 | 54.6k | 8m 27s |
| prepare_pr* | MiniMax-M3 | 1 | 45.2k | 2.6k | 202.4k | 0 | 14 | 0 | 43s |
| compose_pr* | MiniMax-M3 | 1 | 36.5k | 1.6k | 104.3k | 0 | 10 | 0 | 33s |
| review_pr* | sonnet | 3 | 444 | 119.3k | 3.0M | 100.4k | 134 | 227.2k | 25m 45s |
| resolve_review* | sonnet | 2 | 3.3k | 36.1k | 3.6M | 89.7k | 136 | 135.4k | 19m 52s |
| **Total** | | | 156.0k | 224.2k | 11.3M | 103.4k | | 589.9k | 1h 26m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 259 | 5210.4 | 0.0 | 34.1 |
| fix | 140 | 6420.3 | 343.2 | 60.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 19 | 188851.2 | 7127.1 | 1900.9 |
| **Total** | **418** | 27071.4 | 1411.1 | 536.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 56 | 16.0k | 1.4M | 85.0k | 12m 28s |
| sonnet | 5 | 4.0k | 195.0k | 8.2M | 504.9k | 1h 8m |
| MiniMax-M3 | 3 | 151.9k | 13.1k | 1.7M | 0 | 4m 35s |