### PR TITLE
Implementation Plan: T5-P5-A3-WP3 Make the INVARIANT_REGISTRY Reflect Actual Enforcement Reality

### DIFF
--- a/src/autoskillit/core/types/_type_invariant_registry.py
+++ b/src/autoskillit/core/types/_type_invariant_registry.py
@@ -82,7 +82,7 @@ INVARIANT_REGISTRY: Final[dict[str, InvariantDef]] = {
         prohibition="Must not read recipe/skill/agent files directly in headless sessions",
         source_doc="SKILL.md",
         gate_target="guards/recipe_read_guard.py",
-        enforcement_layer="hook-deny",
+        enforcement_layer="server-side",
         backends=_BOTH,
     ),
     "write-path-prefix": InvariantDef(
@@ -90,7 +90,7 @@ INVARIANT_REGISTRY: Final[dict[str, InvariantDef]] = {
         prohibition="Writes outside allowed prefix are blocked in write-scoped sessions",
         source_doc="SKILL.md",
         gate_target="guards/write_guard.py",
-        enforcement_layer="hook-deny",
+        enforcement_layer="server-side",
         backends=_CLAUDE_ONLY,
     ),
     "skill-orchestration-from-L1": InvariantDef(

--- a/tests/core/test_invariant_registry.py
+++ b/tests/core/test_invariant_registry.py
@@ -100,6 +100,20 @@ def test_env_key_enforcement_layer() -> None:
     assert INVARIANT_REGISTRY["env-key-in-with-args"].enforcement_layer == "server-side"
 
 
+def test_recipe_read_enforcement_layer() -> None:
+    """recipe-read-headless must have enforcement_layer='server-side'."""
+    from autoskillit.core import INVARIANT_REGISTRY
+
+    assert INVARIANT_REGISTRY["recipe-read-headless"].enforcement_layer == "server-side"
+
+
+def test_write_path_prefix_enforcement_layer() -> None:
+    """write-path-prefix must have enforcement_layer='server-side'."""
+    from autoskillit.core import INVARIANT_REGISTRY
+
+    assert INVARIANT_REGISTRY["write-path-prefix"].enforcement_layer == "server-side"
+
+
 def test_all_gate_targets_are_nonempty() -> None:
     """Every gate_target must be a non-empty string."""
     from autoskillit.core import INVARIANT_REGISTRY


### PR DESCRIPTION
## Summary

Update two `INVARIANT_REGISTRY` entries — `recipe-read-headless` and `write-path-prefix` — to have `enforcement_layer="server-side"` instead of `"hook-deny"`. This reflects the actual enforcement reality: P5-A3-WP1 (commit `c9ed35e3d`, PR #4105) added server-side guards `_check_recipe_read_prohibition()` and `_check_write_target_boundary()` in `server/_guards.py`, which are injected into `run_cmd` and `run_python` tool handlers in `server/tools/tools_execution.py`. The registry entries still say `"hook-deny"` — this WP updates them to match reality. Add two pin tests asserting the new values.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260628-200621-936012/.autoskillit/temp/make-plan/t5-p5-a3-wp3-invariant-registry-enforcement-layer_plan_2026-06-28_201500.md`

Closes #4035

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 46 | 4.9k | 563.1k | 73.4k | 22 | 76.1k | 4m 37s |
| verify* | sonnet | 1 | 44 | 3.8k | 161.4k | 41.5k | 15 | 23.7k | 1m 53s |
| implement* | MiniMax-M3 | 1 | 59.2k | 4.3k | 1.3M | 0 | 59 | 0 | 2m 5s |
| audit_impl* | sonnet | 1 | 52 | 3.4k | 198.4k | 39.2k | 13 | 23.5k | 2m 13s |
| prepare_pr* | MiniMax-M3 | 1 | 39.7k | 1.9k | 146.6k | 0 | 12 | 0 | 26s |
| compose_pr* | MiniMax-M3 | 1 | 36.0k | 1.4k | 140.8k | 0 | 12 | 0 | 38s |
| review_pr* | sonnet | 3 | 382 | 32.5k | 2.1M | 56.0k | 109 | 112.3k | 10m 11s |
| **Total** | | | 135.4k | 52.2k | 4.6M | 73.4k | | 235.5k | 22m 5s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 18 | 74595.6 | 0.0 | 241.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **18** | 256762.6 | 13083.8 | 2901.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 46 | 4.9k | 563.1k | 76.1k | 4m 37s |
| sonnet | 3 | 478 | 39.7k | 2.4M | 159.4k | 14m 18s |
| MiniMax-M3 | 3 | 134.9k | 7.7k | 1.6M | 0 | 3m 9s |