### PR TITLE
Implementation Plan: T5-P5-A4-WP4 Ensure run_skill Never Silently Returns a Degraded Payload

### DIFF
--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -67,6 +67,7 @@ from autoskillit.server.tools._execution_helpers import (
     validate_path_arg_anchoring,
 )
 from autoskillit.server.tools._preflight import _get_fix_required_hook_matchers
+from autoskillit.server.tools._types import ToolFailureEnvelope
 
 logger = get_logger(__name__)
 
@@ -1124,7 +1125,26 @@ async def run_skill(
                         _refresh_quota_cache(tool_ctx.config.quota_guard),
                         label="quota_post_run_refresh",
                     )
-                return skill_result.to_json()
+                _json_str = skill_result.to_json()
+                try:
+                    _parsed = json.loads(_json_str)
+                except Exception:
+                    _parsed = {}
+                _missing = {"success", "exit_code"} - _parsed.keys()
+                if _missing:
+                    logger.warning(
+                        "run_skill_degraded_payload",
+                        missing_keys=sorted(_missing),
+                    )
+                    return json.dumps(
+                        ToolFailureEnvelope(
+                            success=False,
+                            error=f"Degraded SkillResult payload: missing keys {sorted(_missing)}",
+                            stage="validate_result:run_skill",
+                            retriable=True,
+                        )
+                    )
+                return _json_str
             except Exception as exc:
                 logger.error("run_skill executor raised unexpectedly", exc_info=True)
                 return SkillResult.crashed(

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -1128,9 +1128,16 @@ async def run_skill(
                 _json_str = skill_result.to_json()
                 try:
                     _parsed = json.loads(_json_str)
-                except Exception:
+                except Exception as exc:
                     logger.warning("run_skill_json_parse_failed", exc_info=True)
-                    _parsed = {}
+                    return json.dumps(
+                        ToolFailureEnvelope(
+                            success=False,
+                            error=f"Degraded SkillResult payload: JSON parse failed: {exc}",
+                            stage="validate_result:run_skill",
+                            retriable=True,
+                        )
+                    )
                 _missing = {"success", "exit_code"} - _parsed.keys()
                 if _missing:
                     logger.warning(

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -1129,12 +1129,13 @@ async def run_skill(
                 try:
                     _parsed = json.loads(_json_str)
                 except Exception:
+                    logger.warning("run_skill_json_parse_failed", exc_info=True)
                     _parsed = {}
                 _missing = {"success", "exit_code"} - _parsed.keys()
                 if _missing:
                     logger.warning(
                         "run_skill_degraded_payload",
-                        missing_keys=sorted(_missing),
+                        absent_fields=sorted(_missing),
                     )
                     return json.dumps(
                         ToolFailureEnvelope(

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -985,7 +985,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "dispatch recovery (+8 net lines)",
     ),
     "tools_execution.py": (
-        1200,
+        1220,
         "REQ-CNST-010-E8: execution tool handlers — run_cmd/run_python/run_skill are the "
         "three primary execution paths; fail-closed existence gate, empty-closure gate "
         "for fabricated skill name rejection, _check_backend_compat fail-closed gate "
@@ -993,7 +993,9 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "dispatch gate add defense-in-depth checks; server-side recipe-read prohibition "
         "and write-target boundary guards add defense-in-depth gate checks; "
         "stale-path is_dir() guards on both init_session and replay-snapshot branches "
-        "crash-close before executor when /dev/shm path has been reclaimed (+26 net lines)",
+        "crash-close before executor when /dev/shm path has been reclaimed (+26 net lines); "
+        "post-serialization validation gate at run_skill return site adds fail-closed "
+        "ToolFailureEnvelope substitution for structurally degraded payloads (+13 net lines)",
     ),
     "execution/backends/codex.py": (
         1150,

--- a/tests/server/test_tools_execution_results.py
+++ b/tests/server/test_tools_execution_results.py
@@ -837,7 +837,7 @@ class TestRunSkillPostSerializationValidation:
         data = json.loads(result_json)
         assert data["success"] is False
         assert data["retriable"] is True
-        assert "exit_code" in data["error"]
+        assert "missing" in data["error"].lower() and "exit_code" in data["error"]
 
     @pytest.mark.anyio
     async def test_valid_to_json_passes_through_unchanged(
@@ -873,6 +873,7 @@ class TestRunSkillPostSerializationValidation:
         assert data["exit_code"] == 0
         assert "retriable" not in data  # No envelope wrapping
         assert data["subtype"] == "success"
+        assert result_json == valid.to_json()
 
 
 class TestCwdExistenceValidation:

--- a/tests/server/test_tools_execution_results.py
+++ b/tests/server/test_tools_execution_results.py
@@ -764,6 +764,117 @@ async def test_run_skill_returns_structured_result_on_cancelled_error(
     assert "cancelled" in data["result"].lower()
 
 
+class TestRunSkillPostSerializationValidation:
+    """Post-serialization validation: run_skill must catch degraded SkillResult payloads."""
+
+    @pytest.mark.anyio
+    async def test_missing_keys_returns_failure_envelope(
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
+    ) -> None:
+        """to_json() omits 'success' and 'exit_code' → run_skill returns retriable envelope."""
+        from autoskillit.core import SkillResult
+        from autoskillit.core.types import RetryReason
+
+        degraded = SkillResult(
+            success=True,
+            result="ok",
+            session_id="sess-degraded",
+            subtype="success",
+            is_error=False,
+            exit_code=0,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+            stderr="",
+        )
+        # Shadow to_json to omit both required keys.
+        degraded.to_json = lambda: '{"result": "ok"}'  # type: ignore[method-assign]
+
+        class DegradedExecutor:
+            async def run(self, *args, **kwargs) -> SkillResult:
+                return degraded
+
+        tool_ctx_kitchen_open.executor = DegradedExecutor()
+        monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+        result_json = await run_skill("/test cmd", str(tmp_path))
+        data = json.loads(result_json)
+        assert data["success"] is False
+        assert data["retriable"] is True
+        assert "validate_result:run_skill" in data["stage"]
+        _msg = data["error"].lower()
+        assert "missing" in _msg or "success" in _msg or "exit_code" in _msg
+
+    @pytest.mark.anyio
+    async def test_missing_exit_code_returns_failure_envelope(
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
+    ) -> None:
+        """to_json() has 'success' but omits 'exit_code' → run_skill returns retriable envelope."""
+        from autoskillit.core import SkillResult
+        from autoskillit.core.types import RetryReason
+
+        degraded = SkillResult(
+            success=True,
+            result="ok",
+            session_id="sess-degraded",
+            subtype="success",
+            is_error=False,
+            exit_code=0,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+            stderr="",
+        )
+        # Shadow to_json to include success but omit exit_code.
+        degraded.to_json = lambda: '{"success": true, "result": "ok"}'  # type: ignore[method-assign]
+
+        class DegradedExecutor:
+            async def run(self, *args, **kwargs) -> SkillResult:
+                return degraded
+
+        tool_ctx_kitchen_open.executor = DegradedExecutor()
+        monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+        result_json = await run_skill("/test cmd", str(tmp_path))
+        data = json.loads(result_json)
+        assert data["success"] is False
+        assert data["retriable"] is True
+        assert "exit_code" in data["error"]
+
+    @pytest.mark.anyio
+    async def test_valid_to_json_passes_through_unchanged(
+        self, tool_ctx_kitchen_open, monkeypatch, tmp_path
+    ) -> None:
+        """When to_json() emits both required keys, run_skill returns that JSON unchanged."""
+        from autoskillit.core import SkillResult
+        from autoskillit.core.types import RetryReason
+
+        valid = SkillResult(
+            success=True,
+            result="ok",
+            session_id="sess-valid",
+            subtype="success",
+            is_error=False,
+            exit_code=0,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+            stderr="",
+        )
+        # Do NOT shadow to_json — use the default implementation.
+
+        class ValidExecutor:
+            async def run(self, *args, **kwargs) -> SkillResult:
+                return valid
+
+        tool_ctx_kitchen_open.executor = ValidExecutor()
+        monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+        result_json = await run_skill("/test cmd", str(tmp_path))
+        data = json.loads(result_json)
+        assert data["success"] is True
+        assert data["exit_code"] == 0
+        assert "retriable" not in data  # No envelope wrapping
+        assert data["subtype"] == "success"
+
+
 class TestCwdExistenceValidation:
     """run_skill and run_cmd reject non-existent cwd before reaching executor/subprocess."""
 


### PR DESCRIPTION
## Summary

Add post-serialization shape validation at the single `return skill_result.to_json()` site in `run_skill` (line 1127 of `tools_execution.py`). After `to_json()` produces a JSON string, parse it back and verify the two structurally required keys (`success`, `exit_code`) are present. If either is missing, log a warning and return a `ToolFailureEnvelope` JSON string with `retriable=True` instead. This prevents silently degraded payloads from reaching the orchestrator.

The existing `_validate_result` helper in `_types.py` cannot be reused here because its `success is not True` check (line 285) would reject every legitimate `SkillResult` where `success=False` — normal failure results are valid payloads, not degraded ones. Instead, the validation uses `ToolFailureEnvelope` directly with an inline key-presence check.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260628-204150-221686/.autoskillit/temp/make-plan/t5-p5-a4-wp4-ensure-run-skill-post-serialization-validation_plan_2026-06-28_210000.md`

Closes #4037

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 53 | 13.7k | 1.1M | 84.6k | 36 | 68.2k | 6m 34s |
| verify* | sonnet | 1 | 68 | 7.2k | 305.9k | 47.8k | 23 | 29.3k | 4m 12s |
| implement* | MiniMax-M3 | 1 | 67.8k | 10.1k | 1.4M | 0 | 60 | 0 | 3m 22s |
| fix* | sonnet | 1 | 174 | 7.7k | 1.1M | 68.6k | 53 | 50.1k | 4m 56s |
| audit_impl* | sonnet | 1 | 70 | 9.3k | 280.0k | 44.0k | 19 | 32.8k | 4m 30s |
| prepare_pr* | MiniMax-M3 | 1 | 42.1k | 4.0k | 149.1k | 0 | 12 | 0 | 52s |
| compose_pr* | MiniMax-M3 | 1 | 36.7k | 2.2k | 217.2k | 0 | 17 | 0 | 43s |
| review_pr* | sonnet | 2 | 386 | 35.3k | 1.7M | 68.1k | 78 | 96.2k | 8m 59s |
| resolve_review* | sonnet | 2 | 306 | 16.5k | 2.1M | 78.8k | 91 | 104.4k | 8m 8s |
| **Total** | | | 147.7k | 106.1k | 8.3M | 84.6k | | 380.9k | 42m 18s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 133 | 10605.2 | 0.0 | 75.8 |
| fix | 9 | 120250.9 | 5565.9 | 853.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 14 | 152895.9 | 7455.9 | 1180.8 |
| **Total** | **156** | 53323.5 | 2441.4 | 680.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 53 | 13.7k | 1.1M | 68.2k | 6m 34s |
| sonnet | 5 | 1.0k | 76.1k | 5.5M | 312.7k | 30m 46s |
| MiniMax-M3 | 3 | 146.6k | 16.3k | 1.8M | 0 | 4m 57s |