### PR TITLE
T5-P5-A8-WP2: Add codex smoke-test-gated live probe class

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -240,7 +240,7 @@ tasks:
 
         set -o pipefail
         set +e
-        $PYTEST_CMD tests/execution/test_smoke_codex.py -m smoke -v --tb=short -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
+        $PYTEST_CMD tests/execution/test_smoke_codex.py tests/execution/backends/test_cli_conformance_probes.py -m smoke -v --tb=short -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
         PYTEST_EXIT=$?
         set +o pipefail
         set -e

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -899,7 +899,13 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
     "_test_filter": frozenset({"arch", "infra", "contracts"}),
     "smoke_utils": frozenset({"test_smoke_utils.py", "recipe", "smoke_utils"}),
     "version": frozenset({"test_version.py", "server", "cli"}),
-    "_probe_canary": frozenset({"core", "execution/backends/test_probe_canary.py"}),
+    "_probe_canary": frozenset(
+        {
+            "core",
+            "execution/backends/test_probe_canary.py",
+            "execution/backends/test_cli_conformance_probes.py",
+        }
+    ),
 }
 
 # ---------------------------------------------------------------------------
@@ -983,7 +989,13 @@ LAYER_CASCADE_AGGRESSIVE: dict[str, frozenset[str]] = {
     "version": frozenset({"test_version.py"}),
     "_test_filter": frozenset({"arch", "contracts"}),
     "report": frozenset({"report"}),
-    "_probe_canary": frozenset({"core", "execution/backends/test_probe_canary.py"}),
+    "_probe_canary": frozenset(
+        {
+            "core",
+            "execution/backends/test_probe_canary.py",
+            "execution/backends/test_cli_conformance_probes.py",
+        }
+    ),
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/execution/AGENTS.md
+++ b/tests/execution/AGENTS.md
@@ -156,3 +156,4 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_codex_deterministic_conformance.py` | Sealed-enum vocabulary, hook event format, and config.toml schema template conformance tests with --update-fixtures review gate |
 | `test_cmd_builder.py` | CmdBuilder ordering invariant and CmdSpec origin tests |
 | `test_coding_agent_backend_conformance.py` | Parametrized conformance tests for all CodingAgentBackend implementations via BackendContractBase |
+| `test_cli_conformance_probes.py` | Live Codex CLI conformance probes: CODEX_SMOKE_TEST-gated probe class wiring real codex exec through shared assertion functions with ProbeCache and CanaryIssueUpdater |

--- a/tests/execution/backends/test_cli_conformance_probes.py
+++ b/tests/execution/backends/test_cli_conformance_probes.py
@@ -217,7 +217,13 @@ class TestCodexLiveProbes:
 
     def test_ndjson_event_vocabulary_conforms(self) -> None:
         self._check_cache()
-        probe_output = self._get_probe_output()
+        try:
+            probe_output = self._get_probe_output()
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            self._record_failure(
+                ErrorKind.NETWORK, "ndjson_event_vocabulary", _get_codex_version(), str(exc)
+            )
+            raise
 
         def _assert(output: _CodexProbeOutput) -> None:
             assert_no_unknown_event_types(output.events)
@@ -229,7 +235,13 @@ class TestCodexLiveProbes:
 
     def test_hook_firing_codex_status(self) -> None:
         self._check_cache()
-        probe_output = self._get_probe_output()
+        try:
+            probe_output = self._get_probe_output()
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            self._record_failure(
+                ErrorKind.NETWORK, "hook_firing_codex_status", _get_codex_version(), str(exc)
+            )
+            raise
 
         def _assert(output: _CodexProbeOutput) -> None:
             if not output.config_dict:
@@ -240,7 +252,13 @@ class TestCodexLiveProbes:
 
     def test_config_acceptance(self) -> None:
         self._check_cache()
-        probe_output = self._get_probe_output()
+        try:
+            probe_output = self._get_probe_output()
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            self._record_failure(
+                ErrorKind.NETWORK, "config_acceptance", _get_codex_version(), str(exc)
+            )
+            raise
 
         def _assert(output: _CodexProbeOutput) -> None:
             if not output.config_dict:

--- a/tests/execution/backends/test_cli_conformance_probes.py
+++ b/tests/execution/backends/test_cli_conformance_probes.py
@@ -1,0 +1,234 @@
+"""Live Codex CLI conformance probes — CODEX_SMOKE_TEST-gated.
+
+Wires real ``codex exec --json`` output through the shared
+``_conformance_assertions.py`` assertion helpers. Each probe checks
+``ProbeCache`` before invoking the CLI, delegates to assertion functions,
+discriminates OSError/TimeoutExpired (network) from AssertionError (schema),
+and records results via ``CanaryState`` + ``CanaryIssueUpdater``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+
+from autoskillit._probe_canary import (
+    CanaryIssueUpdater,
+    CanaryState,
+    ErrorKind,
+)
+from autoskillit.execution.backends._probe_cache import (
+    ProbeResult,
+    read_probe_cache,
+    write_probe_cache,
+)
+from tests.execution.backends._conformance_assertions import (
+    assert_config_schema,
+    assert_hook_event_format,
+    assert_no_unknown_event_types,
+    assert_session_start_present,
+    assert_turn_completed_usage_nonzero,
+    assert_vocabulary_coverage,
+)
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.large, pytest.mark.smoke]
+
+_SKIP_REASON = (
+    "Set CODEX_SMOKE_TEST=1 and one of: CODEX_API_KEY, OPENAI_API_KEY,"
+    " or ~/.codex/auth.json to run Codex smoke tests"
+)
+
+_skip_unless_codex_smoke = pytest.mark.skipif(
+    not os.environ.get("CODEX_SMOKE_TEST")
+    or (
+        not os.environ.get("CODEX_API_KEY")
+        and not os.environ.get("OPENAI_API_KEY")
+        and not Path("~/.codex/auth.json").expanduser().exists()
+    ),
+    reason=_SKIP_REASON,
+)
+
+_PROBE_BACKEND = "codex"
+_CANARY_TITLE_PREFIX = "[Canary] codex conformance probe"
+
+
+class _CodexProbeOutput(NamedTuple):
+    events: list[dict]
+    config_dict: dict
+    cli_version: str
+
+
+def _get_codex_version() -> str:
+    try:
+        result = subprocess.run(
+            ["codex", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.stdout.strip() or "unknown"
+    except (OSError, subprocess.TimeoutExpired):
+        return "unknown"
+
+
+def _run_codex_probe() -> _CodexProbeOutput:
+    timeout = int(os.environ.get("CODEX_SMOKE_TIMEOUT", "60"))
+    result = subprocess.run(
+        [
+            "codex",
+            "exec",
+            "--json",
+            "--sandbox",
+            "workspace-write",
+            "Respond with exactly: hello",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        msg = f"codex exec failed with rc={result.returncode}: {result.stderr}"
+        raise OSError(msg)
+
+    events: list[dict] = []
+    for line in result.stdout.splitlines():
+        try:
+            events.append(json.loads(line))
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+    config_dict: dict = {}
+    for evt in events:
+        if evt.get("type") == "session_configuration":
+            config_dict = evt.get("configuration", evt)
+            break
+
+    return _CodexProbeOutput(
+        events=events,
+        config_dict=config_dict,
+        cli_version=_get_codex_version(),
+    )
+
+
+def _make_canary_body(probe_name: str, kind: ErrorKind, cli_version: str, detail: str) -> str:
+    return (
+        f"**Probe:** {probe_name}\n"
+        f"**Backend:** {_PROBE_BACKEND}\n"
+        f"**CLI Version:** {cli_version}\n"
+        f"**Failure Type:** {kind.value}\n"
+        f"**Detail:** {detail}\n"
+    )
+
+
+@_skip_unless_codex_smoke
+class TestCodexLiveProbes:
+    """Live Codex CLI conformance probes.
+
+    Each probe: cache check → subprocess → assertion delegation →
+    error discrimination → canary recording.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _probe_state(self, tmp_path: Path) -> tuple[Path, Path]:
+        self._cache_path = tmp_path / "probe_cache.json"
+        self._state_path = tmp_path / "canary_state.json"
+        return self._cache_path, self._state_path
+
+    def _check_cache(self, cli_version: str) -> None:
+        cached = read_probe_cache(self._cache_path, cli_version)
+        if cached is not None and cached.passed:
+            pytest.skip(f"Probe cached as passed for {cli_version}")
+
+    def _record_success(self, cli_version: str) -> None:
+        state = CanaryState.load(self._state_path)
+        state.record_success()
+        state.save(self._state_path)
+        write_probe_cache(
+            self._cache_path,
+            ProbeResult(
+                cli_version=cli_version,
+                passed=True,
+                failure_detail=None,
+                probe_timestamp=datetime.now(UTC).isoformat(),
+            ),
+        )
+
+    def _record_failure(
+        self, kind: ErrorKind, probe_name: str, cli_version: str, detail: str
+    ) -> None:
+        state = CanaryState.load(self._state_path)
+        state.record_failure(kind)
+        if state.should_report():
+            repo_slug = os.environ.get("GITHUB_REPOSITORY", "")
+            if repo_slug and "/" in repo_slug:
+                owner, repo = repo_slug.split("/", 1)
+                updater = CanaryIssueUpdater(owner=owner, repo=repo)
+                title = f"{_CANARY_TITLE_PREFIX}: {probe_name}"
+                body = _make_canary_body(probe_name, kind, cli_version, detail)
+                updater.ensure_issue(state, title, body)
+        state.save(self._state_path)
+        write_probe_cache(
+            self._cache_path,
+            ProbeResult(
+                cli_version=cli_version,
+                passed=False,
+                failure_detail=detail,
+                probe_timestamp=datetime.now(UTC).isoformat(),
+            ),
+        )
+
+    def _run_probe_with_discrimination(
+        self, probe_name: str, probe_output: _CodexProbeOutput, assertion_fn
+    ) -> None:
+        try:
+            assertion_fn(probe_output)
+            self._record_success(probe_output.cli_version)
+        except AssertionError as exc:
+            self._record_failure(ErrorKind.SCHEMA, probe_name, probe_output.cli_version, str(exc))
+            raise
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            self._record_failure(ErrorKind.NETWORK, probe_name, probe_output.cli_version, str(exc))
+            raise
+
+    @pytest.fixture(scope="class")
+    def codex_probe_output(self) -> _CodexProbeOutput:
+        return _run_codex_probe()
+
+    def test_ndjson_event_vocabulary_conforms(self, codex_probe_output: _CodexProbeOutput) -> None:
+        self._check_cache(codex_probe_output.cli_version)
+
+        def _assert(output: _CodexProbeOutput) -> None:
+            assert_no_unknown_event_types(output.events)
+            assert_session_start_present(output.events)
+            assert_turn_completed_usage_nonzero(output.events)
+            assert_vocabulary_coverage(output.events, {"thread.started", "turn.completed"})
+
+        self._run_probe_with_discrimination("ndjson_event_vocabulary", codex_probe_output, _assert)
+
+    def test_hook_firing_codex_status(self, codex_probe_output: _CodexProbeOutput) -> None:
+        self._check_cache(codex_probe_output.cli_version)
+
+        def _assert(output: _CodexProbeOutput) -> None:
+            if not output.config_dict:
+                pytest.skip("No session_configuration event in NDJSON output")
+            assert_hook_event_format(output.config_dict)
+
+        self._run_probe_with_discrimination(
+            "hook_firing_codex_status", codex_probe_output, _assert
+        )
+
+    def test_config_acceptance(self, codex_probe_output: _CodexProbeOutput) -> None:
+        self._check_cache(codex_probe_output.cli_version)
+
+        def _assert(output: _CodexProbeOutput) -> None:
+            if not output.config_dict:
+                pytest.skip("No session_configuration event in NDJSON output")
+            assert_config_schema(output.config_dict, output.cli_version)
+
+        self._run_probe_with_discrimination("config_acceptance", codex_probe_output, _assert)

--- a/tests/execution/backends/test_cli_conformance_probes.py
+++ b/tests/execution/backends/test_cli_conformance_probes.py
@@ -140,7 +140,8 @@ class TestCodexLiveProbes:
         self._state_path = tmp_path / "canary_state.json"
         return self._cache_path, self._state_path
 
-    def _check_cache(self, cli_version: str) -> None:
+    def _check_cache(self) -> None:
+        cli_version = _get_codex_version()
         cached = read_probe_cache(self._cache_path, cli_version)
         if cached is not None and cached.passed:
             pytest.skip(f"Probe cached as passed for {cli_version}")
@@ -196,12 +197,17 @@ class TestCodexLiveProbes:
             self._record_failure(ErrorKind.NETWORK, probe_name, probe_output.cli_version, str(exc))
             raise
 
-    @pytest.fixture(scope="class")
-    def codex_probe_output(self) -> _CodexProbeOutput:
-        return _run_codex_probe()
+    _cls_probe_output: _CodexProbeOutput | None = None
 
-    def test_ndjson_event_vocabulary_conforms(self, codex_probe_output: _CodexProbeOutput) -> None:
-        self._check_cache(codex_probe_output.cli_version)
+    @classmethod
+    def _get_probe_output(cls) -> _CodexProbeOutput:
+        if cls._cls_probe_output is None:
+            cls._cls_probe_output = _run_codex_probe()
+        return cls._cls_probe_output
+
+    def test_ndjson_event_vocabulary_conforms(self) -> None:
+        self._check_cache()
+        probe_output = self._get_probe_output()
 
         def _assert(output: _CodexProbeOutput) -> None:
             assert_no_unknown_event_types(output.events)
@@ -209,26 +215,26 @@ class TestCodexLiveProbes:
             assert_turn_completed_usage_nonzero(output.events)
             assert_vocabulary_coverage(output.events, {"thread.started", "turn.completed"})
 
-        self._run_probe_with_discrimination("ndjson_event_vocabulary", codex_probe_output, _assert)
+        self._run_probe_with_discrimination("ndjson_event_vocabulary", probe_output, _assert)
 
-    def test_hook_firing_codex_status(self, codex_probe_output: _CodexProbeOutput) -> None:
-        self._check_cache(codex_probe_output.cli_version)
+    def test_hook_firing_codex_status(self) -> None:
+        self._check_cache()
+        probe_output = self._get_probe_output()
 
         def _assert(output: _CodexProbeOutput) -> None:
             if not output.config_dict:
                 pytest.skip("No session_configuration event in NDJSON output")
             assert_hook_event_format(output.config_dict)
 
-        self._run_probe_with_discrimination(
-            "hook_firing_codex_status", codex_probe_output, _assert
-        )
+        self._run_probe_with_discrimination("hook_firing_codex_status", probe_output, _assert)
 
-    def test_config_acceptance(self, codex_probe_output: _CodexProbeOutput) -> None:
-        self._check_cache(codex_probe_output.cli_version)
+    def test_config_acceptance(self) -> None:
+        self._check_cache()
+        probe_output = self._get_probe_output()
 
         def _assert(output: _CodexProbeOutput) -> None:
             if not output.config_dict:
                 pytest.skip("No session_configuration event in NDJSON output")
             assert_config_schema(output.config_dict, output.cli_version)
 
-        self._run_probe_with_discrimination("config_acceptance", codex_probe_output, _assert)
+        self._run_probe_with_discrimination("config_acceptance", probe_output, _assert)

--- a/tests/execution/backends/test_cli_conformance_probes.py
+++ b/tests/execution/backends/test_cli_conformance_probes.py
@@ -134,10 +134,17 @@ class TestCodexLiveProbes:
     error discrimination → canary recording.
     """
 
+    _cls_state_dir: Path | None = None
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _probe_class_state_dir(self, tmp_path_factory: pytest.TempPathFactory) -> None:
+        type(self)._cls_state_dir = tmp_path_factory.mktemp("canary_state")
+
     @pytest.fixture(autouse=True)
     def _probe_state(self, tmp_path: Path) -> None:
         self._cache_path = tmp_path / "probe_cache.json"
-        self._state_path = tmp_path / "canary_state.json"
+        cls_dir = type(self)._cls_state_dir
+        self._state_path = (cls_dir if cls_dir is not None else tmp_path) / "canary_state.json"
 
     def _check_cache(self) -> None:
         cli_version = _get_codex_version()

--- a/tests/execution/backends/test_cli_conformance_probes.py
+++ b/tests/execution/backends/test_cli_conformance_probes.py
@@ -194,11 +194,18 @@ class TestCodexLiveProbes:
             raise
 
     _cls_probe_output: _CodexProbeOutput | None = None
+    _cls_probe_exc: BaseException | None = None
 
     @classmethod
     def _get_probe_output(cls) -> _CodexProbeOutput:
+        if cls._cls_probe_exc is not None:
+            raise cls._cls_probe_exc
         if cls._cls_probe_output is None:
-            cls._cls_probe_output = _run_codex_probe()
+            try:
+                cls._cls_probe_output = _run_codex_probe()
+            except BaseException as exc:
+                cls._cls_probe_exc = exc
+                raise
         return cls._cls_probe_output
 
     def test_ndjson_event_vocabulary_conforms(self) -> None:

--- a/tests/execution/backends/test_cli_conformance_probes.py
+++ b/tests/execution/backends/test_cli_conformance_probes.py
@@ -135,10 +135,9 @@ class TestCodexLiveProbes:
     """
 
     @pytest.fixture(autouse=True)
-    def _probe_state(self, tmp_path: Path) -> tuple[Path, Path]:
+    def _probe_state(self, tmp_path: Path) -> None:
         self._cache_path = tmp_path / "probe_cache.json"
         self._state_path = tmp_path / "canary_state.json"
-        return self._cache_path, self._state_path
 
     def _check_cache(self) -> None:
         cli_version = _get_codex_version()
@@ -165,6 +164,7 @@ class TestCodexLiveProbes:
     ) -> None:
         state = CanaryState.load(self._state_path)
         state.record_failure(kind)
+        state.save(self._state_path)
         if state.should_report():
             repo_slug = os.environ.get("GITHUB_REPOSITORY", "")
             if repo_slug and "/" in repo_slug:
@@ -173,7 +173,6 @@ class TestCodexLiveProbes:
                 title = f"{_CANARY_TITLE_PREFIX}: {probe_name}"
                 body = _make_canary_body(probe_name, kind, cli_version, detail)
                 updater.ensure_issue(state, title, body)
-        state.save(self._state_path)
         write_probe_cache(
             self._cache_path,
             ProbeResult(
@@ -192,9 +191,6 @@ class TestCodexLiveProbes:
             self._record_success(probe_output.cli_version)
         except AssertionError as exc:
             self._record_failure(ErrorKind.SCHEMA, probe_name, probe_output.cli_version, str(exc))
-            raise
-        except (OSError, subprocess.TimeoutExpired) as exc:
-            self._record_failure(ErrorKind.NETWORK, probe_name, probe_output.cli_version, str(exc))
             raise
 
     _cls_probe_output: _CodexProbeOutput | None = None


### PR DESCRIPTION
## Summary

Adds `TestCodexLiveProbes` — a `CODEX_SMOKE_TEST`-gated test class that exercises real Codex CLI invocations through the shared `_conformance_assertions.py` assertion functions, with a structurally correct cache-first ordering so `read_probe_cache` is consulted before any subprocess is spawned. Registers the new file in the test filter cascade maps, smoke-test Taskfile task, and `tests/execution/AGENTS.md` so the gated probes are discoverable but skipped by default.

<details>
<summary>Individual Group Plans</summary>

### Plan 1 — T5-P5-A8-WP2 Codex Live Probes

Create `tests/execution/backends/test_cli_conformance_probes.py` containing `TestCodexLiveProbes` — a `CODEX_SMOKE_TEST`-gated test class that wires real Codex CLI execution through the shared `_conformance_assertions.py` assertion functions. Each probe method checks `ProbeCache` before invoking `subprocess.run`, delegates assertions to `_conformance_assertions.py`, discriminates `OSError`/`TimeoutExpired` (network) from `AssertionError` (schema), and records results via `CanaryState` + `CanaryIssueUpdater`. Also updates the test filter cascade maps, Taskfile smoke task, and AGENTS.md documentation to register the new file.

### Plan 2 — T5-P5-A8-WP2 ProbeCache-Before-Subprocess Remediation

Restructure `TestCodexLiveProbes` in `tests/execution/backends/test_cli_conformance_probes.py` so that `read_probe_cache` is checked **before** `_run_codex_probe()` fires. The current class-scoped `codex_probe_output` fixture runs the subprocess unconditionally at class collection time, making cache-based skip structurally impossible. The fix removes the fixture and introduces a class-level lazy accessor that defers the subprocess call until the first cache-miss probe method actually needs it.

</details>

Closes #4042

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/impl-20260629-021241-797128/.autoskillit/temp/make-plan/T5-P5-A8-WP2_codex_live_probes_plan_2026-06-29_022100.md`
- `/home/talon/projects/autoskillit-runs/impl-20260629-021241-797128/.autoskillit/temp/make-plan/T5-P5-A8-WP2_codex_live_probes_remediation_plan_2026-06-29_094638.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 106 | 21.5k | 2.4M | 99.6k | 73 | 136.9k | 16m 54s |
| verify* | sonnet | 2 | 120 | 14.8k | 525.2k | 52.3k | 34 | 62.7k | 6m 49s |
| implement* | MiniMax-M3 | 2 | 133.2k | 13.0k | 3.0M | 74.2k | 114 | 0 | 7m 35s |
| audit_impl* | sonnet | 2 | 1.4k | 32.4k | 514.4k | 62.6k | 33 | 88.0k | 11m 17s |
| prepare_pr* | MiniMax-M3 | 1 | 46.3k | 3.2k | 198.7k | 0 | 17 | 0 | 48s |
| compose_pr* | MiniMax-M3 | 1 | 36.6k | 2.7k | 220.2k | 0 | 16 | 0 | 1m 8s |
| review_pr* | sonnet | 2 | 298 | 94.4k | 2.1M | 102.9k | 98 | 168.1k | 21m 56s |
| resolve_review* | sonnet | 2 | 396 | 40.0k | 3.2M | 87.9k | 115 | 138.4k | 15m 18s |
| **Total** | | | 218.4k | 221.9k | 12.1M | 102.9k | | 594.1k | 1h 21m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 289 | 10361.5 | 0.0 | 44.9 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 50 | 63913.0 | 2767.5 | 799.2 |
| **Total** | **339** | 35785.3 | 1752.4 | 654.5 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 106 | 21.5k | 2.4M | 136.9k | 16m 54s |
| sonnet | 4 | 2.2k | 181.6k | 6.4M | 457.2k | 55m 21s |
| MiniMax-M3 | 3 | 216.1k | 18.9k | 3.4M | 0 | 9m 32s |