### PR TITLE
[FIX] Rectify: Vacuous Gate Reachability Blind Spot Bypasses Dispatch Admission Control

### DIFF
--- a/src/autoskillit/recipe/_recipe_composition.py
+++ b/src/autoskillit/recipe/_recipe_composition.py
@@ -10,8 +10,6 @@ from typing import Any
 import regex as re
 
 from autoskillit.core import CAPABILITY_INGREDIENT_TO_SKIP_GUARD, YAMLError, load_yaml
-from autoskillit.recipe._analysis_bfs import bfs_reachable
-from autoskillit.recipe._analysis_graph import _build_step_graph
 from autoskillit.recipe._contracts_types import INPUT_REF_RE
 from autoskillit.recipe.io import find_sub_recipe_by_name
 from autoskillit.recipe.io import load_recipe as _load_recipe_from_path
@@ -226,27 +224,26 @@ def _is_vacuous_gate(
 
 
 def _gate_reachable_post_prune(post_prune_recipe: Any, gate_step_name: str) -> bool:
-    """Return True if gate_step_name is reachable from the entry step in the
-    post-prune flow graph.
+    """Return True if any surviving step routes to gate_step_name.
 
-    Uses `_analysis_graph._build_step_graph` (which handles on_exhausted edges,
-    on_result.routes legacy format, and skip_when_false bypass edges) plus
-    `bfs_reachable` from `_analysis_bfs`. Entry step is determined by the
-    no-in-edges heuristic (matches `rules_reachability.py:89-93`).
+    Uses `_collect_all_route_targets` to check all routing fields
+    (on_success, on_failure, on_context_limit, on_rate_limit, on_exhausted,
+    on_result conditions/routes). A gate with at least one incoming routing
+    edge from a surviving step is considered reachable.
+
+    BFS from entry is insufficient because unrelated pruning (e.g.
+    claim_and_resolve with a default-condition redirect to a failure step)
+    can disconnect the entry step from the main pipeline while the gate
+    remains routable via other surviving steps.
     """
     if not post_prune_recipe or not getattr(post_prune_recipe, "steps", None):
         return False
-    graph = _build_step_graph(post_prune_recipe)
-    all_targets = {t for targets in graph.values() for t in targets}
-    entry = next(
-        (name for name in post_prune_recipe.steps if name not in all_targets),
-        next(iter(post_prune_recipe.steps), None),
-    )
-    if entry is None:
-        return False
-    if gate_step_name == entry:
-        return True
-    return gate_step_name in bfs_reachable(graph, entry)
+    for step_name, step in post_prune_recipe.steps.items():
+        if step_name == gate_step_name:
+            continue
+        if gate_step_name in _collect_all_route_targets(step):
+            return True
+    return False
 
 
 def _drop_sub_recipe_step(recipe: Any, step_name: str) -> Any:

--- a/src/autoskillit/recipe/_recipe_composition.py
+++ b/src/autoskillit/recipe/_recipe_composition.py
@@ -10,6 +10,8 @@ from typing import Any
 import regex as re
 
 from autoskillit.core import CAPABILITY_INGREDIENT_TO_SKIP_GUARD, YAMLError, load_yaml
+from autoskillit.recipe._analysis_bfs import bfs_reachable
+from autoskillit.recipe._analysis_graph import _build_step_graph
 from autoskillit.recipe._contracts_types import INPUT_REF_RE
 from autoskillit.recipe.io import find_sub_recipe_by_name
 from autoskillit.recipe.io import load_recipe as _load_recipe_from_path
@@ -168,6 +170,7 @@ def _compute_capability_feasibility(
             skip_resolutions=skip_resolutions,
             pre_prune_steps=pre_prune_steps,
             post_prune_steps=steps,
+            post_prune_recipe=post_prune_recipe,
         ):
             continue
         infeasible.append(step_name)
@@ -182,8 +185,15 @@ def _is_vacuous_gate(
     skip_resolutions: dict[str, bool | None] | None,
     pre_prune_steps: dict[str, Any] | None,
     post_prune_steps: dict[str, Any],
+    post_prune_recipe: Any,
 ) -> bool:
-    """Return True if the gate is vacuous — its guarded operations were all pruned."""
+    """Return True if the gate is vacuous — its guarded operations were all pruned
+    AND the gate step is unreachable in the post-prune flow graph.
+
+    A gate whose guarded steps are all pruned is only vacuous if no surviving
+    step routes to it. Route-repair in `_prune_skipped_steps` can redirect
+    upstream steps directly to the gate, making it reachable and executable.
+    """
     if skip_resolutions is None or pre_prune_steps is None:
         return False
     for cap_key in gate_input_keys:
@@ -210,7 +220,33 @@ def _is_vacuous_gate(
                 break
         if live_uses_capability:
             return False
+    if _gate_reachable_post_prune(post_prune_recipe, gate_step_name):
+        return False
     return True
+
+
+def _gate_reachable_post_prune(post_prune_recipe: Any, gate_step_name: str) -> bool:
+    """Return True if gate_step_name is reachable from the entry step in the
+    post-prune flow graph.
+
+    Uses `_analysis_graph._build_step_graph` (which handles on_exhausted edges,
+    on_result.routes legacy format, and skip_when_false bypass edges) plus
+    `bfs_reachable` from `_analysis_bfs`. Entry step is determined by the
+    no-in-edges heuristic (matches `rules_reachability.py:89-93`).
+    """
+    if not post_prune_recipe or not getattr(post_prune_recipe, "steps", None):
+        return False
+    graph = _build_step_graph(post_prune_recipe)
+    all_targets = {t for targets in graph.values() for t in targets}
+    entry = next(
+        (name for name in post_prune_recipe.steps if name not in all_targets),
+        next(iter(post_prune_recipe.steps), None),
+    )
+    if entry is None:
+        return False
+    if gate_step_name == entry:
+        return True
+    return gate_step_name in bfs_reachable(graph, entry)
 
 
 def _drop_sub_recipe_step(recipe: Any, step_name: str) -> Any:

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -243,6 +243,14 @@ async def load_recipe(
                     f"Recipe is infeasible on current backend: "
                     f"steps {result.get('infeasible_steps', [])} route to terminal failure."
                 )
+                return json.dumps(
+                    {
+                        "success": False,
+                        "dispatch_infeasible": True,
+                        "infeasible_steps": result.get("infeasible_steps", []),
+                        "user_visible_message": result["user_visible_message"],
+                    }
+                )
             if ingredients_only:
                 result = strip_ingredients_only_keys(result)
             _required_keys: frozenset[str] = frozenset()

--- a/tests/arch/test_capability_admission_control.py
+++ b/tests/arch/test_capability_admission_control.py
@@ -152,6 +152,34 @@ def test_compute_capability_feasibility_receives_skip_resolutions() -> None:
     pytest.fail("load_and_validate function not found in _api.py")
 
 
+def test_compute_capability_feasibility_forwards_post_prune_recipe() -> None:
+    """_compute_capability_feasibility must pass post_prune_recipe to
+    _is_vacuous_gate so the reachability guard has access to the full Recipe
+    object for graph analysis."""
+    comp_path = SRC_ROOT / "recipe" / "_recipe_composition.py"
+    tree = ast.parse(comp_path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "_compute_capability_feasibility"
+        ):
+            for child in ast.walk(node):
+                if (
+                    isinstance(child, ast.Call)
+                    and isinstance(child.func, ast.Name)
+                    and child.func.id == "_is_vacuous_gate"
+                ):
+                    kw_names = {kw.arg for kw in child.keywords if kw.arg is not None}
+                    assert "post_prune_recipe" in kw_names, (
+                        "_compute_capability_feasibility must pass post_prune_recipe "
+                        "kwarg to _is_vacuous_gate for reachability-aware vacuity "
+                        "detection."
+                    )
+                    return
+            pytest.fail("_is_vacuous_gate call not found in _compute_capability_feasibility")
+    pytest.fail("_compute_capability_feasibility function not found in _recipe_composition.py")
+
+
 def test_dispatch_food_truck_injects_capability_overrides() -> None:
     """dispatch_food_truck must reference _build_capability_overrides to inject
     backend capability signals into the load_and_validate call."""

--- a/tests/recipe/AGENTS.md
+++ b/tests/recipe/AGENTS.md
@@ -84,6 +84,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_promote_to_main_wrapper.py` | Tests for the promote-to-main wrapper recipe |
 | `test_pseudocode_sync_rule.py` | Tests for the pseudocode-callable-divergence semantic rule |
 | `test_recipe_backend_composition_matrix.py` | Recipe x backend composition matrix: parametrized CI gate validating every (recipe, backend) combination with declared-unsupported and known-broken governance |
+| `test_recipe_composition_vacuous_gate.py` | Tests for reachability-aware `_is_vacuous_gate`: gate reachable post-prune is NOT vacuous, unreachable gate IS vacuous, all bundled gate-equipped recipes must report dispatch_feasible=False under codex |
 | `test_recipe_ci_applicable_routing.py` | Structural tests for ci_applicable routing guards across all wait_for_ci chains |
 | `test_recipe_ci_contracts.py` | Cross-recipe ci_event/branch coherence and remote_url structural tests |
 | `test_recipe_ci_watch_event.py` | Tests for CI watch event in recipe steps |

--- a/tests/recipe/test_bundled_recipes_dispatch_ready.py
+++ b/tests/recipe/test_bundled_recipes_dispatch_ready.py
@@ -266,8 +266,9 @@ def test_card_and_semantic_rules_agree_on_errors(recipe_name: str, tmp_path: Pat
 
 
 def test_codex_implementation_dispatch_infeasible() -> None:
-    """Codex backend + implementation recipe must report dispatch_feasible=True
-    when gate_backend_write is vacuous (all guarded steps were pruned)."""
+    """Codex backend + implementation recipe must report dispatch_feasible=False
+    when gate_backend_write is reachable post-prune (route-repair redirects
+    upstream steps to the gate after implement is pruned)."""
     result = load_and_validate(
         "implementation",
         project_dir=_PROJECT_ROOT,
@@ -275,11 +276,12 @@ def test_codex_implementation_dispatch_infeasible() -> None:
         backend_name="codex",
     )
     assert result["valid"] is True
-    assert result.get("dispatch_feasible") is True, (
-        "When all backend_supports_git_write-gated steps are pruned, "
-        "gate_backend_write is vacuous and should NOT block dispatch."
+    assert result.get("dispatch_feasible") is False, (
+        "When implement is pruned but create_impl_worktree.on_success is "
+        "route-repaired to gate_backend_write, the gate is reachable and "
+        "must block dispatch as infeasible."
     )
-    assert "gate_backend_write" not in result.get("infeasible_steps", [])
+    assert "gate_backend_write" in result.get("infeasible_steps", [])
 
 
 def test_claude_implementation_dispatch_feasible() -> None:
@@ -328,10 +330,13 @@ _CAPABILITY_GATE_RECIPES = _discover_capability_gate_recipes()
 
 @pytest.mark.parametrize("recipe_name", _CAPABILITY_GATE_RECIPES)
 def test_codex_capability_gate_recipes(recipe_name: str) -> None:
-    """Every recipe with a gate_backend_write step must pass vacuous-gate
-    detection under codex overrides — either dispatch_feasible=True (gate
-    is vacuous) or dispatch_feasible=False with gate in infeasible_steps
-    (gate guards live steps)."""
+    """Every recipe with a gate_backend_write step must report dispatch_feasible=False
+    with gate_backend_write in infeasible_steps when the gate is reachable post-prune.
+
+    Route-repair in _prune_skipped_steps redirects create_impl_worktree.on_success
+    to gate_backend_write after pruning the guarded steps, making the gate reachable
+    from the entry step. Admission control must identify this as an infeasible pipeline.
+    """
     result = load_and_validate(
         recipe_name,
         project_dir=_PROJECT_ROOT,
@@ -339,12 +344,12 @@ def test_codex_capability_gate_recipes(recipe_name: str) -> None:
         backend_name="codex",
     )
     assert result.get("valid") is True
-    dispatch_feasible = result.get("dispatch_feasible")
-    infeasible_steps = result.get("infeasible_steps", [])
-    if dispatch_feasible is True:
-        assert "gate_backend_write" not in infeasible_steps
-    else:
-        assert dispatch_feasible is False, (
-            f"Expected dispatch_feasible to be explicitly False, got {dispatch_feasible!r}"
-        )
-        assert "gate_backend_write" in infeasible_steps
+    assert result.get("dispatch_feasible") is False, (
+        f"Recipe '{recipe_name}' must report dispatch_feasible=False when "
+        f"gate_backend_write is reachable post-prune; got: "
+        f"{result.get('dispatch_feasible')!r}"
+    )
+    assert "gate_backend_write" in result.get("infeasible_steps", []), (
+        f"Recipe '{recipe_name}' must list gate_backend_write in infeasible_steps; "
+        f"got: {result.get('infeasible_steps')}"
+    )

--- a/tests/recipe/test_recipe_composition_vacuous_gate.py
+++ b/tests/recipe/test_recipe_composition_vacuous_gate.py
@@ -39,6 +39,7 @@ class _StubStep:
     on_result: object | None = None
     skip_when_false: str | None = None
     optional: bool = False
+    sub_recipe: str | None = None
 
 
 @dataclass

--- a/tests/recipe/test_recipe_composition_vacuous_gate.py
+++ b/tests/recipe/test_recipe_composition_vacuous_gate.py
@@ -1,0 +1,184 @@
+"""Tests for reachability-aware vacuous gate detection in _is_vacuous_gate.
+
+The vacuous gate exemption (`_is_vacuous_gate` returning True) allowed
+dispatch to pass admission control when all guarded steps were pruned —
+but route-repair in `_prune_skipped_steps` can redirect upstream steps
+directly to the gate, making it reachable and executable in the
+post-prune flow graph. These tests pin the correct behavior:
+
+- A gate reachable from the entry step is NOT vacuous (it will execute
+  and fail at runtime → must be reported as infeasible).
+- A gate with no incoming routing edges is vacuous (all guards were
+  pruned and nothing routes to it → safe to exempt).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+@dataclass
+class _StubStep:
+    tool: str | None = None
+    action: str | None = None
+    note: str | None = None
+    with_args: dict | None = None
+    on_success: str | None = None
+    on_failure: str | None = None
+    on_context_limit: str | None = None
+    on_rate_limit: str | None = None
+    on_exhausted: str | None = None
+    on_result: object | None = None
+    skip_when_false: str | None = None
+    optional: bool = False
+
+
+@dataclass
+class _StubRecipe:
+    steps: dict = field(default_factory=dict)
+    ingredients: dict = field(default_factory=dict)
+
+
+class _StubPreStep:
+    def __init__(self, skip_when_false: str) -> None:
+        self.skip_when_false = skip_when_false
+
+
+def _build_recipe(steps: dict[str, dict]) -> _StubRecipe:
+    """Build a Recipe-like object from a flat step-dict (name -> fields)."""
+    stub_steps: dict[str, _StubStep] = {}
+    for step_name, fields in steps.items():
+        stub_steps[step_name] = _StubStep(**fields)
+    return _StubRecipe(steps=stub_steps)
+
+
+def test_is_vacuous_gate_returns_false_when_gate_reachable_post_prune() -> None:
+    """Gate is reachable via create_impl_worktree.on_success → gate_backend_write.
+
+    With `implement` pruned but `create_impl_worktree.on_success` redirected to
+    `gate_backend_write` by route-repair, the gate is reachable from the entry
+    step. _is_vacuous_gate must return False (not vacuous) → infeasible.
+    """
+    from autoskillit.recipe._recipe_composition import _is_vacuous_gate
+
+    recipe = _build_recipe(
+        {
+            "create_impl_worktree": {"on_success": "gate_backend_write"},
+            "gate_backend_write": {
+                "tool": "run_python",
+                "with_args": {
+                    "callable": "autoskillit.smoke_utils.gate_backend_write",
+                    "backend_supports_git_write": "false",
+                },
+                "on_failure": "escalate",
+                "on_exhausted": "escalate",
+            },
+        }
+    )
+
+    gate_input_keys = {"backend_supports_git_write"}
+    pre_prune_steps = {
+        "implement": _StubPreStep(skip_when_false="inputs.backend_supports_git_write"),
+    }
+    skip_resolutions: dict = {"implement": False}
+    post_prune_steps = recipe.steps
+
+    result = _is_vacuous_gate(
+        gate_input_keys,
+        gate_step_name="gate_backend_write",
+        skip_resolutions=skip_resolutions,
+        pre_prune_steps=pre_prune_steps,
+        post_prune_steps=post_prune_steps,
+        post_prune_recipe=recipe,
+    )
+
+    assert result is False, (
+        "Gate is reachable via create_impl_worktree.on_success after route-repair; "
+        "must NOT be treated as vacuous."
+    )
+
+
+def test_is_vacuous_gate_returns_true_when_gate_unreachable_post_prune() -> None:
+    """Gate has no incoming routing edges (truly unreachable after pruning).
+
+    When all guarded steps are pruned AND no other step routes to the gate,
+    the gate is truly unreachable. _is_vacuous_gate must return True (vacuous).
+    """
+    from autoskillit.recipe._recipe_composition import _is_vacuous_gate
+
+    recipe = _build_recipe(
+        {
+            "create_impl_worktree": {"on_success": "done"},
+            "gate_backend_write": {
+                "tool": "run_python",
+                "with_args": {
+                    "callable": "autoskillit.smoke_utils.gate_backend_write",
+                    "backend_supports_git_write": "false",
+                },
+                "on_failure": "escalate",
+                "on_exhausted": "escalate",
+            },
+        }
+    )
+
+    gate_input_keys = {"backend_supports_git_write"}
+    pre_prune_steps = {
+        "implement": _StubPreStep(skip_when_false="inputs.backend_supports_git_write"),
+    }
+    skip_resolutions: dict = {"implement": False}
+    post_prune_steps = recipe.steps
+
+    result = _is_vacuous_gate(
+        gate_input_keys,
+        gate_step_name="gate_backend_write",
+        skip_resolutions=skip_resolutions,
+        pre_prune_steps=pre_prune_steps,
+        post_prune_steps=post_prune_steps,
+        post_prune_recipe=recipe,
+    )
+
+    assert result is True, (
+        "Gate has no incoming routing edges and all guards pruned; must be treated as vacuous."
+    )
+
+
+@pytest.mark.parametrize(
+    "recipe_name",
+    ["implementation", "remediation", "implementation-groups"],
+)
+def test_compute_capability_feasibility_returns_infeasible_for_codex_recipes(
+    recipe_name: str,
+) -> None:
+    """All three gate-equipped recipes must report dispatch_feasible=False
+    when backend_supports_git_write=false under codex backend.
+
+    Route-repair redirects create_impl_worktree.on_success to gate_backend_write
+    after pruning `implement`, making the gate reachable. Admission control
+    must identify this as an infeasible pipeline.
+    """
+    from autoskillit.recipe._api import load_and_validate
+
+    result = load_and_validate(
+        recipe_name,
+        project_dir=_PROJECT_ROOT,
+        ingredient_overrides={"backend_supports_git_write": "false"},
+        backend_name="codex",
+    )
+    assert result["valid"] is True
+    assert result.get("dispatch_feasible") is False, (
+        f"Recipe '{recipe_name}' with backend_supports_git_write=false under codex "
+        f"must report dispatch_feasible=False (gate is reachable post-prune); "
+        f"got: {result.get('dispatch_feasible')}"
+    )
+    assert "gate_backend_write" in result.get("infeasible_steps", []), (
+        f"Recipe '{recipe_name}' must list gate_backend_write in infeasible_steps; "
+        f"got: {result.get('infeasible_steps')}"
+    )

--- a/tests/server/test_backend_ingredient_injection.py
+++ b/tests/server/test_backend_ingredient_injection.py
@@ -496,11 +496,12 @@ class TestRealCompositionPruning:
         )
 
     @pytest.mark.anyio
-    async def test_codex_open_kitchen_returns_success(self, tmp_path: Path) -> None:
+    async def test_codex_open_kitchen_blocks_on_reachable_gate(self, tmp_path: Path) -> None:
         """End-to-end integration: open_kitchen with codex backend on the bundled
-        implementation recipe must return success=True because vacuous-gate
-        detection recognises that all backend_supports_git_write-guarded steps
-        were pruned, making gate_backend_write vacuous.
+        implementation recipe must hard-block because gate_backend_write is reachable
+        post-prune (route-repair redirects create_impl_worktree.on_success to the
+        gate after implement is pruned). Admission control reports dispatch_feasible=False
+        and open_kitchen must reject the pipeline.
         """
         from autoskillit.server.tools.tools_kitchen import open_kitchen
 
@@ -554,11 +555,14 @@ class TestRealCompositionPruning:
 
             result = json.loads(result_str)
 
-        assert result.get("success") is True, (
-            f"open_kitchen must accept codex backend (vacuous gate); got: {result}"
+        assert result.get("success") is False, (
+            f"open_kitchen must hard-block codex backend (reachable gate); got: {result}"
         )
-        assert result.get("dispatch_feasible") is True, (
-            "dispatch_feasible must be True when "
-            f"gate_backend_write is vacuous; got: "
+        assert result.get("dispatch_feasible") is False, (
+            "dispatch_feasible must be False when "
+            f"gate_backend_write is reachable post-prune; got: "
             f"{result.get('dispatch_feasible')}"
+        )
+        assert "gate_backend_write" in result.get("infeasible_steps", []), (
+            f"infeasible_steps must list gate_backend_write; got: {result.get('infeasible_steps')}"
         )

--- a/tests/server/test_backend_ingredient_injection.py
+++ b/tests/server/test_backend_ingredient_injection.py
@@ -558,10 +558,9 @@ class TestRealCompositionPruning:
         assert result.get("success") is False, (
             f"open_kitchen must hard-block codex backend (reachable gate); got: {result}"
         )
-        assert result.get("dispatch_feasible") is False, (
-            "dispatch_feasible must be False when "
-            f"gate_backend_write is reachable post-prune; got: "
-            f"{result.get('dispatch_feasible')}"
+        assert result.get("kitchen") == "dispatch_infeasible", (
+            "kitchen must be 'dispatch_infeasible' when gate_backend_write is "
+            f"reachable post-prune; got: {result.get('kitchen')!r}"
         )
         assert "gate_backend_write" in result.get("infeasible_steps", []), (
             f"infeasible_steps must list gate_backend_write; got: {result.get('infeasible_steps')}"

--- a/tests/server/test_capability_admission_e2e.py
+++ b/tests/server/test_capability_admission_e2e.py
@@ -29,10 +29,11 @@ def test_capability_gate_callables_includes_gate_backend_write() -> None:
     assert "gate_backend_write" in CAPABILITY_GATE_CALLABLES
 
 
-def test_codex_backend_produces_feasible_recipe_via_vacuous_gate() -> None:
+def test_codex_backend_reachable_gate_returns_infeasible() -> None:
     """Codex + implementation recipe chain: backend_supports_git_write=false
-    produces dispatch_feasible=True because vacuous-gate detection recognises
-    all guarded steps were pruned."""
+    produces dispatch_feasible=False because the reachable gate (post-prune
+    route-repair redirects create_impl_worktree.on_success to gate_backend_write)
+    blocks dispatch via admission control."""
     result = load_and_validate(
         "implementation",
         project_dir=_PROJECT_ROOT,
@@ -40,8 +41,8 @@ def test_codex_backend_produces_feasible_recipe_via_vacuous_gate() -> None:
         backend_name="codex",
     )
     assert result.get("valid") is True
-    assert result.get("dispatch_feasible") is True
-    assert "gate_backend_write" not in result.get("infeasible_steps", [])
+    assert result.get("dispatch_feasible") is False
+    assert "gate_backend_write" in result.get("infeasible_steps", [])
 
 
 def test_claude_code_backend_produces_feasible_recipe() -> None:

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -624,3 +624,33 @@ class TestLoadRecipeFailClosed:
         parsed = json.loads(raw)
         assert parsed["success"] is False
         assert "content" in parsed["error"]
+
+    @pytest.mark.anyio
+    async def test_load_recipe_blocks_on_dispatch_infeasible(self, monkeypatch, tmp_path):
+        """load_recipe must hard-block when dispatch_feasible=False — no recipe
+        content is delivered to the caller when the pipeline is infeasible."""
+        monkeypatch.chdir(tmp_path)
+        from autoskillit.recipe._api_cache import _LOAD_CACHE
+
+        _LOAD_CACHE.clear()
+        test_result = {
+            "valid": True,
+            "content": "name: blocked-recipe\nsteps:\n  build:\n    cmd: task build\n",
+            "dispatch_feasible": False,
+            "infeasible_steps": ["gate_backend_write"],
+        }
+        monkeypatch.setattr(self.ctx.recipes, "load_and_validate", lambda *a, **kw: test_result)
+        monkeypatch.setattr(self.ctx.recipes, "find", lambda *a, **kw: None)
+        with patch(
+            "autoskillit.server.tools.tools_recipe._apply_triage_gate",
+            new=AsyncMock(return_value=test_result),
+        ):
+            raw = await load_recipe(name="blocked-recipe")
+        parsed = json.loads(raw)
+        assert parsed["success"] is False
+        assert parsed.get("dispatch_infeasible") is True
+        assert "gate_backend_write" in parsed.get("infeasible_steps", [])
+        assert "content" not in parsed, (
+            "load_recipe must NOT deliver recipe content when dispatch is infeasible; "
+            f"got keys: {list(parsed.keys())}"
+        )


### PR DESCRIPTION
## Summary

`_is_vacuous_gate` (`_recipe_composition.py:178-213`) declares a capability gate step vacuous by checking whether guarded steps were pruned and whether surviving steps consume the capability ingredient — but never checks whether the gate step itself is **reachable** in the post-prune flow graph. Route-repair in `_prune_skipped_steps` can redirect upstream steps to point directly to the gate, making it reachable and executable even after all guarded steps are pruned. The result: Codex+implementation pipelines pass admission control, execute 21 minutes of side-effecting steps, then fail deterministically at the gate.

The architectural weakness is that admission-control functions (`_compute_capability_feasibility`, `_is_vacuous_gate`) operate on **flat step dictionaries** using property-only checks, while the recipe layer has mature BFS reachability machinery (`bfs_reachable`, `_build_step_graph` in `_analysis_bfs.py`) that is only consumed by semantic rules via `ValidationContext` — never by admission control.

The immunity approach: make graph-awareness a **structural requirement** for all admission-control decisions by threading the post-prune step graph through `_compute_capability_feasibility` and `_is_vacuous_gate`, and adding a reachability gate that short-circuits the vacuous determination when the gate step is unreachable.

## Requirements

# Investigation: Codex Pipeline DOA Bypass via _is_vacuous_gate Reachability Blind Spot

**Date:** 2026-06-30
**Scope:** Why Codex+implementation pipeline passes dispatch_infeasible admission control and runs 21 minutes of irreversible side effects before dying at gate_backend_write, despite PR #4094 and #4130 adding capability admission control.
**Mode:** Deep Analysis (2 exploration batches + adversarial challenge + post-report validation; 9 subagents)

## Summary

The Codex+implementation pipeline bypasses admission control because `_is_vacuous_gate` (`_recipe_composition.py:178-213`, introduced by PR #4130 on June 27) incorrectly declares `gate_backend_write` as "vacuous" — concluding that since all guarded steps were pruned, the gate has nothing left to guard and should not trigger `dispatch_infeasible`. But `_is_vacuous_gate` only checks whether surviving steps *use* the capability ingredient in their `with_args`; it does **not** check whether the gate step itself remains *reachable* in the post-prune flow graph. After `_prune_skipped_steps` prunes `implement`, route-repair redirects `create_impl_worktree.on_success` from `implement` to `gate_backend_write`, making the gate directly reachable. The pipeline is dispatched, runs 11 side-effecting steps (~21 minutes), then `gate_backend_write` fires and routes to `release_issue_failure` — exactly the DOA outcome that admission control was designed to prevent.

This is the third oscillation of a pendulum pattern: PR #4094 blocks DOA pipelines → PR #4130 unblocks (vacuous-gate exemption goes too far) → today's failure. The structural cause is that admission control operates on heuristic inference (pattern-matching callables against registries) rather than author-declared intent (the `purpose_critical` step annotation proposed in PR #4094's REQ-SCHEMA-001, which was never implemented).

## Root Cause

**Primary (architectural):** `_is_vacuous_gate` at `_recipe_composition.py:178-213` has a **reachability blind spot**. It determines vacuity by checking two conditions: (1) at least one pre-prune step with a matching `skip_when_false` guard was pruned (`pruned_for_capability`), and (2) no surviving step (other than the gate itself) references the capability ingredient in `with_args` (`live_uses_capability`). Both conditions are met for Codex+implementation. But the function never checks whether the gate step is reachable from any surviving step via routing fields (`on_success`, `on_failure`, `on_result`, etc.). After route-repair, `create_impl_worktree.on_success` points directly to `gate_backend_write`. The gate is reachable, will execute, and will deterministically fail — but `_is_vacuous_gate` returns `True`. [SUPPORTED]

**Proximate (why the reachability check is missing):** PR #4130 was solving a real false-positive problem — #4094's admission control blocked all Codex+implementation runs even though the pruned recipe's gate was *intended* to be a defense-in-depth terminal. The vacuous-gate concept is architecturally correct (a gate CAN be genuinely unreachable), but the implementation checks the wrong predicate. It asks "does any surviving step consume the capability?" when it should also ask "is the gate step itself reachable from the entry point?" [SUPPORTED]

**Why prior fixes did not address this:** The fix chain follows a pendulum pattern:
1. **100+ pre-#4094 fixes** — each patched the step where the previous run died (downstream relocation)
2. **PR #4094 (June 12)** — admission control at load time (correct architecture, but over-blocked)
3. **PR #4130 (June 27)** — vacuous-gate exemption (correct intent, but reachability gap re-opened the hole)
4. **Today (June 30)** — pipeline passes admission and wastes 21 minutes before failing

The `purpose_critical` per-step annotation proposed in PR #4094's design (REQ-SCHEMA-001) was never implemented. The system uses inference-based heuristics layered on inference-based heuristics, each layer correcting the prior while introducing new failure surface. [SUPPORTED]

## Affected Components

- `src/autoskillit/recipe/_recipe_composition.py:178-213` — `_is_vacuous_gate()`: missing reachability check [SUPPORTED]
- `src/autoskillit/recipe/_recipe_composition.py:109-175` — `_compute_capability_feasibility()`: calls `_is_vacuous_gate` and trusts its result [SUPPORTED]
- `src/autoskillit/recipe/_recipe_composition.py:401-524` — `_prune_skipped_steps()` (function); route-repair logic at lines 460-520 redirects `create_impl_worktree.on_success` to `gate_backend_write` [SUPPORTED]
- `src/autoskillit/recipe/_api.py:405-412` — `load_and_validate()`: calls `_compute_capability_feasibility`, propagates `dispatch_feasible=True` [SUPPORTED]
- `src/autoskillit/server/tools/tools_kitchen.py:844-847` — `open_kitchen` feasibility check: passes because `dispatch_feasible=True` [SUPPORTED]
- `src/autoskillit/recipes/implementation.yaml:298-365` — `create_impl_worktree` (no guard) → `implement` (guarded, line 328) → `gate_backend_write` (no guard) topology [SUPPORTED]
- `src/autoskillit/recipes/remediation.yaml:335-405` — Same topology (`create_impl_worktree` at 335, `implement` at 347, `gate_backend_write` at 396-405) [SUPPORTED]
- `src/autoskillit/recipes/implementation-groups.yaml:261-323` — Same topology [SUPPORTED]
- `src/autoskillit/recipe/_analysis_bfs.py:17,58` — `bfs_reachable()` and `_build_step_graph()` — existing reachability machinery not used by `_is_vacuous_gate` [SUPPORTED]
- `src/autoskillit/core/types/_type_constants.py:95-118` — `BACKEND_CAPABILITY_INGREDIENTS`, `CAPABILITY_GATE_CALLABLES`, `CAPABILITY_INGREDIENT_TO_SKIP_GUARD` registries [SUPPORTED]

## Data Flow

1. User runs `AUTOSKILLIT_FEATURES__CODEX_BACKEND=true AUTOSKILLIT_AGENT_BACKEND__BACKEND=codex autoskillit order`
2. `get_backend("codex")` → `CodexBackend` → `capabilities.git_metadata_writable=False` (`codex.py:594`)
3. `open_kitchen(name="implementation")` → `_backend_capability_overrides()` → `{"backend_supports_git_write": "false"}` (`_auto_overrides.py:27-28`)
4. `_session_overrides.update(_backend_capability_overrides(...))` injects `"false"` (line 659); `_promote_capability_keys(_config_layer, _session_overrides)` copies it into config-authoritative layer so it wins the merge (line 661); merged at line 662
5. `load_and_validate("implementation", ingredient_overrides={"backend_supports_git_write": "false"})` → `_prune_skipped_steps()`:
   - Prunes `implement` (line 328: `skip_when_false: inputs.backend_supports_git_write`)
   - Route-repair: `create_impl_worktree.on_success` redirected from `implement` → `gate_backend_write` (lines 464-465, 484-485)
   - Prunes `retry_worktree`, `fix`, `merge_gate_fix`, `rebase_conflict_fix`, `resolve_review`, `resolve_pre_review_conflicts` — same guard
6. `_compute_capability_feasibility()` evaluates surviving `gate_backend_write`:
   - `tool=run_python` ✓, callable in `CAPABILITY_GATE_CALLABLES` ✓, `all_falsy=True` ✓, `on_exhausted="escalate"` (schema default) ✓
   - Calls `_is_vacuous_gate()`: `pruned_for_capability=True` (implement pruned), `live_uses_capability=False` (no surviving step has `backend_supports_git_write` in with_args) → returns `True`
   - Gate NOT added to `infeasible` → `dispatch_feasible=True`
7. `open_kitchen` returns `success=True` → kitchen gate opens → orchestrator starts executing
8. Side-effecting steps execute: `bootstrap_clone` (~3s), `claim_and_resolve_issue` (~3s), `create_and_publish_branch` (~3s), `make-plan` (~13min), `review-approach` (~5min), `dry-walkthrough` (~8min), `create_impl_worktree` (~1s)
9. `gate_backend_write(backend_supports_git_write="false")` → `{"backend_capable": "false"}` → routes to `release_issue_failure`
10. Issue labeled `fail`, clone registered as error, worktree abandoned. ~21 minutes wasted.

## Test Gap Analysis

Tests **pin the bug as correct behavior** — the same pattern as the June 12 investigation:

- `tests/server/test_backend_ingredient_injection.py:554-564` — asserts Codex + implementation `open_kitchen` returns `success=True` and `dispatch_feasible=True` (changed by PR #4130 from `success=False, kitchen=dispatch_infeasible`) [SUPPORTED]
- `tests/recipe/test_bundled_recipes_dispatch_ready.py:268-282` — function named `test_codex_implementation_dispatch_infeasible` but asserts `dispatch_feasible is True` (name-assertion mismatch from pendulum) [SUPPORTED]
- `tests/recipe/test_bundled_recipes_dispatch_ready.py:329-350` — `test_codex_capability_gate_recipes` uses disjunctive assertion accepting EITHER `True` OR `False` — cannot catch a new class of regression [SUPPORTED]
- No end-to-end test simulates a full Codex+implementation pipeline (open_kitchen → execute steps → verify side-effect prevention). All tests are layer-local. [SUPPORTED]

## Similar Patterns

- `_check_dispatch_feasibility` (`_preflight.py:34-114`) solves the analogous problem for `run_skill` steps — iterates steps, checks per-step provider profile, skips steps routed to a capable backend. Same pattern needed for `run_python` capability gates. [SUPPORTED]
- The recipe graph rule `failure-verdict-bypass-reachable` (#3630) already performs terminal-classified reachability using `bfs_reachable()` and `_build_step_graph()`. The machinery for the correct check exists. [SUPPORTED]
- The `create_impl_worktree` step executes at the orchestrator/host level (unsandboxed `run_cmd`), not inside a Codex session. All host-side git operations succeed on Codex — the irreducible gap is only `implement` committing inside the sandbox. [SUPPORTED]

## Design Intent Findings

- **`_is_vacuous_gate` (PR #4130, commit `1112c0f3f`, 2026-06-27):** Introduced to fix false-positive blocking from PR #4094. Commit message: "A gate step (`gate_backend_write`) that guards already-pruned operations survives pruning and blocks the entire recipe. ... Three independent subsystems — step pruning, capability feasibility, and per-step backend override — operate without cross-communication." The function's purpose is to detect genuinely unreachable gates and exempt them from infeasibility. The purpose is correct; the reachability predicate is incomplete. [SUPPORTED]
- **`_compute_capability_feasibility` (PR #4094, commit `cfb6ecc51`, 2026-06-12):** Introduced as the "definitive" admission control after 84+ downstream fixes. PR body: "84 `[FIX]` commits over ~3 weeks have patched individual links in the capability injection chain without closing the architectural gap." REQ-SCHEMA-001 proposed a `purpose_critical` step annotation; it was never implemented — the heuristic approach was substituted. [SUPPORTED]
- **`gate_backend_write` step (PR #3960, commit `207deda91`, 2026-06-09):** Converts DOA pipeline ending from false-success to honest-failure. Never intended to prevent wasted work — only to make the waste end honestly. [SUPPORTED]
- **`BackendCapabilities.git_metadata_writable` (PR #3844, commit `5a971233d`, 2026-06-06):** Documents the Codex sandbox constraint. Static declaration, no runtime probe. Correct. [SUPPORTED]

## Historical Context

This is the third oscillation of a confirmed pendulum pattern:

**The pendulum:**
- 100+ pre-#4094 fixes (May-June 2026): each patched the step where the previous run died
- PR #4094 (June 12): admission control blocks DOA pipelines — over-blocked (gate vacuously infeasible)
- PR #4130 (June 27): vacuous-gate exemption — under-blocked (reachability gap)
- Today (June 30): pipeline passes admission, wastes 21 minutes, fails at gate

**Fix chain (all verified by commit message + diff):**
#3844 → #3880 → #3892 → #3902 → #3960 → #3973 → #3980 → #3981 → #3995 → #4068 → #4071 → #4075 → #4086 → #4087 → #4094 → #4130

**Prior investigations directly on this topic:** `investigation_codex_gate_backend_write_recurrence_2026-06-12_083200.md` (June 12, deep analysis, 9 subagents), `investigation_codex_dispatch_infeasible_2026-06-12_151200.md` (June 12, deep analysis). Both identified the root cause correctly but proposed fixes that were either not implemented as designed (purpose_critical) or introduced new gaps (vacuous-gate).

**This is a recurring pattern — consider running `/rectify` for architectural immunity after resolving the immediate issue.**

## External Research

- Codex CLI `workspace-write` sandbox protects `.git/` as read-only by design (Linux landlock/bwrap). Headless `codex exec` cannot use `--sandbox danger-full-access` with `approval_policy=never`. This constraint is structural and unfixable from AutoSkillit's side. Source: openai.com/codex/concepts/sandboxing, openai/codex PR #19852. [SUPPORTED]
- Aider performs all git operations host-side (LLM never touches `.git/`). AutoSkillit's static capability declaration is the most robust multi-backend pattern but is consumed only mid-pipeline, not at admission with correct reachability. [SUPPORTED]

## Scope Boundary

**Investigated:** `_is_vacuous_gate` logic and its reachability blind spot; all three affected recipes (implementation, remediation, implementation-groups); `_prune_skipped_steps` route-repair mechanism; `_compute_capability_feasibility` full logic; all five admission-control enforcement surfaces (normal open_kitchen, deferred open_kitchen, get_recipe, load_recipe, dispatch_food_truck); 16-commit fix chain; installed vs. repo version parity; existing BFS reachability machinery; adversarial challenge of root cause (7 counterhypotheses tested, all refuted).

**Not yet explored:** Whether `load_recipe` soft enforcement (sets flag but doesn't early-return at `tools_recipe.py:240-245`) is a latent exploit path; whether `purpose_critical` annotation is still the correct long-term fix or whether reachability alone is sufficient; exact GitHub `fail`-label issue count attributable to this family; whether research/merge-prs recipes silently degrade on Codex (no gate step, so no DOA signal).

## Recommendations

**Single recommendation: Add post-prune reachability check to `_is_vacuous_gate`.**

`_is_vacuous_gate` (`_recipe_composition.py:178-213`) must verify that the gate step is NOT reachable from any surviving step before declaring it vacuous. The check should use the existing `_collect_all_route_targets` helper (same file, line 25) which already covers all routing fields (`on_success`, `on_failure`, `on_context_limit`, `on_rate_limit`, `on_exhausted`, `on_result` conditions).

After the `for cap_key in gate_input_keys` loop completes (line 212 is inside the loop body), at the same indentation level as `return True` (line 213):
- Scan `post_prune_steps` for any step (other than the gate itself) whose route targets include `gate_step_name`
- If found, return `False` — the gate is reachable and therefore not vacuous

This leverages existing infrastructure (`_collect_all_route_targets` at line 25) and adds a single structural check to close the reachability gap. No schema changes, no new registries, no heuristic layers.

**Complementary actions:**
1. Fix the misnamed test `test_codex_implementation_dispatch_infeasible` to assert `dispatch_feasible=False` (reversing PR #4130's flip back to #4094's correct contract)
2. Add an end-to-end test that verifies Codex+implementation is rejected pre-claim (not just at load_and_validate level, but at open_kitchen/dispatch_food_truck level)
3. Harden `load_recipe` enforcement at `tools_recipe.py:240-245` from soft (flag-only) to hard (early-return refusal)

**Killed alternatives:**
- *Remove `_is_vacuous_gate` entirely* — killed: re-introduces the false-positive from #4094 for any future recipe with genuinely unreachable gates
- *Add `purpose_critical` annotation (REQ-SCHEMA-001)* — killed as immediate fix: correct long-term but scope is too large for the acute issue; reachability check is sufficient and composable with purpose_critical if added later
- *Add `skip_when_false` to `create_impl_worktree`* — killed: `create_impl_worktree` correctly executes at host level (unsandboxed); blocking it blocks the worktree for non-gate uses
- *Hand-key `backend_supports_git_write` check in `_check_dispatch_feasibility`* — killed: same rot class as prior fixes; does not generalize to next capability

## Breakage Analysis

- **Recommendation:** Add post-prune reachability check to `_is_vacuous_gate`
  - **Breakage surface:** Tests pinning `dispatch_feasible=True` for Codex+implementation: `test_backend_ingredient_injection.py:554-564`, `test_bundled_recipes_dispatch_ready.py:268-282`, `test_capability_admission_e2e.py` (vacuous-gate test). All must be updated to assert `dispatch_feasible=False` and `infeasible_steps=["gate_backend_write"]`.
  - **Prior reverts:** None found on admission control or vacuous-gate logic (`git log --grep="revert" -i`)
  - **Downstream contract violations:** None — `gate_backend_write` step is retained as defense-in-depth; `skip_when_false` pruning unchanged; research/merge-prs recipes unaffected (no `gate_backend_write` step). Fleet dispatch gains earlier refusal. `ingredients_only=true` discovery flow is unaffected (infeasibility is on the recipe, not the ingredients).
  - **Implementation sites easy to miss:** The deferred-recall `open_kitchen` path (tools_kitchen.py:731-734) is a second enforcement site; `load_recipe` (tools_recipe.py:240-245) needs hard enforcement upgrade; fleet `dispatch_food_truck` (tools_fleet_dispatch.py:340-351) already checks `dispatch_feasible`.
  - **Risk level:** LOW — concentrated change in one function (`_is_vacuous_gate`), test inversions, and one soft→hard enforcement upgrade in `load_recipe`.

## Confidence Levels

| Finding | Confidence |
|---------|-----------|
| `_is_vacuous_gate` missing reachability check is the root cause | SUPPORTED |
| Route-repair makes `gate_backend_write` reachable via `create_impl_worktree` | SUPPORTED |
| All three gate recipes (implementation, remediation, implementation-groups) affected | SUPPORTED |
| Existing BFS machinery can be reused for the fix | SUPPORTED |
| No version skew — installed 0.10.831 == repo HEAD | SUPPORTED |
| PR #4130 introduced the regression; PR #4094 was correct but over-blocked | SUPPORTED |
| Pendulum pattern across the fix chain | SUPPORTED |
| `purpose_critical` annotation (REQ-SCHEMA-001) never implemented | SUPPORTED |
| Tests pin the bug as correct behavior | SUPPORTED |
| Adversarial challenge: 7 counterhypotheses tested, all refuted | SUPPORTED |
| `load_recipe` soft enforcement is a latent gap | NEEDS-EVIDENCE (structural observation; no observed exploit) |
| Research-family recipe silent degradation on Codex | NEEDS-EVIDENCE (no gate step = no DOA signal; no incident observed) |

Closes #4161

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260630-104324-145470/.autoskillit/temp/rectify/rectify_vacuous_gate_reachability_2026-06-30_104500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 76 | 28.6k | 3.1M | 134.0k | 70 | 141.5k | 25m 44s |
| review_approach* | opus[1m] | 1 | 34 | 6.3k | 318.7k | 67.6k | 13 | 48.8k | 7m 39s |
| dry_walkthrough* | opus | 1 | 63 | 16.5k | 2.1M | 114.9k | 50 | 115.1k | 10m 7s |
| implement* | MiniMax-M3 | 1 | 117.2k | 16.8k | 4.4M | 0 | 96 | 0 | 4m 32s |
| assess* | opus[1m] | 1 | 68 | 34.4k | 4.3M | 149.2k | 84 | 127.2k | 16m 34s |
| audit_impl* | opus[1m] | 1 | 4.9k | 7.1k | 418.8k | 66.3k | 22 | 44.2k | 5m 54s |
| prepare_pr* | MiniMax-M3 | 1 | 62.6k | 7.4k | 300.3k | 0 | 20 | 0 | 57s |
| compose_pr* | MiniMax-M3 | 1 | 52.3k | 6.0k | 230.4k | 0 | 13 | 0 | 57s |
| review_pr* | opus[1m] | 2 | 81 | 51.3k | 1.8M | 96.5k | 68 | 142.5k | 14m 34s |
| resolve_review* | opus[1m] | 1 | 43 | 4.1k | 918.4k | 63.8k | 29 | 41.5k | 3m 43s |
| **Total** | | | 237.4k | 178.6k | 17.9M | 149.2k | | 660.7k | 1h 30m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 365 | 12017.3 | 0.0 | 46.0 |
| assess | 43 | 100372.6 | 2957.4 | 800.6 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **408** | 43825.3 | 1619.5 | 437.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 6 | 5.2k | 131.9k | 10.9M | 545.6k | 1h 14m |
| opus | 1 | 63 | 16.5k | 2.1M | 115.1k | 10m 7s |
| MiniMax-M3 | 3 | 232.1k | 30.2k | 4.9M | 0 | 6m 27s |