### PR TITLE
Rectify: Ingredient Authority Feedback Contract — Silent-Clobber vs Hard-Reject Asymmetry

### DIFF
--- a/src/autoskillit/config/__init__.py
+++ b/src/autoskillit/config/__init__.py
@@ -11,6 +11,7 @@ from autoskillit.config._config_dataclasses import (
 from autoskillit.config.ingredient_defaults import (
     SERVER_AUTHORITATIVE_CONFIG_PATHS,
     SERVER_AUTHORITATIVE_INGREDIENTS,
+    SERVER_AUTHORITATIVE_KEY_HINTS,
     apply_config_authoritative_overrides,
     build_config_authoritative_layer,
     iter_display_categories,
@@ -99,6 +100,7 @@ __all__ = [
     "BACKEND_CAPABILITY_INGREDIENTS",
     "SERVER_AUTHORITATIVE_CONFIG_PATHS",
     "SERVER_AUTHORITATIVE_INGREDIENTS",
+    "SERVER_AUTHORITATIVE_KEY_HINTS",
     "apply_config_authoritative_overrides",
     "build_config_authoritative_layer",
     "validate_layer_keys",

--- a/src/autoskillit/config/__init__.py
+++ b/src/autoskillit/config/__init__.py
@@ -9,6 +9,7 @@ from autoskillit.config._config_dataclasses import (
     _MAX_CONCURRENT_DISPATCHES as _MAX_CONCURRENT_DISPATCHES,
 )
 from autoskillit.config.ingredient_defaults import (
+    SERVER_AUTHORITATIVE_CONFIG_PATHS,
     SERVER_AUTHORITATIVE_INGREDIENTS,
     apply_config_authoritative_overrides,
     build_config_authoritative_layer,
@@ -96,6 +97,7 @@ __all__ = [
     "load_config",
     "resolve_ingredient_defaults",
     "BACKEND_CAPABILITY_INGREDIENTS",
+    "SERVER_AUTHORITATIVE_CONFIG_PATHS",
     "SERVER_AUTHORITATIVE_INGREDIENTS",
     "apply_config_authoritative_overrides",
     "build_config_authoritative_layer",

--- a/src/autoskillit/config/ingredient_defaults.py
+++ b/src/autoskillit/config/ingredient_defaults.py
@@ -125,6 +125,13 @@ SERVER_AUTHORITATIVE_INGREDIENTS: frozenset[str] = CONFIG_AUTHORITY_KEYS - {
     "backend_supports_git_write",
 }
 
+SERVER_AUTHORITATIVE_CONFIG_PATHS: dict[str, str] = {
+    "base_branch": "branching.default_base_branch",
+    "local_review_rounds": "review.local_review_rounds",
+    "adversarial_review_level": "plan.adversarial_review_level",
+    "post_run_diagnostics": "diagnostics.post_run_analysis",
+}
+
 
 def resolve_ingredient_defaults(project_dir: Path) -> dict[str, str]:
     """Resolve auto-detect ingredient values from the project environment."""

--- a/src/autoskillit/config/ingredient_defaults.py
+++ b/src/autoskillit/config/ingredient_defaults.py
@@ -132,6 +132,13 @@ SERVER_AUTHORITATIVE_CONFIG_PATHS: dict[str, str] = {
     "post_run_diagnostics": "diagnostics.post_run_analysis",
 }
 
+SERVER_AUTHORITATIVE_KEY_HINTS: dict[str, str] = {
+    "post_run_diagnostics": (
+        "For post_run_diagnostics diagnostics outside of a live run, "
+        "use run_skill /autoskillit:analyze-pipeline-health"
+    ),
+}
+
 
 def resolve_ingredient_defaults(project_dir: Path) -> dict[str, str]:
     """Resolve auto-detect ingredient values from the project environment."""

--- a/src/autoskillit/hooks/formatters/_fmt_recipe.py
+++ b/src/autoskillit/hooks/formatters/_fmt_recipe.py
@@ -28,6 +28,7 @@ _FMT_LOAD_RECIPE_RENDERED: frozenset[str] = frozenset(
         "content",
         "ingredients_table",
         "orchestration_rules",
+        "warnings",
     }
 )
 _FMT_LOAD_RECIPE_SUPPRESSED: frozenset[str] = frozenset(
@@ -119,6 +120,9 @@ def _fmt_recipe_body(data: Mapping[str, Any]) -> list[str]:
     orch_rules = data.get("orchestration_rules")
     if orch_rules:
         lines.append(f"\n{orch_rules}")
+    warnings = data.get("warnings") or []
+    for warning in warnings:
+        lines.append(f"\n{_WARN_MARK} {warning}")
     return lines
 
 
@@ -168,6 +172,7 @@ _FMT_OPEN_KITCHEN_RENDERED: frozenset[str] = frozenset(
         "ingredients_table",
         "orchestration_rules",
         "version",
+        "warnings",
     }
 )
 _FMT_OPEN_KITCHEN_SUPPRESSED: frozenset[str] = frozenset(

--- a/src/autoskillit/recipe/_recipe_ingredients.py
+++ b/src/autoskillit/recipe/_recipe_ingredients.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from autoskillit.core import (
     TerminalColumn,
@@ -129,6 +129,7 @@ class LoadRecipeResult(TypedDict, total=False):
     post_prune_step_names: list[str]
     dispatch_feasible: bool
     infeasible_steps: list[str]
+    warnings: NotRequired[list[str]]
 
 
 class OpenKitchenResult(TypedDict, total=False):
@@ -157,6 +158,7 @@ class OpenKitchenResult(TypedDict, total=False):
     post_prune_step_names: list[str]
     dispatch_feasible: bool
     infeasible_steps: list[str]
+    warnings: NotRequired[list[str]]
     # Post-return keys injected by open_kitchen handler (4 keys)
     success: bool
     kitchen: str

--- a/src/autoskillit/server/tools/AGENTS.md
+++ b/src/autoskillit/server/tools/AGENTS.md
@@ -8,6 +8,7 @@ MCP `@mcp.tool()` handlers registered on import (20 tool modules).
 |------|---------|
 | `__init__.py` | Docstring-only — tools register via `@mcp.tool()` on import |
 | `_auto_overrides.py` | Shared `_build_auto_overrides()` factory for server-authoritative ingredient injection |
+| `_authority_feedback.py` | Authority-clobber warning builder and structured rejection envelope constructor for server-authoritative ingredient violations (single source of truth shared by open_kitchen, load_recipe, lock_ingredients) |
 | `_cancellation_shield.py` | `_cancellation_shield` decorator — catches `asyncio.CancelledError` at MCP tool boundary, returns structured JSON |
 | `_types.py` | TypedDict definitions for server tool JSON responses (RunSkillResult, RunCmdResult, ToolFailureEnvelope, etc.) and failure envelope factory helpers |
 | `tools_kitchen.py` | `open_kitchen`, `close_kitchen` (gate lifecycle), `recipe://` MCP resource |

--- a/src/autoskillit/server/tools/_authority_feedback.py
+++ b/src/autoskillit/server/tools/_authority_feedback.py
@@ -6,15 +6,20 @@ route through this module to guarantee consistency across warning and rejection 
 
 from __future__ import annotations
 
+from typing import Any
+
 from autoskillit.config import (
     SERVER_AUTHORITATIVE_CONFIG_PATHS,
     SERVER_AUTHORITATIVE_INGREDIENTS,
+    SERVER_AUTHORITATIVE_KEY_HINTS,
 )
 
 
 def build_authority_clobber_warnings(
     overrides: dict[str, str],
     config_layer: dict[str, str],
+    *,
+    caller_tool: str = "open_kitchen",
 ) -> list[str]:
     """Return warnings for overrides clobbered by server-authoritative layer."""
     warnings: list[str] = []
@@ -25,7 +30,7 @@ def build_authority_clobber_warnings(
             warnings.append(
                 f"Override for server-authoritative ingredient '{key}' ignored — "
                 f"server value '{server_value}' (from config {config_path}) wins; "
-                f"set the config key and re-call open_kitchen to change it"
+                f"set the config key and re-call {caller_tool} to change it"
             )
         else:
             warnings.append(
@@ -35,7 +40,7 @@ def build_authority_clobber_warnings(
     return warnings
 
 
-def build_authority_rejection_envelope(rejected_keys: set[str]) -> dict:
+def build_authority_rejection_envelope(rejected_keys: set[str]) -> dict[str, Any]:
     """Return a structured failure envelope for lock_ingredients server-authoritative rejection."""
     config_backed: list[str] = []
     runtime_derived: list[str] = []
@@ -56,11 +61,10 @@ def build_authority_rejection_envelope(rejected_keys: set[str]) -> dict:
             "Runtime-derived server-authoritative ingredients "
             "(set by dispatch runtime, not user-configurable): " + ", ".join(runtime_derived)
         )
-    if "post_run_diagnostics" in rejected_keys:
-        parts.append(
-            "For post_run_diagnostics diagnostics outside of a live run, "
-            "use run_skill /autoskillit:analyze-pipeline-health"
-        )
+    for key in sorted(rejected_keys):
+        hint = SERVER_AUTHORITATIVE_KEY_HINTS.get(key)
+        if hint:
+            parts.append(hint)
     parts.append("This rejection does NOT affect the running pipeline.")
 
     return {

--- a/src/autoskillit/server/tools/_authority_feedback.py
+++ b/src/autoskillit/server/tools/_authority_feedback.py
@@ -1,0 +1,75 @@
+"""Shared authority-violation feedback helpers for open_kitchen, load_recipe, and lock_ingredients.
+
+Single source of truth for authority feedback text — all three tool surfaces
+route through this module to guarantee consistency across warning and rejection paths.
+"""
+
+from __future__ import annotations
+
+from autoskillit.config.ingredient_defaults import (
+    SERVER_AUTHORITATIVE_CONFIG_PATHS,
+    SERVER_AUTHORITATIVE_INGREDIENTS,
+)
+
+
+def build_authority_clobber_warnings(
+    overrides: dict[str, str],
+    config_layer: dict[str, str],
+) -> list[str]:
+    """Return warnings for caller-supplied overrides that were clobbered by the server-authoritative layer."""
+    warnings: list[str] = []
+    for key in sorted(set(overrides.keys()) & SERVER_AUTHORITATIVE_INGREDIENTS):
+        config_path = SERVER_AUTHORITATIVE_CONFIG_PATHS.get(key)
+        server_value = config_layer.get(key, "")
+        if config_path:
+            warnings.append(
+                f"Override for server-authoritative ingredient '{key}' ignored — "
+                f"server value '{server_value}' (from config {config_path}) wins; "
+                f"set the config key and re-call open_kitchen to change it"
+            )
+        else:
+            warnings.append(
+                f"Override for server-authoritative ingredient '{key}' ignored — "
+                f"set by the dispatch runtime at session launch, not user-configurable"
+            )
+    return warnings
+
+
+def build_authority_rejection_envelope(rejected_keys: set[str]) -> dict:
+    """Return a structured failure envelope for lock_ingredients server-authoritative rejection."""
+    config_backed: list[str] = []
+    runtime_derived: list[str] = []
+    for key in sorted(rejected_keys):
+        if key in SERVER_AUTHORITATIVE_CONFIG_PATHS:
+            config_backed.append(f"{key} ({SERVER_AUTHORITATIVE_CONFIG_PATHS[key]})")
+        else:
+            runtime_derived.append(key)
+
+    parts: list[str] = []
+    if config_backed:
+        parts.append(
+            "Config-backed server-authoritative ingredients (set via config): "
+            + ", ".join(config_backed)
+        )
+    if runtime_derived:
+        parts.append(
+            "Runtime-derived server-authoritative ingredients (set by dispatch runtime, not user-configurable): "
+            + ", ".join(runtime_derived)
+        )
+    if "post_run_diagnostics" in rejected_keys:
+        parts.append(
+            "For post_run_diagnostics diagnostics outside of a live run, "
+            "use run_skill /autoskillit:analyze-pipeline-health"
+        )
+    parts.append("This rejection does NOT affect the running pipeline.")
+
+    return {
+        "success": False,
+        "error": (
+            f"Cannot lock server-authoritative ingredients: {sorted(rejected_keys)}. "
+            "These are set by the server and cannot be overridden."
+        ),
+        "stage": "ingredient_authority_validation",
+        "retriable": False,
+        "user_visible_message": ". ".join(parts),
+    }

--- a/src/autoskillit/server/tools/_authority_feedback.py
+++ b/src/autoskillit/server/tools/_authority_feedback.py
@@ -6,7 +6,7 @@ route through this module to guarantee consistency across warning and rejection 
 
 from __future__ import annotations
 
-from autoskillit.config.ingredient_defaults import (
+from autoskillit.config import (
     SERVER_AUTHORITATIVE_CONFIG_PATHS,
     SERVER_AUTHORITATIVE_INGREDIENTS,
 )
@@ -16,7 +16,7 @@ def build_authority_clobber_warnings(
     overrides: dict[str, str],
     config_layer: dict[str, str],
 ) -> list[str]:
-    """Return warnings for caller-supplied overrides that were clobbered by the server-authoritative layer."""
+    """Return warnings for overrides clobbered by server-authoritative layer."""
     warnings: list[str] = []
     for key in sorted(set(overrides.keys()) & SERVER_AUTHORITATIVE_INGREDIENTS):
         config_path = SERVER_AUTHORITATIVE_CONFIG_PATHS.get(key)
@@ -53,8 +53,8 @@ def build_authority_rejection_envelope(rejected_keys: set[str]) -> dict:
         )
     if runtime_derived:
         parts.append(
-            "Runtime-derived server-authoritative ingredients (set by dispatch runtime, not user-configurable): "
-            + ", ".join(runtime_derived)
+            "Runtime-derived server-authoritative ingredients "
+            "(set by dispatch runtime, not user-configurable): " + ", ".join(runtime_derived)
         )
     if "post_run_diagnostics" in rejected_keys:
         parts.append(

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -60,6 +60,10 @@ from autoskillit.server._misc import (
     strip_ingredients_only_keys,
 )
 from autoskillit.server._notify import track_response_size
+from autoskillit.server.tools._authority_feedback import (
+    build_authority_clobber_warnings,
+    build_authority_rejection_envelope,
+)
 from autoskillit.server.tools._auto_overrides import (
     _promote_capability_keys,
     _provider_aware_capability_overrides,
@@ -526,17 +530,20 @@ def _check_override_keys(
     overrides: dict[str, str] | None,
     declared: frozenset[str],
     session_keys: set[str],
+    config_layer: dict[str, str],
 ) -> list[str]:
     if not overrides:
         return []
     user_keys = set(overrides.keys()) - session_keys - SERVER_AUTHORITATIVE_INGREDIENTS
     unknown = user_keys - declared
-    if not unknown:
-        return []
-    return [
-        f"Unknown override keys ignored: {sorted(unknown)}. "
-        f"Valid ingredient keys: {sorted(declared)}"
-    ]
+    warnings: list[str] = []
+    if unknown:
+        warnings.append(
+            f"Unknown override keys ignored: {sorted(unknown)}. "
+            f"Valid ingredient keys: {sorted(declared)}"
+        )
+    warnings.extend(build_authority_clobber_warnings(overrides, config_layer))
+    return warnings
 
 
 @mcp.tool(
@@ -560,7 +567,10 @@ async def open_kitchen(
     Args:
         name: Optional recipe name to load immediately after opening.
         overrides: Optional dict of ingredient name → value to override recipe defaults.
-            Use to activate hidden features (e.g., ``{"sprint_mode": "true"}``).
+            Use to activate hidden features (e.g., ``{"sprint_mode": "true"}``). Ingredients
+            with ``authority: config`` (base_branch, local_review_rounds,
+            adversarial_review_level, post_run_diagnostics) cannot be set via overrides —
+            they resolve from server config and caller values are ignored with a warning.
         ingredients_only: When True and name is provided, return only the ingredient
             schema (ingredients_table, validity, suggestions) without the full recipe
             content, orchestration rules, or sous-chef discipline. Use for dispatch
@@ -802,6 +812,7 @@ async def open_kitchen(
                         overrides,
                         frozenset(_deferred_recipe_obj.ingredients.keys()),
                         set(_session_overrides.keys()),
+                        _config_layer,
                     )
                     if _override_warnings:
                         result["warnings"] = _override_warnings
@@ -919,6 +930,7 @@ async def open_kitchen(
                     overrides,
                     frozenset(_normal_recipe_obj.ingredients.keys()),
                     set(_session_overrides.keys()),
+                    _config_layer,
                 )
                 if _override_warnings:
                     result["warnings"] = _override_warnings
@@ -1193,6 +1205,11 @@ async def lock_ingredients(
     run_skill calls for steps whose skip_when_false ingredient is locked
     to a falsy value will be denied.
 
+    Server-authoritative ingredients (base_branch, local_review_rounds,
+    adversarial_review_level, post_run_diagnostics, is_fleet_dispatch,
+    dispatch_id) are rejected with a structured error envelope; the
+    rejected key names appear in both ``error`` and ``user_visible_message``.
+
     Call with unlock=["ingredient_name"] to release a lock.
 
     Never raises.
@@ -1216,16 +1233,7 @@ async def lock_ingredients(
         if locked:
             server_auth_overlap = set(locked.keys()) & SERVER_AUTHORITATIVE_INGREDIENTS
             if server_auth_overlap:
-                return json.dumps(
-                    {
-                        "success": False,
-                        "error": (
-                            f"Cannot lock server-authoritative ingredients: "
-                            f"{sorted(server_auth_overlap)}. "
-                            "These are set by the server and cannot be overridden."
-                        ),
-                    }
-                )
+                return json.dumps(build_authority_rejection_envelope(server_auth_overlap))
 
         if not locked and not unlock:
             return json.dumps(

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -277,7 +277,9 @@ async def load_recipe(
                         f"{_infeasible_envelope['escape_hatch']}"
                     )
                 return json.dumps(_infeasible_envelope)
-            _authority_warnings = build_authority_clobber_warnings(overrides or {}, _config_layer)
+            _authority_warnings = build_authority_clobber_warnings(
+                overrides or {}, _config_layer, caller_tool="load_recipe"
+            )
             if _authority_warnings:
                 result["warnings"] = _authority_warnings
             if ingredients_only:

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -25,6 +25,7 @@ from autoskillit.server._misc import (
 )
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._state import _get_ctx_or_none
+from autoskillit.server.tools._authority_feedback import build_authority_clobber_warnings
 from autoskillit.server.tools._auto_overrides import (
     _promote_capability_keys,
     _provider_aware_capability_overrides,
@@ -276,6 +277,9 @@ async def load_recipe(
                         f"{_infeasible_envelope['escape_hatch']}"
                     )
                 return json.dumps(_infeasible_envelope)
+            _authority_warnings = build_authority_clobber_warnings(overrides or {}, _config_layer)
+            if _authority_warnings:
+                result["warnings"] = _authority_warnings
             if ingredients_only:
                 result = strip_ingredients_only_keys(result)
             _required_keys: frozenset[str] = frozenset()

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -847,6 +847,24 @@ translate those instructions into `lock_ingredients` calls **immediately after
 `open_kitchen`**. This converts natural language into machine-enforced locks that
 persist for the entire session.
 
+### Server-authoritative ingredients — cannot be locked
+
+Some ingredients are server-authoritative: `lock_ingredients` will reject them with a
+structured error. Do not attempt to lock them — use the config or runtime mechanism
+listed instead:
+
+- `base_branch` → config: `branching.default_base_branch`
+- `local_review_rounds` → config: `review.local_review_rounds`
+- `adversarial_review_level` → config: `plan.adversarial_review_level`
+- `post_run_diagnostics` → config: `diagnostics.post_run_analysis` (for one-off diagnostics outside a live run, use `run_skill /autoskillit:analyze-pipeline-health`)
+- `is_fleet_dispatch` → set by dispatch runtime at session launch, not user-configurable
+- `dispatch_id` → set by dispatch runtime at session launch, not user-configurable
+
+A server-authoritative rejection from `lock_ingredients` is advisory: report it to
+the user in one sentence and continue the pipeline. Do NOT generalize this to all
+configuration-tool failures — an infrastructure lock-write failure means a user
+instruction was silently unenforced, and the existing halt doctrine applies there.
+
 ### When to call lock_ingredients
 
 - User says "skip investigate" → `lock_ingredients(locked={"investigate": "false"}, pipeline_id="<pid>")`

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -398,7 +398,7 @@ SUBPKG_CASCADE_EXECUTION: dict[str, frozenset[str]] = {
 
 MODULE_CASCADE_CONFIG: dict[str, frozenset[str]] = {
     "_config_loader": frozenset({"config", "cli"}),
-    "ingredient_defaults": frozenset({"config", "recipe"}),
+    "ingredient_defaults": frozenset({"config", "recipe", "server"}),
 }
 
 MODULE_CASCADE_RECIPE: dict[str, frozenset[str]] = {

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -880,7 +880,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "pipeline": 12,
         "fleet": 23,  # +_issue_url_helpers.py  # noqa: E501
         "recipe/rules": 51,  # +commit_guard_regression_route +rules_model +rules_gitignored_deliverable  # noqa: E501
-        "server/tools": 27,  # +_preflight.py (dispatch-feasibility preflight)
+        "server/tools": 28,  # +_preflight.py +_authority_feedback.py
         "hooks/guards": 32,  # +fleet_claim_guard, +reset_resume_gate, +recipe_read_guard
         "execution/backends": 12,  # +_composite_locator.py, +_probe_cache.py
     }
@@ -967,7 +967,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "co-located with the execution engine that calls them",
     ),
     "tools_kitchen.py": (
-        1345,
+        1360,
         "REQ-CNST-010-E7: kitchen tool handlers — open_kitchen and lock_ingredients require "
         "inline validation helpers (_check_override_keys, _build_ingredient_key_suggestions) "
         "for ingredient key validation; splitting would cross import-layer boundaries; "

--- a/tests/contracts/test_exogenous_string_coupling.py
+++ b/tests/contracts/test_exogenous_string_coupling.py
@@ -57,6 +57,30 @@ def test_quota_post_warning_trigger_coupled_to_sous_chef_skill():
     )
 
 
+def test_server_authoritative_ingredients_coupled_to_sous_chef_skill():
+    """Every SERVER_AUTHORITATIVE_INGREDIENTS member must appear in the sous-chef SKILL.md
+    INGREDIENT LOCKING section so the guidance stays in sync with the registry."""
+    from autoskillit.config.ingredient_defaults import SERVER_AUTHORITATIVE_INGREDIENTS
+    from autoskillit.core import pkg_root
+
+    skill_path = pkg_root() / "skills" / "sous-chef" / "SKILL.md"
+    assert skill_path.exists(), "sous-chef SKILL.md not found"
+    content = skill_path.read_text()
+
+    section_start = content.find("## INGREDIENT LOCKING — STRUCTURAL ENFORCEMENT")
+    assert section_start != -1, "INGREDIENT LOCKING section not found in sous-chef SKILL.md"
+    section_end = content.find("---", section_start)
+    if section_end == -1:
+        section_end = len(content)
+    section = content[section_start:section_end]
+
+    for key in sorted(SERVER_AUTHORITATIVE_INGREDIENTS):
+        assert key in section, (
+            f"sous-chef SKILL.md INGREDIENT LOCKING section must mention "
+            f"server-authoritative ingredient {key!r}; not found in section text"
+        )
+
+
 def test_quota_post_budget_exceeded_trigger_coupled_to_food_truck_prompt():
     """QUOTA_POST_BUDGET_EXCEEDED_TRIGGER must appear verbatim in the food truck prompt."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -119,11 +119,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 90),
     # tools_kitchen.py — hook config, quota guard, git_ops_policy, ingredient locks overlay
-    ("src/autoskillit/server/tools/tools_kitchen.py", 222),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 241),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 275),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 1070),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 1130),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 226),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 245),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 279),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1082),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1142),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict

--- a/tests/server/test_lock_ingredients.py
+++ b/tests/server/test_lock_ingredients.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -382,7 +383,13 @@ class TestAuthorityFeedbackConsistency:
             "diagram": None,
             "ingredients_table": "--- TABLE ---",
         }
-        mock_ctx.recipes.find.return_value = None
+        mock_recipe_info = MagicMock()
+        mock_recipe_info.path = Path("/fake/recipe.yaml")
+        mock_ctx.recipes.find.return_value = mock_recipe_info
+        mock_recipe_obj = MagicMock()
+        mock_recipe_obj.steps = {"do": MagicMock()}
+        mock_recipe_obj.ingredients = {k: MagicMock() for k in SERVER_AUTHORITATIVE_INGREDIENTS}
+        mock_ctx.recipes.load.return_value = mock_recipe_obj
         mock_ctx.config.migration.suppressed = []
         mock_ctx.kitchen_id = "test-kitchen"
         mock_ctx.config.linux_tracing.log_dir = ""

--- a/tests/server/test_lock_ingredients.py
+++ b/tests/server/test_lock_ingredients.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -99,6 +99,40 @@ class TestLockIngredientsRejectsServerAuthoritative:
 
         assert result["success"] is False
         assert "server-authoritative" in result["error"].lower()
+
+
+@pytest.mark.parametrize(
+    "server_auth_key",
+    ["post_run_diagnostics", "base_branch"],
+)
+@pytest.mark.anyio
+async def test_lock_ingredients_envelope_has_structured_fields(server_auth_key, tmp_path):
+    """Server-authoritative rejection envelope must carry user_visible_message, stage, retriable."""  # noqa: E501
+    temp_dir = tmp_path / ".autoskillit" / "temp"
+    temp_dir.mkdir(parents=True)
+    (temp_dir / ".hook_config.json").write_text("{}")
+
+    ctx = _make_mock_ctx()
+    ctx.project_dir = tmp_path
+    ctx.active_recipe_steps = {}
+
+    with patch("autoskillit.server._get_ctx", return_value=ctx):
+        from autoskillit.server.tools.tools_kitchen import lock_ingredients
+
+        result = json.loads(
+            await lock_ingredients(locked={server_auth_key: "value"}, pipeline_id="a")
+        )
+
+    assert result["success"] is False
+    assert "server-authoritative" in result["error"].lower()
+    assert "stage" in result
+    assert isinstance(result["stage"], str)
+    assert len(result["stage"]) > 0
+    assert "retriable" in result
+    assert result["retriable"] is False
+    assert "user_visible_message" in result
+    assert isinstance(result["user_visible_message"], str)
+    assert len(result["user_visible_message"]) > 0
 
 
 class TestLockIngredientsUnlock:
@@ -321,6 +355,87 @@ class TestLockIngredientsUnknownKeyValidation:
             result = json.loads(await lock_ingredients(unlock=["audit_impl"], pipeline_id="a"))
 
         assert result["success"] is True
+
+
+class TestAuthorityFeedbackConsistency:
+    """Cross-tool consistency: every SERVER_AUTHORITATIVE_INGREDIENTS key must
+    produce feedback on BOTH open_kitchen and lock_ingredients surfaces."""
+
+    @pytest.mark.anyio
+    async def test_every_authority_key_emits_feedback_on_both_surfaces(
+        self, tmp_path, monkeypatch
+    ):
+        # --- open_kitchen: authority clobber warning must appear ---
+        from unittest.mock import MagicMock
+
+        from autoskillit.config.ingredient_defaults import SERVER_AUTHORITATIVE_INGREDIENTS
+        from tests.server._helpers import _PATCHED_DEFAULTS
+        from tests.server.conftest import _make_mock_ctx
+
+        mock_ctx = _make_mock_ctx()
+        mock_ctx.enable_components = AsyncMock()
+        mock_ctx.recipes = MagicMock()
+        mock_ctx.recipes.load_and_validate.return_value = {
+            "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+            "valid": True,
+            "suggestions": [],
+            "diagram": None,
+            "ingredients_table": "--- TABLE ---",
+        }
+        mock_ctx.recipes.find.return_value = None
+        mock_ctx.config.migration.suppressed = []
+        mock_ctx.kitchen_id = "test-kitchen"
+        mock_ctx.config.linux_tracing.log_dir = ""
+
+        with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+            with patch("autoskillit.server.logger"):
+                with patch(
+                    "autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()
+                ):
+                    with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+                        with patch(
+                            "autoskillit.server.tools.tools_kitchen.resolve_kitchen_id",
+                            return_value="test-kitchen",
+                        ):
+                            with patch(
+                                "autoskillit.server.tools.tools_kitchen.resolve_ingredient_defaults",
+                                return_value=_PATCHED_DEFAULTS,
+                            ):
+                                from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+                                for key in sorted(SERVER_AUTHORITATIVE_INGREDIENTS):
+                                    result_str = await open_kitchen(
+                                        name="demo",
+                                        overrides={key: "clobber_value"},
+                                        ctx=mock_ctx,
+                                    )
+                                    parsed = json.loads(result_str)
+                                    warnings = parsed.get("warnings") or []
+                                    matching = [w for w in warnings if key in w]
+                                    assert matching, (
+                                        f"open_kitchen must emit a warning mentioning {key!r} "
+                                        f"when overridden; got warnings={warnings}"
+                                    )
+
+        # --- lock_ingredients: structured rejection must mention each key ---
+        temp_dir = tmp_path / ".autoskillit" / "temp"
+        temp_dir.mkdir(parents=True)
+        (temp_dir / ".hook_config.json").write_text("{}")
+
+        ctx_lk = _make_mock_ctx()
+        ctx_lk.project_dir = tmp_path
+        ctx_lk.active_recipe_steps = {}
+
+        with patch("autoskillit.server._get_ctx", return_value=ctx_lk):
+            from autoskillit.server.tools.tools_kitchen import lock_ingredients
+
+            for key in sorted(SERVER_AUTHORITATIVE_INGREDIENTS):
+                result = json.loads(await lock_ingredients(locked={key: "value"}, pipeline_id="a"))
+                assert result["success"] is False
+                assert key in result["user_visible_message"], (
+                    f"lock_ingredients user_visible_message must mention {key!r}; "
+                    f"got {result['user_visible_message']!r}"
+                )
 
 
 class TestLockIngredientsConcurrentFlock:

--- a/tests/server/test_open_kitchen_deferred_recall.py
+++ b/tests/server/test_open_kitchen_deferred_recall.py
@@ -409,6 +409,19 @@ async def test_deferred_recall_preserves_active_locks(tmp_path):
     ctx.active_recipe_steps = {"investigate": MagicMock(skip_when_false="inputs.investigate")}
     ctx.active_recipe_ingredients = frozenset(["investigate"])
     ctx.gate.enabled = True
+    ctx.recipes.load_and_validate.return_value = {
+        "content": "name: test-recipe\nsteps:\n  investigate:\n    tool: run_cmd\n",
+        "valid": True,
+        "suggestions": [],
+        "diagram": None,
+        "ingredients_table": "--- TABLE ---",
+        "requires_packs": [],
+        "requires_features": [],
+        "content_hash": "abc",
+        "composite_hash": "def",
+        "recipe_version": "1.0",
+        "post_prune_step_names": ["investigate"],
+    }
 
     mock_recipe_info = MagicMock()
     mock_recipe_info.path = Path("/fake/.autoskillit/recipes/test-recipe.yaml")

--- a/tests/server/test_open_kitchen_deferred_recall.py
+++ b/tests/server/test_open_kitchen_deferred_recall.py
@@ -405,6 +405,7 @@ async def test_deferred_recall_preserves_active_locks(tmp_path):
     (temp_dir / ".hook_config.json").write_text("{}")
 
     ctx = _make_deferred_recall_ctx("test-recipe")
+    ctx.project_dir = tmp_path
     ctx.active_recipe_steps = {"investigate": MagicMock(skip_when_false="inputs.investigate")}
     ctx.active_recipe_ingredients = frozenset(["investigate"])
     ctx.gate.enabled = True

--- a/tests/server/test_open_kitchen_deferred_recall.py
+++ b/tests/server/test_open_kitchen_deferred_recall.py
@@ -393,3 +393,43 @@ async def test_cold_open_kitchen_runs_handler():
 
     mock_handler.assert_called_once()
     assert isinstance(result, str)
+
+
+@pytest.mark.anyio
+async def test_deferred_recall_preserves_active_locks(tmp_path):
+    """Locks survive across deferred-recall re-open (overlay file persists)."""
+    from autoskillit.server.tools.tools_kitchen import lock_ingredients, open_kitchen
+
+    temp_dir = tmp_path / ".autoskillit" / "temp"
+    temp_dir.mkdir(parents=True)
+    (temp_dir / ".hook_config.json").write_text("{}")
+
+    ctx = _make_deferred_recall_ctx("test-recipe")
+    ctx.active_recipe_steps = {"investigate": MagicMock(skip_when_false="inputs.investigate")}
+    ctx.active_recipe_ingredients = frozenset(["investigate"])
+    ctx.gate.enabled = True
+
+    mock_recipe_info = MagicMock()
+    mock_recipe_info.path = Path("/fake/.autoskillit/recipes/test-recipe.yaml")
+    ctx.recipes.find.return_value = mock_recipe_info
+    mock_recipe_obj = MagicMock()
+    mock_recipe_obj.steps = {"investigate": MagicMock()}
+    mock_recipe_obj.ingredients = {"investigate": MagicMock()}
+    ctx.recipes.load.return_value = mock_recipe_obj
+
+    with patch("autoskillit.server._get_ctx", return_value=ctx):
+        # Lock investigate=false
+        lock_result = json.loads(
+            await lock_ingredients(locked={"investigate": "false"}, pipeline_id="a")
+        )
+        assert lock_result["success"] is True
+
+        # Re-open kitchen (deferred-recall path) — locks must still be in effect
+        result_str = await open_kitchen(name="test-recipe", ctx=ctx)
+        parsed = json.loads(result_str)
+        assert parsed["success"] is True
+
+        overlay_path = temp_dir / ".hook_config_overlay.json"
+        assert overlay_path.exists(), "Overlay must persist across re-open"
+        data = json.loads(overlay_path.read_text())
+        assert data["locked_ingredients"]["a"]["investigate"] == "false"

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -456,6 +456,66 @@ async def test_open_kitchen_config_authority_overrides_caller(tmp_path, monkeypa
 
 
 @pytest.mark.anyio
+async def test_open_kitchen_emits_authority_clobber_warning(tmp_path, monkeypatch):
+    """open_kitchen must emit a warning naming the clobbered key and its config path."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+    mock_ctx.recipes = MagicMock()
+    mock_recipe_obj = MagicMock()
+    mock_recipe_obj.steps = {"do": MagicMock()}
+    mock_recipe_obj.ingredients = {"base_branch": MagicMock(), "post_run_diagnostics": MagicMock()}
+    mock_ctx.recipes.load.return_value = mock_recipe_obj
+    mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+        "valid": True,
+        "suggestions": [],
+        "diagram": None,
+        "ingredients_table": "--- TABLE ---",
+    }
+    mock_ctx.recipes.find.return_value = None
+    mock_ctx.config.migration.suppressed = []
+    mock_ctx.kitchen_id = "test-kitchen-abc"
+    mock_ctx.config.linux_tracing.log_dir = ""
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()
+            ):
+                with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+                    with patch(
+                        "autoskillit.server.tools.tools_kitchen.resolve_kitchen_id",
+                        return_value="test-kitchen-abc",
+                    ):
+                        with patch(
+                            "autoskillit.server.tools.tools_kitchen.resolve_ingredient_defaults",
+                            return_value={
+                                "base_branch": "develop",
+                                "post_run_diagnostics": "false",
+                                "is_fleet_dispatch": "false",
+                                "dispatch_id": "",
+                            },
+                        ):
+                            from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+                            result_str = await open_kitchen(
+                                name="demo",
+                                overrides={"post_run_diagnostics": "true"},
+                                ctx=mock_ctx,
+                            )
+
+    parsed = json.loads(result_str)
+    warnings = parsed.get("warnings") or []
+    matching = [w for w in warnings if "post_run_diagnostics" in w]
+    assert matching, f"Expected a warning naming post_run_diagnostics; got warnings={warnings}"
+    assert any("diagnostics.post_run_analysis" in w for w in warnings), (
+        f"Expected the warning to name the config path diagnostics.post_run_analysis; "
+        f"got warnings={warnings}"
+    )
+
+
+@pytest.mark.anyio
 async def test_open_kitchen_with_config_authority_ingredient(monkeypatch):
     """Full open_kitchen path: config value wins over caller override in rendered output."""
     import autoskillit.recipe._api_cache as cache_mod

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -473,7 +474,9 @@ async def test_open_kitchen_emits_authority_clobber_warning(tmp_path, monkeypatc
         "diagram": None,
         "ingredients_table": "--- TABLE ---",
     }
-    mock_ctx.recipes.find.return_value = None
+    mock_recipe_info = MagicMock()
+    mock_recipe_info.path = Path("/fake/recipe.yaml")
+    mock_ctx.recipes.find.return_value = mock_recipe_info
     mock_ctx.config.migration.suppressed = []
     mock_ctx.kitchen_id = "test-kitchen-abc"
     mock_ctx.config.linux_tracing.log_dir = ""

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -545,6 +545,68 @@ class TestLoadRecipeIngredientsOnly:
         assert "suggestions" in result
 
 
+class TestLoadRecipeAuthorityClobber:
+    """load_recipe must emit an authority-clobber warning when a server-authoritative
+    key is overridden by the caller. Enforcement (config-layer wins) already works;
+    this test verifies the *feedback* contract."""
+
+    @pytest.mark.anyio
+    async def test_load_recipe_emits_authority_warning(self, tmp_path, monkeypatch):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from tests.server.conftest import _make_mock_ctx
+
+        monkeypatch.chdir(tmp_path)
+        mock_ctx = _make_mock_ctx()
+        mock_ctx.enable_components = AsyncMock()
+        mock_ctx.recipes = MagicMock()
+        mock_recipe_obj = MagicMock()
+        mock_recipe_obj.steps = {"do": MagicMock()}
+        mock_recipe_obj.ingredients = {"post_run_diagnostics": MagicMock()}
+        mock_ctx.recipes.load.return_value = mock_recipe_obj
+        mock_ctx.recipes.load_and_validate.return_value = {
+            "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+            "valid": True,
+            "suggestions": [],
+            "diagram": None,
+            "ingredients_table": "--- TABLE ---",
+        }
+        mock_ctx.recipes.find.return_value = None
+        mock_ctx.config.migration.suppressed = []
+        mock_ctx.kitchen_id = "test-kitchen"
+        mock_ctx.config.linux_tracing.log_dir = ""
+
+        with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+            with patch("autoskillit.server.logger"):
+                with patch(
+                    "autoskillit.server.tools.tools_recipe.resolve_kitchen_id",
+                    return_value="test-kitchen",
+                ):
+                    with patch(
+                        "autoskillit.server.tools.tools_recipe.resolve_ingredient_defaults",
+                        return_value={
+                            "base_branch": "develop",
+                            "post_run_diagnostics": "false",
+                            "is_fleet_dispatch": "false",
+                            "dispatch_id": "",
+                        },
+                    ):
+                        from autoskillit.server.tools.tools_recipe import load_recipe
+
+                        result_str = await load_recipe(
+                            name="demo",
+                            overrides={"post_run_diagnostics": "true"},
+                            ctx=mock_ctx,
+                        )
+
+        parsed = json.loads(result_str)
+        warnings = parsed.get("warnings") or []
+        matching = [w for w in warnings if "post_run_diagnostics" in w]
+        assert matching, (
+            f"load_recipe must emit a warning naming post_run_diagnostics; got warnings={warnings}"
+        )
+
+
 # 1i: load_recipe tool surfaces validation failure
 class TestLoadRecipeSurfacesValidationFailure:
     """When load_and_validate returns valid=False, the load_recipe tool must include

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -576,28 +576,27 @@ class TestLoadRecipeAuthorityClobber:
         mock_ctx.kitchen_id = "test-kitchen"
         mock_ctx.config.linux_tracing.log_dir = ""
 
-        with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch(
+            "autoskillit.server.tools.tools_recipe._get_ctx_or_none",
+            return_value=mock_ctx,
+        ):
             with patch("autoskillit.server.logger"):
                 with patch(
-                    "autoskillit.server.tools.tools_recipe.resolve_kitchen_id",
-                    return_value="test-kitchen",
+                    "autoskillit.server.tools.tools_recipe.resolve_ingredient_defaults",
+                    return_value={
+                        "base_branch": "develop",
+                        "post_run_diagnostics": "false",
+                        "is_fleet_dispatch": "false",
+                        "dispatch_id": "",
+                    },
                 ):
-                    with patch(
-                        "autoskillit.server.tools.tools_recipe.resolve_ingredient_defaults",
-                        return_value={
-                            "base_branch": "develop",
-                            "post_run_diagnostics": "false",
-                            "is_fleet_dispatch": "false",
-                            "dispatch_id": "",
-                        },
-                    ):
-                        from autoskillit.server.tools.tools_recipe import load_recipe
+                    from autoskillit.server.tools.tools_recipe import load_recipe
 
-                        result_str = await load_recipe(
-                            name="demo",
-                            overrides={"post_run_diagnostics": "true"},
-                            ctx=mock_ctx,
-                        )
+                    result_str = await load_recipe(
+                        name="demo",
+                        overrides={"post_run_diagnostics": "true"},
+                        ctx=mock_ctx,
+                    )
 
         parsed = json.loads(result_str)
         warnings = parsed.get("warnings") or []

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -580,23 +580,26 @@ class TestLoadRecipeAuthorityClobber:
             "autoskillit.server.tools.tools_recipe._get_ctx_or_none",
             return_value=mock_ctx,
         ):
-            with patch("autoskillit.server.logger"):
-                with patch(
-                    "autoskillit.server.tools.tools_recipe.resolve_ingredient_defaults",
-                    return_value={
-                        "base_branch": "develop",
-                        "post_run_diagnostics": "false",
-                        "is_fleet_dispatch": "false",
-                        "dispatch_id": "",
-                    },
-                ):
-                    from autoskillit.server.tools.tools_recipe import load_recipe
+            with patch(
+                "autoskillit.server.tools.tools_recipe._require_enabled",
+                return_value=None,
+            ):
+                with patch("autoskillit.server.logger"):
+                    with patch(
+                        "autoskillit.server.tools.tools_recipe.resolve_ingredient_defaults",
+                        return_value={
+                            "base_branch": "develop",
+                            "post_run_diagnostics": "false",
+                            "is_fleet_dispatch": "false",
+                            "dispatch_id": "",
+                        },
+                    ):
+                        from autoskillit.server.tools.tools_recipe import load_recipe
 
-                    result_str = await load_recipe(
-                        name="demo",
-                        overrides={"post_run_diagnostics": "true"},
-                        ctx=mock_ctx,
-                    )
+                        result_str = await load_recipe(
+                            name="demo",
+                            overrides={"post_run_diagnostics": "true"},
+                        )
 
         parsed = json.loads(result_str)
         warnings = parsed.get("warnings") or []

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -607,6 +607,16 @@ class TestLoadRecipeAuthorityClobber:
         assert matching, (
             f"load_recipe must emit a warning naming post_run_diagnostics; got warnings={warnings}"
         )
+        server_value_match = [w for w in warnings if "server value 'false'" in w]
+        assert server_value_match, (
+            "Authority-clobber warning must confirm config value won — "
+            f"expected \"server value 'false'\" in warning text; got warnings={warnings}"
+        )
+        caller_value_absent = [w for w in warnings if "server value 'true'" in w]
+        assert not caller_value_absent, (
+            "Authority-clobber warning must NOT report the caller override as the server value — "
+            f"got warnings={warnings}"
+        )
 
 
 # 1i: load_recipe tool surfaces validation failure


### PR DESCRIPTION
## Summary

The server-authoritative ingredient system has a three-layer contract defect: `open_kitchen` silently clobbers caller overrides for server-authoritative keys (no warning), `lock_ingredients` hard-rejects the same keys with a bare error envelope (no `user_visible_message`, `stage`, or `retriable`), and sous-chef guidance routes orchestrators directly into the rejection with no carve-out. The architectural weakness is that authority enforcement happens at merge-time (rightmost-wins dict merge) rather than at the tool's input validation boundary, and no structural invariant couples the two surfaces or enforces feedback on authority violations.

The immunity plan introduces an **Authority Feedback Contract** — a structural guarantee that every tool surface handling server-authoritative ingredients must produce visible, actionable feedback when a caller attempts to set/lock a controlled key. This is enforced by a shared authority-violation helper, an envelope shape invariant, formatter coverage, cross-tool consistency tests, and exogenous coupling tests anchoring sous-chef guidance to the frozenset membership.

Closes #4169

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260702-121330-450039/.autoskillit/temp/rectify/rectify_ingredient_authority_feedback_contract_2026-07-02_121330.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 11.0k | 26.3k | 1.2M | 116.9k | 44 | 117.3k | 31m 47s |
| review_approach* | opus[1m] | 1 | 12.4k | 5.8k | 235.4k | 60.4k | 11 | 45.3k | 6m 51s |
| dry_walkthrough* | opus | 2 | 88 | 19.4k | 3.3M | 118.6k | 104 | 163.6k | 12m 10s |
| implement* | MiniMax-M3 | 2 | 192.4k | 22.5k | 9.2M | 0 | 167 | 0 | 7m 25s |
| assess* | opus[1m] | 1 | 138 | 29.3k | 11.0M | 142.5k | 201 | 123.4k | 20m 35s |
| audit_impl* | opus[1m] | 2 | 66 | 39.5k | 1.1M | 81.3k | 46 | 120.9k | 21m 26s |
| make_plan* | opus[1m] | 1 | 52 | 4.7k | 885.5k | 65.3k | 26 | 48.0k | 3m 3s |
| prepare_pr* | MiniMax-M3 | 1 | 56.5k | 1.8k | 303.4k | 0 | 15 | 0 | 29s |
| compose_pr* | MiniMax-M3 | 1 | 43.6k | 1.2k | 428.9k | 0 | 12 | 0 | 45s |
| review_pr* | opus[1m] | 1 | 145 | 43.1k | 919.2k | 109.4k | 35 | 90.9k | 12m 8s |
| resolve_review* | opus[1m] | 1 | 52 | 19.0k | 1.9M | 92.4k | 59 | 73.9k | 10m 46s |
| **Total** | | | 316.5k | 212.6k | 30.6M | 142.5k | | 783.2k | 2h 7m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 473 | 19405.1 | 0.0 | 47.6 |
| assess | 66 | 166617.8 | 1869.7 | 444.3 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 31 | 62780.3 | 2382.5 | 612.7 |
| **Total** | **570** | 53671.3 | 1374.0 | 373.1 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 7 | 23.8k | 167.8k | 17.4M | 619.6k | 1h 46m |
| opus | 1 | 88 | 19.4k | 3.3M | 163.6k | 12m 10s |
| MiniMax-M3 | 3 | 292.6k | 25.4k | 9.9M | 0 | 8m 38s |