### PR TITLE
[REMEDIATION] Plan-vs-Issue Coverage Gate — Pipeline Scope Fidelity Enforcement

### DIFF
--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -140,6 +140,9 @@ from autoskillit.recipe.rules import rules_inline_script as _rules_inline_script
 from autoskillit.recipe.rules import rules_inputs as _rules_inputs  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_isolation as _rules_isolation  # noqa: E402 F401
 from autoskillit.recipe.rules import (
+    rules_issue_scope_threading as _rules_issue_scope_threading,  # noqa: E402 F401
+)
+from autoskillit.recipe.rules import (
     rules_loop_artifact_scope as _rules_loop_artifact_scope,  # noqa: E402 F401
 )
 from autoskillit.recipe.rules import rules_loop_counter as _rules_loop_counter  # noqa: E402 F401

--- a/src/autoskillit/recipe/rules/AGENTS.md
+++ b/src/autoskillit/recipe/rules/AGENTS.md
@@ -1,6 +1,6 @@
 # rules/
 
-Semantic validation rule modules for recipe analysis (48 flat rule files + 4 subdirectories).
+Semantic validation rule modules for recipe analysis (49 flat rule files + 4 subdirectories).
 
 ## Subdirectories
 
@@ -38,6 +38,7 @@ See each subdirectory's AGENTS.md for details.
 | `rules_inline_script.py` | Detects inline shell scripts in `run_cmd` cmd fields |
 | `rules_inputs.py` | Input/ingredient validation; version compatibility checks |
 | `rules_isolation.py` | Workspace isolation rules (prevents operating on source repo) |
+| `rules_issue_scope_threading.py` | issue-scope-not-threaded-to-walkthrough semantic rule: ensures dry-walkthrough receives issue_url in recipes with issue_url ingredients |
 | `rules_merge.py` | `merge_worktree` routing completeness |
 | `rules_model.py` | Model field adequacy: flags context-intensive steps with empty model (dispatch_items users) |
 | `rules_merge_context.py` | Merge gate test output context forwarding enforcement |

--- a/src/autoskillit/recipe/rules/rules_issue_scope_threading.py
+++ b/src/autoskillit/recipe/rules/rules_issue_scope_threading.py
@@ -1,0 +1,56 @@
+"""issue-scope-not-threaded-to-walkthrough: dry-walkthrough must receive issue context."""
+
+from __future__ import annotations
+
+from autoskillit.core import Severity
+from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe.contracts import resolve_skill_name
+from autoskillit.recipe.registry import RuleFinding, make_finding, semantic_rule
+
+
+def _has_issue_ingredient(ctx: ValidationContext) -> bool:
+    return "issue_url" in ctx.recipe.ingredients or "issue_number" in ctx.recipe.ingredients
+
+
+def _threads_issue_context(with_args: dict[str, str]) -> bool:
+    return "issue_url" in with_args or "issue_number" in with_args
+
+
+@semantic_rule(
+    name="issue-scope-not-threaded-to-walkthrough",
+    description=(
+        "A dry-walkthrough step in a recipe with an issue_url (or issue_number) "
+        "ingredient must receive issue_url (or issue_number) via its with: block. "
+        "Without this, dry-walkthrough cannot validate plan-vs-issue coverage, "
+        "allowing silent descoping of issue-enumerated remediation items."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_issue_scope_threading(ctx: ValidationContext) -> list[RuleFinding]:
+    if not _has_issue_ingredient(ctx):
+        return []
+
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        skill = resolve_skill_name(step.with_args.get("skill_command", ""))
+        if skill != "dry-walkthrough":
+            continue
+        if _threads_issue_context(step.with_args):
+            continue
+        findings.append(
+            make_finding(
+                rule_name="issue-scope-not-threaded-to-walkthrough",
+                step_name=step_name,
+                message=(
+                    f"Step '{step_name}' invokes dry-walkthrough but does not thread "
+                    f"issue_url (or issue_number) via its with: block. The recipe has "
+                    f"an issue ingredient but dry-walkthrough cannot fetch the issue "
+                    f"body for Step 4.6 plan-vs-issue coverage validation. Add "
+                    f"'issue_url: ${{{{ inputs.issue_url }}}}' (or issue_number) to "
+                    f"the step's with: block."
+                ),
+            )
+        )
+    return findings

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -46,6 +46,7 @@ _PSEUDOCODE_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
         ("promote-to-main", "pr_url"),
         ("promote-to-main", "timestamp"),
         ("audit-impl", "implementation_ref"),
+        ("dry-walkthrough", "issue_number"),
     }
 )
 

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -191,6 +191,9 @@ skills:
     - name: plan_path
       type: file_path
       required: true
+    - name: issue_url
+      type: string
+      required: false
     outputs: []
     write_behavior: always
   implement-worktree:

--- a/src/autoskillit/recipes/diagrams/implementation-groups.md
+++ b/src/autoskillit/recipes/diagrams/implementation-groups.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:f0b9b6a9aaeedd513a73303b939fda5cfc2c287e9c3dd060bb79df7a99a48c41 -->
+<!-- autoskillit-recipe-hash: sha256:80116d401c9651eee17f00716f391c69e7b05a4102eb49457c8576c41406690c -->
 <!-- autoskillit-diagram-format: v7 -->
 ## implementation-groups
 Group-based implementation with per-group plan/implement/test cycles and PR gates.

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:d3afca55385bea3028a28ec4354299c0fa8c03318976b921db7354eff380be57 -->
+<!-- autoskillit-recipe-hash: sha256:763e88cd01af821d1f9928dcb6a6b20a4a90a87ce8f98bce8ce704aaed939e92 -->
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 

--- a/src/autoskillit/recipes/diagrams/remediation.md
+++ b/src/autoskillit/recipes/diagrams/remediation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:98efa055bc27ca8057fe1dc01887cbe1e2094b036a71bd34a6469cc52d637c18 -->
+<!-- autoskillit-recipe-hash: sha256:41bcf96c7bd11600295e9010d870546faa88d3b273f89a471a4d4fbb6c5ae03c -->
 <!-- autoskillit-diagram-format: v7 -->
 ## remediation
 Investigate, rectify, implement, and merge a bug fix with CI and PR gates.

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -250,6 +250,7 @@
         "cwd": "${{ context.work_dir }}",
         "step_name": "verify",
         "review_path": "${{ context.review_path }}",
+        "issue_url": "${{ inputs.issue_url }}",
         "output_dir": "{{AUTOSKILLIT_TEMP}}"
       },
       "on_success": "create_impl_worktree",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -253,6 +253,7 @@ steps:
       cwd: "${{ context.work_dir }}"
       step_name: "verify"
       review_path: "${{ context.review_path }}"
+      issue_url: "${{ inputs.issue_url }}"
       output_dir: "{{AUTOSKILLIT_TEMP}}"
     on_success: create_impl_worktree
     on_failure: release_issue_failure

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -271,6 +271,7 @@
         "cwd": "${{ context.work_dir }}",
         "step_name": "verify",
         "review_path": "${{ context.review_path }}",
+        "issue_url": "${{ inputs.issue_url }}",
         "output_dir": "{{AUTOSKILLIT_TEMP}}"
       },
       "on_success": "create_impl_worktree",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -288,6 +288,7 @@ steps:
       cwd: ${{ context.work_dir }}
       step_name: verify
       review_path: ${{ context.review_path }}
+      issue_url: ${{ inputs.issue_url }}
       output_dir: '{{AUTOSKILLIT_TEMP}}'
     on_success: create_impl_worktree
     on_failure: release_issue_failure

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -303,6 +303,7 @@
         "cwd": "${{ context.work_dir }}",
         "output_dir": "{{AUTOSKILLIT_TEMP}}",
         "review_path": "${{ context.review_path }}",
+        "issue_url": "${{ inputs.issue_url }}",
         "step_name": "dry_walkthrough"
       },
       "on_success": "create_impl_worktree",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -326,6 +326,7 @@ steps:
       cwd: ${{ context.work_dir }}
       output_dir: '{{AUTOSKILLIT_TEMP}}'
       review_path: ${{ context.review_path }}
+      issue_url: ${{ inputs.issue_url }}
       step_name: dry_walkthrough
     on_success: create_impl_worktree
     on_failure: release_issue_failure

--- a/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
+++ b/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
@@ -31,6 +31,7 @@ The plan file must remain a **clean, self-contained implementation instruction s
 ## Arguments
 
 `{plan_path}`   — Absolute path to the plan file to validate (optional: falls back to most recent {{AUTOSKILLIT_TEMP}}/ artifact if omitted)
+`{issue_url}`   — (Optional) GitHub issue URL. When provided, enables plan-vs-issue coverage check in Step 4.6.
 
 ## Critical Constraints
 
@@ -218,6 +219,49 @@ This is a quick cross-reference sanity check — not a deep audit.
 Gather all weak-signal git findings and open-issue area overlaps into a list.
 These are forwarded to Step 7 for inclusion in the `### Historical Context` terminal section.
 If Part A and Part B produce no findings, record: "No historical regressions or issue overlaps detected."
+
+### Step 4.6: Plan-vs-Issue Coverage Check
+
+If `issue_url` or `issue_number` was provided to this skill, verify that the plan covers every remediation/requirement item enumerated in the source issue. Without this check, a planner that silently drops an item produces a plan that the implementation pipeline faithfully follows — leaving the issue item unaddressed.
+
+1. **Guard:** If `issue_url` or `issue_number` is not provided, skip this step and record: "Plan-vs-issue coverage check skipped — no issue context provided."
+
+2. **Fetch the issue body:**
+   ```bash
+   gh issue view {issue_number} --json body -q .body
+   ```
+
+3. **Extract enumerated items** from the issue body. Scan for patterns indicating structured remediation or requirement items:
+   - `R0`, `R1`, `R2`, … (Rn pattern)
+   - `REQ-*-NNN` patterns
+   - Numbered lists under `## Remediation`, `## Requirements`, or `## Items` headings
+   - Checkbox items (`- [ ]` or `- [x]`) under scope headings
+
+4. **If no enumerated items found:** Skip the coverage check — the issue does not use structured enumeration. Record: "No enumerated items detected in issue body — coverage check not applicable."
+
+5. **Cross-reference each enumerated item** against plan phases and steps:
+   - For each item, search the plan text for the item's label (e.g., "R0"), its description keywords, and its referenced file paths
+   - Classify as `COVERED` (plan step explicitly addresses this item) or `UNMAPPED` (no plan step addresses it)
+
+6. **If any items are UNMAPPED:** Do NOT stamp the plan. Output a blocking failure:
+   ```
+   ## Dry Walkthrough FAILED — Plan-vs-Issue Coverage Gap
+
+   **Plan:** {path}
+   **Issue:** #{issue_number}
+   **Status:** FAILED — plan does not cover all issue-enumerated items
+
+   ### Unmapped Items
+   - {item_label}: {item_description} — not addressed by any plan step
+
+   The plan must cover every remediation/requirement item enumerated in the source
+   issue. If an item cannot be delivered, re-scope the issue body first (issue body
+   is the source of truth per AGENTS.md §3.4) and re-plan. Do not descope items
+   in the plan.
+   ```
+   Stop execution — do not proceed to Step 5.
+
+7. **If all items are COVERED:** Record coverage confirmation and proceed to Step 5.
 
 ### Step 5: Fix the Plan
 

--- a/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
+++ b/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
@@ -224,7 +224,7 @@ If Part A and Part B produce no findings, record: "No historical regressions or 
 
 If `issue_url` or `issue_number` was provided to this skill, verify that the plan covers every remediation/requirement item enumerated in the source issue. Without this check, a planner that silently drops an item produces a plan that the implementation pipeline faithfully follows — leaving the issue item unaddressed.
 
-1. **Guard:** If `issue_url` or `issue_number` is not provided, skip this step and record: "Plan-vs-issue coverage check skipped — no issue context provided."
+1. **Guard:** If `issue_url` or `issue_number` is not provided, omit this check and record: "Plan-vs-issue coverage check omitted — no issue context provided."
 
 2. **Fetch the issue body:**
    ```bash
@@ -237,7 +237,7 @@ If `issue_url` or `issue_number` was provided to this skill, verify that the pla
    - Numbered lists under `## Remediation`, `## Requirements`, or `## Items` headings
    - Checkbox items (`- [ ]` or `- [x]`) under scope headings
 
-4. **If no enumerated items found:** Skip the coverage check — the issue does not use structured enumeration. Record: "No enumerated items detected in issue body — coverage check not applicable."
+4. **When the issue body contains no enumerated items:** The issue does not use structured enumeration — coverage validation is not applicable. Record: "No enumerated items detected in issue body — coverage check not applicable."
 
 5. **Cross-reference each enumerated item** against plan phases and steps:
    - For each item, search the plan text for the item's label (e.g., "R0"), its description keywords, and its referenced file paths

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -323,7 +323,7 @@ Before writing the final plan, verify:
 - Include verification steps
 - Be willing to recommend significant refactoring if that's the right answer
 - Issue all Task calls in a single message to maximize parallelism
-- The plan must cover every remediation/requirement item enumerated in the source issue; if an item cannot be delivered, stop and surface it — do not descope it in the plan
+- The plan must cover every remediation item enumerated in the source issue; if an item cannot be delivered, stop and surface it — do not descope it in the plan
 
 ## Output
 

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -323,6 +323,7 @@ Before writing the final plan, verify:
 - Include verification steps
 - Be willing to recommend significant refactoring if that's the right answer
 - Issue all Task calls in a single message to maximize parallelism
+- The plan must cover every remediation/requirement item enumerated in the source issue; if an item cannot be delivered, stop and surface it — do not descope it in the plan
 
 ## Output
 

--- a/src/autoskillit/skills_extended/rectify/SKILL.md
+++ b/src/autoskillit/skills_extended/rectify/SKILL.md
@@ -61,7 +61,7 @@ Do not change any code.
   ```
   This token is MANDATORY — the pipeline cannot capture the output without it.
 - The solution must solve more than just the immediate issue
-- The plan must cover every remediation/requirement item enumerated in the source issue; if an item cannot be delivered, stop and surface it — do not descope it in the plan
+- The plan must cover every remediation item enumerated in the source issue; if an item cannot be delivered, stop and surface it — do not descope it in the plan
 
 ## Rectify Workflow
 

--- a/src/autoskillit/skills_extended/rectify/SKILL.md
+++ b/src/autoskillit/skills_extended/rectify/SKILL.md
@@ -61,6 +61,7 @@ Do not change any code.
   ```
   This token is MANDATORY — the pipeline cannot capture the output without it.
 - The solution must solve more than just the immediate issue
+- The plan must cover every remediation/requirement item enumerated in the source issue; if an item cannot be delivered, stop and surface it — do not descope it in the plan
 
 ## Rectify Workflow
 

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -431,6 +431,7 @@ MODULE_CASCADE_RECIPE: dict[str, frozenset[str]] = {
     "rules_inline_script": frozenset({"recipe"}),
     "rules_inputs": frozenset({"recipe"}),
     "rules_isolation": frozenset({"recipe"}),
+    "rules_issue_scope_threading": frozenset({"recipe"}),
     "rules_loop_counter": frozenset({"recipe"}),
     "rules_merge": frozenset({"recipe"}),
     "rules_packs": frozenset({"recipe"}),

--- a/tests/arch/test_pyright_suppression_allowlist.py
+++ b/tests/arch/test_pyright_suppression_allowlist.py
@@ -20,7 +20,7 @@ _PYRIGHT_RE = re.compile(r"#\s*pyright:\s*ignore|#.*--\s*pyright:\s*ignore")
 PRODUCTION_ALLOWLIST: dict[tuple[str, int], str] = {
     (
         "recipe/__init__.py",
-        262,
+        265,
     ): "lazy-registry: method added by _register_rule_module() side effects",
     ("recipe/_api.py", 281): "lazy-registry: RULE_REGISTRY_HASH set by _finalize_registry()",
 }

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -879,7 +879,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "hooks": 14,  # +recipe_confirmed_post_hook.py
         "pipeline": 12,
         "fleet": 23,  # +_issue_url_helpers.py  # noqa: E501
-        "recipe/rules": 51,  # +commit_guard_regression_route +rules_model +rules_gitignored_deliverable  # noqa: E501
+        "recipe/rules": 52,  # +commit_guard_regression_route +rules_model +rules_gitignored_deliverable +rules_issue_scope_threading  # noqa: E501
         "server/tools": 28,  # +_preflight.py +_authority_feedback.py
         "hooks/guards": 32,  # +fleet_claim_guard, +reset_resume_gate, +recipe_read_guard
         "execution/backends": 12,  # +_composite_locator.py, +_probe_cache.py

--- a/tests/contracts/AGENTS.md
+++ b/tests/contracts/AGENTS.md
@@ -95,6 +95,7 @@ Protocol satisfaction, package gateway, and skill contract compliance tests.
 | `test_no_interpreter_writes_in_skills.py` | Contract: no SKILL.md may prescribe interpreter-mediated file writes (python3 -c / heredoc with write APIs) |
 | `test_dry_walkthrough_transformation_extent.py` | Contract test: dry-walkthrough SKILL.md Step 2 must check transformation extent/scope |
 | `test_dry_walkthrough_arch_catalog_reference.py` | Contract test: dry-walkthrough SKILL.md Step 4 must reference the Architectural Constraint Catalog |
+| `test_dry_walkthrough_issue_coverage.py` | Contract test: dry-walkthrough SKILL.md must contain plan-vs-issue coverage check step (Step 4.6) |
 | `test_download_data_contracts.py` | Contract tests for download-data SKILL.md — external dataset acquisition step |
 | `test_source_attribution_contracts.py` | Cross-skill contract: source-attribution prohibition in dual-source skills |
 | `test_project_local_skill_delivery_contract.py` | Symmetric delivery contract tests for project-local skill overrides |

--- a/tests/contracts/test_dry_walkthrough_issue_coverage.py
+++ b/tests/contracts/test_dry_walkthrough_issue_coverage.py
@@ -1,0 +1,120 @@
+"""Contract test: dry-walkthrough SKILL.md must contain plan-vs-issue coverage check step."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
+
+_SKILL_MD = (
+    Path(__file__).resolve().parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "dry-walkthrough"
+    / "SKILL.md"
+)
+
+
+def _read_skill_md() -> str:
+    return _SKILL_MD.read_text()
+
+
+def test_dry_walkthrough_has_issue_coverage_step():
+    """dry-walkthrough SKILL.md must contain Step 4.6 for plan-vs-issue coverage."""
+    content = _read_skill_md()
+    assert re.search(
+        r"###\s+Step\s+4\.6[\s:].*Plan-vs-Issue\s+Coverage\s+Check",
+        content,
+        re.DOTALL,
+    ), (
+        "dry-walkthrough/SKILL.md must contain a '### Step 4.6' section titled "
+        "'Plan-vs-Issue Coverage Check'"
+    )
+
+
+def test_dry_walkthrough_issue_coverage_positioned_after_step45():
+    """Step 4.6 must appear between Step 4.5 and Step 5."""
+    content = _read_skill_md()
+    step45_pos = content.find("### Step 4.5")
+    step46_pos = content.find("### Step 4.6")
+    step5_pos = content.find("### Step 5:")
+    assert step45_pos != -1, "Step 4.5 section must exist"
+    assert step46_pos != -1, "Step 4.6 section must exist"
+    assert step5_pos != -1, "Step 5 section must exist"
+    assert step45_pos < step46_pos < step5_pos, (
+        "Step 4.6 must be positioned between Step 4.5 and Step 5 in dry-walkthrough/SKILL.md"
+    )
+
+
+def test_dry_walkthrough_issue_coverage_references_issue_context():
+    """Step 4.6 must reference issue_url or issue_number."""
+    content = _read_skill_md()
+    step46_section = content[content.find("### Step 4.6") : content.find("### Step 5:")]
+    assert "issue_url" in step46_section or "issue_number" in step46_section, (
+        "dry-walkthrough SKILL.md Step 4.6 must reference issue_url or issue_number"
+    )
+
+
+def test_dry_walkthrough_issue_coverage_checks_enumerated_items():
+    """Step 4.6 must mention enumerated or remediation item language."""
+    content = _read_skill_md()
+    step46_section = content[content.find("### Step 4.6") : content.find("### Step 5:")]
+    assert re.search(
+        r"enumerated|remediation item|requirement item",
+        step46_section,
+        re.IGNORECASE,
+    ), (
+        "dry-walkthrough SKILL.md Step 4.6 must mention 'enumerated', 'remediation item', "
+        "or 'requirement item' to describe the scope check"
+    )
+
+
+def test_dry_walkthrough_issue_coverage_blocks_on_missing():
+    """Step 4.6 must specify blocking/failing when items are unmapped."""
+    content = _read_skill_md()
+    step46_section = content[content.find("### Step 4.6") : content.find("### Step 5:")]
+    assert re.search(
+        r"UNMAPPED|FAIL|block|do not stamp|not stamp",
+        step46_section,
+        re.IGNORECASE,
+    ), (
+        "dry-walkthrough SKILL.md Step 4.6 must specify blocking/failing behavior when "
+        "enumerated items are not mapped to plan steps"
+    )
+
+
+def test_dry_walkthrough_issue_coverage_fetches_issue_body():
+    """Step 4.6 must reference gh issue view or fetch_github_issue for issue body retrieval."""
+    content = _read_skill_md()
+    step46_section = content[content.find("### Step 4.6") : content.find("### Step 5:")]
+    assert "gh issue view" in step46_section or "fetch_github_issue" in step46_section, (
+        "dry-walkthrough SKILL.md Step 4.6 must reference 'gh issue view' or "
+        "'fetch_github_issue' for issue body retrieval"
+    )
+
+
+def test_dry_walkthrough_issue_coverage_graceful_skip():
+    """Step 4.6 must specify graceful skip when issue_url is not provided."""
+    content = _read_skill_md()
+    step46_section = content[content.find("### Step 4.6") : content.find("### Step 5:")]
+    assert re.search(
+        r"skip\s+this\s+step|not\s+provided|no\s+issue\s+context",
+        step46_section,
+        re.IGNORECASE,
+    ), (
+        "dry-walkthrough SKILL.md Step 4.6 must specify graceful skip when issue_url "
+        "or issue_number is not provided (non-issue-sourced pipelines)"
+    )
+
+
+def test_dry_walkthrough_arguments_documents_issue_url():
+    """dry-walkthrough SKILL.md Arguments section must document issue_url."""
+    content = _read_skill_md()
+    args_section = content[content.find("## Arguments") : content.find("## Critical Constraints")]
+    assert "issue_url" in args_section, (
+        "dry-walkthrough SKILL.md Arguments section must document the issue_url argument"
+    )

--- a/tests/recipe/AGENTS.md
+++ b/tests/recipe/AGENTS.md
@@ -159,6 +159,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_rules_inputs.py` | Tests for inputs semantic validation rule |
 | `test_rules_integration_predicate.py` | Tests for integration_predicate semantic validation rule |
 | `test_rules_isolation.py` | Tests for isolation semantic validation rule |
+| `test_rules_issue_scope_threading.py` | Tests for issue-scope-not-threaded-to-walkthrough semantic validation rule |
 | `test_rules_merge.py` | Tests for merge semantic validation rule |
 | `test_rules_merge_base_unpublished.py` | Tests for merge_base_unpublished semantic validation rule |
 | `test_rules_merge_queue_push.py` | Tests for merge_queue_push semantic validation rule |

--- a/tests/recipe/test_rules_issue_scope_threading.py
+++ b/tests/recipe/test_rules_issue_scope_threading.py
@@ -1,0 +1,113 @@
+"""Tests for issue-scope-not-threaded-to-walkthrough semantic validation rule.
+
+Verifies that dry-walkthrough steps in recipes with an issue_url (or issue_number)
+ingredient receive that ingredient via their with: block. Recipes without issue
+ingredients are unaffected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core.types import Severity
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
+from autoskillit.recipe.validator import run_semantic_rules
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+_RULE_NAME = "issue-scope-not-threaded-to-walkthrough"
+
+_DW_CMD_NO_THREAD = "/autoskillit:dry-walkthrough ${{ context.plan_path }}"
+
+
+def _make_recipe(
+    steps: dict[str, RecipeStep],
+    ingredients: dict[str, RecipeIngredient] | None = None,
+) -> Recipe:
+    return Recipe(
+        name="test",
+        description="test",
+        steps=steps,
+        ingredients=ingredients or {},
+        kitchen_rules=["test"],
+    )
+
+
+def _issue_url_ingredient() -> dict[str, RecipeIngredient]:
+    return {"issue_url": RecipeIngredient(description="GitHub issue URL")}
+
+
+def _findings(steps: dict[str, RecipeStep], ingredients: dict[str, RecipeIngredient]) -> list:
+    recipe = _make_recipe(steps, ingredients)
+    return [f for f in run_semantic_rules(recipe) if f.rule == _RULE_NAME]
+
+
+def _dry_walkthrough_steps(with_args: dict[str, str]) -> dict[str, RecipeStep]:
+    return {
+        "dry_walkthrough": RecipeStep(
+            tool="run_skill",
+            with_args={"skill_command": _DW_CMD_NO_THREAD, **with_args},
+        ),
+        "done": RecipeStep(action="stop"),
+    }
+
+
+def test_dry_walkthrough_with_issue_url_threaded_passes():
+    """dry-walkthrough receiving issue_url must not fire."""
+    findings = _findings(
+        _dry_walkthrough_steps({"issue_url": "${{ inputs.issue_url }}"}),
+        _issue_url_ingredient(),
+    )
+    assert findings == []
+
+
+def test_dry_walkthrough_without_issue_url_fires():
+    """dry-walkthrough missing issue_url in a recipe with issue_url ingredient must fire."""
+    findings = _findings(_dry_walkthrough_steps({}), _issue_url_ingredient())
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.ERROR
+    assert findings[0].step_name == "dry_walkthrough"
+    assert "issue_url" in findings[0].message
+
+
+def test_dry_walkthrough_without_issue_ingredient_passes():
+    """Recipes without issue_url or issue_number ingredient must not fire."""
+    findings = _findings(_dry_walkthrough_steps({}), {})
+    assert findings == []
+
+
+def test_dry_walkthrough_with_issue_number_threaded_passes():
+    """dry-walkthrough receiving issue_number (alternative) must not fire."""
+    findings = _findings(
+        _dry_walkthrough_steps({"issue_number": "${{ inputs.issue_number }}"}),
+        {"issue_number": RecipeIngredient(description="GitHub issue number")},
+    )
+    assert findings == []
+
+
+def test_non_dry_walkthrough_step_does_not_fire():
+    """Steps invoking other skills must not trigger this rule."""
+    steps = {
+        "audit_impl": RecipeStep(
+            tool="run_skill",
+            with_args={"skill_command": "/autoskillit:audit-impl ${{ context.plan_path }}"},
+        ),
+        "done": RecipeStep(action="stop"),
+    }
+    findings = _findings(steps, _issue_url_ingredient())
+    assert findings == []
+
+
+@pytest.mark.parametrize(
+    "recipe_name",
+    ["remediation.yaml", "implementation.yaml"],
+)
+def test_bundled_recipes_pass_issue_scope_threading_rule(recipe_name: str) -> None:
+    """Bundled recipes with dry-walkthrough steps must thread issue_url."""
+    recipe = load_recipe(builtin_recipes_dir() / recipe_name)
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == _RULE_NAME]
+    assert findings == [], (
+        f"{recipe_name} must not trigger {_RULE_NAME}. "
+        f"Findings: {[(f.step_name, f.message) for f in findings]}"
+    )

--- a/tests/skills/AGENTS.md
+++ b/tests/skills/AGENTS.md
@@ -36,6 +36,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 | `test_phoropter_structural.py` | Registry-driven structural assertions for all phoropter lens families and slugs (vis-lens, arch-lens, exp-lens) discovered from phoropter-registry.yaml |
 | `test_plan_experiment_schema_contracts.py` | Contract tests: plan-experiment YAML frontmatter schema and revision_guidance argument |
 | `test_planner_extract_domain.py` | Planner extract domain tests |
+| `test_planner_no_descope_rule.py` | Contract tests verifying rectify and make-plan SKILL.md contain no-descope rule for issue-enumerated items |
 | `test_planner_refine_cycle_breaking.py` | Tests for planner-refine SKILL.md 2-node cycle-breaking documentation |
 | `test_planner_skill_contracts.py` | Planner skill contract tests |
 | `test_project_local_audit_skill_content.py` | Tests for project-local audit skill content |

--- a/tests/skills/test_planner_no_descope_rule.py
+++ b/tests/skills/test_planner_no_descope_rule.py
@@ -1,0 +1,51 @@
+"""Contract tests: rectify and make-plan SKILL.md must contain no-descope rule."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from tests._helpers import extract_always_block
+
+pytestmark = [pytest.mark.layer("skills"), pytest.mark.small]
+
+
+def _read_rectify() -> str:
+    from autoskillit.core.paths import pkg_root
+
+    return (pkg_root() / "skills_extended" / "rectify" / "SKILL.md").read_text()
+
+
+def _read_make_plan() -> str:
+    from autoskillit.core.paths import pkg_root
+
+    return (pkg_root() / "skills_extended" / "make-plan" / "SKILL.md").read_text()
+
+
+_NO_DESCOPE_PATTERN = re.compile(
+    r"plan\s+must\s+cover\s+every\s+(remediation|requirement)\s+item",
+    re.IGNORECASE,
+)
+
+
+def test_rectify_contains_no_descope_rule():
+    """rectify SKILL.md must contain the no-descope rule in its ALWAYS section."""
+    always_block = extract_always_block(_read_rectify())
+    assert _NO_DESCOPE_PATTERN.search(always_block), (
+        "rectify/SKILL.md ALWAYS section must contain the no-descope rule: "
+        "'The plan must cover every remediation/requirement item enumerated in the "
+        "source issue; if an item cannot be delivered, stop and surface it — "
+        "do not descope it in the plan'"
+    )
+
+
+def test_make_plan_contains_no_descope_rule():
+    """make-plan SKILL.md must contain the no-descope rule in its ALWAYS section."""
+    always_block = extract_always_block(_read_make_plan())
+    assert _NO_DESCOPE_PATTERN.search(always_block), (
+        "make-plan/SKILL.md ALWAYS section must contain the no-descope rule: "
+        "'The plan must cover every remediation/requirement item enumerated in the "
+        "source issue; if an item cannot be delivered, stop and surface it — "
+        "do not descope it in the plan'"
+    )


### PR DESCRIPTION
## Summary

The remediation pipeline silently descopes issue-enumerated remediation items because every validation stage compares artifacts to the **plan** but nothing compares the plan to the **source issue**. This is the third occurrence (#4164, #4168, #4172). The architectural weakness: issue context enters the pipeline once (at `investigate` or `bridge_investigation`), is consumed by the planner as unstructured narrative, and is never referenced again. The plan becomes the sole authority for all downstream stages, so a planner that drops items produces a pipeline that faithfully implements an incomplete plan and declares success.

The immunity approach introduces a **plan-vs-issue coverage gate** at `dry-walkthrough` (the last pre-implementation checkpoint), backed by a **recipe semantic rule** that structurally enforces `issue_url` threading to any `dry-walkthrough` step in recipes with issue-sourced pipelines. This makes silent descoping structurally impossible: the gate catches it at validation time, and the rule catches recipe authors who forget to thread the input.

## Requirements

**R1 — dry-walkthrough plan-vs-issue coverage check.** dry-walkthrough (`src/autoskillit/skills_extended/dry-walkthrough/SKILL.md`), which already receives both the plan file and the issue context in both recipes (`implementation.yaml` `verify` step; `remediation.yaml` `dry_walkthrough` step at line 321), gains a coverage check: every enumerated remediation/requirement item in the source issue body (R0/R1/…, REQ-*-NNN, or numbered remediation lists) must map to at least one plan step. Any unmapped item fails the walkthrough with the item named. Plans are not permitted to descope issue-enumerated items; the failure message directs the operator to re-scope the issue body first (issue body is the source of truth, per AGENTS.md §3.4) and re-plan.

**R2 — planner guidance, one line each.** Add a single line to the planning skills' instructions — `make-plan` (implementation route) and `rectify` (remediation route, the skill that produced the descoped plan): the plan must cover every remediation/requirement item enumerated in the source issue; if an item cannot be delivered, stop and surface it — do not descope it in the plan.

## Acceptance

- A plan omitting an issue-enumerated item fails dry-walkthrough with the missing item identified by its issue label (e.g., "R0").
- `make-plan` and `rectify` SKILL.md each carry the one-line no-descope rule.
- Regression test(s) following existing dry-walkthrough test patterns cover: (a) full coverage passes, (b) one missing enumerated item fails and names it, (c) issues without enumerated items are unaffected.

## Out of scope

- The descoped R0 itself (capability-driven auto-route restoration) — tracked as #4174 (`recipe:implementation`).
- compose-pr/prepare-pr hardening (PR scope list must reflect the plan, not the issue verbatim) and arming `review_pr` non-local posting — real gaps observed in this incident, but secondary; note here for the record only.
- The develop-merge autoclose gap (default branch `main` last merged 2026-05-08, so "Closes #N" on develop-merged PRs never fires — #3495, #3675, #4171 all remain open despite Closes tags). Process-wide, pre-existing, not introduced by this pipeline.

Closes #4173

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260703-084252-414125/.autoskillit/temp/rectify/rectify_plan_vs_issue_coverage_gate_2026-07-03_084252.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 3.4k | 25.7k | 2.8M | 141.6k | 54 | 122.6k | 27m 5s |
| review_approach* | opus[1m] | 1 | 5.6k | 7.2k | 270.0k | 73.6k | 14 | 58.8k | 8m 36s |
| dry_walkthrough* | opus | 1 | 55 | 20.4k | 2.1M | 95.4k | 63 | 76.3k | 14m 4s |
| implement* | MiniMax-M3 | 1 | 131.5k | 27.2k | 9.9M | 0 | 158 | 0 | 9m 20s |
| **Total** | | | 140.6k | 80.6k | 15.1M | 141.6k | | 257.7k | 59m 6s |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 564 | 17622.0 | 0.0 | 48.2 |
| **Total** | **564** | 26784.5 | 456.9 | 142.8 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 2 | 9.0k | 33.0k | 3.1M | 181.4k | 35m 42s |
| opus | 1 | 55 | 20.4k | 2.1M | 76.3k | 14m 4s |
| MiniMax-M3 | 1 | 131.5k | 27.2k | 9.9M | 0 | 9m 20s |