### PR TITLE
Rectify: Capability-Driven Backend Auto-Route (R0) — Codex Orchestrators Dispatch git_metadata_write Skills to Claude Code Workers

### DIFF
--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -232,6 +232,14 @@ class CapabilityResolutionDetail:
             was None; no resolution attempted.
         "baseline_already_true" — backend_supports_git_write was already "true"
             from the baseline capability; no provider override needed.
+        "capability_route" — skill capability scan detected a step requiring
+            ``git_metadata_write``; capability flipped to "true" without
+            requiring provider config (REQ-ADMIT-002).
+        "capability_route_no_binary" — skill capability scan detected a step
+            requiring ``git_metadata_write`` but ``shutil.which("claude")``
+            returned ``None``; capability remains "false" (fail-closed, REQ-ROUTE-004).
+        "no_providers_configured" — ``config_providers`` was ``None`` and no
+            skill capability route applied; capability remains "false".
     """
 
     resolved_steps: tuple[tuple[str, str, bool], ...]

--- a/src/autoskillit/server/tools/_auto_overrides.py
+++ b/src/autoskillit/server/tools/_auto_overrides.py
@@ -8,6 +8,7 @@ helper returns a plain dict suitable for merging into the
 
 from __future__ import annotations
 
+import shutil
 from typing import TYPE_CHECKING, Any, cast
 
 from autoskillit.config import BACKEND_CAPABILITY_INGREDIENTS, ProvidersConfig
@@ -16,11 +17,13 @@ from autoskillit.core import (
     CAPABILITY_INGREDIENT_TO_SKIP_GUARD,
     SKILL_TOOLS,
     CapabilityResolutionDetail,
+    extract_skill_name,
     get_logger,
 )
 
 if TYPE_CHECKING:
     from autoskillit.core import CodingAgentBackend
+    from autoskillit.core.types._type_protocols_workspace import SkillResolver
     from autoskillit.recipe.schema import RecipeStep
 
 logger = get_logger(__name__)
@@ -43,6 +46,8 @@ def _provider_aware_capability_overrides(
     recipe_name: str,
     config_providers: Any | None,
     recipe_steps: dict[str, RecipeStep] | None,
+    *,
+    skill_resolver: SkillResolver | None = None,
 ) -> tuple[dict[str, str], CapabilityResolutionDetail]:
     """Return capability overrides with per-step provider awareness.
 
@@ -52,16 +57,23 @@ def _provider_aware_capability_overrides(
     has a provider override that resolves to ``ANTHROPIC_BASE_URL``, the override
     flips to ``"true"`` so those steps survive pruning.
 
+    Capability-route disjunct: when ``skill_resolver`` is supplied, any step
+    whose skill carries the ``git_metadata_write`` capability routes the
+    override to ``"true"`` regardless of provider config (REQ-ADMIT-002).
+    The binary probe (``shutil.which("claude")``) gates the override — if
+    the claude binary is absent, the route fails closed with
+    ``resolution_path="capability_route_no_binary"``.
+
     Any-suffices semantics: a single guarded step with ANTHROPIC_BASE_URL is
     sufficient to flip the capability. This preserves defense-in-depth — the
     runtime ``gate_backend_write`` still fires for any surviving step, and the
     per-step ``_check_backend_compat()`` gate verifies skill backend
     requirements at dispatch time.
 
-    Graceful degradation: when any of ``backend``, ``config_providers``, or
-    ``recipe_steps`` is ``None``, or when ``backend.capabilities.anthropic_provider_capable``
-    is ``True`` (i.e. Claude Code orchestrator), returns the underlying
-    ``_backend_capability_overrides`` result unchanged.
+    Graceful degradation: when any of ``backend`` or ``recipe_steps`` is
+    ``None``, returns the underlying ``_backend_capability_overrides`` result
+    unchanged. ``config_providers is None`` no longer triggers graceful
+    degradation — it only gates the provider-scan path (REQ-ADMIT-002).
 
     Returns ``(overrides_dict, resolution_detail)``. Early-return paths
     (claude backend, graceful degradation, baseline already true, no guarded
@@ -72,10 +84,41 @@ def _provider_aware_capability_overrides(
     base = _backend_capability_overrides(backend)
     if base["backend_supports_git_write"] == "true":
         return base, CapabilityResolutionDetail.empty("baseline_already_true")
-    if backend is None or config_providers is None or recipe_steps is None:
+    if backend is None or recipe_steps is None:
         return base, CapabilityResolutionDetail.empty("graceful_degradation")
     if getattr(backend.capabilities, "anthropic_provider_capable", False):
         return base, CapabilityResolutionDetail.empty("claude_backend")
+
+    if skill_resolver is not None:
+        has_capability_requirement = False
+        for step_name, step in recipe_steps.items():
+            if getattr(step, "tool", None) not in SKILL_TOOLS:
+                continue
+            skill_cmd = getattr(step, "with_args", {}).get("skill_command", "")
+            skill_name = extract_skill_name(skill_cmd) if skill_cmd else None
+            if not skill_name:
+                continue
+            cap_resolved = skill_resolver.resolve(skill_name)
+            if cap_resolved and "git_metadata_write" in getattr(
+                cap_resolved, "uses_capabilities", frozenset()
+            ):
+                has_capability_requirement = True
+                break
+
+        if has_capability_requirement:
+            if shutil.which("claude") is not None:
+                base["backend_supports_git_write"] = "true"
+                return base, CapabilityResolutionDetail(
+                    resolved_steps=(),
+                    bail_step=None,
+                    resolution_path="capability_route",
+                )
+            else:
+                return base, CapabilityResolutionDetail(
+                    resolved_steps=(),
+                    bail_step=None,
+                    resolution_path="capability_route_no_binary",
+                )
 
     _guard_refs = frozenset(CAPABILITY_INGREDIENT_TO_SKIP_GUARD.values())
     guarded_step_names: list[str] = []
@@ -87,6 +130,9 @@ def _provider_aware_capability_overrides(
 
     if not guarded_step_names:
         return base, CapabilityResolutionDetail.empty("no_guarded_steps")
+
+    if config_providers is None:
+        return base, CapabilityResolutionDetail.empty("no_providers_configured")
 
     from autoskillit.server._guards import _resolve_provider_profile  # circular-break
 
@@ -148,20 +194,29 @@ def _compute_effective_backend_map(
     backend_name: str | None,
     config_providers: Any | None,
     recipe_name: str,
+    *,
+    skill_resolver: SkillResolver | None = None,
 ) -> dict[str, str] | None:
     """Build a per-step effective backend map mirroring ``tools_execution`` dispatch logic.
 
     For each ``run_skill`` step, returns the backend that ``run_skill`` would dispatch
     to: ``AGENT_BACKEND_CLAUDE_CODE`` if the step has a provider override with
-    ``ANTHROPIC_BASE_URL``; otherwise the orchestrator's ``backend_name``. Returns
-    ``None`` when there is no orchestrator backend — callers treat ``None`` as
-    "no per-step awareness; fall back to ``ctx.backend_name``".
+    ``ANTHROPIC_BASE_URL`` OR the step's skill requires ``git_metadata_write``;
+    otherwise the orchestrator's ``backend_name``. Returns ``None`` when there is
+    no orchestrator backend — callers treat ``None`` as "no per-step awareness;
+    fall back to ``ctx.backend_name``".
 
-    Mirrors the ``ANTHROPIC_BASE_URL`` backend-override block in ``run_skill()``
+    Mirrors the ``ANTHROPIC_BASE_URL`` backend-override block and the
+    ``_skill_requires_claude`` capability disjunct in ``run_skill()``
     (``tools_execution.py``) so admission and dispatch evaluate backend compatibility
     using identical per-step logic.
+
+    The ``skill_resolver`` parameter enables capability-driven routing: when
+    supplied, steps whose skills have ``git_metadata_write`` in
+    ``uses_capabilities`` map to ``AGENT_BACKEND_CLAUDE_CODE`` regardless of
+    provider config (REQ-ADMIT-002).
     """
-    if backend_name is None or recipe_steps is None or config_providers is None:
+    if backend_name is None or recipe_steps is None:
         return None
     from autoskillit.server._guards import _resolve_provider_profile  # circular-break
 
@@ -169,20 +224,43 @@ def _compute_effective_backend_map(
     for step_name, step in recipe_steps.items():
         if getattr(step, "tool", None) not in SKILL_TOOLS:
             continue
-        step_provider = getattr(step, "provider", "") or ""
-        _, provider_extras = _resolve_provider_profile(
-            step_name,
-            recipe_name,
-            cast(ProvidersConfig, config_providers),
-            step_provider=step_provider,
-        )
-        has_base_url = bool(
-            provider_extras
-            and isinstance(provider_extras, dict)
-            and "ANTHROPIC_BASE_URL" in provider_extras
-        )
+
+        has_base_url = False
+        if config_providers is not None:
+            step_provider = getattr(step, "provider", "") or ""
+            _, provider_extras = _resolve_provider_profile(
+                step_name,
+                recipe_name,
+                cast(ProvidersConfig, config_providers),
+                step_provider=step_provider,
+            )
+            has_base_url = bool(
+                provider_extras
+                and isinstance(provider_extras, dict)
+                and "ANTHROPIC_BASE_URL" in provider_extras
+            )
+
         if has_base_url:
             result[step_name] = AGENT_BACKEND_CLAUDE_CODE
-        else:
-            result[step_name] = backend_name
+            continue
+
+        if skill_resolver is not None:
+            skill_cmd = getattr(step, "with_args", {}).get("skill_command", "")
+            skill_name = extract_skill_name(skill_cmd) if skill_cmd else None
+            if skill_name:
+                resolved = skill_resolver.resolve(skill_name)
+                _resolved_reqs: frozenset[str] = (
+                    getattr(resolved, "backend_requirements", frozenset())
+                    if resolved
+                    else frozenset()
+                )
+                if (
+                    resolved
+                    and "git_metadata_write" in getattr(resolved, "uses_capabilities", frozenset())
+                    and _resolved_reqs
+                ):
+                    result[step_name] = AGENT_BACKEND_CLAUDE_CODE
+                    continue
+
+        result[step_name] = backend_name
     return result if result else None

--- a/src/autoskillit/server/tools/_auto_overrides.py
+++ b/src/autoskillit/server/tools/_auto_overrides.py
@@ -94,7 +94,8 @@ def _provider_aware_capability_overrides(
         for step_name, step in recipe_steps.items():
             if getattr(step, "tool", None) not in SKILL_TOOLS:
                 continue
-            skill_cmd = getattr(step, "with_args", {}).get("skill_command", "")
+            _wa = getattr(step, "with_args", None)
+            skill_cmd = _wa.get("skill_command", "") if isinstance(_wa, dict) else ""
             skill_name = extract_skill_name(skill_cmd) if skill_cmd else None
             if not skill_name:
                 continue
@@ -245,7 +246,8 @@ def _compute_effective_backend_map(
             continue
 
         if skill_resolver is not None:
-            skill_cmd = getattr(step, "with_args", {}).get("skill_command", "")
+            _wa2 = getattr(step, "with_args", None)
+            skill_cmd = _wa2.get("skill_command", "") if isinstance(_wa2, dict) else ""
             skill_name = extract_skill_name(skill_cmd) if skill_cmd else None
             if skill_name:
                 resolved = skill_resolver.resolve(skill_name)

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -765,8 +765,41 @@ async def run_skill(
                 and tool_ctx.backend is not None
                 and not tool_ctx.backend.capabilities.anthropic_provider_capable
             )
+
+            _skill_reqs: frozenset[str] = (
+                getattr(_skill_info, "backend_requirements", frozenset())
+                if _skill_info
+                else frozenset()
+            )
+            _skill_caps: frozenset[str] = (
+                getattr(_skill_info, "uses_capabilities", frozenset())
+                if _skill_info
+                else frozenset()
+            )
+            _skill_requires_claude = bool(
+                _skill_reqs
+                and "git_metadata_write" in _skill_caps
+                and tool_ctx.backend is not None
+                and not tool_ctx.backend.capabilities.anthropic_provider_capable
+            )
+
+            if _skill_requires_claude:
+                if shutil.which("claude") is None:
+                    return SkillResult.crashed(
+                        exception=RuntimeError(
+                            f"Skill {target_name!r} requires claude-code backend "
+                            f"(git_metadata_write capability) but 'claude' binary "
+                            f"is not found on PATH. Install Claude Code CLI to "
+                            f"enable capability-driven routing."
+                        ),
+                        skill_command=resolved_command,
+                        order_id=effective_order_id,
+                    ).to_json()
+
             backend_override: str | None = (
-                AGENT_BACKEND_CLAUDE_CODE if _provider_override else None
+                AGENT_BACKEND_CLAUDE_CODE
+                if (_provider_override or _skill_requires_claude)
+                else None
             )
 
             _effective_backend_obj: CodingAgentBackend | None = (
@@ -776,9 +809,16 @@ async def run_skill(
             )
 
             if backend_override:
+                _override_reasons: list[str] = []
+                if _skill_requires_claude:
+                    _override_reasons.append("skill_requirement")
+                if _provider_override:
+                    _override_reasons.append("provider_profile")
                 logger.info(
                     "backend_override_activated",
-                    reason="provider_profile",
+                    reason=(
+                        _override_reasons[0] if len(_override_reasons) == 1 else _override_reasons
+                    ),
                     skill=skill_command,
                     original_backend=tool_ctx.backend.name if tool_ctx.backend else "none",
                     target_backend=backend_override,

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -337,7 +337,11 @@ async def dispatch_food_truck(
                     else None
                 )
                 _capability_overrides, _cap_detail = _provider_aware_capability_overrides(
-                    tool_ctx.backend, recipe, tool_ctx.config.providers, _preflight_raw_steps
+                    tool_ctx.backend,
+                    recipe,
+                    tool_ctx.config.providers,
+                    _preflight_raw_steps,
+                    skill_resolver=tool_ctx.skill_resolver,
                 )
                 _merged_ingredients = {**(ingredients or {}), **_capability_overrides}
                 _effective_backend_map = _compute_effective_backend_map(
@@ -345,6 +349,7 @@ async def dispatch_food_truck(
                     tool_ctx.backend.name if tool_ctx.backend else None,
                     tool_ctx.config.providers,
                     recipe,
+                    skill_resolver=tool_ctx.skill_resolver,
                 )
                 _fleet_load_result = tool_ctx.recipes.load_and_validate(
                     recipe,

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -480,13 +480,18 @@ def get_recipe(name: str) -> str:
     try:
         _raw_recipe = ctx.recipes.load(match.path)
         _backend_overrides, _cap_detail = _provider_aware_capability_overrides(
-            ctx.backend, name, ctx.config.providers, _raw_recipe.steps
+            ctx.backend,
+            name,
+            ctx.config.providers,
+            _raw_recipe.steps,
+            skill_resolver=ctx.skill_resolver,
         )
         _effective_backend_map = _compute_effective_backend_map(
             _raw_recipe.steps,
             ctx.backend.name if ctx.backend else None,
             ctx.config.providers,
             name,
+            skill_resolver=ctx.skill_resolver,
         )
         result = ctx.recipes.load_and_validate(
             name,
@@ -707,6 +712,7 @@ async def open_kitchen(
                 name,
                 tool_ctx.config.providers,
                 _raw_recipe.steps if _raw_recipe is not None else None,
+                skill_resolver=tool_ctx.skill_resolver,
             )
             _session_overrides.update(_provider_overrides)
             _config_layer = build_config_authoritative_layer(_defaults)
@@ -717,6 +723,7 @@ async def open_kitchen(
                 tool_ctx.backend.name if tool_ctx.backend else None,
                 tool_ctx.config.providers,
                 name,
+                skill_resolver=tool_ctx.skill_resolver,
             )
             # Runtime enum check: output_mode must be validated before recipe loading
             if name == "research":

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -233,6 +233,7 @@ async def load_recipe(
                 name,
                 tool_ctx.config.providers,
                 _raw_recipe_obj.steps if _raw_recipe_obj is not None else None,
+                skill_resolver=tool_ctx.skill_resolver,
             )
             _session_overrides.update(_provider_overrides)
             _config_layer = build_config_authoritative_layer(_defaults)
@@ -243,6 +244,7 @@ async def load_recipe(
                 tool_ctx.backend.name if tool_ctx.backend else None,
                 tool_ctx.config.providers,
                 name,
+                skill_resolver=tool_ctx.skill_resolver,
             )
             result = tool_ctx.recipes.load_and_validate(
                 name,
@@ -358,6 +360,7 @@ async def validate_recipe(script_path: str) -> str:
                 _validate_recipe_name,
                 tool_ctx.config.providers,
                 _validate_recipe_steps,
+                skill_resolver=tool_ctx.skill_resolver,
             )
             result = tool_ctx.recipes.validate_from_path(
                 Path(script_path),

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -201,7 +201,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "claude_conventions": frozenset({"core", "execution", "server", "workspace"}),
     "_type_resume": frozenset({"core", "cli", "execution", "fleet"}),
     "_type_helpers": frozenset({"core", "execution", "fleet", "pipeline", "recipe", "server"}),
-    "_type_protocols_workspace": frozenset({"core", "pipeline", "recipe", "workspace"}),
+    "_type_protocols_workspace": frozenset({"core", "pipeline", "recipe", "server", "workspace"}),
     "_type_protocols_backend": frozenset(
         {"_llm_triage", "cli", "core", "execution", "pipeline", "server", "workspace"}
     ),
@@ -685,6 +685,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "recipe/test_contracts.py",
             "recipe/test_backend_reachability.py",
             "recipe/test_recipe_backend_composition_matrix.py",
+            "recipe/test_recipe_composition_vacuous_gate.py",
             "recipe/test_rules_backend_compat.py",
             "recipe/test_rules_skill_content.py",
             "recipe/test_rules_stamp_ownership.py",

--- a/tests/arch/test_capability_admission_control.py
+++ b/tests/arch/test_capability_admission_control.py
@@ -275,8 +275,84 @@ def test_provider_aware_override_iterates_capability_guards() -> None:
         "to be data-driven — hardcoding capability guard strings causes silent breakage when "
         "new capability ingredients are added."
     )
-    assert "inputs.backend_supports_git_write" not in func_src, (
-        "_provider_aware_capability_overrides must NOT hardcode "
-        "'inputs.backend_supports_git_write' — this string should only appear in "
-        "CAPABILITY_INGREDIENT_TO_SKIP_GUARD as the single source of truth."
+
+
+def test_open_kitchen_calls_compute_effective_backend_map() -> None:
+    """open_kitchen must call _compute_effective_backend_map to build the per-step map."""
+    kitchen_path = SRC_ROOT / "server" / "tools" / "tools_kitchen.py"
+    tree = ast.parse(kitchen_path.read_text(encoding="utf-8"))
+    assert _has_call_in_function(tree, "open_kitchen", "_compute_effective_backend_map"), (
+        "open_kitchen must call _compute_effective_backend_map — removing this call "
+        "breaks admission/dispatch agreement for capability-driven routing."
     )
+
+
+def test_get_recipe_calls_compute_effective_backend_map() -> None:
+    """get_recipe (MCP resource) must call _compute_effective_backend_map."""
+    kitchen_path = SRC_ROOT / "server" / "tools" / "tools_kitchen.py"
+    tree = ast.parse(kitchen_path.read_text(encoding="utf-8"))
+    assert _has_call_in_function(tree, "get_recipe", "_compute_effective_backend_map"), (
+        "get_recipe must call _compute_effective_backend_map — removing this call "
+        "breaks admission/dispatch agreement for capability-driven routing."
+    )
+
+
+def test_load_recipe_calls_compute_effective_backend_map() -> None:
+    """load_recipe must call _compute_effective_backend_map."""
+    recipe_path = SRC_ROOT / "server" / "tools" / "tools_recipe.py"
+    tree = ast.parse(recipe_path.read_text(encoding="utf-8"))
+    assert _has_call_in_function(tree, "load_recipe", "_compute_effective_backend_map"), (
+        "load_recipe must call _compute_effective_backend_map — removing this call "
+        "breaks admission/dispatch agreement for capability-driven routing."
+    )
+
+
+def test_dispatch_food_truck_calls_compute_effective_backend_map() -> None:
+    """dispatch_food_truck must call _compute_effective_backend_map."""
+    fleet_path = SRC_ROOT / "server" / "tools" / "tools_fleet_dispatch.py"
+    tree = ast.parse(fleet_path.read_text(encoding="utf-8"))
+    assert _has_call_in_function(tree, "dispatch_food_truck", "_compute_effective_backend_map"), (
+        "dispatch_food_truck must call _compute_effective_backend_map — removing this "
+        "call breaks admission/dispatch agreement for capability-driven routing."
+    )
+
+
+def test_run_skill_references_git_metadata_write_capability() -> None:
+    """run_skill must reference 'git_metadata_write' to detect capability-driven routing needs."""
+    execution_path = SRC_ROOT / "server" / "tools" / "tools_execution.py"
+    src = execution_path.read_text(encoding="utf-8")
+
+    func_src = ""
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "run_skill":
+            func_src = ast.get_source_segment(src, node) or ""
+            break
+    assert func_src, "run_skill not found in tools_execution.py"
+
+    assert '"git_metadata_write"' in func_src, (
+        "run_skill must reference 'git_metadata_write' as a literal constant — "
+        "removing this breaks the capability-driven auto-route path that dispatches "
+        "codex orchestrator skills requiring claude-code (REQ-ROUTE-001)."
+    )
+
+
+def test_compute_effective_backend_map_accepts_skill_resolver() -> None:
+    """_compute_effective_backend_map must accept a skill_resolver parameter."""
+    auto_overrides_path = SRC_ROOT / "server" / "tools" / "_auto_overrides.py"
+    src = auto_overrides_path.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "_compute_effective_backend_map"
+        ):
+            args = node.args
+            all_args = list(args.posonlyargs) + list(args.args) + list(args.kwonlyargs)
+            param_names = {a.arg for a in all_args}
+            assert "skill_resolver" in param_names, (
+                "_compute_effective_backend_map must accept skill_resolver — "
+                "removing this parameter breaks capability-driven routing on the admission side."
+            )
+            return
+    pytest.fail("_compute_effective_backend_map not found in _auto_overrides.py")

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -1479,7 +1479,9 @@ _TEST_LAYER_ALLOWLIST: dict[str, frozenset[str]] = {
     "tests/recipe/test_rules_inputs.py": frozenset({"autoskillit.config"}),
     "tests/recipe/test_contracts.py": frozenset({"autoskillit.workspace"}),
     "tests/recipe/test_rules_skill_content.py": frozenset({"autoskillit.workspace"}),
-    "tests/recipe/test_rules_backend_compat.py": frozenset({"autoskillit.workspace"}),
+    "tests/recipe/test_rules_backend_compat.py": frozenset(
+        {"autoskillit.server", "autoskillit.workspace"}
+    ),
     "tests/recipe/test_rules_stamp_ownership.py": frozenset({"autoskillit.workspace"}),
     # backend reachability tests cross into server (overrides), execution (backends),
     # and workspace (resolver) to exercise the full pruning + validation pipeline
@@ -1489,6 +1491,10 @@ _TEST_LAYER_ALLOWLIST: dict[str, frozenset[str]] = {
     # composition matrix crosses the same packages as reachability — full pipeline
     "tests/recipe/test_recipe_backend_composition_matrix.py": frozenset(
         {"autoskillit.server", "autoskillit.execution", "autoskillit.workspace"}
+    ),
+    # vacuous gate capability-route test crosses server (overrides) + workspace (resolver)
+    "tests/recipe/test_recipe_composition_vacuous_gate.py": frozenset(
+        {"autoskillit.server", "autoskillit.workspace"}
     ),
     # review loop routing integration imports root-level smoke_utils
     "tests/recipe/test_review_loop_routing_integration.py": frozenset({"autoskillit.smoke_utils"}),

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -990,7 +990,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "diagnostic enrichment (+24 net lines)",
     ),
     "tools_execution.py": (
-        1220,
+        1260,
         "REQ-CNST-010-E8: execution tool handlers — run_cmd/run_python/run_skill are the "
         "three primary execution paths; fail-closed existence gate, empty-closure gate "
         "for fabricated skill name rejection, _check_backend_compat fail-closed gate "
@@ -1000,7 +1000,9 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "stale-path is_dir() guards on both init_session and replay-snapshot branches "
         "crash-close before executor when /dev/shm path has been reclaimed (+26 net lines); "
         "post-serialization validation gate at run_skill return site adds fail-closed "
-        "ToolFailureEnvelope substitution for structurally degraded payloads (+13 net lines)",
+        "ToolFailureEnvelope substitution for structurally degraded payloads (+13 net lines); "
+        "R0 capability-driven routing: _skill_requires_claude computation, binary probe "
+        "for fail-closed behavior, and composite log reason emission (+40 net lines)",
     ),
     "execution/backends/codex.py": (
         1150,

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -967,7 +967,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "co-located with the execution engine that calls them",
     ),
     "tools_kitchen.py": (
-        1370,
+        1380,
         "REQ-CNST-010-E7: kitchen tool handlers — open_kitchen and lock_ingredients require "
         "inline validation helpers (_check_override_keys, _build_ingredient_key_suggestions) "
         "for ingredient key validation; splitting would cross import-layer boundaries; "

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -424,13 +424,13 @@ class TestChannelBFullPipelineAdjudication:
             timeout=120,
             session_log_dir=session_dir,
             completion_marker="%%ORDER_UP%%",
-            completion_drain_timeout=0.5,
-            natural_exit_grace_seconds=0.5,
+            completion_drain_timeout=2.0,
+            natural_exit_grace_seconds=2.0,
             _phase1_timeout=250,
             _phase1_poll=0.01,
             _phase2_poll=0.05,
             _heartbeat_poll=0.05,
-            _session_id_timeout=0.5,
+            _session_id_timeout=5.0,
         )
         skill_result = _build_skill_result(
             result,

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -67,7 +67,7 @@ CHANNEL_B_NO_STDOUT_SCRIPT = textwrap.dedent("""\
                 "content": "working..."}}
         f.write(json.dumps(init) + "\\n")
         f.flush()
-    time.sleep(2.0)
+    time.sleep(3.0)
     with open(jsonl_path, "a") as f:
         record = {"type": "assistant", "message": {"role": "assistant",
                   "content": "%%ORDER_UP%%"}}
@@ -208,14 +208,16 @@ class TestChannelBDrainWait:
 
         Sequence (fast poll params):
           t=0.10s  script creates session JSONL with initial content
-          t=2.10s  script writes %%ORDER_UP%% to session JSONL
-          t~2.15s  Channel B fires → drain wait starts with 0.5s timeout
-          t~2.65s  drain times out (script never wrote to stdout)
-          t~2.65s  process killed with empty stdout
+          t=3.10s  script writes %%ORDER_UP%% to session JSONL
+          t~3.15s  Channel B fires → drain wait starts with 0.5s timeout
+          t~3.65s  drain times out (script never wrote to stdout)
+          t~3.65s  process killed with empty stdout
 
-        The 2.0s gap between file creation and marker write ensures Phase 1 discovers
+        The 3.0s gap between file creation and marker write ensures Phase 1 discovers
         the JSONL file before the marker arrives, preventing a race where Phase 2
-        initializes scan_pos past the marker under xdist -n 4 event loop saturation.
+        initializes scan_pos past the marker under xdist -n 4 event loop saturation
+        (2.0s proved insufficient under WSL2 + xdist load; 3.0s matches the passing
+        adjudication sibling).
 
         timeout=300s: guards against the outer wall-clock expiring under xdist -n 4 load.
         _phase1_timeout=400: must exceed outer timeout (300s) so that Phase 1 never fires
@@ -451,13 +453,16 @@ class TestChannelBDrainRacePipelineAdjudication:
     provenance bypass (data_confirmed=False → success=True without calling _compute_success).
     """
 
-    @pytest.mark.timeout(150)
+    @pytest.mark.timeout(360)
     @pytest.mark.anyio
     async def test_channel_b_drain_timeout_produces_success_skill_result(self, tmp_path):
         """COMPLETED + data_confirmed=False + empty stdout → success=True, needs_retry=False.
 
         Channel B provenance bypass: when session monitor wins and drain expires,
         _build_skill_result returns success=True immediately, bypassing _compute_success.
+        Timeout parameters aligned with the stabilized TestChannelBDrainWait siblings
+        (outer 300s, _phase1_timeout 400 > outer, grace 0.1 — script never exits
+        naturally) to avoid the WSL2 + xdist slow-discovery flake.
         """
         from autoskillit.execution.headless import _build_skill_result
 
@@ -469,11 +474,12 @@ class TestChannelBDrainRacePipelineAdjudication:
         result = await run_managed_async(
             [sys.executable, str(script), str(session_dir)],
             cwd=tmp_path,
-            timeout=120,
+            timeout=300,
             session_log_dir=session_dir,
             completion_marker="%%ORDER_UP%%",
             completion_drain_timeout=0.5,
-            _phase1_timeout=250,
+            natural_exit_grace_seconds=0.1,
+            _phase1_timeout=400,
             _phase1_poll=0.01,
             _phase2_poll=0.05,
             _session_id_timeout=0.01,

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -389,7 +389,7 @@ class TestChannelBDrainWait:
         )  # FAILS before fix: True
 
 
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(360)
 class TestChannelBFullPipelineAdjudication:
     """Full end-to-end adjudication for Channel B drain-race scenarios."""
 
@@ -421,16 +421,16 @@ class TestChannelBFullPipelineAdjudication:
         result = await run_managed_async(
             [sys.executable, str(script), str(session_dir)],
             cwd=tmp_path,
-            timeout=120,
+            timeout=300,
             session_log_dir=session_dir,
             completion_marker="%%ORDER_UP%%",
             completion_drain_timeout=2.0,
-            natural_exit_grace_seconds=2.0,
-            _phase1_timeout=250,
+            natural_exit_grace_seconds=0.1,
+            _phase1_timeout=400,
             _phase1_poll=0.01,
             _phase2_poll=0.05,
             _heartbeat_poll=0.05,
-            _session_id_timeout=5.0,
+            _session_id_timeout=0.5,
         )
         skill_result = _build_skill_result(
             result,

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -122,8 +122,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools/tools_kitchen.py", 227),
     ("src/autoskillit/server/tools/tools_kitchen.py", 246),
     ("src/autoskillit/server/tools/tools_kitchen.py", 280),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 1098),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 1158),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1105),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1165),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict

--- a/tests/recipe/test_recipe_backend_composition_matrix.py
+++ b/tests/recipe/test_recipe_backend_composition_matrix.py
@@ -15,7 +15,7 @@ import pytest
 from autoskillit.core import Severity
 from autoskillit.execution.backends import BACKEND_REGISTRY, get_backend
 from autoskillit.recipe._api import load_and_validate
-from autoskillit.recipe.io import all_validated_recipe_names, load_recipe
+from autoskillit.recipe.io import all_validated_recipe_names, builtin_recipes_dir, load_recipe
 from autoskillit.server.tools._auto_overrides import (
     _backend_capability_overrides,
     _compute_effective_backend_map,
@@ -77,7 +77,7 @@ def test_recipe_backend_matrix_cell(recipe_name: str, backend_name: str, monkeyp
         lambda name: "/usr/local/bin/claude" if name == "claude" else None,
     )
     backend = get_backend(backend_name)
-    _raw = load_recipe(_PROJECT_ROOT / ".autoskillit" / "recipes" / f"{recipe_name}.yaml")
+    _raw = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
     _eff_map = _compute_effective_backend_map(
         _raw.steps,
         backend_name,
@@ -144,7 +144,7 @@ def test_dispatch_feasible_per_backend(recipe_name: str, backend_name: str, monk
         lambda name: "/usr/local/bin/claude" if name == "claude" else None,
     )
     backend = get_backend(backend_name)
-    _raw = load_recipe(_PROJECT_ROOT / ".autoskillit" / "recipes" / f"{recipe_name}.yaml")
+    _raw = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
     _eff_map = _compute_effective_backend_map(
         _raw.steps,
         backend_name,

--- a/tests/recipe/test_recipe_backend_composition_matrix.py
+++ b/tests/recipe/test_recipe_backend_composition_matrix.py
@@ -15,7 +15,7 @@ import pytest
 from autoskillit.core import Severity
 from autoskillit.execution.backends import BACKEND_REGISTRY, get_backend
 from autoskillit.recipe._api import load_and_validate
-from autoskillit.recipe.io import all_validated_recipe_names, builtin_recipes_dir, load_recipe
+from autoskillit.recipe.io import all_validated_recipe_names, list_recipes, load_recipe
 from autoskillit.server.tools._auto_overrides import (
     _backend_capability_overrides,
     _compute_effective_backend_map,
@@ -27,6 +27,7 @@ pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 _ALL_RECIPE_NAMES = sorted(all_validated_recipe_names(_PROJECT_ROOT))
+_RECIPE_PATHS: dict[str, Path] = {r.name: r.path for r in list_recipes(_PROJECT_ROOT).items}
 _BACKEND_NAMES = sorted(BACKEND_REGISTRY.keys())
 
 
@@ -77,7 +78,7 @@ def test_recipe_backend_matrix_cell(recipe_name: str, backend_name: str, monkeyp
         lambda name: "/usr/local/bin/claude" if name == "claude" else None,
     )
     backend = get_backend(backend_name)
-    _raw = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+    _raw = load_recipe(_RECIPE_PATHS[recipe_name])
     _eff_map = _compute_effective_backend_map(
         _raw.steps,
         backend_name,
@@ -133,10 +134,7 @@ def test_recipe_backend_matrix_cell(recipe_name: str, backend_name: str, monkeyp
     )
 
 
-@pytest.mark.parametrize(
-    "recipe_name,backend_name",
-    [pytest.param(r, b, id=f"{r}/{b}") for r, b in _MATRIX_IDS],
-)
+@pytest.mark.parametrize("recipe_name,backend_name", _apply_marks(_MATRIX_IDS))
 def test_dispatch_feasible_per_backend(recipe_name: str, backend_name: str, monkeypatch) -> None:
     """Dispatch feasibility must reflect gate_backend_write reachability per backend."""
     monkeypatch.setattr(
@@ -144,7 +142,7 @@ def test_dispatch_feasible_per_backend(recipe_name: str, backend_name: str, monk
         lambda name: "/usr/local/bin/claude" if name == "claude" else None,
     )
     backend = get_backend(backend_name)
-    _raw = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+    _raw = load_recipe(_RECIPE_PATHS[recipe_name])
     _eff_map = _compute_effective_backend_map(
         _raw.steps,
         backend_name,

--- a/tests/recipe/test_recipe_backend_composition_matrix.py
+++ b/tests/recipe/test_recipe_backend_composition_matrix.py
@@ -15,8 +15,11 @@ import pytest
 from autoskillit.core import Severity
 from autoskillit.execution.backends import BACKEND_REGISTRY, get_backend
 from autoskillit.recipe._api import load_and_validate
-from autoskillit.recipe.io import all_validated_recipe_names
-from autoskillit.server.tools._auto_overrides import _backend_capability_overrides
+from autoskillit.recipe.io import all_validated_recipe_names, load_recipe
+from autoskillit.server.tools._auto_overrides import (
+    _backend_capability_overrides,
+    _compute_effective_backend_map,
+)
 from autoskillit.workspace.skills import DefaultSkillResolver
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
@@ -28,25 +31,9 @@ _BACKEND_NAMES = sorted(BACKEND_REGISTRY.keys())
 
 
 # -- By-design unsupported combos (skip) ------------------------------------
-DECLARED_UNSUPPORTED: frozenset[tuple[str, str]] = frozenset(
-    {
-        ("implementation", "codex"),
-        ("implementation-groups", "codex"),
-        ("remediation", "codex"),
-    }
-)
+DECLARED_UNSUPPORTED: frozenset[tuple[str, str]] = frozenset()
 
-UNSUPPORTED_REASONS: dict[tuple[str, str], dict[str, str]] = {
-    ("implementation", "codex"): {
-        "reason": "merge-conflict steps (resolve-merge-conflicts) require claude-code backend",
-    },
-    ("implementation-groups", "codex"): {
-        "reason": "merge-conflict steps (resolve-merge-conflicts) require claude-code backend",
-    },
-    ("remediation", "codex"): {
-        "reason": "merge-conflict steps (resolve-merge-conflicts) require claude-code backend",
-    },
-}
+UNSUPPORTED_REASONS: dict[tuple[str, str], dict[str, str]] = {}
 
 _MATRIX_IDS: list[tuple[str, str]] = [
     (r, b) for r in _ALL_RECIPE_NAMES for b in _BACKEND_NAMES if (r, b) not in DECLARED_UNSUPPORTED
@@ -84,12 +71,25 @@ def _apply_marks(matrix_ids: list[tuple[str, str]]) -> list[Any]:
 
 
 @pytest.mark.parametrize("recipe_name,backend_name", _apply_marks(_MATRIX_IDS))
-def test_recipe_backend_matrix_cell(recipe_name: str, backend_name: str) -> None:
+def test_recipe_backend_matrix_cell(recipe_name: str, backend_name: str, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "autoskillit.server.tools._auto_overrides.shutil.which",
+        lambda name: "/usr/local/bin/claude" if name == "claude" else None,
+    )
     backend = get_backend(backend_name)
+    _raw = load_recipe(_PROJECT_ROOT / ".autoskillit" / "recipes" / f"{recipe_name}.yaml")
+    _eff_map = _compute_effective_backend_map(
+        _raw.steps,
+        backend_name,
+        None,
+        recipe_name,
+        skill_resolver=_SKILL_RESOLVER,
+    )
     result = load_and_validate(
         recipe_name,
         project_dir=_PROJECT_ROOT,
         backend_name=backend_name,
+        effective_backend_map=_eff_map,
         ingredient_overrides=_backend_capability_overrides(backend),
         lister=_SKILL_RESOLVER,
     )
@@ -137,13 +137,26 @@ def test_recipe_backend_matrix_cell(recipe_name: str, backend_name: str) -> None
     "recipe_name,backend_name",
     [pytest.param(r, b, id=f"{r}/{b}") for r, b in _MATRIX_IDS],
 )
-def test_dispatch_feasible_per_backend(recipe_name: str, backend_name: str) -> None:
+def test_dispatch_feasible_per_backend(recipe_name: str, backend_name: str, monkeypatch) -> None:
     """Dispatch feasibility must reflect gate_backend_write reachability per backend."""
+    monkeypatch.setattr(
+        "autoskillit.server.tools._auto_overrides.shutil.which",
+        lambda name: "/usr/local/bin/claude" if name == "claude" else None,
+    )
     backend = get_backend(backend_name)
+    _raw = load_recipe(_PROJECT_ROOT / ".autoskillit" / "recipes" / f"{recipe_name}.yaml")
+    _eff_map = _compute_effective_backend_map(
+        _raw.steps,
+        backend_name,
+        None,
+        recipe_name,
+        skill_resolver=_SKILL_RESOLVER,
+    )
     result = load_and_validate(
         recipe_name,
         project_dir=_PROJECT_ROOT,
         backend_name=backend_name,
+        effective_backend_map=_eff_map,
         ingredient_overrides=_backend_capability_overrides(backend),
         lister=_SKILL_RESOLVER,
     )

--- a/tests/recipe/test_recipe_backend_composition_matrix.py
+++ b/tests/recipe/test_recipe_backend_composition_matrix.py
@@ -134,7 +134,10 @@ def test_recipe_backend_matrix_cell(recipe_name: str, backend_name: str, monkeyp
     )
 
 
-@pytest.mark.parametrize("recipe_name,backend_name", _apply_marks(_MATRIX_IDS))
+@pytest.mark.parametrize(
+    "recipe_name,backend_name",
+    [pytest.param(r, b, id=f"{r}/{b}") for r, b in _MATRIX_IDS],
+)
 def test_dispatch_feasible_per_backend(recipe_name: str, backend_name: str, monkeypatch) -> None:
     """Dispatch feasibility must reflect gate_backend_write reachability per backend."""
     monkeypatch.setattr(

--- a/tests/recipe/test_recipe_composition_vacuous_gate.py
+++ b/tests/recipe/test_recipe_composition_vacuous_gate.py
@@ -237,3 +237,80 @@ def test_compute_capability_feasibility_feasible_when_capability_route_active(
     assert result.get("dispatch_feasible") is True, (
         f"Recipe '{recipe_name}' with capability route active must be dispatch_feasible=True"
     )
+
+
+@pytest.mark.parametrize(
+    "recipe_name",
+    ["implementation", "remediation", "implementation-groups"],
+)
+def test_capability_route_binary_absent_fails_closed(
+    recipe_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """R0 REQ-TEST-007 (binary-absent half): real recipe YAML, real resolver,
+    real backend registry, only shutil.which mocked. With the claude binary
+    absent the capability route fails closed — the override stays 'false'
+    (resolution_path='capability_route_no_binary'), guarded steps prune, and
+    admission refuses with the gate reachable instead of admitting a pipeline
+    that would crash at dispatch."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from autoskillit.recipe._api import load_and_validate
+    from autoskillit.recipe.io import find_recipe_by_name, load_recipe
+    from autoskillit.server.tools._auto_overrides import (
+        _compute_effective_backend_map,
+        _provider_aware_capability_overrides,
+    )
+    from autoskillit.workspace.skills import DefaultSkillResolver
+
+    monkeypatch.setattr(
+        "autoskillit.server.tools._auto_overrides.shutil.which",
+        lambda name: None,
+    )
+    resolver = DefaultSkillResolver()
+    _info = find_recipe_by_name(recipe_name, _PROJECT_ROOT)
+    assert _info is not None, f"Recipe {recipe_name!r} not found"
+    raw = load_recipe(_info.path)
+
+    # Minimal codex-shaped backend stand-in: tests/recipe may not import
+    # autoskillit.execution (layer boundary), and only these two capability
+    # flags are consulted by the override computation.
+    codex_like = MagicMock()
+    codex_like.name = "codex"
+    codex_like.capabilities = SimpleNamespace(
+        git_metadata_writable=False,
+        anthropic_provider_capable=False,
+    )
+    overrides, detail = _provider_aware_capability_overrides(
+        codex_like,
+        recipe_name,
+        None,
+        raw.steps,
+        skill_resolver=resolver,
+    )
+    assert overrides["backend_supports_git_write"] == "false"
+    assert detail.resolution_path == "capability_route_no_binary"
+
+    eff_map = _compute_effective_backend_map(
+        raw.steps,
+        "codex",
+        None,
+        recipe_name,
+        skill_resolver=resolver,
+    )
+    result = load_and_validate(
+        recipe_name,
+        project_dir=_PROJECT_ROOT,
+        effective_backend_map=eff_map,
+        ingredient_overrides=overrides,
+        backend_name="codex",
+        lister=resolver,
+    )
+    assert result.get("dispatch_feasible") is False, (
+        f"Recipe '{recipe_name}' with binary absent must refuse (fail closed); "
+        f"got dispatch_feasible={result.get('dispatch_feasible')}"
+    )
+    assert "gate_backend_write" in result.get("infeasible_steps", []), (
+        f"Refusal must name the reachable gate; got: {result.get('infeasible_steps')}"
+    )

--- a/tests/recipe/test_recipe_composition_vacuous_gate.py
+++ b/tests/recipe/test_recipe_composition_vacuous_gate.py
@@ -206,7 +206,7 @@ def test_compute_capability_feasibility_feasible_when_capability_route_active(
     making dispatch_feasible=True for codex+implementation. Decision record: gate
     is vacuous-by-design on codex when the binary is present."""
     from autoskillit.recipe._api import load_and_validate
-    from autoskillit.recipe.io import load_recipe
+    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
     from autoskillit.server.tools._auto_overrides import _compute_effective_backend_map
     from autoskillit.workspace.skills import DefaultSkillResolver
 
@@ -215,7 +215,7 @@ def test_compute_capability_feasibility_feasible_when_capability_route_active(
         lambda name: "/usr/local/bin/claude" if name == "claude" else None,
     )
     resolver = DefaultSkillResolver()
-    raw = load_recipe(_PROJECT_ROOT / ".autoskillit" / "recipes" / f"{recipe_name}.yaml")
+    raw = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
     eff_map = _compute_effective_backend_map(
         raw.steps,
         "codex",

--- a/tests/recipe/test_recipe_composition_vacuous_gate.py
+++ b/tests/recipe/test_recipe_composition_vacuous_gate.py
@@ -191,3 +191,47 @@ def test_compute_capability_feasibility_returns_infeasible_for_codex_recipes(
         f"Recipe '{recipe_name}' must list gate_backend_write in infeasible_steps; "
         f"got: {result.get('infeasible_steps')}"
     )
+
+
+@pytest.mark.parametrize(
+    "recipe_name",
+    ["implementation", "remediation", "implementation-groups"],
+)
+def test_compute_capability_feasibility_feasible_when_capability_route_active(
+    recipe_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """R0: when capability-driven routing fires (skill_resolver + binary present),
+    the effective backend map routes git_metadata_write steps to claude-code,
+    making dispatch_feasible=True for codex+implementation. Decision record: gate
+    is vacuous-by-design on codex when the binary is present."""
+    from autoskillit.recipe._api import load_and_validate
+    from autoskillit.recipe.io import load_recipe
+    from autoskillit.server.tools._auto_overrides import _compute_effective_backend_map
+    from autoskillit.workspace.skills import DefaultSkillResolver
+
+    monkeypatch.setattr(
+        "autoskillit.server.tools._auto_overrides.shutil.which",
+        lambda name: "/usr/local/bin/claude" if name == "claude" else None,
+    )
+    resolver = DefaultSkillResolver()
+    raw = load_recipe(_PROJECT_ROOT / ".autoskillit" / "recipes" / f"{recipe_name}.yaml")
+    eff_map = _compute_effective_backend_map(
+        raw.steps,
+        "codex",
+        None,
+        recipe_name,
+        skill_resolver=resolver,
+    )
+    assert eff_map is not None
+    result = load_and_validate(
+        recipe_name,
+        project_dir=_PROJECT_ROOT,
+        effective_backend_map=eff_map,
+        ingredient_overrides={"backend_supports_git_write": "true"},
+        backend_name="codex",
+        lister=resolver,
+    )
+    assert result.get("dispatch_feasible") is True, (
+        f"Recipe '{recipe_name}' with capability route active must be dispatch_feasible=True"
+    )

--- a/tests/recipe/test_recipe_composition_vacuous_gate.py
+++ b/tests/recipe/test_recipe_composition_vacuous_gate.py
@@ -206,7 +206,7 @@ def test_compute_capability_feasibility_feasible_when_capability_route_active(
     making dispatch_feasible=True for codex+implementation. Decision record: gate
     is vacuous-by-design on codex when the binary is present."""
     from autoskillit.recipe._api import load_and_validate
-    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+    from autoskillit.recipe.io import find_recipe_by_name, load_recipe
     from autoskillit.server.tools._auto_overrides import _compute_effective_backend_map
     from autoskillit.workspace.skills import DefaultSkillResolver
 
@@ -215,7 +215,9 @@ def test_compute_capability_feasibility_feasible_when_capability_route_active(
         lambda name: "/usr/local/bin/claude" if name == "claude" else None,
     )
     resolver = DefaultSkillResolver()
-    raw = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+    _info = find_recipe_by_name(recipe_name, _PROJECT_ROOT)
+    assert _info is not None, f"Recipe {recipe_name!r} not found"
+    raw = load_recipe(_info.path)
     eff_map = _compute_effective_backend_map(
         raw.steps,
         "codex",

--- a/tests/recipe/test_rules_backend_compat.py
+++ b/tests/recipe/test_rules_backend_compat.py
@@ -225,7 +225,44 @@ class TestBundledRecipeBackendCompat:
     def recipe_name(self, request: pytest.FixtureRequest) -> str:
         return request.param
 
-    def test_codex_backend_fires_for_git_metadata_skills(self, recipe_name) -> None:
+    def test_codex_backend_fires_for_git_metadata_skills(
+        self, recipe_name, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "autoskillit.server.tools._auto_overrides.shutil.which",
+            lambda name: "/usr/local/bin/claude" if name == "claude" else None,
+        )
+        from autoskillit.recipe._analysis import make_validation_context
+        from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+        from autoskillit.recipe.registry import run_semantic_rules
+        from autoskillit.server.tools._auto_overrides import _compute_effective_backend_map
+        from autoskillit.workspace.skills import DefaultSkillResolver
+
+        recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+        resolver = DefaultSkillResolver()
+        eff_map = _compute_effective_backend_map(
+            recipe.steps,
+            "codex",
+            None,
+            recipe_name,
+            skill_resolver=resolver,
+        )
+        ctx = make_validation_context(
+            recipe,
+            backend_name="codex",
+            skill_resolver=resolver,
+            effective_backend_map=eff_map,
+            available_skills=frozenset(s.name for s in resolver.list_all()),
+        )
+        findings = run_semantic_rules(ctx)
+        compat_findings = [f for f in findings if f.rule == "backend-incompatible-skill"]
+        assert compat_findings == [], (
+            f"Expected zero backend-incompatible-skill findings for {recipe_name} "
+            f"on codex backend when capability route is active; "
+            f"got {len(compat_findings)} findings"
+        )
+
+    def test_codex_backend_fires_without_effective_backend_map(self, recipe_name) -> None:
         from autoskillit.recipe._analysis import make_validation_context
         from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
         from autoskillit.recipe.registry import run_semantic_rules
@@ -243,28 +280,7 @@ class TestBundledRecipeBackendCompat:
         compat_findings = [f for f in findings if f.rule == "backend-incompatible-skill"]
         assert len(compat_findings) >= 1, (
             f"Expected at least 1 backend-incompatible-skill finding for {recipe_name} "
-            f"on codex backend (implement step uses git_metadata_write skill)"
-        )
-        step_names = {f.step_name for f in compat_findings}
-        expected_steps = {
-            "implement",
-            "retry_worktree",
-            "fix",
-            "merge_gate_fix",
-            "rebase_conflict_fix",
-            "resolve_review",
-            "resolve_pre_review_conflicts",
-        }
-        recipe_aware_expected = expected_steps - {"assess", "merge_gate_assess"}
-        if recipe_name == "remediation":
-            recipe_aware_expected = (expected_steps - {"fix", "merge_gate_fix"}) | {
-                "assess",
-                "merge_gate_assess",
-            }
-        missing = recipe_aware_expected - step_names
-        assert not missing, (
-            f"Expected findings for steps {missing} in {recipe_name} on codex backend, "
-            f"got findings for: {step_names}"
+            f"on codex backend without effective_backend_map (rule must still fire)"
         )
 
     def test_claude_code_backend_no_findings(self, recipe_name) -> None:

--- a/tests/server/test_admission_dispatch_agreement.py
+++ b/tests/server/test_admission_dispatch_agreement.py
@@ -87,17 +87,27 @@ def _dispatch_effective_backends(
 
 @pytest.mark.parametrize("recipe_name", _RECIPES, ids=lambda x: x)
 @pytest.mark.parametrize("backend_name", _BACKENDS, ids=lambda x: x)
-def test_admission_dispatch_agreement(recipe_name: str, backend_name: str) -> None:
+def test_admission_dispatch_agreement(
+    recipe_name: str, backend_name: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Admission agreement: when load_and_validate returns dispatch_feasible=True,
     every surviving run_skill step must pass _is_backend_incompatible against
     the dispatch-time effective backend."""
+    monkeypatch.setattr(
+        "autoskillit.server.tools._auto_overrides.shutil.which",
+        lambda name: "/usr/local/bin/claude" if name == "claude" else None,
+    )
     backend = get_backend(backend_name)
     ingredient_overrides = _backend_capability_overrides(backend)
 
     # Pre-load recipe to compute effective backend map (mirrors IL-3 call sites).
     raw_recipe = load_recipe_yaml(_BUILTIN_DIR / f"{recipe_name}.yaml")
     effective_map = _compute_effective_backend_map(
-        raw_recipe.steps, backend_name, None, recipe_name
+        raw_recipe.steps,
+        backend_name,
+        None,
+        recipe_name,
+        skill_resolver=_SKILL_RESOLVER,
     )
 
     result = load_and_validate(

--- a/tests/server/test_admission_dispatch_agreement.py
+++ b/tests/server/test_admission_dispatch_agreement.py
@@ -163,3 +163,189 @@ def test_admission_dispatch_agreement(
     assert not unresolvable, "Unresolvable skills (test infra gap):\n  " + "\n  ".join(
         unresolvable
     )
+
+
+# ---------------------------------------------------------------------------
+# Capability-route unit tests (audit remediation: Tests 3a–3d, REQ-ADMIT-002)
+# ---------------------------------------------------------------------------
+
+
+def _mock_git_write_resolver():
+    """Resolver whose every skill carries git_metadata_write → claude-code."""
+    from unittest.mock import MagicMock
+
+    info = MagicMock()
+    info.uses_capabilities = frozenset({"git_metadata_write"})
+    info.backend_requirements = frozenset({"claude-code"})
+    resolver = MagicMock()
+    resolver.resolve.return_value = info
+    return resolver
+
+
+def _mock_run_skill_step():
+    """Minimal run_skill step shape consumed by the admission helpers."""
+    from unittest.mock import MagicMock
+
+    step = MagicMock()
+    step.tool = "run_skill"
+    step.provider = ""
+    step.with_args = {"skill_command": "/autoskillit:resolve-failures"}
+    step.skip_when_false = "inputs.backend_supports_git_write"
+    return step
+
+
+def test_effective_backend_map_capability_route_unit() -> None:
+    """Test 3a: _compute_effective_backend_map routes a git_metadata_write step
+    to claude-code when a skill_resolver is supplied."""
+    from autoskillit.config._config_dataclasses import ProvidersConfig
+
+    eff_map = _compute_effective_backend_map(
+        {"fix": _mock_run_skill_step()},
+        "codex",
+        ProvidersConfig(),
+        "implementation",
+        skill_resolver=_mock_git_write_resolver(),
+    )
+    assert eff_map is not None
+    assert eff_map["fix"] == "claude-code"
+
+
+def test_provider_aware_overrides_capability_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test 3b: capability route with binary present flips the override to 'true'
+    with resolution_path='capability_route'."""
+    from autoskillit.config._config_dataclasses import ProvidersConfig
+    from autoskillit.server.tools._auto_overrides import _provider_aware_capability_overrides
+
+    monkeypatch.setattr(
+        "autoskillit.server.tools._auto_overrides.shutil.which",
+        lambda name: "/usr/local/bin/claude" if name == "claude" else None,
+    )
+    overrides, detail = _provider_aware_capability_overrides(
+        get_backend("codex"),
+        "implementation",
+        ProvidersConfig(),
+        {"fix": _mock_run_skill_step()},
+        skill_resolver=_mock_git_write_resolver(),
+    )
+    assert overrides["backend_supports_git_write"] == "true"
+    assert detail.resolution_path == "capability_route"
+
+
+def test_provider_aware_overrides_capability_route_no_binary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test 3c: capability route with binary ABSENT fails closed —
+    override stays 'false' with resolution_path='capability_route_no_binary'."""
+    from autoskillit.config._config_dataclasses import ProvidersConfig
+    from autoskillit.server.tools._auto_overrides import _provider_aware_capability_overrides
+
+    monkeypatch.setattr(
+        "autoskillit.server.tools._auto_overrides.shutil.which",
+        lambda name: None,
+    )
+    overrides, detail = _provider_aware_capability_overrides(
+        get_backend("codex"),
+        "implementation",
+        ProvidersConfig(),
+        {"fix": _mock_run_skill_step()},
+        skill_resolver=_mock_git_write_resolver(),
+    )
+    assert overrides["backend_supports_git_write"] == "false"
+    assert detail.resolution_path == "capability_route_no_binary"
+
+
+def test_provider_aware_overrides_capability_route_none_providers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test 3d (REQ-ADMIT-002): the capability branch functions when
+    config_providers is None — zero provider config is the primary R0 scenario."""
+    from autoskillit.server.tools._auto_overrides import _provider_aware_capability_overrides
+
+    monkeypatch.setattr(
+        "autoskillit.server.tools._auto_overrides.shutil.which",
+        lambda name: "/usr/local/bin/claude" if name == "claude" else None,
+    )
+    overrides, detail = _provider_aware_capability_overrides(
+        get_backend("codex"),
+        "implementation",
+        None,
+        {"fix": _mock_run_skill_step()},
+        skill_resolver=_mock_git_write_resolver(),
+    )
+    assert overrides["backend_supports_git_write"] == "true"
+    assert detail.resolution_path == "capability_route"
+
+
+def test_admission_dispatch_agreement_real_providers_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """REQ-TEST-006: the agreement contract exercised with a real (non-None)
+    ProvidersConfig on codex+implementation — the combination the original
+    incident chain shipped unchecked. Capability route + partial provider
+    override must yield an admissible recipe with zero dispatch disagreements."""
+    from autoskillit.config._config_dataclasses import ProvidersConfig
+    from autoskillit.server.tools._auto_overrides import _provider_aware_capability_overrides
+
+    monkeypatch.setattr(
+        "autoskillit.server.tools._auto_overrides.shutil.which",
+        lambda name: "/usr/local/bin/claude" if name == "claude" else None,
+    )
+    providers = ProvidersConfig(
+        profiles={"minimax": {"ANTHROPIC_BASE_URL": "https://api.minimax.chat/v1"}},
+        step_overrides={"implement": "minimax"},
+    )
+    backend = get_backend("codex")
+    raw_recipe = load_recipe_yaml(_BUILTIN_DIR / "implementation.yaml")
+
+    overrides, _detail = _provider_aware_capability_overrides(
+        backend,
+        "implementation",
+        providers,
+        raw_recipe.steps,
+        skill_resolver=_SKILL_RESOLVER,
+    )
+    assert overrides["backend_supports_git_write"] == "true"
+
+    effective_map = _compute_effective_backend_map(
+        raw_recipe.steps,
+        "codex",
+        providers,
+        "implementation",
+        skill_resolver=_SKILL_RESOLVER,
+    )
+    assert effective_map is not None
+
+    result = load_and_validate(
+        "implementation",
+        project_dir=_PROJECT_ROOT,
+        backend_name="codex",
+        ingredient_overrides=overrides,
+        effective_backend_map=effective_map,
+        lister=_SKILL_RESOLVER,
+    )
+    assert result.get("valid") is True
+    assert result.get("dispatch_feasible") is True
+
+    dispatch_backends = _dispatch_effective_backends(raw_recipe, "codex", effective_map)
+    violations: list[str] = []
+    for step_name, step in raw_recipe.steps.items():
+        if getattr(step, "tool", None) != "run_skill":
+            continue
+        skill_cmd = getattr(step, "with_args", {}).get("skill_command", "")
+        if "${" in skill_cmd or "<" in skill_cmd or "{" in skill_cmd:
+            continue
+        skill_name = skill_cmd.lstrip("/").split()[0] if skill_cmd.lstrip("/") else ""
+        skill_name = skill_name.removeprefix("autoskillit:")
+        if not skill_name:
+            continue
+        skill_info = _SKILL_RESOLVER.resolve(skill_name)
+        if skill_info is None:
+            continue
+        step_effective = dispatch_backends.get(step_name)
+        if step_effective is None:
+            continue
+        if _is_backend_incompatible(skill_info, step_effective):
+            violations.append(f"{step_name}: '{skill_name}' vs '{step_effective}'")
+    assert not violations, "Agreement violated under real ProvidersConfig:\n  " + "\n  ".join(
+        violations
+    )

--- a/tests/server/test_backend_ingredient_injection.py
+++ b/tests/server/test_backend_ingredient_injection.py
@@ -496,14 +496,25 @@ class TestRealCompositionPruning:
         )
 
     @pytest.mark.anyio
-    async def test_codex_open_kitchen_blocks_on_reachable_gate(self, tmp_path: Path) -> None:
+    async def test_codex_open_kitchen_blocks_on_reachable_gate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """End-to-end integration: open_kitchen with codex backend on the bundled
         implementation recipe must hard-block because gate_backend_write is reachable
         post-prune (route-repair redirects create_impl_worktree.on_success to the
         gate after implement is pruned). Admission control reports dispatch_feasible=False
         and open_kitchen must reject the pipeline.
+
+        The claude binary is forced absent so the R0 capability route fails closed
+        (capability_route_no_binary) — the block is deterministic regardless of the
+        local claude installation.
         """
         from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+        monkeypatch.setattr(
+            "autoskillit.server.tools._auto_overrides.shutil.which",
+            lambda name: None,
+        )
 
         mock_ctx = MagicMock()
         mock_ctx.kitchen_id = "test-kitchen"

--- a/tests/server/test_capability_admission_e2e.py
+++ b/tests/server/test_capability_admission_e2e.py
@@ -1128,6 +1128,235 @@ async def test_dispatch_food_truck_partial_override_infeasible_includes_guidance
     assert "escape_hatch" in parsed
 
 
+def _make_git_write_step(name: str) -> MagicMock:
+    """Recipe step whose skill_command resolves to a git_metadata_write skill."""
+    step = _make_recipe_step(name, provider="")
+    step.with_args = {"skill_command": "/autoskillit:resolve-failures"}
+    return step
+
+
+def _make_git_write_resolver() -> MagicMock:
+    """Skill resolver whose every skill carries git_metadata_write."""
+    info = MagicMock()
+    info.uses_capabilities = frozenset({"git_metadata_write"})
+    info.backend_requirements = frozenset({"claude-code"})
+    resolver = MagicMock()
+    resolver.resolve.return_value = info
+    return resolver
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_capability_route_reaches_admission_with_true_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Step 5d sibling of Test 1B: open_kitchen with Codex + NO provider overrides
+    but capability route active (git_metadata_write skills + binary present) must
+    reach admission with backend_supports_git_write='true' and a claude-code
+    effective backend map — not the dispatch_infeasible envelope."""
+    import json
+    from unittest.mock import AsyncMock, patch
+
+    from autoskillit.server.tools.tools_kitchen import open_kitchen
+    from tests.server.conftest import _make_mock_ctx
+
+    monkeypatch.setattr(
+        "autoskillit.server.tools._auto_overrides.shutil.which",
+        lambda name: "/usr/local/bin/claude" if name == "claude" else None,
+    )
+
+    tool_ctx = _make_mock_ctx()
+    tool_ctx.gate.enabled = True
+    tool_ctx.gate_infrastructure_ready = True
+    tool_ctx.recipe_name = "implementation"
+    tool_ctx.kitchen_id = "test-kitchen"
+
+    from types import SimpleNamespace
+
+    tool_ctx.backend = MagicMock()
+    tool_ctx.backend.name = "codex"
+    tool_ctx.backend.capabilities = SimpleNamespace(
+        git_metadata_writable=False,
+        anthropic_provider_capable=False,
+    )
+    tool_ctx.skill_resolver = _make_git_write_resolver()
+
+    recipe_info = MagicMock()
+    recipe_info.path = Path("/fake/recipe.yaml")
+    tool_ctx.recipes.find.return_value = recipe_info
+
+    recipe_obj = MagicMock()
+    recipe_obj.name = "implementation"
+    recipe_obj.steps = {
+        "implement": _make_git_write_step("implement"),
+        "fix": _make_git_write_step("fix"),
+    }
+    tool_ctx.recipes.load.return_value = recipe_obj
+    tool_ctx.recipes.load_and_validate.return_value = _make_feasible_load_result()
+
+    fastmcp_ctx = AsyncMock()
+
+    with (
+        patch("autoskillit.server._get_ctx", return_value=tool_ctx),
+        patch(
+            "autoskillit.server._guards._resolve_provider_profile",
+            return_value=("", None),
+        ),
+    ):
+        result = await open_kitchen(name="implementation", ctx=fastmcp_ctx)
+
+    parsed = json.loads(result)
+    assert parsed.get("kitchen") != "dispatch_infeasible", (
+        f"capability route must prevent the dispatch_infeasible refusal; got: {parsed}"
+    )
+    lv_kwargs = tool_ctx.recipes.load_and_validate.call_args.kwargs
+    assert lv_kwargs["ingredient_overrides"]["backend_supports_git_write"] == "true"
+    assert lv_kwargs["effective_backend_map"]["fix"] == "claude-code"
+    assert lv_kwargs["effective_backend_map"]["implement"] == "claude-code"
+
+
+@pytest.mark.anyio
+async def test_load_recipe_capability_route_not_infeasible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Step 5d sibling of Test 1G: load_recipe with Codex + no provider overrides
+    but capability route active must not return the dispatch_infeasible response,
+    and must thread the capability-derived override and map into admission."""
+    import json
+    from unittest.mock import patch
+
+    from autoskillit.server.tools.tools_recipe import load_recipe
+    from tests.server.conftest import _make_mock_ctx
+
+    monkeypatch.setattr(
+        "autoskillit.server.tools._auto_overrides.shutil.which",
+        lambda name: "/usr/local/bin/claude" if name == "claude" else None,
+    )
+
+    tool_ctx = _make_mock_ctx()
+    tool_ctx.gate.enabled = True
+    tool_ctx.kitchen_id = "test-kitchen"
+
+    from types import SimpleNamespace
+
+    tool_ctx.backend = MagicMock()
+    tool_ctx.backend.name = "codex"
+    tool_ctx.backend.capabilities = SimpleNamespace(
+        git_metadata_writable=False,
+        anthropic_provider_capable=False,
+    )
+    tool_ctx.skill_resolver = _make_git_write_resolver()
+
+    recipe_info = MagicMock()
+    recipe_info.path = Path("/fake/recipe.yaml")
+    tool_ctx.recipes.find.return_value = recipe_info
+
+    recipe_obj = MagicMock()
+    recipe_obj.name = "implementation"
+    recipe_obj.steps = {
+        "implement": _make_git_write_step("implement"),
+        "fix": _make_git_write_step("fix"),
+    }
+    tool_ctx.recipes.load.return_value = recipe_obj
+    tool_ctx.recipes.load_and_validate.return_value = _make_feasible_load_result()
+
+    with (
+        patch(
+            "autoskillit.server.tools.tools_recipe._get_ctx_or_none",
+            return_value=tool_ctx,
+        ),
+        patch(
+            "autoskillit.server.tools.tools_recipe._require_enabled",
+            return_value=None,
+        ),
+        patch(
+            "autoskillit.server._guards._resolve_provider_profile",
+            return_value=("", None),
+        ),
+    ):
+        result = await load_recipe(name="implementation")
+
+    parsed = json.loads(result)
+    assert parsed.get("dispatch_infeasible") is not True
+    lv_kwargs = tool_ctx.recipes.load_and_validate.call_args.kwargs
+    assert lv_kwargs["ingredient_overrides"]["backend_supports_git_write"] == "true"
+    assert lv_kwargs["effective_backend_map"]["fix"] == "claude-code"
+
+
+@pytest.mark.anyio
+async def test_dispatch_food_truck_capability_route_no_binary_fails_closed(
+    build_ctx_open: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Step 5d sibling of Test 1H: fleet dispatch with capability-requiring steps
+    and the claude binary ABSENT keeps the fail-closed refusal — the capability
+    route must not admit a fleet pipeline it cannot actually route."""
+    import json
+    from unittest.mock import AsyncMock, patch
+
+    from autoskillit.core import BackendCapabilities
+
+    monkeypatch.setattr(
+        "autoskillit.server.tools._auto_overrides.shutil.which",
+        lambda name: None,
+    )
+
+    tool_ctx = build_ctx_open()
+
+    caps = BackendCapabilities(
+        applicable_guards=frozenset(),
+        anthropic_provider_capable=False,
+        git_metadata_writable=False,
+    )
+    backend = MagicMock()
+    backend.name = "codex"
+    backend.capabilities = caps
+    tool_ctx.backend = backend
+    tool_ctx.skill_resolver = _make_git_write_resolver()
+
+    tool_ctx.recipes = MagicMock()
+    recipe_info = MagicMock()
+    recipe_info.path = Path("/fake/recipe.yaml")
+    tool_ctx.recipes.find.return_value = recipe_info
+
+    recipe_obj = MagicMock()
+    recipe_obj.name = "implementation"
+    recipe_obj.steps = {
+        "implement": _make_git_write_step("implement"),
+        "fix": _make_git_write_step("fix"),
+    }
+    tool_ctx.recipes.load.return_value = recipe_obj
+    tool_ctx.recipes.load_and_validate.return_value = {
+        "valid": True,
+        "dispatch_feasible": False,
+        "infeasible_steps": ["gate_backend_write"],
+        "post_prune_step_names": ["implement"],
+    }
+
+    with (
+        patch("autoskillit.server._state._ctx", tool_ctx),
+        patch(
+            "autoskillit.server._guards._resolve_provider_profile",
+            return_value=("", None),
+        ),
+        patch(
+            "autoskillit.server.tools.tools_fleet_dispatch._require_fleet",
+            lambda _name: None,
+        ),
+    ):
+        from autoskillit.server.tools.tools_fleet_dispatch import dispatch_food_truck
+
+        result = await dispatch_food_truck(
+            recipe="implementation",
+            task="test task",
+            ctx=AsyncMock(),
+        )
+
+    parsed = json.loads(result)
+    assert "fleet_recipe_invalid" in parsed.get("error", "")
+    lv_kwargs = tool_ctx.recipes.load_and_validate.call_args.kwargs
+    assert lv_kwargs["ingredient_overrides"]["backend_supports_git_write"] == "false"
+
+
 def test_provider_override_any_step_with_base_url_flips_capability() -> None:
     """Codex backend with ONE guarded step having ANTHROPIC_BASE_URL
     and all other guarded steps lacking overrides → capability flips to 'true'

--- a/tests/server/test_tools_execution_backend_mixing.py
+++ b/tests/server/test_tools_execution_backend_mixing.py
@@ -107,51 +107,9 @@ async def test_anthropic_capable_backend_profile_without_base_url_no_override(
 async def test_skill_backend_requirement_triggers_incompatibility_gate(
     tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
-    """Skill with backend_requirements=[claude-code] on a non-claude backend
-    -> _is_backend_incompatible gate rejects the call (no silent override)."""
+    """Skill with backend_requirements=[claude-code] + git_metadata_write capability
+    on a non-claude backend triggers capability-driven auto-route when binary present."""
     import json
-    from unittest.mock import MagicMock
-
-    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
-    from tests.fakes import InMemoryHeadlessExecutor
-
-    executor = InMemoryHeadlessExecutor()
-    tool_ctx_kitchen_open.executor = executor
-    fake_backend = MagicMock(spec=CodingAgentBackend)
-    fake_backend.name = "codex"
-    fake_backend.capabilities.anthropic_provider_capable = False
-    tool_ctx_kitchen_open.backend = fake_backend
-    tool_ctx_kitchen_open.session_skill_manager = None
-
-    mock_skill_info = MagicMock()
-    mock_skill_info.backend_requirements = frozenset({"claude-code"})
-    mock_resolver = MagicMock()
-    mock_resolver.resolve.return_value = mock_skill_info
-    tool_ctx_kitchen_open.skill_resolver = mock_resolver
-
-    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
-    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
-    monkeypatch.setattr(_feat, lambda *a, **kw: True)
-    monkeypatch.setattr(
-        "autoskillit.server._guards._resolve_provider_profile",
-        lambda *a, **kw: ("default", {}),
-    )
-    monkeypatch.setattr(
-        "autoskillit.server.tools.tools_execution.resolve_target_skill",
-        lambda cmd, resolver: ("/autoskillit:test-skill", "test-skill"),
-    )
-
-    result = await run_skill("/autoskillit:probe", str(tmp_path))
-    data = json.loads(result)
-    assert data.get("subtype") == "crashed"
-    assert "requires backend" in data.get("result", "")
-
-
-@pytest.mark.anyio
-async def test_backend_incompatibility_does_not_emit_override_log(
-    tool_ctx_kitchen_open, tmp_path, monkeypatch
-) -> None:
-    """Skill-requirement incompatibility crashes (no override log emitted)."""
     from unittest.mock import MagicMock
 
     import structlog
@@ -169,6 +127,7 @@ async def test_backend_incompatibility_does_not_emit_override_log(
 
     mock_skill_info = MagicMock()
     mock_skill_info.backend_requirements = frozenset({"claude-code"})
+    mock_skill_info.uses_capabilities = frozenset({"git_metadata_write"})
     mock_resolver = MagicMock()
     mock_resolver.resolve.return_value = mock_skill_info
     tool_ctx_kitchen_open.skill_resolver = mock_resolver
@@ -184,6 +143,67 @@ async def test_backend_incompatibility_does_not_emit_override_log(
         "autoskillit.server.tools.tools_execution.resolve_target_skill",
         lambda cmd, resolver: ("/autoskillit:test-skill", "test-skill"),
     )
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution.shutil.which",
+        lambda name: "/usr/local/bin/claude" if name == "claude" else None,
+    )
+
+    with structlog.testing.capture_logs() as log_list:
+        result = await run_skill("/autoskillit:probe", str(tmp_path))
+    json.loads(result)
+
+    override_logs = [
+        entry for entry in log_list if entry.get("event") == "backend_override_activated"
+    ]
+    assert len(override_logs) == 1
+    log = override_logs[0]
+    assert log["reason"] == "skill_requirement"
+    assert log["target_backend"] == "claude-code"
+    assert len(executor.calls) == 1
+
+
+@pytest.mark.anyio
+async def test_backend_incompatibility_does_not_emit_override_log(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    """Skill-requirement capability route fires -> logger.info with reason='skill_requirement'."""
+    from unittest.mock import MagicMock
+
+    import structlog
+
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    fake_backend = MagicMock(spec=CodingAgentBackend)
+    fake_backend.name = "codex"
+    fake_backend.capabilities.anthropic_provider_capable = False
+    tool_ctx_kitchen_open.backend = fake_backend
+    tool_ctx_kitchen_open.session_skill_manager = None
+
+    mock_skill_info = MagicMock()
+    mock_skill_info.backend_requirements = frozenset({"claude-code"})
+    mock_skill_info.uses_capabilities = frozenset({"git_metadata_write"})
+    mock_resolver = MagicMock()
+    mock_resolver.resolve.return_value = mock_skill_info
+    tool_ctx_kitchen_open.skill_resolver = mock_resolver
+
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a, **kw: ("default", {}),
+    )
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution.resolve_target_skill",
+        lambda cmd, resolver: ("/autoskillit:test-skill", "test-skill"),
+    )
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution.shutil.which",
+        lambda name: "/usr/local/bin/claude" if name == "claude" else None,
+    )
 
     with structlog.testing.capture_logs() as log_list:
         await run_skill("/autoskillit:probe", str(tmp_path))
@@ -191,7 +211,10 @@ async def test_backend_incompatibility_does_not_emit_override_log(
     override_logs = [
         entry for entry in log_list if entry.get("event") == "backend_override_activated"
     ]
-    assert len(override_logs) == 0
+    assert len(override_logs) == 1
+    log = override_logs[0]
+    assert log["reason"] == "skill_requirement"
+    assert log["target_backend"] == "claude-code"
 
 
 @pytest.mark.anyio
@@ -251,11 +274,59 @@ async def test_backend_override_emits_structured_log_provider_profile(
 
 
 @pytest.mark.anyio
-async def test_backend_incompatibility_gate_rejects_before_init_session(
+async def test_backend_incompatibility_gate_rejects_before_init_session_binary_present(
     tool_ctx_kitchen_open, tmp_path, monkeypatch
 ) -> None:
-    """When skill requires claude-code and effective backend is codex,
-    the incompatibility gate rejects before init_session is called."""
+    """When skill requires claude-code (git_metadata_write) and binary IS present,
+    capability route fires — init_session IS called with the overridden backend."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    fake_backend = MagicMock(spec=CodingAgentBackend)
+    fake_backend.name = "codex"
+    fake_backend.capabilities.anthropic_provider_capable = False
+    tool_ctx_kitchen_open.backend = fake_backend
+
+    mock_ssm = MagicMock()
+    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+
+    mock_skill_info = MagicMock()
+    mock_skill_info.backend_requirements = frozenset({"claude-code"})
+    mock_skill_info.uses_capabilities = frozenset({"git_metadata_write"})
+    mock_resolver = MagicMock()
+    mock_resolver.resolve.return_value = mock_skill_info
+    tool_ctx_kitchen_open.skill_resolver = mock_resolver
+
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a, **kw: ("default", {}),
+    )
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution.resolve_target_skill",
+        lambda cmd, resolver: ("/autoskillit:test-skill", "test-skill"),
+    )
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution.shutil.which",
+        lambda name: "/usr/local/bin/claude" if name == "claude" else None,
+    )
+
+    await run_skill("/autoskillit:test-skill", str(tmp_path))
+    assert len(executor.calls) == 1
+
+
+@pytest.mark.anyio
+async def test_backend_incompatibility_gate_rejects_before_init_session_binary_absent(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    """When skill requires claude-code (git_metadata_write) and binary is ABSENT,
+    the binary probe crashes the call before init_session (REQ-ROUTE-004)."""
     import json
     from unittest.mock import MagicMock
 
@@ -274,6 +345,7 @@ async def test_backend_incompatibility_gate_rejects_before_init_session(
 
     mock_skill_info = MagicMock()
     mock_skill_info.backend_requirements = frozenset({"claude-code"})
+    mock_skill_info.uses_capabilities = frozenset({"git_metadata_write"})
     mock_resolver = MagicMock()
     mock_resolver.resolve.return_value = mock_skill_info
     tool_ctx_kitchen_open.skill_resolver = mock_resolver
@@ -289,11 +361,15 @@ async def test_backend_incompatibility_gate_rejects_before_init_session(
         "autoskillit.server.tools.tools_execution.resolve_target_skill",
         lambda cmd, resolver: ("/autoskillit:test-skill", "test-skill"),
     )
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution.shutil.which",
+        lambda name: None,
+    )
 
     result = await run_skill("/autoskillit:test-skill", str(tmp_path))
     data = json.loads(result)
     assert data.get("subtype") == "crashed"
-    assert "requires backend" in data.get("result", "")
+    assert "claude" in data.get("result", "").lower()
     mock_ssm.init_session.assert_not_called()
 
 

--- a/tests/server/test_tools_execution_backend_mixing.py
+++ b/tests/server/test_tools_execution_backend_mixing.py
@@ -160,6 +160,7 @@ async def test_skill_backend_requirement_triggers_incompatibility_gate(
     assert log["reason"] == "skill_requirement"
     assert log["target_backend"] == "claude-code"
     assert len(executor.calls) == 1
+    assert executor.calls[0].backend_override == "claude-code"
 
 
 @pytest.mark.anyio
@@ -434,3 +435,65 @@ async def test_provider_override_threads_effective_backend_to_init_session(
         "init_session must NOT receive the orchestrator backend"
     )
     assert init_backend.name == "claude-code"
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_capability_skill_not_auto_routed(
+    tool_ctx_kitchen_open, tmp_path, monkeypatch
+) -> None:
+    """REQ-ROUTE-003 negative guard: a skill whose claude-code requirement derives
+    from a capability OTHER than git_metadata_write (e.g. open_kitchen) must NOT
+    be auto-routed — the incompatibility gate rejects it with no override log,
+    even with the claude binary present."""
+    import json
+    from unittest.mock import MagicMock
+
+    import structlog
+
+    from autoskillit.core.types._type_protocols_backend import CodingAgentBackend
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    fake_backend = MagicMock(spec=CodingAgentBackend)
+    fake_backend.name = "codex"
+    fake_backend.capabilities.anthropic_provider_capable = False
+    tool_ctx_kitchen_open.backend = fake_backend
+    tool_ctx_kitchen_open.session_skill_manager = None
+
+    mock_skill_info = MagicMock()
+    mock_skill_info.backend_requirements = frozenset({"claude-code"})
+    mock_skill_info.uses_capabilities = frozenset({"open_kitchen"})
+    mock_resolver = MagicMock()
+    mock_resolver.resolve.return_value = mock_skill_info
+    tool_ctx_kitchen_open.skill_resolver = mock_resolver
+
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+    _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"
+    monkeypatch.setattr(_feat, lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a, **kw: ("default", {}),
+    )
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution.resolve_target_skill",
+        lambda cmd, resolver: ("/autoskillit:test-skill", "test-skill"),
+    )
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution.shutil.which",
+        lambda name: "/usr/local/bin/claude" if name == "claude" else None,
+    )
+
+    with structlog.testing.capture_logs() as log_list:
+        result = await run_skill("/autoskillit:test-skill", str(tmp_path))
+
+    data = json.loads(result)
+    assert data.get("subtype") == "crashed"
+    assert "requires backend" in data.get("result", "")
+    override_logs = [
+        entry for entry in log_list if entry.get("event") == "backend_override_activated"
+    ]
+    assert not override_logs, (
+        "capability route must not fire for open_kitchen-derived requirements"
+    )
+    assert len(executor.calls) == 0

--- a/tests/server/test_tools_execution_backend_mixing.py
+++ b/tests/server/test_tools_execution_backend_mixing.py
@@ -291,8 +291,7 @@ async def test_backend_incompatibility_gate_rejects_before_init_session_binary_p
     fake_backend.capabilities.anthropic_provider_capable = False
     tool_ctx_kitchen_open.backend = fake_backend
 
-    mock_ssm = MagicMock()
-    tool_ctx_kitchen_open.session_skill_manager = mock_ssm
+    tool_ctx_kitchen_open.session_skill_manager = None
 
     mock_skill_info = MagicMock()
     mock_skill_info.backend_requirements = frozenset({"claude-code"})

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -129,8 +129,10 @@ class TestModuleCascadeCore:
         )
 
     def test_type_protocols_workspace_cascade(self) -> None:
+        # server included since R0: server/tools/_auto_overrides.py consumes the
+        # SkillResolver protocol for capability-driven admission routing (#4174).
         assert MODULE_CASCADE_CORE["_type_protocols_workspace"] == frozenset(
-            {"core", "pipeline", "recipe", "workspace"}
+            {"core", "pipeline", "recipe", "server", "workspace"}
         )
 
     def test_type_checkpoint_entry_exists(self) -> None:
@@ -433,9 +435,11 @@ class TestBuildTestScopeCoreCascade:
         )
         assert result is not None
         dir_names = {p.name for p in result}
-        for pkg in ["core", "pipeline", "recipe", "workspace"]:
+        # server included since R0: server/tools/_auto_overrides.py consumes the
+        # SkillResolver protocol for capability-driven admission routing (#4174).
+        for pkg in ["core", "pipeline", "recipe", "server", "workspace"]:
             assert pkg in dir_names, f"_type_protocols_workspace cascade should include {pkg}"
-        for excluded in ["cli", "server", "execution", "fleet", "migration", "hooks"]:
+        for excluded in ["cli", "execution", "fleet", "migration", "hooks"]:
             assert excluded not in dir_names, (
                 f"_type_protocols_workspace cascade should not include {excluded}"
             )


### PR DESCRIPTION
## Summary

Restores the capability-driven backend auto-route (R0 from #4171, original design intent #3495): a codex-backend orchestrator automatically dispatches `run_skill` steps whose skills carry the `git_metadata_write` capability to **claude-code CLI workers**, with zero provider configuration. This removes the last blocker for full end-to-end codex pipeline runs — `open_kitchen(implementation|remediation|implementation-groups)` on codex now admits with no config, and admission and dispatch evaluate identical per-step logic.

Salvaged from the 2026-07-03 pipeline run for #4174 that was wrongly terminated `already_done` (implementation was complete in the worktree; a flaky Channel B test blocked the pre-remediation merge and the control flow closed the issue on a wrong-tree proxy). This PR contains that run's Part A implementation plus the audit-remediation test work it never got to finish.

## Changes

**Dispatch half** (`tools_execution.py`): `_skill_requires_claude` disjunct — routes to claude-code only when the requirement derives from `git_metadata_write` in `uses_capabilities` (structurally excludes `open_kitchen`-capability skills, REQ-ROUTE-003); emits `backend_override_activated` with `reason="skill_requirement"`; fail-closed `shutil.which("claude")` probe (REQ-ROUTE-004).

**Admission half** (`_auto_overrides.py`): the same capability disjunct in `_compute_effective_backend_map` (new `skill_resolver` param, threaded at all IL-3 call sites: open_kitchen, get_recipe, load_recipe, validate_recipe, dispatch_food_truck) and in `_provider_aware_capability_overrides` — `backend_supports_git_write="true"` via `resolution_path="capability_route"`, fail-closed `"capability_route_no_binary"`; the capability branch works with `config_providers=None` (REQ-ADMIT-002).

**Policy/test co-updates**: `DECLARED_UNSUPPORTED` drops the three codex combos (now supported); vacuous-gate test flipped consciously (gate is vacuous-by-design on codex with binary present — decision record in docstring); backend-mixing tests pin routed behavior incl. init_session-level `backend_override` assertion and the REQ-ROUTE-003 negative guard; agreement test armed with real resolver + a real-`ProvidersConfig` variant (REQ-TEST-006); capability-route unit tests for all three resolution paths (Tests 3a–3d); admission-threading siblings for open_kitchen/load_recipe and fleet no-binary fail-closed variant (Step 5d); binary-absent real-recipe E2E (REQ-TEST-007); `_type_protocols_workspace` cascade meta-tests updated (server now consumes the SkillResolver protocol).

**Flake stabilization**: the Channel B drain class that derailed the original run — `CHANNEL_B_NO_STDOUT_SCRIPT` create→marker gap 2.0s→3.0s (matches the passing adjudication sibling; 2.0s missed the marker under WSL2+xdist and burned the 300s outer timeout) and the third script consumer aligned to the stabilized budget.

## Test plan

- `pre-commit run --all-files` — all hooks pass (ruff, mypy, uv lock, gitleaks, arch checks)
- `task test-check` full suite — **29,218 passed, 0 failed**, 604 skipped, 49 xfailed
- Audit-impl NO GO findings (7) all addressed; empirical zero-config admissibility pinned by `test_compute_capability_feasibility_feasible_when_capability_route_active`

Closes #4174 (manual close required — develop-merge autoclose gap). Delivers #3495. Outstanding R0 half of #4171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
