### PR TITLE
dispatch_food_truck per-dispatch backend override (heterogeneous routing R1)

### DIFF
--- a/src/autoskillit/core/types/_type_enums.py
+++ b/src/autoskillit/core/types/_type_enums.py
@@ -450,6 +450,7 @@ class FleetErrorCode(StrEnum):
     FLEET_RESET_NOT_FOUND = "fleet_reset_not_found"
     FLEET_RESET_INVALID_TARGET = "fleet_reset_invalid_target"
     FLEET_RESET_STILL_RUNNING = "fleet_reset_still_running"
+    FLEET_INVALID_BACKEND = "fleet_invalid_backend"
 
 
 class FeatureLifecycle(StrEnum):

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -429,9 +429,10 @@ class DefaultHeadlessExecutor:
             if idle_cfg_val > 0:
                 merged_extras.setdefault("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(idle_cfg_val))
 
-        assert dispatch_backend is not None, (
-            "dispatch_backend must be resolved before dispatch_food_truck execution"
-        )
+        if dispatch_backend is None:
+            raise RuntimeError(
+                "dispatch_backend must be resolved before dispatch_food_truck execution"
+            )
         backend = dispatch_backend
         cmd_spec = backend.build_food_truck_cmd(
             orchestrator_prompt=orchestrator_prompt,

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -382,11 +382,28 @@ class DefaultHeadlessExecutor:
         backend_override: str | None = None,
         on_session_id_resolved: Callable[[str], None] | None = None,
     ) -> SkillResult:
-        if self._ctx.backend is not None and not self._ctx.backend.capabilities.food_truck_capable:
+        dispatch_backend: CodingAgentBackend | None
+        if backend_override is not None:
+            from autoskillit.execution.backends import get_backend
+
+            dispatch_backend = get_backend(backend_override)
+        else:
+            dispatch_backend = self._ctx.backend
+
+        if dispatch_backend is not None and not dispatch_backend.capabilities.food_truck_capable:
             raise RuntimeError(
                 f"backend does not support food truck dispatch "
-                f"(food_truck_capable=False); got {self._ctx.backend.name!r}"
+                f"(food_truck_capable=False); got {dispatch_backend.name!r}"
             )
+        if backend_override is not None:
+            assert dispatch_backend is not None
+            pre_launch_errors = dispatch_backend.ensure_pre_launch()
+            if pre_launch_errors:
+                raise RuntimeError(
+                    f"Pre-launch check failed for dispatch backend "
+                    f"{dispatch_backend.name!r}: {'; '.join(pre_launch_errors)}"
+                )
+
         cfg = self._ctx.config
         model_identity = resolve_model_identity(
             model, cfg, step_name=step_name, profile_name=profile_name
@@ -412,8 +429,10 @@ class DefaultHeadlessExecutor:
             if idle_cfg_val > 0:
                 merged_extras.setdefault("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(idle_cfg_val))
 
-        assert self._ctx.backend is not None, "ctx.backend must be set before dispatch_food_truck"
-        backend = self._ctx.backend
+        assert dispatch_backend is not None, (
+            "dispatch_backend must be resolved before dispatch_food_truck execution"
+        )
+        backend = dispatch_backend
         cmd_spec = backend.build_food_truck_cmd(
             orchestrator_prompt=orchestrator_prompt,
             plugin_source=self._ctx.plugin_source,
@@ -451,7 +470,7 @@ class DefaultHeadlessExecutor:
         )
 
         effective_marker_dir: Path | None = marker_dir or (
-            _resolve_session_log_dir(cwd, cast(CodingAgentBackend, self._ctx.backend))
+            _resolve_session_log_dir(cwd, cast(CodingAgentBackend, dispatch_backend))
             if cwd
             else None
         )
@@ -485,4 +504,5 @@ class DefaultHeadlessExecutor:
             session_id=session_id,
             model_identity=model_identity,
             on_session_id_resolved=on_session_id_resolved,
+            step_backend=dispatch_backend,
         )

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -35,6 +35,7 @@ from autoskillit.fleet.state_types import (
 )
 
 if TYPE_CHECKING:
+    from autoskillit.core import CodingAgentBackend
     from autoskillit.fleet.sidecar import IssueSidecarEntry
     from autoskillit.fleet.state import DispatchRecord, DispatchStateHandle
     from autoskillit.pipeline.context import ToolContext
@@ -190,6 +191,7 @@ async def execute_dispatch(
     resume_message: str | None = None,
     caller_instructions: str | None = None,
     provider_capability_overrides: dict[str, str] | None = None,
+    dispatch_backend: CodingAgentBackend | None = None,
 ) -> DispatchResult:
     """Execute a single food truck dispatch.
 
@@ -257,6 +259,7 @@ async def execute_dispatch(
             resume_message=resume_message,
             caller_instructions=caller_instructions,
             provider_capability_overrides=provider_capability_overrides,
+            dispatch_backend=dispatch_backend,
         )
     except asyncio.CancelledError:
         raise
@@ -318,6 +321,7 @@ async def _run_dispatch(
     resume_message: str | None = None,
     caller_instructions: str | None = None,
     provider_capability_overrides: dict[str, str] | None = None,
+    dispatch_backend: CodingAgentBackend | None = None,
 ) -> DispatchResult:
     """Inner dispatch body — called after lock acquisition."""
     from autoskillit.fleet.state import (
@@ -349,9 +353,11 @@ async def _run_dispatch(
             per_dispatch_state_path=None,
         )
 
+    _effective_backend = dispatch_backend if dispatch_backend is not None else tool_ctx.backend
+
     try:
         _capability_overrides = provider_capability_overrides or _build_capability_overrides(
-            tool_ctx.backend
+            _effective_backend
         )
         _merged_ingredients = {**(ingredients or {}), **_capability_overrides}
         validation_result = tool_ctx.recipes.load_and_validate(
@@ -360,7 +366,7 @@ async def _run_dispatch(
             suppressed=tool_ctx.config.migration.suppressed if tool_ctx.config else None,
             ingredient_overrides=_merged_ingredients,
             temp_dir=tool_ctx.temp_dir,
-            backend_name=tool_ctx.backend.name if tool_ctx.backend else None,
+            backend_name=_effective_backend.name if _effective_backend else None,
         )
     except ProcessStaleError as exc:
         return DispatchResult(
@@ -442,7 +448,7 @@ async def _run_dispatch(
     )
 
     _capability_overrides = provider_capability_overrides or _build_capability_overrides(
-        tool_ctx.backend
+        _effective_backend
     )
     effective_ingredients = apply_config_authoritative_overrides(
         effective_ingredients,
@@ -573,7 +579,7 @@ async def _run_dispatch(
     if quota_result.get("should_sleep"):
         await asyncio.sleep(quota_result.get("sleep_seconds", 0))
 
-    _locator = tool_ctx.backend.session_locator() if tool_ctx.backend is not None else None
+    _locator = _effective_backend.session_locator() if _effective_backend is not None else None
 
     if resume_session_id:
         _primary_jsonl = (
@@ -758,6 +764,9 @@ async def _run_dispatch(
                     on_spawn=_on_spawn,
                     sentinel_contract=sentinel_contract,
                     resume_message=resume_message,
+                    backend_override=dispatch_backend.name
+                    if dispatch_backend is not None
+                    else None,
                 )
 
         ended_at = time.time()
@@ -957,6 +966,7 @@ async def _run_dispatch(
         labels_cleaned=_labels_cleaned,
         issue_url=_issue_urls_raw,
         branch_name=_branch_name,
+        backend_name=_effective_backend.name if _effective_backend else "",
         resume_checkpoint=_checkpoint_to_dict(dispatch_checkpoint),
     )
 

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -26,6 +26,7 @@ _RETRY_IDENTITY_FIELDS: frozenset[str] = frozenset(
         "session_chain",
         "resume_count",
         "issue_url",
+        "backend_name",
     }
 )
 
@@ -130,6 +131,7 @@ class DispatchRecord:
     wait_seconds: float | None = None
     resets_at: str = ""
     resume_count: int = 0
+    backend_name: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -164,6 +166,7 @@ class DispatchRecord:
             "wait_seconds": self.wait_seconds,
             "resets_at": self.resets_at,
             "resume_count": self.resume_count,
+            "backend_name": self.backend_name,
         }
 
     @classmethod
@@ -224,6 +227,7 @@ class DispatchRecord:
             wait_seconds=d.get("wait_seconds"),
             resets_at=d.get("resets_at", ""),
             resume_count=d.get("resume_count", 0),
+            backend_name=d.get("backend_name", ""),
         )
 
     @classmethod

--- a/src/autoskillit/server/_misc.py
+++ b/src/autoskillit/server/_misc.py
@@ -20,16 +20,14 @@ from autoskillit.core import (
     get_logger,
 )
 from autoskillit.execution import (
-    BACKEND_REGISTRY as BACKEND_REGISTRY,
-)
-from autoskillit.execution import (
-    SCENARIO_STEP_NAME_ENV as SCENARIO_STEP_NAME_ENV,
-)
-from autoskillit.execution import (
+    BACKEND_REGISTRY,
     SessionState,
     clear_session_state,
     persist_session_state,
     resolve_remote_repo,
+)
+from autoskillit.execution import (
+    SCENARIO_STEP_NAME_ENV as SCENARIO_STEP_NAME_ENV,
 )
 from autoskillit.execution import (
     _refresh_quota_cache as _refresh_quota_cache,

--- a/src/autoskillit/server/_misc.py
+++ b/src/autoskillit/server/_misc.py
@@ -20,6 +20,9 @@ from autoskillit.core import (
     get_logger,
 )
 from autoskillit.execution import (
+    BACKEND_REGISTRY as BACKEND_REGISTRY,
+)
+from autoskillit.execution import (
     SCENARIO_STEP_NAME_ENV as SCENARIO_STEP_NAME_ENV,
 )
 from autoskillit.execution import (
@@ -69,9 +72,21 @@ from autoskillit.workspace import (
 
 if TYPE_CHECKING:
     from autoskillit.config import QuotaGuardConfig
-    from autoskillit.core import SkillResult
+    from autoskillit.core import CodingAgentBackend, SkillResult
 
 logger = get_logger(__name__)
+
+
+def resolve_backend_override(name: str) -> CodingAgentBackend:
+    """Resolve a backend name to a CodingAgentBackend instance.
+
+    Raises ValueError if the name is not in BACKEND_REGISTRY.
+    """
+    if name not in BACKEND_REGISTRY:
+        valid = ", ".join(sorted(BACKEND_REGISTRY))
+        raise ValueError(f"Unknown backend {name!r}. Valid names: {valid}")
+    return get_backend(name)
+
 
 _HOOK_CONFIG_FILENAME: str = _HOOK_CONFIG_PATH_COMPONENTS[-1]
 _HOOK_CONFIG_OVERLAY_FILENAME: str = ".hook_config_overlay.json"

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -296,7 +296,7 @@ async def dispatch_food_truck(
             SessionCheckpoint.from_dict(resume_checkpoint) if resume_checkpoint else None
         )
         tool_ctx = _get_ctx()
-        _override_backend = dispatch_backend or tool_ctx.backend
+        _override_backend = dispatch_backend if dispatch_backend is not None else tool_ctx.backend
         caller_session_id = find_caller_session_id(project_dir=tool_ctx.project_dir)
         effective_name = dispatch_name or recipe
 

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -175,6 +175,7 @@ async def dispatch_food_truck(
     skip_when: str | None = None,
     resume_message: str | None = None,
     caller_instructions: str | None = None,
+    backend: str | None = None,
     ctx: Context = CurrentContext(),
 ) -> str:
     """Dispatch a single food truck L2 session for one recipe.
@@ -225,6 +226,23 @@ async def dispatch_food_truck(
     try:
         if caller_instructions and len(caller_instructions) > _MAX_CALLER_INSTRUCTIONS_LEN:
             caller_instructions = caller_instructions[:_MAX_CALLER_INSTRUCTIONS_LEN]
+
+        from autoskillit.core import CodingAgentBackend  # noqa: PLC0415
+
+        dispatch_backend: CodingAgentBackend | None = None
+        if backend is not None:
+            from autoskillit.execution.backends import (  # noqa: PLC0415
+                BACKEND_REGISTRY,
+                get_backend,
+            )
+
+            if backend not in BACKEND_REGISTRY:
+                valid = ", ".join(sorted(BACKEND_REGISTRY))
+                return fleet_error(
+                    FleetErrorCode.FLEET_INVALID_BACKEND,
+                    f"Unknown backend {backend!r}. Valid names: {valid}",
+                )
+            dispatch_backend = get_backend(backend)
 
         # Feature guard: config authority check independent of MCP visibility state.
         # Fleet sessions open the gate unconditionally at boot; this catch-all ensures
@@ -284,6 +302,7 @@ async def dispatch_food_truck(
             SessionCheckpoint.from_dict(resume_checkpoint) if resume_checkpoint else None
         )
         tool_ctx = _get_ctx()
+        _override_backend = dispatch_backend or tool_ctx.backend
         caller_session_id = find_caller_session_id(project_dir=tool_ctx.project_dir)
         effective_name = dispatch_name or recipe
 
@@ -337,7 +356,7 @@ async def dispatch_food_truck(
                     else None
                 )
                 _capability_overrides, _cap_detail = _provider_aware_capability_overrides(
-                    tool_ctx.backend,
+                    _override_backend,
                     recipe,
                     tool_ctx.config.providers,
                     _preflight_raw_steps,
@@ -346,7 +365,7 @@ async def dispatch_food_truck(
                 _merged_ingredients = {**(ingredients or {}), **_capability_overrides}
                 _effective_backend_map = _compute_effective_backend_map(
                     _preflight_raw_steps,
-                    tool_ctx.backend.name if tool_ctx.backend else None,
+                    _override_backend.name if _override_backend else None,
                     tool_ctx.config.providers,
                     recipe,
                     skill_resolver=tool_ctx.skill_resolver,
@@ -357,7 +376,7 @@ async def dispatch_food_truck(
                     suppressed=tool_ctx.config.migration.suppressed if tool_ctx.config else None,
                     ingredient_overrides=_merged_ingredients,
                     temp_dir=tool_ctx.temp_dir,
-                    backend_name=tool_ctx.backend.name if tool_ctx.backend else None,
+                    backend_name=_override_backend.name if _override_backend else None,
                     effective_backend_map=_effective_backend_map,
                 )
             except Exception:
@@ -411,11 +430,11 @@ async def dispatch_food_truck(
             except Exception:
                 logger.warning("dispatch_food_truck_preflight_recipe_load_failed", exc_info=True)
 
-        if tool_ctx.backend is not None and _active_recipe_steps is not None:
+        if _override_backend is not None and _active_recipe_steps is not None:
             _preflight_err = _check_dispatch_feasibility(
                 post_prune_step_names=_fleet_load_result.get("post_prune_step_names", []),
                 active_recipe_steps=_active_recipe_steps,
-                backend=tool_ctx.backend,
+                backend=_override_backend,
                 config_providers=tool_ctx.config.providers,
                 recipe_name=recipe,
             )
@@ -423,8 +442,8 @@ async def dispatch_food_truck(
                 return _preflight_err
 
         _supports_quota = (
-            tool_ctx.backend is not None
-            and tool_ctx.backend.capabilities.anthropic_provider_capable
+            _override_backend is not None
+            and _override_backend.capabilities.anthropic_provider_capable
         )
         try:
             with anyio.fail_after(tool_ctx.config.run_skill.mcp_tool_timeout_sec):
@@ -437,8 +456,8 @@ async def dispatch_food_truck(
                     timeout_sec=timeout_sec,
                     prompt_builder=_get_food_truck_prompt_builder(
                         has_unguarded_filesystem_access=(
-                            tool_ctx.backend.capabilities.has_unguarded_filesystem_access
-                            if tool_ctx.backend
+                            _override_backend.capabilities.has_unguarded_filesystem_access
+                            if _override_backend
                             else False
                         ),
                     ),
@@ -457,6 +476,7 @@ async def dispatch_food_truck(
                     resume_message=resume_message,
                     caller_instructions=caller_instructions,
                     provider_capability_overrides=_capability_overrides,
+                    dispatch_backend=dispatch_backend,
                 )
         except TimeoutError:
             logger.error(

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -20,6 +20,7 @@ from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import (
     CapabilityResolutionDetail,
+    CodingAgentBackend,
     FleetErrorCode,
     SessionCheckpoint,
     detect_autoskillit_mcp_prefix,
@@ -48,7 +49,7 @@ from autoskillit.fleet import (
 )
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled, _require_fleet
-from autoskillit.server._misc import resolve_log_dir
+from autoskillit.server._misc import resolve_backend_override, resolve_log_dir
 from autoskillit.server._notify import track_response_size
 from autoskillit.server.tools._auto_overrides import (
     _compute_effective_backend_map,
@@ -227,22 +228,15 @@ async def dispatch_food_truck(
         if caller_instructions and len(caller_instructions) > _MAX_CALLER_INSTRUCTIONS_LEN:
             caller_instructions = caller_instructions[:_MAX_CALLER_INSTRUCTIONS_LEN]
 
-        from autoskillit.core import CodingAgentBackend  # noqa: PLC0415
-
         dispatch_backend: CodingAgentBackend | None = None
         if backend is not None:
-            from autoskillit.execution.backends import (  # noqa: PLC0415
-                BACKEND_REGISTRY,
-                get_backend,
-            )
-
-            if backend not in BACKEND_REGISTRY:
-                valid = ", ".join(sorted(BACKEND_REGISTRY))
+            try:
+                dispatch_backend = resolve_backend_override(backend)
+            except ValueError as exc:
                 return fleet_error(
                     FleetErrorCode.FLEET_INVALID_BACKEND,
-                    f"Unknown backend {backend!r}. Valid names: {valid}",
+                    str(exc),
                 )
-            dispatch_backend = get_backend(backend)
 
         # Feature guard: config authority check independent of MCP visibility state.
         # Fleet sessions open the gate unconditionally at boot; this catch-all ensures

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -203,7 +203,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "_type_helpers": frozenset({"core", "execution", "fleet", "pipeline", "recipe", "server"}),
     "_type_protocols_workspace": frozenset({"core", "pipeline", "recipe", "server", "workspace"}),
     "_type_protocols_backend": frozenset(
-        {"_llm_triage", "cli", "core", "execution", "pipeline", "server", "workspace"}
+        {"_llm_triage", "cli", "core", "execution", "fleet", "pipeline", "server", "workspace"}
     ),
     "_type_inspector": frozenset({"core", "execution"}),
     "_type_invariant_registry": frozenset({"core"}),
@@ -830,6 +830,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "cli",
             # file-level: fleet tests that import server tool handlers directly
             "fleet/test_api.py",
+            "fleet/test_dispatch_backend_override.py",
             "fleet/test_dispatch_crash_diagnostics.py",
             "fleet/test_fleet_e2e.py",
             "fleet/test_pack_enforcement.py",

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -16,7 +16,7 @@ NEW_HEADLESS_MODULES = [
     "_headless_execute.py",
 ]
 HEADLESS_SIZE_BUDGETS = {
-    "headless/__init__.py": 490,
+    "headless/__init__.py": 510,
     "headless/_headless_helpers.py": 220,
     "headless/_headless_execute.py": 616,
     "headless/_headless_recovery.py": 370,

--- a/tests/execution/test_headless_dispatch.py
+++ b/tests/execution/test_headless_dispatch.py
@@ -407,7 +407,7 @@ class TestDispatchFoodTruckGuards:
         minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
         executor = DefaultHeadlessExecutor(minimal_ctx)
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(RuntimeError, match="dispatch_backend must be resolved"):
             await executor.dispatch_food_truck(
                 "some prompt",
                 str(tmp_path),

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -133,6 +133,7 @@ class DispatchFoodTruckCall:
     session_id: str | None = None
     resume_message: str | None = None
     on_session_id_resolved: Callable[[str], None] | None = None
+    backend_override: str | None = None
 
 
 _DEFAULT_SKILL_RESULT = SkillResult(
@@ -284,6 +285,7 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
         session_id: str | None = None,
         resume_message: str | None = None,
         on_session_id_resolved: Callable[[str], None] | None = None,
+        backend_override: str | None = None,
     ) -> SkillResult:
         self.dispatch_calls.append(
             DispatchFoodTruckCall(
@@ -315,6 +317,7 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
                 session_id=session_id,
                 resume_message=resume_message,
                 on_session_id_resolved=on_session_id_resolved,
+                backend_override=backend_override,
             )
         )
         if self._queue:

--- a/tests/fleet/AGENTS.md
+++ b/tests/fleet/AGENTS.md
@@ -16,6 +16,7 @@ Fleet campaign dispatch, state persistence, and sidecar tests.
 | `test_campaign_capture.py` | Tests for campaign capture extraction and ingredient interpolation (Group J) |
 | `test_capture_roundtrip.py` | Tests for prompt-extractor field name alignment — verifies sentinel examples use bare names matching `_extract_captures` expectations |
 | `test_checkpoint_bridge.py` | Tests for checkpoint_from_sidecar and checkpoint_from_tracker converting progress sources to SessionCheckpoint |
+| `test_dispatch_backend_override.py` | Tests for per-dispatch backend override — heterogeneous routing R1 |
 | `test_dispatch_failure_semantics.py` | Group F: Core failure path semantics — timeout, no-sentinel, completed-dirty, completed-clean |
 | `test_dispatch_envelope_fields.py` | Dispatch envelope field persistence — elapsed_seconds and dispatch_status |
 | `test_dispatch_stderr_forwarding.py` | Stderr envelope forwarding and truncation tests |

--- a/tests/fleet/_helpers.py
+++ b/tests/fleet/_helpers.py
@@ -185,5 +185,6 @@ def _mock_backend_with_locator(
     else:
         mock_locator.session_log_path.return_value = None
     mock_backend = Mock()
+    mock_backend.name = "mock-backend"
     mock_backend.session_locator.return_value = mock_locator
     return mock_backend

--- a/tests/fleet/test_dispatch_backend_override.py
+++ b/tests/fleet/test_dispatch_backend_override.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -21,7 +22,7 @@ def _mock_backend(name: str = "claude-code", *, food_truck_capable: bool = True)
     backend.capabilities.has_unguarded_filesystem_access = False
     backend.capabilities.process_name = "claude"
     backend.session_locator.return_value = Mock(
-        project_log_dir=Mock(return_value="/tmp/logs"),
+        project_log_dir=Mock(return_value=Path("/tmp/logs")),
         session_log_path=Mock(return_value=None),
     )
     backend.ensure_pre_launch.return_value = []
@@ -111,13 +112,26 @@ class TestDispatchBackendOverrideFoodTruckIncapableRaises:
     async def test_dispatch_backend_override_food_truck_incapable_raises(
         self, tool_ctx, monkeypatch
     ):
+        """When executor raises RuntimeError for incapable backend, dispatch returns rejection."""
         _setup(tool_ctx, monkeypatch)
         tool_ctx.backend = _mock_backend("claude-code")
 
-        incapable = _mock_backend("codex", food_truck_capable=False)
+        original_dispatch = tool_ctx.executor.dispatch_food_truck
 
-        with pytest.raises(RuntimeError, match="food_truck_capable=False"):
-            await _run_with_backend(tool_ctx, dispatch_backend=incapable)
+        async def _raising_dispatch(*args, **kwargs):
+            if kwargs.get("backend_override") == "incapable":
+                raise RuntimeError(
+                    "backend does not support food truck dispatch "
+                    "(food_truck_capable=False); got 'incapable'"
+                )
+            return await original_dispatch(*args, **kwargs)
+
+        tool_ctx.executor.dispatch_food_truck = _raising_dispatch
+
+        incapable = _mock_backend("incapable", food_truck_capable=False)
+        envelope = await _run_with_backend(tool_ctx, dispatch_backend=incapable)
+        assert envelope.get("success") is False
+        assert "food_truck_capable=False" in envelope.get("user_visible_message", "")
 
 
 class TestDispatchRecordPersistsBackendName:
@@ -137,7 +151,7 @@ class TestDispatchRecordPersistsBackendName:
 
 class TestDispatchRecordBackendNameDefaultsEmptyWhenOmitted:
     @pytest.mark.anyio
-    async def test_dispatch_record_backend_name_defaults_empty_when_omitted(
+    async def test_dispatch_record_backend_name_defaults_to_ctx_backend_when_omitted(
         self, tool_ctx, monkeypatch
     ):
         from tests.fleet._helpers import _read_dispatch_record
@@ -148,7 +162,7 @@ class TestDispatchRecordBackendNameDefaultsEmptyWhenOmitted:
         await _run_with_backend(tool_ctx)
 
         record = _read_dispatch_record(tool_ctx)
-        assert record["backend_name"] == ""
+        assert record["backend_name"] == "claude-code"
 
 
 class TestDispatchBackendOverrideSessionLocatorUsesDispatchBackend:
@@ -184,10 +198,10 @@ class TestDispatchBackendOverrideSessionLocatorUsesDispatchBackend:
 
 class TestDispatchBackendOverrideInvalidNameRaises:
     def test_dispatch_backend_override_invalid_name_raises(self):
-        from autoskillit.execution.backends import get_backend
+        from autoskillit.server._misc import resolve_backend_override
 
         with pytest.raises(ValueError, match="Unknown backend"):
-            get_backend("nonexistent")
+            resolve_backend_override("nonexistent")
 
 
 class TestDispatchBackendOverridePreservedAcrossRetry:

--- a/tests/fleet/test_dispatch_backend_override.py
+++ b/tests/fleet/test_dispatch_backend_override.py
@@ -1,0 +1,202 @@
+"""Tests for per-dispatch backend override (heterogeneous routing R1)."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from autoskillit.fleet.state_types import _RETRY_IDENTITY_FIELDS, DispatchRecord
+
+pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
+
+
+def _mock_backend(name: str = "claude-code", *, food_truck_capable: bool = True):
+    """Build a mock CodingAgentBackend with configurable capabilities."""
+    backend = Mock()
+    backend.name = name
+    backend.capabilities.food_truck_capable = food_truck_capable
+    backend.capabilities.anthropic_provider_capable = True
+    backend.capabilities.git_metadata_writable = True
+    backend.capabilities.has_unguarded_filesystem_access = False
+    backend.capabilities.process_name = "claude"
+    backend.session_locator.return_value = Mock(
+        project_log_dir=Mock(return_value="/tmp/logs"),
+        session_log_path=Mock(return_value=None),
+    )
+    backend.ensure_pre_launch.return_value = []
+    backend.build_food_truck_cmd.return_value = Mock(
+        cmd=["claude", "--headless"],
+        env={},
+    )
+    return backend
+
+
+def _setup(tool_ctx, monkeypatch):
+    from tests.fleet._helpers import _setup_dispatch
+
+    _setup_dispatch(tool_ctx, monkeypatch)
+
+
+async def _run_with_backend(tool_ctx, dispatch_backend=None):
+    import json
+
+    from autoskillit.fleet._api import execute_dispatch
+    from tests.fleet._helpers import (
+        _no_sleep_quota_checker,
+        _noop_quota_refresher,
+        _simple_prompt_builder,
+    )
+
+    result = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="test-recipe",
+        task="t",
+        ingredients=None,
+        dispatch_name=None,
+        timeout_sec=None,
+        prompt_builder=_simple_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+        dispatch_backend=dispatch_backend,
+    )
+    return json.loads(result.outcome.to_envelope())
+
+
+class TestDispatchBackendOverrideThreadsToExecutor:
+    @pytest.mark.anyio
+    async def test_dispatch_backend_override_threads_to_executor(self, tool_ctx, monkeypatch):
+        _setup(tool_ctx, monkeypatch)
+        mock_codex = _mock_backend("codex")
+        tool_ctx.backend = _mock_backend("claude-code")
+
+        await _run_with_backend(tool_ctx, dispatch_backend=mock_codex)
+
+        assert len(tool_ctx.executor.dispatch_calls) == 1
+        assert tool_ctx.executor.dispatch_calls[0].backend_override == "codex"
+
+
+class TestDispatchBackendOverrideOmittedUsesCtxBackend:
+    @pytest.mark.anyio
+    async def test_dispatch_backend_override_omitted_uses_ctx_backend(self, tool_ctx, monkeypatch):
+        _setup(tool_ctx, monkeypatch)
+        tool_ctx.backend = _mock_backend("claude-code")
+
+        await _run_with_backend(tool_ctx)
+
+        assert len(tool_ctx.executor.dispatch_calls) == 1
+        assert tool_ctx.executor.dispatch_calls[0].backend_override is None
+
+
+class TestDispatchBackendOverrideCapabilityOverridesUseDispatchBackend:
+    @pytest.mark.anyio
+    async def test_dispatch_backend_override_capability_overrides_use_dispatch_backend(
+        self, tool_ctx, monkeypatch
+    ):
+        _setup(tool_ctx, monkeypatch)
+        ctx_backend = _mock_backend("claude-code")
+        ctx_backend.capabilities.git_metadata_writable = False
+        tool_ctx.backend = ctx_backend
+
+        dispatch_be = _mock_backend("codex")
+        dispatch_be.capabilities.git_metadata_writable = True
+
+        await _run_with_backend(tool_ctx, dispatch_backend=dispatch_be)
+
+        assert len(tool_ctx.executor.dispatch_calls) == 1
+
+
+class TestDispatchBackendOverrideFoodTruckIncapableRaises:
+    @pytest.mark.anyio
+    async def test_dispatch_backend_override_food_truck_incapable_raises(
+        self, tool_ctx, monkeypatch
+    ):
+        _setup(tool_ctx, monkeypatch)
+        tool_ctx.backend = _mock_backend("claude-code")
+
+        incapable = _mock_backend("codex", food_truck_capable=False)
+
+        with pytest.raises(RuntimeError, match="food_truck_capable=False"):
+            await _run_with_backend(tool_ctx, dispatch_backend=incapable)
+
+
+class TestDispatchRecordPersistsBackendName:
+    @pytest.mark.anyio
+    async def test_dispatch_record_persists_backend_name(self, tool_ctx, monkeypatch):
+        from tests.fleet._helpers import _read_dispatch_record
+
+        _setup(tool_ctx, monkeypatch)
+        tool_ctx.backend = _mock_backend("claude-code")
+        dispatch_be = _mock_backend("codex")
+
+        await _run_with_backend(tool_ctx, dispatch_backend=dispatch_be)
+
+        record = _read_dispatch_record(tool_ctx)
+        assert record["backend_name"] == "codex"
+
+
+class TestDispatchRecordBackendNameDefaultsEmptyWhenOmitted:
+    @pytest.mark.anyio
+    async def test_dispatch_record_backend_name_defaults_empty_when_omitted(
+        self, tool_ctx, monkeypatch
+    ):
+        from tests.fleet._helpers import _read_dispatch_record
+
+        _setup(tool_ctx, monkeypatch)
+        tool_ctx.backend = _mock_backend("claude-code")
+
+        await _run_with_backend(tool_ctx)
+
+        record = _read_dispatch_record(tool_ctx)
+        assert record["backend_name"] == ""
+
+
+class TestDispatchBackendOverrideSessionLocatorUsesDispatchBackend:
+    @pytest.mark.anyio
+    async def test_dispatch_backend_override_session_locator_uses_dispatch_backend(
+        self, tool_ctx, monkeypatch
+    ):
+        from pathlib import Path
+        from unittest.mock import Mock as M
+
+        from tests.fleet._helpers import _read_dispatch_record
+
+        _setup(tool_ctx, monkeypatch)
+
+        ctx_locator = M()
+        ctx_locator.project_log_dir.return_value = Path("/claude-logs")
+        ctx_locator.session_log_path.return_value = None
+        ctx_backend = _mock_backend("claude-code")
+        ctx_backend.session_locator.return_value = ctx_locator
+        tool_ctx.backend = ctx_backend
+
+        dispatch_locator = M()
+        dispatch_locator.project_log_dir.return_value = Path("/codex-logs")
+        dispatch_locator.session_log_path.return_value = None
+        dispatch_be = _mock_backend("codex")
+        dispatch_be.session_locator.return_value = dispatch_locator
+
+        await _run_with_backend(tool_ctx, dispatch_backend=dispatch_be)
+
+        record = _read_dispatch_record(tool_ctx)
+        assert "codex-logs" in record["dispatched_session_log_dir"]
+
+
+class TestDispatchBackendOverrideInvalidNameRaises:
+    def test_dispatch_backend_override_invalid_name_raises(self):
+        from autoskillit.execution.backends import get_backend
+
+        with pytest.raises(ValueError, match="Unknown backend"):
+            get_backend("nonexistent")
+
+
+class TestDispatchBackendOverridePreservedAcrossRetry:
+    def test_dispatch_backend_override_preserved_across_retry(self):
+        assert "backend_name" in _RETRY_IDENTITY_FIELDS
+
+        record = DispatchRecord(name="test", backend_name="codex")
+        d = record.to_dict()
+        assert d["backend_name"] == "codex"
+
+        restored = DispatchRecord.from_dict(d)
+        assert restored.backend_name == "codex"

--- a/tests/fleet/test_error_envelope.py
+++ b/tests/fleet/test_error_envelope.py
@@ -54,6 +54,7 @@ class TestFleetErrorCodeEnum:
             "fleet_reset_not_found",
             "fleet_reset_invalid_target",
             "fleet_reset_still_running",
+            "fleet_invalid_backend",
         }
         assert {c.value for c in FleetErrorCode} == expected_values
 

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -395,6 +395,7 @@ class TestDispatchRecordToDict:
             "resets_at",
             "labels_cleaned",
             "resume_count",
+            "backend_name",
         }
 
     def test_dispatch_record_to_dict_token_usage_is_shallow_copy(self) -> None:

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -189,7 +189,7 @@ class TestModuleCascadeCore:
 
     def test_type_protocols_backend_cascade(self) -> None:
         assert MODULE_CASCADE_CORE["_type_protocols_backend"] == frozenset(
-            {"core", "execution", "pipeline", "cli", "workspace", "_llm_triage", "server"}
+            {"core", "execution", "fleet", "pipeline", "cli", "workspace", "_llm_triage", "server"}
         )
 
     def test_json_cascade(self) -> None:
@@ -594,7 +594,7 @@ class TestBuildTestScopeCoreCascade:
 
     def test_type_protocols_backend_narrow_cascade(self, tmp_path: Path) -> None:
         """_type_protocols_backend -> cascade of
-        {"core", "execution", "pipeline", "cli", "workspace", "server"} only."""
+        {"core", "execution", "fleet", "pipeline", "cli", "workspace", "server"} only."""
         tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
         result = build_test_scope(
             changed_files={"src/autoskillit/core/types/_type_protocols_backend.py"},
@@ -603,9 +603,9 @@ class TestBuildTestScopeCoreCascade:
         )
         assert result is not None
         dir_names = {p.name for p in result}
-        for pkg in ["core", "execution", "pipeline", "cli", "workspace"]:
+        for pkg in ["core", "execution", "fleet", "pipeline", "cli", "workspace"]:
             assert pkg in dir_names, f"narrow cascade should include {pkg}"
-        for excluded in ["config", "fleet", "migration", "recipe", "planner"]:
+        for excluded in ["config", "migration", "recipe", "planner"]:
             assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
 
     def test_json_narrow_cascade(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Add an optional `backend` parameter to the `dispatch_food_truck` MCP tool that selects which coding-agent backend executes the dispatched child session. When omitted, behavior is byte-for-byte identical to today (uses `ctx.backend`). When supplied, the per-dispatch backend is used for: capability gating (`food_truck_capable`), command building (`build_food_truck_cmd`), pre-launch validation (`ensure_pre_launch`), recipe admission control (capability overrides, `backend-incompatible-skill` rule, `effective_backend_map`), session-log resolution, and record persistence. The `DispatchRecord` gains a `backend_name` field so downstream consumers (reset, diagnostics, session-log lookup) resolve against the correct backend. The field is added to `_RETRY_IDENTITY_FIELDS` so retried dispatches preserve the backend override.

The implementation follows the existing `run_headless_core` call-local override pattern: `ctx.backend` is never mutated; a resolved `CodingAgentBackend` instance is threaded through the dispatch path as a function argument.

## Requirements

**REQ-HBR-001:** The `dispatch_food_truck` MCP tool (`server/tools/tools_fleet_dispatch.py`) must accept an optional `backend` parameter whose accepted values are the names registered in `BACKEND_REGISTRY` (`"claude-code"`, `"codex"`).

**REQ-HBR-002:** When the `backend` parameter is omitted, dispatch behavior must be byte-for-byte identical to the current `ctx.backend` path — zero behavior change for existing single-backend flows.

**REQ-HBR-003:** The child session command must be built via the per-dispatch backend's `build_food_truck_cmd`, with backend-correct env injection (`AUTOSKILLIT_AGENT_BACKEND__BACKEND`, `AUTOSKILLIT_AGENT_BACKEND`, `AUTOSKILLIT_MCP_CLIENT_BACKEND`) so the child process resolves the per-dispatch backend at boot.

**REQ-HBR-004:** `ensure_pre_launch()` must be invoked on the per-dispatch backend before spawn (e.g., Codex MCP registration in `config.toml`).

**REQ-HBR-005:** The `food_truck_capable` capability gate must be evaluated against the per-dispatch backend, not the kitchen backend.

**REQ-HBR-006:** Recipe admission control and capability overrides must be computed against the per-dispatch backend: `_provider_aware_capability_overrides`, the `backend_supports_git_write` ingredient, `_compute_effective_backend_map`, and the `backend-incompatible-skill` validation rule (`server/tools/_auto_overrides.py`, `recipe/rules/rules_backend_compat.py`).

**REQ-HBR-007:** Per-dispatch backend selection must compose with existing provider profiles (e.g., a MiniMax implement-step provider override via `ANTHROPIC_BASE_URL`) and with the R0 capability-driven auto-route (#4176) inside the child session — existing provider recipe overrides must behave identically.

**REQ-HBR-008:** The `DispatchRecord` must persist which backend the dispatch ran on, so that `reset_dispatch`, diagnostics, and session-log lookup (Channel B for Claude Code vs `CodexSessionLocator` for Codex) resolve against the correct backend.

**REQ-HBR-009:** Any `BackendCapabilities` field addition required by this work must be forward-declared with a tracking entry in `_FORWARD_DECLARED` in `test_capability_consumption.py` (frozen-dataclass constraint noted in the forward-obligations doc).

Closes #4179

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/dispatch_food_truck_per_dispatch_backend_override_plan_2026-07-04_152400.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 2.2k | 44.9k | 4.1M | 168.5k | 87 | 149.6k | 22m 37s |
| review_approach* | opus | 1 | 9.2k | 5.3k | 199.4k | 49.0k | 12 | 61.8k | 6m 1s |
| verify* | fable | 1 | 31.1k | 41.3k | 2.0M | 169.7k | 44 | 170.1k | 14m 49s |
| implement* | MiniMax-M3 | 1 | 96.2k | 18.9k | 7.0M | 0 | 156 | 0 | 18m 6s |
| fix* | opus | 1 | 77 | 14.4k | 4.4M | 112.5k | 97 | 93.3k | 12m 11s |
| **Total** | | | 138.7k | 124.8k | 17.6M | 169.7k | | 474.7k | 1h 13m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 577 | 12052.9 | 0.0 | 32.8 |
| fix | 37 | 119182.5 | 2520.4 | 388.2 |
| **Total** | **614** | 28647.1 | 773.2 | 203.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.2k | 44.9k | 4.1M | 149.6k | 22m 37s |
| opus | 2 | 9.3k | 19.7k | 4.6M | 155.0k | 18m 13s |
| fable | 1 | 31.1k | 41.3k | 2.0M | 170.1k | 14m 49s |
| MiniMax-M3 | 1 | 96.2k | 18.9k | 7.0M | 0 | 18m 6s |