### PR TITLE
Demote post_run_diagnostics to Config-as-Default & Complete Feedback Contract

### DIFF
--- a/docs/developer/diagnostics.md
+++ b/docs/developer/diagnostics.md
@@ -86,6 +86,22 @@ linux_tracing:
   log_dir: ""            # empty = platform default, set absolute path to override
 ```
 
+## Per-Run Enablement
+
+By default, `post_run_diagnostics` resolves from `diagnostics.post_run_analysis` (shipped
+default: `false`). To enable diagnostics for a single run, the orchestrator can pass
+`overrides={"post_run_diagnostics": "true"}` to `open_kitchen`. The override takes effect
+for that kitchen session only and does not modify the persistent config.
+
+The orchestrator can also lock the value for the session via
+`lock_ingredients(locked={"post_run_diagnostics": "true"})` to ensure it is not overridden
+by downstream steps.
+
+For post-hoc diagnostics on a completed run, use:
+```bash
+run_skill /autoskillit:analyze-pipeline-health <kitchen_id>
+```
+
 ## Finding Problematic Sessions
 
 ```bash

--- a/src/autoskillit/config/__init__.py
+++ b/src/autoskillit/config/__init__.py
@@ -9,11 +9,13 @@ from autoskillit.config._config_dataclasses import (
     _MAX_CONCURRENT_DISPATCHES as _MAX_CONCURRENT_DISPATCHES,
 )
 from autoskillit.config.ingredient_defaults import (
+    CONFIG_DEFAULT_INGREDIENTS,
     SERVER_AUTHORITATIVE_CONFIG_PATHS,
     SERVER_AUTHORITATIVE_INGREDIENTS,
     SERVER_AUTHORITATIVE_KEY_HINTS,
     apply_config_authoritative_overrides,
     build_config_authoritative_layer,
+    build_config_default_layer,
     iter_display_categories,
     resolve_ingredient_defaults,
 )
@@ -98,11 +100,13 @@ __all__ = [
     "load_config",
     "resolve_ingredient_defaults",
     "BACKEND_CAPABILITY_INGREDIENTS",
+    "CONFIG_DEFAULT_INGREDIENTS",
     "SERVER_AUTHORITATIVE_CONFIG_PATHS",
     "SERVER_AUTHORITATIVE_INGREDIENTS",
     "SERVER_AUTHORITATIVE_KEY_HINTS",
     "apply_config_authoritative_overrides",
     "build_config_authoritative_layer",
+    "build_config_default_layer",
     "validate_layer_keys",
     "write_config_layer",
 ]

--- a/src/autoskillit/config/ingredient_defaults.py
+++ b/src/autoskillit/config/ingredient_defaults.py
@@ -129,15 +129,16 @@ SERVER_AUTHORITATIVE_CONFIG_PATHS: dict[str, str] = {
     "base_branch": "branching.default_base_branch",
     "local_review_rounds": "review.local_review_rounds",
     "adversarial_review_level": "plan.adversarial_review_level",
-    "post_run_diagnostics": "diagnostics.post_run_analysis",
 }
 
-SERVER_AUTHORITATIVE_KEY_HINTS: dict[str, str] = {
-    "post_run_diagnostics": (
-        "For post_run_diagnostics diagnostics outside of a live run, "
-        "use run_skill /autoskillit:analyze-pipeline-health"
-    ),
-}
+SERVER_AUTHORITATIVE_KEY_HINTS: dict[str, str] = {}
+
+CONFIG_DEFAULT_INGREDIENTS: frozenset[str] = frozenset({"post_run_diagnostics"})
+
+
+def build_config_default_layer(defaults: dict[str, str]) -> dict[str, str]:
+    """Return config-derived defaults for overridable config-backed ingredients."""
+    return {k: v for k, v in defaults.items() if k in CONFIG_DEFAULT_INGREDIENTS}
 
 
 def resolve_ingredient_defaults(project_dir: Path) -> dict[str, str]:

--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -293,7 +293,6 @@ CONFIG_AUTHORITY_KEYS: frozenset[str] = frozenset(
         "base_branch",
         "local_review_rounds",
         "adversarial_review_level",
-        "post_run_diagnostics",
         "is_fleet_dispatch",
         "dispatch_id",
         "backend_supports_git_write",

--- a/src/autoskillit/recipes/campaigns/promote-to-main.json
+++ b/src/autoskillit/recipes/campaigns/promote-to-main.json
@@ -42,8 +42,7 @@
     "post_run_diagnostics": {
       "description": "Run diagnostic analysis after pipeline completion",
       "default": "false",
-      "hidden": true,
-      "authority": "config"
+      "hidden": true
     },
     "kitchen_id": {
       "description": "Kitchen session identifier (auto-injected)",

--- a/src/autoskillit/recipes/campaigns/promote-to-main.yaml
+++ b/src/autoskillit/recipes/campaigns/promote-to-main.yaml
@@ -40,7 +40,6 @@ ingredients:
     description: Run diagnostic analysis after pipeline completion
     default: "false"
     hidden: true
-    authority: config
   kitchen_id:
     description: Kitchen session identifier (auto-injected)
     default: ""

--- a/src/autoskillit/recipes/diagrams/implementation-groups.md
+++ b/src/autoskillit/recipes/diagrams/implementation-groups.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:0f49b5fc315fc868772e622bb750e3e6e8e97720a95c66650380e928fd906b3b -->
+<!-- autoskillit-recipe-hash: sha256:2310836c43bb41076120ecbdde14e07a4bb6e3d6ccc7a8ed1aeb26c2060ebbbe -->
 <!-- autoskillit-diagram-format: v7 -->
 ## implementation-groups
 Group-based implementation with per-group plan/implement/test cycles and PR gates.

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:79bcba561e8f80d219930dbf03f90ad87e0918caaa281147408058ab7e6998ad -->
+<!-- autoskillit-recipe-hash: sha256:e3f859c4f5832bf752747af0016266272c7950bb6169b606f359cb85f364d83d -->
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 

--- a/src/autoskillit/recipes/diagrams/merge-prs.md
+++ b/src/autoskillit/recipes/diagrams/merge-prs.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:a5e0288f51345023d8161c7568652dc056eb49b396ab23f7803ff26d62e98ed4 -->
+<!-- autoskillit-recipe-hash: sha256:05073b188f0ff2ea36f2d04bf9b113e1f18417d769629c8f1299d2680635ce4b -->
 <!-- autoskillit-diagram-format: v7 -->
 ## merge-prs
 Merge multiple PRs into an integration branch with conflict resolution and CI gates.

--- a/src/autoskillit/recipes/diagrams/remediation.md
+++ b/src/autoskillit/recipes/diagrams/remediation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:b32dfc7c9a01ea3a4c4e071fe933b356773d27f70ae78feb4fadba16e0e7b1e4 -->
+<!-- autoskillit-recipe-hash: sha256:2fd77ce6e61a5214c1f77b880694dfb80c115f3d4864f5b1051e20ae3958c3e7 -->
 <!-- autoskillit-diagram-format: v7 -->
 ## remediation
 Investigate, rectify, implement, and merge a bug fix with CI and PR gates.

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -97,6 +97,27 @@
       "description": "Set to 'true' when process-issues has already claimed this issue upfront. Allows claim_issue defense step to pass through without aborting.",
       "default": "false",
       "hidden": true
+    },
+    "post_run_diagnostics": {
+      "description": "Run diagnostic analysis after pipeline completion",
+      "default": "false",
+      "hidden": true
+    },
+    "kitchen_id": {
+      "description": "Kitchen session identifier (auto-injected)",
+      "default": "",
+      "hidden": true
+    },
+    "dispatch_id": {
+      "description": "Fleet dispatch identifier (auto-injected, empty in non-fleet sessions)",
+      "default": "",
+      "hidden": true,
+      "authority": "config"
+    },
+    "diagnostics_log_dir": {
+      "description": "Resolved diagnostics log directory path (auto-injected)",
+      "default": "",
+      "hidden": true
     }
   },
   "kitchen_rules": [
@@ -1470,8 +1491,25 @@
         "status": "error",
         "step_name": "register_clone_no_ci"
       },
+      "on_success": "run_diagnostic_no_ci",
+      "on_failure": "run_diagnostic_no_ci"
+    },
+    "run_diagnostic_no_ci": {
+      "description": "Run post-pipeline diagnostic analysis on session logs (no-CI path)",
+      "tool": "run_skill",
+      "model": "",
+      "stale_threshold": 2400,
+      "optional": true,
+      "skip_when_false": "inputs.post_run_diagnostics",
+      "with": {
+        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }} --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}",
+        "cwd": "${{ context.work_dir }}",
+        "step_name": "post_run_diagnostics"
+      },
       "on_success": "escalate_stop_no_ci",
-      "on_failure": "escalate_stop_no_ci"
+      "on_failure": "escalate_stop_no_ci",
+      "on_context_limit": "escalate_stop_no_ci",
+      "note": "Execute this diagnostic step. Failures are logged but do not alter pipeline routing.\n"
     },
     "escalate_stop_no_ci": {
       "action": "stop",
@@ -2359,9 +2397,26 @@
         "status": "unconfirmed",
         "step_name": "register_clone_unconfirmed"
       },
+      "on_success": "run_diagnostic_unconfirmed",
+      "on_failure": "run_diagnostic_unconfirmed",
+      "note": "Called when a merge-wait step times out before merge is confirmed. Does NOT call release_issue — the in-progress label stays on the issue so operators can see the PR is still actively queued. The clone is preserved (status: unconfirmed) for human inspection.\n"
+    },
+    "run_diagnostic_unconfirmed": {
+      "description": "Run post-pipeline diagnostic analysis (unconfirmed path)",
+      "tool": "run_skill",
+      "model": "",
+      "stale_threshold": 2400,
+      "optional": true,
+      "skip_when_false": "inputs.post_run_diagnostics",
+      "with": {
+        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }} --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}",
+        "cwd": "${{ context.work_dir }}",
+        "step_name": "post_run_diagnostics"
+      },
       "on_success": "done_unconfirmed",
       "on_failure": "done_unconfirmed",
-      "note": "Called when a merge-wait step times out before merge is confirmed. Does NOT call release_issue — the in-progress label stays on the issue so operators can see the PR is still actively queued. The clone is preserved (status: unconfirmed) for human inspection.\n"
+      "on_context_limit": "done_unconfirmed",
+      "note": "Execute this diagnostic step. Failures are logged but do not alter pipeline routing.\n"
     },
     "done_unconfirmed": {
       "action": "stop",
@@ -2456,8 +2511,25 @@
         "status": "success",
         "step_name": "register_clone_success"
       },
+      "on_success": "run_diagnostic",
+      "on_failure": "run_diagnostic"
+    },
+    "run_diagnostic": {
+      "description": "Run post-pipeline diagnostic analysis on session logs",
+      "tool": "run_skill",
+      "model": "",
+      "stale_threshold": 2400,
+      "optional": true,
+      "skip_when_false": "inputs.post_run_diagnostics",
+      "with": {
+        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }} --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}",
+        "cwd": "${{ context.work_dir }}",
+        "step_name": "post_run_diagnostics"
+      },
       "on_success": "done",
-      "on_failure": "done"
+      "on_failure": "done",
+      "on_context_limit": "done",
+      "note": "Execute this diagnostic step. Failures are logged but do not alter pipeline routing. Both on_failure and on_context_limit route to the same terminal as on_success.\n"
     },
     "register_clone_failure": {
       "description": "Register clone as preserved (error pipeline)",
@@ -2467,8 +2539,25 @@
         "status": "error",
         "step_name": "register_clone_failure"
       },
+      "on_success": "run_diagnostic_error",
+      "on_failure": "run_diagnostic_error"
+    },
+    "run_diagnostic_error": {
+      "description": "Run post-pipeline diagnostic analysis on session logs (error path)",
+      "tool": "run_skill",
+      "model": "",
+      "stale_threshold": 2400,
+      "optional": true,
+      "skip_when_false": "inputs.post_run_diagnostics",
+      "with": {
+        "skill_command": "/autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }} --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}",
+        "cwd": "${{ context.work_dir }}",
+        "step_name": "post_run_diagnostics"
+      },
       "on_success": "escalate_stop",
-      "on_failure": "escalate_stop"
+      "on_failure": "escalate_stop",
+      "on_context_limit": "escalate_stop",
+      "note": "Execute this diagnostic step. Failures are logged but do not alter pipeline routing.\n"
     },
     "done": {
       "action": "stop",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -83,6 +83,23 @@ ingredients:
     description: "Set to 'true' when process-issues has already claimed this issue upfront. Allows claim_issue defense step to pass through without aborting."
     default: "false"
     hidden: true
+  post_run_diagnostics:
+    description: Run diagnostic analysis after pipeline completion
+    default: 'false'
+    hidden: true
+  kitchen_id:
+    description: Kitchen session identifier (auto-injected)
+    default: ''
+    hidden: true
+  dispatch_id:
+    description: Fleet dispatch identifier (auto-injected, empty in non-fleet sessions)
+    default: ''
+    hidden: true
+    authority: config
+  diagnostics_log_dir:
+    description: Resolved diagnostics log directory path (auto-injected)
+    default: ''
+    hidden: true
 
 kitchen_rules:
 - "NEVER use native Claude Code tools (Read, Grep, Glob, Edit, Write, Bash, Agent, WebFetch, WebSearch, NotebookEdit) from the orchestrator. All work is delegated through run_skill."
@@ -1319,8 +1336,26 @@ steps:
       clone_path: "${{ context.work_dir }}"
       status: "error"
       step_name: register_clone_no_ci
+    on_success: run_diagnostic_no_ci
+    on_failure: run_diagnostic_no_ci
+
+  run_diagnostic_no_ci:
+    description: Run post-pipeline diagnostic analysis on session logs (no-CI path)
+    tool: run_skill
+    model: ''
+    stale_threshold: 2400
+    optional: true
+    skip_when_false: inputs.post_run_diagnostics
+    with:
+      skill_command: /autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}
+        --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}
+      cwd: ${{ context.work_dir }}
+      step_name: post_run_diagnostics
     on_success: escalate_stop_no_ci
     on_failure: escalate_stop_no_ci
+    on_context_limit: escalate_stop_no_ci
+    note: >
+      Execute this diagnostic step. Failures are logged but do not alter pipeline routing.
 
   escalate_stop_no_ci:
     action: stop
@@ -2105,13 +2140,31 @@ steps:
       clone_path: "${{ context.work_dir }}"
       status: "unconfirmed"
       step_name: register_clone_unconfirmed
-    on_success: done_unconfirmed
-    on_failure: done_unconfirmed
+    on_success: run_diagnostic_unconfirmed
+    on_failure: run_diagnostic_unconfirmed
     note: >
       Called when a merge-wait step times out before merge is confirmed.
       Does NOT call release_issue — the in-progress label stays on the issue
       so operators can see the PR is still actively queued. The clone is
       preserved (status: unconfirmed) for human inspection.
+
+  run_diagnostic_unconfirmed:
+    description: Run post-pipeline diagnostic analysis (unconfirmed path)
+    tool: run_skill
+    model: ''
+    stale_threshold: 2400
+    optional: true
+    skip_when_false: inputs.post_run_diagnostics
+    with:
+      skill_command: /autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}
+        --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}
+      cwd: ${{ context.work_dir }}
+      step_name: post_run_diagnostics
+    on_success: done_unconfirmed
+    on_failure: done_unconfirmed
+    on_context_limit: done_unconfirmed
+    note: >
+      Execute this diagnostic step. Failures are logged but do not alter pipeline routing.
 
   done_unconfirmed:
     action: stop
@@ -2223,8 +2276,27 @@ steps:
       clone_path: "${{ context.work_dir }}"
       status: "success"
       step_name: register_clone_success
+    on_success: run_diagnostic
+    on_failure: run_diagnostic
+
+  run_diagnostic:
+    description: Run post-pipeline diagnostic analysis on session logs
+    tool: run_skill
+    model: ''
+    stale_threshold: 2400
+    optional: true
+    skip_when_false: inputs.post_run_diagnostics
+    with:
+      skill_command: /autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}
+        --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}
+      cwd: ${{ context.work_dir }}
+      step_name: post_run_diagnostics
     on_success: done
     on_failure: done
+    on_context_limit: done
+    note: >
+      Execute this diagnostic step. Failures are logged but do not alter pipeline
+      routing. Both on_failure and on_context_limit route to the same terminal as on_success.
 
   register_clone_failure:
     description: "Register clone as preserved (error pipeline)"
@@ -2233,8 +2305,26 @@ steps:
       clone_path: "${{ context.work_dir }}"
       status: "error"
       step_name: register_clone_failure
+    on_success: run_diagnostic_error
+    on_failure: run_diagnostic_error
+
+  run_diagnostic_error:
+    description: Run post-pipeline diagnostic analysis on session logs (error path)
+    tool: run_skill
+    model: ''
+    stale_threshold: 2400
+    optional: true
+    skip_when_false: inputs.post_run_diagnostics
+    with:
+      skill_command: /autoskillit:analyze-pipeline-health ${{ inputs.kitchen_id }}
+        --dispatch-id=${{ inputs.dispatch_id }} --diagnostics-log-dir=${{ inputs.diagnostics_log_dir }}
+      cwd: ${{ context.work_dir }}
+      step_name: post_run_diagnostics
     on_success: escalate_stop
     on_failure: escalate_stop
+    on_context_limit: escalate_stop
+    note: >
+      Execute this diagnostic step. Failures are logged but do not alter pipeline routing.
 
   done:
     action: stop

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -111,8 +111,7 @@
     "post_run_diagnostics": {
       "description": "Run diagnostic analysis after pipeline completion",
       "default": "false",
-      "hidden": true,
-      "authority": "config"
+      "hidden": true
     },
     "kitchen_id": {
       "description": "Kitchen session identifier (auto-injected)",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -103,7 +103,6 @@ ingredients:
     description: Run diagnostic analysis after pipeline completion
     default: 'false'
     hidden: true
-    authority: config
   kitchen_id:
     description: Kitchen session identifier (auto-injected)
     default: ''

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -37,8 +37,7 @@
     "post_run_diagnostics": {
       "description": "Run diagnostic analysis after pipeline completion",
       "default": "false",
-      "hidden": true,
-      "authority": "config"
+      "hidden": true
     },
     "kitchen_id": {
       "description": "Kitchen session identifier (auto-injected)",

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -37,7 +37,6 @@ ingredients:
     description: Run diagnostic analysis after pipeline completion
     default: 'false'
     hidden: true
-    authority: config
   kitchen_id:
     description: Kitchen session identifier (auto-injected)
     default: ''

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -123,8 +123,7 @@
     "post_run_diagnostics": {
       "description": "Run diagnostic analysis after pipeline completion",
       "default": "false",
-      "hidden": true,
-      "authority": "config"
+      "hidden": true
     },
     "kitchen_id": {
       "description": "Kitchen session identifier (auto-injected)",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -136,7 +136,6 @@ ingredients:
     description: Run diagnostic analysis after pipeline completion
     default: 'false'
     hidden: true
-    authority: config
   kitchen_id:
     description: Kitchen session identifier (auto-injected)
     default: ''

--- a/src/autoskillit/server/tools/_authority_feedback.py
+++ b/src/autoskillit/server/tools/_authority_feedback.py
@@ -37,6 +37,9 @@ def build_authority_clobber_warnings(
                 f"Override for server-authoritative ingredient '{key}' ignored — "
                 f"set by the dispatch runtime at session launch, not user-configurable"
             )
+        hint = SERVER_AUTHORITATIVE_KEY_HINTS.get(key)
+        if hint:
+            warnings.append(hint)
     return warnings
 
 

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -19,6 +19,7 @@ from autoskillit import __version__
 from autoskillit.config import (
     SERVER_AUTHORITATIVE_INGREDIENTS,
     build_config_authoritative_layer,
+    build_config_default_layer,
     iter_display_categories,
     resolve_ingredient_defaults,
 )
@@ -493,11 +494,16 @@ def get_recipe(name: str) -> str:
             name,
             skill_resolver=ctx.skill_resolver,
         )
+        _config_default = build_config_default_layer(_defaults)
         result = ctx.recipes.load_and_validate(
             name,
             ctx.project_dir,
             resolved_defaults=_defaults,
-            ingredient_overrides={**_backend_overrides, **_config_layer},
+            ingredient_overrides={
+                **_config_default,
+                **_backend_overrides,
+                **_config_layer,
+            },
             backend_name=ctx.backend.name if ctx.backend else None,
             effective_backend_map=_effective_backend_map,
         )
@@ -582,8 +588,10 @@ async def open_kitchen(
         overrides: Optional dict of ingredient name → value to override recipe defaults.
             Use to activate hidden features (e.g., ``{"sprint_mode": "true"}``). Ingredients
             with ``authority: config`` (base_branch, local_review_rounds,
-            adversarial_review_level, post_run_diagnostics) cannot be set via overrides —
-            they resolve from server config and caller values are ignored with a warning.
+            adversarial_review_level) cannot be set via overrides — they resolve from
+            server config and caller values are ignored with a warning.
+            Config-default ingredients (post_run_diagnostics) use config as the default
+            but an explicit override wins.
         ingredients_only: When True and name is provided, return only the ingredient
             schema (ingredients_table, validity, suggestions) without the full recipe
             content, orchestration rules, or sous-chef discipline. Use for dispatch
@@ -716,8 +724,14 @@ async def open_kitchen(
             )
             _session_overrides.update(_provider_overrides)
             _config_layer = build_config_authoritative_layer(_defaults)
+            _config_default = build_config_default_layer(_defaults)
             _promote_capability_keys(_config_layer, _session_overrides)
-            _merged_overrides = {**_session_overrides, **(overrides or {}), **_config_layer}
+            _merged_overrides = {
+                **_config_default,
+                **_session_overrides,
+                **(overrides or {}),
+                **_config_layer,
+            }
             _effective_backend_map = _compute_effective_backend_map(
                 _raw_recipe.steps if _raw_recipe is not None else None,
                 tool_ctx.backend.name if tool_ctx.backend else None,
@@ -1229,7 +1243,7 @@ async def lock_ingredients(
     to a falsy value will be denied.
 
     Server-authoritative ingredients (base_branch, local_review_rounds,
-    adversarial_review_level, post_run_diagnostics, is_fleet_dispatch,
+    adversarial_review_level, is_fleet_dispatch,
     dispatch_id) are rejected with a structured error envelope; the
     rejected key names appear in both ``error`` and ``user_visible_message``.
 

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -12,6 +12,7 @@ from fastmcp.dependencies import CurrentContext
 
 from autoskillit.config import (
     build_config_authoritative_layer,
+    build_config_default_layer,
     resolve_ingredient_defaults,
 )
 from autoskillit.core import FLEET_DISPATCH_TOOLS, get_logger, temp_dir_display_str  # noqa: F401
@@ -237,8 +238,14 @@ async def load_recipe(
             )
             _session_overrides.update(_provider_overrides)
             _config_layer = build_config_authoritative_layer(_defaults)
+            _config_default = build_config_default_layer(_defaults)
             _promote_capability_keys(_config_layer, _session_overrides)
-            _merged_overrides = {**_session_overrides, **(overrides or {}), **_config_layer}
+            _merged_overrides = {
+                **_config_default,
+                **_session_overrides,
+                **(overrides or {}),
+                **_config_layer,
+            }
             _effective_backend_map = _compute_effective_backend_map(
                 _raw_recipe_obj.steps if _raw_recipe_obj is not None else None,
                 tool_ctx.backend.name if tool_ctx.backend else None,

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -840,6 +840,16 @@ every step at full fidelity regardless of session length.
 
 ---
 
+### open_kitchen warnings — mandatory relay
+
+When `open_kitchen` returns a non-empty `warnings` array in its result, relay each
+warning to the user in your next response before proceeding with the pipeline. Do not
+suppress, reword, or batch these warnings — they indicate that a user-supplied override
+was silently overridden by server policy, and the user must know which instructions were
+not honored.
+
+---
+
 ## INGREDIENT LOCKING — STRUCTURAL ENFORCEMENT
 
 When the user requests skipping or enabling specific recipe steps at session start,
@@ -856,7 +866,6 @@ listed instead:
 - `base_branch` → config: `branching.default_base_branch`
 - `local_review_rounds` → config: `review.local_review_rounds`
 - `adversarial_review_level` → config: `plan.adversarial_review_level`
-- `post_run_diagnostics` → config: `diagnostics.post_run_analysis` (for one-off diagnostics outside a live run, use `run_skill /autoskillit:analyze-pipeline-health`)
 - `is_fleet_dispatch` → set by dispatch runtime at session launch, not user-configurable
 - `dispatch_id` → set by dispatch runtime at session launch, not user-configurable
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -967,7 +967,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "co-located with the execution engine that calls them",
     ),
     "tools_kitchen.py": (
-        1380,
+        1395,
         "REQ-CNST-010-E7: kitchen tool handlers — open_kitchen and lock_ingredients require "
         "inline validation helpers (_check_override_keys, _build_ingredient_key_suggestions) "
         "for ingredient key validation; splitting would cross import-layer boundaries; "
@@ -987,7 +987,9 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "graceful degradation when recipes.find raises (+10 net lines)"
         "; CapabilityResolutionDetail destructive tuple at open_kitchen call sites and "
         "_dispatch_infeasible_response accepting capability_detail kwarg for none_pass "
-        "diagnostic enrichment (+24 net lines)",
+        "diagnostic enrichment (+24 net lines)"
+        "; config-default ingredient layer: build_config_default_layer call and "
+        "docstring update for post_run_diagnostics demotion (+10 net lines)",
     ),
     "tools_execution.py": (
         1260,

--- a/tests/config/test_helpers.py
+++ b/tests/config/test_helpers.py
@@ -193,15 +193,20 @@ def test_resolve_ingredient_defaults_base_branch_from_config(tmp_path):
 
 def test_server_authoritative_ingredients_covers_resolved_defaults(tmp_path):
     """1a: Every config-resolvable key from resolve_ingredient_defaults must be declared
-    in SERVER_AUTHORITATIVE_INGREDIENTS."""
-    from autoskillit.config import SERVER_AUTHORITATIVE_INGREDIENTS, resolve_ingredient_defaults
+    in SERVER_AUTHORITATIVE_INGREDIENTS or CONFIG_DEFAULT_INGREDIENTS."""
+    from autoskillit.config import (
+        CONFIG_DEFAULT_INGREDIENTS,
+        SERVER_AUTHORITATIVE_INGREDIENTS,
+        resolve_ingredient_defaults,
+    )
 
     subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
     defaults = resolve_ingredient_defaults(tmp_path)
     config_resolvable = {k for k in defaults if k != "source_dir"}
-    missing = config_resolvable - SERVER_AUTHORITATIVE_INGREDIENTS
+    missing = config_resolvable - SERVER_AUTHORITATIVE_INGREDIENTS - CONFIG_DEFAULT_INGREDIENTS
     assert not missing, (
-        f"Config-resolvable keys missing from SERVER_AUTHORITATIVE_INGREDIENTS: {missing}"
+        f"Config-resolvable keys missing from SERVER_AUTHORITATIVE_INGREDIENTS or "
+        f"CONFIG_DEFAULT_INGREDIENTS: {missing}"
     )
 
 
@@ -271,3 +276,19 @@ def test_apply_config_authoritative_overrides_unknown_key_warns_and_retains(tmp_
 
     assert result["totally_unknown_key"] == "caller-value"
     assert any("config-authority key" in e.get("event", "") for e in cap_logs)
+
+
+# T4: REQ-ING-003
+def test_post_run_diagnostics_not_server_authoritative() -> None:
+    """post_run_diagnostics must be a config-default, not server-authoritative."""
+    from autoskillit.config import SERVER_AUTHORITATIVE_INGREDIENTS
+
+    assert "post_run_diagnostics" not in SERVER_AUTHORITATIVE_INGREDIENTS
+
+
+# T6: REQ-ING-005
+def test_post_run_diagnostics_in_config_default_ingredients() -> None:
+    """post_run_diagnostics must be in CONFIG_DEFAULT_INGREDIENTS."""
+    from autoskillit.config import CONFIG_DEFAULT_INGREDIENTS
+
+    assert "post_run_diagnostics" in CONFIG_DEFAULT_INGREDIENTS

--- a/tests/core/test_type_constants.py
+++ b/tests/core/test_type_constants.py
@@ -301,7 +301,7 @@ def test_skill_tools_matches_expected() -> None:
 
 
 def test_config_authority_keys_constant() -> None:
-    """CONFIG_AUTHORITY_KEYS must be a frozenset of exactly the 8 known config-authority keys."""
+    """CONFIG_AUTHORITY_KEYS must be a frozenset of exactly the 7 known config-authority keys."""
     from autoskillit.core import CONFIG_AUTHORITY_KEYS
 
     assert isinstance(CONFIG_AUTHORITY_KEYS, frozenset)
@@ -311,7 +311,6 @@ def test_config_authority_keys_constant() -> None:
             "base_branch",
             "local_review_rounds",
             "adversarial_review_level",
-            "post_run_diagnostics",
             "is_fleet_dispatch",
             "dispatch_id",
             "backend_supports_git_write",

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -119,11 +119,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 90),
     # tools_kitchen.py — hook config, quota guard, git_ops_policy, ingredient locks overlay
-    ("src/autoskillit/server/tools/tools_kitchen.py", 227),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 246),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 280),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 1105),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 1165),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 228),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 247),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 281),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1119),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1179),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict

--- a/tests/recipe/test_diagnostic_steps.py
+++ b/tests/recipe/test_diagnostic_steps.py
@@ -51,3 +51,44 @@ def test_run_diagnostic_steps_have_required_fields(recipe_name):
             assert step.skip_when_false == "inputs.post_run_diagnostics", (
                 f"{name} skip_when_false must be inputs.post_run_diagnostics"
             )
+
+
+# T7: REQ-TEST-004
+def test_implementation_family_recipes_route_terminals_through_diagnostics() -> None:
+    """REQ-TEST-004: Every register_clone_* terminal in implementation-family recipes
+    routes through a run_diagnostic* step gated on post_run_diagnostics."""
+    recipes_dir = builtin_recipes_dir()
+    target_names = ["implementation.yaml", "implementation-groups.yaml"]
+    missing: list[str] = []
+    for name in target_names:
+        path = recipes_dir / name
+        if not path.exists():
+            missing.append(name)
+    assert not missing, f"Recipe files not found: {missing}"
+
+    diag_step_prefixes = ("run_diagnostic",)
+    required_post_run_refs = ("inputs.post_run_diagnostics",)
+
+    for name in target_names:
+        recipe_path = recipes_dir / name
+        recipe = load_recipe(recipe_path)
+        steps = recipe.steps
+        clone_steps = [(n, s) for n, s in steps.items() if n.startswith("register_clone_")]
+        assert clone_steps, f"{name}: expected at least one register_clone_* step"
+        for step_name, cs in clone_steps:
+            # The step must route on_success to a run_diagnostic* step
+            next_step = cs.on_success
+            assert next_step is not None, f"{name}: {step_name} has no on_success"
+            assert next_step.startswith(diag_step_prefixes), (
+                f"{name}: {step_name}.on_success={next_step!r} must start with "
+                f"{diag_step_prefixes!r}"
+            )
+            # The run_diagnostic* step must gate on inputs.post_run_diagnostics
+            diag = steps.get(next_step)
+            assert diag is not None, (
+                f"{name}: step {step_name} routes to {next_step!r} but no such step exists"
+            )
+            assert diag.skip_when_false in required_post_run_refs, (
+                f"{name}: {next_step}.skip_when_false={diag.skip_when_false!r} "
+                f"must reference one of {required_post_run_refs!r}"
+            )

--- a/tests/recipe/test_implementation_groups_pr_decomposition.py
+++ b/tests/recipe/test_implementation_groups_pr_decomposition.py
@@ -68,7 +68,7 @@ def test_done_unconfirmed_stop_exists(recipe) -> None:
 
 
 def test_register_clone_unconfirmed_routes_to_done_unconfirmed(recipe) -> None:
-    """register_clone_unconfirmed must route to done_unconfirmed, not done."""
+    """register_clone_unconfirmed must route to run_diagnostic_unconfirmed."""
     step = recipe.steps["register_clone_unconfirmed"]
-    assert step.on_success == "done_unconfirmed"
-    assert step.on_failure == "done_unconfirmed"
+    assert step.on_success == "run_diagnostic_unconfirmed"
+    assert step.on_failure == "run_diagnostic_unconfirmed"

--- a/tests/server/_helpers.py
+++ b/tests/server/_helpers.py
@@ -75,7 +75,6 @@ _PATCHED_DEFAULTS = {
     "base_branch": "develop",
     "local_review_rounds": "7",
     "adversarial_review_level": "aggressive",
-    "post_run_diagnostics": "true",
     "is_fleet_dispatch": "true",
     "dispatch_id": "test-dispatch-999",
 }

--- a/tests/server/_helpers.py
+++ b/tests/server/_helpers.py
@@ -77,6 +77,7 @@ _PATCHED_DEFAULTS = {
     "adversarial_review_level": "aggressive",
     "is_fleet_dispatch": "true",
     "dispatch_id": "test-dispatch-999",
+    "post_run_diagnostics": "true",
 }
 
 _SERVER_ONLY_KEYS = frozenset({"kitchen_id", "diagnostics_log_dir", "backend_supports_git_write"})

--- a/tests/server/test_lock_ingredients.py
+++ b/tests/server/test_lock_ingredients.py
@@ -104,7 +104,7 @@ class TestLockIngredientsRejectsServerAuthoritative:
 
 @pytest.mark.parametrize(
     "server_auth_key",
-    ["post_run_diagnostics", "base_branch"],
+    ["adversarial_review_level", "base_branch"],
 )
 @pytest.mark.anyio
 async def test_lock_ingredients_envelope_has_structured_fields(server_auth_key, tmp_path):
@@ -486,3 +486,28 @@ class TestLockIngredientsConcurrentFlock:
         data = json.loads(overlay.read_text())
         assert "a" in data["locked_ingredients"]
         assert "b" in data["locked_ingredients"]
+
+
+# T3: REQ-ING-004
+@pytest.mark.anyio
+async def test_post_run_diagnostics_lockable(tmp_path):
+    """REQ-ING-004: lock_ingredients accepts post_run_diagnostics."""
+    temp_dir = tmp_path / ".autoskillit" / "temp"
+    temp_dir.mkdir(parents=True)
+    (temp_dir / ".hook_config.json").write_text("{}")
+
+    ctx = _make_mock_ctx()
+    ctx.project_dir = tmp_path
+    ctx.active_recipe_steps = {}
+
+    with patch("autoskillit.server._get_ctx", return_value=ctx):
+        from autoskillit.server.tools.tools_kitchen import lock_ingredients
+
+        result_str = await lock_ingredients(
+            locked={"post_run_diagnostics": "true"}, pipeline_id="a"
+        )
+
+    result = json.loads(result_str)
+    assert result.get("success") is True, (
+        f"post_run_diagnostics must be lockable; got result={result}"
+    )

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -1153,11 +1153,8 @@ async def test_post_run_diagnostics_override_wins_over_config(tmp_path, monkeypa
     assert overrides["post_run_diagnostics"] == "true", (
         f"Override must win; got overrides={overrides}"
     )
-    # Also: post_run_diagnostics is no longer in SERVER_AUTHORITATIVE_INGREDIENTS,
-    # so no clobber warning should fire for it.
     call_args_list = mock_ctx.recipes.load_and_validate.call_args_list
     assert call_args_list, "open_kitchen should call load_and_validate"
-    # post_run_diagnostics was successfully passed through — verify via overrides dict above.
 
 
 # T2: REQ-ING-002

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -345,14 +345,18 @@ async def test_config_layer_keys_match_server_authoritative_ingredients(tmp_path
                             # No caller overrides — _merged_overrides == _auto_overrides
                             await open_kitchen(name="demo", ctx=mock_ctx)
 
-    from autoskillit.config.ingredient_defaults import SERVER_AUTHORITATIVE_INGREDIENTS
+    from autoskillit.config.ingredient_defaults import (
+        CONFIG_DEFAULT_INGREDIENTS,
+        SERVER_AUTHORITATIVE_INGREDIENTS,
+    )
 
     call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
     overrides = call_kwargs["ingredient_overrides"]
     config_resolvable_in_overrides = frozenset(overrides.keys()) - _SERVER_ONLY_KEYS
-    assert config_resolvable_in_overrides == SERVER_AUTHORITATIVE_INGREDIENTS, (
-        f"Mismatch: added={config_resolvable_in_overrides - SERVER_AUTHORITATIVE_INGREDIENTS}, "
-        f"missing={SERVER_AUTHORITATIVE_INGREDIENTS - config_resolvable_in_overrides}"
+    expected = SERVER_AUTHORITATIVE_INGREDIENTS | CONFIG_DEFAULT_INGREDIENTS
+    assert config_resolvable_in_overrides == expected, (
+        f"Mismatch: added={config_resolvable_in_overrides - expected}, "
+        f"missing={expected - config_resolvable_in_overrides}"
     )
 
 
@@ -465,7 +469,7 @@ async def test_open_kitchen_emits_authority_clobber_warning(tmp_path, monkeypatc
     mock_ctx.recipes = MagicMock()
     mock_recipe_obj = MagicMock()
     mock_recipe_obj.steps = {"do": MagicMock()}
-    mock_recipe_obj.ingredients = {"base_branch": MagicMock(), "post_run_diagnostics": MagicMock()}
+    mock_recipe_obj.ingredients = {"base_branch": MagicMock()}
     mock_ctx.recipes.load.return_value = mock_recipe_obj
     mock_ctx.recipes.load_and_validate.return_value = {
         "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
@@ -495,7 +499,6 @@ async def test_open_kitchen_emits_authority_clobber_warning(tmp_path, monkeypatc
                             "autoskillit.server.tools.tools_kitchen.resolve_ingredient_defaults",
                             return_value={
                                 "base_branch": "develop",
-                                "post_run_diagnostics": "false",
                                 "is_fleet_dispatch": "false",
                                 "dispatch_id": "",
                             },
@@ -504,16 +507,16 @@ async def test_open_kitchen_emits_authority_clobber_warning(tmp_path, monkeypatc
 
                             result_str = await open_kitchen(
                                 name="demo",
-                                overrides={"post_run_diagnostics": "true"},
+                                overrides={"base_branch": "custom-branch"},
                                 ctx=mock_ctx,
                             )
 
     parsed = json.loads(result_str)
     warnings = parsed.get("warnings") or []
-    matching = [w for w in warnings if "post_run_diagnostics" in w]
-    assert matching, f"Expected a warning naming post_run_diagnostics; got warnings={warnings}"
-    assert any("diagnostics.post_run_analysis" in w for w in warnings), (
-        f"Expected the warning to name the config path diagnostics.post_run_analysis; "
+    matching = [w for w in warnings if "base_branch" in w]
+    assert matching, f"Expected a warning naming base_branch; got warnings={warnings}"
+    assert any("branching.default_base_branch" in w for w in warnings), (
+        f"Expected the warning to name the config path branching.default_base_branch; "
         f"got warnings={warnings}"
     )
 
@@ -1085,3 +1088,152 @@ def test_recipe_validation_error_response_handles_malformed_suggestions():
     response = json.loads(_recipe_validation_error_response("demo", result))
     assert "unknown structural error" not in response["user_visible_message"]
     assert response["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# post_run_diagnostics demotion tests (T1, T2, T5)
+# ---------------------------------------------------------------------------
+
+
+# T1: REQ-ING-001
+@pytest.mark.anyio
+async def test_post_run_diagnostics_override_wins_over_config(tmp_path, monkeypatch):
+    """REQ-ING-001: open_kitchen override for post_run_diagnostics wins over config."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+    mock_ctx.recipes = MagicMock()
+    mock_recipe_obj = MagicMock()
+    mock_recipe_obj.steps = {"do": MagicMock()}
+    mock_recipe_obj.ingredients = {"post_run_diagnostics": MagicMock()}
+    mock_ctx.recipes.load.return_value = mock_recipe_obj
+    mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+        "valid": True,
+        "suggestions": [],
+        "diagram": None,
+        "ingredients_table": "--- TABLE ---",
+    }
+    mock_recipe_info = MagicMock()
+    mock_recipe_info.path = Path("/fake/recipe.yaml")
+    mock_ctx.recipes.find.return_value = mock_recipe_info
+    mock_ctx.config.migration.suppressed = []
+    mock_ctx.kitchen_id = "test-kitchen-abc"
+    mock_ctx.config.linux_tracing.log_dir = ""
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()
+            ):
+                with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+                    with patch(
+                        "autoskillit.server.tools.tools_kitchen.resolve_kitchen_id",
+                        return_value="test-kitchen-abc",
+                    ):
+                        with patch(
+                            "autoskillit.server.tools.tools_kitchen.resolve_ingredient_defaults",
+                            return_value={
+                                "base_branch": "develop",
+                                "post_run_diagnostics": "false",
+                                "is_fleet_dispatch": "false",
+                                "dispatch_id": "",
+                            },
+                        ):
+                            from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+                            await open_kitchen(
+                                name="demo",
+                                overrides={"post_run_diagnostics": "true"},
+                                ctx=mock_ctx,
+                            )
+
+    call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
+    overrides = call_kwargs["ingredient_overrides"]
+    assert overrides["post_run_diagnostics"] == "true", (
+        f"Override must win; got overrides={overrides}"
+    )
+    # Also: post_run_diagnostics is no longer in SERVER_AUTHORITATIVE_INGREDIENTS,
+    # so no clobber warning should fire for it.
+    call_args_list = mock_ctx.recipes.load_and_validate.call_args_list
+    assert call_args_list, "open_kitchen should call load_and_validate"
+    # post_run_diagnostics was successfully passed through — verify via overrides dict above.
+
+
+# T2: REQ-ING-002
+@pytest.mark.anyio
+async def test_post_run_diagnostics_config_default_applied(tmp_path, monkeypatch):
+    """REQ-ING-002: Without override, config value is used as default."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+    mock_ctx.recipes = MagicMock()
+    mock_recipe_obj = MagicMock()
+    mock_recipe_obj.steps = {"do": MagicMock()}
+    mock_recipe_obj.ingredients = {"post_run_diagnostics": MagicMock()}
+    mock_ctx.recipes.load.return_value = mock_recipe_obj
+    mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+        "valid": True,
+        "suggestions": [],
+        "diagram": None,
+        "ingredients_table": "--- TABLE ---",
+    }
+    mock_recipe_info = MagicMock()
+    mock_recipe_info.path = Path("/fake/recipe.yaml")
+    mock_ctx.recipes.find.return_value = mock_recipe_info
+    mock_ctx.config.migration.suppressed = []
+    mock_ctx.kitchen_id = "test-kitchen-abc"
+    mock_ctx.config.linux_tracing.log_dir = ""
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()
+            ):
+                with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+                    with patch(
+                        "autoskillit.server.tools.tools_kitchen.resolve_kitchen_id",
+                        return_value="test-kitchen-abc",
+                    ):
+                        with patch(
+                            "autoskillit.server.tools.tools_kitchen.resolve_ingredient_defaults",
+                            return_value={
+                                "base_branch": "develop",
+                                "post_run_diagnostics": "true",
+                                "is_fleet_dispatch": "false",
+                                "dispatch_id": "",
+                            },
+                        ):
+                            from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+                            await open_kitchen(name="demo", ctx=mock_ctx)
+
+    call_kwargs = mock_ctx.recipes.load_and_validate.call_args.kwargs
+    overrides = call_kwargs["ingredient_overrides"]
+    assert overrides["post_run_diagnostics"] == "true", (
+        f"Config default must apply; got overrides={overrides}"
+    )
+
+
+# T5: REQ-FDB-001
+def test_clobber_warning_includes_hint_when_available(monkeypatch):
+    """REQ-FDB-001: Clobber warning includes SERVER_AUTHORITATIVE_KEY_HINTS line."""
+    from autoskillit.server.tools._authority_feedback import (
+        SERVER_AUTHORITATIVE_KEY_HINTS,
+        build_authority_clobber_warnings,
+    )
+
+    monkeypatch.setitem(
+        SERVER_AUTHORITATIVE_KEY_HINTS, "base_branch", "<test hint for base_branch>"
+    )
+    try:
+        warnings = build_authority_clobber_warnings(
+            {"base_branch": "x"}, config_layer={"base_branch": "develop"}
+        )
+    finally:
+        SERVER_AUTHORITATIVE_KEY_HINTS.pop("base_branch", None)
+
+    assert any("<test hint for base_branch>" in w for w in warnings), (
+        f"Hint must be appended to warnings; got warnings={warnings}"
+    )

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -562,7 +562,7 @@ class TestLoadRecipeAuthorityClobber:
         mock_ctx.recipes = MagicMock()
         mock_recipe_obj = MagicMock()
         mock_recipe_obj.steps = {"do": MagicMock()}
-        mock_recipe_obj.ingredients = {"post_run_diagnostics": MagicMock()}
+        mock_recipe_obj.ingredients = {"base_branch": MagicMock()}
         mock_ctx.recipes.load.return_value = mock_recipe_obj
         mock_ctx.recipes.load_and_validate.return_value = {
             "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
@@ -589,7 +589,6 @@ class TestLoadRecipeAuthorityClobber:
                         "autoskillit.server.tools.tools_recipe.resolve_ingredient_defaults",
                         return_value={
                             "base_branch": "develop",
-                            "post_run_diagnostics": "false",
                             "is_fleet_dispatch": "false",
                             "dispatch_id": "",
                         },
@@ -598,14 +597,14 @@ class TestLoadRecipeAuthorityClobber:
 
                         result_str = await load_recipe(
                             name="demo",
-                            overrides={"post_run_diagnostics": "true"},
+                            overrides={"base_branch": "custom"},
                         )
 
         parsed = json.loads(result_str)
         warnings = parsed.get("warnings") or []
-        matching = [w for w in warnings if "post_run_diagnostics" in w]
+        matching = [w for w in warnings if "base_branch" in w]
         assert matching, (
-            f"load_recipe must emit a warning naming post_run_diagnostics; got warnings={warnings}"
+            f"load_recipe must emit a warning naming base_branch; got warnings={warnings}"
         )
         server_value_match = [w for w in warnings if "server value 'false'" in w]
         assert server_value_match, (

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -606,12 +606,12 @@ class TestLoadRecipeAuthorityClobber:
         assert matching, (
             f"load_recipe must emit a warning naming base_branch; got warnings={warnings}"
         )
-        server_value_match = [w for w in warnings if "server value 'false'" in w]
+        server_value_match = [w for w in warnings if "server value 'develop'" in w]
         assert server_value_match, (
             "Authority-clobber warning must confirm config value won — "
-            f"expected \"server value 'false'\" in warning text; got warnings={warnings}"
+            f"expected \"server value 'develop'\" in warning text; got warnings={warnings}"
         )
-        caller_value_absent = [w for w in warnings if "server value 'true'" in w]
+        caller_value_absent = [w for w in warnings if "server value 'custom'" in w]
         assert not caller_value_absent, (
             "Authority-clobber warning must NOT report the caller override as the server value — "
             f"got warnings={warnings}"

--- a/tests/server/test_tools_recipe.py
+++ b/tests/server/test_tools_recipe.py
@@ -549,7 +549,6 @@ async def test_load_recipe_injects_hidden_ingredient_overrides(tool_ctx_kitchen_
     call_kwargs = tool_ctx_kitchen_open.recipes.load_and_validate.call_args.kwargs
     overrides = call_kwargs["ingredient_overrides"]
     assert overrides["kitchen_id"] == "test-kitchen-xyz"
-    assert overrides["post_run_diagnostics"] == _PATCHED_DEFAULTS["post_run_diagnostics"]
 
 
 @pytest.mark.anyio
@@ -581,7 +580,6 @@ async def test_load_recipe_config_authority_overrides_caller(tool_ctx_kitchen_op
             "autoskillit.server.tools.tools_recipe.resolve_ingredient_defaults",
             return_value={
                 "base_branch": "develop",
-                "post_run_diagnostics": "false",
                 "is_fleet_dispatch": "false",
                 "dispatch_id": "",
             },
@@ -627,7 +625,6 @@ async def test_load_recipe_with_config_authority_ingredient(tool_ctx_kitchen_ope
             "autoskillit.server.tools.tools_recipe.resolve_ingredient_defaults",
             return_value={
                 "base_branch": "develop",
-                "post_run_diagnostics": "false",
                 "is_fleet_dispatch": "false",
                 "dispatch_id": "",
             },


### PR DESCRIPTION
## Summary

This plan demotes `post_run_diagnostics` from a server-authoritative ingredient to a config-as-default ingredient. After this change: (1) an explicit `open_kitchen` override for `post_run_diagnostics` wins over the config value, (2) absent an override the config value `diagnostics.post_run_analysis` remains the default source, (3) the key becomes lockable via `lock_ingredients`, (4) clobber warnings for remaining authoritative keys gain hint parity with the lock-rejection envelope, (5) a sous-chef rule requires the orchestrator to relay `open_kitchen` warnings, and (6) `implementation-groups.yaml` terminal paths gain `run_diagnostic*` step parity with `implementation.yaml`.

## Requirements

**ING — ingredient authority**

- **REQ-ING-001:** An explicit `open_kitchen` override for `post_run_diagnostics` must win over the config-derived value (the key must no longer be a member of `SERVER_AUTHORITATIVE_INGREDIENTS`).
- **REQ-ING-002:** Absent a caller override, `post_run_diagnostics` must continue to resolve from `diagnostics.post_run_analysis` (config remains the default source; the shipped default stays `false`).
- **REQ-ING-003:** Every recipe declaring `post_run_diagnostics` with `authority: config` must drop that authority marker so validation and admission match the new behavior.
- **REQ-ING-004:** `lock_ingredients` must accept locking `post_run_diagnostics`, and the lock must be enforced by the existing lock/trace mechanism like any other lockable ingredient.
- **REQ-ING-005:** The `open_kitchen` docstring and the sous-chef server-authoritative do-not-lock list must no longer name `post_run_diagnostics` among the authoritative examples.

**FDB — feedback parity (remaining authoritative keys)**

- **REQ-FDB-001:** The `open_kitchen` clobber warning for a server-authoritative key must include that key's `SERVER_AUTHORITATIVE_KEY_HINTS` line when one exists, matching the `lock_ingredients` rejection envelope.

**SKL — consumption contract**

- **REQ-SKL-001:** Sous-chef discipline must require that when `open_kitchen` returns a non-empty `warnings` array, each warning is relayed to the user in the orchestrator's next response before the pipeline proceeds (an immediate-action rule; no deferred-action obligations).

**PAR — parity and documentation**

- **REQ-PAR-001:** implementation-groups.yaml terminal paths must route through `run_diagnostic*` steps gated on `post_run_diagnostics` with parity to implementation.yaml (today it declares the ingredient but contains zero diagnostic steps, so the feature can never fire there).
- **REQ-PAR-002:** `diagnostics.post_run_analysis` and the per-run override behavior must be documented in docs/.

**TEST — co-update surface**

- **REQ-TEST-001:** A test must pin that `open_kitchen(overrides={"post_run_diagnostics": "true"})` with config `false` resolves the ingredient to `true`, and that with no override the config value is used.
- **REQ-TEST-002:** Existing tests that use `post_run_diagnostics` as their server-authoritative example (authority-feedback and frozenset-membership tests from #4169/PR #4170 and #3185) must be migrated to a remaining authoritative key (e.g., `base_branch`) without losing coverage.
- **REQ-TEST-003:** A test must pin hint parity: the clobber warning text for a hinted authoritative key contains the hint line.
- **REQ-TEST-004:** A recipe-level test must assert that every `register_clone_*` terminal in the three implementation-family recipes routes through a `run_diagnostic*` step gated on `post_run_diagnostics`.

Closes #4180

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260704-151702-234347/.autoskillit/temp/make-plan/demote_post_run_diagnostics_plan_2026-07-04_160500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 1 | 2.2k | 44.9k | 4.1M | 168.5k | 87 | 149.6k | 22m 37s |
| review_approach* | opus | 1 | 9.2k | 5.3k | 199.4k | 49.0k | 12 | 61.8k | 6m 1s |
| verify* | fable | 1 | 31.1k | 41.3k | 2.0M | 169.7k | 44 | 170.1k | 14m 49s |
| implement* | MiniMax-M3 | 1 | 96.2k | 18.9k | 7.0M | 0 | 156 | 0 | 18m 6s |
| fix* | opus | 2 | 117 | 17.4k | 5.0M | 112.5k | 123 | 130.3k | 16m 25s |
| audit_impl* | opus | 1 | 49 | 32.4k | 750.7k | 108.5k | 39 | 93.5k | 14m 1s |
| prepare_pr* | MiniMax-M3 | 1 | 56.9k | 2.6k | 297.6k | 0 | 16 | 0 | 46s |
| compose_pr* | MiniMax-M3 | 1 | 44.5k | 1.7k | 210.7k | 0 | 10 | 0 | 30s |
| review_pr* | opus | 1 | 29 | 30.6k | 747.7k | 103.2k | 35 | 87.2k | 8m 23s |
| resolve_review* | opus | 1 | 52 | 9.2k | 963.6k | 69.3k | 36 | 51.0k | 6m 52s |
| **Total** | | | 240.3k | 204.1k | 21.2M | 169.7k | | 743.5k | 1h 48m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 577 | 12052.9 | 0.0 | 32.8 |
| fix | 37 | 135594.4 | 3522.5 | 469.7 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 3 | 321213.3 | 17015.7 | 3052.3 |
| **Total** | **617** | 34306.0 | 1205.0 | 330.9 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 2.2k | 44.9k | 4.1M | 149.6k | 22m 37s |
| opus | 5 | 9.5k | 94.8k | 7.7M | 423.8k | 51m 45s |
| fable | 1 | 31.1k | 41.3k | 2.0M | 170.1k | 14m 49s |
| MiniMax-M3 | 3 | 197.6k | 23.2k | 7.5M | 0 | 19m 22s |