### PR TITLE
Headless One-Shot Recipe Dispatch CLI

### DIFF
--- a/src/autoskillit/cli/fleet/AGENTS.md
+++ b/src/autoskillit/cli/fleet/AGENTS.md
@@ -10,4 +10,5 @@ Fleet campaign CLI subcommands for multi-issue dispatch orchestration.
 | `_fleet_display.py` | Status display: `_render_status_display()`, `_watch_loop()`, `_STATUS_COLUMNS`, `render_fleet_error()` |
 | `_fleet_lifecycle.py` | Thin wrapper delegating reap to `fleet._dispatch_reaper`; `_pick_resume_campaign()` |
 | `_fleet_preview.py` | Pre-launch dispatch preview: `_build_dispatch_recipe_table()`, `_print_dispatch_preview()` |
+| `_fleet_run.py` | `fleet_run` command body + `_fleet_run_error` JSON envelope helper (extracted from `__init__.py`) |
 | `_fleet_session.py` | `_launch_fleet_session()` — builds Claude interactive session for fleet campaigns |

--- a/src/autoskillit/cli/fleet/AGENTS.md
+++ b/src/autoskillit/cli/fleet/AGENTS.md
@@ -6,7 +6,7 @@ Fleet campaign CLI subcommands for multi-issue dispatch orchestration.
 
 | File | Purpose |
 |------|---------|
-| `__init__.py` | Main module: `fleet_app` Cyclopts sub-app with `campaign`, `dispatch`, `list`, `status` commands |
+| `__init__.py` | Main module: `fleet_app` Cyclopts sub-app with `campaign`, `dispatch`, `list`, `run`, `status` commands |
 | `_fleet_display.py` | Status display: `_render_status_display()`, `_watch_loop()`, `_STATUS_COLUMNS`, `render_fleet_error()` |
 | `_fleet_lifecycle.py` | Thin wrapper delegating reap to `fleet._dispatch_reaper`; `_pick_resume_campaign()` |
 | `_fleet_preview.py` | Pre-launch dispatch preview: `_build_dispatch_recipe_table()`, `_print_dispatch_preview()` |

--- a/src/autoskillit/cli/fleet/__init__.py
+++ b/src/autoskillit/cli/fleet/__init__.py
@@ -9,7 +9,7 @@ import shutil
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, NoReturn
 from uuid import uuid4
 
 from cyclopts import App, Parameter
@@ -49,6 +49,21 @@ def _require_fleet(cfg: AutomationConfig) -> None:
             file=sys.stderr,
         )
         raise SystemExit(1)
+
+
+def _fleet_run_error(error: str, message: str, exit_code: int = 1) -> NoReturn:
+    """Print a JSON error envelope to stdout and exit nonzero.
+
+    Headless-only error helper: emits machine-readable JSON so dispatch
+    callers can parse the refusal rather than scraping stderr text.
+    """
+    envelope = {
+        "success": False,
+        "error": error,
+        "user_visible_message": message,
+    }
+    print(json.dumps(envelope))
+    raise SystemExit(exit_code)
 
 
 if TYPE_CHECKING:
@@ -408,3 +423,69 @@ def fleet_status(
             return
 
         print(_render_terminal_table(columns, rows_list))
+
+
+@fleet_app.command(name="run")
+def fleet_run(
+    recipe: str,
+    *,
+    task: Annotated[str, Parameter(name=["--task", "-t"])] = "",
+    ingredient: Annotated[tuple[str, ...], Parameter(name=["--ingredient", "-i"])] = (),
+    backend: Annotated[str | None, Parameter(name=["--backend"])] = None,
+    timeout_sec: Annotated[int | None, Parameter(name=["--timeout-sec"])] = None,
+    resume_session_id: Annotated[str | None, Parameter(name=["--resume-session-id"])] = None,
+    prior_dispatch_id: Annotated[str | None, Parameter(name=["--prior-dispatch-id"])] = None,
+    disable_quota_guard: Annotated[bool, Parameter(name=["--disable-quota-guard"])] = False,
+) -> None:
+    """One-shot headless recipe dispatch (experimental).
+
+    Dispatches a single recipe run non-interactively. Prints the dispatch
+    result envelope as JSON on stdout. Exit 0 on SUCCESS, nonzero otherwise.
+    """
+    # --- Session-type guard (retained for headless — prevents recursive dispatch) ---
+    if os.environ.get("AUTOSKILLIT_SESSION_TYPE") in ("skill", "leaf"):
+        _fleet_run_error(
+            "FLEET_SESSION_TYPE_BLOCKED",
+            "'fleet run' cannot run inside a skill or leaf session.",
+        )
+    # NOTE: CLAUDECODE guard intentionally NOT applied — REQ-HFD-006
+
+    # --- Config + feature gates ---
+    from autoskillit.config import load_config
+
+    try:
+        cfg = load_config(Path.cwd())
+    except Exception as exc:
+        logger.error("fleet run: failed to load config", exc_info=True)
+        _fleet_run_error("FLEET_CONFIG_ERROR", f"Failed to load config: {exc}")
+
+    # Fleet base feature check (equivalent to _require_fleet but with JSON output)
+    if not is_feature_enabled(
+        "fleet", cfg.features, experimental_enabled=cfg.experimental_enabled
+    ):
+        _fleet_run_error(
+            "FLEET_FEATURE_DISABLED",
+            "The 'fleet' feature is not enabled.\n"
+            "Enable with: features.experimental_enabled: true in your config\n"
+            "Or set: AUTOSKILLIT_FEATURES__FLEET=true",
+        )
+
+    # Headless run feature check
+    if not is_feature_enabled(
+        "fleet_headless_run",
+        cfg.features,
+        experimental_enabled=cfg.experimental_enabled,
+    ):
+        _fleet_run_error(
+            "FLEET_FEATURE_DISABLED",
+            "The 'fleet_headless_run' feature is not enabled.\n"
+            "Enable with: features.experimental_enabled: true\n"
+            "Or: features.fleet_headless_run: true\n"
+            "Or: AUTOSKILLIT_FEATURES__FLEET_HEADLESS_RUN=true",
+        )
+
+    # --- Part B implements the dispatch body here ---
+    _fleet_run_error(
+        "FLEET_NOT_IMPLEMENTED",
+        "'fleet run' dispatch is not yet implemented. See Part B.",
+    )

--- a/src/autoskillit/cli/fleet/__init__.py
+++ b/src/autoskillit/cli/fleet/__init__.py
@@ -9,7 +9,7 @@ import shutil
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, NoReturn
+from typing import TYPE_CHECKING, Annotated
 from uuid import uuid4
 
 from cyclopts import App, Parameter
@@ -31,6 +31,7 @@ from autoskillit.cli.fleet._fleet_preview import (
     _FLEET_DISPATCH_GREETINGS,
     _print_dispatch_preview,
 )
+from autoskillit.cli.fleet._fleet_run import fleet_run
 from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
 from autoskillit.core import TerminalColumn, get_logger, is_feature_enabled
 
@@ -49,21 +50,6 @@ def _require_fleet(cfg: AutomationConfig) -> None:
             file=sys.stderr,
         )
         raise SystemExit(1)
-
-
-def _fleet_run_error(error: str, message: str, exit_code: int = 1) -> NoReturn:
-    """Print a JSON error envelope to stdout and exit nonzero.
-
-    Headless-only error helper: emits machine-readable JSON so dispatch
-    callers can parse the refusal rather than scraping stderr text.
-    """
-    envelope = {
-        "success": False,
-        "error": error,
-        "user_visible_message": message,
-    }
-    print(json.dumps(envelope))
-    raise SystemExit(exit_code)
 
 
 if TYPE_CHECKING:
@@ -425,67 +411,4 @@ def fleet_status(
         print(_render_terminal_table(columns, rows_list))
 
 
-@fleet_app.command(name="run")
-def fleet_run(
-    recipe: str,
-    *,
-    task: Annotated[str, Parameter(name=["--task", "-t"])] = "",
-    ingredient: Annotated[tuple[str, ...], Parameter(name=["--ingredient", "-i"])] = (),
-    backend: Annotated[str | None, Parameter(name=["--backend"])] = None,
-    timeout_sec: Annotated[int | None, Parameter(name=["--timeout-sec"])] = None,
-    resume_session_id: Annotated[str | None, Parameter(name=["--resume-session-id"])] = None,
-    prior_dispatch_id: Annotated[str | None, Parameter(name=["--prior-dispatch-id"])] = None,
-    disable_quota_guard: Annotated[bool, Parameter(name=["--disable-quota-guard"])] = False,
-) -> None:
-    """One-shot headless recipe dispatch (experimental).
-
-    Dispatches a single recipe run non-interactively. Prints the dispatch
-    result envelope as JSON on stdout. Exit 0 on SUCCESS, nonzero otherwise.
-    """
-    # --- Session-type guard (retained for headless — prevents recursive dispatch) ---
-    if os.environ.get("AUTOSKILLIT_SESSION_TYPE") in ("skill", "leaf"):
-        _fleet_run_error(
-            "FLEET_SESSION_TYPE_BLOCKED",
-            "'fleet run' cannot run inside a skill or leaf session.",
-        )
-    # NOTE: CLAUDECODE guard intentionally NOT applied — REQ-HFD-006
-
-    # --- Config + feature gates ---
-    from autoskillit.config import load_config
-
-    try:
-        cfg = load_config(Path.cwd())
-    except Exception as exc:
-        logger.error("fleet run: failed to load config", exc_info=True)
-        _fleet_run_error("FLEET_CONFIG_ERROR", f"Failed to load config: {exc}")
-
-    # Fleet base feature check (equivalent to _require_fleet but with JSON output)
-    if not is_feature_enabled(
-        "fleet", cfg.features, experimental_enabled=cfg.experimental_enabled
-    ):
-        _fleet_run_error(
-            "FLEET_FEATURE_DISABLED",
-            "The 'fleet' feature is not enabled.\n"
-            "Enable with: features.experimental_enabled: true in your config\n"
-            "Or set: AUTOSKILLIT_FEATURES__FLEET=true",
-        )
-
-    # Headless run feature check
-    if not is_feature_enabled(
-        "fleet_headless_run",
-        cfg.features,
-        experimental_enabled=cfg.experimental_enabled,
-    ):
-        _fleet_run_error(
-            "FLEET_FEATURE_DISABLED",
-            "The 'fleet_headless_run' feature is not enabled.\n"
-            "Enable with: features.experimental_enabled: true\n"
-            "Or: features.fleet_headless_run: true\n"
-            "Or: AUTOSKILLIT_FEATURES__FLEET_HEADLESS_RUN=true",
-        )
-
-    # --- Part B implements the dispatch body here ---
-    _fleet_run_error(
-        "FLEET_NOT_IMPLEMENTED",
-        "'fleet run' dispatch is not yet implemented. See Part B.",
-    )
+fleet_run = fleet_app.command(name="run")(fleet_run)

--- a/src/autoskillit/cli/fleet/_fleet_run.py
+++ b/src/autoskillit/cli/fleet/_fleet_run.py
@@ -1,0 +1,85 @@
+"""Headless one-shot fleet dispatch command."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Annotated, NoReturn
+
+from cyclopts import Parameter
+
+from autoskillit.core import get_logger, is_feature_enabled
+
+logger = get_logger(__name__)
+
+
+def _fleet_run_error(error: str, message: str, exit_code: int = 1) -> NoReturn:
+    envelope = {"success": False, "error": error, "user_visible_message": message}
+    print(json.dumps(envelope))
+    raise SystemExit(exit_code)
+
+
+def fleet_run(
+    recipe: str,
+    *,
+    task: Annotated[str, Parameter(name=["--task", "-t"])] = "",
+    ingredient: Annotated[tuple[str, ...], Parameter(name=["--ingredient", "-i"])] = (),
+    backend: Annotated[str | None, Parameter(name=["--backend"])] = None,
+    timeout_sec: Annotated[int | None, Parameter(name=["--timeout-sec"])] = None,
+    resume_session_id: Annotated[str | None, Parameter(name=["--resume-session-id"])] = None,
+    prior_dispatch_id: Annotated[str | None, Parameter(name=["--prior-dispatch-id"])] = None,
+    disable_quota_guard: Annotated[bool, Parameter(name=["--disable-quota-guard"])] = False,
+) -> None:
+    """One-shot headless recipe dispatch (experimental).
+
+    Dispatches a single recipe run non-interactively. Prints the dispatch
+    result envelope as JSON on stdout. Exit 0 on SUCCESS, nonzero otherwise.
+    """
+    # --- Session-type guard (retained for headless — prevents recursive dispatch) ---
+    if os.environ.get("AUTOSKILLIT_SESSION_TYPE") in ("skill", "leaf"):
+        _fleet_run_error(
+            "FLEET_SESSION_TYPE_BLOCKED",
+            "'fleet run' cannot run inside a skill or leaf session.",
+        )
+    # NOTE: CLAUDECODE guard intentionally NOT applied — REQ-HFD-006
+
+    # --- Config + feature gates ---
+    from autoskillit.config import load_config
+
+    try:
+        cfg = load_config(Path.cwd())
+    except Exception as exc:
+        logger.error("fleet run: failed to load config", exc_info=True)
+        _fleet_run_error("FLEET_CONFIG_ERROR", f"Failed to load config: {exc}")
+
+    # Fleet base feature check (equivalent to _require_fleet but with JSON output)
+    if not is_feature_enabled(
+        "fleet", cfg.features, experimental_enabled=cfg.experimental_enabled
+    ):
+        _fleet_run_error(
+            "FLEET_FEATURE_DISABLED",
+            "The 'fleet' feature is not enabled.\n"
+            "Enable with: features.experimental_enabled: true in your config\n"
+            "Or set: AUTOSKILLIT_FEATURES__FLEET=true",
+        )
+
+    # Headless run feature check
+    if not is_feature_enabled(
+        "fleet_headless_run",
+        cfg.features,
+        experimental_enabled=cfg.experimental_enabled,
+    ):
+        _fleet_run_error(
+            "FLEET_FEATURE_DISABLED",
+            "The 'fleet_headless_run' feature is not enabled.\n"
+            "Enable with: features.experimental_enabled: true\n"
+            "Or: features.fleet_headless_run: true\n"
+            "Or: AUTOSKILLIT_FEATURES__FLEET_HEADLESS_RUN=true",
+        )
+
+    # --- Part B implements the dispatch body here ---
+    _fleet_run_error(
+        "FLEET_NOT_IMPLEMENTED",
+        "'fleet run' dispatch is not yet implemented. See Part B.",
+    )

--- a/src/autoskillit/cli/fleet/_fleet_run.py
+++ b/src/autoskillit/cli/fleet/_fleet_run.py
@@ -194,12 +194,12 @@ def fleet_run(
                 disable_quota_guard=disable_quota_guard,
             )
         )
-    except (KeyboardInterrupt, SystemExit) as exc:
+    except KeyboardInterrupt as exc:
         logger.error("fleet run: dispatch interrupted: %s", exc)
         _fleet_run_error(
             "FLEET_DISPATCH_INTERRUPTED", "Dispatch interrupted by signal.", exit_code=1
         )
-    except BaseException as exc:
+    except Exception as exc:
         logger.error("fleet run: dispatch crashed", exc_info=True)
         _fleet_run_error("FLEET_L3_STARTUP_OR_CRASH", str(exc))
 

--- a/src/autoskillit/cli/fleet/_fleet_run.py
+++ b/src/autoskillit/cli/fleet/_fleet_run.py
@@ -40,7 +40,7 @@ async def _execute_fleet_run(
 
     from autoskillit.core import detect_autoskillit_mcp_prefix
     from autoskillit.fleet import _build_food_truck_prompt, execute_dispatch
-    from autoskillit.server._factory import make_context
+    from autoskillit.server import make_context
 
     ctx = make_context(cfg, project_dir=Path.cwd())
 
@@ -168,7 +168,7 @@ def fleet_run(
     # --- Resolve backend ---
     dispatch_backend = None
     if backend is not None:
-        from autoskillit.server._misc import resolve_backend_override
+        from autoskillit.server import resolve_backend_override
 
         try:
             dispatch_backend = resolve_backend_override(backend)

--- a/src/autoskillit/cli/fleet/_fleet_run.py
+++ b/src/autoskillit/cli/fleet/_fleet_run.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Annotated, NoReturn
+from typing import TYPE_CHECKING, Annotated, NoReturn
 
 from cyclopts import Parameter
 
 from autoskillit.core import get_logger, is_feature_enabled
+
+if TYPE_CHECKING:
+    from autoskillit.config import AutomationConfig
+    from autoskillit.core import CodingAgentBackend
+    from autoskillit.fleet import DispatchResult
 
 logger = get_logger(__name__)
 
@@ -18,6 +23,75 @@ def _fleet_run_error(error: str, message: str, exit_code: int = 1) -> NoReturn:
     envelope = {"success": False, "error": error, "user_visible_message": message}
     print(json.dumps(envelope))
     raise SystemExit(exit_code)
+
+
+async def _execute_fleet_run(
+    cfg: AutomationConfig,
+    recipe: str,
+    task: str,
+    ingredients: dict[str, str] | None,
+    timeout_sec: int | None,
+    dispatch_backend: CodingAgentBackend | None,
+    resume_session_id: str | None,
+    prior_dispatch_id: str | None,
+    disable_quota_guard: bool,
+) -> DispatchResult:
+    import functools
+
+    from autoskillit.core import detect_autoskillit_mcp_prefix
+    from autoskillit.fleet import _build_food_truck_prompt, execute_dispatch
+    from autoskillit.server._factory import make_context
+
+    ctx = make_context(cfg, project_dir=Path.cwd())
+
+    effective_backend = dispatch_backend or ctx.backend
+    has_ufa = (
+        effective_backend.capabilities.has_unguarded_filesystem_access
+        if effective_backend
+        else False
+    )
+    prompt_builder = functools.partial(
+        _build_food_truck_prompt,
+        mcp_prefix=detect_autoskillit_mcp_prefix(),
+        has_unguarded_filesystem_access=has_ufa,
+    )
+
+    if disable_quota_guard:
+
+        async def quota_checker(_cfg: object) -> dict[str, object]:
+            return {"should_sleep": False}
+    else:
+        from autoskillit.execution import check_and_sleep_if_needed
+
+        _supports_quota = (
+            effective_backend.capabilities.anthropic_provider_capable
+            if effective_backend
+            else True
+        )
+
+        async def quota_checker(_cfg: object) -> dict[str, object]:
+            return await check_and_sleep_if_needed(
+                _cfg, provider="anthropic" if _supports_quota else ""
+            )
+
+    async def quota_refresher(_cfg: object) -> None:
+        pass
+
+    return await execute_dispatch(
+        tool_ctx=ctx,
+        recipe=recipe,
+        task=task,
+        ingredients=ingredients,
+        dispatch_name=None,
+        timeout_sec=timeout_sec,
+        prompt_builder=prompt_builder,
+        quota_checker=quota_checker,
+        quota_refresher=quota_refresher,
+        cache_invalidator=None,
+        resume_session_id=resume_session_id,
+        prior_dispatch_id=prior_dispatch_id,
+        dispatch_backend=dispatch_backend,
+    )
 
 
 def fleet_run(
@@ -78,8 +152,65 @@ def fleet_run(
             "Or: AUTOSKILLIT_FEATURES__FLEET_HEADLESS_RUN=true",
         )
 
-    # --- Part B implements the dispatch body here ---
-    _fleet_run_error(
-        "FLEET_NOT_IMPLEMENTED",
-        "'fleet run' dispatch is not yet implemented. See Part B.",
-    )
+    # --- Parse ingredients ---
+    ingredients: dict[str, str] | None = None
+    if ingredient:
+        ingredients = {}
+        for item in ingredient:
+            if "=" not in item:
+                _fleet_run_error(
+                    "FLEET_INVALID_ARGUMENT",
+                    f"Ingredient must be key=value, got: {item!r}",
+                )
+            k, v = item.split("=", 1)
+            ingredients[k] = v
+
+    # --- Resolve backend ---
+    dispatch_backend = None
+    if backend is not None:
+        from autoskillit.server._misc import resolve_backend_override
+
+        try:
+            dispatch_backend = resolve_backend_override(backend)
+        except ValueError as exc:
+            _fleet_run_error("FLEET_INVALID_BACKEND", str(exc))
+
+    # --- Run dispatch ---
+    import asyncio
+
+    from autoskillit.fleet import DispatchRejected, DispatchStatus
+
+    try:
+        result = asyncio.run(
+            _execute_fleet_run(
+                cfg=cfg,
+                recipe=recipe,
+                task=task,
+                ingredients=ingredients,
+                timeout_sec=timeout_sec,
+                dispatch_backend=dispatch_backend,
+                resume_session_id=resume_session_id,
+                prior_dispatch_id=prior_dispatch_id,
+                disable_quota_guard=disable_quota_guard,
+            )
+        )
+    except (KeyboardInterrupt, SystemExit) as exc:
+        logger.error("fleet run: dispatch interrupted: %s", exc)
+        _fleet_run_error(
+            "FLEET_DISPATCH_INTERRUPTED", "Dispatch interrupted by signal.", exit_code=1
+        )
+    except BaseException as exc:
+        logger.error("fleet run: dispatch crashed", exc_info=True)
+        _fleet_run_error("FLEET_L3_STARTUP_OR_CRASH", str(exc))
+
+    # --- Output result envelope ---
+    print(result.outcome.to_envelope())
+
+    # --- Exit code (DispatchRejected has no .success/.dispatch_status — check it first) ---
+    if isinstance(result.outcome, DispatchRejected):
+        raise SystemExit(3)
+    if result.outcome.success:
+        raise SystemExit(0)
+    if result.outcome.dispatch_status == DispatchStatus.RESUMABLE:
+        raise SystemExit(2)
+    raise SystemExit(1)

--- a/src/autoskillit/core/types/_type_constants_features.py
+++ b/src/autoskillit/core/types/_type_constants_features.py
@@ -60,6 +60,17 @@ FEATURE_REGISTRY: dict[str, FeatureDef] = {
         default_enabled=False,
         since_version="0.9.119",
     ),
+    "fleet_headless_run": FeatureDef(
+        lifecycle=FeatureLifecycle.EXPERIMENTAL,
+        description="Headless one-shot recipe dispatch via CLI (fleet run)",
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+        tier=1,
+        default_enabled=False,
+        depends_on=frozenset({"fleet"}),
+        since_version="0.10.845",
+    ),
     "planner": FeatureDef(
         lifecycle=FeatureLifecycle.EXPERIMENTAL,
         description=(

--- a/src/autoskillit/server/__init__.py
+++ b/src/autoskillit/server/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     # Public utilities consumed by CLI and tests
     "version_info",
     "make_context",
+    "resolve_backend_override",
     # Wire-format compatibility middleware
     "ClaudeCodeCompatMiddleware",
     # Session-type visibility dispatcher (callable by tests)
@@ -77,6 +78,7 @@ from autoskillit.server import (  # noqa: E402, F401
     _notify,
 )
 from autoskillit.server._factory import make_context  # noqa: E402, F401
+from autoskillit.server._misc import resolve_backend_override  # noqa: E402, F401
 from autoskillit.server._session_type import _apply_session_type_visibility  # noqa: E402, F401
 from autoskillit.server.tools import (  # noqa: E402, F401
     tools_agents as _tools_agents,

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -63,6 +63,7 @@ _PRINT_EXEMPT = frozenset(
         "_fleet_display.py",
         "_fleet_lifecycle.py",
         "_fleet_preview.py",
+        "_fleet_run.py",
         "_fleet_session.py",
         "_session_picker.py",
         "_fleet.py",

--- a/tests/arch/test_feature_markers.py
+++ b/tests/arch/test_feature_markers.py
@@ -31,6 +31,7 @@ _FLEET_CROSS_DIR_FILES: frozenset[Path] = frozenset(
         _TESTS_ROOT / "cli" / "test_fleet_campaign.py",
         _TESTS_ROOT / "cli" / "test_fleet_status.py",
         _TESTS_ROOT / "cli" / "test_fleet_list.py",
+        _TESTS_ROOT / "cli" / "test_fleet_run.py",
         _TESTS_ROOT / "server" / "test_tools_dispatch.py",
         _TESTS_ROOT / "server" / "test_tools_dispatch_validation.py",
         _TESTS_ROOT / "server" / "test_tools_dispatch_params.py",

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -345,6 +345,32 @@ def test_build_features_dict_franchise_raises_config_schema_error():
         AutomationConfig._build_features_dict({"franchise": True})
 
 
+# ── fleet_headless_run feature registry tests ─────────────────────────────────
+
+
+def test_fleet_headless_run_in_feature_registry():
+    """fleet_headless_run is registered with correct FeatureDef field values."""
+    from autoskillit.core.types._type_constants_features import FEATURE_REGISTRY
+    from autoskillit.core.types._type_enums import FeatureLifecycle
+
+    entry = FEATURE_REGISTRY["fleet_headless_run"]
+    assert entry.lifecycle == FeatureLifecycle.EXPERIMENTAL
+    assert entry.tier == 1
+    assert entry.default_enabled is False
+    assert entry.tool_tags == frozenset()
+    assert entry.skill_categories == frozenset()
+    assert entry.depends_on == frozenset({"fleet"})
+    assert entry.import_package is None
+
+
+def test_fleet_headless_run_promoted_by_experimental_blanket():
+    """fleet_headless_run has no requires_backend_alignment, experimental blanket promotes it."""
+    from autoskillit.core.feature_flags import is_feature_enabled
+
+    assert is_feature_enabled("fleet_headless_run", {}, experimental_enabled=True) is True
+    assert is_feature_enabled("fleet_headless_run", {}, experimental_enabled=False) is False
+
+
 # ── Providers feature registry tests ─────────────────────────────────────────
 
 

--- a/tests/cli/AGENTS.md
+++ b/tests/cli/AGENTS.md
@@ -43,6 +43,7 @@ CLI command, subcommand, and interactive workflow tests.
 | `test_fleet_campaign_preview.py` | Tests: fleet_campaign shows preview + confirmation before launch |
 | `test_fleet_dispatch.py` | Tests: fleet CLI dispatch command |
 | `test_fleet_list.py` | Tests: fleet CLI list command |
+| `test_fleet_run.py` | Tests: fleet CLI run command gates — session-type guard, feature gates, CLAUDECODE relaxation |
 | `test_fleet_session.py` | Tests: _launch_fleet_session forwards ingredients_table to prompt builder |
 | `test_fleet_split.py` | Structural guard for fleet test split |
 | `test_fleet_status.py` | Tests: fleet CLI status command |

--- a/tests/cli/test_fleet_list.py
+++ b/tests/cli/test_fleet_list.py
@@ -97,7 +97,7 @@ class TestFleetCLIRegistration:
 
         assert "campaign" in _subcommand_names(fleet_app)
 
-    def test_fleet_run_command_not_registered(self) -> None:
+    def test_fleet_run_command_registered(self) -> None:
         from autoskillit.cli.fleet import fleet_app
 
-        assert "run" not in _subcommand_names(fleet_app)
+        assert "run" in _subcommand_names(fleet_app)

--- a/tests/cli/test_fleet_run.py
+++ b/tests/cli/test_fleet_run.py
@@ -1,4 +1,4 @@
-"""Tests: fleet CLI run command gates — session-type guard, feature gates, CLAUDECODE relaxation."""
+"""Tests: fleet run command gates — session guard, feature gates, CLAUDECODE relaxation."""
 
 from __future__ import annotations
 
@@ -31,7 +31,7 @@ class TestFleetRunGates:
     def test_fleet_run_blocks_in_leaf_session(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
     ) -> None:
-        """fleet_run exits with JSON FLEET_SESSION_TYPE_BLOCKED when AUTOSKILLIT_SESSION_TYPE=leaf."""
+        """fleet_run exits with FLEET_SESSION_TYPE_BLOCKED when SESSION_TYPE=leaf."""
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "leaf")
         monkeypatch.setattr(
             "autoskillit.config.load_config",
@@ -50,7 +50,7 @@ class TestFleetRunGates:
     def test_fleet_run_blocks_in_skill_session(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
     ) -> None:
-        """fleet_run exits with JSON FLEET_SESSION_TYPE_BLOCKED when AUTOSKILLIT_SESSION_TYPE=skill."""
+        """fleet_run exits with FLEET_SESSION_TYPE_BLOCKED when SESSION_TYPE=skill."""
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "skill")
         monkeypatch.setattr(
             "autoskillit.config.load_config",

--- a/tests/cli/test_fleet_run.py
+++ b/tests/cli/test_fleet_run.py
@@ -3,8 +3,17 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from autoskillit.core import FleetErrorCode
+from autoskillit.fleet import (
+    DispatchCompleted,
+    DispatchRejected,
+    DispatchResult,
+    DispatchStatus,
+)
 
 pytestmark = [
     pytest.mark.layer("cli"),
@@ -25,6 +34,39 @@ def _make_test_config(
             "experimental_enabled": experimental_enabled,
         },
     )()
+
+
+def _mock_success_result(dispatch_id="test-dispatch-001", session_id="test-session-001"):
+    return DispatchResult(
+        outcome=DispatchCompleted(
+            success=True,
+            dispatch_status=DispatchStatus.SUCCESS,
+            dispatch_id=dispatch_id,
+            dispatched_session_id=session_id,
+            reason="completed",
+        ),
+    )
+
+
+def _mock_failure_result(status=DispatchStatus.FAILURE):
+    return DispatchResult(
+        outcome=DispatchCompleted(
+            success=False,
+            dispatch_status=status,
+            dispatch_id="test-dispatch-002",
+            dispatched_session_id="test-session-002",
+            reason="failed",
+        ),
+    )
+
+
+def _mock_rejected_result():
+    return DispatchResult(
+        outcome=DispatchRejected(
+            error_code=FleetErrorCode.FLEET_RECIPE_NOT_FOUND,
+            message="recipe not found",
+        ),
+    )
 
 
 class TestFleetRunGates:
@@ -137,3 +179,304 @@ class TestFleetRunGates:
         assert envelope["success"] is False
         assert envelope["error"] == "FLEET_FEATURE_DISABLED"
         assert "fleet" in envelope["user_visible_message"].lower()
+
+
+class TestFleetRunDispatch:
+    """Tests for the Part B dispatch body."""
+
+    def test_fleet_run_parses_ingredients(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--ingredient k1=v1 --ingredient k2=v2 produces {"k1": "v1", "k2": "v2"}."""
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
+        )
+        captured_args: dict[str, object] = {}
+
+        async def fake_execute(**kwargs: object) -> DispatchResult:
+            captured_args.update(kwargs)
+            return _mock_success_result()
+
+        with patch(
+            "autoskillit.cli.fleet._fleet_run._execute_fleet_run",
+            new=AsyncMock(side_effect=fake_execute),
+        ):
+            from autoskillit.cli.fleet import fleet_run
+
+            with pytest.raises(SystemExit):
+                fleet_run(
+                    "test-recipe",
+                    ingredient=("key1=val1", "key2=val2"),
+                    task="test task",
+                )
+        assert captured_args["ingredients"] == {"key1": "val1", "key2": "val2"}
+
+    def test_fleet_run_rejects_invalid_ingredient(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """--ingredient without = sign produces JSON error."""
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
+        )
+        from autoskillit.cli.fleet import fleet_run
+
+        with pytest.raises(SystemExit):
+            fleet_run("test-recipe", ingredient=("noequals",), task="test")
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["success"] is False
+        assert envelope["error"] == "FLEET_INVALID_ARGUMENT"
+
+    def test_fleet_run_resolves_backend(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--backend claude-code resolves to a backend with name == claude-code."""
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
+        )
+        fake_backend = MagicMock()
+        fake_backend.name = "claude-code"
+        monkeypatch.setattr(
+            "autoskillit.server._misc.resolve_backend_override",
+            lambda name: fake_backend,
+        )
+        captured_args: dict[str, object] = {}
+
+        async def fake_execute(**kwargs: object) -> DispatchResult:
+            captured_args.update(kwargs)
+            return _mock_success_result()
+
+        with patch(
+            "autoskillit.cli.fleet._fleet_run._execute_fleet_run",
+            new=AsyncMock(side_effect=fake_execute),
+        ):
+            from autoskillit.cli.fleet import fleet_run
+
+            with pytest.raises(SystemExit):
+                fleet_run("test-recipe", backend="claude-code", task="test")
+        assert captured_args["dispatch_backend"] is fake_backend
+
+    def test_fleet_run_rejects_invalid_backend(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """--backend unknown-backend produces JSON error."""
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
+        )
+
+        def fake_resolve(name: str) -> object:
+            raise ValueError(f"Unknown backend {name!r}. Valid names: claude-code, codex")
+
+        monkeypatch.setattr(
+            "autoskillit.server._misc.resolve_backend_override",
+            fake_resolve,
+        )
+        from autoskillit.cli.fleet import fleet_run
+
+        with pytest.raises(SystemExit):
+            fleet_run("test-recipe", backend="invalid", task="test")
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["success"] is False
+        assert envelope["error"] == "FLEET_INVALID_BACKEND"
+
+    def test_fleet_run_exit_code_success(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Exit code 0 when dispatch succeeds."""
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
+        )
+        with patch(
+            "autoskillit.cli.fleet._fleet_run._execute_fleet_run",
+            new=AsyncMock(return_value=_mock_success_result()),
+        ):
+            from autoskillit.cli.fleet import fleet_run
+
+            with pytest.raises(SystemExit) as exc:
+                fleet_run("test-recipe", task="test")
+        assert exc.value.code == 0
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["success"] is True
+
+    def test_fleet_run_exit_code_failure(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Exit code 1 when dispatch fails."""
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
+        )
+        with patch(
+            "autoskillit.cli.fleet._fleet_run._execute_fleet_run",
+            new=AsyncMock(return_value=_mock_failure_result(status=DispatchStatus.FAILURE)),
+        ):
+            from autoskillit.cli.fleet import fleet_run
+
+            with pytest.raises(SystemExit) as exc:
+                fleet_run("test-recipe", task="test")
+        assert exc.value.code == 1
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["success"] is False
+
+    def test_fleet_run_exit_code_resumable(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Exit code 2 when dispatch is resumable — distinct from general failure."""
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
+        )
+        with patch(
+            "autoskillit.cli.fleet._fleet_run._execute_fleet_run",
+            new=AsyncMock(return_value=_mock_failure_result(status=DispatchStatus.RESUMABLE)),
+        ):
+            from autoskillit.cli.fleet import fleet_run
+
+            with pytest.raises(SystemExit) as exc:
+                fleet_run("test-recipe", task="test")
+        assert exc.value.code == 2
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["dispatch_status"] == "resumable"
+
+    def test_fleet_run_exit_code_rejected(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Exit code 3 when dispatch is rejected pre-launch."""
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
+        )
+        with patch(
+            "autoskillit.cli.fleet._fleet_run._execute_fleet_run",
+            new=AsyncMock(return_value=_mock_rejected_result()),
+        ):
+            from autoskillit.cli.fleet import fleet_run
+
+            with pytest.raises(SystemExit) as exc:
+                fleet_run("test-recipe", task="test")
+        assert exc.value.code == 3
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["kind"] == "rejected"
+
+    def test_fleet_run_prints_json_envelope(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Stdout contains valid JSON with dispatch_id, dispatched_session_id, dispatch_status."""
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
+        )
+        with patch(
+            "autoskillit.cli.fleet._fleet_run._execute_fleet_run",
+            new=AsyncMock(return_value=_mock_success_result()),
+        ):
+            from autoskillit.cli.fleet import fleet_run
+
+            with pytest.raises(SystemExit):
+                fleet_run("test-recipe", task="test")
+        envelope = json.loads(capsys.readouterr().out)
+        assert "dispatch_id" in envelope
+        assert "dispatched_session_id" in envelope
+        assert "dispatch_status" in envelope
+
+    def test_fleet_run_disable_quota_guard(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--disable-quota-guard passes a no-op quota checker."""
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
+        )
+
+        from autoskillit.execution import check_and_sleep_if_needed
+
+        fake_ctx = MagicMock()
+        fake_ctx.backend = None
+        fake_ctx.config = MagicMock()
+        monkeypatch.setattr(
+            "autoskillit.server._factory.make_context",
+            lambda cfg, **kwargs: fake_ctx,
+        )
+
+        captured: dict[str, object] = {}
+
+        async def fake_execute_dispatch(**kwargs: object) -> DispatchResult:
+            captured["quota_checker"] = kwargs["quota_checker"]
+            captured["quota_refresher"] = kwargs["quota_refresher"]
+            return _mock_success_result()
+
+        monkeypatch.setattr(
+            "autoskillit.fleet.execute_dispatch",
+            fake_execute_dispatch,
+        )
+
+        from autoskillit.cli.fleet import fleet_run
+
+        with pytest.raises(SystemExit):
+            fleet_run("test-recipe", task="test", disable_quota_guard=True)
+
+        quota_checker = captured["quota_checker"]
+        assert quota_checker is not check_and_sleep_if_needed
+
+    def test_fleet_run_passes_resume_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--resume-session-id and --prior-dispatch-id are forwarded to execute_dispatch."""
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
+        )
+        captured_args: dict[str, object] = {}
+
+        async def fake_execute(**kwargs: object) -> DispatchResult:
+            captured_args.update(kwargs)
+            return _mock_success_result()
+
+        with patch(
+            "autoskillit.cli.fleet._fleet_run._execute_fleet_run",
+            new=AsyncMock(side_effect=fake_execute),
+        ):
+            from autoskillit.cli.fleet import fleet_run
+
+            with pytest.raises(SystemExit):
+                fleet_run(
+                    "test-recipe",
+                    task="test",
+                    resume_session_id="sess-123",
+                    prior_dispatch_id="disp-456",
+                )
+        assert captured_args["resume_session_id"] == "sess-123"
+        assert captured_args["prior_dispatch_id"] == "disp-456"
+
+    def test_fleet_run_uses_fleet_semaphore(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """ToolContext is constructed via make_context — FleetSemaphore auto-wired."""
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
+        )
+        make_context_calls: list[object] = []
+        fake_ctx = MagicMock()
+        fake_ctx.backend = None
+        fake_ctx.config = MagicMock()
+        fake_ctx.fleet_lock = MagicMock()
+
+        def fake_make_context(cfg: object, **kwargs: object) -> MagicMock:
+            make_context_calls.append(cfg)
+            return fake_ctx
+
+        monkeypatch.setattr(
+            "autoskillit.server._factory.make_context",
+            fake_make_context,
+        )
+
+        async def fake_execute_dispatch(**kwargs: object) -> DispatchResult:
+            return _mock_success_result()
+
+        monkeypatch.setattr(
+            "autoskillit.fleet.execute_dispatch",
+            fake_execute_dispatch,
+        )
+
+        from autoskillit.cli.fleet import fleet_run
+
+        with pytest.raises(SystemExit):
+            fleet_run("test-recipe", task="test")
+
+        assert len(make_context_calls) == 1
+        assert fake_ctx.fleet_lock is not None

--- a/tests/cli/test_fleet_run.py
+++ b/tests/cli/test_fleet_run.py
@@ -75,10 +75,6 @@ class TestFleetRunGates:
     ) -> None:
         """fleet_run exits with FLEET_SESSION_TYPE_BLOCKED when SESSION_TYPE=leaf."""
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "leaf")
-        monkeypatch.setattr(
-            "autoskillit.config.load_config",
-            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
-        )
         from autoskillit.cli.fleet import fleet_run
 
         with pytest.raises(SystemExit) as exc_info:
@@ -94,10 +90,6 @@ class TestFleetRunGates:
     ) -> None:
         """fleet_run exits with FLEET_SESSION_TYPE_BLOCKED when SESSION_TYPE=skill."""
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "skill")
-        monkeypatch.setattr(
-            "autoskillit.config.load_config",
-            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
-        )
         from autoskillit.cli.fleet import fleet_run
 
         with pytest.raises(SystemExit) as exc_info:
@@ -386,8 +378,6 @@ class TestFleetRunDispatch:
             lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
         )
 
-        from autoskillit.execution import check_and_sleep_if_needed
-
         fake_ctx = MagicMock()
         fake_ctx.backend = None
         fake_ctx.config = MagicMock()
@@ -413,8 +403,11 @@ class TestFleetRunDispatch:
         with pytest.raises(SystemExit):
             fleet_run("test-recipe", task="test", disable_quota_guard=True)
 
+        import asyncio
+
         quota_checker = captured["quota_checker"]
-        assert quota_checker is not check_and_sleep_if_needed
+        result = asyncio.run(quota_checker(None))
+        assert result == {"should_sleep": False}
 
     def test_fleet_run_passes_resume_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """--resume-session-id and --prior-dispatch-id are forwarded to execute_dispatch."""
@@ -465,7 +458,10 @@ class TestFleetRunDispatch:
             fake_make_context,
         )
 
+        dispatch_ctx: list[object] = []
+
         async def fake_execute_dispatch(**kwargs: object) -> DispatchResult:
+            dispatch_ctx.append(kwargs.get("tool_ctx"))
             return _mock_success_result()
 
         monkeypatch.setattr(
@@ -479,4 +475,5 @@ class TestFleetRunDispatch:
             fleet_run("test-recipe", task="test")
 
         assert len(make_context_calls) == 1
-        assert fake_ctx.fleet_lock is not None
+        assert len(dispatch_ctx) == 1
+        assert dispatch_ctx[0] is fake_ctx

--- a/tests/cli/test_fleet_run.py
+++ b/tests/cli/test_fleet_run.py
@@ -235,7 +235,7 @@ class TestFleetRunDispatch:
         fake_backend = MagicMock()
         fake_backend.name = "claude-code"
         monkeypatch.setattr(
-            "autoskillit.server._misc.resolve_backend_override",
+            "autoskillit.server.resolve_backend_override",
             lambda name: fake_backend,
         )
         captured_args: dict[str, object] = {}
@@ -267,7 +267,7 @@ class TestFleetRunDispatch:
             raise ValueError(f"Unknown backend {name!r}. Valid names: claude-code, codex")
 
         monkeypatch.setattr(
-            "autoskillit.server._misc.resolve_backend_override",
+            "autoskillit.server.resolve_backend_override",
             fake_resolve,
         )
         from autoskillit.cli.fleet import fleet_run
@@ -392,7 +392,7 @@ class TestFleetRunDispatch:
         fake_ctx.backend = None
         fake_ctx.config = MagicMock()
         monkeypatch.setattr(
-            "autoskillit.server._factory.make_context",
+            "autoskillit.server.make_context",
             lambda cfg, **kwargs: fake_ctx,
         )
 
@@ -461,7 +461,7 @@ class TestFleetRunDispatch:
             return fake_ctx
 
         monkeypatch.setattr(
-            "autoskillit.server._factory.make_context",
+            "autoskillit.server.make_context",
             fake_make_context,
         )
 

--- a/tests/cli/test_fleet_run.py
+++ b/tests/cli/test_fleet_run.py
@@ -1,0 +1,139 @@
+"""Tests: fleet CLI run command gates — session-type guard, feature gates, CLAUDECODE relaxation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = [
+    pytest.mark.layer("cli"),
+    pytest.mark.medium,
+    pytest.mark.feature("fleet"),
+]
+
+
+def _make_test_config(
+    *, fleet: bool = False, fleet_headless_run: bool = False, experimental_enabled: bool = False
+) -> object:
+    """Build a lightweight config mock for `load_config` substitute."""
+    return type(
+        "C",
+        (),
+        {
+            "features": {"fleet": fleet, "fleet_headless_run": fleet_headless_run},
+            "experimental_enabled": experimental_enabled,
+        },
+    )()
+
+
+class TestFleetRunGates:
+    def test_fleet_run_blocks_in_leaf_session(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """fleet_run exits with JSON FLEET_SESSION_TYPE_BLOCKED when AUTOSKILLIT_SESSION_TYPE=leaf."""
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "leaf")
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
+        )
+        from autoskillit.cli.fleet import fleet_run
+
+        with pytest.raises(SystemExit) as exc_info:
+            fleet_run("test-recipe")
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        envelope = json.loads(captured.out)
+        assert envelope["success"] is False
+        assert envelope["error"] == "FLEET_SESSION_TYPE_BLOCKED"
+
+    def test_fleet_run_blocks_in_skill_session(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """fleet_run exits with JSON FLEET_SESSION_TYPE_BLOCKED when AUTOSKILLIT_SESSION_TYPE=skill."""
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "skill")
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(fleet=True, fleet_headless_run=True),
+        )
+        from autoskillit.cli.fleet import fleet_run
+
+        with pytest.raises(SystemExit) as exc_info:
+            fleet_run("test-recipe")
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        envelope = json.loads(captured.out)
+        assert envelope["success"] is False
+        assert envelope["error"] == "FLEET_SESSION_TYPE_BLOCKED"
+
+    def test_fleet_run_allows_claudecode_env(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """CLAUDECODE env var is NOT a blocker — fleet_run proceeds past it to the feature gate."""
+        monkeypatch.setenv("CLAUDECODE", "1")
+        monkeypatch.delenv("AUTOSKILLIT_SESSION_TYPE", raising=False)
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(
+                fleet=True, fleet_headless_run=False, experimental_enabled=True
+            ),
+        )
+        from autoskillit.cli.fleet import fleet_run
+
+        with pytest.raises(SystemExit) as exc_info:
+            fleet_run("test-recipe")
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        envelope = json.loads(captured.out)
+        # Must NOT be a CLAUDECODE error — must be a feature gate error
+        assert "CLAUDECODE" not in captured.out
+        assert envelope["error"] == "FLEET_FEATURE_DISABLED"
+
+    def test_fleet_run_exits_when_feature_disabled(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """fleet_run exits with JSON FLEET_FEATURE_DISABLED when fleet_headless_run is disabled."""
+        monkeypatch.delenv("AUTOSKILLIT_SESSION_TYPE", raising=False)
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+        # Config: fleet=True, fleet_headless_run=False. experimental_enabled must be False too
+        # so the feature is genuinely rejected (otherwise the blanket would promote it).
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(
+                fleet=True, fleet_headless_run=False, experimental_enabled=False
+            ),
+        )
+        from autoskillit.cli.fleet import fleet_run
+
+        with pytest.raises(SystemExit) as exc_info:
+            fleet_run("test-recipe")
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        envelope = json.loads(captured.out)
+        assert envelope["success"] is False
+        assert envelope["error"] == "FLEET_FEATURE_DISABLED"
+        assert "fleet_headless_run" in envelope["user_visible_message"]
+
+    def test_fleet_run_exits_when_fleet_disabled(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """fleet_run exits with JSON FLEET_FEATURE_DISABLED when base fleet feature is disabled."""
+        monkeypatch.delenv("AUTOSKILLIT_SESSION_TYPE", raising=False)
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+        # Config: fleet=False, fleet_headless_run=False. experimental_enabled False.
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: _make_test_config(
+                fleet=False, fleet_headless_run=False, experimental_enabled=False
+            ),
+        )
+        from autoskillit.cli.fleet import fleet_run
+
+        with pytest.raises(SystemExit) as exc_info:
+            fleet_run("test-recipe")
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        envelope = json.loads(captured.out)
+        assert envelope["success"] is False
+        assert envelope["error"] == "FLEET_FEATURE_DISABLED"
+        assert "fleet" in envelope["user_visible_message"].lower()


### PR DESCRIPTION
## Summary

Adds the `autoskillit fleet run <recipe>` CLI command for non-interactive, one-shot recipe dispatch. The command is gated behind a new `fleet_headless_run` experimental feature flag and reuses the existing dispatch machinery (`execute_dispatch` / `_run_dispatch`) — dispatch record persistence, sidecar, liveness heartbeat, automatic label cleanup, `FleetSemaphore` concurrency control, and quota-guard behavior — so CLI and kitchen-initiated dispatches share the same `max_concurrent_dispatches` budget. Results are emitted as a JSON envelope on stdout with distinct exit codes for SUCCESS / FAILURE / REFUSED / RESUMABLE / timeout outcomes, and resume is supported via `--resume-session-id` / `--prior-dispatch-id`. The CLAUDECODE guard is intentionally relaxed for this headless path while the skill/leaf session-type guard is retained to prevent recursive dispatch.

<details>
<summary>Individual Group Plans</summary>

### Group 1: Part A — Feature flag registration, CLI skeleton, runtime gates

Part A registers the `fleet_headless_run` feature flag in `FEATURE_REGISTRY` and adds the `fleet_run` CLI command skeleton to `fleet_app` with all argument definitions (REQ-HFD-001/004/008). The command applies runtime feature gates (REQ-HFD-009/010) that produce JSON error envelopes on stdout for machine-readable refusal, enforces the session-type guard with intentionally relaxed `CLAUDECODE` (REQ-HFD-006), and exits with a stub error when gates pass (dispatch implementation deferred to Part B). The canary test `test_fleet_run_command_not_registered` is deleted in the same commit as command registration. Feature registry integrity tests and CLI gate tests are added.

Part B will cover the dispatch implementation — `ToolContext` construction via `make_context`, `asyncio.run(execute_dispatch(...))` call, JSON result envelope output, exit code mapping, resume support, `FleetSemaphore` acquisition, quota guard behavior, and backend resolution (separate task).

### Group 2: Part B — Dispatch body, exit codes, quota guard

Part B implements the dispatch body of the `fleet_run` CLI command registered in Part A. It replaces the `FLEET_NOT_IMPLEMENTED` stub with a working dispatch pipeline: `ToolContext` construction via `make_context` (REQ-HFD-005), `asyncio.run(execute_dispatch(...))` reusing the existing fleet dispatch machinery (REQ-HFD-002), JSON result envelope output on stdout (REQ-HFD-003), exit code mapping with distinct code for RESUMABLE outcomes (REQ-HFD-003), resume support via `--resume-session-id` and `--prior-dispatch-id` (REQ-HFD-004), `FleetSemaphore` concurrency control (REQ-HFD-007), quota guard with `--disable-quota-guard` opt-out (REQ-HFD-008), and `--backend` resolution via `resolve_backend_override` (REQ-HFD-001).

Part A covered feature flag registration, CLI command skeleton, argument parsing, runtime gates, and canary test deletion (separate task, already implemented).

</details>

## Requirements

**REQ-HFD-001:** A new CLI command (suggested: `autoskillit fleet run <recipe>`) must execute a single recipe dispatch non-interactively, accepting a positional recipe name, a `--task` string, repeatable `--ingredient key=value` overrides, an optional `--backend` (names from `BACKEND_REGISTRY`, with the same `resolve_backend_override` semantics and per-dispatch admission control as #4179/#4182), and an optional `--timeout-sec`.

**REQ-HFD-002:** The command must reuse the existing dispatch machinery (`execute_dispatch` / `_run_dispatch` in `fleet/_api.py`) — dispatch record persistence, sidecar, liveness heartbeat, and automatic label cleanup on failure — with no parallel implementation of any of it.

**REQ-HFD-003:** The command must print the dispatch result envelope as JSON on stdout (`dispatch_id`, `dispatched_session_id`, `dispatch_status`, `l3_payload`, `token_usage`) and exit 0 on SUCCESS and nonzero on FAILURE/REFUSED/timeout, with a distinct exit code or JSON field identifying RESUMABLE outcomes.

**REQ-HFD-004:** The command must support resume via `--resume-session-id` and `--prior-dispatch-id`, mirroring `dispatch_food_truck`'s resume discipline for RESUMABLE outcomes.

**REQ-HFD-005:** The command must run entirely in the invoking process tree on the package version installed at invocation time, with zero dependency on any long-lived kitchen MCP server or open kitchen gate.

**REQ-HFD-006:** The command must not require a TTY and must be invocable from inside a Claude Code session: the `CLAUDECODE` guard is relaxed for this headless command (that guard protects interactive terminal UX, which does not apply), while the skill/leaf session-type guard (`AUTOSKILLIT_SESSION_TYPE` in `("skill", "leaf")`) is retained to prevent recursive dispatch from leaf sessions.

**REQ-HFD-007:** The command must respect FleetConfig concurrency by acquiring the same `FleetSemaphore` gate as kitchen-initiated dispatches, so CLI and kitchen dispatches share `max_concurrent_dispatches`.

**REQ-HFD-008:** Quota-guard behavior must be defined for the headless path: either the guard is honored with a clear JSON refusal envelope, or an explicit `--disable-quota-guard` flag provides the same semantics as the MCP tool.

**REQ-HFD-009:** The command must be gated behind a new dedicated feature flag registered in `FEATURE_REGISTRY` (`core/types/_type_constants_features.py:42`) — suggested name `fleet_headless_run` — declared with `lifecycle=FeatureLifecycle.EXPERIMENTAL` (`core/types/_type_enums.py:456`), `default_enabled=False`, `depends_on=frozenset({"fleet"})`, `tool_tags=frozenset()` and `skill_categories=frozenset()` (this feature adds a CLI command, not MCP tools or skills), `import_package=None`, `tier=1` (matching the fleet/planner/providers entries), and `since_version` set to the shipping release.

**REQ-HFD-010:** The CLI entry point must gate at runtime following the `_require_fleet` precedent (`cli/fleet/__init__.py:40`): check `is_feature_enabled("fleet_headless_run", cfg.features, experimental_enabled=cfg.experimental_enabled)` AND retain the existing `_require_fleet(cfg)` check — both checks are required because `is_feature_enabled` (`core/feature_flags.py:16`) does not enforce `depends_on` at resolution time. On refusal, exit nonzero with an enablement hint (blanket: `features.experimental_enabled: true` in config; per-feature: `features.fleet_headless_run: true` or `AUTOSKILLIT_FEATURES__FLEET_HEADLESS_RUN=true`); in the headless path the refusal must also be a machine-readable JSON envelope on stdout.

**REQ-HFD-011:** Feature resolution must follow the existing experimental contract with no new mechanism: the blanket switch is the config key `features.experimental_enabled` (popped from the features dict at `config/settings.py:404` into `AutomationConfig.experimental_enabled`, `settings.py:388`, defaulting to `is_dev_install()` when unset, `settings.py:407`); the new entry must surface automatically in `autoskillit features list` / `features status` (`cli/_features.py`); registry integrity assertions must be added following the `tests/fleet/test_fleet_rename_integrity.py` precedent (assert the entry's lifecycle, depends_on, and tag fields).

Closes #4189

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/impl-20260705-214515-338429/.autoskillit/temp/make-plan/fleet_headless_run_plan_2026-07-05_214800_part_a.md`
- `/home/talon/projects/autoskillit-runs/impl-20260705-214515-338429/.autoskillit/temp/make-plan/fleet_headless_run_plan_2026-07-05_214800_part_b.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 1 | 53 | 13.2k | 3.0M | 182.3k | 100 | 33.3k | 34m 38s |
| review_approach* | opus[1m] | 1 | 8.9k | 6.1k | 266.4k | 49.2k | 14 | 42.2k | 5m 50s |
| dry_walkthrough* | opus | 1 | 53 | 18.6k | 1.9M | 90.0k | 51 | 90.1k | 11m 8s |
| implement* | MiniMax-M3 | 1 | 155.2k | 25.6k | 10.3M | 0 | 162 | 0 | 9m 28s |
| assess* | opus[1m] | 1 | 158 | 45.7k | 22.5M | 232.8k | 256 | 213.5k | 37m 59s |
| **Total** | | | 164.4k | 109.2k | 38.0M | 232.8k | | 379.2k | 1h 39m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 900 | 11423.6 | 0.0 | 28.4 |
| assess | 221 | 101736.4 | 966.2 | 206.7 |
| **Total** | **1121** | 33874.3 | 338.2 | 97.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 3 | 9.1k | 65.0k | 25.8M | 289.0k | 1h 18m |
| opus | 1 | 53 | 18.6k | 1.9M | 90.1k | 11m 8s |
| MiniMax-M3 | 1 | 155.2k | 25.6k | 10.3M | 0 | 9m 28s |