### PR TITLE
[FIX] Verdict Precondition Immunity — PART A (Contract and Semantic Rule Layer)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ A coding-agent plugin that orchestrates automated skill-driven workflows using h
     - `*Def` — static definition of a registered entity (e.g., `HookDef`, `PackDef`, `FeatureDef`, `RuleDef`). Typically a `NamedTuple` or `@dataclass(frozen=True)`, used as elements in a registry or lookup table. Typically lives in `core/`; stdlib-only types importable from hook scripts may live at the package root (e.g., `HookDef` in `hook_registry.py`).
     - `*Spec` — behavioral specification or validation rule (e.g., `ExperimentTypeSpec`, `WriteBehaviorSpec`). Typically a `@dataclass` or `TypedDict` configuring a pipeline or validation stage. Typically lives in `recipe/` or domain layers; `*Spec` types used by IL-0 core protocols live in `core/` (e.g., `WriteBehaviorSpec` in `core/types/_type_results.py`).
   * **Commit discipline**: Always create NEW commits. Never use `git commit --amend`, `--fixup`, or `--squash` unless the active recipe or SKILL.md explicitly requires it. This applies to all session types including headless sessions.
+  * **Multi-part plan green-gate invariant**: Every part of a multi-part plan must independently pass `task test-check`. If a part's changes invalidate a pre-existing test, that test must be updated, removed, or marked `xfail(strict=True)` in the same part. The `xfail(strict=True)` bridge is the canonical mechanism: `check_test_passed` ignores xfailed counts; `strict=True` forces cleanup when the xfail condition is resolved.
 
 #### **3.1.a. Pre-commit Hooks**
 

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -192,6 +192,9 @@ from autoskillit.recipe.rules import (  # noqa: E402
 from autoskillit.recipe.rules import rules_tools as _rules_tools  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_verdict as _rules_verdict  # noqa: E402 F401
 from autoskillit.recipe.rules import (
+    rules_verdict_context as _rules_verdict_context,  # noqa: E402 F401
+)
+from autoskillit.recipe.rules import (
     rules_verdict_degradation as _rules_verdict_degradation,  # noqa: E402 F401
 )
 from autoskillit.recipe.rules import rules_worktree as _rules_worktree  # noqa: E402 F401

--- a/src/autoskillit/recipe/rules/AGENTS.md
+++ b/src/autoskillit/recipe/rules/AGENTS.md
@@ -1,6 +1,6 @@
 # rules/
 
-Semantic validation rule modules for recipe analysis (49 flat rule files + 4 subdirectories).
+Semantic validation rule modules for recipe analysis (50 flat rule files + 4 subdirectories).
 
 ## Subdirectories
 
@@ -68,6 +68,7 @@ See each subdirectory's AGENTS.md for details.
 | `rules_terminal_convergence.py` | Success-stop reason uniqueness; detects convergent success paths with shared reasons |
 | `rules_tools.py` | MCP tool name validity (must be in known tool sets) |
 | `rules_verdict.py` | Skill verdict routing completeness and cross-step consistency |
+| `rules_verdict_context.py` | Verdict-context precondition: CI-dependent verdicts require CI context in skill invocation args |
 | `rules_verdict_degradation.py` | verdict-ungated-degradation: errors when degradation path emits a verdict used by nominal success path |
 | `rules_worktree.py` | Worktree and retry validation rules |
 

--- a/src/autoskillit/recipe/rules/AGENTS.md
+++ b/src/autoskillit/recipe/rules/AGENTS.md
@@ -1,6 +1,6 @@
 # rules/
 
-Semantic validation rule modules for recipe analysis (50 flat rule files + 4 subdirectories).
+Semantic validation rule modules for recipe analysis (53 flat rule files + 4 subdirectories).
 
 ## Subdirectories
 

--- a/src/autoskillit/recipe/rules/rules_verdict_context.py
+++ b/src/autoskillit/recipe/rules/rules_verdict_context.py
@@ -1,0 +1,114 @@
+"""Verdict-context precondition rule.
+
+Fires ERROR when a ``run_skill`` step invokes a skill whose ``allowed_values``
+contains a CI-context-dependent verdict (``ci_only_failure``) and the step's
+``skill_command`` does NOT reference any CI context variable (``diagnosis_path``
+or ``ci_conclusion`` or equivalent), AND the step routes ``ci_only_failure`` to
+an escalation/failure target.
+
+Without CI context, the skill cannot possibly emit ``ci_only_failure`` (which
+requires knowing the CI diagnosis). Routing it to escalation makes the verdict
+semantically impossible — a terminal kill on a verdict that can never fire.
+"""
+
+from __future__ import annotations
+
+import regex as re
+
+from autoskillit.core import Severity, get_logger, resolve_skill_name
+from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._skill_helpers import get_allowed_values_for_skill
+from autoskillit.recipe.registry import RuleFinding, make_finding, semantic_rule
+
+logger = get_logger(__name__)
+
+_CI_CONTEXT_DEPENDENT_VERDICTS = frozenset({"ci_only_failure"})
+
+_CI_CONTEXT_VAR_PATTERN = re.compile(
+    r"(?:context\.)?(?:diagnosis_path|ci_conclusion|merge_gate_ci_conclusion"
+    r"|merge_gate_diagnosis_path|ci_failed_jobs)"
+)
+
+_ESCALATION_KEYWORDS = ("failure", "escalat", "stop")
+
+
+def _classify_route_target(target: str) -> str:
+    """Classify a route target as 'escalation' or 'continuation'.
+
+    Inlined here (not imported from rules_verdict.py) because rule modules
+    must not cross-import per rules/AGENTS.md architecture constraint.
+    """
+    if any(kw in target for kw in _ESCALATION_KEYWORDS):
+        return "escalation"
+    return "continuation"
+
+
+@semantic_rule(
+    name="verdict-context-precondition",
+    description=(
+        "A run_skill step invoking a skill whose allowed_values contains a CI-context-"
+        "dependent verdict (ci_only_failure) must reference CI context (diagnosis_path, "
+        "ci_conclusion, or equivalent) in its skill_command AND must not route that "
+        "verdict to escalation without that context — otherwise the verdict is "
+        "semantically impossible to emit and the escalation route is dead."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_verdict_context_precondition(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        skill_command = str((step.with_args or {}).get("skill_command") or "")
+        skill_name = resolve_skill_name(skill_command)
+        if not skill_name:
+            continue
+
+        allowed_by_output = get_allowed_values_for_skill(skill_name)
+        if not allowed_by_output:
+            continue
+
+        ci_context_values = set()
+        for _output, values in allowed_by_output.items():
+            for v in values:
+                if v in _CI_CONTEXT_DEPENDENT_VERDICTS:
+                    ci_context_values.add(v)
+        if not ci_context_values:
+            continue
+
+        if not _CI_CONTEXT_VAR_PATTERN.search(skill_command):
+            continue
+
+        if not step.on_result or not step.on_result.conditions:
+            continue
+
+        for condition in step.on_result.conditions:
+            when = condition.when
+            if not when or when.strip() == "true":
+                continue
+            for value in ci_context_values:
+                if re.search(r"\b" + re.escape(value) + r"\b", when):
+                    classification = _classify_route_target(condition.route or "")
+                    if classification == "continuation":
+                        continue
+                    findings.append(
+                        make_finding(
+                            rule_name="verdict-context-precondition",
+                            step_name=step_name,
+                            message=(
+                                f"Step '{step_name}' invokes '{skill_name}' whose "
+                                f"allowed_values contains '{value}' (a CI-context-dependent "
+                                f"verdict), but the skill_command does NOT reference any "
+                                f"CI context variable (diagnosis_path, ci_conclusion, "
+                                f"merge_gate_ci_conclusion, merge_gate_diagnosis_path, or "
+                                f"ci_failed_jobs). Without CI context, the skill cannot emit "
+                                f"'{value}', yet the step routes it to escalation target "
+                                f"'{condition.route}'. Add CI context to skill_command "
+                                f"(e.g., pass 'ci_conclusion: ${{{{ context.ci_conclusion }}}}') "
+                                f"or route '{value}' to a non-escalation target."
+                            ),
+                        )
+                    )
+
+    return findings

--- a/src/autoskillit/recipe/rules/rules_verdict_context.py
+++ b/src/autoskillit/recipe/rules/rules_verdict_context.py
@@ -25,7 +25,7 @@ logger = get_logger(__name__)
 _CI_CONTEXT_DEPENDENT_VERDICTS = frozenset({"ci_only_failure"})
 
 _CI_CONTEXT_VAR_PATTERN = re.compile(
-    r"(?:context\.)?(?:diagnosis_path|ci_conclusion|merge_gate_ci_conclusion"
+    r"(?:\{\{.*?)?context\.(?:diagnosis_path|ci_conclusion|merge_gate_ci_conclusion"
     r"|merge_gate_diagnosis_path|ci_failed_jobs)"
 )
 

--- a/src/autoskillit/recipe/rules/rules_verdict_context.py
+++ b/src/autoskillit/recipe/rules/rules_verdict_context.py
@@ -77,7 +77,7 @@ def _check_verdict_context_precondition(ctx: ValidationContext) -> list[RuleFind
         if not ci_context_values:
             continue
 
-        if not _CI_CONTEXT_VAR_PATTERN.search(skill_command):
+        if _CI_CONTEXT_VAR_PATTERN.search(skill_command):
             continue
 
         if not step.on_result or not step.on_result.conditions:

--- a/src/autoskillit/recipes/diagrams/implementation-groups.md
+++ b/src/autoskillit/recipes/diagrams/implementation-groups.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:ccbe41c996f70117edb5291bb8b680771a1bdca92891d2908a62ba06860b2dfd -->
+<!-- autoskillit-recipe-hash: sha256:7b1752e3b62d4cff41b935c363aa6655fabd231943791784009db587633a70c0 -->
 <!-- autoskillit-diagram-format: v7 -->
 ## implementation-groups
 Group-based implementation with per-group plan/implement/test cycles and PR gates.

--- a/src/autoskillit/recipes/diagrams/implementation-groups.md
+++ b/src/autoskillit/recipes/diagrams/implementation-groups.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:7c834c9017922b349cf3e5143e3fb36c9c7cf635004d9c6156887d0ad8264b28 -->
+<!-- autoskillit-recipe-hash: sha256:ccbe41c996f70117edb5291bb8b680771a1bdca92891d2908a62ba06860b2dfd -->
 <!-- autoskillit-diagram-format: v7 -->
 ## implementation-groups
 Group-based implementation with per-group plan/implement/test cycles and PR gates.

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:01403cfdbbbfa4def12473fbeb3ad3ad85abd1e7d41826ddaab41cc6f40837be -->
+<!-- autoskillit-recipe-hash: sha256:512146091e1b0925b6963280a929d4586ce652d0b498d43a5280ed5b724f459c -->
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:8ff83b430c66857bccb910882b8f7d75d7e1b769f74c839a1907fd23725e5d7e -->
+<!-- autoskillit-recipe-hash: sha256:01403cfdbbbfa4def12473fbeb3ad3ad85abd1e7d41826ddaab41cc6f40837be -->
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 

--- a/src/autoskillit/recipes/diagrams/merge-prs.md
+++ b/src/autoskillit/recipes/diagrams/merge-prs.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:b54d9d547d121742144fe91399484fbe13bee622d1173b34a327a52c059f3bfd -->
+<!-- autoskillit-recipe-hash: sha256:6e4a54cb48efe524194a19916db628a1556a7c2a18c5e384f9f1c4e8c70b4f43 -->
 <!-- autoskillit-diagram-format: v7 -->
 ## merge-prs
 Merge multiple PRs into an integration branch with conflict resolution and CI gates.

--- a/src/autoskillit/recipes/diagrams/remediation.md
+++ b/src/autoskillit/recipes/diagrams/remediation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:eb80d1d2efe270969da7627b36be32f756cb1f1c29153e22433f7a6a846e8a74 -->
+<!-- autoskillit-recipe-hash: sha256:0dd8a6d577c45dc893c71b1ad17f770901470f2e128bc911a6bdd35c9deb30ac -->
 <!-- autoskillit-diagram-format: v7 -->
 ## remediation
 Investigate, rectify, implement, and merge a bug fix with CI and PR gates.

--- a/src/autoskillit/recipes/diagrams/remediation.md
+++ b/src/autoskillit/recipes/diagrams/remediation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:0dd8a6d577c45dc893c71b1ad17f770901470f2e128bc911a6bdd35c9deb30ac -->
+<!-- autoskillit-recipe-hash: sha256:c0b46f2ed86362d2104bf8689e07345e746a29f01479ecae013e2c2e266a74d3 -->
 <!-- autoskillit-diagram-format: v7 -->
 ## remediation
 Investigate, rectify, implement, and merge a bug fix with CI and PR gates.

--- a/src/autoskillit/recipes/diagrams/research.md
+++ b/src/autoskillit/recipes/diagrams/research.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:1d61758ec0da78599ff3979d01bad2cedffd1eb616aee634e84d90374f37e12b -->
+<!-- autoskillit-recipe-hash: sha256:716a6a916046c4dd631d2e137243270886087992c31146f0396f7fb4b5451364 -->
 <!-- autoskillit-diagram-format: v7 -->
 
 ## research

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -657,7 +657,7 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
-          "route": "release_issue_failure"
+          "route": "test"
         },
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
@@ -731,7 +731,7 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
-          "route": "release_issue_failure"
+          "route": "merge_gate_test"
         },
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
@@ -1574,7 +1574,7 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
-          "route": "release_issue_failure"
+          "route": "check_flake_loop"
         },
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
@@ -1585,7 +1585,7 @@
         }
       ],
       "on_failure": "release_issue_failure",
-      "note": "Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci structured output to avoid redundant CI failure re-investigation. Routes via on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses (sibling fix may have landed), flake_suspected routes to check_flake_loop (bounded by ci_flake_count <= 3, shared across all diagnose_ci callers; escalates to release_issue_failure when exceeded), ci_only_failure escalates to human. Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.\n"
+      "note": "Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci structured output to avoid redundant CI failure re-investigation. Routes via on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses (sibling fix may have landed), flake_suspected routes to check_flake_loop (bounded by ci_flake_count <= 3, shared across all diagnose_ci callers; escalates to release_issue_failure when exceeded), ci_only_failure routes to check_flake_loop (bounded retry, then escalates via max_exceeded). Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.\n"
     },
     "pre_resolve_rebase": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -1134,7 +1134,7 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
-          "route": "release_issue_failure"
+          "route": "pre_review_rebase"
         },
         {
           "route": "release_issue_failure"
@@ -1146,7 +1146,7 @@
       "optional_context_refs": [
         "review_mode"
       ],
-      "note": "Runs when review_pr reports issues (verdict=changes_requested). The clone (context.work_dir) has the feature branch (context.merge_target) checked out. resolve-review fetches inline and summary review comments via the GitHub API, applies fixes for each actionable finding (critical + warning severity), and commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/ flake_suspected all route to pre_review_rebase (fetch+rebase before push); ci_only_failure escalates to release_issue_failure.\n"
+      "note": "Runs when review_pr reports issues (verdict=changes_requested). The clone (context.work_dir) has the feature branch (context.merge_target) checked out. resolve-review fetches inline and summary review comments via the GitHub API, applies fixes for each actionable finding (critical + warning severity), and commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/ flake_suspected/ci_only_failure all route to pre_review_rebase (fetch+rebase before push); ci_only_failure cannot be emitted without CI context.\n"
     },
     "pre_review_rebase": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -599,7 +599,7 @@ steps:
     - when: "${{ result.verdict }} == 'flake_suspected'"
       route: test
     - when: "${{ result.verdict }} == 'ci_only_failure'"
-      route: release_issue_failure
+      route: test
     - when: "${{ result.verdict }} == 'no_test_infrastructure'"
       route: release_issue_failure
     - route: release_issue_failure
@@ -652,7 +652,7 @@ steps:
     - when: "${{ result.verdict }} == 'flake_suspected'"
       route: merge_gate_test
     - when: "${{ result.verdict }} == 'ci_only_failure'"
-      route: release_issue_failure
+      route: merge_gate_test
     - when: "${{ result.verdict }} == 'no_test_infrastructure'"
       route: release_issue_failure
     - route: release_issue_failure
@@ -1416,7 +1416,7 @@ steps:
     - when: "${{ result.verdict }} == 'flake_suspected'"
       route: check_flake_loop
     - when: "${{ result.verdict }} == 'ci_only_failure'"
-      route: release_issue_failure
+      route: check_flake_loop
     - when: "${{ result.verdict }} == 'no_test_infrastructure'"
       route: release_issue_failure
     - route: release_issue_failure
@@ -1428,7 +1428,8 @@ steps:
       on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses
       (sibling fix may have landed), flake_suspected routes to check_flake_loop (bounded
       by ci_flake_count <= 3, shared across all diagnose_ci callers; escalates to
-      release_issue_failure when exceeded), ci_only_failure escalates to human.
+      release_issue_failure when exceeded), ci_only_failure routes to check_flake_loop
+      (bounded retry, then escalates via max_exceeded).
       Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.
 
   pre_resolve_rebase:

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -1007,7 +1007,7 @@ steps:
     - when: "${{ result.verdict }} == 'flake_suspected'"
       route: pre_review_rebase
     - when: "${{ result.verdict }} == 'ci_only_failure'"
-      route: release_issue_failure
+      route: pre_review_rebase
     - route: release_issue_failure
     on_failure: release_issue_failure
     optional: true
@@ -1020,8 +1020,8 @@ steps:
       resolve-review fetches inline and summary review comments via the GitHub API,
       applies fixes for each actionable finding (critical + warning severity), and
       commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/
-      flake_suspected all route to pre_review_rebase (fetch+rebase before push);
-      ci_only_failure escalates to release_issue_failure.
+      flake_suspected/ci_only_failure all route to pre_review_rebase (fetch+rebase
+      before push); ci_only_failure cannot be emitted without CI context.
 
   pre_review_rebase:
     tool: run_python

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -1207,7 +1207,7 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
-          "route": "release_issue_failure"
+          "route": "pre_review_rebase"
         },
         {
           "route": "release_issue_failure"
@@ -1219,7 +1219,7 @@
       "optional_context_refs": [
         "review_mode"
       ],
-      "note": "Runs when review_pr reports issues (verdict=changes_requested). The clone (context.work_dir) has the feature branch (context.merge_target) checked out. resolve-review fetches inline and summary review comments via the GitHub API, applies fixes for each actionable finding (critical + warning severity), and commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/ flake_suspected all route to pre_review_rebase (fetch+rebase before push); ci_only_failure escalates to release_issue_failure.\n"
+      "note": "Runs when review_pr reports issues (verdict=changes_requested). The clone (context.work_dir) has the feature branch (context.merge_target) checked out. resolve-review fetches inline and summary review comments via the GitHub API, applies fixes for each actionable finding (critical + warning severity), and commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/ flake_suspected/ci_only_failure all route to pre_review_rebase (fetch+rebase before push); ci_only_failure cannot be emitted without CI context.\n"
     },
     "pre_review_rebase": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -734,7 +734,7 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
-          "route": "release_issue_failure"
+          "route": "test"
         },
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
@@ -812,7 +812,7 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
-          "route": "release_issue_failure"
+          "route": "merge_gate_test"
         },
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
@@ -2340,7 +2340,7 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
-          "route": "release_issue_failure"
+          "route": "check_flake_loop"
         },
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
@@ -2351,7 +2351,7 @@
         }
       ],
       "on_failure": "release_issue_failure",
-      "note": "Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci structured output to avoid redundant CI failure re-investigation. Routes via on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses (sibling fix may have landed), flake_suspected routes to check_flake_loop (bounded by ci_flake_count <= 3, shared across all diagnose_ci callers; escalates to release_issue_failure when exceeded), ci_only_failure escalates to human. Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.\n"
+      "note": "Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci structured output to avoid redundant CI failure re-investigation. Routes via on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses (sibling fix may have landed), flake_suspected routes to check_flake_loop (bounded by ci_flake_count <= 3, shared across all diagnose_ci callers; escalates to release_issue_failure when exceeded), ci_only_failure routes to check_flake_loop (bounded retry, then escalates via max_exceeded). Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.\n"
     },
     "pre_resolve_rebase": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1093,7 +1093,7 @@ steps:
     - when: ${{ result.verdict }} == 'flake_suspected'
       route: pre_review_rebase
     - when: ${{ result.verdict }} == 'ci_only_failure'
-      route: release_issue_failure
+      route: pre_review_rebase
     - route: release_issue_failure
     on_failure: release_issue_failure
     optional: true
@@ -1105,8 +1105,8 @@ steps:
       resolve-review fetches inline and summary review comments via the GitHub API,
       applies fixes for each actionable finding (critical + warning severity), and
       commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/
-      flake_suspected all route to pre_review_rebase (fetch+rebase before push); ci_only_failure
-      escalates to release_issue_failure.
+      flake_suspected/ci_only_failure all route to pre_review_rebase (fetch+rebase
+      before push); ci_only_failure cannot be emitted without CI context.
 
       '
   pre_review_rebase:

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -682,7 +682,7 @@ steps:
     - when: ${{ result.verdict }} == 'flake_suspected'
       route: test
     - when: ${{ result.verdict }} == 'ci_only_failure'
-      route: release_issue_failure
+      route: test
     - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: release_issue_failure
     - route: release_issue_failure
@@ -739,7 +739,7 @@ steps:
     - when: ${{ result.verdict }} == 'flake_suspected'
       route: merge_gate_test
     - when: ${{ result.verdict }} == 'ci_only_failure'
-      route: release_issue_failure
+      route: merge_gate_test
     - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: release_issue_failure
     - route: release_issue_failure
@@ -2105,7 +2105,7 @@ steps:
     - when: ${{ result.verdict }} == 'flake_suspected'
       route: check_flake_loop
     - when: ${{ result.verdict }} == 'ci_only_failure'
-      route: release_issue_failure
+      route: check_flake_loop
     - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: release_issue_failure
     - route: release_issue_failure
@@ -2116,7 +2116,8 @@ steps:
       on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses
       (sibling fix may have landed), flake_suspected routes to check_flake_loop (bounded
       by ci_flake_count <= 3, shared across all diagnose_ci callers; escalates to
-      release_issue_failure when exceeded), ci_only_failure escalates to human.
+      release_issue_failure when exceeded), ci_only_failure routes to check_flake_loop
+      (bounded retry, then escalates via max_exceeded).
       Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.
 
       '

--- a/src/autoskillit/recipes/merge-prs.json
+++ b/src/autoskillit/recipes/merge-prs.json
@@ -1194,7 +1194,7 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
-          "route": "register_clone_failure"
+          "route": "test"
         },
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
@@ -1564,7 +1564,7 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
-          "route": "register_clone_failure"
+          "route": "pre_review_rebase_integration"
         },
         {
           "route": "register_clone_failure"

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -1161,7 +1161,7 @@ steps:
     - when: ${{ result.verdict }} == 'flake_suspected'
       route: test
     - when: ${{ result.verdict }} == 'ci_only_failure'
-      route: register_clone_failure
+      route: test
     - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: register_clone_failure
     - route: register_clone_failure
@@ -1525,7 +1525,7 @@ steps:
     - when: ${{ result.verdict }} == 'flake_suspected'
       route: register_clone_failure
     - when: ${{ result.verdict }} == 'ci_only_failure'
-      route: register_clone_failure
+      route: pre_review_rebase_integration
     - route: register_clone_failure
     on_failure: register_clone_failure
     skip_when_false: inputs.backend_supports_git_write

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -1348,7 +1348,7 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
-          "route": "release_issue_failure"
+          "route": "pre_review_rebase"
         },
         {
           "route": "release_issue_failure"
@@ -1357,7 +1357,7 @@
       "on_failure": "release_issue_failure",
       "optional": true,
       "skip_when_false": "inputs.backend_supports_git_write",
-      "note": "Runs when review_pr reports issues (verdict=changes_requested). The clone (context.work_dir) has the feature branch (context.merge_target) checked out. resolve-review fetches inline and summary review comments via the GitHub API, applies fixes for each actionable finding (critical + warning severity), and commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/ flake_suspected all route to pre_review_rebase (fetch+rebase before push); ci_only_failure escalates to release_issue_failure.\n",
+      "note": "Runs when review_pr reports issues (verdict=changes_requested). The clone (context.work_dir) has the feature branch (context.merge_target) checked out. resolve-review fetches inline and summary review comments via the GitHub API, applies fixes for each actionable finding (critical + warning severity), and commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/ flake_suspected/ci_only_failure all route to pre_review_rebase (fetch+rebase before push); ci_only_failure cannot be emitted without CI context.\n",
       "optional_context_refs": [
         "review_mode"
       ]

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -728,7 +728,7 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
-          "route": "release_issue_failure"
+          "route": "test"
         },
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
@@ -806,7 +806,7 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
-          "route": "release_issue_failure"
+          "route": "merge_gate_test"
         },
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
@@ -2480,7 +2480,7 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
-          "route": "release_issue_failure"
+          "route": "check_flake_loop"
         },
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",
@@ -2491,7 +2491,7 @@
         }
       ],
       "on_failure": "release_issue_failure",
-      "note": "Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci structured output to avoid redundant CI failure re-investigation. Routes via on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses (sibling fix may have landed), flake_suspected routes to check_flake_loop (bounded by ci_flake_count <= 3, shared across all diagnose_ci callers; escalates to release_issue_failure when exceeded), ci_only_failure escalates to human. Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.\n"
+      "note": "Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci structured output to avoid redundant CI failure re-investigation. Routes via on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses (sibling fix may have landed), flake_suspected routes to check_flake_loop (bounded by ci_flake_count <= 3, shared across all diagnose_ci callers; escalates to release_issue_failure when exceeded), ci_only_failure routes to check_flake_loop (bounded retry, then escalates via max_exceeded). Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.\n"
     },
     "pre_resolve_rebase": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -670,7 +670,7 @@ steps:
     - when: ${{ result.verdict }} == 'flake_suspected'
       route: test
     - when: ${{ result.verdict }} == 'ci_only_failure'
-      route: release_issue_failure
+      route: test
     - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: release_issue_failure
     - route: release_issue_failure
@@ -726,7 +726,7 @@ steps:
     - when: ${{ result.verdict }} == 'flake_suspected'
       route: merge_gate_test
     - when: ${{ result.verdict }} == 'ci_only_failure'
-      route: release_issue_failure
+      route: merge_gate_test
     - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: release_issue_failure
     - route: release_issue_failure
@@ -2216,7 +2216,7 @@ steps:
     - when: ${{ result.verdict }} == 'flake_suspected'
       route: check_flake_loop
     - when: ${{ result.verdict }} == 'ci_only_failure'
-      route: release_issue_failure
+      route: check_flake_loop
     - when: ${{ result.verdict }} == 'no_test_infrastructure'
       route: release_issue_failure
     - route: release_issue_failure
@@ -2226,7 +2226,8 @@ steps:
       on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses
       (sibling fix may have landed), flake_suspected routes to check_flake_loop (bounded
       by ci_flake_count <= 3, shared across all diagnose_ci callers; escalates to
-      release_issue_failure when exceeded), ci_only_failure escalates to human.
+      release_issue_failure when exceeded), ci_only_failure routes to check_flake_loop
+      (bounded retry, then escalates via max_exceeded).
       Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.
 
       '

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1203,7 +1203,7 @@ steps:
     - when: ${{ result.verdict }} == 'flake_suspected'
       route: pre_review_rebase
     - when: ${{ result.verdict }} == 'ci_only_failure'
-      route: release_issue_failure
+      route: pre_review_rebase
     - route: release_issue_failure
     on_failure: release_issue_failure
     optional: true
@@ -1213,8 +1213,8 @@ steps:
       resolve-review fetches inline and summary review comments via the GitHub API,
       applies fixes for each actionable finding (critical + warning severity), and
       commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/
-      flake_suspected all route to pre_review_rebase (fetch+rebase before push); ci_only_failure
-      escalates to release_issue_failure.
+      flake_suspected/ci_only_failure all route to pre_review_rebase (fetch+rebase
+      before push); ci_only_failure cannot be emitted without CI context.
 
       '
     optional_context_refs:

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -655,7 +655,7 @@
         },
         {
           "when": "${{ context.verdict }} == 'ci_only_failure'",
-          "route": "escalate_stop"
+          "route": "retest"
         },
         {
           "when": "${{ context.verdict }} == 'no_test_infrastructure'",

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -610,7 +610,7 @@ steps:
     - when: "${{ context.verdict }} == 'flake_suspected'"
       route: retest
     - when: "${{ context.verdict }} == 'ci_only_failure'"
-      route: escalate_stop
+      route: retest
     - when: "${{ context.verdict }} == 'no_test_infrastructure'"
       route: escalate_stop
     - route: escalate_stop

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -977,7 +977,7 @@
         },
         {
           "when": "${{ result.verdict }} == 'ci_only_failure'",
-          "route": "escalate_stop"
+          "route": "retest"
         },
         {
           "when": "${{ result.verdict }} == 'no_test_infrastructure'",

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -918,7 +918,7 @@ steps:
     - when: "${{ result.verdict }} == 'flake_suspected'"
       route: retest
     - when: "${{ result.verdict }} == 'ci_only_failure'"
-      route: escalate_stop
+      route: retest
     - when: "${{ result.verdict }} == 'no_test_infrastructure'"
       route: escalate_stop
     - route: escalate_stop

--- a/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
+++ b/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
@@ -158,6 +158,20 @@ PROJECT RULES CHECKLIST:
 
 **Architectural constraint enforcement:** Read the Architectural Constraint Catalog table in `resolve-review/SKILL.md` (under the heading "Architectural Constraint Catalog — consult before classifying ACCEPT"). For each code sample or code block in the plan, verify it does not violate any cataloged constraint. If a violation is found, flag it with the constraint name and enforcing test file, and note the required alternative (e.g., "Plan line 260 uses `.write_text()` — REQ-AST-002 requires `_atomic_write()`").
 
+### Step 4.3: Pipeline Gate Compatibility Check
+
+Scan the plan text (this part only — do not read other parts) for any statement that a test is expected to fail after implementation. Detectable patterns include:
+- "test will fail" / "test is expected to fail" / "test remains red"
+- "exception of test_X" / "single expected failure"
+- "deferred to Part [B/C/...]" in the context of test changes
+- "removal deferred" / "deletion deferred" for test files
+
+**If any such pattern is found:** Emit `Dry Walkthrough FAILED` with reason: "Plan declares expected test failure after implementation — gate incompatible. Each part must independently pass the test gate. Use xfail(strict=True) bridging or co-locate the test change."
+
+This check does not require cross-part reading — a plan declaring a post-part red test in its own text is gate-incompatible by definition.
+
+Stop execution — do not proceed to Step 5.
+
 ### Step 4.5: Historical Regression Check
 
 Run a lightweight two-part scan to detect whether the plan risks reintroducing

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -341,6 +341,9 @@ If the plan exceeds 500 lines, split it into multiple files (`_part_a`, `_part_b
 - Include only a brief plain-text note about what subsequent parts cover (e.g., "Part B will cover X and Y — implement as a separate task").
 - The title of each part file MUST include `— PART A ONLY` (or B, C, etc.) so scope is immediately visible.
 - Each part file MUST open with the scope warning block shown in the multi-part template below.
+- **Every part MUST independently pass `task test-check`.** A part that registers a symbol, adds a route, or changes behavior that causes a pre-existing test to fail must also update, remove, or `xfail`-bridge that test in the same part. Split boundaries must keep gate-prerequisites with the code that triggers them.
+  - **`xfail(strict=True)` bridge:** When a test must temporarily fail during a multi-part implementation (e.g., a deletion-guard canary that will be removed in a later part), mark it with `pytest.mark.xfail(strict=True, reason="<symbol> registered in Part X; guard removed in Part Y")` in the current part. `check_test_passed` ignores xfailed counts, so the gate passes. `strict=True` ensures the xfail mark is removed when the guard is deleted — if the test starts passing unexpectedly (because the later part landed), CI breaks until the mark is cleaned up.
+  - **Deletion-guard canaries** (tests asserting a name/symbol/command is absent) must be removed or xfail-bridged in the same part that re-registers the name. Never defer canary removal to a later part.
 
 Save the plan to: `{{AUTOSKILLIT_TEMP}}/make-plan/{task_name}_plan_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 

--- a/src/autoskillit/skills_extended/resolve-failures/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-failures/SKILL.md
@@ -330,10 +330,10 @@ on `verdict`:
 - `ci_only_failure` → `release_issue_failure` (human escalation)
 - `no_test_infrastructure` → `release_issue_failure` / `escalate_stop` / `register_clone_failure` (depending on recipe)
 
-**Invariant:** `ci_only_failure` MAY be emitted when `fixes_applied >= 1` if the remaining
-failures (after the fix) are all CI-only. The verdict reflects the status of the remaining
-failures, not whether fixes were applied. If a fix was committed and all tests pass, the
-verdict is `real_fix`.
+**Invariant:** `ci_only_failure` is NEVER emitted when `fixes_applied >= 1`. The Step 2d
+decision table applies ONLY on the no-fix path (`fixes_applied == 0`). If a fix was
+committed and all tests pass, the verdict is `real_fix`. If a fix was committed but some
+tests still fail, re-enter the fix loop — do not fall through to Step 2d.
 
 ### Step 5: Report Failure
 - Total fix iterations attempted

--- a/tests/arch/test_pyright_suppression_allowlist.py
+++ b/tests/arch/test_pyright_suppression_allowlist.py
@@ -20,7 +20,7 @@ _PYRIGHT_RE = re.compile(r"#\s*pyright:\s*ignore|#.*--\s*pyright:\s*ignore")
 PRODUCTION_ALLOWLIST: dict[tuple[str, int], str] = {
     (
         "recipe/__init__.py",
-        268,
+        271,
     ): "lazy-registry: method added by _register_rule_module() side effects",
     ("recipe/_api.py", 281): "lazy-registry: RULE_REGISTRY_HASH set by _finalize_registry()",
 }

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -879,7 +879,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "hooks": 14,  # +recipe_confirmed_post_hook.py
         "pipeline": 12,
         "fleet": 23,  # +_issue_url_helpers.py  # noqa: E501
-        "recipe/rules": 53,  # +commit_guard_regression_route +rules_model +rules_gitignored_deliverable +rules_issue_scope_threading +rules_inventory_gate_bilateral  # noqa: E501
+        "recipe/rules": 54,  # +commit_guard_regression_route +rules_model +rules_gitignored_deliverable +rules_issue_scope_threading +rules_inventory_gate_bilateral +rules_verdict_context  # noqa: E501
         "server/tools": 28,  # +_preflight.py +_authority_feedback.py
         "hooks/guards": 32,  # +fleet_claim_guard, +reset_resume_gate, +recipe_read_guard
         "execution/backends": 12,  # +_composite_locator.py, +_probe_cache.py

--- a/tests/recipe/AGENTS.md
+++ b/tests/recipe/AGENTS.md
@@ -204,6 +204,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_rules_tools.py` | Tests for tools semantic validation rule |
 | `test_rules_unsatisfied_input.py` | Tests for unsatisfied_input semantic validation rule |
 | `test_rules_verdict.py` | Tests for verdict semantic validation rule |
+| `test_rules_verdict_context.py` | Verdict-context precondition semantic rule tests |
 | `test_rules_verdict_degradation.py` | Tests for verdict-ungated-degradation semantic rule |
 | `test_rules_weak_constraint.py` | Tests for weak_constraint semantic validation rule |
 | `test_rules_worktree.py` | Tests for worktree semantic validation rule |

--- a/tests/recipe/test_resolve_ci_routing_invariant.py
+++ b/tests/recipe/test_resolve_ci_routing_invariant.py
@@ -155,28 +155,17 @@ def test_resolve_ci_on_result_routes_real_fix_to_re_push(recipe_name: str) -> No
         )
 
 
-_CI_CONTEXT_VARS = (
-    "diagnosis_path",
-    "ci_conclusion",
-    "merge_gate_ci_conclusion",
-    "merge_gate_diagnosis_path",
-    "ci_failed_jobs",
-)
-
-
 @pytest.mark.parametrize("recipe_name", _PIPELINE_RECIPES)
 def test_resolve_ci_on_result_routes_escalation_verdicts_to_failure(
     recipe_name: str,
 ) -> None:
-    """ci_only_failure must route to escalation only when CI context is available."""
+    """no_test_infrastructure must always route to escalation regardless of CI context."""
     recipe_path = _RECIPES_DIR / recipe_name
     recipe = load_recipe(recipe_path)
     resolve_steps = _find_resolve_steps_reaching_push(recipe)
     for step_name, step in resolve_steps:
         if step.on_result is None:
             continue
-        cmd = (step.with_args or {}).get("skill_command", "")
-        has_ci_context = any(v in cmd for v in _CI_CONTEXT_VARS)
         for verdict in ("no_test_infrastructure",):
             routes = [
                 cond.route
@@ -185,18 +174,11 @@ def test_resolve_ci_on_result_routes_escalation_verdicts_to_failure(
             ]
             if not routes:
                 continue
-            if has_ci_context:
-                assert any("failure" in r or "escalat" in r for r in routes), (
-                    f"{recipe_name}/{step_name}: verdict={verdict} must route to "
-                    f"a failure/escalation step when CI context is available, "
-                    f"got routes: {routes}"
-                )
-            else:
-                assert not any("failure" in r or "escalat" in r for r in routes), (
-                    f"{recipe_name}/{step_name}: verdict={verdict} must NOT route "
-                    f"to escalation without CI context (verdict is semantically "
-                    f"impossible), got routes: {routes}"
-                )
+            assert any("failure" in r or "escalat" in r for r in routes), (
+                f"{recipe_name}/{step_name}: verdict={verdict} must route to "
+                f"a failure/escalation step (no_test_infrastructure is always "
+                f"detectable regardless of CI context), got routes: {routes}"
+            )
 
 
 @pytest.mark.parametrize("recipe_name", _PIPELINE_RECIPES)

--- a/tests/recipe/test_resolve_ci_routing_invariant.py
+++ b/tests/recipe/test_resolve_ci_routing_invariant.py
@@ -155,17 +155,28 @@ def test_resolve_ci_on_result_routes_real_fix_to_re_push(recipe_name: str) -> No
         )
 
 
+_CI_CONTEXT_VARS = (
+    "diagnosis_path",
+    "ci_conclusion",
+    "merge_gate_ci_conclusion",
+    "merge_gate_diagnosis_path",
+    "ci_failed_jobs",
+)
+
+
 @pytest.mark.parametrize("recipe_name", _PIPELINE_RECIPES)
 def test_resolve_ci_on_result_routes_escalation_verdicts_to_failure(
     recipe_name: str,
 ) -> None:
-    """ci_only_failure must route to release_issue_failure."""
+    """ci_only_failure must route to escalation only when CI context is available."""
     recipe_path = _RECIPES_DIR / recipe_name
     recipe = load_recipe(recipe_path)
     resolve_steps = _find_resolve_steps_reaching_push(recipe)
     for step_name, step in resolve_steps:
         if step.on_result is None:
             continue
+        cmd = (step.with_args or {}).get("skill_command", "")
+        has_ci_context = any(v in cmd for v in _CI_CONTEXT_VARS)
         for verdict in ("ci_only_failure",):
             routes = [
                 cond.route
@@ -173,11 +184,19 @@ def test_resolve_ci_on_result_routes_escalation_verdicts_to_failure(
                 if cond.when and verdict in cond.when
             ]
             if not routes:
-                continue  # if not present yet, other tests catch missing verdict
-            assert any("failure" in r or "escalat" in r for r in routes), (
-                f"{recipe_name}/{step_name}: verdict={verdict} must route to "
-                f"a failure/escalation step, got routes: {routes}"
-            )
+                continue
+            if has_ci_context:
+                assert any("failure" in r or "escalat" in r for r in routes), (
+                    f"{recipe_name}/{step_name}: verdict={verdict} must route to "
+                    f"a failure/escalation step when CI context is available, "
+                    f"got routes: {routes}"
+                )
+            else:
+                assert not any("failure" in r or "escalat" in r for r in routes), (
+                    f"{recipe_name}/{step_name}: verdict={verdict} must NOT route "
+                    f"to escalation without CI context (verdict is semantically "
+                    f"impossible), got routes: {routes}"
+                )
 
 
 @pytest.mark.parametrize("recipe_name", _PIPELINE_RECIPES)

--- a/tests/recipe/test_resolve_ci_routing_invariant.py
+++ b/tests/recipe/test_resolve_ci_routing_invariant.py
@@ -177,7 +177,7 @@ def test_resolve_ci_on_result_routes_escalation_verdicts_to_failure(
             continue
         cmd = (step.with_args or {}).get("skill_command", "")
         has_ci_context = any(v in cmd for v in _CI_CONTEXT_VARS)
-        for verdict in ("ci_only_failure",):
+        for verdict in ("no_test_infrastructure",):
             routes = [
                 cond.route
                 for cond in (step.on_result.conditions or [])
@@ -311,4 +311,54 @@ def test_check_flake_loop_step_exists(recipe_name: str) -> None:
     assert any("failure" in r or "escalat" in r for r in max_routes), (
         f"{recipe_name}: check_flake_loop max_exceeded=true must route to "
         f"a failure/escalation step, got routes: {max_routes}"
+    )
+
+
+@pytest.mark.parametrize("recipe_name", _PIPELINE_RECIPES)
+def test_ci_only_failure_routes_to_continuation(recipe_name: str) -> None:
+    """All resolve-failures steps must route ci_only_failure to continuation, not escalation."""
+    recipe_path = _RECIPES_DIR / recipe_name
+    recipe = load_recipe(recipe_path)
+    violations = []
+    for step_name, step in recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        cmd = (step.with_args or {}).get("skill_command", "")
+        if "resolve-failures" not in cmd:
+            continue
+        if step.on_result is None:
+            continue
+        for cond in step.on_result.conditions or []:
+            if cond.when and "ci_only_failure" in cond.when:
+                if _classify_route_target(cond.route) == "escalation":
+                    violations.append(f"{step_name}: ci_only_failure → {cond.route}")
+    assert not violations, (
+        f"{recipe_name}: ci_only_failure must route to continuation (re-diagnosis), "
+        f"not escalation. Violations: {violations}"
+    )
+
+
+@pytest.mark.parametrize("recipe_name", _PIPELINE_RECIPES)
+def test_ci_only_failure_routes_symmetric_across_steps(recipe_name: str) -> None:
+    """All resolve-failures steps must classify ci_only_failure to the same outcome category."""
+    recipe_path = _RECIPES_DIR / recipe_name
+    recipe = load_recipe(recipe_path)
+    classifications: list[tuple[str, str]] = []
+    for step_name, step in recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        cmd = (step.with_args or {}).get("skill_command", "")
+        if "resolve-failures" not in cmd:
+            continue
+        if step.on_result is None:
+            continue
+        for cond in step.on_result.conditions or []:
+            if cond.when and "ci_only_failure" in cond.when:
+                cls = _classify_route_target(cond.route)
+                classifications.append((step_name, cls))
+    assert classifications, f"{recipe_name}: no ci_only_failure routes found"
+    distinct = {cls for _, cls in classifications}
+    assert len(distinct) == 1, (
+        f"{recipe_name}: ci_only_failure classifies inconsistently across steps. "
+        f"Classifications: {classifications}. All steps must agree on continuation vs escalation."
     )

--- a/tests/recipe/test_rules_verdict_context.py
+++ b/tests/recipe/test_rules_verdict_context.py
@@ -49,7 +49,7 @@ _MANIFEST: dict = {
 
 
 def _make_fix_step_no_ci_context() -> RecipeStep:
-    """Pre-merge `fix` step: no CI context in skill_command, routes ci_only_failure to escalation."""
+    """Pre-merge fix step: no CI context, routes ci_only_failure to escalation."""
     return RecipeStep(
         name="fix",
         tool="run_skill",
@@ -169,7 +169,7 @@ def _make_recipe_with_non_terminal_route() -> Recipe:
 def test_verdict_context_precondition_fires_on_fix_step_without_ci_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Rule fires ERROR when a pre-merge fix step has no CI context but routes ci_only_failure to escalation."""
+    """Rule fires ERROR when fix step has no CI context but routes to escalation."""
     monkeypatch.setattr(_contracts, "load_bundled_manifest", lambda: _MANIFEST)
 
     recipe = _make_recipe_with_fix_step()

--- a/tests/recipe/test_rules_verdict_context.py
+++ b/tests/recipe/test_rules_verdict_context.py
@@ -1,0 +1,219 @@
+"""Tests for the verdict-context-precondition semantic rule.
+
+Verifies that a ``run_skill`` step invoking a skill whose ``allowed_values``
+contains a CI-context-dependent verdict (``ci_only_failure``) does NOT route
+that verdict to escalation without referencing CI context in its
+``skill_command``. Without CI context the verdict is semantically impossible
+to emit, so routing it to escalation creates a dead-but-deadly trap.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import autoskillit.recipe.contracts as _contracts
+from autoskillit.core.types import Severity
+from autoskillit.recipe.schema import (
+    Recipe,
+    RecipeStep,
+    StepResultCondition,
+    StepResultRoute,
+)
+from autoskillit.recipe.validator import run_semantic_rules
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+_SKILL_NAME = "resolve-failures"
+
+_MANIFEST: dict = {
+    "version": "0.1.0",
+    "skills": {
+        _SKILL_NAME: {
+            "inputs": [],
+            "outputs": [
+                {
+                    "name": "verdict",
+                    "type": "string",
+                    "allowed_values": [
+                        "real_fix",
+                        "already_green",
+                        "flake_suspected",
+                        "ci_only_failure",
+                        "no_test_infrastructure",
+                    ],
+                }
+            ],
+        }
+    },
+}
+
+
+def _make_fix_step_no_ci_context() -> RecipeStep:
+    """Pre-merge `fix` step: no CI context in skill_command, routes ci_only_failure to escalation."""
+    return RecipeStep(
+        name="fix",
+        tool="run_skill",
+        with_args={
+            "skill_command": "/autoskillit:resolve-failures main main main",
+        },
+        capture={"verdict": "${{ result.verdict }}"},
+        on_result=StepResultRoute(
+            conditions=[
+                StepResultCondition(
+                    route="release_issue_failure",
+                    when="${{ result.verdict }} == ci_only_failure",
+                ),
+                StepResultCondition(route="test", when="true"),
+            ]
+        ),
+    )
+
+
+def _make_recipe_with_fix_step() -> Recipe:
+    recipe = Recipe(
+        name="test",
+        description="test",
+        kitchen_rules=["test"],
+        steps={
+            "fix": _make_fix_step_no_ci_context(),
+            "release_issue_failure": RecipeStep(
+                action="stop",
+                message="escalation",
+            ),
+            "test": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo test"},
+            ),
+        },
+    )
+    return recipe
+
+
+def _make_recipe_with_resolve_ci() -> Recipe:
+    """Post-CI resolve_ci step: skill_command references CI context vars."""
+    return Recipe(
+        name="test",
+        description="test",
+        kitchen_rules=["test"],
+        steps={
+            "resolve_ci": RecipeStep(
+                name="resolve_ci",
+                tool="run_skill",
+                with_args={
+                    "skill_command": (
+                        "/autoskillit:resolve-failures main main main "
+                        "${{ context.ci_conclusion }} "
+                        "${{ context.ci_failed_jobs }} "
+                        "${{ context.diagnosis_path }}"
+                    ),
+                },
+                capture={"verdict": "${{ result.verdict }}"},
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            route="release_issue_failure",
+                            when="${{ result.verdict }} == ci_only_failure",
+                        ),
+                        StepResultCondition(route="re_push", when="true"),
+                    ]
+                ),
+            ),
+            "release_issue_failure": RecipeStep(
+                action="stop",
+                message="escalation",
+            ),
+            "re_push": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo push"},
+            ),
+        },
+    )
+
+
+def _make_recipe_with_non_terminal_route() -> Recipe:
+    """Step that routes ci_only_failure to a continuation step (re-diagnosis), not escalation."""
+    return Recipe(
+        name="test",
+        description="test",
+        kitchen_rules=["test"],
+        steps={
+            "resolve_local": RecipeStep(
+                name="resolve_local",
+                tool="run_skill",
+                with_args={
+                    "skill_command": "/autoskillit:resolve-failures main main main",
+                },
+                capture={"verdict": "${{ result.verdict }}"},
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            route="diagnose_again",
+                            when="${{ result.verdict }} == ci_only_failure",
+                        ),
+                        StepResultCondition(route="test", when="true"),
+                    ]
+                ),
+            ),
+            "diagnose_again": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo diagnose"},
+            ),
+            "test": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "echo test"},
+            ),
+        },
+    )
+
+
+def test_verdict_context_precondition_fires_on_fix_step_without_ci_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rule fires ERROR when a pre-merge fix step has no CI context but routes ci_only_failure to escalation."""
+    monkeypatch.setattr(_contracts, "load_bundled_manifest", lambda: _MANIFEST)
+
+    recipe = _make_recipe_with_fix_step()
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "verdict-context-precondition"]
+
+    assert len(rule_findings) >= 1, (
+        "verdict-context-precondition must fire when a run_skill step routes "
+        "ci_only_failure to escalation but its skill_command has no CI context. "
+        f"All findings: {[(f.rule, f.severity) for f in findings]}"
+    )
+    assert rule_findings[0].severity == Severity.ERROR
+    assert rule_findings[0].step_name == "fix"
+    assert "ci_only_failure" in rule_findings[0].message
+
+
+def test_verdict_context_precondition_does_not_fire_with_ci_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rule does NOT fire when resolve_ci step has CI context in skill_command."""
+    monkeypatch.setattr(_contracts, "load_bundled_manifest", lambda: _MANIFEST)
+
+    recipe = _make_recipe_with_resolve_ci()
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "verdict-context-precondition"]
+
+    assert rule_findings == [], (
+        "verdict-context-precondition must NOT fire when skill_command references "
+        f"CI context (ci_conclusion, diagnosis_path). Got: {rule_findings}"
+    )
+
+
+def test_verdict_context_precondition_does_not_fire_with_non_terminal_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rule does NOT fire when ci_only_failure routes to a non-escalation target."""
+    monkeypatch.setattr(_contracts, "load_bundled_manifest", lambda: _MANIFEST)
+
+    recipe = _make_recipe_with_non_terminal_route()
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "verdict-context-precondition"]
+
+    assert rule_findings == [], (
+        "verdict-context-precondition must NOT fire when ci_only_failure routes "
+        "to a continuation step (re-diagnosis) rather than escalation. "
+        f"Got: {rule_findings}"
+    )

--- a/tests/skills/AGENTS.md
+++ b/tests/skills/AGENTS.md
@@ -17,6 +17,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 | `test_audit_impl_named_deviation.py` | Tests for NAMED_DEVIATION classification in audit-impl slice auditor |
 | `test_audit_review_decisions_contracts.py` | Contract tests for the audit-review-decisions skill SKILL.md |
 | `test_make_plan_false_positive.py` | Tests for false_positive verdict support in make-plan SKILL.md |
+| `test_make_plan_multipart_contracts.py` | Contract tests for make-plan multi-part green-gate rule and xfail bridge documentation |
 | `test_compose_pr.py` | Guard tests for compose-pr/SKILL.md template structure |
 | `test_conflict_resolution_guards.py` | Structural guards for conflict resolution safeguards in SKILL.md files |
 | `test_deletion_regression_guards.py` | Structural guards for deletion regression detection in merge-pr and review-pr skills |

--- a/tests/skills/test_dry_walkthrough_contracts.py
+++ b/tests/skills/test_dry_walkthrough_contracts.py
@@ -5,6 +5,8 @@ for Step 4.5: Historical Regression Check — the git history scan and
 GitHub issues cross-reference between Step 4 (Project Rules) and Step 5 (Fix Plan).
 """
 
+import re
+
 import pytest
 
 from autoskillit.core.paths import pkg_root
@@ -36,6 +38,33 @@ def test_dry_walkthrough_has_historical_regression_step(skill_text: str) -> None
     assert "Step 4.5" in skill_text, (
         "dry-walkthrough SKILL.md must contain a 'Step 4.5: Historical Regression Check' "
         "section inserted between Step 4 (Project Rules) and Step 5 (Fix the Plan)"
+    )
+
+
+def test_dry_walkthrough_rejects_plan_declared_test_failure(skill_text: str) -> None:
+    """dry-walkthrough must FAIL when the plan declares an expected test failure."""
+    assert re.search(
+        r"(plan|text)\s+(states?|declares?|admits?|expects?)\s+.*(test|gate)\s+.*(fail|red|break)",
+        skill_text,
+        re.IGNORECASE | re.DOTALL,
+    ) and re.search(
+        r"(FAIL|block|reject|error)",
+        skill_text,
+        re.IGNORECASE,
+    ), (
+        "dry-walkthrough SKILL.md must contain a blocking check that rejects "
+        "plans declaring expected test failures"
+    )
+
+
+def test_dry_walkthrough_has_gate_compatibility_step() -> None:
+    """dry-walkthrough must contain a Step 4.3: Pipeline Gate Compatibility Check section."""
+    skill_path = pkg_root() / "skills_extended" / "dry-walkthrough" / "SKILL.md"
+    content = skill_path.read_text()
+    assert "Step 4.3" in content, (
+        "dry-walkthrough SKILL.md must contain a 'Step 4.3: Pipeline Gate "
+        "Compatibility Check' section inserted between Step 4 (Project Rules) "
+        "and Step 4.5 (Historical Regression Check)"
     )
 
 

--- a/tests/skills/test_make_plan_multipart_contracts.py
+++ b/tests/skills/test_make_plan_multipart_contracts.py
@@ -1,0 +1,82 @@
+"""Contract tests for make-plan multi-part green-gate rule and xfail bridge documentation.
+
+Validates that make-plan/SKILL.md contains the CRITICAL multi-part rules
+required for per-part test-gate independence:
+- Every part must independently pass the test gate
+- Test invalidation changes must be co-located with triggering code (or xfail-bridged)
+- ``xfail(strict=True)`` is documented as the canonical bridge mechanism
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("skills"), pytest.mark.small]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SKILL_MD = _REPO_ROOT / "src/autoskillit/skills_extended/make-plan/SKILL.md"
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    """Load make-plan SKILL.md content.
+
+    Defined locally (not via conftest) because the conftest ``skill_text``
+    fixture targets investigate/SKILL.md.
+    """
+    assert _SKILL_MD.exists(), f"SKILL.md not found at {_SKILL_MD}"
+    return _SKILL_MD.read_text()
+
+
+def test_make_plan_green_gate_rule_exists(skill_text: str) -> None:
+    """make-plan must require each part to independently pass the test gate."""
+    assert re.search(
+        r"(every|each)\s+part\s+must\s+(independently\s+)?(pass|leave)\s+(.*test|.*green|.*gate)",
+        skill_text,
+        re.IGNORECASE,
+    ), (
+        "make-plan SKILL.md must contain a multi-part rule requiring each part "
+        "to independently pass the test gate"
+    )
+
+
+def test_make_plan_test_invalidation_colocation_rule(skill_text: str) -> None:
+    """make-plan must require test changes co-located with triggering code changes."""
+    assert re.search(
+        r"(test|guard).*invalidat.*same\s+part|same\s+part.*(test|guard).*invalidat",
+        skill_text,
+        re.IGNORECASE | re.DOTALL,
+    ) or re.search(
+        r"xfail.*bridge|bridge.*xfail",
+        skill_text,
+        re.IGNORECASE,
+    ), (
+        "make-plan SKILL.md must require test invalidation changes to be "
+        "co-located with the code that triggers them, or use xfail bridging"
+    )
+
+
+def test_make_plan_documents_xfail_bridge(skill_text: str) -> None:
+    """make-plan must document xfail(strict=True) as the canonical bridge mechanism."""
+    assert re.search(
+        r"xfail.*strict.*True|strict.*True.*xfail",
+        skill_text,
+    ), (
+        "make-plan SKILL.md must document xfail(strict=True) as the canonical "
+        "multi-part bridge mechanism for cross-part test dependencies"
+    )
+
+
+def test_make_plan_documents_deletion_guard_canary_rule(skill_text: str) -> None:
+    """make-plan must prohibit deferring deletion-guard canary removal to a later part."""
+    assert re.search(
+        r"deletion.guard\s+canar|deletion-guard\s+canary",
+        skill_text,
+        re.IGNORECASE,
+    ), (
+        "make-plan SKILL.md must document that deletion-guard canaries must be "
+        "removed or xfail-bridged in the same part that re-registers the name"
+    )

--- a/tests/skills/test_resolve_failures_ci_aware.py
+++ b/tests/skills/test_resolve_failures_ci_aware.py
@@ -359,9 +359,10 @@ def test_ci_only_failure_invariant_not_weakened(skill_text: str) -> None:
 
 def test_ci_only_failure_hard_invariant_pinned(skill_text: str) -> None:
     """Pin the hard invariant: ci_only_failure NEVER when fixes_applied >= 1."""
+    invariant = _extract_invariant_paragraph(skill_text)
     assert re.search(
-        r"\*\*Invariant:\*\*.*ci_only_failure.*NEVER.*fixes_applied\s*>=\s*1",
-        skill_text,
+        r"ci_only_failure.*NEVER.*fixes_applied\s*>=\s*1",
+        invariant,
     ), "Invariant paragraph must contain 'ci_only_failure NEVER ... fixes_applied >= 1'"
 
 

--- a/tests/skills/test_resolve_failures_ci_aware.py
+++ b/tests/skills/test_resolve_failures_ci_aware.py
@@ -289,20 +289,80 @@ def test_step2d_table_scoped_to_no_fix_path(skill_text: str) -> None:
     )
 
 
-def test_ci_only_failure_requires_no_fix_applied(skill_text: str) -> None:
-    """ci_only_failure must only be emittable when no fix was applied."""
+def _extract_invariant_paragraph(skill_text: str) -> str:
+    """Extract the invariant paragraph from SKILL.md.
+
+    Scoped to the single paragraph starting with **Invariant:** — does NOT
+    use re.DOTALL across the full document (which caused the 476059fbb
+    weakening to evade detection).
+    """
+    lines = skill_text.splitlines()
+    in_paragraph = False
+    collected: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not in_paragraph:
+            if stripped.startswith("**Invariant:**") or stripped.startswith("> **Invariant:**"):
+                in_paragraph = True
+                collected.append(stripped)
+            continue
+        if stripped == "":
+            break
+        if stripped.startswith("### "):
+            break
+        collected.append(stripped)
+    assert collected, "resolve-failures SKILL.md must contain an **Invariant:** paragraph"
+    return " ".join(collected)
+
+
+def test_ci_only_failure_invariant_paragraph_exists(skill_text: str) -> None:
+    """The invariant paragraph must exist with a clear anchor."""
+    invariant = _extract_invariant_paragraph(skill_text)
+    assert "ci_only_failure" in invariant, "Invariant paragraph must reference ci_only_failure"
+
+
+def test_ci_only_failure_invariant_requires_no_fix(skill_text: str) -> None:
+    """Invariant paragraph: ci_only_failure must require no-fix-applied.
+
+    Scoped to the invariant paragraph (not full-DOTALL across SKILL.md).
+    The weakening language from 476059fbb would appear WITHIN this paragraph.
+    """
+    invariant = _extract_invariant_paragraph(skill_text)
     assert re.search(
-        r"ci_only_failure.*(no fix|never.*fix.*applied|fixes_applied.*0|without.*commit)",
-        skill_text,
-        re.IGNORECASE | re.DOTALL,
-    ) or re.search(
-        r"(no fix|never.*fix|fixes_applied.*0).*ci_only_failure",
-        skill_text,
-        re.IGNORECASE | re.DOTALL,
+        r"ci_only_failure.*?(?:NEVER|must\s+not|is\s+not\s+emitted)",
+        invariant,
+        re.IGNORECASE,
     ), (
-        "resolve-failures SKILL.md must explicitly state that ci_only_failure "
-        "is only emitted when no fix was applied"
+        "Invariant paragraph must state ci_only_failure is NEVER/must not/is not emitted "
+        "when fixes_applied >= 1"
     )
+
+
+def test_ci_only_failure_invariant_not_weakened(skill_text: str) -> None:
+    """Invariant paragraph must not contain the weakening language from 476059fbb.
+
+    The weakening said: 'ci_only_failure MAY be emitted when fixes_applied >= 1'.
+    This test catches any attempt to re-introduce that exact softening.
+    """
+    invariant = _extract_invariant_paragraph(skill_text)
+    forbidden_phrases = (
+        "MAY be emitted when fixes_applied >= 1",
+        "MAY be emitted when fixes_applied>=1",
+        "may be emitted when fixes_applied",
+    )
+    for phrase in forbidden_phrases:
+        assert phrase not in invariant, (
+            f"Invariant paragraph must not contain weakening language: {phrase!r}. "
+            f"The invariant was weakened in 476059fbb; this test prevents regression."
+        )
+
+
+def test_ci_only_failure_hard_invariant_pinned(skill_text: str) -> None:
+    """Pin the hard invariant: ci_only_failure NEVER when fixes_applied >= 1."""
+    assert re.search(
+        r"\*\*Invariant:\*\*.*ci_only_failure.*NEVER.*fixes_applied\s*>=\s*1",
+        skill_text,
+    ), "Invariant paragraph must contain 'ci_only_failure NEVER ... fixes_applied >= 1'"
 
 
 def test_step3_green_always_yields_real_fix(skill_text: str) -> None:
@@ -317,4 +377,48 @@ def test_step3_green_always_yields_real_fix(skill_text: str) -> None:
     assert "real_fix" in step3_text, "Step 3 must directly assign verdict = real_fix on green exit"
     assert "step 2d" not in step3_text.lower() or "do not" in step3_text.lower(), (
         "Step 3 must not redirect back to Step 2d for verdict evaluation"
+    )
+
+
+def test_step3_excludes_ci_only_failure(skill_text: str) -> None:
+    """Step 3 (fix loop) must NOT reference ci_only_failure.
+
+    ci_only_failure applies ONLY on the no-fix path (Step 2d). If it appears
+    in Step 3, it suggests Step 3 might emit ci_only_failure after applying
+    fixes — which violates the hard invariant.
+    """
+    step3_match = re.search(
+        r"### Step 3.*?(?=\n### Step [45]|\Z)",
+        skill_text,
+        re.DOTALL,
+    )
+    assert step3_match is not None, "### Step 3 section must exist in SKILL.md"
+    step3_text = step3_match.group(0)
+    assert "ci_only_failure" not in step3_text, (
+        "Step 3 (fix loop) must not reference ci_only_failure — that verdict is "
+        "only valid on the no-fix path (Step 2d, fixes_applied == 0)"
+    )
+
+
+def test_invariant_paragraph_no_permissive_ci_only_failure(skill_text: str) -> None:
+    """Invariant paragraph must not permit ci_only_failure with fixes_applied >= 1.
+
+    Specifically: no phrase matching ci_only_failure ... (allowed|permitted|may|valid)
+    in proximity to fixes_applied >= 1 or 'after a fix' or 'after the fix'.
+    """
+    invariant = _extract_invariant_paragraph(skill_text)
+    permissive = re.search(
+        r"ci_only_failure.*?(allowed|permitted|may\s+be\s+valid|may\s+be\s+emitted)",
+        invariant,
+        re.IGNORECASE,
+    )
+    after_fix = re.search(
+        r"(after\s+(a|the)\s+fix|fixes_applied\s*>=\s*1|fixes_applied\s*>=\s*1\s+if)",
+        invariant,
+        re.IGNORECASE,
+    )
+    assert not (permissive and after_fix), (
+        "Invariant paragraph must not permit ci_only_failure after fixes are applied. "
+        f"Found permissive phrase: {permissive.group(0) if permissive else None!r} "
+        f"near: {after_fix.group(0) if after_fix else None!r}"
     )


### PR DESCRIPTION
## Summary

A pipeline run was killed by a four-layer gap: (1) make-plan split a canary test deletion into Part B while Part A registered the forbidden command, (2) dry-walkthrough stamped a plan that declared an expected red test, (3) resolve-failures emitted `ci_only_failure` for a locally-failing test — a verdict whose precondition (`local_result = PASS`) was unmet, and (4) the recipe routed this mechanically-impossible verdict to a terminal kill. This is the 4th generation of "LLM-emitted verdict with unmet preconditions terminates the pipeline."

Part A addresses the **contract and semantic rule layer** — the architectural root that makes all four gaps exploitable. Without mechanical validation, any SKILL.md prose fix can regress via prose rewording (as happened across #1954 → #3610 → #4190). Part A delivers: verdict enum enforcement in contracts, a new semantic rule for verdict-context precondition validation, and hardened regression tests for the resolve-failures invariant. Subsequent parts address make-plan green-gate enforcement and dry-walkthrough gate-compatibility checking.

## Requirements

## What happened

Implementation run `impl-20260705-184231-936209` for #4189 (`autoskillit fleet run` CLI) was killed at the pre-merge `fix` step. Part A of a two-part plan registered the `fleet run` subcommand while deletion of the pre-existing deletion-guard test `test_fleet_run_command_not_registered` (`tests/cli/test_fleet_list.py:100`) was deferred to Part B — so Part A's local test gate could never pass. resolve-failures fixed 3 of 4 failures, then emitted `verdict=ci_only_failure` for the remaining locally-reproducible canary failure, and the recipe routed to `release_issue_failure → register_clone_failure → escalate_stop`.

## Root cause — four stacked gaps (one per layer)

1. **make-plan (origin):** the 500-line split trigger + "implementation vs. tests" boundary stranded the canary deletion in Part B. Multi-part rules (`make-plan/SKILL.md` lines 337–343) are scope-isolation only — **no invariant that each part must leave `task test-check` green**. The planner's own Registry Tracer flagged the canary CRITICAL (F1) pre-split; the split put the fix on the wrong side and no rule caught it.
2. **dry-walkthrough:** read Part A's own admission ("`task test-all` passes with the single exception of `test_fleet_run_command_not_registered`") and recorded it under **Verified**, then stamped the plan "Implement as-is". It checks the test *command name* (SKILL.md lines 149–156), never the predicted *outcome*. No pipeline-gate compatibility check exists.
3. **resolve-failures:** no verdict exists for a plan-acknowledged deferred failure. The session anchored on the weakened invariant "`ci_only_failure` MAY be emitted when `fixes_applied >= 1`…" and skipped the "…if the remaining failures are all CI-only" qualifier. Per the skill's own decision table (lines 186–196) every `ci_only_failure` row requires **Local result = PASS** — the canary fails locally (verified empirically in the worktree). It also exited the fix loop after 2 of 3 iterations via the tests-green reporting path (Step 4) instead of Step 5 (Report Failure).
4. **Recipe routing:** the pre-merge `fix` step (`implementation.yaml:661–698`) is reachable only via a **local** test failure before any CI run — an honest `ci_only_failure` is mechanically impossible there. The route functions purely as an unconditional kill for misclassifications. The same trap exists in `merge_gate_fix`, `implementation-groups.yaml`, `remediation.yaml`, and `research-implement.yaml`.

## Recurring regression (3rd generation)

- `953e27c54` (#1954, 2026-05-05): added hard invariant "`ci_only_failure` is NEVER emitted when `fixes_applied >= 1`".
- `476059fbb` (#3610 fix, 2026-06-02): side-effect weakened it to "MAY be emitted … if all CI-only" — the loophole-shaped text this session misread.
- The regression test `test_ci_only_failure_requires_no_fix_applied` (`tests/skills/test_resolve_failures_ci_aware.py:292`) uses DOTALL regexes across the whole document and still passes with the weakened text — verified against current SKILL.md.
- This is at least the 4th manifestation of "LLM-emitted verdict with unmet preconditions → terminal routing" (#1954, #1031/#1035, #3268, this).

## Existing escape hatch never used

`check_test_passed` ignores `xfailed` counts (verified empirically: exit 0 + "45 xfailed" → gate passes; locked in by `tests/server/test_tools_workspace.py:181`). Marking the canary `xfail(strict=True)` in Part A would have passed the gate with forced cleanup semantics. No skill guidance mentions this mechanism.

## Recommended remediation

1. **make-plan:** add a multi-part CRITICAL rule — every part must independently pass `task test-check`; any pre-existing test invalidated by a part's changes must be updated/removed/xfail-bridged in that same part; split boundaries keep gate-prerequisites with the code that triggers them.
2. **dry-walkthrough:** blocking FAIL when the plan text declares any test expected to fail after the part's implementation (detectable from a single part; no cross-part read required).
3. **resolve-failures:** restore the hard invariant (give partial-fix-with-CI-only-remainder its own verdict if genuinely needed); mandate Step 5 (Report Failure) as the sole exit when tests remain red with iterations remaining; optionally add a `plan_blocked` verdict for plan-acknowledged deferred failures.
4. **Contracts/orchestrator:** enum-constrain `verdict` in skill contracts (currently unconstrained `type: string`); reject or re-route `ci_only_failure` emitted from steps reachable only via local test failure — mechanical precondition validation instead of prose trust.
5. **Test hardening:** pin the invariant paragraph in `test_resolve_failures_ci_aware.py` with an anchored, paragraph-scoped assertion so the next prose softening fails CI.

Closes #4190

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260706-083036-399312/.autoskillit/temp/rectify/rectify_verdict_precondition_immunity_2026-07-06_083036_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify* | opus[1m] | 2 | 141 | 42.4k | 7.5M | 182.3k | 188 | 179.9k | 1h 5m |
| review_approach* | opus[1m] | 2 | 28.7k | 12.4k | 510.2k | 49.2k | 28 | 91.6k | 15m 10s |
| dry_walkthrough* | opus | 5 | 592 | 87.5k | 9.1M | 125.3k | 259 | 342.7k | 50m 1s |
| implement* | MiniMax-M3 | 5 | 597.7k | 72.3k | 27.6M | 146.4k | 573 | 0 | 33m 10s |
| assess* | opus[1m] | 2 | 273 | 79.1k | 30.5M | 232.8k | 409 | 329.0k | 1h 7m |
| audit_impl* | opus[1m] | 4 | 3.1k | 56.3k | 2.8M | 99.4k | 137 | 281.2k | 41m 12s |
| make_plan* | opus[1m] | 1 | 28 | 3.3k | 436.6k | 52.2k | 18 | 34.3k | 2m 5s |
| prepare_pr* | MiniMax-M3 | 1 | 54.1k | 4.7k | 806.6k | 59.6k | 30 | 0 | 1m 45s |
| compose_pr* | MiniMax-M3 | 1 | 43.6k | 2.4k | 221.7k | 0 | 11 | 0 | 32s |
| **Total** | | | 728.2k | 360.4k | 79.5M | 232.8k | | 1.3M | 4h 37m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 1617 | 17089.0 | 0.0 | 44.7 |
| assess | 318 | 95773.3 | 1034.6 | 248.8 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **1935** | 41060.9 | 650.5 | 186.2 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 5 | 32.3k | 193.5k | 41.7M | 915.9k | 3h 11m |
| opus | 1 | 592 | 87.5k | 9.1M | 342.7k | 50m 1s |
| MiniMax-M3 | 3 | 695.4k | 79.4k | 28.7M | 0 | 35m 27s |