### PR TITLE
fix: thread effective_backend_map and admission tests for Codex

### DIFF
--- a/src/autoskillit/cli/fleet/_fleet_run.py
+++ b/src/autoskillit/cli/fleet/_fleet_run.py
@@ -44,6 +44,32 @@ async def _execute_fleet_run(
 
     ctx = make_context(cfg, project_dir=Path.cwd())
 
+    from autoskillit.server import (  # noqa: PLC0415
+        _compute_effective_backend_map,
+        _provider_aware_capability_overrides,
+    )
+
+    _recipe_info = ctx.recipes.find(recipe, ctx.project_dir) if ctx.recipes else None
+    _raw_steps = (
+        ctx.recipes.load(_recipe_info.path).steps
+        if _recipe_info is not None and ctx.recipes is not None
+        else None
+    )
+    _prov_overrides, _ = _provider_aware_capability_overrides(
+        dispatch_backend,
+        recipe,
+        ctx.config.providers,
+        _raw_steps,
+        skill_resolver=ctx.skill_resolver,
+    )
+    _effective_backend_map = _compute_effective_backend_map(
+        _raw_steps,
+        dispatch_backend.name if dispatch_backend else None,
+        ctx.config.providers,
+        recipe,
+        skill_resolver=ctx.skill_resolver,
+    )
+
     effective_backend = dispatch_backend or ctx.backend
     has_ufa = (
         effective_backend.capabilities.has_unguarded_filesystem_access
@@ -91,6 +117,8 @@ async def _execute_fleet_run(
         resume_session_id=resume_session_id,
         prior_dispatch_id=prior_dispatch_id,
         dispatch_backend=dispatch_backend,
+        provider_capability_overrides=_prov_overrides,
+        effective_backend_map=_effective_backend_map,
     )
 
 

--- a/src/autoskillit/core/types/_type_protocols_recipe.py
+++ b/src/autoskillit/core/types/_type_protocols_recipe.py
@@ -53,6 +53,7 @@ class RecipeRepository(Protocol):
         *,
         backend_name: str | None = None,
         ingredient_overrides: dict[str, str] | None = None,
+        effective_backend_map: dict[str, str] | None = None,
     ) -> dict[str, Any]: ...
 
     def list_all(

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -192,6 +192,7 @@ async def execute_dispatch(
     caller_instructions: str | None = None,
     provider_capability_overrides: dict[str, str] | None = None,
     dispatch_backend: CodingAgentBackend | None = None,
+    effective_backend_map: dict[str, str] | None = None,
 ) -> DispatchResult:
     """Execute a single food truck dispatch.
 
@@ -260,6 +261,7 @@ async def execute_dispatch(
             caller_instructions=caller_instructions,
             provider_capability_overrides=provider_capability_overrides,
             dispatch_backend=dispatch_backend,
+            effective_backend_map=effective_backend_map,
         )
     except asyncio.CancelledError:
         raise
@@ -322,6 +324,7 @@ async def _run_dispatch(
     caller_instructions: str | None = None,
     provider_capability_overrides: dict[str, str] | None = None,
     dispatch_backend: CodingAgentBackend | None = None,
+    effective_backend_map: dict[str, str] | None = None,
 ) -> DispatchResult:
     """Inner dispatch body — called after lock acquisition."""
     from autoskillit.fleet.state import (
@@ -367,6 +370,7 @@ async def _run_dispatch(
             ingredient_overrides=_merged_ingredients,
             temp_dir=tool_ctx.temp_dir,
             backend_name=_effective_backend.name if _effective_backend else None,
+            effective_backend_map=effective_backend_map,
         )
     except ProcessStaleError as exc:
         return DispatchResult(

--- a/src/autoskillit/recipe/_api_listing.py
+++ b/src/autoskillit/recipe/_api_listing.py
@@ -78,6 +78,7 @@ def validate_from_path(
     lister: SkillLister | None = None,
     backend_name: str | None = None,
     ingredient_overrides: dict[str, str] | None = None,
+    effective_backend_map: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Validate a recipe YAML file at the given path.
 
@@ -132,6 +133,7 @@ def validate_from_path(
             available_skills=frozenset(s.name for s in lister.list_all()),
             skill_resolver=_skill_resolver,
             backend_name=backend_name,
+            effective_backend_map=effective_backend_map,
         )
         _pre_prune_findings = run_semantic_rules(pre_prune_ctx)
         recipe, _skip_resolutions = _prune_skipped_steps(
@@ -143,6 +145,7 @@ def validate_from_path(
         available_skills=known_skills,
         skill_resolver=_skill_resolver,
         backend_name=backend_name,
+        effective_backend_map=effective_backend_map,
     )
     report = ctx.dataflow
     semantic_findings = run_semantic_rules(ctx)

--- a/src/autoskillit/recipe/repository.py
+++ b/src/autoskillit/recipe/repository.py
@@ -126,12 +126,14 @@ class DefaultRecipeRepository:
         *,
         backend_name: str | None = None,
         ingredient_overrides: dict[str, str] | None = None,
+        effective_backend_map: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         return _api.validate_from_path(
             script_path,
             temp_dir_relpath=temp_dir_relpath,
             backend_name=backend_name,
             ingredient_overrides=ingredient_overrides,
+            effective_backend_map=effective_backend_map,
         )
 
     def list_all(

--- a/src/autoskillit/server/__init__.py
+++ b/src/autoskillit/server/__init__.py
@@ -57,6 +57,9 @@ __all__ = [
     "version_info",
     "make_context",
     "resolve_backend_override",
+    # Admission helpers consumed by CLI (re-exported to avoid cross-submodule imports)
+    "_provider_aware_capability_overrides",
+    "_compute_effective_backend_map",
     # Wire-format compatibility middleware
     "ClaudeCodeCompatMiddleware",
     # Session-type visibility dispatcher (callable by tests)
@@ -139,6 +142,10 @@ from autoskillit.server.tools import (  # noqa: E402, F401
 )
 from autoskillit.server.tools import (  # noqa: E402, F401
     tools_workspace as _tools_workspace,
+)
+from autoskillit.server.tools._auto_overrides import (  # noqa: E402, F401
+    _compute_effective_backend_map,
+    _provider_aware_capability_overrides,
 )
 from autoskillit.server.tools.tools_kitchen import _build_tool_category_listing  # noqa: E402, F401
 

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -341,6 +341,7 @@ async def dispatch_food_truck(
         _fleet_load_result: dict[str, Any] = {}
         _capability_overrides: dict[str, str] = {}
         _cap_detail: CapabilityResolutionDetail | None = None
+        _effective_backend_map: dict[str, str] | None = None
         if tool_ctx.recipes is not None:
             try:
                 _preflight_recipe_info = tool_ctx.recipes.find(recipe, tool_ctx.project_dir)
@@ -471,6 +472,7 @@ async def dispatch_food_truck(
                     caller_instructions=caller_instructions,
                     provider_capability_overrides=_capability_overrides,
                     dispatch_backend=dispatch_backend,
+                    effective_backend_map=_effective_backend_map,
                 )
         except TimeoutError:
             logger.error(

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -369,11 +369,19 @@ async def validate_recipe(script_path: str) -> str:
                 _validate_recipe_steps,
                 skill_resolver=tool_ctx.skill_resolver,
             )
+            _validate_effective_backend_map = _compute_effective_backend_map(
+                _validate_recipe_steps,
+                tool_ctx.backend.name if tool_ctx.backend else None,
+                tool_ctx.config.providers,
+                _validate_recipe_name,
+                skill_resolver=tool_ctx.skill_resolver,
+            )
             result = tool_ctx.recipes.validate_from_path(
                 Path(script_path),
                 temp_dir_relpath=temp_dir_display_str(tool_ctx.config.workspace.temp_dir),
                 backend_name=tool_ctx.backend.name if tool_ctx.backend else None,
                 ingredient_overrides=_cap_overrides,
+                effective_backend_map=_validate_effective_backend_map,
             )
             return json.dumps(result)
     except Exception as exc:

--- a/tests/arch/test_capability_admission_control.py
+++ b/tests/arch/test_capability_admission_control.py
@@ -337,6 +337,112 @@ def test_run_skill_references_git_metadata_write_capability() -> None:
     )
 
 
+def test_execute_dispatch_accepts_effective_backend_map() -> None:
+    """execute_dispatch signature must include effective_backend_map parameter."""
+    import inspect
+
+    from autoskillit.fleet._api import execute_dispatch
+
+    sig = inspect.signature(execute_dispatch)
+    assert "effective_backend_map" in sig.parameters, (
+        "execute_dispatch must accept effective_backend_map — "
+        "without it the CLI and dispatch_food_truck cannot thread the per-step map "
+        "into the engine's internal load_and_validate call."
+    )
+
+
+def _find_load_and_validate_call_in_run_dispatch(src: str) -> ast.Call | None:
+    """Return the load_and_validate Call node inside _run_dispatch, or None."""
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "_run_dispatch":
+            for child in ast.walk(node):
+                if (
+                    isinstance(child, ast.Call)
+                    and isinstance(child.func, ast.Attribute)
+                    and child.func.attr == "load_and_validate"
+                ):
+                    return child
+    return None
+
+
+def test_run_dispatch_passes_effective_backend_map_to_load_and_validate() -> None:
+    """_run_dispatch must pass effective_backend_map kwarg to load_and_validate."""
+    api_path = SRC_ROOT / "fleet" / "_api.py"
+    src = api_path.read_text(encoding="utf-8")
+    call_node = _find_load_and_validate_call_in_run_dispatch(src)
+    assert call_node is not None, (
+        "load_and_validate call not found inside _run_dispatch in fleet/_api.py"
+    )
+    kw_names = {kw.arg for kw in call_node.keywords if kw.arg is not None}
+    assert "effective_backend_map" in kw_names, (
+        "_run_dispatch must pass effective_backend_map to load_and_validate — "
+        "without it the engine's validation always runs without per-step routing context."
+    )
+
+
+def test_execute_fleet_run_calls_provider_aware_capability_overrides() -> None:
+    """_execute_fleet_run must call _provider_aware_capability_overrides (CLI admission parity)."""
+    fleet_run_path = SRC_ROOT / "cli" / "fleet" / "_fleet_run.py"
+    tree = ast.parse(fleet_run_path.read_text(encoding="utf-8"))
+    assert _has_call_in_function(
+        tree, "_execute_fleet_run", "_provider_aware_capability_overrides"
+    ), (
+        "_execute_fleet_run must call _provider_aware_capability_overrides — "
+        "without this, the CLI path does not compute provider-aware capability signals "
+        "before dispatching, causing backend-incompatible-skill errors for Codex runs."
+    )
+
+
+def test_execute_fleet_run_calls_compute_effective_backend_map() -> None:
+    """_execute_fleet_run must call _compute_effective_backend_map (CLI admission parity)."""
+    fleet_run_path = SRC_ROOT / "cli" / "fleet" / "_fleet_run.py"
+    tree = ast.parse(fleet_run_path.read_text(encoding="utf-8"))
+    assert _has_call_in_function(tree, "_execute_fleet_run", "_compute_effective_backend_map"), (
+        "_execute_fleet_run must call _compute_effective_backend_map — "
+        "without this, the CLI path never computes per-step routing and always "
+        "evaluates backend-compat with a flat backend map."
+    )
+
+
+def test_dispatch_food_truck_forwards_effective_backend_map_to_execute_dispatch() -> None:
+    """dispatch_food_truck must pass effective_backend_map to execute_dispatch call."""
+    fleet_path = SRC_ROOT / "server" / "tools" / "tools_fleet_dispatch.py"
+    src = fleet_path.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "dispatch_food_truck":
+            for child in ast.walk(node):
+                if (
+                    isinstance(child, ast.Call)
+                    and isinstance(child.func, ast.Name)
+                    and child.func.id == "execute_dispatch"
+                ):
+                    kw_names = {kw.arg for kw in child.keywords if kw.arg is not None}
+                    assert "effective_backend_map" in kw_names, (
+                        "dispatch_food_truck must pass effective_backend_map to "
+                        "execute_dispatch — without it, the per-step routing map "
+                        "computed by the preflight is silently dropped at the engine boundary."
+                    )
+                    return
+            pytest.fail("execute_dispatch call not found inside dispatch_food_truck")
+    pytest.fail("dispatch_food_truck function not found in tools_fleet_dispatch.py")
+
+
+def test_validate_from_path_accepts_effective_backend_map() -> None:
+    """validate_from_path signature must accept effective_backend_map."""
+    import inspect
+
+    from autoskillit.recipe._api_listing import validate_from_path
+
+    sig = inspect.signature(validate_from_path)
+    assert "effective_backend_map" in sig.parameters, (
+        "validate_from_path must accept effective_backend_map — "
+        "without it the validate_recipe MCP tool cannot thread per-step routing "
+        "context into backend-compat rule evaluation."
+    )
+
+
 def test_compute_effective_backend_map_accepts_skill_resolver() -> None:
     """_compute_effective_backend_map must accept a skill_resolver parameter."""
     auto_overrides_path = SRC_ROOT / "server" / "tools" / "_auto_overrides.py"

--- a/tests/arch/test_feature_markers.py
+++ b/tests/arch/test_feature_markers.py
@@ -32,6 +32,7 @@ _FLEET_CROSS_DIR_FILES: frozenset[Path] = frozenset(
         _TESTS_ROOT / "cli" / "test_fleet_status.py",
         _TESTS_ROOT / "cli" / "test_fleet_list.py",
         _TESTS_ROOT / "cli" / "test_fleet_run.py",
+        _TESTS_ROOT / "cli" / "test_fleet_run_admission.py",
         _TESTS_ROOT / "server" / "test_tools_dispatch.py",
         _TESTS_ROOT / "server" / "test_tools_dispatch_validation.py",
         _TESTS_ROOT / "server" / "test_tools_dispatch_params.py",

--- a/tests/cli/AGENTS.md
+++ b/tests/cli/AGENTS.md
@@ -44,6 +44,7 @@ CLI command, subcommand, and interactive workflow tests.
 | `test_fleet_dispatch.py` | Tests: fleet CLI dispatch command |
 | `test_fleet_list.py` | Tests: fleet CLI list command |
 | `test_fleet_run.py` | Tests: fleet CLI run command gates — session-type guard, feature gates, CLAUDECODE relaxation |
+| `test_fleet_run_admission.py` | Tests: fleet run CLI backend admission — effective_backend_map threading, fail-closed rejection, CLI/kitchen agreement (issue #4197) |
 | `test_fleet_session.py` | Tests: _launch_fleet_session forwards ingredients_table to prompt builder |
 | `test_fleet_split.py` | Structural guard for fleet test split |
 | `test_fleet_status.py` | Tests: fleet CLI status command |

--- a/tests/cli/AGENTS.md
+++ b/tests/cli/AGENTS.md
@@ -44,7 +44,7 @@ CLI command, subcommand, and interactive workflow tests.
 | `test_fleet_dispatch.py` | Tests: fleet CLI dispatch command |
 | `test_fleet_list.py` | Tests: fleet CLI list command |
 | `test_fleet_run.py` | Tests: fleet CLI run command gates — session-type guard, feature gates, CLAUDECODE relaxation |
-| `test_fleet_run_admission.py` | Tests: fleet run CLI backend admission — effective_backend_map threading, fail-closed rejection, CLI/kitchen agreement (issue #4197) |
+| `test_fleet_run_admission.py` | Tests: fleet run CLI backend admission — effective_backend_map threading, fail-closed rejection path (shutil.which=None), CLI/kitchen agreement (issue #4197) |
 | `test_fleet_session.py` | Tests: _launch_fleet_session forwards ingredients_table to prompt builder |
 | `test_fleet_split.py` | Structural guard for fleet test split |
 | `test_fleet_status.py` | Tests: fleet CLI status command |

--- a/tests/cli/test_fleet_run_admission.py
+++ b/tests/cli/test_fleet_run_admission.py
@@ -224,42 +224,176 @@ class TestFleetRunCliAdmission:
             "fleet_recipe_invalid must appear in the output envelope when recipe is rejected"
         )
 
-    def test_admission_agreement_cli_computes_same_map_as_kitchen(
-        self,
-        tmp_path: Path,
+    def test_fleet_run_cli_codex_fails_without_claude_binary(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path
     ) -> None:
-        """_compute_effective_backend_map is deterministic across CLI and kitchen paths.
+        """_execute_fleet_run with codex backend fails closed when claude binary is absent.
 
-        Both _execute_fleet_run and dispatch_food_truck call _compute_effective_backend_map
-        with equivalent inputs. This verifies the function produces identical output for
-        both callers given the same recipe steps and backend.
+        Exercises the real admission path: fleet_run CLI → _execute_fleet_run (real, not
+        mocked) → execute_dispatch (real) → _run_dispatch → load_and_validate (real fake,
+        not MagicMock). shutil.which=None in the _auto_overrides namespace triggers the
+        no-claude-binary scenario; InMemoryRecipeRepository returns backend-incompatible-skill.
         """
-        from autoskillit.server.tools._auto_overrides import _compute_effective_backend_map
+        from tests.fakes import InMemoryRecipeRepository
 
-        recipe_steps: dict[str, Any] = {}
-        backend_name = "codex"
-        config_providers = None
-        recipe_name = "test-recipe"
-
-        cli_map = _compute_effective_backend_map(
-            recipe_steps,
-            backend_name,
-            config_providers,
-            recipe_name,
-            skill_resolver=None,
+        # Configure InMemoryRecipeRepository to return a backend-incompatible rejection.
+        # load_and_validate is NOT a MagicMock — it runs the real InMemoryRecipeRepository
+        # logic (records calls, checks _validated, raises RecipeNotFoundError if absent).
+        repo = InMemoryRecipeRepository()
+        repo.set_validated(
+            "test-recipe",
+            {
+                "valid": False,
+                "errors": ["backend-incompatible-skill: step-1 requires claude-code"],
+            },
         )
 
+        # Build ctx. Use MagicMock for find/load (pre-dispatch recipe lookups in
+        # _execute_fleet_run); wire load_and_validate to the real InMemoryRecipeRepository
+        # method so the dispatch path exercises real fake logic.
+        codex_backend = _make_codex_backend()
+        ctx = MagicMock()
+        ctx.project_dir = tmp_path
+        ctx.skill_resolver = None
+        ctx.config.providers = None
+        ctx.config.migration.suppressed = None
+        ctx.temp_dir = tmp_path / ".autoskillit" / "temp"
+        ctx.backend = codex_backend
+
+        # fleet_lock: execute_dispatch awaits lock.acquire() then calls lock.release() sync.
+        ctx.fleet_lock.at_capacity.return_value = False
+        ctx.fleet_lock.acquire = AsyncMock(return_value=None)
+
+        # Pre-dispatch recipe lookups in _execute_fleet_run (find/load for steps computation)
+        recipe_info = MagicMock()
+        recipe_info.path = tmp_path / "test-recipe.yaml"
+        ctx.recipes.find.return_value = recipe_info
+        ctx.recipes.load.return_value.steps = {}
+
+        # Override load_and_validate on the MagicMock to use the real InMemoryRecipeRepository
+        # method — this is a real fake, not a predetermined return-value mock.
+        ctx.recipes.load_and_validate = repo.load_and_validate
+
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: type(
+                "C",
+                (),
+                {
+                    "features": {"fleet": True, "fleet_headless_run": True},
+                    "experimental_enabled": True,
+                },
+            )(),
+        )
+        monkeypatch.setattr(
+            "autoskillit.server.resolve_backend_override",
+            lambda name: codex_backend,
+        )
+        # shutil.which=None in the _auto_overrides namespace: no claude binary.
+        # This exercises the real _provider_aware_capability_overrides and
+        # _compute_effective_backend_map code paths inside _execute_fleet_run.
+        monkeypatch.setattr(
+            "autoskillit.server.tools._auto_overrides.shutil.which",
+            lambda cmd: None,
+        )
+        monkeypatch.setattr(
+            "autoskillit.server.make_context",
+            lambda _cfg, project_dir=None: ctx,
+        )
+
+        from autoskillit.cli.fleet import fleet_run
+
+        with pytest.raises(SystemExit) as exc_info:
+            fleet_run("test-recipe", backend="codex")
+
+        assert exc_info.value.code == 3, (
+            "Exit code must be 3 (FLEET_RECIPE_INVALID) when admission fails"
+        )
+        captured_out = capsys.readouterr()
+        envelope = json.loads(captured_out.out)
+        assert envelope.get("error") == "fleet_recipe_invalid", (
+            "fleet_recipe_invalid must appear in the output envelope"
+        )
+        rejection_message = envelope.get("message", "")
+        assert "backend-incompatible-skill" in rejection_message, (
+            f"backend-incompatible-skill must be present in the rejection message; "
+            f"got: {rejection_message!r}"
+        )
+
+        # Verify the real dispatch path was exercised: load_and_validate was called with
+        # the effective_backend_map kwarg from the real _execute_fleet_run computation.
+        lav_calls = [c for c in repo.calls if c["method"] == "load_and_validate"]
+        assert lav_calls, (
+            "load_and_validate must be called through the real dispatch path — "
+            "if this assertion fails, execute_dispatch was not reached"
+        )
+        assert "effective_backend_map" in lav_calls[0], (
+            "load_and_validate call must include effective_backend_map kwarg — "
+            "REQ-004: effective_backend_map must be threaded to load_and_validate"
+        )
+
+    @pytest.mark.parametrize("backend_name", ["codex", "claude-code"])
+    def test_admission_agreement_cli_matches_kitchen_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, backend_name: str
+    ) -> None:
+        """effective_backend_map at execute_dispatch is identical from CLI and kitchen paths.
+
+        Runs _execute_fleet_run with a spy on execute_dispatch to capture the
+        effective_backend_map kwarg (CLI path). Separately computes what dispatch_food_truck
+        would pass to execute_dispatch by calling _compute_effective_backend_map directly
+        with equivalent inputs (kitchen path). Asserts the two values are equal.
+
+        Parametrized over backends to guard against per-backend routing divergence.
+        """
+        from autoskillit.server import _compute_effective_backend_map
+
+        captured: dict[str, object] = {}
+
+        async def spy_dispatch(**kwargs: object) -> DispatchResult:
+            captured.update(kwargs)
+            return _make_success_result()
+
+        # Build backend mock for the requested backend_name
+        if backend_name == "codex":
+            backend = _make_codex_backend()
+        else:
+            backend = MagicMock()
+            backend.name = "claude-code"
+            backend.capabilities.git_metadata_writable = True
+            backend.capabilities.has_unguarded_filesystem_access = False
+            backend.capabilities.anthropic_provider_capable = True
+
+        # Run CLI path via existing _run_execute_fleet_run helper.
+        # _run_execute_fleet_run mocks execute_dispatch with spy_dispatch so the real
+        # _execute_fleet_run computation (_compute_effective_backend_map, etc.) runs but
+        # dispatch does not. spy_dispatch captures all kwargs passed to execute_dispatch.
+        asyncio.run(
+            _run_execute_fleet_run(
+                monkeypatch=monkeypatch,
+                tmp_path=tmp_path,
+                dispatch_backend=backend,
+                execute_dispatch_fn=spy_dispatch,
+            )
+        )
+
+        cli_map = captured.get("effective_backend_map")
+
+        # Kitchen path: compute what dispatch_food_truck passes to execute_dispatch.
+        # dispatch_food_truck calls _compute_effective_backend_map(recipe_steps, backend_name,
+        # config_providers, recipe_name, skill_resolver=skill_resolver) with the same recipe
+        # steps that _make_mock_ctx returns (empty dict).
+        recipe_steps: dict[str, Any] = {}
         kitchen_map = _compute_effective_backend_map(
             recipe_steps,
             backend_name,
-            config_providers,
-            recipe_name,
+            None,  # config_providers
+            "test-recipe",
             skill_resolver=None,
         )
 
         assert cli_map == kitchen_map, (
-            f"CLI path map {cli_map!r} != kitchen path map {kitchen_map!r} — "
-            "_compute_effective_backend_map must be deterministic given the same inputs."
+            f"CLI path effective_backend_map {cli_map!r} != "
+            f"kitchen path {kitchen_map!r} for backend {backend_name!r}. "
+            "Both _execute_fleet_run and dispatch_food_truck must pass identical "
+            "effective_backend_map values to execute_dispatch."
         )
-        # cli_map may be None for recipes with no steps (empty dict returns None);
-        # the equality assertion above is the key invariant.

--- a/tests/cli/test_fleet_run_admission.py
+++ b/tests/cli/test_fleet_run_admission.py
@@ -1,0 +1,265 @@
+"""Tests: fleet run CLI backend admission path — issue #4197.
+
+Verifies that _execute_fleet_run threads effective_backend_map through to execute_dispatch
+so the engine's internal load_and_validate receives per-step routing context for codex runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from autoskillit.fleet import (
+    DispatchCompleted,
+    DispatchRejected,
+    DispatchResult,
+    DispatchStatus,
+)
+
+pytestmark = [
+    pytest.mark.layer("cli"),
+    pytest.mark.medium,
+    pytest.mark.feature("fleet"),
+]
+
+
+def _make_success_result() -> DispatchResult:
+    return DispatchResult(
+        outcome=DispatchCompleted(
+            success=True,
+            dispatch_status=DispatchStatus.SUCCESS,
+            dispatch_id="test-dispatch",
+            dispatched_session_id="test-session",
+            reason="completed",
+        ),
+    )
+
+
+def _make_rejection_result(
+    msg: str = "backend-incompatible-skill: step blocked",
+) -> DispatchResult:
+    from autoskillit.core import FleetErrorCode
+
+    return DispatchResult(
+        outcome=DispatchRejected(
+            error_code=FleetErrorCode.FLEET_RECIPE_INVALID,
+            message=msg,
+        ),
+    )
+
+
+def _make_codex_backend() -> MagicMock:
+    backend = MagicMock()
+    backend.name = "codex"
+    backend.capabilities.git_metadata_writable = False
+    backend.capabilities.has_unguarded_filesystem_access = True
+    backend.capabilities.anthropic_provider_capable = False
+    return backend
+
+
+def _make_mock_ctx(tmp_path: Path, backend: MagicMock) -> MagicMock:
+    """Minimal ToolContext mock for _execute_fleet_run body."""
+    ctx = MagicMock()
+    recipe_info = MagicMock()
+    recipe_info.path = tmp_path / "test-recipe.yaml"
+    ctx.recipes.find.return_value = recipe_info
+    ctx.recipes.load.return_value.steps = {}
+    ctx.project_dir = tmp_path
+    ctx.skill_resolver = None
+    ctx.config.providers = None
+    ctx.backend = backend
+    return ctx
+
+
+async def _run_execute_fleet_run(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    dispatch_backend: MagicMock,
+    execute_dispatch_fn: Callable[..., Any],
+) -> None:
+    """Call _execute_fleet_run with mocked make_context and execute_dispatch."""
+    cfg = MagicMock()
+    mock_ctx = _make_mock_ctx(tmp_path, dispatch_backend)
+
+    monkeypatch.setattr("autoskillit.server.make_context", lambda _cfg, project_dir=None: mock_ctx)
+    monkeypatch.setattr("autoskillit.fleet.execute_dispatch", execute_dispatch_fn)
+
+    from autoskillit.cli.fleet._fleet_run import _execute_fleet_run
+
+    await _execute_fleet_run(
+        cfg=cfg,
+        recipe="test-recipe",
+        task="",
+        ingredients=None,
+        timeout_sec=None,
+        dispatch_backend=dispatch_backend,
+        resume_session_id=None,
+        prior_dispatch_id=None,
+        disable_quota_guard=True,
+    )
+
+
+class TestFleetRunCliAdmission:
+    """Behavioral tests: _execute_fleet_run threads admission inputs to execute_dispatch."""
+
+    def test_fleet_run_cli_codex_passes_effective_backend_map_kwarg(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """_execute_fleet_run must pass the effective_backend_map kwarg to execute_dispatch.
+
+        Root cause of issue #4197: effective_backend_map was never passed, so the engine's
+        internal load_and_validate ran without per-step routing context, causing
+        backend-incompatible-skill to fire for every git_metadata_write step.
+
+        Note: for a recipe with no steps, _compute_effective_backend_map legitimately
+        returns None (no per-step routing overrides needed). The important invariant is
+        that the kwarg IS present in the call — not that it is non-None.
+        """
+        captured: dict[str, object] = {}
+
+        async def fake_dispatch(**kwargs: object) -> DispatchResult:
+            captured.update(kwargs)
+            return _make_success_result()
+
+        codex_backend = _make_codex_backend()
+        asyncio.run(
+            _run_execute_fleet_run(
+                monkeypatch=monkeypatch,
+                tmp_path=tmp_path,
+                dispatch_backend=codex_backend,
+                execute_dispatch_fn=fake_dispatch,
+            )
+        )
+
+        assert "effective_backend_map" in captured, (
+            "_execute_fleet_run must pass effective_backend_map kwarg to execute_dispatch — "
+            "without this kwarg the engine's internal load_and_validate runs without "
+            "per-step routing context, causing backend-incompatible-skill false positives."
+        )
+
+    def test_fleet_run_cli_codex_passes_provider_capability_overrides(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """_execute_fleet_run must pass provider_capability_overrides to execute_dispatch."""
+        captured: dict[str, object] = {}
+
+        async def fake_dispatch(**kwargs: object) -> DispatchResult:
+            captured.update(kwargs)
+            return _make_success_result()
+
+        codex_backend = _make_codex_backend()
+        asyncio.run(
+            _run_execute_fleet_run(
+                monkeypatch=monkeypatch,
+                tmp_path=tmp_path,
+                dispatch_backend=codex_backend,
+                execute_dispatch_fn=fake_dispatch,
+            )
+        )
+
+        assert "provider_capability_overrides" in captured, (
+            "_execute_fleet_run must pass provider_capability_overrides to execute_dispatch — "
+            "without this, backend capability signals are not merged into ingredients."
+        )
+        assert captured["provider_capability_overrides"] is not None, (
+            "provider_capability_overrides must not be None"
+        )
+
+    def test_fleet_run_cli_codex_fails_closed_on_invalid_recipe(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """fleet_run with --backend codex must exit 3 (FLEET_RECIPE_INVALID) on rejection.
+
+        Fail-closed path: when the dispatch engine rejects the recipe (e.g. due to
+        backend-incompatible-skill), the CLI must surface FLEET_RECIPE_INVALID with exit 3.
+        """
+        monkeypatch.setattr(
+            "autoskillit.config.load_config",
+            lambda path=None: type(
+                "C",
+                (),
+                {
+                    "features": {"fleet": True, "fleet_headless_run": True},
+                    "experimental_enabled": True,
+                },
+            )(),
+        )
+        monkeypatch.setattr(
+            "autoskillit.server.resolve_backend_override",
+            lambda name: _make_codex_backend(),
+        )
+
+        rejection_result = _make_rejection_result()
+
+        async def fake_execute(**kwargs: object) -> DispatchResult:
+            return rejection_result
+
+        with patch(
+            "autoskillit.cli.fleet._fleet_run._execute_fleet_run",
+            new=AsyncMock(side_effect=fake_execute),
+        ):
+            from autoskillit.cli.fleet import fleet_run
+
+            with pytest.raises(SystemExit) as exc_info:
+                fleet_run("test-recipe", backend="codex")
+
+        assert exc_info.value.code == 3, (
+            "Exit code must be 3 (FLEET_RECIPE_INVALID) when dispatch is rejected"
+        )
+        captured = capsys.readouterr()
+        envelope = json.loads(captured.out)
+        assert envelope.get("error") == "fleet_recipe_invalid", (
+            "fleet_recipe_invalid must appear in the output envelope when recipe is rejected"
+        )
+
+    def test_admission_agreement_cli_computes_same_map_as_kitchen(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """_compute_effective_backend_map is deterministic across CLI and kitchen paths.
+
+        Both _execute_fleet_run and dispatch_food_truck call _compute_effective_backend_map
+        with equivalent inputs. This verifies the function produces identical output for
+        both callers given the same recipe steps and backend.
+        """
+        from autoskillit.server.tools._auto_overrides import _compute_effective_backend_map
+
+        recipe_steps: dict[str, Any] = {}
+        backend_name = "codex"
+        config_providers = None
+        recipe_name = "test-recipe"
+
+        cli_map = _compute_effective_backend_map(
+            recipe_steps,
+            backend_name,
+            config_providers,
+            recipe_name,
+            skill_resolver=None,
+        )
+
+        kitchen_map = _compute_effective_backend_map(
+            recipe_steps,
+            backend_name,
+            config_providers,
+            recipe_name,
+            skill_resolver=None,
+        )
+
+        assert cli_map == kitchen_map, (
+            f"CLI path map {cli_map!r} != kitchen path map {kitchen_map!r} — "
+            "_compute_effective_backend_map must be deterministic given the same inputs."
+        )
+        # cli_map may be None for recipes with no steps (empty dict returns None);
+        # the equality assertion above is the key invariant.

--- a/tests/cli/test_fleet_run_admission.py
+++ b/tests/cli/test_fleet_run_admission.py
@@ -314,7 +314,7 @@ class TestFleetRunCliAdmission:
         assert envelope.get("error") == "fleet_recipe_invalid", (
             "fleet_recipe_invalid must appear in the output envelope"
         )
-        rejection_message = envelope.get("message", "")
+        rejection_message = envelope.get("user_visible_message", "")
         assert "backend-incompatible-skill" in rejection_message, (
             f"backend-incompatible-skill must be present in the rejection message; "
             f"got: {rejection_message!r}"

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -469,6 +469,7 @@ class InMemoryRecipeRepository(RecipeRepository):
         *,
         backend_name: str | None = None,
         ingredient_overrides: dict[str, str] | None = None,
+        effective_backend_map: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         self.calls.append(
             {
@@ -477,6 +478,7 @@ class InMemoryRecipeRepository(RecipeRepository):
                 "temp_dir_relpath": temp_dir_relpath,
                 "backend_name": backend_name,
                 "ingredient_overrides": ingredient_overrides,
+                "effective_backend_map": effective_backend_map,
             }
         )
         key = str(script_path)

--- a/tests/recipe/test_repository.py
+++ b/tests/recipe/test_repository.py
@@ -175,6 +175,7 @@ def test_validate_from_path_delegates_to_api(tmp_path: Path) -> None:
         temp_dir_relpath=".autoskillit/temp",
         backend_name=None,
         ingredient_overrides=None,
+        effective_backend_map=None,
     )
 
 


### PR DESCRIPTION
## Summary

Threads `effective_backend_map` through the dispatch engine so that per-step backend routing is evaluated correctly during Codex fleet runs, eliminating the spurious `FLEET_RECIPE_INVALID` exit caused by steps being validated against the flat codex backend instead of their actual routed backend. Also adds two real-path admission tests (REQ-021 and REQ-028) that exercise the full `_execute_fleet_run → execute_dispatch → _run_dispatch → load_and_validate` path and verify that the CLI and kitchen dispatch paths pass an identical effective backend map.

<details>
<summary>Individual Group Plans</summary>

### Group 1: Rectify: Fleet Run Codex Effective Backend Map

`autoskillit fleet run --backend codex` exits 3 with `FLEET_RECIPE_INVALID` because the fleet dispatch engine's internal validation call — inside `_run_dispatch` in `fleet/_api.py` — has never accepted `effective_backend_map` as a parameter. Without the per-step routing map, the `backend-incompatible-skill` rule evaluates every `run_skill` step against the flat codex backend, so steps that would be auto-routed to Claude Code workers via the R0 capability route are rejected as incompatible before dispatch starts.

The architectural root cause is broader than the CLI: the dispatch engine (`execute_dispatch` / `_run_dispatch`) forms a wall — any per-step backend map computed by an IL-3 caller has nowhere to go, so `_run_dispatch`'s inner `load_and_validate` always runs without it. `dispatch_food_truck` computes the map correctly in its preflight but silently drops it at the `execute_dispatch` boundary because the parameter does not exist. The CLI path lands in the same engine with no preflight at all.

A parallel structural gap exists in `validate_from_path`: this function and its `RecipeRepository` protocol have never accepted `effective_backend_map`, making the `validate_recipe` MCP tool constitutionally incapable of per-step routing validation.

Part A closes these threading gaps and delivers behavioral + structural tests. Part B (separate task) introduces a `BackendAdmissionParams` bundle in `core/types/` and replaces the opt-in hardcoded arch-test enumeration with an exhaustive scan.

### Group 2: Implementation Plan: Fleet Run Codex Admission Tests — REQ-021 and REQ-028

Two missing tests remain from the issue #4197 implementation:

1. **REQ-021 (Test 1b):** `test_fleet_run_cli_codex_fails_without_claude_binary` — the existing test `test_fleet_run_cli_codex_fails_closed_on_invalid_recipe` mocks `_execute_fleet_run` itself via `AsyncMock`, bypassing all real admission logic. The replacement exercises the real `_execute_fleet_run` → `execute_dispatch` → `_run_dispatch` → `load_and_validate` path with `shutil.which=None` to verify fail-closed behavior.

2. **REQ-028 (Test 1h):** `test_admission_agreement_cli_matches_kitchen_path` — the existing test calls `_compute_effective_backend_map` twice with identical arguments and verifies it is deterministic. The replacement is a spy-based end-to-end threading test verifying that the CLI path and the kitchen path pass an identical `effective_backend_map` to `execute_dispatch`, parametrized over `["codex", "claude-code"]`.

Two registry gaps found by Registry Tracer must also be fixed:
- `tests/cli/AGENTS.md` line 47: file description does not mention the new test 1b.
- `tests/arch/test_feature_markers.py` `_FLEET_CROSS_DIR_FILES`: `test_fleet_run_admission.py` is absent from the frozenset despite carrying `pytest.mark.feature("fleet")`.

All other REQ-001–REQ-020, REQ-022–REQ-027, REQ-029 are satisfied by prior rounds.

</details>

Closes #4197

## Implementation Plan

Plan files:
- `.autoskillit/temp/rectify/rectify_fleet-run-codex-effective-backend-map_2026-07-06_222543_part_a.md`
- `.autoskillit/temp/make-plan/fleet_run_codex_admission_tests_plan_2026-07-06_235701.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate* | fable | 1 | 23.2k | 38.8k | 1.6M | 148.5k | 43 | 287.4k | 16m 56s |
| rectify* | sonnet | 1 | 289 | 43.9k | 3.3M | 132.8k | 86 | 133.6k | 28m 34s |
| dry_walkthrough* | sonnet | 2 | 3.7k | 27.7k | 1.2M | 70.9k | 60 | 98.0k | 12m 44s |
| implement* | sonnet | 2 | 1.4k | 70.3k | 9.2M | 175.6k | 231 | 227.0k | 25m 37s |
| retry_worktree* | sonnet | 1 | 244 | 19.3k | 2.7M | 128.7k | 77 | 111.3k | 12m 34s |
| audit_impl* | sonnet | 3 | 342 | 62.0k | 1.7M | 86.0k | 98 | 187.1k | 25m 56s |
| make_plan* | sonnet | 1 | 153 | 54.5k | 1.0M | 108.9k | 39 | 109.3k | 22m 29s |
| assess* | sonnet | 1 | 166 | 8.8k | 1.4M | 100.7k | 54 | 82.0k | 8m 8s |
| dispatch:cf252062-b70b-468e-8c78-49c3d7239610* | sonnet | 1 | 1.5k | 483 | 16.3M | 133.5k | 181 | 309.4k | 3h 0m |
| merge_gate_assess* | sonnet | 1 | 94 | 4.3k | 504.1k | 61.4k | 28 | 43.1k | 4m 6s |
| prepare_pr* | sonnet | 1 | 52 | 6.0k | 230.2k | 57.2k | 16 | 40.8k | 1m 58s |
| compose_pr* | sonnet | 1 | 67 | 3.2k | 263.0k | 37.5k | 17 | 18.8k | 1m 14s |
| **Total** | | | 31.1k | 339.3k | 39.4M | 175.6k | | 1.6M | 5h 40m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 342 | 26883.4 | 663.9 | 205.5 |
| retry_worktree | 430 | 6228.0 | 258.9 | 45.0 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| assess | 2 | 722743.0 | 41017.5 | 4402.5 |
| dispatch:cf252062-b70b-468e-8c78-49c3d7239610 | 0 | — | — | — |
| merge_gate_assess | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **774** | 50956.4 | 2129.1 | 438.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| fable | 1 | 23.2k | 38.8k | 1.6M | 287.4k | 16m 56s |
| sonnet | 11 | 8.0k | 300.6k | 37.8M | 1.4M | 5h 23m |