### PR TITLE
Implementation Plan: Remediation — source-dir-enforcement-seam Part A

### DIFF
--- a/src/autoskillit/config/ingredient_defaults.py
+++ b/src/autoskillit/config/ingredient_defaults.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Protocol
 
 from autoskillit.core import (
+    BACKEND_CAPABILITY_INGREDIENTS,
     CONFIG_AUTHORITY_KEYS,
     DISPATCH_ID_ENV_VAR,
     FLEET_MENU_TOOLS,
@@ -205,18 +206,25 @@ def apply_config_authoritative_overrides(
     resolved = resolve_ingredient_defaults(project_dir)
     result = dict(effective_ingredients)
     for key in config_keys:
-        if key in resolved:
-            result[key] = resolved[key]
-        elif capability_overrides and key in capability_overrides:
-            # Fallback: only reached when resolve_ingredient_defaults() has no value for
-            # this key. Adding a key to resolve_ingredient_defaults shadows this branch.
-            result[key] = capability_overrides[key]
-        else:
-            logger.warning(
-                "config-authority key %r not found in resolved defaults — "
-                "caller-supplied value retained (config-authoritative contract not enforced)",
-                key,
-            )
+        if key in SERVER_AUTHORITATIVE_INGREDIENTS:
+            if key in resolved:
+                result[key] = resolved[key]
+            else:
+                logger.warning(
+                    "config-authority key %r not found in resolved defaults — "
+                    "caller-supplied value retained (config-authoritative contract not enforced)",
+                    key,
+                )
+        elif key in BACKEND_CAPABILITY_INGREDIENTS:
+            if capability_overrides and key in capability_overrides:
+                result[key] = capability_overrides[key]
+            else:
+                logger.warning(
+                    "config-authority key %r not found in resolved defaults — "
+                    "caller-supplied value retained (config-authoritative contract not enforced)",
+                    key,
+                )
+        # else: key is caller-sovereign (e.g., source_dir) — leave result unchanged
     return result
 
 

--- a/src/autoskillit/config/ingredient_defaults.py
+++ b/src/autoskillit/config/ingredient_defaults.py
@@ -224,6 +224,12 @@ def apply_config_authoritative_overrides(
                     "caller-supplied value retained (config-authoritative contract not enforced)",
                     key,
                 )
+        elif key not in CONFIG_AUTHORITY_KEYS:
+            logger.warning(
+                "config-authority key %r is not a recognized enforcement key — "
+                "caller-supplied value retained",
+                key,
+            )
         # else: key is caller-sovereign (e.g., source_dir) — leave result unchanged
     return result
 

--- a/src/autoskillit/config/ingredient_defaults.py
+++ b/src/autoskillit/config/ingredient_defaults.py
@@ -224,12 +224,6 @@ def apply_config_authoritative_overrides(
                     "caller-supplied value retained (config-authoritative contract not enforced)",
                     key,
                 )
-        elif key not in CONFIG_AUTHORITY_KEYS:
-            logger.warning(
-                "config-authority key %r is not a recognized enforcement key — "
-                "caller-supplied value retained",
-                key,
-            )
         # else: key is caller-sovereign (e.g., source_dir) — leave result unchanged
     return result
 

--- a/src/autoskillit/config/ingredient_defaults.py
+++ b/src/autoskillit/config/ingredient_defaults.py
@@ -220,8 +220,8 @@ def apply_config_authoritative_overrides(
                 result[key] = capability_overrides[key]
             else:
                 logger.warning(
-                    "config-authority key %r not found in resolved defaults — "
-                    "caller-supplied value retained (config-authoritative contract not enforced)",
+                    "capability-based key %r not found in capability_overrides — "
+                    "caller-supplied value retained (capability contract not enforced)",
                     key,
                 )
         # else: key is caller-sovereign (e.g., source_dir) — leave result unchanged

--- a/tests/config/test_helpers.py
+++ b/tests/config/test_helpers.py
@@ -247,12 +247,11 @@ def test_apply_config_authoritative_overrides_capability_key_overrides_caller(tm
     assert result["backend_supports_git_write"] == "false"
 
 
-def test_apply_config_authoritative_overrides_unknown_key_warns_and_retains(tmp_path):
-    """A config-authority key not in any registry (truly unknown) must trigger the
-    warning-and-retain path, not the capability override path."""
+def test_apply_config_authoritative_overrides_unknown_key_retains_caller_value(tmp_path):
+    """A config-authority key not in SERVER_AUTHORITATIVE_INGREDIENTS or
+    BACKEND_CAPABILITY_INGREDIENTS is caller-sovereign — the caller-supplied value
+    is retained silently (no warning)."""
     from types import SimpleNamespace
-
-    import structlog.testing
 
     from autoskillit.config import apply_config_authoritative_overrides
 
@@ -260,12 +259,9 @@ def test_apply_config_authoritative_overrides_unknown_key_warns_and_retains(tmp_
         "totally_unknown_key": SimpleNamespace(authority="config"),
     }
 
-    with (
-        patch(
-            "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
-            return_value={},
-        ),
-        structlog.testing.capture_logs() as cap_logs,
+    with patch(
+        "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
+        return_value={},
     ):
         result = apply_config_authoritative_overrides(
             {"totally_unknown_key": "caller-value"},
@@ -275,7 +271,6 @@ def test_apply_config_authoritative_overrides_unknown_key_warns_and_retains(tmp_
         )
 
     assert result["totally_unknown_key"] == "caller-value"
-    assert any("config-authority key" in e.get("event", "") for e in cap_logs)
 
 
 # T4: REQ-ING-003

--- a/tests/config/test_helpers.py
+++ b/tests/config/test_helpers.py
@@ -253,15 +253,20 @@ def test_apply_config_authoritative_overrides_unknown_key_retains_caller_value(t
     is retained silently (no warning)."""
     from types import SimpleNamespace
 
+    import structlog.testing
+
     from autoskillit.config import apply_config_authoritative_overrides
 
     recipe_ingredients = {
         "totally_unknown_key": SimpleNamespace(authority="config"),
     }
 
-    with patch(
-        "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
-        return_value={},
+    with (
+        patch(
+            "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
+            return_value={},
+        ),
+        structlog.testing.capture_logs() as cap_logs,
     ):
         result = apply_config_authoritative_overrides(
             {"totally_unknown_key": "caller-value"},
@@ -271,6 +276,7 @@ def test_apply_config_authoritative_overrides_unknown_key_retains_caller_value(t
         )
 
     assert result["totally_unknown_key"] == "caller-value"
+    assert not any("config-authority key" in e.get("event", "") for e in cap_logs)
 
 
 # T4: REQ-ING-003

--- a/tests/fleet/test_dispatch_ingredient_validation.py
+++ b/tests/fleet/test_dispatch_ingredient_validation.py
@@ -319,8 +319,9 @@ class TestConfigAuthoritativeIngredientInjection:
 
     @pytest.mark.anyio
     async def test_config_authoritative_ingredients_injected_for_all_resolved_keys(self, tool_ctx):
-        """All ingredients declared authority='config' receive config values,
-        not just base_branch."""
+        """SERVER_AUTHORITATIVE_INGREDIENTS keys with authority='config' receive config values;
+        source_dir with authority='config' is caller-sovereign and is NOT overridden from
+        resolved defaults."""
         from unittest.mock import patch
 
         from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeKind
@@ -373,7 +374,9 @@ class TestConfigAuthoritativeIngredientInjection:
             )
 
         assert captured["ingredients"]["base_branch"] == "develop"
-        assert captured["ingredients"]["source_dir"] == "/repo/src"
+        # source_dir is caller-sovereign — the URL from resolve_ingredient_defaults must NOT
+        # be injected even when the recipe declares authority="config".
+        assert captured["ingredients"].get("source_dir") != "/repo/src"
         assert captured["ingredients"]["local_review_rounds"] == "3"
 
     @pytest.mark.anyio
@@ -536,6 +539,152 @@ class TestConfigAuthoritativeIngredientInjection:
             )
 
         assert captured["ingredients"]["backend_supports_git_write"] == "false"
+
+    @pytest.mark.anyio
+    async def test_apply_config_authoritative_overrides_source_dir_preserves_caller_local_path(
+        self, tool_ctx
+    ):
+        """When the recipe declares source_dir with authority='config' and the caller
+        supplies a local path, apply_config_authoritative_overrides must preserve the
+        caller's value — source_dir is caller-sovereign project identity."""
+        from unittest.mock import patch
+
+        from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeKind
+
+        _setup_config_authority_recipe(
+            tool_ctx,
+            Recipe(
+                name="test-recipe",
+                description="test",
+                kind=RecipeKind.STANDARD,
+                ingredients={
+                    "source_dir": RecipeIngredient(
+                        description="Source directory", default="", authority="config"
+                    ),
+                },
+            ),
+        )
+        captured: dict = {}
+
+        def _capture_prompt_builder(**kwargs):
+            captured.update(kwargs)
+            return "prompt"
+
+        from autoskillit.fleet._api import execute_dispatch
+
+        with patch(
+            "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
+            return_value={
+                "source_dir": "https://github.com/TalonT-Org/AutoSkillit",
+                "base_branch": "main",
+            },
+        ):
+            await execute_dispatch(
+                tool_ctx=tool_ctx,
+                recipe="test-recipe",
+                task="t",
+                ingredients={"source_dir": "/home/user/myproject"},
+                dispatch_name=None,
+                timeout_sec=None,
+                prompt_builder=_capture_prompt_builder,
+                quota_checker=_no_sleep_quota_checker,
+                quota_refresher=_noop_quota_refresher,
+            )
+
+        assert captured["ingredients"]["source_dir"] == "/home/user/myproject"
+
+    @pytest.mark.anyio
+    async def test_apply_config_authoritative_overrides_source_dir_not_injected_when_absent(
+        self, tool_ctx
+    ):
+        """When the recipe declares source_dir with authority='config' but the caller
+        does not supply source_dir, the URL from resolve_ingredient_defaults must NOT
+        be injected — source_dir is caller-sovereign and must not be auto-populated."""
+        from unittest.mock import patch
+
+        from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeKind
+
+        _setup_config_authority_recipe(
+            tool_ctx,
+            Recipe(
+                name="test-recipe",
+                description="test",
+                kind=RecipeKind.STANDARD,
+                ingredients={
+                    "source_dir": RecipeIngredient(
+                        description="Source directory", default="", authority="config"
+                    ),
+                },
+            ),
+        )
+        captured: dict = {}
+
+        def _capture_prompt_builder(**kwargs):
+            captured.update(kwargs)
+            return "prompt"
+
+        from autoskillit.fleet._api import execute_dispatch
+
+        with patch(
+            "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
+            return_value={"source_dir": "https://github.com/TalonT-Org/AutoSkillit"},
+        ):
+            await execute_dispatch(
+                tool_ctx=tool_ctx,
+                recipe="test-recipe",
+                task="t",
+                ingredients={},
+                dispatch_name=None,
+                timeout_sec=None,
+                prompt_builder=_capture_prompt_builder,
+                quota_checker=_no_sleep_quota_checker,
+                quota_refresher=_noop_quota_refresher,
+            )
+
+        assert (
+            captured["ingredients"].get("source_dir")
+            != "https://github.com/TalonT-Org/AutoSkillit"
+        )
+
+    def test_apply_config_authoritative_overrides_only_mutates_enforcement_keys(self, tmp_path):
+        """For a recipe that declares ALL CONFIG_AUTHORITY_KEYS as authority='config',
+        the function must only mutate keys in SERVER_AUTHORITATIVE_INGREDIENTS |
+        BACKEND_CAPABILITY_INGREDIENTS. source_dir is caller-sovereign and must not
+        appear in the changed-key set."""
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from autoskillit.config import apply_config_authoritative_overrides
+        from autoskillit.config.ingredient_defaults import (
+            BACKEND_CAPABILITY_INGREDIENTS,
+            SERVER_AUTHORITATIVE_INGREDIENTS,
+        )
+        from autoskillit.core import CONFIG_AUTHORITY_KEYS
+
+        recipe_ingredients = {
+            key: SimpleNamespace(authority="config") for key in CONFIG_AUTHORITY_KEYS
+        }
+        resolved_values = {key: f"resolved-{key}" for key in CONFIG_AUTHORITY_KEYS}
+        capability_values = {key: f"cap-{key}" for key in BACKEND_CAPABILITY_INGREDIENTS}
+
+        with patch(
+            "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
+            return_value=resolved_values,
+        ):
+            result = apply_config_authoritative_overrides(
+                {},
+                recipe_ingredients,
+                tmp_path,
+                capability_overrides=capability_values,
+            )
+
+        changed_keys = set(result.keys())
+        assert changed_keys <= (
+            SERVER_AUTHORITATIVE_INGREDIENTS | BACKEND_CAPABILITY_INGREDIENTS
+        ), (
+            f"apply_config_authoritative_overrides mutated caller-sovereign keys: "
+            f"{changed_keys - (SERVER_AUTHORITATIVE_INGREDIENTS | BACKEND_CAPABILITY_INGREDIENTS)}"
+        )
 
 
 def test_capability_overrides_dict_covers_registry_keys():

--- a/tests/fleet/test_dispatch_ingredient_validation.py
+++ b/tests/fleet/test_dispatch_ingredient_validation.py
@@ -593,58 +593,31 @@ class TestConfigAuthoritativeIngredientInjection:
 
         assert captured["ingredients"]["source_dir"] == "/home/user/myproject"
 
-    @pytest.mark.anyio
-    async def test_apply_config_authoritative_overrides_source_dir_not_injected_when_absent(
-        self, tool_ctx
+    def test_apply_config_authoritative_overrides_source_dir_not_injected_when_absent(
+        self, tmp_path
     ):
-        """When the recipe declares source_dir with authority='config' but the caller
-        does not supply source_dir, the URL from resolve_ingredient_defaults must NOT
-        be injected — source_dir is caller-sovereign and must not be auto-populated."""
+        """When the caller does not supply source_dir, apply_config_authoritative_overrides
+        must not inject the URL returned by resolve_ingredient_defaults — source_dir is
+        caller-sovereign and must remain absent from the result."""
+        from types import SimpleNamespace
         from unittest.mock import patch
 
-        from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeKind
+        from autoskillit.config import apply_config_authoritative_overrides
 
-        _setup_config_authority_recipe(
-            tool_ctx,
-            Recipe(
-                name="test-recipe",
-                description="test",
-                kind=RecipeKind.STANDARD,
-                ingredients={
-                    "source_dir": RecipeIngredient(
-                        description="Source directory", default="", authority="config"
-                    ),
-                },
-            ),
-        )
-        captured: dict = {}
-
-        def _capture_prompt_builder(**kwargs):
-            captured.update(kwargs)
-            return "prompt"
-
-        from autoskillit.fleet._api import execute_dispatch
-
+        recipe_ingredients = {
+            "source_dir": SimpleNamespace(authority="config"),
+        }
         with patch(
             "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
             return_value={"source_dir": "https://github.com/TalonT-Org/AutoSkillit"},
         ):
-            await execute_dispatch(
-                tool_ctx=tool_ctx,
-                recipe="test-recipe",
-                task="t",
-                ingredients={},
-                dispatch_name=None,
-                timeout_sec=None,
-                prompt_builder=_capture_prompt_builder,
-                quota_checker=_no_sleep_quota_checker,
-                quota_refresher=_noop_quota_refresher,
+            result = apply_config_authoritative_overrides(
+                {},
+                recipe_ingredients,
+                tmp_path,
             )
 
-        assert (
-            captured["ingredients"].get("source_dir")
-            != "https://github.com/TalonT-Org/AutoSkillit"
-        )
+        assert "source_dir" not in result
 
     def test_apply_config_authoritative_overrides_only_mutates_enforcement_keys(self, tmp_path):
         """For a recipe that declares ALL CONFIG_AUTHORITY_KEYS as authority='config',

--- a/tests/fleet/test_dispatch_ingredient_validation.py
+++ b/tests/fleet/test_dispatch_ingredient_validation.py
@@ -459,11 +459,16 @@ class TestConfigAuthoritativeIngredientInjection:
             captured.update(kwargs)
             return "prompt"
 
+        import structlog.testing
+
         from autoskillit.fleet._api import execute_dispatch
 
-        with patch(
-            "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
-            return_value={},  # key absent from all registries
+        with (
+            patch(
+                "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
+                return_value={},  # key absent from all registries
+            ),
+            structlog.testing.capture_logs() as cap_logs,
         ):
             await execute_dispatch(
                 tool_ctx=tool_ctx,
@@ -478,6 +483,7 @@ class TestConfigAuthoritativeIngredientInjection:
             )
 
         assert captured["ingredients"]["truly_unknown_key"] == "caller-supplied"
+        assert not any("config-authority key" in e.get("event", "") for e in cap_logs)
 
     @pytest.mark.anyio
     async def test_non_writable_backend_forces_git_write_false_at_dispatch(self, tool_ctx):

--- a/tests/fleet/test_dispatch_ingredient_validation.py
+++ b/tests/fleet/test_dispatch_ingredient_validation.py
@@ -434,11 +434,9 @@ class TestConfigAuthoritativeIngredientInjection:
         self, tool_ctx
     ):
         """When a config-authority key is absent from resolved defaults AND not in
-        BACKEND_CAPABILITY_INGREDIENTS, the caller-supplied value is retained and a
-        warning is logged."""
+        BACKEND_CAPABILITY_INGREDIENTS, the caller-supplied value is retained silently
+        (caller-sovereign path — no warning)."""
         from unittest.mock import patch
-
-        import structlog.testing
 
         from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeKind
 
@@ -463,28 +461,23 @@ class TestConfigAuthoritativeIngredientInjection:
 
         from autoskillit.fleet._api import execute_dispatch
 
-        with structlog.testing.capture_logs() as cap_logs:
-            with patch(
-                "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
-                return_value={},  # key absent from all registries
-            ):
-                await execute_dispatch(
-                    tool_ctx=tool_ctx,
-                    recipe="test-recipe",
-                    task="t",
-                    ingredients={"truly_unknown_key": "caller-supplied"},
-                    dispatch_name=None,
-                    timeout_sec=None,
-                    prompt_builder=_capture_prompt_builder,
-                    quota_checker=_no_sleep_quota_checker,
-                    quota_refresher=_noop_quota_refresher,
-                )
+        with patch(
+            "autoskillit.config.ingredient_defaults.resolve_ingredient_defaults",
+            return_value={},  # key absent from all registries
+        ):
+            await execute_dispatch(
+                tool_ctx=tool_ctx,
+                recipe="test-recipe",
+                task="t",
+                ingredients={"truly_unknown_key": "caller-supplied"},
+                dispatch_name=None,
+                timeout_sec=None,
+                prompt_builder=_capture_prompt_builder,
+                quota_checker=_no_sleep_quota_checker,
+                quota_refresher=_noop_quota_refresher,
+            )
 
         assert captured["ingredients"]["truly_unknown_key"] == "caller-supplied"
-        assert any(
-            e.get("log_level") == "warning" and "config-authority key" in e.get("event", "")
-            for e in cap_logs
-        )
 
     @pytest.mark.anyio
     async def test_non_writable_backend_forces_git_write_false_at_dispatch(self, tool_ctx):


### PR DESCRIPTION
## Summary

Two concrete code defects were left behind by the prior implementation round and are cited in the remediation audit:

1. **REQ-004 — unauthorized fourth branch**: `apply_config_authoritative_overrides` in `src/autoskillit/config/ingredient_defaults.py` contains a fourth `elif key not in CONFIG_AUTHORITY_KEYS: logger.warning(...)` branch that the plan never authorized. The plan specifies exactly three branches: `SERVER_AUTHORITATIVE_INGREDIENTS`, `BACKEND_CAPABILITY_INGREDIENTS`, and an implicit `else` (caller-sovereign). The fourth branch must be removed so the loop body matches the specified three-branch structure.

2. **REQ-009 — weak T2 assertion**: The T2 test `test_apply_config_authoritative_overrides_source_dir_not_injected_when_absent` uses `captured["ingredients"].get("source_dir") != URL` — a weaker assertion that passes if `source_dir` is present with any non-URL value (e.g., the empty string `""` injected by `execute_dispatch` when the caller omits the ingredient and the recipe defines `default=""`). The test must assert `"source_dir" not in result` against the output of `apply_config_authoritative_overrides` directly, bypassing the `execute_dispatch` default-injection path.

Both changes are in the same commit to satisfy the green-gate invariant (the T2 test must pass after the function fix, and the function fix changes the behavior T2 validates).

Part B (introducing `CALLER_SOVEREIGN_INGREDIENTS`, tightening config-authority-requires-resolve-source, removing `authority: config` from 15 recipe YAMLs) is a separate task and must NOT be implemented here.

Closes #4200

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260707-023904-630849/.autoskillit/temp/make-plan/remediation_source-dir-enforcement-seam-part-a_plan_2026-07-07_035458.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate* | fable | 1 | 8.9k | 34.4k | 769.5k | 126.2k | 27 | 136.5k | 24m 45s |
| rectify* | sonnet | 1 | 219 | 38.1k | 2.1M | 118.9k | 72 | 119.6k | 20m 17s |
| dry_walkthrough* | sonnet | 2 | 1.7k | 24.8k | 924.2k | 61.7k | 54 | 85.0k | 10m 12s |
| implement* | sonnet | 2 | 290 | 18.8k | 1.8M | 77.2k | 87 | 96.3k | 8m 32s |
| assess* | sonnet | 3 | 354 | 23.0k | 2.0M | 66.4k | 108 | 118.0k | 15m 5s |
| audit_impl* | sonnet | 2 | 194 | 45.7k | 1.0M | 72.0k | 65 | 108.0k | 16m 16s |
| make_plan* | sonnet | 1 | 103 | 10.0k | 577.4k | 63.8k | 30 | 49.4k | 3m 17s |
| prepare_pr* | MiniMax-M3 | 1 | 42.2k | 2.6k | 153.7k | 44.1k | 12 | 0 | 43s |
| compose_pr* | MiniMax-M3 | 1 | 35.7k | 2.5k | 182.9k | 0 | 13 | 0 | 37s |
| review_pr* | sonnet | 1 | 156 | 25.6k | 1.1M | 79.7k | 48 | 61.6k | 7m 7s |
| resolve_review* | sonnet | 1 | 239 | 11.3k | 1.7M | 75.0k | 74 | 56.9k | 6m 18s |
| **Total** | | | 90.0k | 236.8k | 12.4M | 126.2k | | 831.4k | 1h 53m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 250 | 7150.7 | 385.4 | 75.0 |
| assess | 66 | 30170.3 | 1787.4 | 349.0 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 28 | 61901.3 | 2033.9 | 402.1 |
| **Total** | **344** | 35996.1 | 2416.9 | 688.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| fable | 1 | 8.9k | 34.4k | 769.5k | 136.5k | 24m 45s |
| sonnet | 8 | 3.2k | 197.3k | 11.3M | 694.9k | 1h 27m |
| MiniMax-M3 | 2 | 77.9k | 5.1k | 336.6k | 0 | 1m 20s |