### PR TITLE
compose-pr: retry gh pr create with backoff and guard resilience

### DIFF
--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -45,6 +45,21 @@ _WRITE_CALL_SITE_RE = re.compile(
 
 _SHELL_OPS: frozenset[str] = frozenset({"&&", "||", ";", "!", "|", "("})
 
+# Shell control words that mark the start of a new command in compound
+# shell constructs (loops, conditionals, case statements). When a `gh` token
+# is preceded by one of these, treat it as the verb of a fresh command — even
+# though shlex does not treat them as operators. Keep this set narrow: only
+# words that legitimately precede a command in real shell scripts.
+_SHELL_CONTROL_WORDS: frozenset[str] = frozenset(
+    {
+        "do",
+        "then",
+        "else",
+        "elif",
+        "in",
+    }
+)
+
 _REDIRECT_TOKEN_RE = re.compile(r"^(\d*)>{1,2}(.+)$")
 _REDIRECT_OP_ONLY_RE = re.compile(r"^(\d*)>{1,2}$")
 _FD_REDIRECT_RE = re.compile(r"^\d*>{1,2}&")

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -53,9 +53,12 @@ _SHELL_OPS: frozenset[str] = frozenset({"&&", "||", ";", "!", "|", "("})
 _SHELL_CONTROL_WORDS: frozenset[str] = frozenset(
     {
         "do",
+        "done",
         "then",
         "else",
         "elif",
+        "esac",
+        "fi",
         "in",
     }
 )

--- a/src/autoskillit/hooks/guards/compose_pr_body_guard.py
+++ b/src/autoskillit/hooks/guards/compose_pr_body_guard.py
@@ -123,9 +123,41 @@ def _resolve_variable_body_path(raw_token: str, tokens: list[str], gh_index: int
     return _resolve_nested_vars(raw_value, assignments)
 
 
+def _preprocess_newlines(cmd: str) -> str:
+    """Replace bare (unquoted) newlines with ' ; ' to preserve command boundaries.
+
+    In shell a bare newline terminates a command just like ';'. shlex.split()
+    collapses newlines to whitespace, so a later command's --body-file can
+    bleed into an earlier gh pr create that has none. Replacing unquoted
+    newlines before tokenisation inserts a proper ';' separator.
+    """
+    result: list[str] = []
+    in_single = False
+    in_double = False
+    i = 0
+    while i < len(cmd):
+        c = cmd[i]
+        if c == "\\" and not in_single and i + 1 < len(cmd):
+            result.append(c)
+            result.append(cmd[i + 1])
+            i += 2
+            continue
+        if c == "'" and not in_double:
+            in_single = not in_single
+        elif c == '"' and not in_single:
+            in_double = not in_double
+        elif c == "\n" and not in_single and not in_double:
+            result.append(" ; ")
+            i += 1
+            continue
+        result.append(c)
+        i += 1
+    return "".join(result)
+
+
 def _extract_body_file_path(cmd: str) -> str | None:
     try:
-        tokens = shlex.split(cmd)
+        tokens = shlex.split(_preprocess_newlines(cmd))
     except ValueError:
         return None
 

--- a/src/autoskillit/hooks/guards/compose_pr_body_guard.py
+++ b/src/autoskillit/hooks/guards/compose_pr_body_guard.py
@@ -20,7 +20,15 @@ _HOOKS_DIR = str(Path(__file__).resolve().parent.parent)
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
-from _command_classification import _SHELL_OPS  # type: ignore[import-not-found]  # noqa: E402
+from _command_classification import (  # type: ignore[import-not-found]  # noqa: E402
+    _SHELL_CONTROL_WORDS,
+    _SHELL_OPS,
+)
+
+# Tokens that mark the boundary of a fresh command — either a shell operator
+# (already in _SHELL_OPS) or a shell control word like `do`/`then` that
+# introduces a new command inside a compound construct (loops, conditionals).
+_GH_COMMAND_BOUNDARY: frozenset[str] = _SHELL_OPS | _SHELL_CONTROL_WORDS
 
 COMPOSE_PR_BODY_DENY_TRIGGER: str = "compose-pr body missing Closes reference"
 
@@ -41,16 +49,20 @@ def _extract_body_file_path(cmd: str) -> str | None:
     for i, tok in enumerate(tokens):
         if tok != "gh":
             continue
-        if i != 0 and tokens[i - 1] not in _SHELL_OPS:
+        if i != 0 and tokens[i - 1] not in _GH_COMMAND_BOUNDARY:
             continue
         if i + 2 >= len(tokens) or tokens[i + 1] != "pr" or tokens[i + 2] != "create":
             continue
         start = i + 3
         for j in range(start, len(tokens)):
             t = tokens[j]
-            if t in _SHELL_OPS:
+            if t in _GH_COMMAND_BOUNDARY:
                 break
-            if t == "--body-file" and j + 1 < len(tokens) and tokens[j + 1] not in _SHELL_OPS:
+            if (
+                t == "--body-file"
+                and j + 1 < len(tokens)
+                and tokens[j + 1] not in _GH_COMMAND_BOUNDARY
+            ):
                 return tokens[j + 1]
             if t.startswith("--body-file="):
                 return t.split("=", 1)[1]

--- a/src/autoskillit/hooks/guards/compose_pr_body_guard.py
+++ b/src/autoskillit/hooks/guards/compose_pr_body_guard.py
@@ -139,13 +139,9 @@ def _extract_body_file_path(cmd: str) -> str | None:
         start = i + 3
         for j in range(start, len(tokens)):
             t = tokens[j]
-            if t in _GH_COMMAND_BOUNDARY:
+            if t in _SHELL_OPS:
                 break
-            if (
-                t == "--body-file"
-                and j + 1 < len(tokens)
-                and tokens[j + 1] not in _GH_COMMAND_BOUNDARY
-            ):
+            if t == "--body-file" and j + 1 < len(tokens) and tokens[j + 1] not in _SHELL_OPS:
                 raw = tokens[j + 1]
                 if raw.startswith("$"):
                     return _resolve_variable_body_path(raw, tokens, i)

--- a/src/autoskillit/hooks/guards/compose_pr_body_guard.py
+++ b/src/autoskillit/hooks/guards/compose_pr_body_guard.py
@@ -39,6 +39,89 @@ _CLOSING_RE = re.compile(
 
 _METADATA_CLOSING_RE = re.compile(r"^-[ \t]*closing_issue:[ \t]*(\S+)", re.MULTILINE)
 
+_SIMPLE_ASSIGN_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
+_VAR_REF_RE = re.compile(r"^\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?$")
+_UNSAFE_ASSIGN_VALUE_RE = re.compile(r"[`()|&;]")
+_NESTED_VAR_RE = re.compile(r"\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?")
+
+# Keywords that open a nesting level (loop/conditional/case bodies).
+_DEPTH_INCREASE: frozenset[str] = frozenset({"while", "for", "until", "if", "case"})
+# Keywords that close a nesting level.
+_DEPTH_DECREASE: frozenset[str] = frozenset({"done", "fi", "esac"})
+
+
+def _collect_depth0_assignments(tokens: list[str], before_index: int) -> dict[str, str]:
+    """Collect simple variable assignments at nesting depth 0 before *before_index*.
+
+    Only assignments with safe values (no command substitution, backticks, or
+    shell operators in the value) are included. Simple $VAR references in values
+    are left as-is for downstream resolution.
+    """
+    assignments: dict[str, str] = {}
+    depth = 0
+    for i, tok in enumerate(tokens):
+        if i >= before_index:
+            break
+        if tok in _DEPTH_INCREASE:
+            depth += 1
+        elif tok in _DEPTH_DECREASE:
+            if depth > 0:
+                depth -= 1
+        elif depth == 0:
+            m = _SIMPLE_ASSIGN_RE.match(tok)
+            if m:
+                name, value = m.group(1), m.group(2)
+                if not _UNSAFE_ASSIGN_VALUE_RE.search(value):
+                    assignments[name] = value
+    return assignments
+
+
+def _resolve_nested_vars(value: str, assignments: dict[str, str]) -> str | None:
+    """Expand simple $VAR references in *value* from *assignments*.
+
+    Returns the expanded string, or None if any variable cannot be resolved
+    (fail-open: caller should treat None as "path unknown").
+    """
+    result_parts: list[str] = []
+    i = 0
+    while i < len(value):
+        if value[i] == "$":
+            m = _NESTED_VAR_RE.match(value, i)
+            if not m:
+                return None
+            var_name = m.group(1)
+            if var_name not in assignments:
+                return None
+            nested_val = assignments[var_name]
+            if "$" in nested_val:
+                return None
+            result_parts.append(nested_val)
+            i = m.end()
+        else:
+            result_parts.append(value[i])
+            i += 1
+    return "".join(result_parts)
+
+
+def _resolve_variable_body_path(raw_token: str, tokens: list[str], gh_index: int) -> str | None:
+    """Resolve a $VAR or ${VAR} body-file token from depth-0 assignments before *gh_index*.
+
+    Returns the resolved path string, or None if resolution fails (fail-open).
+    """
+    m = _VAR_REF_RE.match(raw_token)
+    if not m:
+        return None
+    var_name = m.group(1)
+
+    assignments = _collect_depth0_assignments(tokens, gh_index)
+    if var_name not in assignments:
+        return None
+
+    raw_value = assignments[var_name]
+    if "$" not in raw_value:
+        return raw_value
+    return _resolve_nested_vars(raw_value, assignments)
+
 
 def _extract_body_file_path(cmd: str) -> str | None:
     try:
@@ -63,9 +146,15 @@ def _extract_body_file_path(cmd: str) -> str | None:
                 and j + 1 < len(tokens)
                 and tokens[j + 1] not in _GH_COMMAND_BOUNDARY
             ):
-                return tokens[j + 1]
+                raw = tokens[j + 1]
+                if raw.startswith("$"):
+                    return _resolve_variable_body_path(raw, tokens, i)
+                return raw
             if t.startswith("--body-file="):
-                return t.split("=", 1)[1]
+                raw = t.split("=", 1)[1]
+                if raw.startswith("$"):
+                    return _resolve_variable_body_path(raw, tokens, i)
+                return raw
     return None
 
 

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -563,12 +563,13 @@ skills:
     - name: pr_url
       type: string
     expected_output_patterns:
-    - "pr_url[ \\t]*=[ \\t]*https://github\\.com/.*/pull/\\d+"
+    - "pr_url[ \\t]*=[ \\t]*(?:https://github\\.com/.*/pull/\\d+)?"
     pattern_examples:
     - "pr_url = https://github.com/owner/repo/pull/42\n%%ORDER_UP%%"
+    - "pr_url = \n%%ORDER_UP%%"
     write_behavior: conditional
     write_expected_when:
-    - "pr_url[ \\t]*=[ \\t]*https://"
+    - "pr_url[ \\t]*=[ \\t]*(?:https://|$)"
     source_pin_fields:
     - field: task_title
       required_source: "prep file ## Title section"

--- a/src/autoskillit/skills_extended/compose-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-pr/SKILL.md
@@ -286,6 +286,11 @@ done
 if [ -n "$PR_URL" ]; then
   printf 'pr_url = %s\n' "$PR_URL"
 fi
+
+if [ "$PR_CREATE_STATUS" -ne 0 ]; then
+  echo "gh pr create failed after $PR_CREATE_ATTEMPT attempt(s):" >&2
+  cat "$PR_CREATE_LOG_DIR/pr_stderr_$ts.$PR_CREATE_ATTEMPT.txt" >&2
+fi
 exit "$PR_CREATE_STATUS"
 ```
 

--- a/src/autoskillit/skills_extended/compose-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-pr/SKILL.md
@@ -242,6 +242,7 @@ PR_CREATE_LOG_DIR={{AUTOSKILLIT_TEMP}}/compose-pr
 PR_CREATE_ATTEMPT=1
 PR_CREATE_MAX=3
 PR_CREATE_STATUS=0
+PR_CREATE_LAST_ATTEMPT=1
 PR_URL=""
 while [ "$PR_CREATE_ATTEMPT" -le "$PR_CREATE_MAX" ]; do
   case "$PR_CREATE_ATTEMPT" in
@@ -256,6 +257,7 @@ while [ "$PR_CREATE_ATTEMPT" -le "$PR_CREATE_MAX" ]; do
        > "$PR_CREATE_LOG_DIR/pr_stdout_$ts.$PR_CREATE_ATTEMPT.txt" \
        2> "$PR_CREATE_LOG_DIR/pr_stderr_$ts.$PR_CREATE_ATTEMPT.txt"
   PR_CREATE_STATUS=$?
+  PR_CREATE_LAST_ATTEMPT=$PR_CREATE_ATTEMPT
   if [ "$PR_CREATE_STATUS" -eq 0 ]; then
     PR_URL=$(grep -E '^https://github\.com/' "$PR_CREATE_LOG_DIR/pr_stdout_$ts.$PR_CREATE_ATTEMPT.txt" | head -1)
     if [ -n "$PR_URL" ]; then
@@ -264,12 +266,13 @@ while [ "$PR_CREATE_ATTEMPT" -le "$PR_CREATE_MAX" ]; do
   fi
   PR_CREATE_ERR=$(cat "$PR_CREATE_LOG_DIR/pr_stderr_$ts.$PR_CREATE_ATTEMPT.txt")
   case "$PR_CREATE_ERR" in
-    # Terminal — do not retry (HTTP 4xx / validation / required-field missing).
+    # Retryable — HTTP 5xx, HTTP 429, secondary rate limit, rate limit, timeout, connection reset/refused.
+    # Classified before broad HTTP 4xx terminal handling so retryable rate limits are not shadowed.
+    *HTTP\ 429*|*secondary\ rate\ limit*|*rate\ limit*|*HTTP\ 5*|*timeout*|*connection\ reset*|*connection\ refused*|*temporary\ DNS*|*internal\ server\ error*|*remote\ server\ error*)
+      : ;;
+    # Terminal — do not retry (broad HTTP 4xx / validation / required-field missing).
     *HTTP\ 4*|*validation*|*required*|*not\ found*)
       break ;;
-    # Transient — retryable (HTTP 5xx, rate limit, timeout, connection reset/refused).
-    *HTTP\ 5*|*HTTP\ 429*|*rate\ limit*|*secondary\ rate\ limit*|*timeout*|*connection\ reset*|*connection\ refused*|*temporary\ DNS*|*internal\ server\ error*|*remote\ server\ error*)
-      : ;;
     # Ambiguous (empty / unknown stderr) — attempt response-loss recovery, then retry.
     *)
       : ;;
@@ -285,11 +288,18 @@ done
 
 if [ -n "$PR_URL" ]; then
   printf 'pr_url = %s\n' "$PR_URL"
+  exit 0
 fi
 
-if [ "$PR_CREATE_STATUS" -ne 0 ]; then
-  echo "gh pr create failed after $PR_CREATE_ATTEMPT attempt(s):" >&2
-  cat "$PR_CREATE_LOG_DIR/pr_stderr_$ts.$PR_CREATE_ATTEMPT.txt" >&2
+if [ "$PR_CREATE_STATUS" -eq 0 ]; then
+  PR_CREATE_STATUS=1
+fi
+echo "gh pr create failed after ${PR_CREATE_LAST_ATTEMPT} attempt(s):" >&2
+LAST_STDERR="$PR_CREATE_LOG_DIR/pr_stderr_$ts.$PR_CREATE_LAST_ATTEMPT.txt"
+if [ -s "$LAST_STDERR" ]; then
+  cat "$LAST_STDERR" >&2
+else
+  echo "gh pr create exited 0 but returned no PR URL after ${PR_CREATE_LAST_ATTEMPT} attempt(s)." >&2
 fi
 exit "$PR_CREATE_STATUS"
 ```
@@ -299,11 +309,13 @@ Bounded retry policy:
 - Backoff sleeps of 1 second before attempt 2 and 2 seconds before attempt 3
 - Each attempt's stdout/stderr captured under `{{AUTOSKILLIT_TEMP}}/compose-pr/`
   so final diagnostics can print useful detail without contaminating the PR URL capture
-- Retry only transient or ambiguous response-loss failures (HTTP 5xx, HTTP 429 / secondary
-  rate limit, timeout, connection reset/refused, temporary DNS resolution, remote/internal
-  server errors)
-- Do not retry terminal validation or usage failures (HTTP 4xx, validation errors, missing
-  required fields, not-found errors)
+- Retryable rate-limit patterns (`HTTP 429`, `secondary rate limit`, broad `rate limit`) are
+  classified before the broad terminal `HTTP 4xx` pattern so they are never shadowed
+- Retry only transient or ambiguous response-loss failures (HTTP 429, secondary rate limit,
+  broad rate limit, HTTP 5xx, timeout, connection reset/refused, temporary DNS resolution,
+  remote/internal server errors)
+- Do not retry terminal validation or usage failures (broad HTTP 4xx, validation errors,
+  missing required fields, not-found errors)
 
 Response-loss recovery: when a create attempt fails with a transient/ambiguous status (or empty
 stderr that suggests the create succeeded but the response was lost), run a best-effort
@@ -311,9 +323,15 @@ stderr that suggests the create succeeded but the response was lost), run a best
 a URL, treat the create as recovered and emit that URL. The recovery path runs only for
 transient/ambiguous failures — never for terminal validation failures.
 
-Final status propagation: `PR_CREATE_STATUS` tracks the last `gh pr create` exit code (or 0 on
-successful URL capture or successful `gh pr view` recovery). The script ends with
-`exit "$PR_CREATE_STATUS"` so terminal failures surface as a non-zero shell status.
+Last-attempt tracking: `PR_CREATE_LAST_ATTEMPT` is set to `$PR_CREATE_ATTEMPT` immediately
+after each `gh pr create` execution. Final failure reporting reads the stderr file for
+`PR_CREATE_LAST_ATTEMPT`, not the post-increment loop counter.
+
+Final status propagation: if the loop exits without a captured or recovered PR URL, the exit
+status is forced nonzero even if the last raw `gh pr create` exit code was 0 (zero-exit/no-URL
+is not a successful outcome). When the last attempt's stderr file is empty or absent (zero-exit
+path), a concise no-URL diagnostic is printed instead. The empty-`pr_url` success path is
+reserved exclusively for Step 4's `gh auth status` preflight failure.
 
 ## Output
 

--- a/src/autoskillit/skills_extended/compose-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-pr/SKILL.md
@@ -248,20 +248,20 @@ while [ "$PR_CREATE_ATTEMPT" -le "$PR_CREATE_MAX" ]; do
     2) sleep 1 ;;
     3) sleep 2 ;;
   esac
-  if gh pr create \
+  gh pr create \
        --base "$BASE_BRANCH" \
        --head "$FEATURE_BRANCH" \
        --title "$TASK_TITLE" \
        --body-file "$PR_CREATE_BODY" \
        > "$PR_CREATE_LOG_DIR/pr_stdout_$ts.$PR_CREATE_ATTEMPT.txt" \
-       2> "$PR_CREATE_LOG_DIR/pr_stderr_$ts.$PR_CREATE_ATTEMPT.txt"; then
+       2> "$PR_CREATE_LOG_DIR/pr_stderr_$ts.$PR_CREATE_ATTEMPT.txt"
+  PR_CREATE_STATUS=$?
+  if [ "$PR_CREATE_STATUS" -eq 0 ]; then
     PR_URL=$(grep -E '^https://github\.com/' "$PR_CREATE_LOG_DIR/pr_stdout_$ts.$PR_CREATE_ATTEMPT.txt" | head -1)
     if [ -n "$PR_URL" ]; then
-      PR_CREATE_STATUS=0
       break
     fi
   fi
-  PR_CREATE_STATUS=$?
   PR_CREATE_ERR=$(cat "$PR_CREATE_LOG_DIR/pr_stderr_$ts.$PR_CREATE_ATTEMPT.txt")
   case "$PR_CREATE_ERR" in
     # Terminal — do not retry (HTTP 4xx / validation / required-field missing).

--- a/src/autoskillit/skills_extended/compose-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-pr/SKILL.md
@@ -241,6 +241,7 @@ PR_CREATE_BODY={{AUTOSKILLIT_TEMP}}/compose-pr/pr_body_$ts.md
 PR_CREATE_LOG_DIR={{AUTOSKILLIT_TEMP}}/compose-pr
 PR_CREATE_ATTEMPT=1
 PR_CREATE_MAX=3
+PR_CREATE_STATUS=0
 PR_URL=""
 while [ "$PR_CREATE_ATTEMPT" -le "$PR_CREATE_MAX" ]; do
   case "$PR_CREATE_ATTEMPT" in
@@ -255,16 +256,28 @@ while [ "$PR_CREATE_ATTEMPT" -le "$PR_CREATE_MAX" ]; do
        > "$PR_CREATE_LOG_DIR/pr_stdout_$ts.$PR_CREATE_ATTEMPT.txt" \
        2> "$PR_CREATE_LOG_DIR/pr_stderr_$ts.$PR_CREATE_ATTEMPT.txt"; then
     PR_URL=$(grep -E '^https://github\.com/' "$PR_CREATE_LOG_DIR/pr_stdout_$ts.$PR_CREATE_ATTEMPT.txt" | head -1)
-    [ -n "$PR_URL" ] && break
+    if [ -n "$PR_URL" ]; then
+      PR_CREATE_STATUS=0
+      break
+    fi
   fi
+  PR_CREATE_STATUS=$?
   PR_CREATE_ERR=$(cat "$PR_CREATE_LOG_DIR/pr_stderr_$ts.$PR_CREATE_ATTEMPT.txt")
   case "$PR_CREATE_ERR" in
+    # Terminal — do not retry (HTTP 4xx / validation / required-field missing).
     *HTTP\ 4*|*validation*|*required*|*not\ found*)
       break ;;
+    # Transient — retryable (HTTP 5xx, rate limit, timeout, connection reset/refused).
+    *HTTP\ 5*|*HTTP\ 429*|*rate\ limit*|*secondary\ rate\ limit*|*timeout*|*connection\ reset*|*connection\ refused*|*temporary\ DNS*|*internal\ server\ error*|*remote\ server\ error*)
+      : ;;
+    # Ambiguous (empty / unknown stderr) — attempt response-loss recovery, then retry.
+    *)
+      : ;;
   esac
   RECOVERED=$(gh pr view "$FEATURE_BRANCH" --json url -q .url 2>/dev/null || true)
   if [ -n "$RECOVERED" ]; then
     PR_URL="$RECOVERED"
+    PR_CREATE_STATUS=0
     break
   fi
   PR_CREATE_ATTEMPT=$((PR_CREATE_ATTEMPT + 1))
@@ -273,6 +286,7 @@ done
 if [ -n "$PR_URL" ]; then
   printf 'pr_url = %s\n' "$PR_URL"
 fi
+exit "$PR_CREATE_STATUS"
 ```
 
 Bounded retry policy:
@@ -280,15 +294,21 @@ Bounded retry policy:
 - Backoff sleeps of 1 second before attempt 2 and 2 seconds before attempt 3
 - Each attempt's stdout/stderr captured under `{{AUTOSKILLIT_TEMP}}/compose-pr/`
   so final diagnostics can print useful detail without contaminating the PR URL capture
-- Retry only transient or ambiguous response-loss failures (HTTP 5xx, secondary rate limit,
-  timeout, connection reset/refused, temporary DNS resolution, remote/internal server errors)
-- Do not retry terminal validation or usage failures (HTTP 4xx, validation errors, missing required fields)
+- Retry only transient or ambiguous response-loss failures (HTTP 5xx, HTTP 429 / secondary
+  rate limit, timeout, connection reset/refused, temporary DNS resolution, remote/internal
+  server errors)
+- Do not retry terminal validation or usage failures (HTTP 4xx, validation errors, missing
+  required fields, not-found errors)
 
 Response-loss recovery: when a create attempt fails with a transient/ambiguous status (or empty
 stderr that suggests the create succeeded but the response was lost), run a best-effort
 `gh pr view "$FEATURE_BRANCH" --json url -q .url` before sleeping and retrying. If it returns
 a URL, treat the create as recovered and emit that URL. The recovery path runs only for
 transient/ambiguous failures — never for terminal validation failures.
+
+Final status propagation: `PR_CREATE_STATUS` tracks the last `gh pr create` exit code (or 0 on
+successful URL capture or successful `gh pr view` recovery). The script ends with
+`exit "$PR_CREATE_STATUS"` so terminal failures surface as a non-zero shell status.
 
 ## Output
 

--- a/src/autoskillit/skills_extended/compose-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-pr/SKILL.md
@@ -77,7 +77,8 @@ Parse positional arguments:
 
 Derive `feature_branch` and set shell variables:
 ```bash
-FEATURE_BRANCH=$(git -C $WORK_DIR rev-parse --abbrev-ref HEAD)
+WORK_DIR=$3
+FEATURE_BRANCH=$(git -C "$WORK_DIR" rev-parse --abbrev-ref HEAD)
 BASE_BRANCH=$4
 ```
 
@@ -230,15 +231,64 @@ If exit code is non-zero:
 
 ### Step 5: Create Pull Request
 
+Run `gh pr create` with bounded retry on transient failures. Capture PR URL from stdout.
+On success or successful response-loss recovery, emit `pr_url = <URL>`. On exhausted retries or
+terminal validation failures, print the final `gh pr create` stderr to stderr and return the
+final create status (the empty-`pr_url` path is reserved for Step 4's `gh auth status` preflight).
+
 ```bash
-gh pr create \
-  --base $BASE_BRANCH \
-  --head $FEATURE_BRANCH \
-  --title "$TASK_TITLE" \
-  --body-file {{AUTOSKILLIT_TEMP}}/compose-pr/pr_body_$ts.md
+PR_CREATE_BODY={{AUTOSKILLIT_TEMP}}/compose-pr/pr_body_$ts.md
+PR_CREATE_LOG_DIR={{AUTOSKILLIT_TEMP}}/compose-pr
+PR_CREATE_ATTEMPT=1
+PR_CREATE_MAX=3
+PR_URL=""
+while [ "$PR_CREATE_ATTEMPT" -le "$PR_CREATE_MAX" ]; do
+  case "$PR_CREATE_ATTEMPT" in
+    2) sleep 1 ;;
+    3) sleep 2 ;;
+  esac
+  if gh pr create \
+       --base "$BASE_BRANCH" \
+       --head "$FEATURE_BRANCH" \
+       --title "$TASK_TITLE" \
+       --body-file "$PR_CREATE_BODY" \
+       > "$PR_CREATE_LOG_DIR/pr_stdout_$ts.$PR_CREATE_ATTEMPT.txt" \
+       2> "$PR_CREATE_LOG_DIR/pr_stderr_$ts.$PR_CREATE_ATTEMPT.txt"; then
+    PR_URL=$(grep -E '^https://github\.com/' "$PR_CREATE_LOG_DIR/pr_stdout_$ts.$PR_CREATE_ATTEMPT.txt" | head -1)
+    [ -n "$PR_URL" ] && break
+  fi
+  PR_CREATE_ERR=$(cat "$PR_CREATE_LOG_DIR/pr_stderr_$ts.$PR_CREATE_ATTEMPT.txt")
+  case "$PR_CREATE_ERR" in
+    *HTTP\ 4*|*validation*|*required*|*not\ found*)
+      break ;;
+  esac
+  RECOVERED=$(gh pr view "$FEATURE_BRANCH" --json url -q .url 2>/dev/null || true)
+  if [ -n "$RECOVERED" ]; then
+    PR_URL="$RECOVERED"
+    break
+  fi
+  PR_CREATE_ATTEMPT=$((PR_CREATE_ATTEMPT + 1))
+done
+
+if [ -n "$PR_URL" ]; then
+  printf 'pr_url = %s\n' "$PR_URL"
+fi
 ```
 
-Capture PR URL from stdout.
+Bounded retry policy:
+- Maximum 3 total `gh pr create` attempts
+- Backoff sleeps of 1 second before attempt 2 and 2 seconds before attempt 3
+- Each attempt's stdout/stderr captured under `{{AUTOSKILLIT_TEMP}}/compose-pr/`
+  so final diagnostics can print useful detail without contaminating the PR URL capture
+- Retry only transient or ambiguous response-loss failures (HTTP 5xx, secondary rate limit,
+  timeout, connection reset/refused, temporary DNS resolution, remote/internal server errors)
+- Do not retry terminal validation or usage failures (HTTP 4xx, validation errors, missing required fields)
+
+Response-loss recovery: when a create attempt fails with a transient/ambiguous status (or empty
+stderr that suggests the create succeeded but the response was lost), run a best-effort
+`gh pr view "$FEATURE_BRANCH" --json url -q .url` before sleeping and retrying. If it returns
+a URL, treat the create as recovered and emit that URL. The recovery path runs only for
+transient/ambiguous failures — never for terminal validation failures.
 
 ## Output
 

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -802,6 +802,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "skills/test_audit_impl_diff_discipline.py",
             "skills/test_skill_variable_threading.py",
             "skills/test_phoropter_structural.py",
+            "skills/test_compose_pr_retry.py",
             "smoke_utils",
         }
     ),

--- a/tests/contracts/test_prepare_compose_pr_contracts.py
+++ b/tests/contracts/test_prepare_compose_pr_contracts.py
@@ -391,3 +391,94 @@ def test_compose_pr_step4_auth_preflight_unchanged():
     assert "pr_url =" in step4, (
         "Step 4 must document the empty pr_url emit path on gh preflight failure"
     )
+
+
+def test_compose_pr_step5_rate_limit_classified_before_broad_4xx():
+    """HTTP 429 and secondary rate limits must precede the broad HTTP 4xx terminal pattern."""
+    bash = _compose_pr_step5_bash()
+
+    http_429_pos = bash.find("HTTP\\ 429")
+    secondary_rl_pos = bash.find("secondary\\ rate\\ limit")
+    rate_limit_pos = bash.find("rate\\ limit")
+
+    assert http_429_pos != -1, "Step 5 must classify HTTP 429 as retryable"
+    assert secondary_rl_pos != -1, "Step 5 must classify secondary rate limit as retryable"
+    assert rate_limit_pos != -1, "Step 5 must classify broad rate limit as retryable"
+
+    # Anchor the broad HTTP 4xx terminal pattern by searching from the terminal comment.
+    terminal_comment_pos = bash.find("Terminal")
+    assert terminal_comment_pos != -1, "Step 5 must have a Terminal failure comment"
+    broad_4xx_in_terminal = bash.find("HTTP\\ 4", terminal_comment_pos)
+    assert broad_4xx_in_terminal != -1, (
+        "Step 5 must have a broad HTTP 4xx pattern in the terminal failure branch"
+    )
+
+    assert http_429_pos < terminal_comment_pos, (
+        "HTTP 429 retryable pattern must appear before the terminal failure branch "
+        f"(found at positions {http_429_pos} vs terminal comment at {terminal_comment_pos})"
+    )
+    assert secondary_rl_pos < terminal_comment_pos, (
+        "secondary rate limit retryable pattern must appear before the terminal failure branch "
+        f"(found at positions {secondary_rl_pos} vs terminal comment at {terminal_comment_pos})"
+    )
+    assert rate_limit_pos < terminal_comment_pos, (
+        "Broad rate limit retryable pattern must appear before the terminal failure branch"
+    )
+
+
+def test_compose_pr_step5_tracks_last_attempt_separately():
+    """Step 5 must set PR_CREATE_LAST_ATTEMPT immediately after each gh pr create execution."""
+    bash = _compose_pr_step5_bash()
+
+    assert "PR_CREATE_LAST_ATTEMPT" in bash, (
+        "Step 5 must declare PR_CREATE_LAST_ATTEMPT to track the last executed attempt"
+    )
+    # The assignment must appear after the gh pr create command (tracks each execution).
+    gh_create_pos = bash.find("gh pr create")
+    last_attempt_assign_pos = bash.find("PR_CREATE_LAST_ATTEMPT=$PR_CREATE_ATTEMPT")
+    assert last_attempt_assign_pos != -1, (
+        "Step 5 must set PR_CREATE_LAST_ATTEMPT=$PR_CREATE_ATTEMPT after each create attempt"
+    )
+    assert last_attempt_assign_pos > gh_create_pos, (
+        "PR_CREATE_LAST_ATTEMPT must be assigned after the gh pr create invocation"
+    )
+
+    # Final error reporting must use PR_CREATE_LAST_ATTEMPT, not the raw loop counter.
+    fail_report_pos = bash.find("gh pr create failed after")
+    assert fail_report_pos != -1, "Step 5 must print a failure message on exhaustion"
+    last_attempt_in_report = bash.find("PR_CREATE_LAST_ATTEMPT", fail_report_pos)
+    assert last_attempt_in_report != -1, (
+        "Final failure reporting must reference PR_CREATE_LAST_ATTEMPT "
+        "(not the post-increment loop counter)"
+    )
+
+
+def test_compose_pr_step5_has_explicit_no_url_failure_branch():
+    """Step 5 must force nonzero status when all attempts end without a PR URL."""
+    bash = _compose_pr_step5_bash()
+
+    # The no-URL failure path must set status to nonzero explicitly.
+    assert "PR_CREATE_STATUS=1" in bash, (
+        "Step 5 must explicitly set PR_CREATE_STATUS=1 when PR_URL is empty "
+        "to prevent zero-exit/no-URL from becoming a silent empty success"
+    )
+    # There must be no unconditional 'pr_url = ' (empty) emit from Step 5.
+    # (Step 4 is the only successful empty-pr_url path.)
+    assert "pr_url = \n" not in bash and "printf 'pr_url = \\n'" not in bash, (
+        "Step 5 must not emit 'pr_url = ' (empty) — that path is reserved for Step 4"
+    )
+
+
+def test_compose_pr_step5_body_file_uses_variable_form():
+    """Step 5 must use --body-file \"$PR_CREATE_BODY\" (guard-resolvable variable form)."""
+    bash = _compose_pr_step5_bash()
+
+    # The guard resolves $PR_CREATE_BODY from the preamble assignment.
+    assert '--body-file "$PR_CREATE_BODY"' in bash, (
+        'Step 5 must pass --body-file "$PR_CREATE_BODY" so the guard can resolve '
+        "the variable from the preamble assignment"
+    )
+    assert "PR_CREATE_BODY=" in bash, (
+        "Step 5 must declare PR_CREATE_BODY= assignment before the loop "
+        "so the guard can resolve it"
+    )

--- a/tests/contracts/test_prepare_compose_pr_contracts.py
+++ b/tests/contracts/test_prepare_compose_pr_contracts.py
@@ -302,3 +302,92 @@ def test_prepare_pr_arch_lens_classification_covers_all_slugs():
         assert slug in step5_text, (
             f"arch-lens slug '{slug}' not found in Step 5 classification table"
         )
+
+
+# ---------------------------------------------------------------------------
+# compose-pr Step 5 bounded retry contract (issue #3987)
+# ---------------------------------------------------------------------------
+
+
+def _compose_pr_step5_bash() -> str:
+    """Return the literal bash block from compose-pr Step 5."""
+    from autoskillit.recipe._skill_placeholder_parser import (
+        extract_bash_blocks,
+        extract_step_sections,
+    )
+
+    text = COMPOSE_PR.read_text()
+    sections = extract_step_sections(text)
+    step5 = sections.get("Step 5")
+    assert step5, "compose-pr/SKILL.md is missing a Step 5 section"
+    blocks = extract_bash_blocks(step5)
+    assert len(blocks) == 1, f"Expected exactly 1 bash block in Step 5, found {len(blocks)}"
+    return blocks[0]
+
+
+def test_compose_pr_step5_has_bounded_retry_count_of_three():
+    """Step 5 must cap total gh pr create attempts at 3."""
+    import re
+
+    bash = _compose_pr_step5_bash()
+    # A loop guard tied to PR_CREATE_MAX whose value is exactly 3.
+    match = re.search(r"PR_CREATE_MAX\s*=\s*(\d+)", bash)
+    assert match, "Step 5 must declare PR_CREATE_MAX to bound retry attempts"
+    assert match.group(1) == "3", f"PR_CREATE_MAX must be 3, got {match.group(1)!r}"
+    assert "PR_CREATE_MAX=3" in bash or "PR_CREATE_MAX = 3" in bash, (
+        "Step 5 must use the canonical PR_CREATE_MAX=3 form"
+    )
+
+
+def test_compose_pr_step5_classifies_transient_failures():
+    """Step 5 must classify transient (HTTP 5xx / network) failures as retryable."""
+    bash = _compose_pr_step5_bash()
+    transient_markers = ["HTTP 5", "rate limit", "timeout", "connection reset"]
+    hits = sum(1 for m in transient_markers if m in bash)
+    assert hits >= 2, (
+        "Step 5 must classify transient failures (HTTP 5xx / rate limit / timeout / "
+        "connection reset) as retryable; found only "
+        f"{hits} of {transient_markers}"
+    )
+
+
+def test_compose_pr_step5_uses_1s_and_2s_backoff_sleeps():
+    """Step 5 must back off 1s before attempt 2 and 2s before attempt 3."""
+    import re
+
+    bash = _compose_pr_step5_bash()
+    sleep_matches = re.findall(r"sleep\s+(\d+)", bash)
+    assert sleep_matches, "Step 5 must include at least one bounded backoff sleep"
+    # Both 1 and 2 must appear somewhere in the backoff ladder.
+    assert "1" in sleep_matches, "Step 5 must sleep 1 second (e.g., before attempt 2)"
+    assert "2" in sleep_matches, "Step 5 must sleep 2 seconds (e.g., before attempt 3)"
+
+
+def test_compose_pr_step5_preserves_pr_arguments():
+    """Step 5 must keep --base, --head, --title, --body-file arguments intact."""
+    bash = _compose_pr_step5_bash()
+    assert "--base" in bash, "Step 5 must include --base argument"
+    assert "--head" in bash, "Step 5 must include --head argument"
+    assert "--title" in bash, "Step 5 must include --title argument"
+    assert "--body-file" in bash, "Step 5 must include --body-file argument"
+    # Literal body-file path with the canonical {{AUTOSKILLIT_TEMP}} prefix
+    # and the $ts.md suffix.
+    assert "{{AUTOSKILLIT_TEMP}}/compose-pr/pr_body_$ts.md" in bash, (
+        "Step 5 must use the literal --body-file path "
+        "{{AUTOSKILLIT_TEMP}}/compose-pr/pr_body_$ts.md"
+    )
+
+
+def test_compose_pr_step4_auth_preflight_unchanged():
+    """Step 4 must retain the gh auth status preflight behavior."""
+    from autoskillit.recipe._skill_placeholder_parser import extract_step_sections
+
+    text = COMPOSE_PR.read_text()
+    sections = extract_step_sections(text)
+    step4 = sections.get("Step 4", "")
+    assert step4, "compose-pr/SKILL.md is missing a Step 4 section"
+    assert "gh auth status" in step4, "Step 4 must run gh auth status preflight"
+    # Empty pr_url emit path must remain documented in Step 4.
+    assert "pr_url =" in step4, (
+        "Step 4 must document the empty pr_url emit path on gh preflight failure"
+    )

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -18,6 +18,18 @@ from autoskillit.hooks._command_classification import (
 pytestmark = [pytest.mark.layer("infra"), pytest.mark.small]
 
 
+def test_shell_control_words_includes_closing_keywords():
+    """_SHELL_CONTROL_WORDS must include the closing keywords added by this task.
+
+    Pinning the shared primitive directly so boundary expansion is not only
+    covered indirectly through compose_pr_body_guard integration tests.
+    """
+    from autoskillit.hooks._command_classification import _SHELL_CONTROL_WORDS  # noqa: PLC0415
+
+    for word in ("esac", "fi", "done"):
+        assert word in _SHELL_CONTROL_WORDS, f"_SHELL_CONTROL_WORDS is missing '{word}'"
+
+
 def test_detects_python3_subprocess_run():
     cmd = "python3 -c \"import subprocess; subprocess.run('gh pr create', shell=True)\""
     assert has_interpreter_wrapped_command(cmd, target_commands=["gh pr create"])

--- a/tests/hooks/test_compose_pr_body_guard.py
+++ b/tests/hooks/test_compose_pr_body_guard.py
@@ -676,3 +676,179 @@ class TestRetryShape:
         output = _run_hook(event, monkeypatch, headless=True)
         # gh pr create has no body-file, so nothing to deny → empty output.
         assert output == ""
+
+
+# ---------------------------------------------------------------------------
+# T11: TestVariableBodyPath — guard resolves $VAR form used by compose-pr Step 5
+# ---------------------------------------------------------------------------
+
+
+class TestVariableBodyPath:
+    """compose-pr Step 5 uses --body-file "$PR_CREATE_BODY" (a variable form).
+
+    The guard must resolve PR_CREATE_BODY from safe depth-0 assignments
+    that appear before the matched gh pr create, handle nested $ts variables
+    in the value, and reject assignments from out-of-scope positions (post-gh
+    or inside alternate control branches).
+    """
+
+    def _make_body_path(self, tmp_path, content: str) -> str:
+        """Create the body file at the compose-pr standard location and return its path."""
+        body_path = tmp_path / ".autoskillit" / "temp" / "compose-pr" / "pr_body_testts.md"
+        body_path.parent.mkdir(parents=True, exist_ok=True)
+        body_path.write_text(content, encoding="utf-8")
+        return str(body_path)
+
+    def test_denies_variable_body_path_after_esac_boundary(self, monkeypatch, tmp_path):
+        """PR_CREATE_BODY variable resolved from preamble; gh pr create after esac → deny."""
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        body_path = self._make_body_path(tmp_path, "Some description with no closing ref")
+
+        cmd = (
+            f"PR_CREATE_BODY={body_path}\n"
+            f"while true; do\n"
+            f'  case "$PR_CREATE_ATTEMPT" in\n'
+            f"    2) sleep 1 ;;\n"
+            f"  esac\n"
+            f'  gh pr create --base main --body-file "$PR_CREATE_BODY"\n'
+            f"  break\n"
+            f"done"
+        )
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert _is_denied(output)
+
+    def test_allows_variable_body_path_with_closing_ref(self, monkeypatch, tmp_path):
+        """PR_CREATE_BODY resolved and body contains Closes #N → guard allows."""
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        body_path = self._make_body_path(tmp_path, "Summary\n\nCloses #123")
+
+        cmd = (
+            f"PR_CREATE_BODY={body_path}\n"
+            f"while true; do\n"
+            f'  case "$PR_CREATE_ATTEMPT" in\n'
+            f"    2) sleep 1 ;;\n"
+            f"  esac\n"
+            f'  gh pr create --base main --body-file "$PR_CREATE_BODY"\n'
+            f"  break\n"
+            f"done"
+        )
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert output == ""
+
+    def test_resolves_nested_ts_variable_in_body_path(self, monkeypatch, tmp_path):
+        """PR_CREATE_BODY contains $ts; both assigned before loop → deny."""
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+
+        compose_dir = tmp_path / ".autoskillit" / "temp" / "compose-pr"
+        compose_dir.mkdir(parents=True, exist_ok=True)
+        body_path = compose_dir / "pr_body_testts.md"
+        body_path.write_text("Some description with no closing ref", encoding="utf-8")
+
+        compose_dir_str = str(compose_dir)
+        cmd = (
+            f"ts=testts\n"
+            f"PR_CREATE_BODY={compose_dir_str}/pr_body_$ts.md\n"
+            f"while true; do\n"
+            f'  case "$PR_CREATE_ATTEMPT" in\n'
+            f"    2) sleep 1 ;;\n"
+            f"  esac\n"
+            f'  gh pr create --base main --body-file "$PR_CREATE_BODY"\n'
+            f"  break\n"
+            f"done"
+        )
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert _is_denied(output)
+
+    def test_denies_variable_body_path_after_fi_boundary(self, monkeypatch, tmp_path):
+        """Guard recognizes gh pr create immediately after fi command boundary."""
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        body_path = self._make_body_path(tmp_path, "No closing ref here")
+
+        cmd = (
+            f"PR_CREATE_BODY={body_path}\n"
+            f'if [ "$PRECONDITION" = "ok" ]; then\n'
+            f"  : # setup\n"
+            f"fi\n"
+            f'gh pr create --base main --body-file "$PR_CREATE_BODY"'
+        )
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert _is_denied(output)
+
+    def test_denies_variable_body_path_after_done_boundary(self, monkeypatch, tmp_path):
+        """Guard recognizes gh pr create immediately after done command boundary."""
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        body_path = self._make_body_path(tmp_path, "No closing ref here")
+
+        cmd = (
+            f"PR_CREATE_BODY={body_path}\n"
+            f"for i in 1; do\n"
+            f"  : # setup\n"
+            f"done\n"
+            f'gh pr create --base main --body-file "$PR_CREATE_BODY"'
+        )
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert _is_denied(output)
+
+    def test_post_gh_assignment_is_not_used(self, monkeypatch, tmp_path):
+        """An assignment appearing after gh pr create must not be used for resolution."""
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        body_path = self._make_body_path(tmp_path, "No closing ref here")
+
+        # PR_CREATE_BODY only assigned AFTER gh pr create — resolution must fail-open.
+        cmd = (
+            f"while true; do\n"
+            f'  gh pr create --base main --body-file "$PR_CREATE_BODY"\n'
+            f"  PR_CREATE_BODY={body_path}\n"
+            f"  break\n"
+            f"done"
+        )
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert output == ""
+
+    def test_alternate_branch_assignment_is_not_used(self, monkeypatch, tmp_path):
+        """Assignment inside an if-then branch cannot be proven to reach the else branch."""
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        body_path = self._make_body_path(tmp_path, "No closing ref here")
+
+        # PR_CREATE_BODY is assigned in the `then` branch; gh pr create is in `else`.
+        # Since the assignment is at depth 1, it must not be collected → fail-open.
+        cmd = (
+            f'if [ "$PRECONDITION" = "ok" ]; then\n'
+            f"  PR_CREATE_BODY={body_path}\n"
+            f"else\n"
+            f'  gh pr create --base main --body-file "$PR_CREATE_BODY"\n'
+            f"fi"
+        )
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert output == ""
+
+    def test_allows_echo_mentioning_variable_form(self, monkeypatch, tmp_path):
+        """Echo of gh pr create with $PR_CREATE_BODY must remain a benign false-positive."""
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        cmd = "echo 'About to run: gh pr create --body-file $PR_CREATE_BODY'"
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert output == ""

--- a/tests/hooks/test_compose_pr_body_guard.py
+++ b/tests/hooks/test_compose_pr_body_guard.py
@@ -565,7 +565,11 @@ class TestRetryShape:
         monkeypatch.chdir(tmp_path)
         _setup_prep_file(tmp_path, "123")
         body = _setup_body_file(tmp_path, "Some description with no closing ref")
-        cmd = f'if [ "$PRECONDITION" = "ok" ]; then\n  gh pr create --body-file {body} --base main\nfi'
+        cmd = (
+            f'if [ "$PRECONDITION" = "ok" ]; then\n'
+            f"  gh pr create --body-file {body} --base main\n"
+            f"fi"
+        )
         event = _build_event(cmd)
         output = _run_hook(event, monkeypatch, headless=True)
         assert _is_denied(output)

--- a/tests/hooks/test_compose_pr_body_guard.py
+++ b/tests/hooks/test_compose_pr_body_guard.py
@@ -518,3 +518,157 @@ class TestSessionScope:
         event = _build_event(cmd)
         output = _run_hook(event, monkeypatch, headless=True)
         assert _is_denied(output)
+
+
+# ---------------------------------------------------------------------------
+# T10: TestRetryShape — guard compatibility with retry-block command shape
+# ---------------------------------------------------------------------------
+
+
+class TestRetryShape:
+    """Step 5 of compose-pr wraps `gh pr create` in a bounded retry loop.
+
+    The guard must still extract the --body-file path when `gh pr create`
+    appears inside `while ... do ... done`, `if ... then ... fi`, or
+    `for ... do ... done` constructs — and still deny when the body file
+    omits the required closing reference. Existing echo/print false-positive
+    protections must remain intact.
+    """
+
+    def test_denies_when_inside_while_loop(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        body = _setup_body_file(tmp_path, "Some description with no closing ref")
+        cmd = (
+            f'while [ "$ATTEMPT" -le 3 ]; do\n'
+            f"  gh pr create --body-file {body} --base main\n"
+            f"  ATTEMPT=$((ATTEMPT + 1))\n"
+            f"done"
+        )
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert _is_denied(output)
+
+    def test_denies_when_inside_for_loop(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        body = _setup_body_file(tmp_path, "Some description with no closing ref")
+        cmd = f"for ATTEMPT in 1 2 3; do\n  gh pr create --body-file {body} --base main\ndone"
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert _is_denied(output)
+
+    def test_denies_when_after_then_keyword(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        body = _setup_body_file(tmp_path, "Some description with no closing ref")
+        cmd = f'if [ "$PRECONDITION" = "ok" ]; then\n  gh pr create --body-file {body} --base main\nfi'
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert _is_denied(output)
+
+    def test_denies_when_after_else_keyword(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        body = _setup_body_file(tmp_path, "Some description with no closing ref")
+        cmd = (
+            f'if [ "$PRECONDITION" = "skip" ]; then\n'
+            f"  :\n"
+            f"else\n"
+            f"  gh pr create --body-file {body} --base main\n"
+            f"fi"
+        )
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert _is_denied(output)
+
+    def test_denies_when_after_elif_keyword(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        body = _setup_body_file(tmp_path, "Some description with no closing ref")
+        cmd = (
+            f'if [ "$A" = "x" ]; then\n'
+            f"  :\n"
+            f'elif [ "$B" = "y" ]; then\n'
+            f"  gh pr create --body-file {body} --base main\n"
+            f"fi"
+        )
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert _is_denied(output)
+
+    def test_allows_when_body_has_closing_ref_inside_loop(self, monkeypatch, tmp_path):
+        """The guard approves loop-wrapped gh pr create when the body contains a closing ref."""
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        body = _setup_body_file(tmp_path, "Summary\n\nCloses #123")
+        cmd = (
+            f"for ATTEMPT in 1 2 3; do\n"
+            f"  gh pr create --body-file {body} --base main\n"
+            f"  ATTEMPT=$((ATTEMPT + 1))\n"
+            f"done"
+        )
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert output == ""
+
+    def test_allows_echo_only_command_mentioning_gh_pr_create(self, monkeypatch, tmp_path):
+        """echo/print of gh pr create text must remain a benign false-positive."""
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        cmd = "echo 'About to run: gh pr create --body-file /tmp/whatever.md --base main'"
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert output == ""
+
+    def test_allows_print_only_command_mentioning_gh_pr_create(self, monkeypatch, tmp_path):
+        """printf of gh pr create text must remain a benign false-positive."""
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        cmd = "printf 'Will run: gh pr create --body-file /tmp/whatever.md --base main\\n'"
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert output == ""
+
+    def test_denies_fused_body_file_inside_loop(self, monkeypatch, tmp_path):
+        """The --body-file=<path> fused form must still be extracted from inside a loop."""
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        body = _setup_body_file(tmp_path, "Some description with no closing ref")
+        cmd = f"for ATTEMPT in 1 2 3; do\n  gh pr create --body-file={body}\ndone"
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        assert _is_denied(output)
+
+    def test_stops_extraction_at_loop_do_keyword(self, monkeypatch, tmp_path):
+        """A --body-file that appears AFTER a `do` keyword on a chained line
+        must not be attributed to a later `gh pr create` invocation.
+
+        With the new boundary set, `do` terminates the previous segment
+        and the next command starts fresh. This test verifies the parser
+        still stops cleanly at the keyword.
+        """
+        monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+        monkeypatch.chdir(tmp_path)
+        _setup_prep_file(tmp_path, "123")
+        # gh pr create has no --body-file, and the curl --body-file that
+        # follows after `do` should not be picked up.
+        cmd = (
+            "while true; do\n"
+            '  gh pr create --title "x" --base main\n'
+            "  curl --body-file /unrelated.md\n"
+            "done"
+        )
+        event = _build_event(cmd)
+        output = _run_hook(event, monkeypatch, headless=True)
+        # gh pr create has no body-file, so nothing to deny → empty output.
+        assert output == ""

--- a/tests/recipe/test_contract_strength.py
+++ b/tests/recipe/test_contract_strength.py
@@ -93,6 +93,7 @@ def test_write_always_skills_require_completion_marker_pattern():
 
 _KNOWN_OPTIONAL_CAPTURE_EXEMPTIONS = frozenset(
     {
+        "compose-pr",
         "promote-to-main",
     }
 )

--- a/tests/skills/AGENTS.md
+++ b/tests/skills/AGENTS.md
@@ -19,6 +19,7 @@ Skill SKILL.md content compliance, placeholder contracts, and verdict guard test
 | `test_make_plan_false_positive.py` | Tests for false_positive verdict support in make-plan SKILL.md |
 | `test_make_plan_multipart_contracts.py` | Contract tests for make-plan multi-part green-gate rule and xfail bridge documentation |
 | `test_compose_pr.py` | Guard tests for compose-pr/SKILL.md template structure |
+| `test_compose_pr_retry.py` | Step 5 bounded retry behavior tests — transient retry, terminal fail-fast, response-loss recovery (fake gh on PATH) |
 | `test_conflict_resolution_guards.py` | Structural guards for conflict resolution safeguards in SKILL.md files |
 | `test_deletion_regression_guards.py` | Structural guards for deletion regression detection in merge-pr and review-pr skills |
 | `test_dry_walkthrough_contracts.py` | Structural contracts for the dry-walkthrough historical regression check step |

--- a/tests/skills/test_compose_pr_retry.py
+++ b/tests/skills/test_compose_pr_retry.py
@@ -1,0 +1,186 @@
+"""Tests for compose-pr Step 5 bounded retry behavior.
+
+Extracts the Step 5 bash block from compose-pr/SKILL.md and executes it
+with a fake `gh` script on PATH to verify transient retry, terminal
+fail-fast, and response-loss recovery.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from autoskillit.recipe._skill_placeholder_parser import (
+    extract_bash_blocks,
+    extract_step_sections,
+)
+
+pytestmark = [pytest.mark.layer("skills"), pytest.mark.medium]
+
+
+SKILL_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "compose-pr"
+    / "SKILL.md"
+)
+
+
+def _step5_bash() -> str:
+    """Return the literal bash block from compose-pr Step 5."""
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    sections = extract_step_sections(text)
+    step5 = sections.get("Step 5")
+    assert step5, "compose-pr/SKILL.md is missing a Step 5 section"
+    blocks = extract_bash_blocks(step5)
+    assert len(blocks) == 1, f"Expected exactly 1 bash block in Step 5, found {len(blocks)}"
+    return blocks[0]
+
+
+_FAKE_GH_TEMPLATE = """#!/bin/bash
+set -u
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  ATTEMPT_FILE="$FAKE_GH_ATTEMPT_FILE"
+  ATTEMPT=$(cat "$ATTEMPT_FILE")
+  ATTEMPT=$((ATTEMPT + 1))
+  printf '%s' "$ATTEMPT" > "$ATTEMPT_FILE"
+  STDOUT_VAR="FAKE_GH_CREATE_${ATTEMPT}_STDOUT"
+  STDERR_VAR="FAKE_GH_CREATE_${ATTEMPT}_STDERR"
+  EXIT_VAR="FAKE_GH_CREATE_${ATTEMPT}_EXIT"
+  if [ -n "${!STDOUT_VAR+x}" ] && [ -n "${!STDOUT_VAR}" ]; then
+    printf '%s\\n' "${!STDOUT_VAR}"
+  fi
+  if [ -n "${!STDERR_VAR+x}" ] && [ -n "${!STDERR_VAR}" ]; then
+    printf '%s\\n' "${!STDERR_VAR}" >&2
+  fi
+  exit "${!EXIT_VAR:-0}"
+fi
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  if [ -n "${FAKE_GH_VIEW_URL+x}" ] && [ -n "$FAKE_GH_VIEW_URL" ]; then
+    printf '%s\\n' "$FAKE_GH_VIEW_URL"
+  fi
+  exit 0
+fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  exit 0
+fi
+echo "fake gh: unsupported: $*" >&2
+exit 99
+"""
+
+
+def _make_fake_gh(tmp_path: Path) -> Path:
+    """Create a fake gh script on a fresh PATH bin dir."""
+    bin_dir = tmp_path / "fakebin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    gh = bin_dir / "gh"
+    gh.write_text(_FAKE_GH_TEMPLATE, encoding="utf-8")
+    gh.chmod(0o755)
+    state = tmp_path / "gh_create_attempts"
+    state.write_text("0", encoding="utf-8")
+    return bin_dir
+
+
+def _run_step5(
+    tmp_path: Path, bin_dir: Path, env_overrides: dict[str, str]
+) -> subprocess.CompletedProcess:
+    """Execute the extracted Step 5 bash block with fake prerequisites."""
+    autotemp = tmp_path / "autotemp"
+    autotemp.mkdir(parents=True, exist_ok=True)
+    log_dir = autotemp / "compose-pr"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    body_path = log_dir / "pr_body_testts.md"
+    body_path.write_text("Summary\n\nCloses #123\n", encoding="utf-8")
+
+    bash = _step5_bash().replace("{{AUTOSKILLIT_TEMP}}", str(autotemp))
+    harness = (
+        "set -u\n"
+        "ts=testts\n"
+        "WORK_DIR=/tmp/no-such-workdir\n"
+        "BASE_BRANCH=main\n"
+        "FEATURE_BRANCH=test-branch\n"
+        "TASK_TITLE='Test PR'\n"
+        "export BASE_BRANCH FEATURE_BRANCH TASK_TITLE ts WORK_DIR\n" + bash
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["AUTOSKILLIT_TEMP"] = str(autotemp)
+    env["FAKE_GH_ATTEMPT_FILE"] = str(tmp_path / "gh_create_attempts")
+    for k, v in env_overrides.items():
+        env[k] = v
+
+    return subprocess.run(
+        ["bash", "-c", harness],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=tmp_path,
+    )
+
+
+class TestStep5Retry:
+    def test_transient_first_attempt_then_success(self, tmp_path):
+        """First gh pr create fails transiently; second attempt succeeds."""
+        bin_dir = _make_fake_gh(tmp_path)
+        proc = _run_step5(
+            tmp_path,
+            bin_dir,
+            env_overrides={
+                "FAKE_GH_CREATE_1_EXIT": "1",
+                "FAKE_GH_CREATE_1_STDERR": "HTTP 503 Service Unavailable",
+                "FAKE_GH_CREATE_2_EXIT": "0",
+                "FAKE_GH_CREATE_2_STDOUT": "https://github.com/owner/repo/pull/42",
+            },
+        )
+        assert proc.returncode == 0
+        assert "pr_url = https://github.com/owner/repo/pull/42" in proc.stdout
+        assert "HTTP 503" not in proc.stdout
+        attempts = int((tmp_path / "gh_create_attempts").read_text())
+        assert attempts == 2
+
+    def test_terminal_validation_error_does_not_retry(self, tmp_path):
+        """Terminal validation error fails fast; no pr view recovery; stderr surfaces."""
+        bin_dir = _make_fake_gh(tmp_path)
+        proc = _run_step5(
+            tmp_path,
+            bin_dir,
+            env_overrides={
+                "FAKE_GH_CREATE_1_EXIT": "1",
+                "FAKE_GH_CREATE_1_STDERR": "HTTP 422 validation failed: missing required field",
+                "FAKE_GH_VIEW_URL": "https://github.com/owner/repo/pull/should-not-be-used",
+            },
+        )
+        assert proc.returncode != 0
+        # pr view recovery must NOT be triggered — url line is absent
+        assert "pr_url = " not in proc.stdout
+        assert "should-not-be-used" not in proc.stdout
+        # terminal stderr surfaces on stderr
+        assert "validation failed" in proc.stderr
+        attempts = int((tmp_path / "gh_create_attempts").read_text())
+        assert attempts == 1
+
+    def test_response_loss_recovery_emits_view_url(self, tmp_path):
+        """Transient failure with successful gh pr view recovery emits recovered URL."""
+        bin_dir = _make_fake_gh(tmp_path)
+        proc = _run_step5(
+            tmp_path,
+            bin_dir,
+            env_overrides={
+                "FAKE_GH_CREATE_1_EXIT": "1",
+                "FAKE_GH_CREATE_1_STDERR": "HTTP 502 Bad Gateway",
+                "FAKE_GH_VIEW_URL": "https://github.com/owner/repo/pull/77",
+            },
+        )
+        assert proc.returncode == 0
+        assert "pr_url = https://github.com/owner/repo/pull/77" in proc.stdout
+        # No second create attempt after recovery
+        attempts = int((tmp_path / "gh_create_attempts").read_text())
+        assert attempts == 1
+        # Recovery diagnostics off stdout
+        assert "Bad Gateway" not in proc.stdout

--- a/tests/skills/test_compose_pr_retry.py
+++ b/tests/skills/test_compose_pr_retry.py
@@ -184,3 +184,81 @@ class TestStep5Retry:
         assert attempts == 1
         # Recovery diagnostics off stdout
         assert "Bad Gateway" not in proc.stdout
+
+    def test_http_429_retries_and_succeeds_on_attempt_2(self, tmp_path):
+        """HTTP 429 Too Many Requests is retryable; second attempt succeeds."""
+        bin_dir = _make_fake_gh(tmp_path)
+        proc = _run_step5(
+            tmp_path,
+            bin_dir,
+            env_overrides={
+                "FAKE_GH_CREATE_1_EXIT": "1",
+                "FAKE_GH_CREATE_1_STDERR": "HTTP 429 Too Many Requests",
+                "FAKE_GH_CREATE_2_EXIT": "0",
+                "FAKE_GH_CREATE_2_STDOUT": "https://github.com/owner/repo/pull/99",
+            },
+        )
+        assert proc.returncode == 0
+        assert "pr_url = https://github.com/owner/repo/pull/99" in proc.stdout
+        attempts = int((tmp_path / "gh_create_attempts").read_text())
+        assert attempts == 2
+
+    def test_secondary_rate_limit_retries_before_success(self, tmp_path):
+        """HTTP 403 secondary rate limit is retryable; second attempt succeeds."""
+        bin_dir = _make_fake_gh(tmp_path)
+        proc = _run_step5(
+            tmp_path,
+            bin_dir,
+            env_overrides={
+                "FAKE_GH_CREATE_1_EXIT": "1",
+                "FAKE_GH_CREATE_1_STDERR": "HTTP 403: secondary rate limit exceeded",
+                "FAKE_GH_CREATE_2_EXIT": "0",
+                "FAKE_GH_CREATE_2_STDOUT": "https://github.com/owner/repo/pull/100",
+            },
+        )
+        assert proc.returncode == 0
+        assert "pr_url = https://github.com/owner/repo/pull/100" in proc.stdout
+        attempts = int((tmp_path / "gh_create_attempts").read_text())
+        assert attempts == 2
+
+    def test_three_transient_failures_exhaust_retry_budget(self, tmp_path):
+        """Three transient failures exhaust the retry budget with correct diagnostics."""
+        bin_dir = _make_fake_gh(tmp_path)
+        proc = _run_step5(
+            tmp_path,
+            bin_dir,
+            env_overrides={
+                "FAKE_GH_CREATE_1_EXIT": "1",
+                "FAKE_GH_CREATE_1_STDERR": "HTTP 503 Service Unavailable",
+                "FAKE_GH_CREATE_2_EXIT": "1",
+                "FAKE_GH_CREATE_2_STDERR": "HTTP 503 Service Unavailable",
+                "FAKE_GH_CREATE_3_EXIT": "1",
+                "FAKE_GH_CREATE_3_STDERR": "HTTP 503 final attempt unavailable",
+            },
+        )
+        assert proc.returncode != 0
+        attempts = int((tmp_path / "gh_create_attempts").read_text())
+        assert attempts == 3
+        assert "gh pr create failed after 3 attempt(s):" in proc.stderr
+        assert "HTTP 503 final attempt unavailable" in proc.stderr
+        # Must not attempt to read a missing attempt-4 stderr file
+        assert "attempt(s): 4" not in proc.stderr
+        assert "$PR_CREATE_ATTEMPT" not in proc.stderr
+
+    def test_zero_exit_no_url_all_attempts_is_failure(self, tmp_path):
+        """gh pr create exits 0 but returns no URL on all attempts → nonzero exit."""
+        bin_dir = _make_fake_gh(tmp_path)
+        proc = _run_step5(
+            tmp_path,
+            bin_dir,
+            env_overrides={
+                # All three attempts exit 0 with no stdout URL and empty stderr.
+                "FAKE_GH_CREATE_1_EXIT": "0",
+                "FAKE_GH_CREATE_2_EXIT": "0",
+                "FAKE_GH_CREATE_3_EXIT": "0",
+                # gh pr view also returns no URL.
+            },
+        )
+        assert proc.returncode != 0
+        # Must not emit a successful empty pr_url token.
+        assert "pr_url = " not in proc.stdout


### PR DESCRIPTION
## Summary

Add bounded shell-level retry around the Step 5 `gh pr create` command in `src/autoskillit/skills_extended/compose-pr/SKILL.md`. The retry runs only after `gh auth status` has passed, preserves the existing `pr_url = ...` output contract, retries only transient API or network failures, and keeps the PR body closing-issue guard effective for the new command shape. The remediation pass keeps HTTP 429 and secondary rate-limit responses retryable, keeps `compose_pr_body_guard.py` effective for the actual Step 5 `PR_CREATE_BODY` command shape, and reports the final executed attempt's stderr when transient retries are exhausted. Step 5 success is defined by capturing or recovering a PR URL, not by `gh pr create` returning exit code 0 alone. The empty `pr_url =` success path remains reserved for Step 4's `gh auth status` preflight when GitHub CLI is unavailable or unauthenticated.

<details>
<summary>Individual Group Plans</summary>

### Group 1: Original retry plan

Add bounded shell-level retry around the Step 5 `gh pr create` command in [SKILL.md](/home/talon/projects/autoskillit-runs/impl-20260707-054510-064511/src/autoskillit/skills_extended/compose-pr/SKILL.md). The retry should apply only after `gh auth status` has passed, preserve the existing `pr_url = ...` output contract, retry only transient API or network failures, and keep the PR body closing-issue guard effective for the new command shape.

### Group 2: Remediation plan

Remediate the remaining `compose-pr` `gh pr create` retry gaps identified by audit-impl. The implementation must keep HTTP 429 and secondary rate-limit responses retryable, keep `compose_pr_body_guard.py` effective for the actual Step 5 `PR_CREATE_BODY` command shape, and report the final executed attempt's stderr when transient retries are exhausted.

Step 5 success must be defined by capturing or recovering a PR URL, not by `gh pr create` returning exit code 0 alone. The empty `pr_url =` success path remains reserved for Step 4's `gh auth status` preflight when GitHub CLI is unavailable or unauthenticated.

</details>

Closes #3987

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/impl-20260707-054510-064511/.autoskillit/temp/make-plan/compose_pr_gh_pr_create_retry_plan_2026-07-07_060736.md`
- `/home/talon/projects/autoskillit-runs/impl-20260707-054510-064511/.autoskillit/temp/make-plan/compose_pr_retry_remediation_plan_2026-07-07_071159.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan* | opus[1m] | 2 | 6.8M | 40.9k | 6.0M | 0 | 0 | 0 | 47m 0s |
| verify* | sonnet | 2 | 1.5M | 28.3k | 1.3M | 0 | 0 | 0 | 21m 14s |
| implement* | MiniMax-M3 | 2 | 519.5k | 73.2k | 11.9M | 0 | 226 | 0 | 38m 0s |
| audit_impl* | sonnet | 2 | 1.6M | 28.3k | 1.4M | 0 | 0 | 0 | 17m 15s |
| retry_worktree* | sonnet | 1 | 276 | 58.9k | 3.9M | 161.0k | 99 | 161.2k | 23m 52s |
| prepare_pr* | MiniMax-M3 | 1 | 45.3k | 2.9k | 187.6k | 0 | 15 | 0 | 51s |
| compose_pr* | MiniMax-M3 | 1 | 33.1k | 2.1k | 132.9k | 35.0k | 12 | 0 | 36s |
| review_pr* | sonnet | 3 | 4.7M | 43.2k | 4.3M | 0 | 0 | 0 | 19m 6s |
| resolve_review* | sonnet | 2 | 428 | 50.7k | 3.6M | 113.5k | 121 | 150.1k | 22m 28s |
| **Total** | | | 15.3M | 328.4k | 32.7M | 161.0k | | 311.3k | 3h 10m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 565 | 21099.7 | 0.0 | 129.5 |
| audit_impl | 0 | — | — | — |
| retry_worktree | 501 | 7789.2 | 321.8 | 117.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 42 | 86573.0 | 3574.3 | 1207.5 |
| **Total** | **1108** | 29551.2 | 281.0 | 296.4 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus[1m] | 1 | 6.8M | 40.9k | 6.0M | 0 | 47m 0s |
| sonnet | 5 | 7.9M | 209.4k | 14.5M | 311.3k | 1h 43m |
| MiniMax-M3 | 3 | 597.8k | 78.1k | 12.2M | 0 | 39m 28s |