### PR TITLE
[FIX] Fix Codex Investigate Report Sandbox

### DIFF
--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -244,10 +244,10 @@ skills:
     - name: investigation_path
       type: file_path
     expected_output_patterns:
-    - "investigation_path[ \\t]*=[ \\t]*/.+"
+    - "investigation_path[ \\t]*=[ \\t]*/.+/investigate/.+\\.md"
     pattern_examples:
-    - "investigation_path = /tmp/investigation.md\n%%ORDER_UP%%"
-    read_only: true
+    - "investigation_path = /tmp/project/run/investigate/investigation_bug_2026-07-08.md\n%%ORDER_UP%%"
+    write_behavior: always
   make-groups:
     inputs:
     - name: source_doc

--- a/src/autoskillit/recipes/diagrams/remediation.md
+++ b/src/autoskillit/recipes/diagrams/remediation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:c8205806500c54e98e1dd94e2f09f106c0b1603fcc60e2958ab70788c59a39c9 -->
+<!-- autoskillit-recipe-hash: sha256:0c8594b80bc296fe525502e13896523cdc864ce3e475526dd9991040eb657382 -->
 <!-- autoskillit-diagram-format: v7 -->
 ## remediation
 Investigate, rectify, implement, and merge a bug fix with CI and PR gates.

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -225,6 +225,7 @@
       "with": {
         "skill_command": "/autoskillit:investigate ${{ '--depth deep ' if inputs.depth == 'deep' else '' }}${{ inputs.task }}",
         "cwd": "${{ context.work_dir }}",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/investigate",
         "step_name": "investigate",
         "issue_url": "${{ inputs.issue_url }}",
         "issue_title": "${{ context.issue_title }}"

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -235,6 +235,7 @@ steps:
       skill_command: /autoskillit:investigate ${{ '--depth deep ' if inputs.depth
         == 'deep' else '' }}${{ inputs.task }}
       cwd: ${{ context.work_dir }}
+      output_dir: '{{AUTOSKILLIT_TEMP}}/investigate'
       step_name: investigate
       issue_url: ${{ inputs.issue_url }}
       issue_title: ${{ context.issue_title }}

--- a/src/autoskillit/skills_extended/investigate/SKILL.md
+++ b/src/autoskillit/skills_extended/investigate/SKILL.md
@@ -96,6 +96,14 @@ tool **before** beginning any analysis. Use the returned `content` field as the 
 - Check for similar existing patterns in codebase
 - Ensure approaches, solutions, and fixes are the appropriate long-term solutions with proper architecture
 
+## Context Limit Behavior
+
+If context pressure interrupts the investigation before the final report token is emitted,
+resume from the partial notes and continue toward the same mandatory report. A successful
+invocation must still write exactly one markdown report under `{{AUTOSKILLIT_TEMP}}/investigate/`
+and emit `investigation_path = {absolute_path_to_investigation_report_file}` as the final
+plain-text line. Do not emit the token until the report exists.
+
 ## Standard Mode Workflow (Steps 1–4)
 
 **Path-existence guard:** Before issuing a `Read` call on a path that is not guaranteed to
@@ -375,7 +383,7 @@ Spawn one adversarial subagent via `Agent(model="sonnet")` whose role is to disc
 
 **If counterevidence is found:** Return to D3 for one additional deepening batch focused on reconciling the contradiction.
 
-**If no counterevidence is found:** The hypothesis stands. Proceed to D5.
+**When the challenge finds no counterevidence:** The hypothesis stands. Proceed to D5.
 
 ### Step D5: Solution Convergence
 

--- a/tests/recipe/test_contract_strength.py
+++ b/tests/recipe/test_contract_strength.py
@@ -23,6 +23,7 @@ _KNOWN_UNGAPPED_WRITE_ALWAYS = frozenset(
         "dry-walkthrough",
         "file-audit-issues",
         "generate-report",
+        "investigate",
         "make-campaign",
         "make-groups",
         "phoropter-null-synthesis",

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -739,12 +739,17 @@ def test_write_behavior_conditional_loaded() -> None:
     assert any("conflict_report_path" in p for p in contract.write_expected_when)
 
 
-def test_write_behavior_defaults_to_none() -> None:
-    """investigate has no write_behavior — defaults to None."""
+def test_investigate_declares_report_write_contract() -> None:
+    """investigate writes a report artifact and must not run read-only."""
     manifest = load_bundled_manifest()
     contract = get_skill_contract("investigate", manifest)
     assert contract is not None
-    assert contract.write_behavior is None
+    assert contract.write_behavior == "always"
+    assert contract.read_only is False
+    assert contract.expected_output_patterns
+    assert any(
+        "/investigate/" in p and p.endswith(".md\n%%ORDER_UP%%") for p in contract.pattern_examples
+    )
 
 
 ALWAYS_WRITE_SKILLS = {
@@ -762,6 +767,7 @@ ALWAYS_WRITE_SKILLS = {
     "implement-experiment",
     "implement-worktree",
     "implement-worktree-no-merge",
+    "investigate",
     "make-campaign",
     "make-groups",
     "phoropter-null-synthesis",

--- a/tests/server/test_tools_execution_write_prefix.py
+++ b/tests/server/test_tools_execution_write_prefix.py
@@ -45,3 +45,30 @@ async def test_allowed_write_prefix_uses_fallback_without_output_dir(
     expected = str(tmp_path / ".autoskillit" / "temp" / "test") + "/"
     assert executor.calls[0].allowed_write_prefix == expected
     assert executor.calls[0].allowed_write_prefixes == (expected,)
+
+
+@pytest.mark.anyio
+async def test_investigate_contract_runs_writable_with_report_watch_dir(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+) -> None:
+    """investigate must not be launched as a read-only skill because it writes a report."""
+    from pathlib import Path
+
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    await run_skill("/autoskillit:investigate regression", str(tmp_path))
+
+    assert len(executor.calls) == 1
+    call = executor.calls[0]
+    assert call.readonly_skill is False
+    assert call.write_behavior is not None
+    assert call.write_behavior.mode == "always"
+    assert call.expected_output_patterns
+
+    report_dir = tmp_path / ".autoskillit" / "temp" / "investigate"
+    assert Path(report_dir) in call.write_watch_dirs
+    assert call.allowed_write_prefix == str(report_dir) + "/"


### PR DESCRIPTION
## Summary

Codex remediation runs were launching the `investigate` skill in a read-only sandbox even
though that skill must write a markdown report and emit an `investigation_path` token. The
fix updates the investigate skill contract to declare mandatory write behavior, gives the
remediation recipe a scoped investigate output directory, refreshes the compiled recipe and
diagram hash, and adds focused regression coverage for the server-side `run_skill` launch
parameters.

## Requirements

Codex-backed remediation runs can reach the first `run_skill` step (`investigate`) but fail before the recipe can continue because the child Codex session is read-only and cannot write the mandatory investigation report artifact under `.autoskillit/temp/investigate/`.

The child can complete useful analysis and emit `%%ORDER_UP`, but `run_skill` adjudicates the step as `adjudicated_failure` because no report file or other write evidence exists. This blocks the pipeline before implementation begins.

The remediation recipe's `investigate` step must be able to produce its required investigation artifact when run under the Codex backend, or the recipe must route that step to a backend/provider/sandbox mode capable of writing the artifact.

If a skill contract requires artifact writes, dispatch/admission should reject unsupported Codex read-only execution before launching a zero-progress child.

Closes #4215

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/codex-loop/issue-4215-narrow-implementation-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
