### PR TITLE
[FIX] Route Codex aliases to GPT-5.6 Sol

### DIFF
--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -182,15 +182,15 @@ CLAUDE_MODEL_ALIASES: dict[str, str] = {
 
 CODEX_MODEL_ALIASES: Mapping[str, str] = MappingProxyType(
     {
-        "sonnet": "gpt-5.5",
-        "opus": "gpt-5.5",
-        "haiku": "gpt-5.5",
+        "sonnet": "gpt-5.6-sol",
+        "opus": "gpt-5.6-sol",
+        "haiku": "gpt-5.6-sol",
     }
 )
 
 CODEX_MODEL_ALIASES_LAST_VERIFIED: str = "2026-07-09"
 
-CODEX_VALID_MODEL_IDS: frozenset[str] = frozenset({"gpt-5.5"})
+CODEX_VALID_MODEL_IDS: frozenset[str] = frozenset({"gpt-5.5", "gpt-5.6-sol"})
 
 assert set(CODEX_MODEL_ALIASES.values()).issubset(CODEX_VALID_MODEL_IDS), (
     "CODEX_MODEL_ALIASES values must all be members of CODEX_VALID_MODEL_IDS; "

--- a/tests/cli/test_doctor_runtime.py
+++ b/tests/cli/test_doctor_runtime.py
@@ -21,7 +21,11 @@ class TestCheckCodexModelAliasStaleness:
         monkeypatch.setattr(
             mod,
             "CODEX_MODEL_ALIASES",
-            {"sonnet": "gpt-5.5", "opus": "gpt-5.5", "haiku": "gpt-5.5"},
+            {
+                "sonnet": "gpt-5.6-sol",
+                "opus": "gpt-5.6-sol",
+                "haiku": "gpt-5.6-sol",
+            },
         )
         result = mod._check_codex_model_alias_staleness()
         assert result.severity == Severity.OK
@@ -45,7 +49,7 @@ class TestCheckCodexModelAliasStaleness:
         monkeypatch.setattr(
             mod,
             "CODEX_MODEL_ALIASES",
-            {"sonnet": "gpt-5.5", "opus": "BOGUS-MODEL"},
+            {"sonnet": "gpt-5.6-sol", "opus": "BOGUS-MODEL"},
         )
         result = mod._check_codex_model_alias_staleness()
         assert result.severity == Severity.WARNING

--- a/tests/execution/backends/test_model_translation.py
+++ b/tests/execution/backends/test_model_translation.py
@@ -23,8 +23,9 @@ class TestCodexTranslateModel:
         assert "[1m]" not in result
         assert result == CODEX_MODEL_ALIASES["opus"]
 
-    def test_passthrough_native(self) -> None:
-        assert CodexBackend().translate_model("gpt-5.5") == "gpt-5.5"
+    @pytest.mark.parametrize("model_id", ["gpt-5.5", "gpt-5.6-sol"])
+    def test_passthrough_native(self, model_id: str) -> None:
+        assert CodexBackend().translate_model(model_id) == model_id
 
     def test_unknown_passthrough(self) -> None:
         assert CodexBackend().translate_model("custom-model-xyz") == "custom-model-xyz"
@@ -175,6 +176,22 @@ class TestCodexEffortInjectionInCmds:
             model="sonnet",
         )
         assert "model_reasoning_effort=high" in list(spec.cmd)
+
+    def test_food_truck_opus_suffix_uses_shared_model_with_xhigh_effort(self) -> None:
+        from autoskillit.core import DirectInstall
+
+        spec = CodexBackend().build_food_truck_cmd(
+            orchestrator_prompt="test",
+            plugin_source=DirectInstall(plugin_dir="/tmp/plugin"),
+            cwd="/repo",
+            completion_marker="%%DONE%%",
+            model="opus[1m]",
+        )
+        cmd = list(spec.cmd)
+        model_idx = cmd.index("--model")
+        assert cmd[model_idx + 1] == CODEX_MODEL_ALIASES["opus"]
+        assert "[1m]" not in cmd[model_idx + 1]
+        assert "model_reasoning_effort=xhigh" in cmd
 
     def test_interactive_cmd_has_effort(self) -> None:
         spec = CodexBackend().build_interactive_cmd(model="sonnet")

--- a/tests/execution/test_model_alias_registry.py
+++ b/tests/execution/test_model_alias_registry.py
@@ -34,6 +34,22 @@ def test_codex_alias_values_in_allowlist() -> None:
         )
 
 
+def test_codex_aliases_use_sol() -> None:
+    from autoskillit.core.types._type_backend import CODEX_MODEL_ALIASES
+
+    assert set(CODEX_MODEL_ALIASES) == {"sonnet", "opus", "haiku"}
+    assert set(CODEX_MODEL_ALIASES.values()) == {"gpt-5.6-sol"}
+
+
+def test_codex_native_model_allowlist_preserves_compatibility() -> None:
+    from autoskillit.core.types._type_backend import is_valid_codex_model_id
+
+    assert is_valid_codex_model_id("gpt-5.6-sol")
+    assert is_valid_codex_model_id("gpt-5.5")
+    assert not is_valid_codex_model_id("gpt-5.4")
+    assert not is_valid_codex_model_id("gpt-5.4-mini")
+
+
 def test_claude_alias_values_in_allowlist() -> None:
     from autoskillit.core.types._type_backend import CLAUDE_MODEL_ALIASES
 


### PR DESCRIPTION
## Summary

Update AutoSkillit's canonical Codex alias registry so every local model class launches
`gpt-5.6-sol`. Preserve model-class behavior through reasoning effort: Sonnet-class
default work uses `high`, Opus-class serious work uses `xhigh`, and explicitly requested
Haiku-class work remains `medium`. Keep explicit native `gpt-5.5` compatibility without
allowing any alias to select it.

- Replace the shared `gpt-5.5` alias target with `gpt-5.6-sol`.
- Add Sol to the valid native model-ID set while retaining explicit 5.5 compatibility.
- Cover exact alias policy, legacy 5.4/mini rejection, doctor validation, native model
  passthrough, suffix stripping, and the Opus food-truck `xhigh` path.

Closes #4218

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/codex-loop/4218-gpt56-sol-pr-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->