### PR TITLE
Rectify: Headless Completion Kills Active Async Subagents

### DIFF
--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -105,6 +105,7 @@ class RunSkillConfig:
     max_suppression_seconds: int = 1800
     stream_idle_timeout_ms: int = 600000
     mcp_tool_timeout_sec: float = 14364.0
+    completion_child_deferral_ceiling_seconds: float = 120.0
 
     # Safety margin (ms) above exit_after_stop_delay_ms that
     # natural_exit_grace_seconds must cover so the drain window can absorb
@@ -118,6 +119,11 @@ class RunSkillConfig:
             raise ValueError(
                 f"stream_idle_timeout_ms={self.stream_idle_timeout_ms} must be >= 0 "
                 "(use 0 to disable injection)."
+            )
+        if self.completion_child_deferral_ceiling_seconds < 0:
+            raise ValueError(
+                f"completion_child_deferral_ceiling_seconds="
+                f"{self.completion_child_deferral_ceiling_seconds} must be >= 0."
             )
         required_ms = self.exit_after_stop_delay_ms + self._EXIT_GRACE_BUFFER_MS
         # Convert seconds → ms for the comparison

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -52,6 +52,7 @@ run_skill:
   max_suppression_seconds: 1800
   stream_idle_timeout_ms: 600000
   mcp_tool_timeout_sec: 14364.0
+  completion_child_deferral_ceiling_seconds: 120.0
 
 model:
   default: sonnet

--- a/src/autoskillit/core/types/_type_subprocess.py
+++ b/src/autoskillit/core/types/_type_subprocess.py
@@ -176,4 +176,5 @@ class SubprocessRunner(Protocol):
         inspector_callback: InspectorCallback | None = None,
         workload_basenames: frozenset[str] | None = None,
         on_session_id_resolved: Callable[[str], None] | None = None,
+        child_deferral_ceiling: float = 0.0,
     ) -> Awaitable[SubprocessResult]: ...

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -262,6 +262,7 @@ async def _execute_claude_headless(
                 linux_tracing_config=linux_tracing_cfg,
                 idle_output_timeout=effective_idle,
                 max_suppression_seconds=cfg.max_suppression_seconds,
+                child_deferral_ceiling=cfg.completion_child_deferral_ceiling_seconds,
                 on_pid_resolved=on_spawn,
                 enable_deadline_extension=enable_deadline_extension,
                 max_extension_seconds=max_extension_seconds,

--- a/src/autoskillit/execution/process/__init__.py
+++ b/src/autoskillit/execution/process/__init__.py
@@ -162,11 +162,21 @@ async def execute_termination_action(
     process_exited_event: anyio.Event,
     grace_seconds: float,
     proc_log: structlog.BoundLogger,
+    pid: int | None = None,
+    marker_dir: Path | None = None,
+    session_id: str | None = None,
+    child_deferral_ceiling: float = 0.0,
 ) -> KillReason:
     """Single authorized executor for all kill decisions in run_managed_async.
 
     This is the ONLY function in process.py permitted to call
     async_kill_process_tree (enforced by test_no_direct_async_kill_process_tree_outside_executor).
+
+    On the DRAIN_THEN_KILL_IF_ALIVE path, when *pid* is provided and
+    *child_deferral_ceiling* > 0, the kill is deferred (bounded by the ceiling)
+    while child processes, an API connection, or an execution marker indicate
+    the subagent is still doing active work — mirroring the stale-kill
+    suppression pattern in _session_log_monitor.
 
     Returns the KillReason that surfaces to SubprocessResult.kill_reason.
     """
@@ -179,10 +189,40 @@ async def execute_termination_action(
             if proc.returncode is not None:
                 proc_log.debug("natural_exit_after_drain", returncode=proc.returncode)
                 return KillReason.NATURAL_EXIT
+            # Child-liveness deferral: same pattern as _session_log_monitor stale-kill suppression
+            if pid is not None and child_deferral_ceiling > 0:
+                deferral_start = anyio.current_time()
+                _poll_interval = 2.0
+                while (anyio.current_time() - deferral_start) < child_deferral_ceiling:
+                    if proc.returncode is not None:
+                        proc_log.debug("natural_exit_during_deferral", returncode=proc.returncode)
+                        return KillReason.NATURAL_EXIT
+                    active = (
+                        _has_active_child_processes(pid)
+                        or _has_active_api_connection(pid)
+                        or (
+                            marker_dir is not None
+                            and _has_active_execution_marker(marker_dir, session_id=session_id)
+                        )
+                    )
+                    if not active:
+                        proc_log.debug("no_active_children_proceeding_to_kill")
+                        break
+                    proc_log.debug(
+                        "child_liveness_deferral",
+                        elapsed=anyio.current_time() - deferral_start,
+                        ceiling=child_deferral_ceiling,
+                    )
+                    await anyio.sleep(_poll_interval)
             proc_log.debug("grace_expired_killing", grace_seconds=grace_seconds)
             await async_kill_process_tree(proc.pid)
             return KillReason.KILL_AFTER_COMPLETION
         case TerminationAction.IMMEDIATE_KILL:
+            if pid is not None and _has_active_child_processes(pid):
+                proc_log.warning(
+                    "immediate_kill_with_active_children",
+                    pid=pid,
+                )
             await async_kill_process_tree(proc.pid)
             return KillReason.INFRA_KILL
         case _ as unreachable:
@@ -221,6 +261,7 @@ async def run_managed_async(
     inspector_callback: InspectorCallback | None = None,
     workload_basenames: frozenset[str] | None = None,
     on_session_id_resolved: Callable[[str], None] | None = None,
+    child_deferral_ceiling: float = 0.0,
 ) -> SubprocessResult:
     """Async subprocess execution with temp file I/O and process tree cleanup.
 
@@ -477,6 +518,10 @@ async def run_managed_async(
                 process_exited_event=signals.process_exited_event,
                 grace_seconds=natural_exit_grace_seconds,
                 proc_log=proc_log,
+                pid=_observed_pid,
+                marker_dir=marker_dir,
+                session_id=session_id,
+                child_deferral_ceiling=child_deferral_ceiling,
             )
 
             # Flush and close before reading
@@ -635,6 +680,7 @@ class DefaultSubprocessRunner:
         inspector_callback: InspectorCallback | None = None,
         workload_basenames: frozenset[str] | None = None,
         on_session_id_resolved: Callable[[str], None] | None = None,
+        child_deferral_ceiling: float = 0.0,
     ) -> SubprocessResult:
         return await run_managed_async(
             cmd,
@@ -653,6 +699,7 @@ class DefaultSubprocessRunner:
             on_pid_resolved=on_pid_resolved,
             enable_deadline_extension=enable_deadline_extension,
             max_extension_seconds=max_extension_seconds,
+            child_deferral_ceiling=child_deferral_ceiling,
             marker_dir=marker_dir,
             session_id=session_id,
             stream_parser=stream_parser,

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -142,6 +142,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
         inspector_callback: InspectorCallback | None = None,
         workload_basenames: frozenset[str] | None = None,
         on_session_id_resolved: Callable[[str], None] | None = None,
+        child_deferral_ceiling: float = 0.0,
     ) -> SubprocessResult:
         step_name = (env or {}).get(SCENARIO_STEP_NAME_ENV, "")
 
@@ -178,6 +179,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
                     step_name=step_name,
                     completion_record_types=completion_record_types,
                     session_record_types=session_record_types,
+                    child_deferral_ceiling=child_deferral_ceiling,
                 )
 
             # Non-Codex, non-PTY with step_name: run inner + record summary.
@@ -203,6 +205,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
                 stream_parser=stream_parser,
                 completion_record_types=completion_record_types,
                 session_record_types=session_record_types,
+                child_deferral_ceiling=child_deferral_ceiling,
             )
             self.recorder.record_non_session_step(
                 step_name=step_name,
@@ -237,6 +240,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
             stream_parser=stream_parser,
             completion_record_types=completion_record_types,
             session_record_types=session_record_types,
+            child_deferral_ceiling=child_deferral_ceiling,
         )
 
     async def _record_session(
@@ -312,6 +316,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
         step_name: str,
         completion_record_types: frozenset[str] = frozenset({"result"}),
         session_record_types: frozenset[str] = frozenset({"assistant"}),
+        child_deferral_ceiling: float = 0.0,
     ) -> SubprocessResult:
         """Record a non-PTY (Codex) session step via cassette files."""
         result = await self._inner(
@@ -336,6 +341,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
             stream_parser=stream_parser,
             completion_record_types=completion_record_types,
             session_record_types=session_record_types,
+            child_deferral_ceiling=child_deferral_ceiling,
         )
 
         if self._scenario_dir is None:
@@ -433,6 +439,7 @@ class ReplayingSubprocessRunner(SubprocessRunner):
         inspector_callback: InspectorCallback | None = None,
         workload_basenames: frozenset[str] | None = None,
         on_session_id_resolved: Callable[[str], None] | None = None,
+        child_deferral_ceiling: float = 0.0,
     ) -> SubprocessResult:
         step_name = (env or {}).get(SCENARIO_STEP_NAME_ENV, "")
 

--- a/tests/arch/test_watcher_signal_consistency.py
+++ b/tests/arch/test_watcher_signal_consistency.py
@@ -12,6 +12,7 @@ pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 _CLI_APP = Path("src/autoskillit/cli/app.py")
 _PROCESS_RACE = Path("src/autoskillit/execution/process/_process_race.py")
 _PROCESS_MONITOR = Path("src/autoskillit/execution/process/_process_monitor.py")
+_PROCESS_INIT = Path("src/autoskillit/execution/process/__init__.py")
 
 _WATCHERS_THAT_MUST_CHECK_EXECUTION_MARKER = frozenset(
     {
@@ -60,5 +61,23 @@ def test_signal_guard_activity_check_calls_has_active_execution_marker(fn_name: 
     callers = _functions_calling_predicate(_CLI_APP, "_has_active_execution_marker")
     assert fn_name in callers, (
         f"{fn_name} in cli/app.py does not call _has_active_execution_marker. "
+        f"Functions that do: {sorted(callers)}"
+    )
+
+
+_KILL_EXECUTORS_THAT_MUST_CHECK_CHILD_LIVENESS = frozenset(
+    {
+        "execute_termination_action",
+    }
+)
+
+
+@pytest.mark.parametrize("executor", sorted(_KILL_EXECUTORS_THAT_MUST_CHECK_CHILD_LIVENESS))
+def test_kill_executor_checks_child_liveness(executor: str) -> None:
+    """Kill executors authorized to call async_kill_process_tree must consult
+    _has_active_child_processes before killing on the COMPLETED path."""
+    callers = _functions_calling_predicate(_PROCESS_INIT, "_has_active_child_processes")
+    assert executor in callers, (
+        f"{executor} does not call _has_active_child_processes. "
         f"Functions that do: {sorted(callers)}"
     )

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -499,6 +499,18 @@ class TestRunSkillConfigStreamIdleTimeout:
             RunSkillConfig(stream_idle_timeout_ms=-1)
 
 
+class TestRunSkillConfigCompletionChildDeferralCeiling:
+    def test_default_completion_child_deferral_ceiling_is_120(self):
+        cfg = AutomationConfig()
+        assert cfg.run_skill.completion_child_deferral_ceiling_seconds == 120.0
+
+    def test_negative_completion_child_deferral_ceiling_raises(self):
+        with pytest.raises(
+            ValueError, match=r"completion_child_deferral_ceiling_seconds=-1(\.0)? must be >= 0"
+        ):
+            RunSkillConfig(completion_child_deferral_ceiling_seconds=-1)
+
+
 class TestLoggingConfig:
     """LoggingConfig dataclass and YAML loading."""
 

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -411,6 +411,7 @@ class TestGroupDApiContractPreservation:
             "inspector_callback",
             "workload_basenames",
             "on_session_id_resolved",
+            "child_deferral_ceiling",
         }
         assert expected == public_params, (
             f"run_managed_async public params changed.\n"
@@ -483,6 +484,7 @@ class TestGroupDApiContractPreservation:
             "inspector_callback",
             "workload_basenames",
             "on_session_id_resolved",
+            "child_deferral_ceiling",
         }
         assert expected == actual, (
             f"DefaultSubprocessRunner.__call__ params changed.\n"

--- a/tests/execution/test_termination_executor.py
+++ b/tests/execution/test_termination_executor.py
@@ -101,7 +101,8 @@ class TestDrainWindowEscalatesToKill:
 
         async def _mock_kill(pid: int, timeout: float = 2.0) -> None:
             kill_calls.append(pid)
-            await proc.aclose()
+            proc.kill()
+            await proc.wait()
 
         import structlog
 
@@ -138,7 +139,8 @@ class TestImmediateKillSkipsDrain:
         async def _mock_kill(pid: int, timeout: float = 2.0) -> None:
             call_time.append(time.monotonic())
             kill_calls.append(pid)
-            await proc.aclose()
+            proc.kill()
+            await proc.wait()
 
         import structlog
 
@@ -219,7 +221,8 @@ class TestChildLivenessDefersKill:
 
         async def _mock_kill(pid: int, timeout: float = 2.0) -> None:
             kill_calls.append(pid)
-            await proc.aclose()
+            proc.kill()
+            await proc.wait()
 
         import structlog
 
@@ -269,7 +272,8 @@ class TestChildLivenessFastKillUnchanged:
 
         async def _mock_kill(pid: int, timeout: float = 2.0) -> None:
             kill_calls.append(pid)
-            await proc.aclose()
+            proc.kill()
+            await proc.wait()
 
         import structlog
 
@@ -317,7 +321,8 @@ class TestChildLivenessCeilingExceeded:
 
         async def _mock_kill(pid: int, timeout: float = 2.0) -> None:
             kill_calls.append(pid)
-            await proc.aclose()
+            proc.kill()
+            await proc.wait()
 
         import structlog
 
@@ -370,7 +375,8 @@ class TestChildLivenessChildExitsDuringDeferral:
 
         async def _mock_kill(pid: int, timeout: float = 2.0) -> None:
             kill_calls.append(pid)
-            await proc.aclose()
+            proc.kill()
+            await proc.wait()
 
         import structlog
 

--- a/tests/execution/test_termination_executor.py
+++ b/tests/execution/test_termination_executor.py
@@ -197,3 +197,214 @@ class TestNoKillNeverTouchesKillHelper:
 
         assert kill_reason == KillReason.NATURAL_EXIT
         assert kill_calls == [], f"NO_KILL must not call async_kill_process_tree, got {kill_calls}"
+
+
+class TestChildLivenessDefersKill:
+    """DRAIN_THEN_KILL_IF_ALIVE + active children: kill is deferred beyond grace_seconds.
+
+    Child-process liveness is simulated via a mock on _has_active_child_processes
+    (the same usage-site patching style already used for async_kill_process_tree
+    in this file) rather than relying on real psutil CPU-percent sampling, which
+    requires a priming call before it reports non-zero usage and would make the
+    test's timing assertions racy under CI load.
+    """
+
+    @pytest.mark.anyio
+    async def test_active_children_defer_kill_past_grace_seconds(self, tmp_path) -> None:
+        """Active child processes defer the kill past grace_seconds, then kill fires."""
+        proc = await _spawn_script(_EXIT_AFTER_SLEEP, ["10.0"], tmp_path)
+        proc_exited_event = anyio.Event()
+
+        kill_calls: list[int] = []
+
+        async def _mock_kill(pid: int, timeout: float = 2.0) -> None:
+            kill_calls.append(pid)
+            await proc.aclose()
+
+        import structlog
+
+        proc_log = structlog.get_logger().bind(pid=proc.pid)
+        start = time.monotonic()
+
+        with (
+            patch(
+                "autoskillit.execution.process.async_kill_process_tree",
+                side_effect=_mock_kill,
+            ),
+            patch(
+                "autoskillit.execution.process._has_active_child_processes",
+                return_value=True,
+            ),
+            patch(
+                "autoskillit.execution.process._has_active_api_connection",
+                return_value=False,
+            ),
+        ):
+            kill_reason = await execute_termination_action(
+                TerminationAction.DRAIN_THEN_KILL_IF_ALIVE,
+                proc=proc,
+                process_exited_event=proc_exited_event,
+                grace_seconds=0.5,
+                proc_log=proc_log,
+                pid=proc.pid,
+                child_deferral_ceiling=1.5,
+            )
+
+        elapsed = time.monotonic() - start
+        assert kill_reason == KillReason.KILL_AFTER_COMPLETION
+        assert len(kill_calls) == 1
+        assert elapsed > 0.5, f"Expected deferral past grace_seconds=0.5, took only {elapsed:.3f}s"
+
+
+class TestChildLivenessFastKillUnchanged:
+    """DRAIN_THEN_KILL_IF_ALIVE + child_deferral_ceiling=0: fast kill unchanged (today)."""
+
+    @pytest.mark.anyio
+    async def test_zero_ceiling_disables_deferral(self, tmp_path) -> None:
+        """child_deferral_ceiling=0 must never consult child-liveness predicates."""
+        proc = await _spawn_script(_EXIT_AFTER_SLEEP, ["10.0"], tmp_path)
+        proc_exited_event = anyio.Event()
+
+        kill_calls: list[int] = []
+
+        async def _mock_kill(pid: int, timeout: float = 2.0) -> None:
+            kill_calls.append(pid)
+            await proc.aclose()
+
+        import structlog
+
+        proc_log = structlog.get_logger().bind(pid=proc.pid)
+        start = time.monotonic()
+
+        with (
+            patch(
+                "autoskillit.execution.process.async_kill_process_tree",
+                side_effect=_mock_kill,
+            ),
+            patch(
+                "autoskillit.execution.process._has_active_child_processes",
+            ) as mock_has_active,
+        ):
+            kill_reason = await execute_termination_action(
+                TerminationAction.DRAIN_THEN_KILL_IF_ALIVE,
+                proc=proc,
+                process_exited_event=proc_exited_event,
+                grace_seconds=0.3,
+                proc_log=proc_log,
+                pid=proc.pid,
+                child_deferral_ceiling=0.0,
+            )
+
+        elapsed = time.monotonic() - start
+        assert kill_reason == KillReason.KILL_AFTER_COMPLETION
+        assert len(kill_calls) == 1, f"Expected exactly one kill call, got {kill_calls}"
+        assert elapsed < 1.0, (
+            f"ceiling=0 should behave like today's fast kill, took {elapsed:.3f}s"
+        )
+        mock_has_active.assert_not_called()
+
+
+class TestChildLivenessCeilingExceeded:
+    """DRAIN_THEN_KILL_IF_ALIVE + active children past ceiling: kill proceeds despite activity."""
+
+    @pytest.mark.anyio
+    async def test_kill_proceeds_once_ceiling_exceeded(self, tmp_path) -> None:
+        """Kill fires shortly after child_deferral_ceiling expires even if child stays active."""
+        proc = await _spawn_script(_EXIT_AFTER_SLEEP, ["10.0"], tmp_path)
+        proc_exited_event = anyio.Event()
+
+        kill_calls: list[int] = []
+
+        async def _mock_kill(pid: int, timeout: float = 2.0) -> None:
+            kill_calls.append(pid)
+            await proc.aclose()
+
+        import structlog
+
+        proc_log = structlog.get_logger().bind(pid=proc.pid)
+        start = time.monotonic()
+
+        with (
+            patch(
+                "autoskillit.execution.process.async_kill_process_tree",
+                side_effect=_mock_kill,
+            ),
+            patch(
+                "autoskillit.execution.process._has_active_child_processes",
+                return_value=True,
+            ),
+            patch(
+                "autoskillit.execution.process._has_active_api_connection",
+                return_value=False,
+            ),
+        ):
+            kill_reason = await execute_termination_action(
+                TerminationAction.DRAIN_THEN_KILL_IF_ALIVE,
+                proc=proc,
+                process_exited_event=proc_exited_event,
+                grace_seconds=0.2,
+                proc_log=proc_log,
+                pid=proc.pid,
+                child_deferral_ceiling=1.0,
+            )
+
+        elapsed_after_grace = (time.monotonic() - start) - 0.2
+        assert kill_reason == KillReason.KILL_AFTER_COMPLETION
+        assert len(kill_calls) == 1
+        assert 1.0 <= elapsed_after_grace <= 3.0, (
+            f"Expected kill within ~1s of ceiling expiry (1.0s), "
+            f"deferral loop ran for {elapsed_after_grace:.3f}s"
+        )
+
+
+class TestChildLivenessChildExitsDuringDeferral:
+    """DRAIN_THEN_KILL_IF_ALIVE: child becomes inactive mid-deferral → kill proceeds."""
+
+    @pytest.mark.anyio
+    async def test_kill_proceeds_once_children_go_inactive(self, tmp_path) -> None:
+        """Once the liveness predicate reports inactive, the next poll proceeds to kill."""
+        proc = await _spawn_script(_EXIT_AFTER_SLEEP, ["10.0"], tmp_path)
+        proc_exited_event = anyio.Event()
+
+        kill_calls: list[int] = []
+
+        async def _mock_kill(pid: int, timeout: float = 2.0) -> None:
+            kill_calls.append(pid)
+            await proc.aclose()
+
+        import structlog
+
+        proc_log = structlog.get_logger().bind(pid=proc.pid)
+        start = time.monotonic()
+
+        with (
+            patch(
+                "autoskillit.execution.process.async_kill_process_tree",
+                side_effect=_mock_kill,
+            ),
+            patch(
+                "autoskillit.execution.process._has_active_child_processes",
+                side_effect=[True, False],
+            ),
+            patch(
+                "autoskillit.execution.process._has_active_api_connection",
+                return_value=False,
+            ),
+        ):
+            kill_reason = await execute_termination_action(
+                TerminationAction.DRAIN_THEN_KILL_IF_ALIVE,
+                proc=proc,
+                process_exited_event=proc_exited_event,
+                grace_seconds=0.2,
+                proc_log=proc_log,
+                pid=proc.pid,
+                child_deferral_ceiling=30.0,
+            )
+
+        elapsed_after_grace = (time.monotonic() - start) - 0.2
+        assert kill_reason == KillReason.KILL_AFTER_COMPLETION
+        assert len(kill_calls) == 1
+        assert elapsed_after_grace < 30.0, (
+            "Kill should proceed as soon as the second poll reports inactivity, "
+            "well before the 30s ceiling"
+        )


### PR DESCRIPTION
## Summary

The completion-triggered kill path (`DRAIN_THEN_KILL_IF_ALIVE`) in `execute_termination_action()` kills the entire process tree after a fixed `grace_seconds` window without checking whether child processes are still active. Three child-liveness predicates (`_has_active_child_processes`, `_has_active_api_connection`, `_has_active_execution_marker`) already exist in `_process_monitor.py`, are already imported into `process/__init__.py`, and are already consumed by two other kill-suppression sites (the stale-kill path and the deadline-extension watcher) — but the completion-kill path has zero visibility into them. Additionally, a structural AST guard (`test_watcher_signal_consistency.py`) enforces that watchers call these predicates, but `execute_termination_action` is not a "watcher" and falls outside the guard's scope — making the gap structurally invisible to the test suite.

Part A delivers: the child-aware completion deferral in `execute_termination_action`, the AST guard extension to cover kill executors, and the full test suite. Part B will cover stream parser event recognition, `background_exec_guard` modernization, and `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` environment enforcement for skill sessions.

Closes #4233

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260713-153841-626795/.autoskillit/temp/rectify/rectify_async_subagent_completion_kill_2026-07-13_160800.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| review_approach* | fable | 1 | 44.1k | 17.7k | 437.1k | 59.6k | 21 | 154.4k | 7m 45s |
| investigate* | opus | 1 | 15 | 8.8k | 419.9k | 89.0k | 50 | 43.7k | 6m 26s |
| rectify* | opus[1m] | 1 | 37 | 7.1k | 1.6M | 150.2k | 83 | 31.4k | 18m 36s |
| dry_walkthrough* | sonnet | 1 | 22.7k | 30.5k | 2.2M | 150.0k | 55 | 150.1k | 5m 24s |
| implement* | sonnet | 1 | 94.8k | 52.4k | 12.0M | 248.1k | 165 | 223.1k | 10m 14s |
| resolve_failures* | opus[1m] | 1 | 56 | 20.6k | 2.0M | 92.2k | 53 | 92.4k | 12m 56s |
| audit_impl* | sonnet | 1 | 33.7k | 36.3k | 7.6M | 154.0k | 112 | 82.4k | 8m 48s |
| prepare_pr* | sonnet | 1 | 9.4k | 7.6k | 586.9k | 68.8k | 23 | 45.4k | 1m 30s |
| compose_pr* | sonnet | 1 | 9.4k | 5.1k | 538.8k | 56.7k | 20 | 32.6k | 1m 4s |
| **Total** | | | 214.3k | 186.1k | 27.3M | 248.1k | | 855.6k | 1h 12m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| review_approach | 0 | — | — | — |
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 0 | — | — | — |
| resolve_failures | 18 | 113792.4 | 5133.2 | 1141.8 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **18** | 1516759.1 | 47535.3 | 10337.3 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| fable | 1 | 44.1k | 17.7k | 437.1k | 154.4k | 7m 45s |
| opus | 1 | 15 | 8.8k | 419.9k | 43.7k | 6m 26s |
| opus[1m] | 2 | 93 | 27.6k | 3.6M | 123.8k | 31m 33s |
| sonnet | 5 | 170.0k | 131.9k | 22.8M | 533.7k | 27m 3s |