### PR TITLE
Remediation Plan: command_guards_verb_position

### DIFF
--- a/src/autoskillit/core/bash_write_targets.py
+++ b/src/autoskillit/core/bash_write_targets.py
@@ -65,6 +65,23 @@ _ENV_VALUE_FLAGS: frozenset[str] = frozenset(
     {"-u", "--unset", "-C", "--chdir", "-S", "--split-string", "--argv0"}
 )
 
+_WRAPPER_VALUE_FLAGS_DETACHED: frozenset[str] = frozenset(
+    {
+        "-u",
+        "--user",
+        "-n",
+        "--adjustment",
+        "-k",
+        "--kill-after",
+        "-s",
+        "--signal",
+        "-g",
+        "--group",
+        "-p",
+        "--priority",
+    }
+)
+
 
 def _resolve_write_target(path: str, cwd: str = "") -> str | None:
     if not path:
@@ -206,6 +223,31 @@ def _is_posix_assignment(token: str) -> bool:
     return all(c.isalnum() or c == "_" for c in name)
 
 
+def _consume_wrapper_options(start: int, segment: list[str]) -> int:
+    """Skip past a wrapper's attached/detached value options.
+
+    Wrappers (sudo, nice, nohup, time, command) accept option flags before
+    the inner command. Many take values either attached (--user=root) or as
+    the next detached token (-u root). Returns the index of the first
+    non-option token.
+    """
+    i = start
+    while i < len(segment):
+        token = segment[i]
+        if token == "--":
+            return i + 1
+        if not token.startswith("-"):
+            return i
+        if "=" in token:
+            i += 1
+            continue
+        if token in _WRAPPER_VALUE_FLAGS_DETACHED and i + 1 < len(segment):
+            i += 2
+            continue
+        i += 1
+    return i
+
+
 def _command_start_index(segment: list[str]) -> int | None:
     if not segment:
         return None
@@ -226,7 +268,11 @@ def _command_start_index(segment: list[str]) -> int | None:
                 start += 1
             continue
         if token in _COMMAND_WRAPPERS:
-            start += 1
+            new_start = _consume_wrapper_options(start + 1, segment)
+            if new_start <= start + 1:
+                start += 1
+                continue
+            start = new_start
             continue
         if token in _WRAPPERS_WITH_DURATION and start + 1 < len(segment):
             start += 2

--- a/src/autoskillit/core/bash_write_targets.py
+++ b/src/autoskillit/core/bash_write_targets.py
@@ -15,7 +15,7 @@ import os
 import re
 import shlex
 
-_SHELL_OPS: frozenset[str] = frozenset({"&&", "||", ";", "!", "|", "("})
+_SPLIT_TOKENS: frozenset[str] = frozenset({"&&", "||", ";", "|", "&"})
 
 _HEREDOC_BODY_RE = re.compile(
     r"(<<-?\s*['\"]?(\w+)['\"]?[^\n]*)\n.*?\n\t*(\2)(?=[ \t]*(?:\n|$))",
@@ -52,6 +52,20 @@ _WRITE_VERBS: frozenset[str] = frozenset(
 
 _GIT_FLAG_WITH_VALUE: frozenset[str] = frozenset({"-C", "--git-dir", "--work-tree", "-c"})
 
+_COMMAND_WRAPPERS: frozenset[str] = frozenset({"command", "nice", "time", "sudo", "nohup"})
+_WRAPPERS_WITH_DURATION: frozenset[str] = frozenset({"timeout"})
+_WRAPPERS_WITH_SHORT_FLAG: frozenset[str] = frozenset({"stdbuf"})
+
+_ENV_NO_VALUE_FLAGS: frozenset[str] = frozenset(
+    {"-i", "-0", "-v", "-V", "--help", "--version", "--ignore-environment", "--null", "--debug"}
+)
+_ENV_VALUE_FLAGS: frozenset[str] = frozenset(
+    {"-u", "--unset", "-C", "--chdir", "-S", "--split-string", "--argv0"}
+)
+_ENV_VALUE_FLAGS_ATTACHED: frozenset[str] = frozenset(
+    {"-u", "--unset", "-C", "--chdir", "--argv0"}
+)
+
 
 def _resolve_write_target(path: str, cwd: str = "") -> str | None:
     if not path:
@@ -73,15 +87,46 @@ def _strip_heredoc_bodies(command: str) -> str:
     return _HEREDOC_BODY_RE.sub(r"\1\n\3", command)
 
 
+def _normalize_newlines(command: str) -> str:
+    result: list[str] = []
+    in_single = False
+    in_double = False
+    i = 0
+    while i < len(command):
+        c = command[i]
+        if c == "\\" and not in_single and i + 1 < len(command):
+            result.append(c)
+            result.append(command[i + 1])
+            i += 2
+            continue
+        if c == "'" and not in_double:
+            in_single = not in_single
+        elif c == '"' and not in_single:
+            in_double = not in_double
+        elif c == "\n" and not in_single and not in_double:
+            result.append(" ; ")
+            i += 1
+            continue
+        result.append(c)
+        i += 1
+    return "".join(result)
+
+
 def _tokenize_command_segments(command: str) -> list[list[str]]:
     try:
-        tokens = shlex.split(_strip_heredoc_bodies(command))
+        lexer = shlex.shlex(
+            _normalize_newlines(_strip_heredoc_bodies(command)),
+            posix=True,
+            punctuation_chars=";&|",
+        )
+        lexer.whitespace_split = True
+        tokens = list(lexer)
     except (ValueError, TypeError):
         return []
     segments: list[list[str]] = []
     current: list[str] = []
     for token in tokens:
-        if token in _SHELL_OPS:
+        if token in _SPLIT_TOKENS:
             if current:
                 segments.append(current)
                 current = []
@@ -148,6 +193,53 @@ def _extract_redirect_targets(tokens: list[str], cwd: str = "") -> list[str]:
                     targets.append(resolved)
         i += 1
     return targets
+
+
+def _is_posix_assignment(token: str) -> bool:
+    if "=" not in token or token.startswith("="):
+        return False
+    name, _sep, _value = token.partition("=")
+    if not name:
+        return False
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def _command_start_index(segment: list[str]) -> int | None:
+    if not segment:
+        return None
+    start = 0
+    while start < len(segment):
+        token = segment[start]
+        if _is_posix_assignment(token):
+            start += 1
+            continue
+        if token == "env":
+            start += 1
+            while start < len(segment) and (
+                segment[start].startswith("-") or "=" in segment[start]
+            ):
+                if segment[start] in _ENV_VALUE_FLAGS and start + 1 < len(segment):
+                    start += 2
+                    continue
+                start += 1
+            continue
+        if token in _COMMAND_WRAPPERS:
+            start += 1
+            continue
+        if token in _WRAPPERS_WITH_DURATION and start + 1 < len(segment):
+            start += 2
+            continue
+        if (
+            token in _WRAPPERS_WITH_SHORT_FLAG
+            and start + 1 < len(segment)
+            and segment[start + 1].startswith("-")
+        ):
+            start += 2
+            continue
+        break
+    return start if start < len(segment) else None
 
 
 def _command_verb(segment: list[str]) -> str:

--- a/src/autoskillit/core/bash_write_targets.py
+++ b/src/autoskillit/core/bash_write_targets.py
@@ -22,6 +22,11 @@ _HEREDOC_BODY_RE = re.compile(
     re.DOTALL,
 )
 
+# After _strip_heredoc_bodies() a heredoc collapses to "<<WORD ...\nWORD".
+# This removes the marker and terminator, keeping the rest of the opening
+# line (real redirects), so segments carry only executable tokens.
+_HEREDOC_MARKER_RE = re.compile(r"<<-?\s*['\"]?(\w+)['\"]?([^\n]*)\n\t*\1(?=[ \t]*(?:\n|$))")
+
 _REDIRECT_TOKEN_RE = re.compile(r"^(\d*)>{1,2}(.+)$")
 _REDIRECT_OP_ONLY_RE = re.compile(r"^(\d*)>{1,2}$")
 _FD_REDIRECT_RE = re.compile(r"^\d*>{1,2}&")
@@ -114,8 +119,9 @@ def _normalize_newlines(command: str) -> str:
 
 def _tokenize_command_segments(command: str) -> list[list[str]]:
     try:
+        stripped = _HEREDOC_MARKER_RE.sub(r"\2", _strip_heredoc_bodies(command))
         lexer = shlex.shlex(
-            _normalize_newlines(_strip_heredoc_bodies(command)),
+            _normalize_newlines(stripped),
             posix=True,
             punctuation_chars=";&|",
         )

--- a/src/autoskillit/core/bash_write_targets.py
+++ b/src/autoskillit/core/bash_write_targets.py
@@ -61,14 +61,8 @@ _COMMAND_WRAPPERS: frozenset[str] = frozenset({"command", "nice", "time", "sudo"
 _WRAPPERS_WITH_DURATION: frozenset[str] = frozenset({"timeout"})
 _WRAPPERS_WITH_SHORT_FLAG: frozenset[str] = frozenset({"stdbuf"})
 
-_ENV_NO_VALUE_FLAGS: frozenset[str] = frozenset(
-    {"-i", "-0", "-v", "-V", "--help", "--version", "--ignore-environment", "--null", "--debug"}
-)
 _ENV_VALUE_FLAGS: frozenset[str] = frozenset(
     {"-u", "--unset", "-C", "--chdir", "-S", "--split-string", "--argv0"}
-)
-_ENV_VALUE_FLAGS_ATTACHED: frozenset[str] = frozenset(
-    {"-u", "--unset", "-C", "--chdir", "--argv0"}
 )
 
 
@@ -249,14 +243,10 @@ def _command_start_index(segment: list[str]) -> int | None:
 
 
 def _command_verb(segment: list[str]) -> str:
-    if not segment:
+    start = _command_start_index(segment)
+    if start is None:
         return ""
-    start = 0
-    if segment[0] == "env" and len(segment) > 1:
-        start = 1
-        while start < len(segment) and (segment[start].startswith("-") or "=" in segment[start]):
-            start += 1
-    return segment[start] if start < len(segment) else ""
+    return segment[start]
 
 
 def _is_gh_command(segment: list[str]) -> bool:
@@ -264,6 +254,11 @@ def _is_gh_command(segment: list[str]) -> bool:
 
 
 def _extract_segment_targets(segment: list[str], cwd: str) -> list[str] | None:
+    start = _command_start_index(segment)
+    if start is None:
+        return None
+    segment = segment[start:]
+
     if _is_gh_command(segment):
         return None
 

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -98,7 +98,6 @@ _ENV_NO_VALUE_FLAGS: frozenset[str] = frozenset(
         "--ignore-environment",
         "--null",
         "--debug",
-        "--split-string",
     }
 )
 _ENV_VALUE_FLAGS: frozenset[str] = frozenset(

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -997,7 +997,7 @@ def _literal_to_string(node: ast.AST) -> str | None:
     return None
 
 
-def extract_interpreter_command_payloads(command: str) -> tuple[list, bool]:
+def extract_interpreter_command_payloads(command: str) -> tuple[list[str | list[str]], bool]:
     """Return (literal command payloads, has_unresolved_subprocess).
 
     Each payload is either a shell-command string (for `shell=True` calls or
@@ -1005,7 +1005,7 @@ def extract_interpreter_command_payloads(command: str) -> tuple[list, bool]:
     calls). has_unresolved_subprocess is True when a matching process-launch
     call was present but its arguments could not be statically resolved.
     """
-    payloads: list = []
+    payloads: list[str | list[str]] = []
     has_unresolved = False
     if not _INTERPRETER_RE.search(command):
         return (payloads, has_unresolved)

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -791,6 +791,42 @@ def extract_shell_command_payloads(command: str) -> list[str]:
     return payloads
 
 
+def tokenize_shell_payload_segments(command: str) -> list[list[str]] | None:
+    """Return tokenized segments for every evaluated shell payload in *command*.
+
+    Walks the outer command and every extracted payload recursively with a
+    ``seen`` set so nested ``bash -c``, ``eval``, and active-substitution
+    payloads are tokenized once without loops. Each successfully parsed
+    segment of every payload is appended to the result so callers can apply
+    verb-position policies like ``command_verb_and_args`` to each segment.
+
+    Returns ``None`` when the outer command or any non-empty evaluated
+    payload cannot be tokenized; callers interpret ``None`` as no deny
+    match (fail-open). Returns ``[]`` when the command has no evaluated
+    shell payload to traverse.
+    """
+    outer = tokenize_command_segments(command)
+    if not outer and command.strip():
+        return None
+
+    result: list[list[str]] = []
+    seen: set[str] = set()
+    queue: list[str] = list(extract_shell_command_payloads(command))
+    while queue:
+        payload = queue.pop(0)
+        if payload in seen:
+            continue
+        seen.add(payload)
+        if not payload.strip():
+            continue
+        segments = tokenize_command_segments(payload)
+        if not segments and payload.strip():
+            return None
+        result.extend(segments)
+        queue.extend(extract_shell_command_payloads(payload))
+    return result
+
+
 def _extract_substitution_payloads(command: str) -> list[str]:
     """Quote/escape-aware state machine that returns active substitution bodies."""
     payloads: list[str] = []

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -45,13 +45,16 @@ _WRITE_CALL_SITE_RE = re.compile(
     r"|shutil\.(?:copy|move|copyfile|copytree)\s*\("
 )
 
-# Operators that terminate a shell token (shlex punctuation_chars set).
+# Operators that terminate a shlex token and split command segments.
+# Parentheses are tracked by the lexer as fused tokens (`(cmd` or `cmd)`)
+# and handled separately in extract_redirect_targets.
 _SHELL_OPERATORS: frozenset[str] = frozenset({"&&", "||", ";", "|", "&"})
 
-# Operators that are emitted as standalone tokens. Parentheses are tracked by
-# the lexer as fused tokens (`(cmd` or `cmd)`) and handled separately in
-# extract_redirect_targets; we only need to split on these here.
-_SPLIT_TOKENS: frozenset[str] = _SHELL_OPERATORS
+# Boundary-adjacency operator set for guards that scan raw shlex.split token
+# streams (pr_create, git_ops, planner_gh_discovery, artifact_download,
+# compose_pr_body): `!` and `(` may precede a fresh command verb there but
+# are not split tokens for the segment lexer above.
+_SHELL_OPS: frozenset[str] = frozenset({"&&", "||", ";", "!", "|", "("})
 
 # Command wrappers whose only effect is to invoke the next command with
 # adjusted environment/priority. The verb is the token after the wrapper.
@@ -166,8 +169,12 @@ _HEREDOC_BODY_RE = re.compile(
     re.DOTALL,
 )
 
+# After strip_heredoc_bodies() a heredoc collapses to "<<WORD ...\nWORD".
+# This removes the marker and terminator, keeping the rest of the opening
+# line (real redirects), so segments carry only executable tokens.
+_HEREDOC_MARKER_RE = re.compile(r"<<-?\s*['\"]?(\w+)['\"]?([^\n]*)\n\t*\1(?=[ \t]*(?:\n|$))")
+
 _PROTECTED_PATH_METADATA_GIT_SUBCOMMANDS: frozenset[str] = frozenset({"add", "diff", "status"})
-_COMMAND_WRAPPERS_DICT: frozenset[str] = _COMMAND_WRAPPERS
 
 _GIT_ADD_CONTENT_FLAGS: frozenset[str] = frozenset(
     {
@@ -281,8 +288,9 @@ def tokenize_command_segments(command: str) -> list[list[str]]:
     Returns [] on shlex parse error (unclosed quotes).
     """
     try:
+        stripped = _HEREDOC_MARKER_RE.sub(r"\2", strip_heredoc_bodies(command))
         lexer = shlex.shlex(
-            _normalize_newlines_for_tokenize(strip_heredoc_bodies(command)),
+            _normalize_newlines_for_tokenize(stripped),
             posix=True,
             punctuation_chars=";&|",
         )
@@ -294,7 +302,7 @@ def tokenize_command_segments(command: str) -> list[list[str]]:
     segments: list[list[str]] = []
     current: list[str] = []
     for token in tokens:
-        if token in _SPLIT_TOKENS:
+        if token in _SHELL_OPERATORS:
             if current:
                 segments.append(current)
                 current = []
@@ -451,28 +459,6 @@ def _consume_wrapper_options(start: int, segment: list[str]) -> int:
     return i
 
 
-def _consume_wrapper(token: str, start: int, segment: list[str]) -> int | None:
-    """Advance *start* past a single wrapper's required and optional args.
-
-    Returns None if a required argument is absent.
-    """
-    if token in _COMMAND_WRAPPERS_DICT:
-        return start
-    if token in _WRAPPERS_WITH_DURATION:
-        if start + 1 >= len(segment):
-            return None
-        return start + 2
-    if token in _WRAPPERS_WITH_SHORT_FLAG:
-        if start + 1 >= len(segment):
-            return None
-        if not segment[start + 1].startswith("-"):
-            return None
-        return start + 2
-    if token == "env":
-        return _consume_env(start + 1, segment)
-    return start
-
-
 def _command_start_index(segment: list[str]) -> int | None:
     if not segment:
         return None
@@ -485,7 +471,7 @@ def _command_start_index(segment: list[str]) -> int | None:
         if token == "env":
             start = _consume_env(start + 1, segment)
             continue
-        if token in _COMMAND_WRAPPERS_DICT:
+        if token in _COMMAND_WRAPPERS:
             start += 1
             continue
         if token in _WRAPPERS_WITH_DURATION and start + 1 < len(segment):
@@ -523,7 +509,7 @@ def command_verb_and_args(segment: list[str]) -> tuple[str, list[str]]:
                 return ("", [])
             start = new_start
             continue
-        if token in _COMMAND_WRAPPERS_DICT:
+        if token in _COMMAND_WRAPPERS:
             # Wrappers (sudo, nice, etc.) may consume attached/detached value options.
             new_start = _consume_wrapper_options(start + 1, segment)
             if new_start <= start + 1:
@@ -760,11 +746,7 @@ def has_nested_shell(command: str) -> bool:
     return bool(_NESTED_SHELL_RE.search(command))
 
 
-# --- Phase 2/3 helpers for unsafe install detection ---
-
-
 _SHELL_INTERPRETERS: frozenset[str] = frozenset({"bash", "sh", "zsh", "dash"})
-_PYTHON_INTERPRETERS: frozenset[str] = frozenset({"python", "python3"})
 
 
 def _normalize_executable(token: str) -> str:
@@ -780,105 +762,6 @@ def _is_shell_interpreter(token: str) -> bool:
         if base.startswith(name) and base[len(name) :].isdigit():
             return True
     return False
-
-
-def _is_python_interpreter(token: str) -> bool:
-    base = _normalize_executable(token)
-    if base in _PYTHON_INTERPRETERS:
-        return True
-    if base.startswith("python") and base[len("python") :].replace(".", "").isdigit():
-        return True
-    return False
-
-
-def _is_pip_executable(token: str) -> bool:
-    base = _normalize_executable(token)
-    if base == "pip":
-        return True
-    if base.startswith("pip") and base[3:].replace(".", "").isdigit():
-        return True
-    return False
-
-
-def _is_uv_executable(token: str) -> bool:
-    return _normalize_executable(token) == "uv"
-
-
-def _is_maturin_executable(token: str) -> bool:
-    return _normalize_executable(token) == "maturin"
-
-
-# Sentinel install subcommand tokens; ordered matchers consume these in sequence.
-_PIP_INSTALL_SUBCOMMAND = "install"
-_UV_PIP_SUBCOMMAND_CHAIN = ("pip", "install")
-_PYTHON_MODULE_PIP_SUBCOMMAND_CHAIN = ("-m", "pip", "install")
-_MATURIN_DEVELOP_SUBCOMMAND = "develop"
-
-
-# Sentinel install subcommand tokens; ordered matchers consume these in sequence.
-_PIP_INSTALL_SUBCOMMAND = "install"
-_UV_PIP_SUBCOMMAND_CHAIN = ("pip", "install")
-_PYTHON_MODULE_PIP_SUBCOMMAND_CHAIN = ("-m", "pip", "install")
-_MATURIN_DEVELOP_SUBCOMMAND = "develop"
-
-
-_PIP_DETACHED_VALUE_FLAGS: frozenset[str] = frozenset(
-    {
-        "-r",
-        "-c",
-        "-t",
-        "-b",
-        "--requirement",
-        "--constraint",
-        "--target",
-        "--prefix",
-        "--src",
-        "--build",
-        "--download",
-        "--index-url",
-        "--extra-index-url",
-        "--find-links",
-        "--editable",
-        "-e",
-    }
-)
-
-
-def _match_pip_install(args: list[str]) -> tuple[list[str], list[str]] | None:
-    """Return (install_args, post_install_args) for `pip install` if matched.
-
-    Consumes leading global pip options then verifies the next non-option
-    token is exactly 'install'. Returns None when the grammar does not match
-    (e.g. `pip help install` or `pip install --help`).
-    """
-    i = 0
-    while i < len(args):
-        token = args[i]
-        if token == "--":
-            i += 1
-            break
-        if token.startswith("-"):
-            if "=" in token:
-                i += 1
-                continue
-            if token in _PIP_DETACHED_VALUE_FLAGS and i + 1 < len(args):
-                i += 2
-                continue
-            i += 1
-            continue
-        break
-    if i >= len(args) or args[i] != _PIP_INSTALL_SUBCOMMAND:
-        return None
-    install_args = args[: i + 1]
-    post_install_args = args[i + 1 :]
-    return (install_args, post_install_args)
-
-
-def _shlex_split_safe(payload: str) -> list[str]:
-    try:
-        return shlex.split(payload)
-    except (ValueError, TypeError):
-        return []
 
 
 def extract_shell_command_payloads(command: str) -> list[str]:
@@ -937,6 +820,7 @@ def _extract_substitution_payloads(command: str) -> list[str]:
                     while inner_end < n and command[inner_end] != "`":
                         inner_end += 1
                     inner = command[j + 1 : inner_end]
+                    payloads.append(inner)
                     payloads.extend(_extract_substitution_payloads(inner))
                     j = inner_end + 1
                     continue

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -7,6 +7,7 @@ _INTERPRETER_LINE_RE.
 
 from __future__ import annotations
 
+import ast
 import os
 import re
 import shlex
@@ -44,7 +45,25 @@ _WRITE_CALL_SITE_RE = re.compile(
     r"|shutil\.(?:copy|move|copyfile|copytree)\s*\("
 )
 
-_SHELL_OPS: frozenset[str] = frozenset({"&&", "||", ";", "!", "|", "("})
+# Operators that terminate a shell token (shlex punctuation_chars set).
+_SHELL_OPERATORS: frozenset[str] = frozenset({"&&", "||", ";", "|", "&"})
+
+# Operators that are emitted as standalone tokens. Parentheses are tracked by
+# the lexer as fused tokens (`(cmd` or `cmd)`) and handled separately in
+# extract_redirect_targets; we only need to split on these here.
+_SPLIT_TOKENS: frozenset[str] = _SHELL_OPERATORS
+
+# Command wrappers whose only effect is to invoke the next command with
+# adjusted environment/priority. The verb is the token after the wrapper.
+# 'xargs' is intentionally excluded: it dispatches a downstream reader and
+# adding it would let `xargs cat src/.../foo.yaml` reach the reader check,
+# weakening xargs-chain bypass detection (see D1 design decision).
+_COMMAND_WRAPPERS: frozenset[str] = frozenset({"command", "nice", "time", "sudo", "nohup"})
+# Wrappers that consume a mandatory DURATION as their first non-wrapper token.
+_WRAPPERS_WITH_DURATION: frozenset[str] = frozenset({"timeout"})
+# Wrappers that take a single short flag as their first non-wrapper token
+# (e.g. 'stdbuf -o0', 'stdbuf -i0', 'stdbuf -e0').
+_WRAPPERS_WITH_SHORT_FLAG: frozenset[str] = frozenset({"stdbuf"})
 
 # Shell control words that mark the start of a new command in compound
 # shell constructs (loops, conditionals, case statements). When a `gh` token
@@ -64,6 +83,78 @@ _SHELL_CONTROL_WORDS: frozenset[str] = frozenset(
     }
 )
 
+# env option arity tables.
+_ENV_NO_VALUE_FLAGS: frozenset[str] = frozenset(
+    {
+        "-i",
+        "-0",
+        "-v",
+        "-V",
+        "--help",
+        "--version",
+        "--ignore-environment",
+        "--null",
+        "--debug",
+        "--split-string",
+    }
+)
+_ENV_VALUE_FLAGS: frozenset[str] = frozenset(
+    {
+        "-u",
+        "--unset",
+        "-C",
+        "--chdir",
+        "-S",
+        "--split-string",
+        "--default-signal",
+        "--ignore-signal",
+        "--block-signal",
+        "--argv0",
+    }
+)
+# Flags that take a value either as the next token or attached with '='.
+_ENV_VALUE_FLAGS_ATTACHED: frozenset[str] = frozenset(
+    {
+        "-u",
+        "--unset",
+        "-C",
+        "--chdir",
+        "--argv0",
+        "--default-signal",
+        "--ignore-signal",
+        "--block-signal",
+    }
+)
+# Wrappers taking a value optionally attached ('-u=root', '--user=root').
+_WRAPPER_VALUE_FLAGS_ATTACHED: frozenset[str] = frozenset(
+    {
+        "-u",
+        "--user",
+        "-n",
+        "--adjustment",
+        "-k",
+        "--kill-after",
+        "-s",
+        "--signal",
+    }
+)
+_WRAPPER_VALUE_FLAGS_DETACHED: frozenset[str] = frozenset(
+    {
+        "-u",
+        "--user",
+        "-n",
+        "--adjustment",
+        "-k",
+        "--kill-after",
+        "-s",
+        "--signal",
+        "-g",
+        "--group",
+        "-p",
+        "--priority",
+    }
+)
+
 _REDIRECT_TOKEN_RE = re.compile(r"^(\d*)>{1,2}(.+)$")
 _REDIRECT_OP_ONLY_RE = re.compile(r"^(\d*)>{1,2}$")
 _FD_REDIRECT_RE = re.compile(r"^\d*>{1,2}&")
@@ -76,17 +167,8 @@ _HEREDOC_BODY_RE = re.compile(
 )
 
 _PROTECTED_PATH_METADATA_GIT_SUBCOMMANDS: frozenset[str] = frozenset({"add", "diff", "status"})
-# Command wrappers whose only effect is to invoke the next command with
-# adjusted environment/priority. The verb is the token after the wrapper.
-# 'xargs' is intentionally excluded: it dispatches a downstream reader and
-# adding it would let `xargs cat src/.../foo.yaml` reach the reader check,
-# weakening xargs-chain bypass detection (see D1 design decision).
-_COMMAND_WRAPPERS: frozenset[str] = frozenset({"command", "nice", "time", "sudo", "nohup"})
-# Wrappers that consume a mandatory DURATION as their first non-wrapper token.
-_WRAPPERS_WITH_DURATION: frozenset[str] = frozenset({"timeout"})
-# Wrappers that take a single short flag as their first non-wrapper token
-# (e.g. 'stdbuf -o0', 'stdbuf -i0', 'stdbuf -e0').
-_WRAPPERS_WITH_SHORT_FLAG: frozenset[str] = frozenset({"stdbuf"})
+_COMMAND_WRAPPERS_DICT: frozenset[str] = _COMMAND_WRAPPERS
+
 _GIT_ADD_CONTENT_FLAGS: frozenset[str] = frozenset(
     {
         "-p",
@@ -166,6 +248,32 @@ def resolve_write_target(path: str, cwd: str = "") -> str | None:
     return None
 
 
+def _normalize_newlines_for_tokenize(command: str) -> str:
+    """Replace bare (unquoted) newlines with ' ; ' so shlex treats them as boundaries."""
+    result: list[str] = []
+    in_single = False
+    in_double = False
+    i = 0
+    while i < len(command):
+        c = command[i]
+        if c == "\\" and not in_single and i + 1 < len(command):
+            result.append(c)
+            result.append(command[i + 1])
+            i += 2
+            continue
+        if c == "'" and not in_double:
+            in_single = not in_single
+        elif c == '"' and not in_single:
+            in_double = not in_double
+        elif c == "\n" and not in_single and not in_double:
+            result.append(" ; ")
+            i += 1
+            continue
+        result.append(c)
+        i += 1
+    return "".join(result)
+
+
 def tokenize_command_segments(command: str) -> list[list[str]]:
     """Split a shell command into segments of (verb, args...) token lists.
 
@@ -173,13 +281,20 @@ def tokenize_command_segments(command: str) -> list[list[str]]:
     Returns [] on shlex parse error (unclosed quotes).
     """
     try:
-        tokens = shlex.split(strip_heredoc_bodies(command))
+        lexer = shlex.shlex(
+            _normalize_newlines_for_tokenize(strip_heredoc_bodies(command)),
+            posix=True,
+            punctuation_chars=";&|",
+        )
+        lexer.whitespace_split = True
+        tokens = list(lexer)
     except (ValueError, TypeError):
         return []
+
     segments: list[list[str]] = []
     current: list[str] = []
     for token in tokens:
-        if token in _SHELL_OPS:
+        if token in _SPLIT_TOKENS:
             if current:
                 segments.append(current)
                 current = []
@@ -261,26 +376,116 @@ def extract_redirect_targets(tokens: list[str], cwd: str = "") -> list[str]:
     return targets
 
 
+def _is_posix_assignment(token: str) -> bool:
+    """Return True if *token* is a leading NAME=value assignment (POSIX env)."""
+    if "=" not in token:
+        return False
+    if token.startswith("="):
+        return False
+    name, _sep, _value = token.partition("=")
+    if not name:
+        return False
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def _consume_env(start: int, segment: list[str]) -> int:
+    """Return the index of the first non-env token after the 'env' wrapper.
+
+    Handles --, no-value flags, value flags (detached and attached), and
+    NAME=value assignments.
+    """
+    i = start
+    # Allow leading whitespace-like wrapper-only segment with no command.
+    while i < len(segment):
+        token = segment[i]
+        if token == "--":
+            i += 1
+            break
+        if token in _ENV_NO_VALUE_FLAGS:
+            i += 1
+            continue
+        if token in _ENV_VALUE_FLAGS_ATTACHED and "=" in token:
+            i += 1
+            continue
+        if token in _ENV_VALUE_FLAGS and i + 1 < len(segment):
+            i += 2
+            continue
+        if token.startswith("-") or _is_posix_assignment(token):
+            if token in _ENV_VALUE_FLAGS and i + 1 < len(segment):
+                i += 2
+                continue
+            # Unknown long flag that may take a value (e.g. --foo=bar).
+            if "=" in token:
+                i += 1
+                continue
+            i += 1
+            continue
+        break
+    return i
+
+
+def _consume_wrapper_options(start: int, segment: list[str]) -> int:
+    """Skip past a wrapper's attached/detached value options.
+
+    Wrappers (sudo, nice, nohup, time, command) accept option flags before
+    the inner command. Many take values either attached (--user=root) or as
+    the next detached token (-u root). Returns the index of the first
+    non-option token.
+    """
+    i = start
+    while i < len(segment):
+        token = segment[i]
+        if token == "--":
+            return i + 1
+        if not token.startswith("-"):
+            return i
+        if "=" in token:
+            i += 1
+            continue
+        if token in _WRAPPER_VALUE_FLAGS_DETACHED and i + 1 < len(segment):
+            i += 2
+            continue
+        i += 1
+    return i
+
+
+def _consume_wrapper(token: str, start: int, segment: list[str]) -> int | None:
+    """Advance *start* past a single wrapper's required and optional args.
+
+    Returns None if a required argument is absent.
+    """
+    if token in _COMMAND_WRAPPERS_DICT:
+        return start
+    if token in _WRAPPERS_WITH_DURATION:
+        if start + 1 >= len(segment):
+            return None
+        return start + 2
+    if token in _WRAPPERS_WITH_SHORT_FLAG:
+        if start + 1 >= len(segment):
+            return None
+        if not segment[start + 1].startswith("-"):
+            return None
+        return start + 2
+    if token == "env":
+        return _consume_env(start + 1, segment)
+    return start
+
+
 def _command_start_index(segment: list[str]) -> int | None:
     if not segment:
         return None
     start = 0
-    # Iteratively strip 'env', command wrappers, and any wrapper-required
-    # argument. This handles nested forms like
-    # 'env FOO=BAR command git diff' and 'command env FOO=BAR git diff'
-    # consistently — the real command verb is the first token that is not a
-    # known env/wrapper prefix. 'xargs' is intentionally not a wrapper
-    # (see _COMMAND_WRAPPERS docstring).
     while start < len(segment):
         token = segment[start]
-        if token == "env" and start + 1 < len(segment):
+        if _is_posix_assignment(token):
             start += 1
-            while start < len(segment) and (
-                segment[start].startswith("-") or "=" in segment[start]
-            ):
-                start += 1
             continue
-        if token in _COMMAND_WRAPPERS:
+        if token == "env":
+            start = _consume_env(start + 1, segment)
+            continue
+        if token in _COMMAND_WRAPPERS_DICT:
             start += 1
             continue
         if token in _WRAPPERS_WITH_DURATION and start + 1 < len(segment):
@@ -297,10 +502,58 @@ def _command_start_index(segment: list[str]) -> int | None:
     return start if start < len(segment) else None
 
 
+def command_verb_and_args(segment: list[str]) -> tuple[str, list[str]]:
+    """Return (verb, args) for *segment*, skipping env/wrappers/assignments.
+
+    The verb is the raw executable token; args are the tokens after it. If
+    the segment ends inside a wrapper or a required wrapper value is
+    absent, returns ("", []).
+    """
+    if not segment:
+        return ("", [])
+    start = 0
+    while start < len(segment):
+        token = segment[start]
+        if _is_posix_assignment(token):
+            start += 1
+            continue
+        if token == "env":
+            new_start = _consume_env(start + 1, segment)
+            if new_start <= start:
+                return ("", [])
+            start = new_start
+            continue
+        if token in _COMMAND_WRAPPERS_DICT:
+            # Wrappers (sudo, nice, etc.) may consume attached/detached value options.
+            new_start = _consume_wrapper_options(start + 1, segment)
+            if new_start <= start + 1:
+                # No options consumed; check for missing required value.
+                start += 1
+                continue
+            start = new_start
+            continue
+        if token in _WRAPPERS_WITH_DURATION:
+            if start + 1 >= len(segment):
+                return ("", [])
+            start += 2
+            continue
+        if token in _WRAPPERS_WITH_SHORT_FLAG:
+            if start + 1 >= len(segment):
+                return ("", [])
+            if not segment[start + 1].startswith("-"):
+                return ("", [])
+            start += 2
+            continue
+        break
+    if start >= len(segment):
+        return ("", [])
+    return (segment[start], segment[start + 1 :])
+
+
 def command_verb(segment: list[str]) -> str:
     """Return the command verb from a segment, skipping 'env' prefix."""
-    start = _command_start_index(segment)
-    return segment[start] if start is not None else ""
+    verb, _args = command_verb_and_args(segment)
+    return verb
 
 
 def is_gh_command(segment: list[str]) -> bool:
@@ -413,7 +666,9 @@ def is_allowed_protected_path_metadata_command(segment: list[str]) -> bool:
 
 def _tokenize_protected_read_segments(command: str) -> list[list[str]]:
     try:
-        lexer = shlex.shlex(command.replace("\n", " ; "), posix=True, punctuation_chars=";&|()")
+        lexer = shlex.shlex(
+            _normalize_newlines_for_tokenize(command), posix=True, punctuation_chars=";&|()"
+        )
         lexer.whitespace_split = True
         tokens = list(lexer)
     except (ValueError, TypeError):
@@ -503,3 +758,355 @@ def has_interpreter_wrapped_command(command: str, *, target_commands: Sequence[s
 
 def has_nested_shell(command: str) -> bool:
     return bool(_NESTED_SHELL_RE.search(command))
+
+
+# --- Phase 2/3 helpers for unsafe install detection ---
+
+
+_SHELL_INTERPRETERS: frozenset[str] = frozenset({"bash", "sh", "zsh", "dash"})
+_PYTHON_INTERPRETERS: frozenset[str] = frozenset({"python", "python3"})
+
+
+def _normalize_executable(token: str) -> str:
+    return os.path.basename(token).lower()
+
+
+def _is_shell_interpreter(token: str) -> bool:
+    base = _normalize_executable(token)
+    if base in _SHELL_INTERPRETERS:
+        return True
+    # Versioned forms: bash5, sh4, dash0.5, zsh5
+    for name in _SHELL_INTERPRETERS:
+        if base.startswith(name) and base[len(name) :].isdigit():
+            return True
+    return False
+
+
+def _is_python_interpreter(token: str) -> bool:
+    base = _normalize_executable(token)
+    if base in _PYTHON_INTERPRETERS:
+        return True
+    if base.startswith("python") and base[len("python") :].replace(".", "").isdigit():
+        return True
+    return False
+
+
+def _is_pip_executable(token: str) -> bool:
+    base = _normalize_executable(token)
+    if base == "pip":
+        return True
+    if base.startswith("pip") and base[3:].replace(".", "").isdigit():
+        return True
+    return False
+
+
+def _is_uv_executable(token: str) -> bool:
+    return _normalize_executable(token) == "uv"
+
+
+def _is_maturin_executable(token: str) -> bool:
+    return _normalize_executable(token) == "maturin"
+
+
+# Sentinel install subcommand tokens; ordered matchers consume these in sequence.
+_PIP_INSTALL_SUBCOMMAND = "install"
+_UV_PIP_SUBCOMMAND_CHAIN = ("pip", "install")
+_PYTHON_MODULE_PIP_SUBCOMMAND_CHAIN = ("-m", "pip", "install")
+_MATURIN_DEVELOP_SUBCOMMAND = "develop"
+
+
+# Sentinel install subcommand tokens; ordered matchers consume these in sequence.
+_PIP_INSTALL_SUBCOMMAND = "install"
+_UV_PIP_SUBCOMMAND_CHAIN = ("pip", "install")
+_PYTHON_MODULE_PIP_SUBCOMMAND_CHAIN = ("-m", "pip", "install")
+_MATURIN_DEVELOP_SUBCOMMAND = "develop"
+
+
+_PIP_DETACHED_VALUE_FLAGS: frozenset[str] = frozenset(
+    {
+        "-r",
+        "-c",
+        "-t",
+        "-b",
+        "--requirement",
+        "--constraint",
+        "--target",
+        "--prefix",
+        "--src",
+        "--build",
+        "--download",
+        "--index-url",
+        "--extra-index-url",
+        "--find-links",
+        "--editable",
+        "-e",
+    }
+)
+
+
+def _match_pip_install(args: list[str]) -> tuple[list[str], list[str]] | None:
+    """Return (install_args, post_install_args) for `pip install` if matched.
+
+    Consumes leading global pip options then verifies the next non-option
+    token is exactly 'install'. Returns None when the grammar does not match
+    (e.g. `pip help install` or `pip install --help`).
+    """
+    i = 0
+    while i < len(args):
+        token = args[i]
+        if token == "--":
+            i += 1
+            break
+        if token.startswith("-"):
+            if "=" in token:
+                i += 1
+                continue
+            if token in _PIP_DETACHED_VALUE_FLAGS and i + 1 < len(args):
+                i += 2
+                continue
+            i += 1
+            continue
+        break
+    if i >= len(args) or args[i] != _PIP_INSTALL_SUBCOMMAND:
+        return None
+    install_args = args[: i + 1]
+    post_install_args = args[i + 1 :]
+    return (install_args, post_install_args)
+
+
+def _shlex_split_safe(payload: str) -> list[str]:
+    try:
+        return shlex.split(payload)
+    except (ValueError, TypeError):
+        return []
+
+
+def extract_shell_command_payloads(command: str) -> list[str]:
+    """Return shell text payloads that will actually be evaluated.
+
+    Includes the argument following `-c` for path-normalized bash/sh/zsh/dash
+    invocations, the joined argument payload for `eval`, balanced `$(...)`
+    payloads and backtick payloads occurring outside single quotes (including
+    those inside double quotes). Nested payloads are extracted recursively.
+    Single-quoted text, escaped substitutions, and heredoc bodies are inert.
+    """
+    payloads: list[str] = []
+    segments = tokenize_command_segments(command)
+    for segment in segments:
+        verb, args = command_verb_and_args(segment)
+        if not verb:
+            continue
+        if _is_shell_interpreter(verb) and args and args[0] == "-c" and len(args) >= 2:
+            payloads.append(args[1])
+            continue
+        if verb == "eval" and args:
+            payloads.append(" ".join(args))
+            continue
+    # Substitution scan
+    for sub in _extract_substitution_payloads(command):
+        payloads.append(sub)
+    return payloads
+
+
+def _extract_substitution_payloads(command: str) -> list[str]:
+    """Quote/escape-aware state machine that returns active substitution bodies."""
+    payloads: list[str] = []
+    i = 0
+    n = len(command)
+    while i < n:
+        c = command[i]
+        if c == "\\" and i + 1 < n:
+            i += 2
+            continue
+        if c == "'":
+            # Skip single-quoted span
+            j = i + 1
+            while j < n and command[j] != "'":
+                j += 1
+            i = j + 1
+            continue
+        if c == '"':
+            # Walk inside double quotes; substitutions are still active here.
+            j = i + 1
+            while j < n and command[j] != '"':
+                if command[j] == "\\" and j + 1 < n:
+                    j += 2
+                    continue
+                if command[j] == "`":
+                    inner_end = j + 1
+                    while inner_end < n and command[inner_end] != "`":
+                        inner_end += 1
+                    inner = command[j + 1 : inner_end]
+                    payloads.extend(_extract_substitution_payloads(inner))
+                    j = inner_end + 1
+                    continue
+                if command[j] == "$" and j + 1 < n and command[j + 1] == "(":
+                    paren_depth = 1
+                    k = j + 2
+                    while k < n and paren_depth > 0:
+                        if command[k] == "(":
+                            paren_depth += 1
+                        elif command[k] == ")":
+                            paren_depth -= 1
+                        if paren_depth == 0:
+                            break
+                        k += 1
+                    inner = command[j + 2 : k]
+                    payloads.append(inner)
+                    payloads.extend(_extract_substitution_payloads(inner))
+                    j = k + 1
+                    continue
+                j += 1
+            i = j + 1
+            continue
+        if c == "`":
+            j = i + 1
+            while j < n and command[j] != "`":
+                if command[j] == "\\" and j + 1 < n:
+                    j += 2
+                    continue
+                j += 1
+            inner = command[i + 1 : j]
+            payloads.append(inner)
+            payloads.extend(_extract_substitution_payloads(inner))
+            i = j + 1
+            continue
+        if c == "$" and i + 1 < n and command[i + 1] == "(":
+            paren_depth = 1
+            j = i + 2
+            while j < n and paren_depth > 0:
+                if command[j] == "(":
+                    paren_depth += 1
+                elif command[j] == ")":
+                    paren_depth -= 1
+                if paren_depth == 0:
+                    break
+                j += 1
+            inner = command[i + 2 : j]
+            payloads.append(inner)
+            payloads.extend(_extract_substitution_payloads(inner))
+            i = j + 1
+            continue
+        i += 1
+    return payloads
+
+
+_PYTHON_SUBPROCESS_FUNCS: frozenset[str] = frozenset(
+    {
+        "subprocess.run",
+        "subprocess.call",
+        "subprocess.Popen",
+        "subprocess.check_call",
+        "subprocess.check_output",
+    }
+)
+_PYTHON_OS_EXEC_FUNCS: frozenset[str] = frozenset(
+    {
+        "os.system",
+        "os.popen",
+        "os.execl",
+        "os.execle",
+        "os.execlp",
+        "os.execv",
+        "os.execvp",
+        "os.execvpe",
+        "os.execve",
+    }
+)
+
+
+def _parse_python_program_literals(program: str) -> list[ast.Call]:
+    """Return subprocess/os call AST nodes found in a Python -c program."""
+    try:
+        tree = ast.parse(program, mode="exec")
+    except SyntaxError:
+        return []
+    calls: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            dotted: str | None = None
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                dotted = f"{func.value.id}.{func.attr}"
+            if dotted in _PYTHON_SUBPROCESS_FUNCS or dotted in _PYTHON_OS_EXEC_FUNCS:
+                calls.append(node)
+    return calls
+
+
+def _literal_to_argv(node: ast.AST) -> list[str] | None:
+    """Return a literal argv list from a list/tuple literal AST node, else None."""
+    if isinstance(node, ast.List):
+        elements = node.elts
+    elif isinstance(node, ast.Tuple):
+        elements = node.elts
+    else:
+        return None
+    out: list[str] = []
+    for elt in elements:
+        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+            out.append(elt.value)
+        else:
+            return None
+    return out
+
+
+def _literal_to_string(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def extract_interpreter_command_payloads(command: str) -> tuple[list, bool]:
+    """Return (literal command payloads, has_unresolved_subprocess).
+
+    Each payload is either a shell-command string (for `shell=True` calls or
+    `os.system`) or an argv token list (for list/tuple literal subprocess
+    calls). has_unresolved_subprocess is True when a matching process-launch
+    call was present but its arguments could not be statically resolved.
+    """
+    payloads: list = []
+    has_unresolved = False
+    if not _INTERPRETER_RE.search(command):
+        return (payloads, has_unresolved)
+    if not _SUBPROCESS_APIS_RE.search(command):
+        return (payloads, has_unresolved)
+
+    # Find each `python* -c "<payload>"` invocation.
+    py_re = re.compile(
+        r"(?:^|&&|\|\||;)\s*(?:env\s+)?(?:python3?(?:\.\d+)?)\s+-c\s+(['\"])(.*?)\1",
+        re.DOTALL,
+    )
+    for match in py_re.finditer(command):
+        program = match.group(2)
+        for call in _parse_python_program_literals(program):
+            args = call.args
+            if not args:
+                continue
+            first = args[0]
+            # shell=True with a string first argument
+            shell_arg = next((kw.value for kw in call.keywords if kw.arg == "shell"), None)
+            is_shell_true = bool(
+                shell_arg is not None
+                and isinstance(shell_arg, ast.Constant)
+                and shell_arg.value is True
+            )
+            if is_shell_true:
+                cmd_str = _literal_to_string(first)
+                if cmd_str is not None:
+                    payloads.append(cmd_str)
+                    continue
+                has_unresolved = True
+                continue
+            # List/tuple argv literal
+            argv = _literal_to_argv(first)
+            if argv is not None:
+                payloads.append(argv)
+                continue
+            # String first argument interpreted as shell via shell=True not set;
+            # treat as shell-command string for os.system/Popen defaults too.
+            cmd_str = _literal_to_string(first)
+            if cmd_str is not None:
+                payloads.append(cmd_str)
+                continue
+            has_unresolved = True
+    return (payloads, has_unresolved)

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -826,6 +826,46 @@ def tokenize_shell_payload_segments(command: str) -> list[list[str]] | None:
     return result
 
 
+def _find_substitution_end(command: str, start: int) -> int:
+    """Return the index of the ``)`` closing a ``$(`` whose body starts at *start*.
+
+    Quotes open a fresh quoting context inside a substitution, so a literal
+    ``)`` within a quoted span must not terminate the scan. Returns
+    ``len(command)`` when the substitution is unclosed.
+    """
+    depth = 1
+    n = len(command)
+    k = start
+    while k < n:
+        ch = command[k]
+        if ch == "\\" and k + 1 < n:
+            k += 2
+            continue
+        if ch == "'":
+            k += 1
+            while k < n and command[k] != "'":
+                k += 1
+            k += 1
+            continue
+        if ch == '"':
+            k += 1
+            while k < n and command[k] != '"':
+                if command[k] == "\\" and k + 1 < n:
+                    k += 2
+                    continue
+                k += 1
+            k += 1
+            continue
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return k
+        k += 1
+    return n
+
+
 def _extract_substitution_payloads(command: str) -> list[str]:
     """Quote/escape-aware state machine that returns active substitution bodies."""
     payloads: list[str] = []
@@ -860,16 +900,7 @@ def _extract_substitution_payloads(command: str) -> list[str]:
                     j = inner_end + 1
                     continue
                 if command[j] == "$" and j + 1 < n and command[j + 1] == "(":
-                    paren_depth = 1
-                    k = j + 2
-                    while k < n and paren_depth > 0:
-                        if command[k] == "(":
-                            paren_depth += 1
-                        elif command[k] == ")":
-                            paren_depth -= 1
-                        if paren_depth == 0:
-                            break
-                        k += 1
+                    k = _find_substitution_end(command, j + 2)
                     inner = command[j + 2 : k]
                     payloads.append(inner)
                     payloads.extend(_extract_substitution_payloads(inner))
@@ -891,16 +922,7 @@ def _extract_substitution_payloads(command: str) -> list[str]:
             i = j + 1
             continue
         if c == "$" and i + 1 < n and command[i + 1] == "(":
-            paren_depth = 1
-            j = i + 2
-            while j < n and paren_depth > 0:
-                if command[j] == "(":
-                    paren_depth += 1
-                elif command[j] == ")":
-                    paren_depth -= 1
-                if paren_depth == 0:
-                    break
-                j += 1
+            j = _find_substitution_end(command, i + 2)
             inner = command[i + 2 : j]
             payloads.append(inner)
             payloads.extend(_extract_substitution_payloads(inner))

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -413,7 +413,7 @@ def _consume_env(start: int, segment: list[str]) -> int:
         if token in _ENV_NO_VALUE_FLAGS:
             i += 1
             continue
-        if token in _ENV_VALUE_FLAGS_ATTACHED and "=" in token:
+        if "=" in token and token.split("=", 1)[0] in _ENV_VALUE_FLAGS_ATTACHED:
             i += 1
             continue
         if token in _ENV_VALUE_FLAGS and i + 1 < len(segment):

--- a/src/autoskillit/hooks/guards/planner_gh_discovery_guard.py
+++ b/src/autoskillit/hooks/guards/planner_gh_discovery_guard.py
@@ -23,8 +23,9 @@ if _HOOKS_DIR not in sys.path:
 
 from _command_classification import (  # type: ignore[import-not-found]  # noqa: E402
     _SHELL_OPS,
+    command_verb_and_args,
     has_interpreter_wrapped_command,
-    has_nested_shell,
+    tokenize_shell_payload_segments,
 )
 
 DISCOVERY_DENY_TRIGGER: str = "Planner skills cannot discover GitHub issues"
@@ -53,6 +54,29 @@ _TARGETED_SUBCOMMANDS: frozenset[tuple[str, str]] = frozenset(
 _API_LISTING_RE = re.compile(r"/repos/[^/]+/[^/]+/(issues|pulls)(?:\?.*)?$")
 
 _API_SPECIFIC_RE = re.compile(r"/repos/[^/]+/[^/]+/(issues|pulls)/\d+")
+
+
+def _is_discovery_segment(segment: list[str]) -> bool:
+    """Return True when *segment* represents a GitHub discovery subcommand.
+
+    Targeted reads (``gh issue view <N>``, ``gh api .../issues/<N>``) return
+    False; ``api`` listings matching ``_API_LISTING_RE`` return True.
+    """
+    verb, args = command_verb_and_args(segment)
+    if verb != "gh" or len(args) < 2:
+        return False
+    pair = (args[0], args[1])
+    if pair in _DISCOVERY_SUBCOMMANDS:
+        return True
+    if pair in _TARGETED_SUBCOMMANDS:
+        return False
+    if args[0] == "api":
+        endpoint = args[1]
+        if _API_SPECIFIC_RE.search(endpoint):
+            return False
+        if _API_LISTING_RE.search(endpoint):
+            return True
+    return False
 
 
 def _is_gh_discovery(cmd: str) -> bool:
@@ -85,11 +109,10 @@ def _is_gh_discovery(cmd: str) -> bool:
     discovery_targets = [f"gh {sub} {cmd_}" for sub, cmd_ in _DISCOVERY_SUBCOMMANDS]
     if has_interpreter_wrapped_command(cmd, target_commands=discovery_targets):
         return True
-    if has_nested_shell(cmd):
-        cmd_lower = cmd.lower()
-        if any(sub in cmd_lower and c in cmd_lower for sub, c in _DISCOVERY_SUBCOMMANDS):
-            return True
-    return False
+    segments = tokenize_shell_payload_segments(cmd)
+    if segments is None:
+        return False
+    return any(_is_discovery_segment(segment) for segment in segments)
 
 
 def main() -> None:

--- a/src/autoskillit/hooks/guards/pr_create_guard.py
+++ b/src/autoskillit/hooks/guards/pr_create_guard.py
@@ -21,8 +21,9 @@ if _HOOKS_DIR not in sys.path:
 
 from _command_classification import (  # type: ignore[import-not-found]  # noqa: E402
     _SHELL_OPS,
+    command_verb_and_args,
     has_interpreter_wrapped_command,
-    has_nested_shell,
+    tokenize_shell_payload_segments,
 )
 from _hook_settings import read_merged_hook_config  # type: ignore[import-not-found]  # noqa: E402
 
@@ -71,8 +72,12 @@ def _is_gh_pr_create(cmd: str) -> bool:
                     return True
     if has_interpreter_wrapped_command(cmd, target_commands=["gh pr create"]):
         return True
-    if has_nested_shell(cmd):
-        if "gh" in cmd and "pr" in cmd and "create" in cmd:
+    segments = tokenize_shell_payload_segments(cmd)
+    if segments is None:
+        return False
+    for segment in segments:
+        verb, args = command_verb_and_args(segment)
+        if verb == "gh" and args[:2] == ["pr", "create"]:
             return True
     return False
 

--- a/src/autoskillit/hooks/guards/unsafe_install_guard.py
+++ b/src/autoskillit/hooks/guards/unsafe_install_guard.py
@@ -197,7 +197,9 @@ def _iter_install_segments(command: str):
         argv_payloads, has_unresolved = extract_interpreter_command_payloads(current)
         for payload in argv_payloads:
             if isinstance(payload, list):
-                yield ("argv-payload", payload, [])
+                result = _classify_install_invocation(payload)
+                if result is not None:
+                    yield result
             elif isinstance(payload, str):
                 if payload not in seen:
                     queue.append(payload)
@@ -213,12 +215,6 @@ def _is_unsafe_editable_install(cmd: str) -> bool:
         if kind == "unresolved-subprocess":
             # A matching process-launch call could not be statically resolved.
             return True
-        if kind == "argv-payload":
-            argv = _install_args
-            if len(argv) >= 2 and _is_pip_executable(argv[0]) and argv[1] == "install":
-                if any(_is_editable_marker(t) for t in argv[2:]):
-                    return True
-            continue
         if any(_is_editable_marker(t) for t in post_install):
             python_target = _python_target_value(post_install)
             if python_target is not None and _is_venv_path(python_target):

--- a/src/autoskillit/hooks/guards/unsafe_install_guard.py
+++ b/src/autoskillit/hooks/guards/unsafe_install_guard.py
@@ -7,6 +7,7 @@ run_cmd at all — they are blocked by skill_orchestration_guard.py).
 """
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -15,48 +16,225 @@ if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
 from _command_classification import (  # type: ignore[import-not-found]  # noqa: E402
-    has_interpreter_wrapped_command,
+    command_verb_and_args,
+    extract_interpreter_command_payloads,
+    extract_shell_command_payloads,
+    strip_heredoc_bodies,
+    tokenize_command_segments,
 )
 
 UNSAFE_INSTALL_DENY_TRIGGER: str = "Blocked: editable install without --python .venv"
 
-_UNSAFE_PATTERNS = (
-    "pip install -e",
-    "pip install --editable",
-    "uv pip install -e",
-    "uv pip install --editable",
-    "maturin develop",
-)
 
-_SYSTEM_FLAG_PATTERN = "pip install"
+def _basename_lower(token: str) -> str:
+    return os.path.basename(token).lower()
+
+
+def _is_pip_executable(token: str) -> bool:
+    base = _basename_lower(token)
+    if base == "pip":
+        return True
+    if base.startswith("pip") and base[3:].replace(".", "").isdigit():
+        return True
+    return False
+
+
+def _is_uv_executable(token: str) -> bool:
+    return _basename_lower(token) == "uv"
+
+
+def _is_maturin_executable(token: str) -> bool:
+    return _basename_lower(token) == "maturin"
+
+
+def _is_python_executable(token: str) -> bool:
+    base = _basename_lower(token)
+    if base == "python" or base == "python3":
+        return True
+    if base.startswith("python") and base[len("python") :].replace(".", "").isdigit():
+        return True
+    return False
+
+
+def _is_venv_path(value: str) -> bool:
+    """Return True if *value* identifies a `.venv` Python interpreter path.
+
+    A safe value has a path component exactly equal to `.venv`. `.venv-poison`
+    and unrelated outer text do not qualify.
+    """
+    if not value:
+        return False
+    if value == ".venv" or value.startswith(".venv/") or value.startswith(".venv\\"):
+        return True
+    if "/.venv/" in ("/" + value) or value.startswith("/.venv"):
+        return True
+    parts = value.replace("\\", "/").split("/")
+    return any(part == ".venv" for part in parts)
+
+
+def _python_target_value(args: list[str]) -> str | None:
+    """Return the value of `--python` if present, else None."""
+    for i, token in enumerate(args):
+        if token == "--python" and i + 1 < len(args):
+            return args[i + 1]
+        if token.startswith("--python="):
+            return token[len("--python=") :]
+    return None
+
+
+def _has_system_flag(args: list[str]) -> bool:
+    return any(token == "--system" for token in args)
+
+
+def _is_editable_marker(token: str) -> bool:
+    return (
+        token == "-e"
+        or token == "--editable"
+        or token.startswith("-e=")
+        or token.startswith("--editable=")
+    )
+
+
+def _find_pip_install(args: list[str]) -> tuple[list[str], list[str]] | None:
+    """Find `pip install` in *args* and return (pre_install, post_install)."""
+    i = 0
+    while i < len(args):
+        token = args[i]
+        if token == "--":
+            i += 1
+            break
+        if token.startswith("-"):
+            if "=" in token:
+                i += 1
+                continue
+            if token in {"-r", "-c", "-t", "-b", "--requirement", "--constraint"} and i + 1 < len(
+                args
+            ):
+                i += 2
+                continue
+            i += 1
+            continue
+        break
+    if i >= len(args) or args[i] != "install":
+        return None
+    return (args[: i + 1], args[i + 1 :])
+
+
+def _classify_install_invocation(
+    segment: list[str],
+) -> tuple[str, list[str], list[str]] | None:
+    """Return (kind, install_args, post_install_args) for matched installs.
+
+    Recognizes ordered grammars:
+    - pip / pip3 / pip3.X install ...
+    - uv pip install ...
+    - python / python3 / python3.X -m pip install ...
+    - maturin develop ...
+    Returns None when the segment is not a matching install invocation.
+    """
+    verb, args = command_verb_and_args(segment)
+    if not verb:
+        return None
+    if _is_pip_executable(verb):
+        match = _find_pip_install(args)
+        if match is None:
+            return None
+        install_args, post_install = match
+        return ("pip", install_args, post_install)
+    if _is_uv_executable(verb):
+        if len(args) < 2 or args[0] != "pip":
+            return None
+        match = _find_pip_install(args[1:])
+        if match is None:
+            return None
+        install_args, post_install = match
+        return ("uv-pip", install_args, post_install)
+    if _is_python_executable(verb):
+        if len(args) < 3 or args[0] != "-m" or args[1] != "pip":
+            return None
+        match = _find_pip_install(args[2:])
+        if match is None:
+            return None
+        install_args, post_install = match
+        return ("module-pip", install_args, post_install)
+    if _is_maturin_executable(verb):
+        if not args or args[0] != "develop":
+            return None
+        return ("maturin", ["develop"], args[1:])
+    return None
+
+
+def _iter_install_segments(command: str):
+    """Yield (kind, install_args, post_install) for every matched invocation.
+
+    Walks the top-level command, then nested shell payloads (recursively),
+    then Python subprocess payloads. Each invocation is classified once.
+    """
+    seen: set[str] = set()
+    queue: list[str] = [command]
+
+    while queue:
+        current = queue.pop(0)
+        if current in seen:
+            continue
+        seen.add(current)
+
+        try:
+            stripped = strip_heredoc_bodies(current)
+            segments = tokenize_command_segments(stripped)
+        except (ValueError, TypeError):
+            segments = []
+
+        for segment in segments:
+            result = _classify_install_invocation(segment)
+            if result is not None:
+                yield result
+
+        for payload in extract_shell_command_payloads(current):
+            if payload not in seen:
+                queue.append(payload)
+
+        argv_payloads, has_unresolved = extract_interpreter_command_payloads(current)
+        for payload in argv_payloads:
+            if isinstance(payload, list):
+                yield ("argv-payload", payload, [])
+            elif isinstance(payload, str):
+                if payload not in seen:
+                    queue.append(payload)
+        if has_unresolved:
+            yield ("unresolved-subprocess", [], [])
 
 
 def _is_unsafe_editable_install(cmd: str) -> bool:
-    """Return True if cmd is an editable install not targeting a .venv Python."""
-    cmd_lower = cmd.lower()
-    if not any(p in cmd_lower for p in _UNSAFE_PATTERNS):
-        return False
-    # Allow if the command explicitly targets a .venv Python via --python.
-    # Use token-level parsing to avoid substring false-positives (e.g. /tmp/.venv-poison/).
-    tokens = cmd_lower.split()
-    for i, token in enumerate(tokens):
-        if token == "--python" and i + 1 < len(tokens):
-            python_arg = tokens[i + 1]
-            if python_arg.startswith(".venv") or "/.venv/" in python_arg:
-                return False
-    unsafe_targets = list(_UNSAFE_PATTERNS)
-    if has_interpreter_wrapped_command(cmd, target_commands=unsafe_targets):
-        return True
-    return True
+    """Return True if *cmd* runs an editable install not targeting .venv Python."""
+    for kind, _install_args, post_install in _iter_install_segments(cmd):
+        if kind == "maturin":
+            return True
+        if kind == "unresolved-subprocess":
+            # A matching process-launch call could not be statically resolved.
+            return True
+        if kind == "argv-payload":
+            argv = _install_args
+            if len(argv) >= 2 and _is_pip_executable(argv[0]) and argv[1] == "install":
+                if any(_is_editable_marker(t) for t in argv[2:]):
+                    return True
+            continue
+        if any(_is_editable_marker(t) for t in post_install):
+            python_target = _python_target_value(post_install)
+            if python_target is not None and _is_venv_path(python_target):
+                continue
+            return True
+    return False
 
 
 def _is_system_install(cmd: str) -> bool:
-    """Return True if cmd is a pip/uv install with --system flag."""
-    cmd_lower = cmd.lower()
-    if _SYSTEM_FLAG_PATTERN not in cmd_lower:
-        return False
-    tokens = cmd_lower.split()
-    return "--system" in tokens
+    """Return True if *cmd* runs a pip/uv-pip install with --system."""
+    for kind, install_args, post_install in _iter_install_segments(cmd):
+        if kind in ("pip", "uv-pip", "module-pip") and _has_system_flag(
+            install_args + post_install
+        ):
+            return True
+    return False
 
 
 def main() -> None:

--- a/src/autoskillit/hooks/guards/unsafe_install_guard.py
+++ b/src/autoskillit/hooks/guards/unsafe_install_guard.py
@@ -9,6 +9,7 @@ run_cmd at all — they are blocked by skill_orchestration_guard.py).
 import json
 import os
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 _HOOKS_DIR = str(Path(__file__).resolve().parent.parent)
@@ -164,7 +165,7 @@ def _classify_install_invocation(
     return None
 
 
-def _iter_install_segments(command: str):
+def _iter_install_segments(command: str) -> Iterator[tuple[str, list[str], list[str]]]:
     """Yield (kind, install_args, post_install) for every matched invocation.
 
     Walks the top-level command, then nested shell payloads (recursively),

--- a/src/autoskillit/hooks/guards/unsafe_install_guard.py
+++ b/src/autoskillit/hooks/guards/unsafe_install_guard.py
@@ -66,7 +66,7 @@ def _is_venv_path(value: str) -> bool:
         return False
     if value == ".venv" or value.startswith(".venv/") or value.startswith(".venv\\"):
         return True
-    if "/.venv/" in ("/" + value) or value.startswith("/.venv"):
+    if "/.venv/" in ("/" + value) or value == "/.venv":
         return True
     parts = value.replace("\\", "/").split("/")
     return any(part == ".venv" for part in parts)

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -948,6 +948,14 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "REQ-CNST-010-E1: canonical type registry — wide surface required to prevent "
         "circular imports; all enums/protocols/constants consolidated here",
     ),
+    "_command_classification.py": (
+        1100,
+        "REQ-CNST-010-E10: shared command-classification primitive consumed by all "
+        "command-inspecting guards — tokenization, shell-payload extraction, "
+        "interpreter-write detection, protected-path reads, and recursive "
+        "payload segmentation for nested-shell verb-position enforcement; "
+        "stdlib-only stdlib boundary prevents splitting across modules.",
+    ),
     "session.py": (
         1060,
         "REQ-CNST-010-E3: session adjudication pipeline — exhaustive match arms "

--- a/tests/core/test_bash_write_targets.py
+++ b/tests/core/test_bash_write_targets.py
@@ -89,6 +89,19 @@ class TestExtractBashWriteTargets:
         )
         assert result == ["/workspace/../outside/evil.txt"]
 
+    def test_sudo_flag_wrapped_git_checkout(self):
+        result = extract_bash_write_targets(
+            "sudo -u root git checkout -- /path/file.txt", cwd="/workspace"
+        )
+        assert result == ["/path/file.txt"]
+
+    def test_sudo_attached_flag_wrapped_rm(self):
+        result = extract_bash_write_targets("sudo --user=root rm /path/file.txt", cwd="/workspace")
+        assert result == ["/path/file.txt"]
+
+    def test_nice_flag_wrapped_tee(self):
+        assert extract_bash_write_targets("nice -n 5 tee /path/out.txt") == ["/path/out.txt"]
+
     def test_assignment_prefixed_git_checkout(self):
         result = extract_bash_write_targets(
             "FOO=bar git checkout -- ../outside/evil.txt", cwd="/workspace"

--- a/tests/core/test_bash_write_targets.py
+++ b/tests/core/test_bash_write_targets.py
@@ -114,6 +114,16 @@ _PARITY_CORPUS: list[tuple[str, str]] = [
     ("python3 - <<'EOF'\nif x > 3:\n    pass\nEOF", "/workspace"),
     # Heredoc with real redirect on opening line — must produce write target
     ("cat <<'EOF' > /workspace/out.txt\nbody content\nEOF", "/workspace"),
+    # Adjacent && boundaries
+    ("echo ok&&pip install -e .", "/workspace"),
+    ("echo ok;pip install -e .", "/workspace"),
+    # Quoted operator text remains argument
+    ('echo "pip && install -e"', "/workspace"),
+    # Leading assignment
+    ("FOO=bar pip install -e . > /tmp/x", "/workspace"),
+    # Wrapper-bound verb
+    ("sudo pip install -e . > /tmp/x", "/workspace"),
+    ("env PIP_CACHE_DIR=/tmp pip install -e . > /tmp/x", "/workspace"),
 ]
 
 

--- a/tests/core/test_bash_write_targets.py
+++ b/tests/core/test_bash_write_targets.py
@@ -83,6 +83,30 @@ class TestExtractBashWriteTargets:
         result = extract_bash_write_targets("echo x > $MY_DIR/out.txt", cwd="/workspace")
         assert result == ["/workspace/.autoskillit/temp/out.txt"]
 
+    def test_sudo_wrapped_git_checkout(self):
+        result = extract_bash_write_targets(
+            "sudo git checkout -- ../outside/evil.txt", cwd="/workspace"
+        )
+        assert result == ["/workspace/../outside/evil.txt"]
+
+    def test_assignment_prefixed_git_checkout(self):
+        result = extract_bash_write_targets(
+            "FOO=bar git checkout -- ../outside/evil.txt", cwd="/workspace"
+        )
+        assert result == ["/workspace/../outside/evil.txt"]
+
+    def test_env_flag_prefixed_git_checkout(self):
+        result = extract_bash_write_targets(
+            "env -C /tmp git checkout -- /path/file.txt", cwd="/workspace"
+        )
+        assert result == ["/path/file.txt"]
+
+    def test_timeout_wrapped_tee(self):
+        assert extract_bash_write_targets("timeout 30 tee /path/out.txt") == ["/path/out.txt"]
+
+    def test_wrapper_only_segment_clean(self):
+        assert extract_bash_write_targets("sudo nohup") == []
+
 
 _PARITY_CORPUS: list[tuple[str, str]] = [
     ("echo x > /path/out.txt", "/workspace"),

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -426,6 +426,13 @@ class TestTokenizeShellPayloadSegments:
         result = tokenize_shell_payload_segments("bash -c \"echo 'unclosed")
         assert result is None
 
+    def test_quoted_close_paren_does_not_truncate_substitution(self):
+        from autoskillit.hooks._command_classification import tokenize_shell_payload_segments
+
+        result = tokenize_shell_payload_segments('echo $(echo "a) b" && gh pr create --fill)')
+        assert result is not None
+        assert ["gh", "pr", "create", "--fill"] in result
+
     def test_no_evaluated_shell_payload_returns_empty_list(self):
         from autoskillit.hooks._command_classification import tokenize_shell_payload_segments
 

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -208,6 +208,15 @@ class TestCommandVerbAndArgs:
         assert verb == "pip"
         assert args == ["install", "-e", "."]
 
+    def test_env_attached_value_flag(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(
+            ["env", "--chdir=/tmp", "--unset=FOO", "pip", "install", "-e", "."]
+        )
+        assert verb == "pip"
+        assert args == ["install", "-e", "."]
+
     def test_env_double_dash_terminator(self):
         from autoskillit.hooks._command_classification import command_verb_and_args
 

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -119,6 +119,325 @@ class TestTokenizeCommandSegments:
         result = tokenize_command_segments("cat file | tee /tmp/out")
         assert result == [["cat", "file"], ["tee", "/tmp/out"]]
 
+    def test_adjacent_ampersand_ampersand(self):
+        result = tokenize_command_segments("echo ok&&pip install -e .")
+        assert len(result) == 2
+        assert result[1] == ["pip", "install", "-e", "."]
+
+    def test_adjacent_semicolon(self):
+        result = tokenize_command_segments("echo ok;pip install -e .")
+        assert len(result) == 2
+        assert result[1] == ["pip", "install", "-e", "."]
+
+    def test_adjacent_pipe(self):
+        result = tokenize_command_segments("echo ok|pip install -e .")
+        assert len(result) == 2
+
+    def test_adjacent_double_pipe(self):
+        result = tokenize_command_segments("echo ok||pip install -e .")
+        assert len(result) == 2
+
+    def test_adjacent_background_ampersand(self):
+        result = tokenize_command_segments("echo ok&pip install -e .")
+        assert len(result) == 2
+
+    def test_bare_newline_separates_segments(self):
+        result = tokenize_command_segments("echo ok\npip install -e .")
+        assert len(result) == 2
+        assert result[1] == ["pip", "install", "-e", "."]
+
+    def test_quoted_operator_remains_argument(self):
+        result = tokenize_command_segments("echo 'pip && install -e .'")
+        assert result == [["echo", "pip && install -e ."]]
+
+    def test_double_quoted_operator_remains_argument(self):
+        result = tokenize_command_segments('echo "a || b"')
+        assert result == [["echo", "a || b"]]
+
+    def test_heredoc_body_stripped_before_tokenize(self):
+        result = tokenize_command_segments("cat <<'EOF'\nbody content with > symbols\nEOF")
+        assert result == [["cat"]]
+
+    def test_op_only_run_is_boundary(self):
+        result = tokenize_command_segments("pip install -e . ; && uv pip install -e .")
+        assert len(result) == 2
+        assert result[1] == ["uv", "pip", "install", "-e", "."]
+
+    def test_parenthesized_subshell(self):
+        result = tokenize_command_segments("(echo hi; echo bye)")
+        assert len(result) == 2
+
+
+class TestCommandVerbAndArgs:
+    def test_returns_verb_and_args(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(["pip", "install", "-e", "."])
+        assert verb == "pip"
+        assert args == ["install", "-e", "."]
+
+    def test_strips_env_assignments(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(["env", "FOO=bar", "pip", "install", "-e", "."])
+        assert verb == "pip"
+        assert args == ["install", "-e", "."]
+
+    def test_strips_leading_posix_assignment(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(["FOO=bar", "pip", "install", "-e", "."])
+        assert verb == "pip"
+        assert args == ["install", "-e", "."]
+
+    def test_env_with_value_taking_flag(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(
+            ["env", "-u", "FOO", "--chdir", "/tmp", "-S", "x", "pip", "install", "-e", "."]
+        )
+        assert verb == "pip"
+        assert args == ["install", "-e", "."]
+
+    def test_env_double_dash_terminator(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(["env", "--", "pip", "install", "-e", "."])
+        assert verb == "pip"
+        assert args == ["install", "-e", "."]
+
+    def test_sudo_wrapper(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(["sudo", "-u", "root", "pip", "install", "-e", "."])
+        assert verb == "pip"
+        assert args == ["install", "-e", "."]
+
+    def test_nice_wrapper(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(["nice", "-n", "5", "pip", "install", "-e", "."])
+        assert verb == "pip"
+        assert args == ["install", "-e", "."]
+
+    def test_timeout_wrapper_mandatory_duration(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(["timeout", "30", "pip", "install", "-e", "."])
+        assert verb == "pip"
+        assert args == ["install", "-e", "."]
+
+    def test_stdbuf_wrapper_short_flag(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(["stdbuf", "-o0", "pip", "install", "-e", "."])
+        assert verb == "pip"
+        assert args == ["install", "-e", "."]
+
+    def test_command_wrapper(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(["command", "pip", "install", "-e", "."])
+        assert verb == "pip"
+        assert args == ["install", "-e", "."]
+
+    def test_nohup_wrapper(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(["nohup", "pip", "install", "-e", "."])
+        assert verb == "pip"
+        assert args == ["install", "-e", "."]
+
+    def test_double_dash_terminator(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(["pip", "--", "install", "-e", "."])
+        assert verb == "pip"
+        assert args == ["--", "install", "-e", "."]
+
+    def test_empty_segment_returns_empty(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args([])
+        assert verb == ""
+        assert args == []
+
+    def test_wrapper_only_returns_empty(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(["env"])
+        assert verb == ""
+        assert args == []
+
+    def test_timeout_missing_duration_returns_empty(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(["timeout"])
+        assert verb == ""
+        assert args == []
+
+    def test_bare_env_wrapper(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(["env"])
+        assert verb == ""
+        assert args == []
+
+    def test_command_verb_delegates_to_command_verb_and_args(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        seg = ["env", "FOO=bar", "pip", "install", "-e", "."]
+        verb_from_helper, _ = command_verb_and_args(seg)
+        assert verb_from_helper == command_verb(seg)
+
+
+class TestExtractShellCommandPayloads:
+    def test_bash_c_payload(self):
+        from autoskillit.hooks._command_classification import extract_shell_command_payloads
+
+        assert extract_shell_command_payloads('bash -c "pip install -e ."') == ["pip install -e ."]
+
+    def test_sh_c_payload(self):
+        from autoskillit.hooks._command_classification import extract_shell_command_payloads
+
+        assert extract_shell_command_payloads('sh -c "pip install -e ."') == ["pip install -e ."]
+
+    def test_zsh_c_payload(self):
+        from autoskillit.hooks._command_classification import extract_shell_command_payloads
+
+        assert extract_shell_command_payloads('zsh -c "pip install -e ."') == ["pip install -e ."]
+
+    def test_dash_c_payload(self):
+        from autoskillit.hooks._command_classification import extract_shell_command_payloads
+
+        assert extract_shell_command_payloads('dash -c "pip install -e ."') == ["pip install -e ."]
+
+    def test_eval_payload(self):
+        from autoskillit.hooks._command_classification import extract_shell_command_payloads
+
+        assert extract_shell_command_payloads('eval "pip install -e ."') == ["pip install -e ."]
+
+    def test_dollar_paren_payload(self):
+        from autoskillit.hooks._command_classification import extract_shell_command_payloads
+
+        payloads = extract_shell_command_payloads("echo $(pip install -e .)")
+        assert payloads == ["pip install -e ."]
+
+    def test_backtick_payload(self):
+        from autoskillit.hooks._command_classification import extract_shell_command_payloads
+
+        payloads = extract_shell_command_payloads("echo `pip install -e .`")
+        assert payloads == ["pip install -e ."]
+
+    def test_double_quoted_substitution_payload(self):
+        from autoskillit.hooks._command_classification import extract_shell_command_payloads
+
+        payloads = extract_shell_command_payloads('echo "$(pip install -e .)"')
+        assert payloads == ["pip install -e ."]
+
+    def test_single_quoted_substitution_inert(self):
+        from autoskillit.hooks._command_classification import extract_shell_command_payloads
+
+        assert extract_shell_command_payloads("echo '$(pip install -e .)'") == []
+
+    def test_escaped_substitution_inert(self):
+        from autoskillit.hooks._command_classification import extract_shell_command_payloads
+
+        assert extract_shell_command_payloads('echo "\\$(pip install -e .)"') == []
+
+    def test_nested_substitution(self):
+        from autoskillit.hooks._command_classification import extract_shell_command_payloads
+
+        payloads = extract_shell_command_payloads('bash -c "echo $(pip install -e .)"')
+        assert "pip install -e ." in payloads
+
+    def test_no_payloads_returns_empty_list(self):
+        from autoskillit.hooks._command_classification import extract_shell_command_payloads
+
+        assert extract_shell_command_payloads("echo hi") == []
+
+    def test_absolute_bash_path_normalized(self):
+        from autoskillit.hooks._command_classification import extract_shell_command_payloads
+
+        assert extract_shell_command_payloads('/bin/bash -c "pip install -e ."') == [
+            "pip install -e ."
+        ]
+
+
+class TestExtractInterpreterCommandPayloads:
+    def test_shell_string_pip_install(self):
+        from autoskillit.hooks._command_classification import (
+            extract_interpreter_command_payloads,
+        )
+
+        payloads, has_unresolved = extract_interpreter_command_payloads(
+            "python -c \"import subprocess; subprocess.run('pip install -e .', shell=True)\""
+        )
+        assert has_unresolved is False
+        assert payloads == ["pip install -e ."]
+
+    def test_argv_list_pip(self):
+        from autoskillit.hooks._command_classification import (
+            extract_interpreter_command_payloads,
+        )
+
+        payloads, has_unresolved = extract_interpreter_command_payloads(
+            "python3 -c \"import subprocess; subprocess.run(['pip','install','-e','.'])\""
+        )
+        assert has_unresolved is False
+        assert payloads == [["pip", "install", "-e", "."]]
+
+    def test_argv_tuple_pip(self):
+        from autoskillit.hooks._command_classification import (
+            extract_interpreter_command_payloads,
+        )
+
+        payloads, has_unresolved = extract_interpreter_command_payloads(
+            "python3 -c \"import subprocess; subprocess.run(('pip','install','--editable','.'))\""
+        )
+        assert has_unresolved is False
+        assert payloads == [["pip", "install", "--editable", "."]]
+
+    def test_argv_list_rg_reader(self):
+        from autoskillit.hooks._command_classification import (
+            extract_interpreter_command_payloads,
+        )
+
+        payloads, has_unresolved = extract_interpreter_command_payloads(
+            "python3 -c \"import subprocess; subprocess.run(['rg', 'pip install -e', 'docs/'])\""
+        )
+        assert has_unresolved is False
+        assert payloads == [["rg", "pip install -e", "docs/"]]
+
+    def test_unresolved_payload_returns_flag(self):
+        from autoskillit.hooks._command_classification import (
+            extract_interpreter_command_payloads,
+        )
+
+        cmd = "python3 -c \"import subprocess; subprocess.run(['pip', cmd, '-e', '.'])\""
+        _payloads, has_unresolved = extract_interpreter_command_payloads(cmd)
+        assert has_unresolved is True
+
+    def test_no_subprocess_returns_empty(self):
+        from autoskillit.hooks._command_classification import (
+            extract_interpreter_command_payloads,
+        )
+
+        payloads, has_unresolved = extract_interpreter_command_payloads(
+            "python3 -c \"print('hello')\""
+        )
+        assert payloads == []
+        assert has_unresolved is False
+
+    def test_non_python_returns_empty(self):
+        from autoskillit.hooks._command_classification import (
+            extract_interpreter_command_payloads,
+        )
+
+        payloads, has_unresolved = extract_interpreter_command_payloads("echo pip install -e .")
+        assert payloads == []
+        assert has_unresolved is False
+
 
 class TestCommandVerb:
     def test_simple_verb(self):

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -199,6 +199,15 @@ class TestCommandVerbAndArgs:
         assert verb == "pip"
         assert args == ["install", "-e", "."]
 
+    def test_env_split_string_consumes_value(self):
+        from autoskillit.hooks._command_classification import command_verb_and_args
+
+        verb, args = command_verb_and_args(
+            ["env", "--split-string", "FOOBAR", "pip", "install", "-e", "."]
+        )
+        assert verb == "pip"
+        assert args == ["install", "-e", "."]
+
     def test_env_double_dash_terminator(self):
         from autoskillit.hooks._command_classification import command_verb_and_args
 

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -364,6 +364,65 @@ class TestExtractShellCommandPayloads:
         ]
 
 
+class TestTokenizeShellPayloadSegments:
+    def test_bash_c_direct_payload(self):
+        from autoskillit.hooks._command_classification import tokenize_shell_payload_segments
+
+        result = tokenize_shell_payload_segments('bash -c "gh pr create --fill"')
+        assert result == [["gh", "pr", "create", "--fill"]]
+
+    def test_absolute_bash_path(self):
+        from autoskillit.hooks._command_classification import tokenize_shell_payload_segments
+
+        result = tokenize_shell_payload_segments('/bin/bash -c "gh pr create --fill"')
+        assert result == [["gh", "pr", "create", "--fill"]]
+
+    def test_env_prefix_wrapper(self):
+        from autoskillit.hooks._command_classification import tokenize_shell_payload_segments
+
+        result = tokenize_shell_payload_segments('env FOO=1 bash -c "gh pr create --fill"')
+        assert result == [["gh", "pr", "create", "--fill"]]
+
+    def test_sudo_wrapper(self):
+        from autoskillit.hooks._command_classification import tokenize_shell_payload_segments
+
+        result = tokenize_shell_payload_segments('sudo /bin/bash -c "gh pr create --fill"')
+        assert result == [["gh", "pr", "create", "--fill"]]
+
+    def test_nested_bash_c_payload(self):
+        from autoskillit.hooks._command_classification import tokenize_shell_payload_segments
+
+        result = tokenize_shell_payload_segments("""bash -c 'bash -c "gh pr create --fill"'""")
+        assert ["gh", "pr", "create", "--fill"] in result
+
+    def test_operator_separated_commands_inside_payload(self):
+        from autoskillit.hooks._command_classification import tokenize_shell_payload_segments
+
+        result = tokenize_shell_payload_segments('bash -c "echo ready && gh pr create --fill"')
+        assert ["echo", "ready"] in result
+        assert ["gh", "pr", "create", "--fill"] in result
+
+    def test_dedupes_repeated_payload_strings(self):
+        from autoskillit.hooks._command_classification import tokenize_shell_payload_segments
+
+        result = tokenize_shell_payload_segments(
+            """bash -c 'gh pr create' && bash -c "gh pr create --fill\""""
+        )
+        flat = [tuple(s) for s in result]
+        assert flat.count(("gh", "pr", "create")) == 1
+
+    def test_malformed_inner_payload_returns_none(self):
+        from autoskillit.hooks._command_classification import tokenize_shell_payload_segments
+
+        result = tokenize_shell_payload_segments("bash -c \"echo 'unclosed")
+        assert result is None
+
+    def test_no_evaluated_shell_payload_returns_empty_list(self):
+        from autoskillit.hooks._command_classification import tokenize_shell_payload_segments
+
+        assert tokenize_shell_payload_segments("gh pr create --fill") == []
+
+
 class TestExtractInterpreterCommandPayloads:
     def test_shell_string_pip_install(self):
         from autoskillit.hooks._command_classification import (

--- a/tests/infra/AGENTS.md
+++ b/tests/infra/AGENTS.md
@@ -24,6 +24,7 @@ CI/CD configuration, security, guard coverage, and release sanity tests.
 | `test_ci_shard_config.py` | Tests for CI shard directory configuration consistency |
 | `test_docs_critical_rules.py` | Tests that `AGENTS.md` (and a few physical-`CLAUDE.md` integrity checks) contain required critical rules (FRICT-1B-3, FRICT-3A-1, FRICT-5-2, FRICT-7-1) |
 | `test_command_guard_completeness.py` | Structural meta-test: command-inspecting guards must cover all command-executing tools |
+| `test_command_guard_verb_position.py` | Structural ratchet: command-inspecting guards must not perform raw substring membership against shell command text — guards must tokenize evaluated payloads and compare verb/argument positions |
 | `test_conformance_probes_workflow.py` | Structural tests for conformance-probes.yml workflow — triggers, permissions, SHA pinning, cache gate, post-failure wiring |
 | `test_coverage_audit.py` | Tests for scripts/compare-coverage-ast.py — AST extraction and coverage comparison |
 | `test_dependency_pins.py` | Dependency pin guards (REQ-DEP-001, REQ-DEP-002) — pytest 9.x, networkx bounds |

--- a/tests/infra/test_command_guard_verb_position.py
+++ b/tests/infra/test_command_guard_verb_position.py
@@ -97,6 +97,10 @@ def _expr_is_tainted(expr: ast.expr, tainted: set[str]) -> bool:
     if isinstance(expr, ast.BinOp) and isinstance(expr.op, ast.BitOr):
         # Allow ``or`` joins of command reads.
         return _expr_is_tainted(expr.left, tainted) and _expr_is_tainted(expr.right, tainted)
+    if isinstance(expr, ast.BoolOp) and isinstance(expr.op, ast.Or):
+        # Boolean ``or`` joins (e.g. ``cmd or ''``) propagate taint if any
+        # operand is tainted — Python short-circuits to the first truthy value.
+        return any(_expr_is_tainted(v, tainted) for v in expr.values)
     if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Attribute):
         if expr.func.attr in {"lower", "casefold"} and isinstance(expr.func.value, ast.Name):
             return expr.func.value.id in tainted

--- a/tests/infra/test_command_guard_verb_position.py
+++ b/tests/infra/test_command_guard_verb_position.py
@@ -1,0 +1,211 @@
+"""Structural ratchet: guards must not perform raw substring membership on shell command text.
+
+Direct ``in`` / ``not in`` checks against raw command strings or simple
+aliases derived from them (``.lower()``, ``or``-joined variants) miss the
+verb position entirely. A guard that searches for the substring ``"pr"``
+inside ``"printer"`` will silently false-positive. This ratchet enforces
+that command-inspecting guards tokenise shell text before comparing.
+
+Scope: only guard scripts returned by ``_find_command_inspecting_guards()``
+from ``test_command_guard_completeness``. Shared command-classification
+internals live outside this ratchet — they are the implementation that
+guards must consume.
+
+The detector must be non-vacuous: synthetic self-tests prove that the
+parser rejects literal-membership, generator-expression aliases, and the
+post-shlex-tokenization pattern, and accepts token-list / positional-arg
+comparisons.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("infra"), pytest.mark.small]
+
+
+# Comparison operators that indicate raw substring membership.
+_RAW_MEMBERSHIP_OPS = (ast.In, ast.NotIn)
+
+
+def _find_command_inspecting_guards() -> list[tuple[str, Path]]:
+    """Reuse the discovery helper from the structural completion test.
+
+    Importing the function (rather than re-implementing it) ensures the two
+    ratchets stay in lockstep.
+    """
+    from tests.infra.test_command_guard_completeness import (
+        _find_command_inspecting_guards as impl,
+    )
+
+    return impl()
+
+
+def _collect_taint_targets(tree: ast.AST) -> set[str]:
+    """Seed taint with function parameters named cmd/command and tool_input reads."""
+    seeds: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            for arg in (*node.args.args, *node.args.kwonlyargs):
+                if arg.arg in {"cmd", "command"}:
+                    seeds.add(arg.arg)
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and len(node.args) >= 1
+        ):
+            first = node.args[0]
+            if isinstance(first, ast.Constant) and first.value in {"cmd", "command"}:
+                seeds.add("<tool_input>")
+    return seeds
+
+
+def _tainted_names(tree: ast.AST, seeds: set[str]) -> set[str]:
+    """Propagate taint through direct aliases, ``or``, and casefold methods.
+
+    A name is tainted when it is assigned from a tainted name or from an
+    expression whose sub-expressions are all tainted. Lower() / casefold()
+    chains preserve taint; calls to other functions do not.
+    """
+    tainted: set[str] = set(seeds)
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+                continue
+            target_name = node.targets[0].id
+            if target_name in tainted:
+                continue
+            value = node.value
+            if _expr_is_tainted(value, tainted):
+                tainted.add(target_name)
+                changed = True
+    return tainted
+
+
+def _expr_is_tainted(expr: ast.expr, tainted: set[str]) -> bool:
+    """Return True when *expr* is built entirely from tainted sub-expressions."""
+    if isinstance(expr, ast.Name):
+        return expr.id in tainted
+    if isinstance(expr, ast.BinOp) and isinstance(expr.op, ast.BitOr):
+        # Allow ``or`` joins of command reads.
+        return _expr_is_tainted(expr.left, tainted) and _expr_is_tainted(expr.right, tainted)
+    if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Attribute):
+        if expr.func.attr in {"lower", "casefold"} and isinstance(expr.func.value, ast.Name):
+            return expr.func.value.id in tainted
+        return False
+    return False
+
+
+def _raw_membership_sites(source: str, cmd_seeds: set[str] | None = None) -> list[tuple[int, str]]:
+    """Return (line_number, fragment) for each tainted raw-membership comparison.
+
+    ``cmd_seeds`` lets synthetic tests inject function parameters named cmd/command
+    even when the source string does not start with a ``def f(cmd):`` signature
+    that the AST would otherwise pick up. Repository scans pass the default None
+    and rely on signature discovery.
+    """
+    tree = ast.parse(source)
+    seeded = _collect_taint_targets(tree)
+    if cmd_seeds:
+        seeded |= cmd_seeds
+    # ``<tool_input>`` is a synthetic sentinel; skip it from variable taint
+    # because it represents a Call result, not a Name identifier.
+    tainted_vars = _tainted_names(tree, seeded - {"<tool_input>"})
+
+    sites: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare):
+            continue
+        if not any(isinstance(op, _RAW_MEMBERSHIP_OPS) for op in node.ops):
+            continue
+        for comparator in node.comparators:
+            name = _comparator_name(comparator)
+            if name is not None and name in tainted_vars:
+                sites.append((node.lineno, ast.unparse(node.comparators[0])))
+                break
+    return sites
+
+
+def _comparator_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+        if isinstance(node.func.value, ast.Name):
+            return node.func.value.id
+    return None
+
+
+class TestRawCommandMembershipRatchet:
+    """Repository-wide scan rejecting raw substring membership in guards."""
+
+    def test_no_raw_membership_in_command_inspecting_guards(self) -> None:
+        guards = _find_command_inspecting_guards()
+        assert guards, "Discovery helper must return at least one guard (non-vacuous ratchet)"
+
+        offenders: list[str] = []
+        for guard_name, script_path in guards:
+            source = script_path.read_text()
+            for lineno, fragment in _raw_membership_sites(source):
+                offenders.append(
+                    f"{guard_name}:{lineno} — raw substring membership ({fragment!r})"
+                )
+
+        assert not offenders, (
+            "Guards must not perform raw substring membership on shell command text. "
+            "Use tokenize_shell_payload_segments() and command_verb_and_args() instead. "
+            "Offending sites:\n  " + "\n  ".join(offenders)
+        )
+
+
+class TestDetectorSyntheticSelfTests:
+    """Synthetic cases proving the detector is non-vacuous."""
+
+    def test_rejects_literal_in_cmd(self) -> None:
+        source = 'def f(cmd):\n    return "create" in cmd\n'
+        assert _raw_membership_sites(source, {"cmd"})
+
+    def test_rejects_generator_expression_alias(self) -> None:
+        source = (
+            "def f(cmd):\n"
+            "    cmd_lower = cmd.lower()\n"
+            "    return any('gh' in cmd_lower and 'pr' in cmd_lower for _ in [1])\n"
+        )
+        # Taint must propagate through the .lower() alias.
+        sites = _raw_membership_sites(source, {"cmd"})
+        assert sites, "Taint must propagate through cmd.lower() aliases"
+
+    def test_rejects_membership_after_unrelated_shlex_split(self) -> None:
+        source = (
+            "import shlex\n"
+            "def f(cmd):\n"
+            "    tokens = shlex.split(cmd)\n"
+            "    return 'gh' in cmd and 'pr' in cmd\n"
+        )
+        assert _raw_membership_sites(source, {"cmd"})
+
+    def test_accepts_membership_against_token_list(self) -> None:
+        source = "def f(cmd):\n    tokens = cmd.split()\n    return 'gh' in tokens\n"
+        assert not _raw_membership_sites(source, {"cmd"})
+
+    def test_accepts_positional_argument_classifier(self) -> None:
+        source = (
+            "from autoskillit.hooks._command_classification import command_verb_and_args\n"
+            "def f(cmd):\n"
+            "    tokens = cmd.split()\n"
+            "    verb, args = command_verb_and_args(tokens)\n"
+            "    return verb == 'gh' and args[:2] == ['pr', 'create']\n"
+        )
+        assert not _raw_membership_sites(source, {"cmd"})
+
+    def test_rejects_or_joined_taint(self) -> None:
+        source = "def f(cmd):\n    alt = cmd or ''\n    return 'create' in alt\n"
+        sites = _raw_membership_sites(source, {"cmd"})
+        assert sites, "Taint must propagate through ``or`` joins"

--- a/tests/infra/test_command_guard_verb_position.py
+++ b/tests/infra/test_command_guard_verb_position.py
@@ -213,3 +213,8 @@ class TestDetectorSyntheticSelfTests:
         source = "def f(cmd):\n    alt = cmd or ''\n    return 'create' in alt\n"
         sites = _raw_membership_sites(source, {"cmd"})
         assert sites, "Taint must propagate through ``or`` joins"
+
+    def test_rejects_bitor_joined_taint(self) -> None:
+        source = "def f(cmd, command):\n    alt = cmd | command\n    return 'create' in alt\n"
+        sites = _raw_membership_sites(source, {"cmd"})
+        assert sites, "Taint must propagate through ``|`` joins"

--- a/tests/infra/test_planner_gh_discovery_guard.py
+++ b/tests/infra/test_planner_gh_discovery_guard.py
@@ -221,3 +221,58 @@ class TestHeadlessGate:
             headless=True,
         )
         assert _is_denied(out)
+
+
+# ---------------------------------------------------------------------------
+# Nested-shell structured-tokenization regressions
+# ---------------------------------------------------------------------------
+
+
+class TestNestedShellAllow:
+    """Nested-shell fallback must not falsely deny prose / grep / view / api-specific."""
+
+    def test_allows_bash_c_prose(self):
+        out = _run_guard('bash -c "echo listing issue tracker items"')
+        assert out.strip() == "", "Words inside bash -c prose must not be denied"
+
+    def test_allows_bash_c_grep_pattern(self):
+        out = _run_guard("sh -c \"grep 'gh issue list' docs/\"")
+        assert out.strip() == "", "Grep pattern inside sh -c must not be denied"
+
+    def test_allows_bash_c_targeted_view(self):
+        out = _run_guard('bash -c "gh issue view 1"')
+        assert out.strip() == "", "Targeted view inside bash -c must not be denied"
+
+    def test_allows_bash_c_api_specific(self):
+        out = _run_guard('bash -c "gh api /repos/o/r/issues/1"')
+        assert out.strip() == "", "Specific API inside bash -c must not be denied"
+
+    def test_allows_malformed_inner_payload(self):
+        """Malformed inner shell text must remain fail-open (no deny)."""
+        out = _run_guard("bash -c \"echo 'unclosed")
+        assert out.strip() == "", "Malformed inner payload must fail open"
+
+
+class TestNestedShellDeny:
+    """Real nested-shell discovery commands must still be denied."""
+
+    def test_denies_bash_c_gh_issue_list(self):
+        out = _run_guard('bash -c "gh issue list --state open"')
+        assert _is_denied(out)
+
+    def test_denies_absolute_bash_with_sudo(self):
+        out = _run_guard('/bin/bash -c "sudo -u root gh pr list"')
+        assert _is_denied(out)
+
+    def test_denies_nested_bash_c(self):
+        out = _run_guard("""bash -c 'bash -c "gh search issues bug"'""")
+        assert _is_denied(out)
+
+    def test_denies_targeted_then_discovery(self):
+        """A targeted read in one segment must not suppress a later discovery segment."""
+        out = _run_guard('bash -c "gh issue view 1 && gh issue list"')
+        assert _is_denied(out)
+
+    def test_denies_bash_c_api_listing(self):
+        out = _run_guard('bash -c "gh api /repos/o/r/issues"')
+        assert _is_denied(out)

--- a/tests/infra/test_pr_create_guard.py
+++ b/tests/infra/test_pr_create_guard.py
@@ -426,3 +426,93 @@ class TestInteractiveKitchenExemption:
         assert _is_denied(buf.getvalue()), (
             "Kitchen open with recipe_allows_pr_create=false must be denied"
         )
+
+
+# ---------------------------------------------------------------------------
+# Nested-shell structured-tokenization regressions
+# ---------------------------------------------------------------------------
+
+
+class TestNestedShellStructuredDetection:
+    """False-positive allow cases for the nested-shell fallback.
+
+    These exercise commands where raw substring membership would falsely deny
+    but structured payload-segment classification must allow.
+    """
+
+    def test_allows_bash_c_prose_without_gh_pr_create(self, tmp_path):
+        out = _run_guard(
+            'bash -c "echo create a pr for the ghost project"',
+            kitchen_open=True,
+            tmpdir=tmp_path,
+        )
+        assert out.strip() == "", "Prose inside bash -c must not be denied"
+
+    def test_allows_bash_c_grep_pattern(self, tmp_path):
+        out = _run_guard(
+            "bash -c \"grep -r 'gh pr create' docs/\"",
+            kitchen_open=True,
+            tmpdir=tmp_path,
+        )
+        assert out.strip() == "", "Grep pattern inside bash -c must not be denied"
+
+    def test_allows_sh_c_prose_words(self, tmp_path):
+        out = _run_guard(
+            'sh -c "echo create a printer ghost"',
+            kitchen_open=True,
+            tmpdir=tmp_path,
+        )
+        assert out.strip() == "", "Words inside sh -c prose must not be denied"
+
+    def test_allows_malformed_inner_payload(self, tmp_path):
+        """Malformed inner shell text must remain fail-open (no deny)."""
+        out = _run_guard(
+            "bash -c \"echo 'unclosed",
+            kitchen_open=True,
+            tmpdir=tmp_path,
+        )
+        assert out.strip() == "", "Malformed inner payload must fail open"
+
+
+class TestNestedShellDenyRegressions:
+    """Real nested-shell `gh pr create` invocations must still be denied."""
+
+    def test_denies_bash_c_gh_pr_create(self, tmp_path):
+        out = _run_guard(
+            'bash -c "gh pr create --fill"',
+            kitchen_open=True,
+            tmpdir=tmp_path,
+        )
+        assert _is_denied(out)
+
+    def test_denies_absolute_bash_path_with_sudo(self, tmp_path):
+        out = _run_guard(
+            '/bin/bash -c "sudo -u root gh pr create --fill"',
+            kitchen_open=True,
+            tmpdir=tmp_path,
+        )
+        assert _is_denied(out)
+
+    def test_denies_nested_bash_c(self, tmp_path):
+        out = _run_guard(
+            """bash -c 'bash -c "gh pr create --fill"'""",
+            kitchen_open=True,
+            tmpdir=tmp_path,
+        )
+        assert _is_denied(out)
+
+    def test_denies_operator_separated_in_payload(self, tmp_path):
+        out = _run_guard(
+            'bash -c "echo ready && gh pr create --fill"',
+            kitchen_open=True,
+            tmpdir=tmp_path,
+        )
+        assert _is_denied(out)
+
+    def test_denies_nested_shell_via_bash_tool(self, tmp_path):
+        out = _run_bash_guard(
+            'bash -c "gh pr create --fill"',
+            kitchen_open=True,
+            tmpdir=tmp_path,
+        )
+        assert _is_denied(out)

--- a/tests/infra/test_unsafe_install_guard.py
+++ b/tests/infra/test_unsafe_install_guard.py
@@ -182,3 +182,487 @@ class TestUnsafeInstallGuardEdgeCases:
         )
         output = _run_guard("irrelevant", raw_stdin=stdin)
         assert output == ""
+
+
+# --- Quoted/read-only false-positive cases ---
+# Each entry exercises a quoted reader/search that mentions an install pattern
+# without actually invoking one. Both _run_guard and _run_bash_guard must allow.
+
+
+_QUOTED_ALLOWED: list[tuple[str, str]] = [
+    ("rg 'pip install -e' docs/", "rg-quoted-single"),
+    ('rg "pip install -e" docs/', "rg-quoted-double"),
+    ('grep -r "pip install --editable" .', "grep-double-quoted"),
+    ('grep -r "pip install --editable" .', "grep-single-quoted-search"),
+    ("git log --grep='pip install -e'", "git-log-single-quoted"),
+    ('git log --grep="pip install -e"', "git-log-double-quoted"),
+    ('echo "Run: pip install -e ."', "echo-double-quoted"),
+    ("echo 'Run: pip install -e .'", "echo-single-quoted"),
+    ("gh issue list --search '\"pip install -e\" guard'", "gh-issue-search"),
+    ('cat "pip install -e"', "cat-double-quoted"),
+    ("cat 'pip install -e'", "cat-single-quoted"),
+    (
+        'git commit -m "docs: pip install -e example"',
+        "git-commit-message",
+    ),
+    (
+        "rg '$(pip install -e .)' docs/",
+        "rg-single-quoted-substitution-inert",
+    ),
+    (
+        'echo "\\$(pip install -e .)"',
+        "echo-escaped-substitution-inert",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [c[0] for c in _QUOTED_ALLOWED],
+    ids=[c[1] for c in _QUOTED_ALLOWED],
+)
+def test_quoted_read_only_run_guard_allowed(cmd: str) -> None:
+    assert not _is_denied(_run_guard(cmd)), f"run_cmd should allow: {cmd!r}"
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [c[0] for c in _QUOTED_ALLOWED],
+    ids=[c[1] for c in _QUOTED_ALLOWED],
+)
+def test_quoted_read_only_bash_guard_allowed(cmd: str) -> None:
+    assert not _is_denied(_run_bash_guard(cmd)), f"Bash tool should allow: {cmd!r}"
+
+
+# --- System-install false-positive cases ---
+# Each has --system as a real token in argument position but no actual pip install.
+
+_SYSTEM_FALSE_POSITIVES: list[tuple[str, str]] = [
+    ('rg "pip install" -- --system', "rg-double-dash-system"),
+    ('echo "avoid pip install" --system', "echo-system-as-arg"),
+    ('grep "pip install" -- --system', "grep-double-dash-system"),
+    ("uv run -- echo install --system", "uv-run-echo-system"),
+    ("uv tool install demo --system", "uv-tool-install-system"),
+]
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [c[0] for c in _SYSTEM_FALSE_POSITIVES],
+    ids=[c[1] for c in _SYSTEM_FALSE_POSITIVES],
+)
+def test_system_install_false_positive_run_guard_allowed(cmd: str) -> None:
+    assert not _is_denied(_run_guard(cmd)), f"run_cmd should allow: {cmd!r}"
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [c[0] for c in _SYSTEM_FALSE_POSITIVES],
+    ids=[c[1] for c in _SYSTEM_FALSE_POSITIVES],
+)
+def test_system_install_false_positive_bash_guard_allowed(cmd: str) -> None:
+    assert not _is_denied(_run_bash_guard(cmd)), f"Bash tool should allow: {cmd!r}"
+
+
+# --- Direct and wrapped deny regressions ---
+
+
+_DIRECT_DENIED: list[tuple[str, str]] = [
+    ("pip install -e .", "pip-install-e-dot"),
+    ("pip install --editable .", "pip-install-editable-dot"),
+    ("uv pip install -e .", "uv-pip-install-e-dot"),
+    ("maturin develop", "maturin-develop"),
+    ("/usr/bin/pip install -e .", "absolute-pip-install-e"),
+    ("/usr/local/bin/uv pip install --editable .", "absolute-uv-pip-install-editable"),
+    ("python -m pip install -e .", "python-m-pip-install-e"),
+    ("python3 -m pip install --editable .", "python3-m-pip-install-editable"),
+    ("pip3 install -e .", "pip3-install-e-dot"),
+    ("FOO=bar pip install -e .", "foo-assignment-pip-install-e"),
+    ("env PIP_CACHE_DIR=/tmp pip install -e .", "env-pip-cache-dir"),
+    ("sudo -u root pip install -e .", "sudo-pip-install-e"),
+    ("nice -n 5 pip install -e .", "nice-pip-install-e"),
+    ("timeout 30 pip install -e .", "timeout-pip-install-e"),
+    ("stdbuf -o0 pip install -e .", "stdbuf-pip-install-e"),
+    # Attached --python=<path> form: must remain unsafe when path is not .venv.
+    ("pip install -e . --python=/usr/bin/python3", "attached-system-python"),
+]
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [c[0] for c in _DIRECT_DENIED],
+    ids=[c[1] for c in _DIRECT_DENIED],
+)
+def test_direct_denied_run_guard(cmd: str) -> None:
+    assert _is_denied(_run_guard(cmd)), f"run_cmd should deny: {cmd!r}"
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [c[0] for c in _DIRECT_DENIED],
+    ids=[c[1] for c in _DIRECT_DENIED],
+)
+def test_direct_denied_bash_guard(cmd: str) -> None:
+    assert _is_denied(_run_bash_guard(cmd)), f"Bash tool should deny: {cmd!r}"
+
+
+# --- Compound-command deny regressions ---
+
+
+_COMPOUND_DENIED: list[tuple[str, str]] = [
+    ("pip install -e . && echo done", "pip-then-echo-spaced"),
+    ("echo ok&&pip install -e .", "echo-then-pip-adjacent"),
+    ("echo ok;pip install -e .", "echo-then-pip-semicolon-adjacent"),
+    ("echo ok || pip install -e .", "echo-or-pip"),
+    ("echo ok | pip install -e .", "echo-pipe-pip"),
+    ("echo ok\npip install -e .", "echo-newline-pip"),
+    ("pip install -e . > /dev/null", "pip-with-redirect"),
+    (
+        "uv pip install -e . --python .venv/bin/python && pip install -e .",
+        "safe-then-unsafe-compound",
+    ),
+    (
+        "rg docs/ && pip install -e .",
+        "reader-then-install",
+    ),
+    (
+        "pip install -e . && rg 'pip install' docs/",
+        "install-then-reader",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [c[0] for c in _COMPOUND_DENIED],
+    ids=[c[1] for c in _COMPOUND_DENIED],
+)
+def test_compound_denied_run_guard(cmd: str) -> None:
+    assert _is_denied(_run_guard(cmd)), f"run_cmd should deny compound: {cmd!r}"
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [c[0] for c in _COMPOUND_DENIED],
+    ids=[c[1] for c in _COMPOUND_DENIED],
+)
+def test_compound_denied_bash_guard(cmd: str) -> None:
+    assert _is_denied(_run_bash_guard(cmd)), f"Bash tool should deny compound: {cmd!r}"
+
+
+# --- Ordered-grammar allow cases ---
+# A token mentioning 'install' must not be confused with a subcommand argument.
+
+
+_GRAMMAR_ALLOWED: list[tuple[str, str]] = [
+    ("pip help install -e", "pip-help-install-e"),
+    ("uv run echo install --system", "uv-run-echo-install-system"),
+    ("uv tool install demo --system", "uv-tool-install-demo"),
+    ("maturin --help develop", "maturin-help-develop"),
+]
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [c[0] for c in _GRAMMAR_ALLOWED],
+    ids=[c[1] for c in _GRAMMAR_ALLOWED],
+)
+def test_grammar_allowed_run_guard(cmd: str) -> None:
+    assert not _is_denied(_run_guard(cmd)), f"run_cmd should allow: {cmd!r}"
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [c[0] for c in _GRAMMAR_ALLOWED],
+    ids=[c[1] for c in _GRAMMAR_ALLOWED],
+)
+def test_grammar_allowed_bash_guard(cmd: str) -> None:
+    assert not _is_denied(_run_bash_guard(cmd)), f"Bash tool should allow: {cmd!r}"
+
+
+# --- Nested shell payload cases ---
+
+
+class TestNestedShellDeny:
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            'bash -c "pip install -e ."',
+            'sh -c "pip install -e ."',
+            'zsh -c "uv pip install --editable ."',
+            'dash -c "pip install --editable ."',
+            'bash -c "maturin develop"',
+            'eval "pip install -e ."',
+        ],
+        ids=[
+            "bash-c-pip",
+            "sh-c-pip",
+            "zsh-c-uv-pip",
+            "dash-c-pip-editable",
+            "bash-c-maturin",
+            "eval-pip",
+        ],
+    )
+    def test_run_guard_denies_nested_shell(self, cmd: str) -> None:
+        assert _is_denied(_run_guard(cmd))
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            'bash -c "pip install -e ."',
+            'sh -c "pip install -e ."',
+            'zsh -c "uv pip install --editable ."',
+            'dash -c "pip install --editable ."',
+            'bash -c "maturin develop"',
+            'eval "pip install -e ."',
+        ],
+        ids=[
+            "bash-c-pip",
+            "sh-c-pip",
+            "zsh-c-uv-pip",
+            "dash-c-pip-editable",
+            "bash-c-maturin",
+            "eval-pip",
+        ],
+    )
+    def test_bash_guard_denies_nested_shell(self, cmd: str) -> None:
+        assert _is_denied(_run_bash_guard(cmd))
+
+
+class TestNestedShellAllow:
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "bash -c \"rg 'pip install -e' docs/\"",
+            'sh -c "rg docs/"',
+            'eval "rg docs/"',
+        ],
+        ids=[
+            "bash-rg-quoted",
+            "sh-rg",
+            "eval-rg",
+        ],
+    )
+    def test_run_guard_allows_inert_nested_shell(self, cmd: str) -> None:
+        assert not _is_denied(_run_guard(cmd))
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "bash -c \"rg 'pip install -e' docs/\"",
+            'sh -c "rg docs/"',
+            'eval "rg docs/"',
+        ],
+        ids=[
+            "bash-rg-quoted",
+            "sh-rg",
+            "eval-rg",
+        ],
+    )
+    def test_bash_guard_allows_inert_nested_shell(self, cmd: str) -> None:
+        assert not _is_denied(_run_bash_guard(cmd))
+
+
+# --- Command substitution cases ---
+
+
+class TestCommandSubstitutionDeny:
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "echo $(pip install -e .)",
+            'echo "$(pip install -e .)"',
+            "echo `pip install -e .`",
+            'echo "`pip install -e .`"',
+        ],
+        ids=[
+            "dollar-paren",
+            "dollar-paren-in-double",
+            "backtick",
+            "backtick-in-double",
+        ],
+    )
+    def test_run_guard_denies_active_substitution(self, cmd: str) -> None:
+        assert _is_denied(_run_guard(cmd))
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "echo $(pip install -e .)",
+            'echo "$(pip install -e .)"',
+            "echo `pip install -e .`",
+            'echo "`pip install -e .`"',
+        ],
+        ids=[
+            "dollar-paren",
+            "dollar-paren-in-double",
+            "backtick",
+            "backtick-in-double",
+        ],
+    )
+    def test_bash_guard_denies_active_substitution(self, cmd: str) -> None:
+        assert _is_denied(_run_bash_guard(cmd))
+
+
+class TestCommandSubstitutionAllow:
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "echo '$(pip install -e .)'",
+            'echo "\\$(pip install -e .)"',
+        ],
+        ids=[
+            "single-quoted-inert",
+            "escaped-inert",
+        ],
+    )
+    def test_run_guard_allows_inert_substitution(self, cmd: str) -> None:
+        assert not _is_denied(_run_guard(cmd))
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "echo '$(pip install -e .)'",
+            'echo "\\$(pip install -e .)"',
+        ],
+        ids=[
+            "single-quoted-inert",
+            "escaped-inert",
+        ],
+    )
+    def test_bash_guard_allows_inert_substitution(self, cmd: str) -> None:
+        assert not _is_denied(_run_bash_guard(cmd))
+
+
+# --- Interpreter subprocess cases ---
+
+
+class TestInterpreterSubprocessDeny:
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "python -c \"import subprocess; subprocess.run('pip install -e .', shell=True)\"",
+            "python3 -c \"import subprocess; subprocess.run(['pip','install','-e','.'])\"",
+            "python3 -c \"import subprocess; subprocess.run(('pip','install','--editable','.'))\"",
+            "python3 -c \"import os; os.system('pip install -e .')\"",
+        ],
+        ids=[
+            "shell-string-pip",
+            "argv-list-pip",
+            "argv-tuple-pip",
+            "os-system-pip",
+        ],
+    )
+    def test_run_guard_denies_interpreter_subprocess(self, cmd: str) -> None:
+        assert _is_denied(_run_guard(cmd))
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "python -c \"import subprocess; subprocess.run('pip install -e .', shell=True)\"",
+            "python3 -c \"import subprocess; subprocess.run(['pip','install','-e','.'])\"",
+            "python3 -c \"import subprocess; subprocess.run(('pip','install','--editable','.'))\"",
+            "python3 -c \"import os; os.system('pip install -e .')\"",
+        ],
+        ids=[
+            "shell-string-pip",
+            "argv-list-pip",
+            "argv-tuple-pip",
+            "os-system-pip",
+        ],
+    )
+    def test_bash_guard_denies_interpreter_subprocess(self, cmd: str) -> None:
+        assert _is_denied(_run_bash_guard(cmd))
+
+
+class TestInterpreterSubprocessAllow:
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "python3 -c \"import subprocess; subprocess.run(['rg', 'pip install -e', 'docs/'])\"",
+        ],
+        ids=["argv-reader-rg"],
+    )
+    def test_run_guard_allows_interpreter_reader(self, cmd: str) -> None:
+        assert not _is_denied(_run_guard(cmd))
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "python3 -c \"import subprocess; subprocess.run(['rg', 'pip install -e', 'docs/'])\"",
+        ],
+        ids=["argv-reader-rg"],
+    )
+    def test_bash_guard_allows_interpreter_reader(self, cmd: str) -> None:
+        assert not _is_denied(_run_bash_guard(cmd))
+
+
+# --- .venv exemption binding ---
+
+
+class TestVenvExemptionBinding:
+    def test_attached_python_venv_allowed_run_guard(self) -> None:
+        """Attached --python=.venv/bin/python is an explicit .venv exemption."""
+        assert not _is_denied(_run_guard("pip install -e . --python=.venv/bin/python"))
+
+    def test_attached_python_venv_allowed_bash_guard(self) -> None:
+        assert not _is_denied(_run_bash_guard("pip install -e . --python=.venv/bin/python"))
+
+    def test_venv_poison_substring_not_exempt_run_guard(self) -> None:
+        """.venv-poison is NOT a .venv path component."""
+        assert _is_denied(_run_guard("pip install -e . --python .venv-poison/bin/python"))
+
+    def test_venv_poison_substring_not_exempt_bash_guard(self) -> None:
+        assert _is_denied(_run_bash_guard("pip install -e . --python .venv-poison/bin/python"))
+
+    def test_later_unsafe_compound_after_safe_run_guard(self) -> None:
+        """Safe install followed by unsafe install must deny."""
+        assert _is_denied(
+            _run_guard("pip install -e . --python .venv/bin/python && pip install -e .")
+        )
+
+    def test_later_unsafe_compound_after_safe_bash_guard(self) -> None:
+        assert _is_denied(
+            _run_bash_guard("pip install -e . --python .venv/bin/python && pip install -e .")
+        )
+
+
+# --- System install scope ---
+
+
+class TestSystemInstallScope:
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "pip install --system requests",
+            "pip install foo --system",
+            "uv pip install --system foo",
+            "uv pip install foo --system",
+        ],
+        ids=[
+            "pip-system-leading",
+            "pip-system-trailing",
+            "uv-pip-system-leading",
+            "uv-pip-system-trailing",
+        ],
+    )
+    def test_run_guard_denies_scoped_system(self, cmd: str) -> None:
+        assert _is_denied(_run_guard(cmd))
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "pip install --system requests",
+            "pip install foo --system",
+            "uv pip install --system foo",
+            "uv pip install foo --system",
+        ],
+        ids=[
+            "pip-system-leading",
+            "pip-system-trailing",
+            "uv-pip-system-leading",
+            "uv-pip-system-trailing",
+        ],
+    )
+    def test_bash_guard_denies_scoped_system(self, cmd: str) -> None:
+        assert _is_denied(_run_bash_guard(cmd))

--- a/tests/infra/test_unsafe_install_guard.py
+++ b/tests/infra/test_unsafe_install_guard.py
@@ -643,6 +643,17 @@ class TestVenvExemptionBinding:
     def test_venv_poison_substring_not_exempt_bash_guard(self) -> None:
         assert _is_denied(_run_bash_guard("pip install -e . --python .venv-poison/bin/python"))
 
+    def test_absolute_venv_poison_not_exempt_run_guard(self) -> None:
+        """Absolute /.venv-poison prefix is NOT a .venv path component."""
+        assert _is_denied(_run_guard("pip install -e . --python /.venv-poison/bin/python"))
+
+    def test_absolute_venv_poison_not_exempt_bash_guard(self) -> None:
+        assert _is_denied(_run_bash_guard("pip install -e . --python /.venv-poison/bin/python"))
+
+    def test_absolute_root_venv_still_exempt_run_guard(self) -> None:
+        """A genuine absolute /.venv/... interpreter path remains exempt."""
+        assert not _is_denied(_run_guard("pip install -e . --python /.venv/bin/python"))
+
     def test_later_unsafe_compound_after_safe_run_guard(self) -> None:
         """Safe install followed by unsafe install must deny."""
         assert _is_denied(

--- a/tests/infra/test_unsafe_install_guard.py
+++ b/tests/infra/test_unsafe_install_guard.py
@@ -545,12 +545,25 @@ class TestInterpreterSubprocessDeny:
             "python3 -c \"import subprocess; subprocess.run(['pip','install','-e','.'])\"",
             "python3 -c \"import subprocess; subprocess.run(('pip','install','--editable','.'))\"",
             "python3 -c \"import os; os.system('pip install -e .')\"",
+            "python3 -c \"import subprocess; subprocess.run(['uv','pip','install','-e','.'])\"",
+            'python3 -c "import subprocess; '
+            "subprocess.run(['python3','-m','pip','install','-e','.'])\"",
+            "python3 -c \"import subprocess; subprocess.run(['maturin','develop'])\"",
+            'python3 -c "import subprocess; '
+            "subprocess.run(['pip','install','--system','requests'])\"",
+            'python3 -c "import subprocess; '
+            "subprocess.run(['uv','pip','install','foo','--system'])\"",
         ],
         ids=[
             "shell-string-pip",
             "argv-list-pip",
             "argv-tuple-pip",
             "os-system-pip",
+            "argv-list-uv-pip",
+            "argv-list-module-pip",
+            "argv-list-maturin",
+            "argv-list-pip-system",
+            "argv-list-uv-pip-system",
         ],
     )
     def test_run_guard_denies_interpreter_subprocess(self, cmd: str) -> None:
@@ -563,12 +576,25 @@ class TestInterpreterSubprocessDeny:
             "python3 -c \"import subprocess; subprocess.run(['pip','install','-e','.'])\"",
             "python3 -c \"import subprocess; subprocess.run(('pip','install','--editable','.'))\"",
             "python3 -c \"import os; os.system('pip install -e .')\"",
+            "python3 -c \"import subprocess; subprocess.run(['uv','pip','install','-e','.'])\"",
+            'python3 -c "import subprocess; '
+            "subprocess.run(['python3','-m','pip','install','-e','.'])\"",
+            "python3 -c \"import subprocess; subprocess.run(['maturin','develop'])\"",
+            'python3 -c "import subprocess; '
+            "subprocess.run(['pip','install','--system','requests'])\"",
+            'python3 -c "import subprocess; '
+            "subprocess.run(['uv','pip','install','foo','--system'])\"",
         ],
         ids=[
             "shell-string-pip",
             "argv-list-pip",
             "argv-tuple-pip",
             "os-system-pip",
+            "argv-list-uv-pip",
+            "argv-list-module-pip",
+            "argv-list-maturin",
+            "argv-list-pip-system",
+            "argv-list-uv-pip-system",
         ],
     )
     def test_bash_guard_denies_interpreter_subprocess(self, cmd: str) -> None:
@@ -580,8 +606,10 @@ class TestInterpreterSubprocessAllow:
         "cmd",
         [
             "python3 -c \"import subprocess; subprocess.run(['rg', 'pip install -e', 'docs/'])\"",
+            'python3 -c "import subprocess; '
+            "subprocess.run(['pip','install','-e','.','--python','.venv/bin/python'])\"",
         ],
-        ids=["argv-reader-rg"],
+        ids=["argv-reader-rg", "argv-pip-venv-exempt"],
     )
     def test_run_guard_allows_interpreter_reader(self, cmd: str) -> None:
         assert not _is_denied(_run_guard(cmd))

--- a/tests/infra/test_unsafe_install_guard.py
+++ b/tests/infra/test_unsafe_install_guard.py
@@ -193,7 +193,7 @@ _QUOTED_ALLOWED: list[tuple[str, str]] = [
     ("rg 'pip install -e' docs/", "rg-quoted-single"),
     ('rg "pip install -e" docs/', "rg-quoted-double"),
     ('grep -r "pip install --editable" .', "grep-double-quoted"),
-    ('grep -r "pip install --editable" .', "grep-single-quoted-search"),
+    ("grep -r 'pip install --editable' .", "grep-single-quoted-search"),
     ("git log --grep='pip install -e'", "git-log-single-quoted"),
     ('git log --grep="pip install -e"', "git-log-double-quoted"),
     ('echo "Run: pip install -e ."', "echo-double-quoted"),


### PR DESCRIPTION
## Summary

Complete the two missing Part A requirements identified by the audit while preserving all already-covered behavior. Limit production and test changes to:

- `src/autoskillit/core/bash_write_targets.py`
- `src/autoskillit/hooks/_command_classification.py`
- `src/autoskillit/hooks/guards/unsafe_install_guard.py`
- `tests/core/test_bash_write_targets.py`
- `tests/hooks/test_command_classification.py`
- `tests/infra/test_unsafe_install_guard.py`

Step 1 completes command-start parity in the IL-0 mirror by correcting `_command_start_index()` (mirroring hook-side env/wrapper/detached option arity, malformed-wrapper handling, `command_verb_and_args()` semantics) and wiring it into `_command_verb()`; extended parity tests cover wrapped write-target commands (FOO=bar, sudo, timeout, stdbuf, nohup) and malformed wrapper cases, asserting identical verbs at both core and hook layers.

Step 2 restores the narrow non-Python/raw interpreter detector: `has_interpreter_wrapped_command()` learns Node `child_process.exec/execSync/spawn/spawnSync` and Perl/Ruby `system(...)`; `_iter_install_segments()` normalizes segments via `command_verb_and_args()` + `shlex.join()` and applies the secondary helper to non-Python interpreter segments only; Python subprocesses remain routed through `extract_interpreter_command_payloads()`; `_is_unsafe_editable_install()` denies the new secondary-interpreter result without any `.venv` raw-text exemption. Tests cover real Node payload denials, inert Node `console.log` allowances, mixed-command denial, secondary denial without `--python .venv` exemption, and the existing fail-closed unresolved Python subprocess branch.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260713-200935-309632/.autoskillit/temp/rectify/remediation_command_guards_verb_position_2026-07-13_224733.md`

Closes #4222

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->