### PR TITLE
[FIX] Input Contract `file_path_list` Type Immunity — Part A

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -222,6 +222,7 @@ from .types import SKILL_TOOLS as SKILL_TOOLS
 from .types import SOUS_CHEF_MANDATORY_SECTIONS as SOUS_CHEF_MANDATORY_SECTIONS
 from .types import TOOL_SUBSET_TAGS as TOOL_SUBSET_TAGS
 from .types import UNGATED_TOOLS as UNGATED_TOOLS
+from .types import VALID_INPUT_SPEC_TYPES as VALID_INPUT_SPEC_TYPES
 from .types import VARIADIC_CLAUDE_FLAGS as VARIADIC_CLAUDE_FLAGS
 from .types import WORKTREE_SKILLS as WORKTREE_SKILLS
 from .types import AgentPackDef as AgentPackDef
@@ -289,7 +290,6 @@ from .types import InfraOutcome as InfraOutcome
 from .types import InputContractResolver as InputContractResolver
 from .types import InputSpec as InputSpec
 from .types import InputSpecType as InputSpecType
-from .types import VALID_INPUT_SPEC_TYPES as VALID_INPUT_SPEC_TYPES
 from .types import InspectorCallback as InspectorCallback
 from .types import InspectorEvidence as InspectorEvidence
 from .types import InspectorVerdict as InspectorVerdict

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -288,6 +288,8 @@ from .types import InfraExitCategory as InfraExitCategory
 from .types import InfraOutcome as InfraOutcome
 from .types import InputContractResolver as InputContractResolver
 from .types import InputSpec as InputSpec
+from .types import InputSpecType as InputSpecType
+from .types import VALID_INPUT_SPEC_TYPES as VALID_INPUT_SPEC_TYPES
 from .types import InspectorCallback as InspectorCallback
 from .types import InspectorEvidence as InspectorEvidence
 from .types import InspectorVerdict as InspectorVerdict

--- a/src/autoskillit/core/types/_type_helpers.py
+++ b/src/autoskillit/core/types/_type_helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import warnings
 from typing import Any
 
@@ -47,16 +48,21 @@ def is_path_like_token(token: str) -> bool:
 def extract_positional_args(skill_command: str) -> list[str]:
     """Extract all positional tokens from a skill_command string.
 
-    Returns tokens after the skill name, split on whitespace, with
-    enclosing quotes stripped. Path-like and non-path tokens are both
-    included, preserving positional order.
+    Returns tokens after the skill name, tokenized with ``shlex.split`` so
+    quoted arguments (including those containing whitespace or newlines)
+    remain one logical argument. Unmatched quotes raise ``ValueError``.
+
+    Path-like and non-path tokens are both included, preserving positional
+    order.
     """
     stripped = skill_command.strip()
     m = _SKILL_CMD_RE.match(stripped)
     if m is None:
         return []
-    tokens = stripped[m.end() :].split()
-    return [t.strip('"').strip("'") for t in tokens]
+    remainder = stripped[m.end() :]
+    if not remainder:
+        return []
+    return shlex.split(remainder)
 
 
 def extract_path_arg(skill_command: str) -> str | None:

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -26,12 +26,14 @@ __all__ = [
     "closure_authority_spec_from_args",
     "ContaminationOutcome",
     "InputSpec",
+    "InputSpecType",
     "LoadReport",
     "LoadResult",
     "ModelIdentity",
     "TestResult",
     "ValidatedAddDir",
     "ValidatedWorktreePath",
+    "VALID_INPUT_SPEC_TYPES",
     "WriteBehaviorSpec",
     "WriteEvidence",
     "FailureRecord",
@@ -50,6 +52,10 @@ __all__ = [
     "SessionIndexEntry",
     "parse_plan_paths",
 ]
+
+VALID_INPUT_SPEC_TYPES = frozenset({"file_path", "directory_path", "file_path_list"})
+
+InputSpecType = Literal["file_path", "directory_path", "file_path_list"]
 
 
 @dataclass
@@ -242,16 +248,26 @@ def parse_plan_paths(raw: str) -> tuple[str, ...]:
 
 @dataclass(frozen=True, slots=True)
 class InputSpec:
-    """Input contract specification for a single file_path or directory_path argument."""
+    """Input contract specification for a scalar or list path argument.
+
+    Covers single-path types (``file_path``, ``directory_path``) and the
+    list variant (``file_path_list``) whose value is one positional token
+    carrying comma- or newline-separated member paths.
+    """
 
     name: str
-    type: Literal["file_path", "directory_path"]
+    type: InputSpecType
     required: bool
     position: int
 
     def __post_init__(self) -> None:
         if self.position < 0:
             raise ValueError(f"InputSpec.position must be >= 0, got {self.position}")
+        if self.type not in VALID_INPUT_SPEC_TYPES:
+            raise ValueError(
+                f"InputSpec.type must be one of {sorted(VALID_INPUT_SPEC_TYPES)}, "
+                f"got {self.type!r}"
+            )
 
 
 @dataclass

--- a/src/autoskillit/recipe/_contracts_manifest.py
+++ b/src/autoskillit/recipe/_contracts_manifest.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal, assert_never, cast
 
 from autoskillit.core import (
+    VALID_INPUT_SPEC_TYPES,
     InputSpec,
+    InputSpecType,
     get_logger,
     load_yaml,
     pkg_root,
@@ -94,7 +96,13 @@ def get_skill_contract(skill_name: str, manifest: dict[str, Any]) -> SkillContra
 
 
 def resolve_input_specs(skill_command: str) -> tuple[InputSpec, ...]:
-    """Resolve InputSpec entries for file_path/directory_path inputs from a skill's contract."""
+    """Resolve InputSpec entries for path-typed inputs from a skill's contract.
+
+    Recognized types are those in ``VALID_INPUT_SPEC_TYPES`` — scalar
+    ``file_path`` / ``directory_path`` and the ``file_path_list`` variant
+    whose value is one positional token carrying comma- or newline-separated
+    member paths. Non-path types (``string``, ``integer``, …) are skipped.
+    """
     name = resolve_skill_name(skill_command)
     if not name:
         return ()
@@ -104,17 +112,22 @@ def resolve_input_specs(skill_command: str) -> tuple[InputSpec, ...]:
     path_position = 0
     specs: list[InputSpec] = []
     for inp in contract.inputs:
-        if inp.type in ("file_path", "directory_path"):
-            narrowed_type = cast(Literal["file_path", "directory_path"], inp.type)
-            specs.append(
-                InputSpec(
-                    name=inp.name,
-                    type=narrowed_type,
-                    required=inp.required,
-                    position=path_position,
+        if inp.type not in VALID_INPUT_SPEC_TYPES:
+            continue
+        narrowed_type = cast(InputSpecType, inp.type)
+        match narrowed_type:
+            case "file_path" | "directory_path" | "file_path_list":
+                specs.append(
+                    InputSpec(
+                        name=inp.name,
+                        type=narrowed_type,
+                        required=inp.required,
+                        position=path_position,
+                    )
                 )
-            )
-            path_position += 1
+                path_position += 1
+            case _ as unreachable:
+                assert_never(unreachable)
     return tuple(specs)
 
 

--- a/src/autoskillit/recipe/rules/dataflow/rules_dataflow_handoff.py
+++ b/src/autoskillit/recipe/rules/dataflow/rules_dataflow_handoff.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from autoskillit.core import SKILL_TOOLS, Severity, get_logger
+from autoskillit.core import SKILL_TOOLS, VALID_INPUT_SPEC_TYPES, Severity, get_logger
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.contracts import (
     get_skill_contract,
@@ -181,7 +181,7 @@ def _check_uncaptured_handoff_consumer(ctx: ValidationContext) -> list[RuleFindi
             file_path_inputs = [
                 inp
                 for inp in consumer_contract.inputs
-                if inp.type in ("file_path", "directory_path") and not inp.required
+                if inp.type in VALID_INPUT_SPEC_TYPES and not inp.required
             ]
             if not file_path_inputs:
                 continue

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -388,11 +388,11 @@ skills:
     outputs: []
   audit-impl:
     inputs:
-    - name: plan_path
-      type: file_path
-      required: false
     - name: all_plan_paths
-      type: file_path
+      type: file_path_list
+      required: false
+    - name: all_conflict_report_paths
+      type: file_path_list
       required: false
     - name: branch_name
       type: string

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -505,7 +505,7 @@ skills:
   prepare-pr:
     inputs:
     - name: plan_paths
-      type: string
+      type: file_path_list
       required: true
     - name: run_name
       type: string
@@ -599,6 +599,9 @@ skills:
       required: true
     - name: audit_verdict
       type: string
+      required: false
+    - name: conflict_report_paths
+      type: file_path_list
       required: false
     - name: domain_partitions_path
       type: file_path

--- a/src/autoskillit/recipes/diagrams/research.md
+++ b/src/autoskillit/recipes/diagrams/research.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:2e88ebb20ec7c39bc5e8940a37e70e62e2696ad248bec9764cda469506f8366e -->
+<!-- autoskillit-recipe-hash: sha256:9b1fb0f1459069e6c47eb94e1c67d113458ddf0accf3c4dd096bdb2aead150e4 -->
 <!-- autoskillit-diagram-format: v7 -->
 
 ## research

--- a/src/autoskillit/recipes/research-implement.json
+++ b/src/autoskillit/recipes/research-implement.json
@@ -356,7 +356,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:audit-impl ${{ context.group_files }} ${{ context.impl_base_sha }} ${{ inputs.base_branch }}",
+        "skill_command": "/autoskillit:audit-impl \"${{ context.group_files }}\" ${{ context.impl_base_sha }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "audit_impl",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/audit-impl",

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -353,7 +353,7 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: "/autoskillit:audit-impl ${{ context.group_files }} ${{ context.impl_base_sha }} ${{ inputs.base_branch }}"
+      skill_command: "/autoskillit:audit-impl \"${{ context.group_files }}\" ${{ context.impl_base_sha }} ${{ inputs.base_branch }}"
       cwd: "${{ context.worktree_path }}"
       step_name: audit_impl
       output_dir: "{{AUTOSKILLIT_TEMP}}/audit-impl"

--- a/src/autoskillit/recipes/research.json
+++ b/src/autoskillit/recipes/research.json
@@ -677,7 +677,7 @@
       "tool": "run_skill",
       "model": "",
       "with": {
-        "skill_command": "/autoskillit:audit-impl ${{ context.group_files }} ${{ context.impl_base_sha }} ${{ inputs.base_branch }}",
+        "skill_command": "/autoskillit:audit-impl \"${{ context.group_files }}\" ${{ context.impl_base_sha }} ${{ inputs.base_branch }}",
         "cwd": "${{ context.worktree_path }}",
         "step_name": "audit_impl",
         "output_dir": "{{AUTOSKILLIT_TEMP}}/audit-impl",

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -662,7 +662,7 @@ steps:
     tool: run_skill
     model: ""
     with:
-      skill_command: "/autoskillit:audit-impl ${{ context.group_files }} ${{ context.impl_base_sha }} ${{ inputs.base_branch }}"
+      skill_command: "/autoskillit:audit-impl \"${{ context.group_files }}\" ${{ context.impl_base_sha }} ${{ inputs.base_branch }}"
       cwd: "${{ context.worktree_path }}"
       step_name: audit_impl
       output_dir: "{{AUTOSKILLIT_TEMP}}/audit-impl"

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, assert_never
 
 import regex as re
 
@@ -17,6 +17,7 @@ from autoskillit.core import (
     extract_skill_name,
     get_logger,
     is_path_like_token,
+    parse_plan_paths,
     session_type,
 )
 from autoskillit.hooks import command_has_blocked_protected_path_read
@@ -277,7 +278,11 @@ def _check_input_contracts(
     if not specs:
         return None
 
-    args = extract_positional_args(skill_command)
+    try:
+        args = extract_positional_args(skill_command)
+    except ValueError as e:
+        skill_label = extract_skill_name(skill_command) or skill_command
+        return gate_error_result(f"Malformed quoting in skill_command for {skill_label}: {e}")
     path_args = [a for a in args if is_path_like_token(a)]
 
     for spec in specs:
@@ -290,20 +295,39 @@ def _check_input_contracts(
             continue
 
         value = path_args[spec.position]
-        resolved = Path(cwd) / value if not Path(value).is_absolute() else Path(value)
 
-        if spec.type == "file_path":
-            if not resolved.is_file():
-                return gate_error_result(
-                    f"Input '{spec.name}' for {extract_skill_name(skill_command)}: "
-                    f"expected a file, path does not exist or is a directory: {resolved}"
-                )
-        elif spec.type == "directory_path":
-            if not resolved.is_dir():
-                return gate_error_result(
-                    f"Input '{spec.name}' for {extract_skill_name(skill_command)}: "
-                    f"expected a directory, path does not exist or is a file: {resolved}"
-                )
+        match spec.type:
+            case "file_path":
+                resolved = Path(cwd) / value if not Path(value).is_absolute() else Path(value)
+                if not resolved.is_file():
+                    return gate_error_result(
+                        f"Input '{spec.name}' for {extract_skill_name(skill_command)}: "
+                        f"expected a file, path does not exist or is a directory: {resolved}"
+                    )
+            case "directory_path":
+                resolved = Path(cwd) / value if not Path(value).is_absolute() else Path(value)
+                if not resolved.is_dir():
+                    return gate_error_result(
+                        f"Input '{spec.name}' for {extract_skill_name(skill_command)}: "
+                        f"expected a directory, path does not exist or is a file: {resolved}"
+                    )
+            case "file_path_list":
+                members = parse_plan_paths(value)
+                missing: list[str] = []
+                for member in members:
+                    member_path = (
+                        Path(cwd) / member if not Path(member).is_absolute() else Path(member)
+                    )
+                    if not member_path.is_file():
+                        missing.append(str(member_path))
+                if missing:
+                    return gate_error_result(
+                        f"Input '{spec.name}' for {extract_skill_name(skill_command)}: "
+                        f"{len(missing)} of {len(members)} expected files do not exist "
+                        f"or are directories: {', '.join(missing)}"
+                    )
+            case _ as unreachable:
+                assert_never(unreachable)
 
     return None
 

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -776,6 +776,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "server/test_tools_kitchen_visibility.py",
             "server/test_tools_execution_step_resolution.py",
             "server/test_tools_execution_input_gates.py",
+            "server/test_tools_execution_input_gates_file_path_list.py",
             "server/test_capability_admission_e2e.py",
             "server/test_admission_dispatch_agreement.py",
             # CLI file-level entries (6 of 38 import autoskillit.recipe):

--- a/tests/arch/AGENTS.md
+++ b/tests/arch/AGENTS.md
@@ -110,6 +110,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_hook_env_var_authority.py` | AST guard: every hook script that reads `AUTOSKILLIT_PROVIDER_PROFILE` must also read `AUTOSKILLIT_AGENT_BACKEND` so backend identity is checked independently of provider routing |
 | `test_serve_surface_registry.py` | Structural tests for `SERVE_SURFACES` frozenset: membership completeness, AST guard that `load_and_validate` is only called from `_serve_helpers.py` |
 | `test_session_type_exhaustive.py` | AST guard: _apply_session_type_visibility must use exhaustive match/assert_never dispatch |
+| `test_input_spec_type_exhaustive.py` | AST guard: InputSpec type dispatch (match/assert_never) and YAML coverage of VALID_INPUT_SPEC_TYPES |
 | `test_notification_fallback_coverage.py` | AST guard: every ctx.enable_components call in server/tools/ must have a non-notification fallback or be in an exempt session-scoped unlock function |
 | `test_cmd_spec_resume_no_string_match.py` | AST guard: no `"--resume" in <expr>` patterns in production code — use CmdSpec.is_resume instead |
 | `test_subagent_filter_guard.py` | AST guard: all assistant-record NDJSON processing sites must use _is_parent_assistant_record or _is_parent_assistant predicate |

--- a/tests/arch/test_input_spec_type_exhaustive.py
+++ b/tests/arch/test_input_spec_type_exhaustive.py
@@ -1,0 +1,106 @@
+"""Arch guard: InputSpec type dispatch must be exhaustive (match/assert_never).
+
+Mirrors test_session_type_exhaustive.py — ensures that adding a new member
+to VALID_INPUT_SPEC_TYPES without wiring a dispatch branch in
+_check_input_contracts or resolve_input_specs fails CI rather than silently
+falling through.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+class _MatchWithAssertNeverVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.has_match = False
+        self.has_assert_never = False
+
+    def visit_Match(self, node: ast.Match) -> None:
+        self.has_match = True
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if isinstance(node.func, ast.Name) and node.func.id == "assert_never":
+            self.has_assert_never = True
+        self.generic_visit(node)
+
+
+def _get_function_body(source: str, func_name: str) -> list[ast.stmt]:
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            return node.body
+    msg = f"{func_name} not found"
+    raise AssertionError(msg)
+
+
+def test_check_input_contracts_uses_match_assert_never():
+    """_check_input_contracts must use match/assert_never for exhaustive dispatch."""
+    from autoskillit.core import paths
+
+    src_file = paths.pkg_root() / "server" / "_guards.py"
+    assert src_file.exists(), f"File not found: {src_file}"
+    body = _get_function_body(src_file.read_text(), "_check_input_contracts")
+    fn_tree = ast.Module(body=body, type_ignores=[])
+    visitor = _MatchWithAssertNeverVisitor()
+    visitor.visit(fn_tree)
+    assert visitor.has_match, (
+        "_check_input_contracts must use a 'match' statement for type dispatch"
+    )
+    assert visitor.has_assert_never, (
+        "_check_input_contracts must call assert_never() to guard against "
+        "unhandled InputSpecType members"
+    )
+
+
+def test_resolve_input_specs_uses_match_assert_never():
+    """resolve_input_specs must use match/assert_never for exhaustive dispatch."""
+    from autoskillit.core import paths
+
+    src_file = paths.pkg_root() / "recipe" / "_contracts_manifest.py"
+    assert src_file.exists(), f"File not found: {src_file}"
+    body = _get_function_body(src_file.read_text(), "resolve_input_specs")
+    fn_tree = ast.Module(body=body, type_ignores=[])
+    visitor = _MatchWithAssertNeverVisitor()
+    visitor.visit(fn_tree)
+    assert visitor.has_match, "resolve_input_specs must use a 'match' statement for type dispatch"
+    assert visitor.has_assert_never, (
+        "resolve_input_specs must call assert_never() to guard against "
+        "unhandled InputSpecType members"
+    )
+
+
+def test_yaml_path_input_types_are_covered():
+    """Every YAML path-like input type must be a member of VALID_INPUT_SPEC_TYPES."""
+    from autoskillit.core import VALID_INPUT_SPEC_TYPES, load_yaml, paths
+
+    yaml_path = paths.pkg_root() / "recipe" / "skill_contracts.yaml"
+    assert yaml_path.exists(), f"YAML not found: {yaml_path}"
+
+    raw = load_yaml(yaml_path)
+
+    yaml_types: set[str] = set()
+    for skill_data in raw.get("skills", {}).values():
+        for inp in skill_data.get("inputs", []):
+            yaml_types.add(inp["type"])
+
+    path_like_yaml_types = {
+        t
+        for t in yaml_types
+        if t.startswith("file_")
+        or t.startswith("directory_")
+        or t.endswith("_path")
+        or t.endswith("_path_list")
+    }
+
+    unrecognized = path_like_yaml_types - set(VALID_INPUT_SPEC_TYPES)
+    assert not unrecognized, (
+        f"YAML declares path-like input types not in VALID_INPUT_SPEC_TYPES: "
+        f"{sorted(unrecognized)}. Add the new type to both VALID_INPUT_SPEC_TYPES "
+        f"and InputSpecType."
+    )

--- a/tests/contracts/test_input_type_semantic_correctness.py
+++ b/tests/contracts/test_input_type_semantic_correctness.py
@@ -14,10 +14,71 @@ pytestmark = [pytest.mark.layer("contracts"), pytest.mark.medium]
 
 _CONTRACTS_YAML = Path(__file__).parents[2] / "src/autoskillit/recipe/skill_contracts.yaml"
 
+# Documented-name aliases for contract inputs whose SKILL.md argument name differs
+# from the contract input name. The classifier searches both the contract input name
+# and any documented alias so SKILL.md language is matched correctly.
+_CONTRACT_ALIASES: dict[tuple[str, str], tuple[str, ...]] = {
+    ("audit-impl", "all_plan_paths"): ("plans_input",),
+    ("audit-impl", "all_conflict_report_paths"): ("conflict_report_paths",),
+    ("open-integration-pr", "conflict_report_paths"): ("conflict_report_paths",),
+    ("prepare-pr", "plan_paths"): ("plan_paths",),
+}
+
+
+def _aliases_for(skill_name: str, input_name: str) -> tuple[str, ...]:
+    return _CONTRACT_ALIASES.get((skill_name, input_name), ())
+
+
+_LIST_SHAPE_SUFFIXES = ("_paths", "_path_list")
+_LIST_SHAPE_PREFIXES = ("all_",)
+
+
+def _is_list_shaped_name(name: str) -> bool:
+    return name.startswith(_LIST_SHAPE_PREFIXES) or name.endswith(_LIST_SHAPE_SUFFIXES)
+
+
+_LIST_COLLECTION_RE = re.compile(
+    r"\b("
+    r"comma[\s-]+separated|comma[\s-]+joined|comma[\s-]+joined|list\s+of|"
+    r"multiple|accumulated|each\s+path|one\s+per|separated\s+by|"
+    r"paths?\s+are\s+supplied|paths?\s+passed\s+in"
+    r")\b",
+    re.IGNORECASE,
+)
+
 
 def _infer_path_kind_from_skillmd(
-    input_name: str, skillmd_text: str
-) -> Literal["file", "directory", "ambiguous"]:
+    input_name: str,
+    skillmd_text: str,
+    *,
+    aliases: tuple[str, ...] = (),
+) -> Literal["file", "directory", "list", "ambiguous"]:
+    """Classify the path kind of a contract input from SKILL.md prose.
+
+    Returns ``"list"`` when the contract input name is list-shaped
+    (``all_`` prefix or ``_paths``/``_path_list`` suffix) and the SKILL.md
+    mention windows around the contract name and any aliases contain collection
+    language such as ``comma-separated`` or ``list of``. Falls through to the
+    existing directory/file inference otherwise.
+    """
+    if _is_list_shaped_name(input_name):
+        search_names = (input_name, *aliases)
+        placeholder_variants = [f"{{{n}}}" for n in search_names]
+        mentions: list[int] = []
+        for name in search_names:
+            mentions.extend(
+                m.start() for m in re.finditer(re.escape(name), skillmd_text, re.IGNORECASE)
+            )
+        for placeholder in placeholder_variants:
+            mentions.extend(
+                m.start() for m in re.finditer(re.escape(placeholder), skillmd_text, re.IGNORECASE)
+            )
+        if mentions:
+            for pos in mentions:
+                window = skillmd_text[max(0, pos - 200) : pos + 200]
+                if _LIST_COLLECTION_RE.search(window):
+                    return "list"
+
     if input_name.endswith(("_dir", "_directory")) or input_name == "run_dir":
         return "directory"
     if "worktree" in input_name or input_name == "workspace":
@@ -64,7 +125,7 @@ def _collect_path_input_params() -> list[tuple[str, str, str]]:
     result = []
     for skill_name, contract in sorted(skills.items()):
         for inp in contract.get("inputs", []):
-            if inp.get("type") in ("file_path", "directory_path"):
+            if inp.get("type") in ("file_path", "directory_path", "file_path_list"):
                 result.append((skill_name, inp["name"], inp["type"]))
     return result
 
@@ -82,6 +143,14 @@ def _resolve_skillmd(skill_name: str) -> str | None:
     return None
 
 
+def _declared_type_to_inferred(declared_type: str) -> str:
+    return {
+        "file_path": "file",
+        "directory_path": "directory",
+        "file_path_list": "list",
+    }[declared_type]
+
+
 @pytest.mark.parametrize(
     "skill_name,input_name,declared_type",
     _PATH_INPUT_PARAMS,
@@ -93,12 +162,124 @@ def test_input_type_matches_skillmd(skill_name: str, input_name: str, declared_t
     if skillmd is None:
         pytest.skip(f"No SKILL.md found for {skill_name}")
 
-    inferred = _infer_path_kind_from_skillmd(input_name, skillmd)
+    aliases = _aliases_for(skill_name, input_name)
+    inferred = _infer_path_kind_from_skillmd(input_name, skillmd, aliases=aliases)
     if inferred == "ambiguous":
+        # Ambiguous scalar inference is tolerable; ambiguous list inference on a
+        # declared list input is not — covered by
+        # test_file_path_list_yaml_entries_have_list_inference.
+        if declared_type == "file_path_list":
+            pytest.fail(
+                f"{skill_name}.{input_name}: declared as file_path_list but classifier "
+                f"could not infer 'list' from SKILL.md"
+            )
         pytest.skip(f"Ambiguous inference for {skill_name}.{input_name}")
 
-    expected_type = "file_path" if inferred == "file" else "directory_path"
+    expected_type = (
+        declared_type
+        if inferred == _declared_type_to_inferred(declared_type)
+        else (
+            "file_path_list"
+            if inferred == "list"
+            else "file_path"
+            if inferred == "file"
+            else "directory_path"
+        )
+    )
     assert declared_type == expected_type, (
         f"{skill_name}.{input_name}: declared as {declared_type!r} in skill_contracts.yaml "
         f"but SKILL.md indicates it should be {expected_type!r}"
     )
+
+
+@pytest.mark.parametrize(
+    "skill_name,input_name,declared_type",
+    [(s, i, t) for (s, i, t) in _PATH_INPUT_PARAMS if t == "file_path_list"],
+    ids=[f"{s}-{i}" for (s, i, t) in _PATH_INPUT_PARAMS if t == "file_path_list"],
+)
+def test_file_path_list_yaml_entries_have_list_inference(
+    skill_name: str, input_name: str, declared_type: str
+) -> None:
+    """Every declared file_path_list input must infer 'list' from its SKILL.md."""
+    assert declared_type == "file_path_list", "parametrize filter precondition"
+    skillmd = _resolve_skillmd(skill_name)
+    if skillmd is None:
+        pytest.skip(f"No SKILL.md found for {skill_name}")
+
+    aliases = _aliases_for(skill_name, input_name)
+    inferred = _infer_path_kind_from_skillmd(input_name, skillmd, aliases=aliases)
+    assert inferred == "list", (
+        f"{skill_name}.{input_name}: declared as file_path_list but classifier "
+        f"inferred {inferred!r} from SKILL.md (aliases={aliases!r})"
+    )
+
+
+def test_collect_path_input_params_includes_file_path_list() -> None:
+    """_collect_path_input_params() must surface file_path_list inputs and be nonempty."""
+    params = _collect_path_input_params()
+    list_types = [t for (_, _, t) in params if t == "file_path_list"]
+    assert list_types, "Expected at least one file_path_list entry in the YAML manifest"
+    assert len(list_types) >= 4, (
+        f"Expected at least four list inputs after Step 2/3 contract changes "
+        f"(audit-impl.all_plan_paths, audit-impl.all_conflict_report_paths, "
+        f"prepare-pr.plan_paths, open-integration-pr.conflict_report_paths); "
+        f"got {len(list_types)}"
+    )
+
+
+@pytest.mark.parametrize(
+    "skill_name,input_name,aliases",
+    [(s, i, a) for (s, i), a in _CONTRACT_ALIASES.items()],
+    ids=[f"{s}-{i}" for (s, i) in _CONTRACT_ALIASES],
+)
+def test_contract_alias_is_mentioned_in_skillmd(
+    skill_name: str, input_name: str, aliases: tuple[str, ...]
+) -> None:
+    """Every configured alias must actually appear in the corresponding SKILL.md."""
+    skillmd = _resolve_skillmd(skill_name)
+    if skillmd is None:
+        pytest.skip(f"No SKILL.md found for {skill_name}")
+
+    for alias in aliases:
+        assert re.search(re.escape(alias), skillmd, re.IGNORECASE), (
+            f"Alias {alias!r} for {skill_name}.{input_name} not found in SKILL.md — "
+            f"remove the alias entry or fix the SKILL.md prose"
+        )
+
+
+@pytest.mark.parametrize(
+    "input_name,skillmd_text,expected",
+    [
+        (
+            "all_plan_paths",
+            "A comma-separated list of `.md` plan file paths. Pass them as one positional.",
+            "list",
+        ),
+        (
+            "all_conflict_report_paths",
+            "Comma-joined absolute paths to conflict resolution reports.",
+            "list",
+        ),
+        (
+            "conflict_report_paths",
+            "Comma-separated list of absolute paths to conflict resolution report files.",
+            "list",
+        ),
+        (
+            "all_diagram_paths",
+            "Comma-separated diagram paths produced by arch-lens skills.",
+            "list",
+        ),
+        (
+            "report_paths",
+            "Multiple accumulated paths accumulated over the run.",
+            "list",
+        ),
+    ],
+)
+def test_list_bucket_inference_unit_cases(
+    input_name: str, skillmd_text: str, expected: str
+) -> None:
+    """Unit cases for the semantic classifier's 'list' bucket."""
+    inferred = _infer_path_kind_from_skillmd(input_name, skillmd_text)
+    assert inferred == expected

--- a/tests/contracts/test_input_type_semantic_correctness.py
+++ b/tests/contracts/test_input_type_semantic_correctness.py
@@ -78,6 +78,9 @@ def _infer_path_kind_from_skillmd(
                 window = skillmd_text[max(0, pos - 200) : pos + 200]
                 if _LIST_COLLECTION_RE.search(window):
                     return "list"
+        else:
+            if _LIST_COLLECTION_RE.search(skillmd_text):
+                return "list"
 
     if input_name.endswith(("_dir", "_directory")) or input_name == "run_dir":
         return "directory"

--- a/tests/core/AGENTS.md
+++ b/tests/core/AGENTS.md
@@ -42,6 +42,8 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_stamp_constants.py` | Tests for DRY_WALKTHROUGH_VERIFIED_MARKER constant |
 | `test_tool_sequence_analysis.py` | Tool sequence analysis tests |
 | `test_type_helpers.py` | Tests for extract_positional_args helper |
+| `test_input_spec_type.py` | InputSpec type system tests — closed type vocabulary validation |
+| `test_parse_plan_paths.py` | parse_plan_paths unit tests — comma/newline splitter used by file_path_list gate |
 | `test_backend_capabilities.py` | Tests for BackendCapabilities frozen invariants and CLAUDE_CODE_CAPABILITIES field values |
 | `test_backend_event_kind.py` | Tests for BackendEventKind StrEnum — member exhaustiveness, values, importability |
 | `test_backend_dataclasses.py` | Tests for CmdSpec, SkillSessionConfig, ClaudeEventData, CodexEventData, SessionEvent, AgentSessionResult — frozen invariants, field types, defaults |

--- a/tests/core/test_input_spec_type.py
+++ b/tests/core/test_input_spec_type.py
@@ -1,0 +1,31 @@
+"""InputSpec type system tests — validate closed type vocabulary."""
+
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+from autoskillit.core import VALID_INPUT_SPEC_TYPES
+from autoskillit.core.types._type_results import InputSpec
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+def test_input_spec_rejects_unknown_type():
+    """Unknown type strings must raise ValueError at construction time."""
+    with pytest.raises(ValueError, match="InputSpec.type must be one of"):
+        InputSpec(name="x", type="file_path_list_v2", required=False, position=0)
+
+
+def test_input_spec_accepts_file_path_list():
+    """file_path_list is a valid member of the closed type set."""
+    spec = InputSpec(name="x", type="file_path_list", required=False, position=0)
+    assert spec.type == "file_path_list"
+
+
+def test_valid_input_spec_types_matches_literal():
+    """VALID_INPUT_SPEC_TYPES must match the Literal members declared on InputSpec.type."""
+    hints = typing.get_type_hints(InputSpec)
+    literal_args = frozenset(typing.get_args(hints["type"]))
+    assert literal_args == VALID_INPUT_SPEC_TYPES

--- a/tests/core/test_parse_plan_paths.py
+++ b/tests/core/test_parse_plan_paths.py
@@ -1,0 +1,33 @@
+"""parse_plan_paths unit tests — covers comma/newline splitter used by file_path_list gate."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import parse_plan_paths
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+def test_comma_separated():
+    assert parse_plan_paths("/a.md,/b.md") == ("/a.md", "/b.md")
+
+
+def test_newline_separated():
+    assert parse_plan_paths("/a.md\n/b.md") == ("/a.md", "/b.md")
+
+
+def test_mixed_delimiters():
+    assert parse_plan_paths("/a.md,/b.md\n/c.md") == ("/a.md", "/b.md", "/c.md")
+
+
+def test_whitespace_stripping():
+    assert parse_plan_paths(" /a.md , /b.md ") == ("/a.md", "/b.md")
+
+
+def test_empty_tokens_filtered():
+    assert parse_plan_paths("/a.md,,/b.md") == ("/a.md", "/b.md")
+
+
+def test_single_path():
+    assert parse_plan_paths("/a.md") == ("/a.md",)

--- a/tests/core/test_type_helpers.py
+++ b/tests/core/test_type_helpers.py
@@ -42,6 +42,20 @@ def test_extract_positional_args_returns_non_path_only():
     assert result == ["foo", "bar"]
 
 
+def test_extract_positional_args_preserves_quoted_newline_value():
+    from autoskillit.core import extract_positional_args
+
+    result = extract_positional_args('/skill "/path/a.md\n/path/b.md" branch')
+    assert result == ["/path/a.md\n/path/b.md", "branch"]
+
+
+def test_extract_positional_args_raises_on_unmatched_quote():
+    from autoskillit.core import extract_positional_args
+
+    with pytest.raises(ValueError):
+        extract_positional_args('/skill "/unclosed branch')
+
+
 class TestExtractSkillName:
     def test_slash_prefix(self):
         from autoskillit.core import extract_skill_name

--- a/tests/recipe/test_research_audit_impl.py
+++ b/tests/recipe/test_research_audit_impl.py
@@ -92,6 +92,15 @@ class TestResearchRecipesAuditImpl:
         skill_cmd = step.with_args.get("skill_command", "")
         assert "context.group_files" in skill_cmd
 
+    def test_audit_impl_group_files_is_quoted(self, recipe) -> None:
+        """context.group_files interpolation must be wrapped in double quotes.
+
+        Newline-separated values must remain one logical argument after shlex tokenization.
+        """
+        step = recipe.steps["audit_impl"]
+        skill_cmd = step.with_args.get("skill_command", "")
+        assert '"${{ context.group_files }}"' in skill_cmd
+
     def test_audit_impl_go_routes_to_run_experiment(self, recipe) -> None:
         """audit_impl on_result GO verdict must route to run_experiment."""
         step = recipe.steps["audit_impl"]

--- a/tests/recipe/test_rules_dataflow_handoff.py
+++ b/tests/recipe/test_rules_dataflow_handoff.py
@@ -119,10 +119,8 @@ class TestUncapturedHandoffConsumerRule:
                 },
             }
         }
+        monkeypatch.setattr("autoskillit.recipe.load_bundled_manifest", lambda: fake_manifest)
         monkeypatch.setattr(_contracts_manifest, "load_bundled_manifest", lambda: fake_manifest)
-        monkeypatch.setattr(
-            "autoskillit.recipe.contracts.load_bundled_manifest", lambda: fake_manifest
-        )
 
         steps = {
             "produce": {
@@ -159,10 +157,8 @@ class TestUncapturedHandoffConsumerRule:
                 },
             }
         }
+        monkeypatch.setattr("autoskillit.recipe.load_bundled_manifest", lambda: fake_manifest)
         monkeypatch.setattr(_contracts_manifest, "load_bundled_manifest", lambda: fake_manifest)
-        monkeypatch.setattr(
-            "autoskillit.recipe.contracts.load_bundled_manifest", lambda: fake_manifest
-        )
 
         steps = {
             "produce": {

--- a/tests/recipe/test_rules_dataflow_handoff.py
+++ b/tests/recipe/test_rules_dataflow_handoff.py
@@ -98,6 +98,92 @@ class TestUncapturedHandoffConsumerRule:
         handoff = [f for f in findings if f.rule == "uncaptured-handoff-consumer"]
         assert handoff == []
 
+    def test_uncaptured_handoff_consumer_fires_for_unwired_file_path_list(
+        self, monkeypatch
+    ) -> None:
+        """file_path_list inputs must be treated as path-typed by the handoff rule.
+
+        Uses an inline manifest with an outputless producer and a consumer whose sole
+        optional path input is file_path_list. The unwired case must fire.
+        """
+        from autoskillit.recipe import _contracts_manifest
+
+        fake_manifest = {
+            "skills": {
+                "fakelist-producer": {"inputs": [], "outputs": []},
+                "fakelist-consumer": {
+                    "inputs": [
+                        {"name": "plan_files", "type": "file_path_list", "required": False}
+                    ],
+                    "outputs": [],
+                },
+            }
+        }
+        monkeypatch.setattr(_contracts_manifest, "load_bundled_manifest", lambda: fake_manifest)
+        monkeypatch.setattr(
+            "autoskillit.recipe.contracts.load_bundled_manifest", lambda: fake_manifest
+        )
+
+        steps = {
+            "produce": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:fakelist-producer"},
+                "on_success": "consume",
+            },
+            "consume": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:fakelist-consumer"},
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+        recipe = _make_workflow(steps)
+        findings = run_semantic_rules(recipe)
+        handoff = [f for f in findings if f.rule == "uncaptured-handoff-consumer"]
+        assert any("plan_files" in f.message for f in handoff)
+
+    def test_uncaptured_handoff_consumer_silent_when_file_path_list_wired(
+        self, monkeypatch
+    ) -> None:
+        """file_path_list input wired via context ref must silence the handoff rule."""
+        from autoskillit.recipe import _contracts_manifest
+
+        fake_manifest = {
+            "skills": {
+                "fakelist-producer": {"inputs": [], "outputs": []},
+                "fakelist-consumer": {
+                    "inputs": [
+                        {"name": "plan_files", "type": "file_path_list", "required": False}
+                    ],
+                    "outputs": [],
+                },
+            }
+        }
+        monkeypatch.setattr(_contracts_manifest, "load_bundled_manifest", lambda: fake_manifest)
+        monkeypatch.setattr(
+            "autoskillit.recipe.contracts.load_bundled_manifest", lambda: fake_manifest
+        )
+
+        steps = {
+            "produce": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:fakelist-producer"},
+                "on_success": "consume",
+            },
+            "consume": {
+                "tool": "run_skill",
+                "with": {
+                    "skill_command": '/autoskillit:fakelist-consumer "${{ context.plan_files }}"'
+                },
+                "on_success": "done",
+            },
+            "done": {"action": "stop", "message": "Done."},
+        }
+        recipe = _make_workflow(steps)
+        findings = run_semantic_rules(recipe)
+        handoff = [f for f in findings if f.rule == "uncaptured-handoff-consumer"]
+        assert handoff == []
+
 
 # ---------------------------------------------------------------------------
 # TestCallableContracts

--- a/tests/recipe/test_rules_dataflow_handoff.py
+++ b/tests/recipe/test_rules_dataflow_handoff.py
@@ -107,6 +107,7 @@ class TestUncapturedHandoffConsumerRule:
         optional path input is file_path_list. The unwired case must fire.
         """
         from autoskillit.recipe import _contracts_manifest
+        from autoskillit.recipe.rules.dataflow import rules_dataflow_handoff
 
         fake_manifest = {
             "skills": {
@@ -121,6 +122,7 @@ class TestUncapturedHandoffConsumerRule:
         }
         monkeypatch.setattr("autoskillit.recipe.load_bundled_manifest", lambda: fake_manifest)
         monkeypatch.setattr(_contracts_manifest, "load_bundled_manifest", lambda: fake_manifest)
+        monkeypatch.setattr(rules_dataflow_handoff, "load_bundled_manifest", lambda: fake_manifest)
 
         steps = {
             "produce": {
@@ -145,6 +147,7 @@ class TestUncapturedHandoffConsumerRule:
     ) -> None:
         """file_path_list input wired via context ref must silence the handoff rule."""
         from autoskillit.recipe import _contracts_manifest
+        from autoskillit.recipe.rules.dataflow import rules_dataflow_handoff
 
         fake_manifest = {
             "skills": {
@@ -159,6 +162,7 @@ class TestUncapturedHandoffConsumerRule:
         }
         monkeypatch.setattr("autoskillit.recipe.load_bundled_manifest", lambda: fake_manifest)
         monkeypatch.setattr(_contracts_manifest, "load_bundled_manifest", lambda: fake_manifest)
+        monkeypatch.setattr(rules_dataflow_handoff, "load_bundled_manifest", lambda: fake_manifest)
 
         steps = {
             "produce": {

--- a/tests/server/AGENTS.md
+++ b/tests/server/AGENTS.md
@@ -75,6 +75,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_tools_dispatch_validation.py` | Tests for dispatch_food_truck validation: gates, input, and semantic validation |
 | `test_tools_execution_command.py` | Tests for run_skill command building, timeouts, env, model, and per-invocation markers |
 | `test_tools_execution_input_gates.py` | Tests for run_skill input validation gates and CWD checking |
+| `test_tools_execution_input_gates_file_path_list.py` | file_path_list gate behavioral tests — comma-separated and quoted newline-separated plan lists |
 | `test_tools_execution_provider.py` | Tests for provider_extras/profile_name forwarding through run_skill() |
 | `test_tools_execution_response.py` | Contract tests: MCP tool response fields use correct enum types |
 | `test_tools_execution_results.py` | Tests for run_skill result shapes, failure paths, timing, flush telemetry, and gate checks |

--- a/tests/server/test_tools_execution_input_gates.py
+++ b/tests/server/test_tools_execution_input_gates.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -493,12 +493,19 @@ def _collect_all_path_input_specs() -> list[tuple[str, str, str]]:
     result = []
     for skill_name, contract in sorted(raw.get("skills", {}).items()):
         for inp in contract.get("inputs", []):
-            if inp.get("type") in ("file_path", "directory_path"):
+            if inp.get("type") in ("file_path", "directory_path", "file_path_list"):
                 result.append((skill_name, inp["name"], inp["type"]))
     return result
 
 
 _ALL_PATH_INPUT_SPECS = _collect_all_path_input_specs()
+
+
+def _collect_file_path_list_specs() -> list[tuple[str, str, str]]:
+    return [(s, i, t) for (s, i, t) in _ALL_PATH_INPUT_SPECS if t == "file_path_list"]
+
+
+_FILE_PATH_LIST_SPECS = _collect_file_path_list_specs()
 
 
 class TestInputContractRealContracts:
@@ -516,18 +523,24 @@ class TestInputContractRealContracts:
         from autoskillit.core import InputSpec
         from autoskillit.server._guards import _check_input_contracts
 
-        narrowed: Literal["file_path", "directory_path"] = (
-            "file_path" if declared_type == "file_path" else "directory_path"
-        )
+        narrowed = cast("Literal['file_path', 'directory_path', 'file_path_list']", declared_type)
         if narrowed == "file_path":
             target = tmp_path / "test_input.md"
             target.write_text("test")
-        else:
+            cmd_value = str(target)
+        elif narrowed == "directory_path":
             target = tmp_path / "test_input_dir"
             target.mkdir()
+            cmd_value = str(target)
+        else:
+            member_a = tmp_path / "test_input_a.md"
+            member_a.write_text("a")
+            member_b = tmp_path / "test_input_b.md"
+            member_b.write_text("b")
+            cmd_value = f"{member_a},{member_b}"
         spec = InputSpec(name=input_name, type=narrowed, required=True, position=0)
         result = _check_input_contracts(
-            f"/autoskillit:{skill_name} {target}",
+            f"/autoskillit:{skill_name} {cmd_value}",
             str(tmp_path),
             resolver=lambda skill_command, _s=spec: (_s,),
         )
@@ -545,24 +558,181 @@ class TestInputContractRealContracts:
         from autoskillit.core import InputSpec
         from autoskillit.server._guards import _check_input_contracts
 
-        narrowed: Literal["file_path", "directory_path"] = (
-            "file_path" if declared_type == "file_path" else "directory_path"
-        )
+        narrowed = cast("Literal['file_path', 'directory_path', 'file_path_list']", declared_type)
         if narrowed == "file_path":
             wrong_target = tmp_path / "wrong_dir"
             wrong_target.mkdir()
-        else:
+            cmd_value = str(wrong_target)
+        elif narrowed == "directory_path":
             wrong_target = tmp_path / "wrong_file.md"
             wrong_target.write_text("test")
+            cmd_value = str(wrong_target)
+        else:
+            existing = tmp_path / "existing_member.md"
+            existing.write_text("ok")
+            missing = tmp_path / "missing_member.md"
+            cmd_value = f"{existing},{missing}"
         spec = InputSpec(name=input_name, type=narrowed, required=True, position=0)
         result = _check_input_contracts(
-            f"/autoskillit:{skill_name} {wrong_target}",
+            f"/autoskillit:{skill_name} {cmd_value}",
             str(tmp_path),
             resolver=lambda skill_command, _s=spec: (_s,),
         )
         assert result is not None
         parsed = json.loads(result)
         assert parsed["success"] is False
+
+
+class TestFilePathListRealResolver:
+    """Real-resolver coverage for declared file_path_list specs."""
+
+    @pytest.mark.parametrize(
+        "skill_name,input_name,declared_type",
+        _FILE_PATH_LIST_SPECS,
+        ids=[f"{s}-{i}" for s, i, _ in _FILE_PATH_LIST_SPECS],
+    )
+    def test_gate_real_resolver_for_file_path_list_specs(
+        self, tmp_path, skill_name: str, input_name: str, declared_type: str
+    ) -> None:
+        """For every file_path_list spec, the real resolver must validate comma-joined members."""
+        from autoskillit.recipe._contracts_manifest import resolve_input_specs
+        from autoskillit.server._guards import _check_input_contracts
+
+        assert declared_type == "file_path_list", "parametrize filter precondition"
+        specs = resolve_input_specs(f"/autoskillit:{skill_name}")
+        target_spec = next((s for s in specs if s.name == input_name), None)
+        assert target_spec is not None, (
+            f"resolver did not surface {skill_name}.{input_name} (specs={specs!r})"
+        )
+
+        cmd_args: list[str] = []
+        for spec in specs:
+            if spec.position < target_spec.position:
+                if spec.type == "file_path":
+                    predecessor = tmp_path / f"pre_{spec.name}.md"
+                    predecessor.write_text("pre")
+                    cmd_args.append(str(predecessor))
+                elif spec.type == "directory_path":
+                    pred_dir = tmp_path / f"pre_{spec.name}_dir"
+                    pred_dir.mkdir()
+                    cmd_args.append(str(pred_dir))
+                else:
+                    a = tmp_path / f"pre_{spec.name}_a.md"
+                    a.write_text("a")
+                    b = tmp_path / f"pre_{spec.name}_b.md"
+                    b.write_text("b")
+                    cmd_args.append(f"{a},{b}")
+        member_a = tmp_path / f"target_{input_name}_a.md"
+        member_a.write_text("a")
+        member_b = tmp_path / f"target_{input_name}_b.md"
+        member_b.write_text("b")
+        cmd_args.append(f"{member_a},{member_b}")
+
+        cmd = f"/autoskillit:{skill_name} {' '.join(cmd_args)}"
+        result = _check_input_contracts(cmd, str(tmp_path), resolve_input_specs)
+        assert result is None, (
+            f"Expected gate acceptance for {skill_name}.{input_name}, got: {result!r}"
+        )
+
+
+class TestPreparePrCrossBinding:
+    """Bundled prepare-pr cross-binding: comma-joined plans must bind plan_paths at position 0."""
+
+    def test_prepare_pr_actual_recipe_shape_accepts_comma_plan_paths(self, tmp_path) -> None:
+        """Bundled recipe shape with comma-joined plans must clear the gate."""
+        from autoskillit.recipe._contracts_manifest import resolve_input_specs
+        from autoskillit.server._guards import _check_input_contracts
+
+        plan_a = tmp_path / "plan_a.md"
+        plan_a.write_text("plan a")
+        plan_b = tmp_path / "plan_b.md"
+        plan_b.write_text("plan b")
+        joined = f"{plan_a},{plan_b}"
+        cmd = f"/autoskillit:prepare-pr {joined} my-run main 123 true"
+        result = _check_input_contracts(cmd, str(tmp_path), resolve_input_specs)
+        assert result is None, f"Expected acceptance, got: {result!r}"
+
+    def test_prepare_pr_plan_list_and_conflict_report_bind_separately(self, tmp_path) -> None:
+        """Comma-joined plans plus optional conflict-report must bind as two path specs."""
+        from autoskillit.recipe._contracts_manifest import resolve_input_specs
+        from autoskillit.server._guards import _check_input_contracts
+
+        plan_a = tmp_path / "plan_a.md"
+        plan_a.write_text("plan a")
+        plan_b = tmp_path / "plan_b.md"
+        plan_b.write_text("plan b")
+        conflict = tmp_path / "conflict.md"
+        conflict.write_text("conflict")
+        joined = f"{plan_a},{plan_b}"
+        cmd = f"/autoskillit:prepare-pr {joined} my-run main 123 true {conflict}"
+        result = _check_input_contracts(cmd, str(tmp_path), resolve_input_specs)
+        assert result is None, f"Expected acceptance, got: {result!r}"
+
+    def test_prepare_pr_missing_conflict_report_is_rejected(self, tmp_path) -> None:
+        """When conflict-report is missing, the scalar spec at path position 1 fails."""
+        from autoskillit.recipe._contracts_manifest import resolve_input_specs
+        from autoskillit.server._guards import _check_input_contracts
+
+        plan_a = tmp_path / "plan_a.md"
+        plan_a.write_text("plan a")
+        plan_b = tmp_path / "plan_b.md"
+        plan_b.write_text("plan b")
+        joined = f"{plan_a},{plan_b}"
+        cmd = f"/autoskillit:prepare-pr {joined} my-run main 123 true /tmp/does-not-exist.md"
+        result = _check_input_contracts(cmd, str(tmp_path), resolve_input_specs)
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert "conflict_report_path" in parsed["result"]
+
+
+class TestOpenIntegrationPrExactShape:
+    """Bundled open-integration-pr shape: conflict_report_paths must bind path position 1."""
+
+    def _make_recipe_shape_files(self, tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+        pr_order = tmp_path / "pr_order.json"
+        pr_order.write_text("{}")
+        conflict_a = tmp_path / "conflict_a.md"
+        conflict_a.write_text("a")
+        conflict_b = tmp_path / "conflict_b.md"
+        conflict_b.write_text("b")
+        domain_partitions = tmp_path / "domain_partitions.json"
+        domain_partitions.write_text("{}")
+        return pr_order, conflict_a, conflict_b, domain_partitions
+
+    def test_open_integration_pr_recipe_shape_accepts_conflict_list(self, tmp_path: Path) -> None:
+        """Comma-joined conflict reports + named domain partitions must validate."""
+        from autoskillit.recipe._contracts_manifest import resolve_input_specs
+        from autoskillit.server._guards import _check_input_contracts
+
+        pr_order, conflict_a, conflict_b, domain_partitions = self._make_recipe_shape_files(
+            tmp_path
+        )
+        cmd = (
+            f"/autoskillit:open-integration-pr batch-branch main {pr_order} GO "
+            f'"{conflict_a},{conflict_b}" domain_partitions_path={domain_partitions}'
+        )
+        result = _check_input_contracts(cmd, str(tmp_path), resolve_input_specs)
+        assert result is None, f"Expected acceptance, got: {result!r}"
+
+    def test_open_integration_pr_missing_conflict_member_rejected(self, tmp_path: Path) -> None:
+        """Missing conflict-report member must be rejected as conflict_report_paths."""
+        from autoskillit.recipe._contracts_manifest import resolve_input_specs
+        from autoskillit.server._guards import _check_input_contracts
+
+        pr_order, conflict_a, _conflict_b, domain_partitions = self._make_recipe_shape_files(
+            tmp_path
+        )
+        missing = tmp_path / "missing_conflict.md"
+        cmd = (
+            f"/autoskillit:open-integration-pr batch-branch main {pr_order} GO "
+            f'"{conflict_a},{missing}" domain_partitions_path={domain_partitions}'
+        )
+        result = _check_input_contracts(cmd, str(tmp_path), resolve_input_specs)
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert "conflict_report_paths" in parsed["result"]
 
 
 class TestInputContractIntegration:

--- a/tests/server/test_tools_execution_input_gates_file_path_list.py
+++ b/tests/server/test_tools_execution_input_gates_file_path_list.py
@@ -1,0 +1,140 @@
+"""file_path_list gate behavioral tests for comma and quoted newline plan lists."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+def _check(skill_command: str, cwd: str, resolver):
+    from autoskillit.server._guards import _check_input_contracts
+
+    return _check_input_contracts(skill_command, cwd, resolver)
+
+
+def _make_spec(name: str, type_: str, position: int, required: bool = False):
+    from autoskillit.core import InputSpec
+
+    return InputSpec(name=name, type=type_, required=required, position=position)
+
+
+def _resolver_for(specs):
+    return lambda skill_command, _s=tuple(specs): _s
+
+
+def test_gate_accepts_comma_separated_plan_list(tmp_path):
+    """Comma-separated existing files in a file_path_list spec must be accepted."""
+    plan_a = tmp_path / "plan_a.md"
+    plan_a.write_text("a")
+    plan_b = tmp_path / "plan_b.md"
+    plan_b.write_text("b")
+    spec = _make_spec("all_plan_paths", "file_path_list", 0)
+    result = _check(
+        f"/autoskillit:audit-impl {plan_a},{plan_b}",
+        str(tmp_path),
+        _resolver_for((spec,)),
+    )
+    assert result is None
+
+
+def test_gate_rejects_comma_list_with_missing_member(tmp_path):
+    """Comma-separated list with one missing member must be rejected naming the missing path."""
+    plan_a = tmp_path / "plan_a.md"
+    plan_a.write_text("a")
+    missing = tmp_path / "missing.md"
+    spec = _make_spec("all_plan_paths", "file_path_list", 0)
+    result = _check(
+        f"/autoskillit:audit-impl {plan_a},{missing}",
+        str(tmp_path),
+        _resolver_for((spec,)),
+    )
+    assert result is not None
+    parsed = json.loads(result)
+    assert parsed["success"] is False
+    assert str(missing) in parsed["result"]
+
+
+def test_gate_rejects_comma_list_all_missing(tmp_path):
+    """All-missing comma list must be rejected naming every missing path."""
+    missing_a = tmp_path / "missing_a.md"
+    missing_b = tmp_path / "missing_b.md"
+    spec = _make_spec("all_plan_paths", "file_path_list", 0)
+    result = _check(
+        f"/autoskillit:audit-impl {missing_a},{missing_b}",
+        str(tmp_path),
+        _resolver_for((spec,)),
+    )
+    assert result is not None
+    parsed = json.loads(result)
+    assert parsed["success"] is False
+    assert str(missing_a) in parsed["result"]
+    assert str(missing_b) in parsed["result"]
+
+
+def test_resolve_input_specs_audit_impl_path_sequence():
+    """audit-impl path-spec sequence must be list, list, scalar in declared order."""
+    from autoskillit.recipe._contracts_manifest import resolve_input_specs
+
+    specs = resolve_input_specs("/autoskillit:audit-impl /plan1.md,/plan2.md main feature/x")
+    names_types_positions = [(s.name, s.type, s.position) for s in specs]
+    assert ("all_plan_paths", "file_path_list", 0) in names_types_positions
+    assert ("closure_authority_path", "file_path", 2) in names_types_positions
+
+
+def test_gate_accepts_quoted_newline_separated_plan_list(tmp_path):
+    """Quoted newline-separated list is preserved as one logical argument and accepted."""
+    from autoskillit.recipe._contracts_manifest import resolve_input_specs
+
+    plan_a = tmp_path / "plan_a.md"
+    plan_a.write_text("a")
+    plan_b = tmp_path / "plan_b.md"
+    plan_b.write_text("b")
+    cmd = f'/autoskillit:audit-impl "{plan_a}\n{plan_b}" main feature/x'
+    resolver = resolve_input_specs
+    result = _check(cmd, str(tmp_path), resolver)
+    assert result is None
+
+
+def test_gate_accepts_audit_impl_conflict_report_list(tmp_path):
+    """merge-prs audit-impl shape: plan list and conflict-report list bind separately."""
+    from autoskillit.recipe._contracts_manifest import resolve_input_specs
+
+    plan_a = tmp_path / "plan_a.md"
+    plan_a.write_text("a")
+    plan_b = tmp_path / "plan_b.md"
+    plan_b.write_text("b")
+    conflict_a = tmp_path / "conflict_a.md"
+    conflict_a.write_text("ca")
+    conflict_b = tmp_path / "conflict_b.md"
+    conflict_b.write_text("cb")
+    cmd = (
+        f'/autoskillit:audit-impl "{plan_a},{plan_b}" branch feature/x "{conflict_a},{conflict_b}"'
+    )
+    resolver = resolve_input_specs
+    result = _check(cmd, str(tmp_path), resolver)
+    assert result is None
+
+
+def test_real_resolver_multi_spec_interaction(tmp_path):
+    """Real resolver with all three path specs — plan list, conflict list, scalar closure."""
+    from autoskillit.recipe._contracts_manifest import resolve_input_specs
+
+    plan_a = tmp_path / "plan_a.md"
+    plan_a.write_text("a")
+    plan_b = tmp_path / "plan_b.md"
+    plan_b.write_text("b")
+    conflict_a = tmp_path / "conflict_a.md"
+    conflict_a.write_text("ca")
+    conflict_b = tmp_path / "conflict_b.md"
+    conflict_b.write_text("cb")
+    authority = tmp_path / "authority.md"
+    authority.write_text("auth")
+    cmd = (
+        f"/autoskillit:audit-impl {plan_a},{plan_b} branch feature/x "
+        f"{conflict_a},{conflict_b} {authority}"
+    )
+    result = _check(cmd, str(tmp_path), resolve_input_specs)
+    assert result is None


### PR DESCRIPTION
## Summary

The input contract validation gate (`_check_input_contracts` in `src/autoskillit/server/_guards.py`) rejects comma-separated plan path lists because the type system (`InputSpec.type`) only recognizes scalar `file_path` and `directory_path`. The `file_path_list` type already exists in `src/autoskillit/recipe/skill_contracts.yaml` for output fields and `parse_plan_paths()` already splits comma-joined strings — but neither is wired into the input contract resolution or validation pipeline. This is a half-finished feature where the type vocabulary, the splitter, and the gate each live in separate modules with no structural enforcement that they stay in sync.

## Requirements

The input-contract layer must accept the same cumulative-plan representations that `audit-impl` accepts, while still validating every constituent path:
- scalar plan file;
- comma-separated plan files;
- supported audit manifest file;
- supported plan directory, if retained by the skill contract.

Each constituent path must exist and have the expected file/directory type. A missing member must fail closed with an error naming that member. The gate must not require workers to alter positional syntax in ways that change skill argument binding.

Scope:
- Introduce collection-aware input validation for `audit-impl` cumulative plans, or replace the scalar contract with a typed representation that preserves the skill accepted forms.
- Remove the ambiguous duplicate scalar `plan_path`/`all_plan_paths` contract shape if it is not semantically valid.
- Add a direct server-gate regression for two comma-separated existing plan files.
- Add a negative regression for one existing plus one missing member.
- Add a bundled-remediation integration regression proving an audit-remediation re-entry reaches the auditor with all accumulated plans in order.
- Add a positional-binding regression preventing a space-separated workaround from silently shifting `implementation_ref` and `base_branch`.

Closes #4229

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260714-070103-362151/.autoskillit/temp/rectify/rectify_input_contract_list_type_immunity_2026-07-14_073000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
