### PR TITLE
Rectify: pre_remediation_merge ref_coherence Recovery — PART A

### DIFF
--- a/src/autoskillit/hooks/formatters/_fmt_execution.py
+++ b/src/autoskillit/hooks/formatters/_fmt_execution.py
@@ -1,10 +1,4 @@
-"""Execution-tool formatters for the pretty_output split.
-
-Hosts ``run_skill``, ``run_cmd``, ``test_check``, ``merge_worktree``. Stdlib-only.
-
-The ``dispatch_food_truck`` formatter lives in ``_fmt_dispatch.py`` to keep
-this module under its file size budget (REQ-FILE-001).
-"""
+"""Execution-tool formatters for pretty_output."""
 
 from __future__ import annotations
 
@@ -327,6 +321,9 @@ _FMT_MERGE_WORKTREE_RENDERED: frozenset[str] = frozenset(
         "abort_failed",
         "abort_stderr",
         "poisoned_installs",
+        "local_sha",
+        "remote_sha",
+        "remote_is_ancestor",
     }
 )
 _FMT_MERGE_WORKTREE_SUPPRESSED: frozenset[str] = frozenset()

--- a/src/autoskillit/recipe/rules/rules_merge.py
+++ b/src/autoskillit/recipe/rules/rules_merge.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from collections import deque
+
 import regex as re
 
 from autoskillit.core import MergeFailedStep, Severity, get_logger
 from autoskillit.recipe._analysis import ValidationContext, bfs_reachable
+from autoskillit.recipe._analysis_bfs import _build_success_step_graph
 from autoskillit.recipe._rule_helpers import _is_loop_guard_step
+from autoskillit.recipe.contracts import resolve_skill_name
 from autoskillit.recipe.registry import RuleFinding, make_finding, semantic_rule
 
 logger = get_logger(__name__)
@@ -59,11 +63,33 @@ _MERGE_FAILURE_DOMAINS: dict[str, str] = {
     MergeFailedStep.TEST_GATE: "code",
     MergeFailedStep.POST_REBASE_TEST_GATE: "code",
     MergeFailedStep.REBASE: "git_conflict",
+    MergeFailedStep.REF_COHERENCE: "push_recovery",
 }
 
 _REQUIRED_SKILL_BY_DOMAIN: dict[str, str] = {
     "code": "resolve-failures",
     "git_conflict": "resolve-merge-conflicts",
+}
+
+# Behavioral recovery classes for domains that cannot be validated by exact skill
+# identity. Keys are domain names; values are the recovery class a route must
+# reach via the nearest-depth success-path traversal.
+_REQUIRED_RECOVERY_CLASS: dict[str, str] = {
+    "push_recovery": "push_recovery",
+}
+
+# Recovery signatures used by _classify_recovery_class. Each signature maps a
+# distinct identity kind to a recovery class. Lookup order is deterministic.
+_RECOVERY_SIGNATURES_TOOL: dict[str, str] = {
+    "push_to_remote": "push_recovery",
+}
+_RECOVERY_SIGNATURES_SKILL: dict[str, str] = {
+    "resolve-failures": "fix_loop",
+    "resolve-merge-conflicts": "rebase_loop",
+    "make-plan": "direct_remediate",
+}
+_RECOVERY_SIGNATURES_CALLABLE: dict[str, str] = {
+    "autoskillit.recipe._cmd_rpc.main_repo_guard": "dirty_retry",
 }
 
 _FAILED_STEP_PATTERN = re.compile(r"result\.failed_step\s*==\s*['\"](\w+)['\"]")
@@ -112,16 +138,227 @@ def _check_merge_routing_completeness(ctx: ValidationContext) -> list[RuleFindin
     return findings
 
 
+# Predicate-qualified keys for cross-site merge routing comparison. Each failed_step
+# may have one or more predicate-qualified variants; the key combines them so
+# duplicate arms never overwrite each other in the per-site evidence map.
+_CROSS_SITE_VARIANT_DEFAULT = "default"
+_CROSS_SITE_VARIANT_ANCESTRY = "ancestry-aware"
+_CROSS_SITE_VARIANT_FALLBACK = "fallback"
+
+
+def _predicate_variant(condition_when: str | None, failed_step_value: str) -> str:
+    """Return a predicate-qualified variant label for a failed_step arm.
+
+    For ref_coherence, distinguish at least ancestry-aware (contains both
+    ``ref_coherence`` and ``remote_is_ancestor``) and fallback (contains
+    ``ref_coherence`` but not ``remote_is_ancestor``). All other failed_steps
+    collapse to a single default variant.
+    """
+    if condition_when is None:
+        return _CROSS_SITE_VARIANT_DEFAULT
+    when_lower = condition_when.lower()
+    if failed_step_value == MergeFailedStep.REF_COHERENCE:
+        has_ref = "ref_coherence" in when_lower
+        has_ancestor = "remote_is_ancestor" in when_lower
+        if has_ref and has_ancestor:
+            return _CROSS_SITE_VARIANT_ANCESTRY
+        if has_ref:
+            return _CROSS_SITE_VARIANT_FALLBACK
+    return _CROSS_SITE_VARIANT_DEFAULT
+
+
+# Exact site pair exemption for the bundled remediation recipe: the
+# pre_remediation_merge and merge steps intentionally diverge for these four
+# failed_step values because pre_remediation_merge runs before remediation
+# starts and merge runs after. ref_coherence must still match across sites.
+_CROSS_SITE_SITE_PAIR_EXEMPTIONS: dict[tuple[str, str], frozenset[str]] = {
+    ("pre_remediation_merge", "merge"): frozenset(
+        {
+            MergeFailedStep.DIRTY_TREE,
+            MergeFailedStep.TEST_GATE,
+            MergeFailedStep.POST_REBASE_TEST_GATE,
+            MergeFailedStep.REBASE,
+        }
+    ),
+}
+
+
+def _check_merge_routing_cross_site_consistency(
+    ctx: ValidationContext,
+) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+
+    merge_sites: dict[str, dict[str, list[tuple[str, str]]]] = {}
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "merge_worktree":
+            continue
+        if not step.on_result or not step.on_result.conditions:
+            continue
+        per_variant: dict[str, list[tuple[str, str]]] = {}
+        for condition in step.on_result.conditions:
+            if condition.when is None:
+                continue
+            m = _FAILED_STEP_PATTERN.search(condition.when)
+            if not m:
+                continue
+            failed_step_value = m.group(1)
+            if failed_step_value not in _RECOVERABLE_FAILED_STEPS:
+                continue
+            variant = _predicate_variant(condition.when, failed_step_value)
+            key = f"{failed_step_value}::{variant}"
+            per_variant.setdefault(key, []).append((condition.route, condition.when))
+        if per_variant:
+            merge_sites[step_name] = per_variant
+
+    site_names = sorted(merge_sites)
+    if len(site_names) < 2:
+        return findings
+
+    all_keys: set[str] = set()
+    for per_variant in merge_sites.values():
+        all_keys.update(per_variant.keys())
+
+    for key in sorted(all_keys):
+        sites_with_key = [s for s in site_names if key in merge_sites[s]]
+        if len(sites_with_key) < 2:
+            continue
+
+        failed_step_value = key.split("::", 1)[0]
+        if all(
+            failed_step_value in _CROSS_SITE_SITE_PAIR_EXEMPTIONS.get((a, b), frozenset())
+            for a in sites_with_key
+            for b in sites_with_key
+            if a != b and (a, b) in _CROSS_SITE_SITE_PAIR_EXEMPTIONS
+        ):
+            continue
+
+        classifications: dict[str, str | None] = {}
+        targets: dict[str, str] = {}
+        for site in sites_with_key:
+            arm = merge_sites[site][key][0]
+            route = arm[0]
+            targets[site] = route
+            classifications[site] = _classify_recovery_class(route, ctx)
+
+        classified = {s: c for s, c in classifications.items() if c is not None}
+        unclassified = [s for s in classifications if classifications[s] is None]
+
+        mismatch = False
+        if classified and unclassified:
+            mismatch = True
+        elif len(classified) >= 2 and len(set(classified.values())) > 1:
+            mismatch = True
+        elif len(unclassified) >= 2:
+            unclassified_targets = {targets[s] for s in unclassified}
+            if len(unclassified_targets) > 1:
+                mismatch = True
+
+        if not mismatch:
+            continue
+
+        site_list = ", ".join(sites_with_key)
+        target_list = ", ".join(f"{s}->{targets[s]}({classifications[s]})" for s in sites_with_key)
+        findings.append(
+            make_finding(
+                rule_name="merge-routing-cross-site-consistency",
+                step_name=sites_with_key[0],
+                message=(
+                    f"merge_worktree sites [{site_list}] have inconsistent predicate-"
+                    f"qualified routing for failed_step '{failed_step_value}' "
+                    f"(variant '{key.split('::', 1)[1]}'): {target_list}. The "
+                    f"same failed_step at different merge sites must reach the "
+                    f"same recovery class."
+                ),
+            )
+        )
+    return findings
+
+
+@semantic_rule(
+    name="merge-routing-cross-site-consistency",
+    description=(
+        "Every merge_worktree step in the same recipe must route each "
+        "predicate-qualified failed_step arm to the same recovery class. "
+        "Recovery class is determined by the nearest-depth success-path "
+        "traversal. Classified-vs-unclassified and different unclassified "
+        "targets are both mismatches."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_merge_routing_cross_site_consistency_decorated(
+    ctx: ValidationContext,
+) -> list[RuleFinding]:
+    return _check_merge_routing_cross_site_consistency(ctx)
+
+
 _SKILL_CMD_PATTERN = re.compile(r"/(?:autoskillit:)?([\w-]+)")
+
+
+def _classify_recovery_class(
+    route: str,
+    ctx: ValidationContext,
+    *,
+    max_depth: int = 4,
+    success_graph: dict[str, set[str]] | None = None,
+) -> str | None:
+    """Classify a recovery route by its nearest-depth recovery signature.
+
+    Traversal is level-ordered (BFS by depth, not by unordered reachable set) over
+    the success-path graph so a later incidental loop target cannot override a
+    nearer recovery signature. Inspection covers tool identity (push_to_remote),
+    exact resolved skill identity, and exact callable identity. The first depth
+    that contains a signature must identify exactly one unique class; if no depth
+    yields a signature within ``max_depth`` or the first signature-bearing depth
+    is ambiguous, return ``None``.
+    """
+    graph = success_graph if success_graph is not None else _build_success_step_graph(ctx.recipe)
+    if route not in graph:
+        return None
+    visited: set[str] = {route}
+    frontier: deque[str] = deque([route])
+    for _depth in range(max_depth + 1):
+        next_frontier: deque[str] = deque()
+        depth_signatures: set[str] = set()
+        for node in frontier:
+            step = ctx.recipe.steps.get(node)
+            if step is not None:
+                if step.tool in _RECOVERY_SIGNATURES_TOOL:
+                    depth_signatures.add(_RECOVERY_SIGNATURES_TOOL[step.tool])
+                if step.tool == "run_skill":
+                    skill_cmd = (step.with_args or {}).get("skill_command", "")
+                    skill_name = resolve_skill_name(skill_cmd)
+                    if skill_name and skill_name in _RECOVERY_SIGNATURES_SKILL:
+                        depth_signatures.add(_RECOVERY_SIGNATURES_SKILL[skill_name])
+                if step.tool == "run_python":
+                    callable_name = (step.with_args or {}).get("callable", "")
+                    if callable_name in _RECOVERY_SIGNATURES_CALLABLE:
+                        depth_signatures.add(_RECOVERY_SIGNATURES_CALLABLE[callable_name])
+            if _depth == max_depth:
+                continue
+            for successor in graph.get(node, ()):
+                if successor in visited:
+                    continue
+                visited.add(successor)
+                next_frontier.append(successor)
+        if len(depth_signatures) == 1:
+            return next(iter(depth_signatures))
+        if len(depth_signatures) > 1:
+            return None
+        if not next_frontier:
+            return None
+        frontier = next_frontier
+    return None
 
 
 @semantic_rule(
     name="merge-failure-skill-domain-mismatch",
     description=(
-        "A merge_worktree on_result condition routes a recoverable failed_step to a "
-        "step whose skill does not match the failure domain. Git-conflict failures "
-        "(rebase) must route to resolve-merge-conflicts; code failures (dirty_tree, "
-        "test_gate, post_rebase_test_gate) must route to resolve-failures."
+        "A merge_worktree on_result condition routes a recoverable failed_step to "
+        "a route whose behavior does not match the failure domain. Git-conflict "
+        "failures (rebase) must route to resolve-merge-conflicts; code failures "
+        "(dirty_tree, test_gate, post_rebase_test_gate) must route to "
+        "resolve-failures; ref_coherence ancestry arms must classify as "
+        "push_recovery."
     ),
     severity=Severity.ERROR,
 )
@@ -129,6 +366,7 @@ def _check_merge_failure_skill_domain_mismatch(
     ctx: ValidationContext,
 ) -> list[RuleFinding]:
     findings: list[RuleFinding] = []
+    success_graph = _build_success_step_graph(ctx.recipe)
     for step_name, step in ctx.recipe.steps.items():
         if step.tool != "merge_worktree":
             continue
@@ -144,6 +382,34 @@ def _check_merge_failure_skill_domain_mismatch(
             failed_step_value = m.group(1)
             domain = _MERGE_FAILURE_DOMAINS.get(failed_step_value)
             if domain is None:
+                continue
+
+            # For REF_COHERENCE only the ancestry-aware arm is validated; the
+            # fallback arm is an intentional escalation terminal whose target
+            # differs from the ancestry arm by design.
+            if failed_step_value == MergeFailedStep.REF_COHERENCE:
+                when_lower = condition.when.lower()
+                if "remote_is_ancestor" not in when_lower:
+                    continue
+                required_class = _REQUIRED_RECOVERY_CLASS.get(domain)
+                if required_class is None:
+                    continue
+                actual_class = _classify_recovery_class(
+                    condition.route, ctx, success_graph=success_graph
+                )
+                if actual_class != required_class:
+                    findings.append(
+                        make_finding(
+                            rule_name="merge-failure-skill-domain-mismatch",
+                            step_name=step_name,
+                            message=(
+                                f"failed_step == '{failed_step_value}' ancestry arm "
+                                f"(domain: {domain}) routes to '{condition.route}' "
+                                f"which classifies as {actual_class!r}, expected "
+                                f"{required_class!r}."
+                            ),
+                        )
+                    )
                 continue
 
             target_step = ctx.recipe.steps.get(condition.route)

--- a/src/autoskillit/recipe/rules/rules_merge.py
+++ b/src/autoskillit/recipe/rules/rules_merge.py
@@ -224,12 +224,13 @@ def _check_merge_routing_cross_site_consistency(
             continue
 
         failed_step_value = key.split("::", 1)[0]
-        if all(
-            failed_step_value in _CROSS_SITE_SITE_PAIR_EXEMPTIONS.get((a, b), frozenset())
-            for a in sites_with_key
-            for b in sites_with_key
-            if a != b and (a, b) in _CROSS_SITE_SITE_PAIR_EXEMPTIONS
-        ):
+        site_set = frozenset(sites_with_key)
+        exemption_match = False
+        for pair, exempt_steps in _CROSS_SITE_SITE_PAIR_EXEMPTIONS.items():
+            if frozenset(pair) == site_set and failed_step_value in exempt_steps:
+                exemption_match = True
+                break
+        if exemption_match:
             continue
 
         classifications: dict[str, str | None] = {}

--- a/src/autoskillit/recipe/rules/rules_worktree.py
+++ b/src/autoskillit/recipe/rules/rules_worktree.py
@@ -353,36 +353,39 @@ def _barrier_has_orphaning_arm(
     success_graph: dict[str, set[str]],
 ) -> bool:
     """Return True if the merge barrier has an explicit failure arm whose route
-    reaches the current worktree creator before re-entering the barrier.
+    reaches the current worktree creator before crossing any merge_worktree barrier.
 
     An arm is unsafe when the creator is reachable from ``cond.route`` without
-    first crossing the barrier itself — that path orphans the current worktree.
-    A route that re-enters the barrier first (bounded retry) is safe; a route
-    that exits to a terminal or reaches a different worktree creator is safe.
+    first crossing any ``merge_worktree`` step — that path orphans the current
+    worktree. A route that re-enters any merge barrier first (bounded retry or
+    secondary merge) is safe; a route that exits to a terminal or reaches a
+    different worktree creator is safe. path_validation is excluded from the
+    failure arms that drive this analysis.
     """
     barrier_step = recipe.steps.get(barrier_step_name)
     if barrier_step is None or barrier_step.tool != "merge_worktree":
         return False
+    # Any merge_worktree step in the recipe is treated as a barrier boundary:
+    # crossing any merge barrier consumes the live worktree, so a route that
+    # re-enters a different merge before reaching the creator is a safe retry.
+    merge_barriers: frozenset[str] = frozenset(
+        name for name, step in recipe.steps.items() if step.tool == "merge_worktree"
+    )
     for condition in _merge_failure_arms(barrier_step):
         route = condition.route
         if route not in success_graph:
             continue
-        # Traverse from cond.route, treating the barrier itself as a non-expanding
-        # boundary. If the creator is visited before the barrier is re-entered,
-        # this arm is unsafe.
         visited: set[str] = {route}
         frontier: set[str] = {route}
         while frontier:
             next_frontier: set[str] = set()
             for node in frontier:
-                if node == barrier_step_name:
-                    continue
                 if node == creator_step_name:
                     return True
                 for successor in success_graph.get(node, ()):
                     if successor in visited:
                         continue
-                    if successor == barrier_step_name:
+                    if successor in merge_barriers:
                         continue
                     visited.add(successor)
                     next_frontier.add(successor)

--- a/src/autoskillit/recipe/rules/rules_worktree.py
+++ b/src/autoskillit/recipe/rules/rules_worktree.py
@@ -8,6 +8,7 @@ import regex as re
 
 from autoskillit.core import (
     SKILL_TOOLS,
+    MergeFailedStep,
     Severity,
     get_logger,
 )
@@ -19,7 +20,9 @@ from autoskillit.recipe.io import iter_steps_with_context
 from autoskillit.recipe.registry import RuleFinding, make_finding, semantic_rule
 
 if TYPE_CHECKING:
-    from autoskillit.recipe.schema import Recipe
+    from autoskillit.recipe.schema import Recipe, RecipeStep, StepResultCondition
+else:
+    from autoskillit.recipe.schema import RecipeStep, StepResultCondition
 
 logger = get_logger(__name__)
 
@@ -317,6 +320,76 @@ def _is_worktree_barrier(step_name: str, ctx_vars: frozenset[str], recipe: Recip
     return False
 
 
+# Conditions matched as explicit merge failure arms for barrier transparency.
+# path_validation is excluded: it occurs before any live worktree is acquired.
+_FAILED_STEP_CONDITION_RE = re.compile(r"\bfailed_step\b\s*==\s*['\"](\w+)['\"]")
+_RESULT_ERROR_CONDITION_RE = re.compile(r"\bresult\.error\b")
+
+
+def _merge_failure_arms(barrier_step: RecipeStep) -> list[StepResultCondition]:
+    """Return the explicit merge failure conditions on a merge_worktree barrier.
+
+    Excludes path_validation because that failure occurs before a live worktree
+    path is acquired, so there is no validated resource for the barrier to consume.
+    """
+    arms: list[StepResultCondition] = []
+    if not barrier_step.on_result or not barrier_step.on_result.conditions:
+        return arms
+    for condition in barrier_step.on_result.conditions:
+        if condition.when is None:
+            continue
+        m = _FAILED_STEP_CONDITION_RE.search(condition.when)
+        if m and m.group(1) == MergeFailedStep.PATH_VALIDATION:
+            continue
+        if m or _RESULT_ERROR_CONDITION_RE.search(condition.when):
+            arms.append(condition)
+    return arms
+
+
+def _barrier_has_orphaning_arm(
+    barrier_step_name: str,
+    creator_step_name: str,
+    recipe: Recipe,
+    success_graph: dict[str, set[str]],
+) -> bool:
+    """Return True if the merge barrier has an explicit failure arm whose route
+    reaches the current worktree creator before re-entering the barrier.
+
+    An arm is unsafe when the creator is reachable from ``cond.route`` without
+    first crossing the barrier itself — that path orphans the current worktree.
+    A route that re-enters the barrier first (bounded retry) is safe; a route
+    that exits to a terminal or reaches a different worktree creator is safe.
+    """
+    barrier_step = recipe.steps.get(barrier_step_name)
+    if barrier_step is None or barrier_step.tool != "merge_worktree":
+        return False
+    for condition in _merge_failure_arms(barrier_step):
+        route = condition.route
+        if route not in success_graph:
+            continue
+        # Traverse from cond.route, treating the barrier itself as a non-expanding
+        # boundary. If the creator is visited before the barrier is re-entered,
+        # this arm is unsafe.
+        visited: set[str] = {route}
+        frontier: set[str] = {route}
+        while frontier:
+            next_frontier: set[str] = set()
+            for node in frontier:
+                if node == barrier_step_name:
+                    continue
+                if node == creator_step_name:
+                    return True
+                for successor in success_graph.get(node, ()):
+                    if successor in visited:
+                        continue
+                    if successor == barrier_step_name:
+                        continue
+                    visited.add(successor)
+                    next_frontier.add(successor)
+            frontier = next_frontier
+    return False
+
+
 @semantic_rule(
     name="worktree-clobber-without-merge",
     description=(
@@ -361,10 +434,23 @@ def _check_worktree_clobber_without_merge(ctx: ValidationContext) -> list[RuleFi
                 s for s in recipe.steps if _is_worktree_barrier(s, captured_vars, recipe)
             }
 
+            # Barrier transparency: a merge_worktree barrier whose explicit failure
+            # arm routes back to this creator without revisiting the barrier does
+            # not actually protect the live worktree. Remove those barriers from
+            # the candidate set; non-merge cleanup barriers retain existing
+            # behavior.
+            transparent_barrier_steps = {
+                s
+                for s in barrier_steps
+                if recipe.steps.get(s) is None
+                or recipe.steps[s].tool != "merge_worktree"
+                or not _barrier_has_orphaning_arm(s, step_name, recipe, success_graph)
+            }
+
             # BFS from successors of the worktree step (within the cycle only)
             # to check if the step itself is reachable without crossing a barrier.
             cycle_successors = success_graph.get(step_name, set()) & cycle_set
-            visited = _bfs_capped(success_graph, cycle_successors, barrier_steps)
+            visited = _bfs_capped(success_graph, cycle_successors, transparent_barrier_steps)
 
             if step_name in visited:
                 cycle_path = "→".join(sorted(cycle_set))

--- a/src/autoskillit/recipes/diagrams/implementation-groups.md
+++ b/src/autoskillit/recipes/diagrams/implementation-groups.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:393e2648fa34ea87f128ec812b8bbd2deaddf0441e6d710646e6a8373d85facd -->
+<!-- autoskillit-recipe-hash: sha256:f19a5fe94fc3fa762b26c94b022eb8dd8a84f8ff9314588a91da76a01193de25 -->
 <!-- autoskillit-diagram-format: v7 -->
 ## implementation-groups
 Group-based implementation with per-group plan/implement/test cycles and PR gates.

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:4ea0feb1d75a6dd61c21d0bde01a00060990610d29240dfc21b9ef1cbd8f518a -->
+<!-- autoskillit-recipe-hash: sha256:fffab1e7c9750b837d5b1091d090e5410152a93ba46d759ed800dfb9964a0cac -->
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 

--- a/src/autoskillit/recipes/diagrams/remediation.md
+++ b/src/autoskillit/recipes/diagrams/remediation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:07605637c5979b8db209515a460ec474dcda1a834d371720bec9f6c35d49f76e -->
+<!-- autoskillit-recipe-hash: sha256:7797f5b58ed9bac3a7728890a599c01312a74432c13e8448749199c800fd7fc0 -->
 <!-- autoskillit-diagram-format: v7 -->
 ## remediation
 Investigate, rectify, implement, and merge a bug fix with CI and PR gates.
@@ -17,6 +17,7 @@ test ↔ assess
 |
 +-- audit_impl → reset_test_fix_counter → reset_merge_test_fix_counter
     → reset_ref_push_counter → pre_remediation_merge → remediate (optional)
+      [local ahead → ref push recovery → pre_remediation_merge]
     → merge_gate_test ↔ merge_gate_assess
        [merge_gate_assess context/rate limit → merge_gate_test]
 |

--- a/src/autoskillit/recipes/diagrams/remediation.md
+++ b/src/autoskillit/recipes/diagrams/remediation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:7797f5b58ed9bac3a7728890a599c01312a74432c13e8448749199c800fd7fc0 -->
+<!-- autoskillit-recipe-hash: sha256:077fad11823ad0404b999cb7bae62ae6b027b2a1f286a6e19b9a0e4da1418fd4 -->
 <!-- autoskillit-diagram-format: v7 -->
 ## remediation
 Investigate, rectify, implement, and merge a bug fix with CI and PR gates.

--- a/src/autoskillit/recipes/implementation-groups.json
+++ b/src/autoskillit/recipes/implementation-groups.json
@@ -650,8 +650,12 @@
           "route": "check_dirty_main_retry"
         },
         {
-          "when": "result.failed_step == 'ref_coherence'",
+          "when": "result.failed_step == 'ref_coherence' and result.remote_is_ancestor == true",
           "route": "check_ref_push_loop"
+        },
+        {
+          "when": "result.failed_step == 'ref_coherence'",
+          "route": "release_issue_failure"
         },
         {
           "when": "result.error",
@@ -662,7 +666,7 @@
         }
       ],
       "on_failure": "release_issue_failure",
-      "note": "After merge, route to inter_part_push to sync the remote branch, then check_next_iteration to process remaining parts/groups before pushing. GROUPS MODE: When all plan_parts for the current group are merged, advance to the next group (back to plan step with the next group's description). When all groups are complete, go to audit_impl (via next_or_done). By default (open_pr=true), merge_target is the feature branch named from run_name. When open_pr=false, merge_target equals base_branch — merges go directly to base. test_gate failures route to fix (resolve-failures) for recovery; all other failures route to release_issue_failure.\n"
+      "note": "After merge, route to inter_part_push to sync the remote branch, then check_next_iteration to process remaining parts/groups before pushing. GROUPS MODE: When all plan_parts for the current group are merged, advance to the next group (back to plan step with the next group's description). When all groups are complete, go to audit_impl (via next_or_done). By default (open_pr=true), merge_target is the feature branch named from run_name. When open_pr=false, merge_target equals base_branch — merges go directly to base. test_gate failures route to fix (resolve-failures) for recovery. Local-ahead ref_coherence mismatches use bounded push recovery; genuine divergence or indeterminate ancestry routes to release_issue_failure. Other failures also route to release_issue_failure.\n"
     },
     "push": {
       "tool": "push_to_remote",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -594,8 +594,10 @@ steps:
       route: check_merge_rebase_loop
     - when: "result.failed_step == 'dirty_main_repo'"
       route: check_dirty_main_retry
-    - when: "result.failed_step == 'ref_coherence'"
+    - when: "result.failed_step == 'ref_coherence' and result.remote_is_ancestor == true"
       route: check_ref_push_loop
+    - when: "result.failed_step == 'ref_coherence'"
+      route: release_issue_failure
     - when: "result.error"
       route: release_issue_failure
     - route: inter_part_push
@@ -608,8 +610,10 @@ steps:
       are complete, go to audit_impl (via next_or_done).
       By default (open_pr=true), merge_target is the feature branch named from run_name.
       When open_pr=false, merge_target equals base_branch — merges go directly to base.
-      test_gate failures route to fix (resolve-failures) for recovery;
-      all other failures route to release_issue_failure.
+      test_gate failures route to fix (resolve-failures) for recovery.
+      Local-ahead ref_coherence mismatches use bounded push recovery; genuine
+      divergence or indeterminate ancestry routes to release_issue_failure.
+      Other failures also route to release_issue_failure.
 
   push:
     tool: push_to_remote

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -692,8 +692,12 @@
           "route": "check_dirty_main_retry"
         },
         {
-          "when": "result.failed_step == 'ref_coherence'",
+          "when": "result.failed_step == 'ref_coherence' and result.remote_is_ancestor == true",
           "route": "check_ref_push_loop"
+        },
+        {
+          "when": "result.failed_step == 'ref_coherence'",
+          "route": "release_issue_failure"
         },
         {
           "when": "result.error",
@@ -704,7 +708,7 @@
         }
       ],
       "on_failure": "release_issue_failure",
-      "note": "After merge, route to inter_part_push to sync the remote branch, then next_or_done to process remaining parts before pushing. By default (open_pr=true), merge_target is the feature branch named from run_name. When open_pr=false, merge_target equals base_branch — merges go directly to base. dirty_tree and test_gate failures route to fix (resolve-failures) for recovery; all other failures route to release_issue_failure.\n"
+      "note": "After merge, route to inter_part_push to sync the remote branch, then next_or_done to process remaining parts before pushing. By default (open_pr=true), merge_target is the feature branch named from run_name. When open_pr=false, merge_target equals base_branch — merges go directly to base. dirty_tree and test_gate failures route to fix (resolve-failures) for recovery. Local-ahead ref_coherence mismatches use bounded push recovery; genuine divergence or indeterminate ancestry routes to release_issue_failure. Other failures also route to release_issue_failure.\n"
     },
     "check_has_commits": {
       "tool": "run_python",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -648,8 +648,10 @@ steps:
       route: check_merge_rebase_loop
     - when: result.failed_step == 'dirty_main_repo'
       route: check_dirty_main_retry
-    - when: result.failed_step == 'ref_coherence'
+    - when: result.failed_step == 'ref_coherence' and result.remote_is_ancestor == true
       route: check_ref_push_loop
+    - when: result.failed_step == 'ref_coherence'
+      route: release_issue_failure
     - when: result.error
       route: release_issue_failure
     - route: inter_part_push
@@ -659,7 +661,9 @@ steps:
       By default (open_pr=true), merge_target is the feature branch named from run_name.
       When open_pr=false, merge_target equals base_branch — merges go directly to
       base. dirty_tree and test_gate failures route to fix (resolve-failures) for
-      recovery; all other failures route to release_issue_failure.
+      recovery. Local-ahead ref_coherence mismatches use bounded push recovery;
+      genuine divergence or indeterminate ancestry routes to release_issue_failure.
+      Other failures also route to release_issue_failure.
 
       '
   check_has_commits:

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -713,15 +713,15 @@
         },
         {
           "when": "result.failed_step == 'test_gate'",
-          "route": "remediate"
+          "route": "release_issue_failure"
         },
         {
           "when": "result.failed_step == 'post_rebase_test_gate'",
-          "route": "remediate"
+          "route": "release_issue_failure"
         },
         {
           "when": "result.failed_step == 'rebase'",
-          "route": "remediate"
+          "route": "release_issue_failure"
         },
         {
           "when": "result.failed_step == 'dirty_main_repo'",
@@ -748,7 +748,7 @@
         }
       ],
       "on_failure": "release_issue_failure",
-      "note": "Merges the current worktree before the remediation cycle creates a new one. Audit NO GO means the implementation is incomplete, not wrong — merge it first, then remediate on top. This prevents orphaning the original worktree when implement re-runs. A local-ahead ref_coherence mismatch uses the shared ref_push_count budget and pre-remediation push recovery; genuine divergence or indeterminate ancestry escalates. dirty_tree routes to commit_guard_pre_remediation to auto-commit before retrying merge. dirty_main_repo routes to main_repo_guard_pre_remediation to stash. test_gate, rebase, and path_validation route to remediate — the remediation plan will address these. path_validation means the worktree was already merged in a prior session. Only hard errors escalate to release_issue_failure.\n"
+      "note": "Merges the current worktree before the remediation cycle creates a new one. Audit NO GO means the implementation is incomplete, not wrong — merge it first, then remediate on top. This prevents orphaning the original worktree when implement re-runs. A local-ahead ref_coherence mismatch uses the shared ref_push_count budget and pre-remediation push recovery; genuine divergence or indeterminate ancestry escalates. dirty_tree routes to commit_guard_pre_remediation to auto-commit before retrying merge. dirty_main_repo routes to main_repo_guard_pre_remediation to stash. test_gate, post_rebase_test_gate, and rebase escalate to release_issue_failure — leaving the worktree live and retrying from a remediation cycle would orphan the original worktree. path_validation means the worktree was already merged in a prior session and routes to remediate.\n"
     },
     "commit_guard_pre_remediation": {
       "tool": "run_python",
@@ -1116,15 +1116,15 @@
         },
         {
           "when": "result.failed_step == 'test_gate'",
-          "route": "check_merge_fix_loop"
+          "route": "release_issue_failure"
         },
         {
           "when": "result.failed_step == 'post_rebase_test_gate'",
-          "route": "check_merge_fix_loop"
+          "route": "release_issue_failure"
         },
         {
           "when": "result.failed_step == 'rebase'",
-          "route": "check_merge_rebase_loop"
+          "route": "release_issue_failure"
         },
         {
           "when": "result.failed_step == 'dirty_main_repo'",

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -656,7 +656,44 @@
       },
       "on_success": "pre_remediation_merge",
       "on_failure": "pre_remediation_merge",
-      "note": "Resets ref_push_count to 0 so each audit-remediation cycle gets a fresh ref-push budget."
+      "note": "Resets ref_push_count to 0 so each audit-remediation cycle gets a fresh ref-push budget shared by normal and pre-remediation recovery."
+    },
+    "check_ref_push_loop_pre_remediation": {
+      "tool": "run_python",
+      "with": {
+        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+        "current_iteration": "${{ context.ref_push_count }}",
+        "max_iterations": "2"
+      },
+      "capture": {
+        "ref_push_count": "${{ result.next_iteration }}"
+      },
+      "on_result": [
+        {
+          "when": "${{ result.max_exceeded }} == true",
+          "route": "release_issue_failure"
+        },
+        {
+          "route": "ref_push_pre_remediation"
+        }
+      ],
+      "on_failure": "release_issue_failure",
+      "optional_context_refs": [
+        "ref_push_count"
+      ],
+      "note": "Pre-remediation ref-coherence recovery guard. Shares ref_push_count (max 2) with check_ref_push_loop. Routes to ref_push_pre_remediation, then commit_guard_pre_remediation and pre_remediation_merge.\n"
+    },
+    "ref_push_pre_remediation": {
+      "tool": "push_to_remote",
+      "with": {
+        "clone_path": "${{ context.work_dir }}",
+        "remote_url": "${{ context.remote_url }}",
+        "branch": "${{ context.merge_target }}",
+        "force": "true"
+      },
+      "on_success": "commit_guard_pre_remediation",
+      "on_failure": "release_issue_failure",
+      "note": "Pushes the feature branch when the remote ref is an ancestor of the local ref, then retries pre_remediation_merge through its commit guard.\n"
     },
     "pre_remediation_merge": {
       "tool": "merge_worktree",
@@ -691,8 +728,12 @@
           "route": "main_repo_guard_pre_remediation"
         },
         {
+          "when": "result.failed_step == 'ref_coherence' and result.remote_is_ancestor == true",
+          "route": "check_ref_push_loop_pre_remediation"
+        },
+        {
           "when": "result.failed_step == 'ref_coherence'",
-          "route": "remediate"
+          "route": "release_issue_failure"
         },
         {
           "when": "result.failed_step == 'path_validation'",
@@ -707,7 +748,7 @@
         }
       ],
       "on_failure": "release_issue_failure",
-      "note": "Merges the current worktree before the remediation cycle creates a new one. Audit NO GO means the implementation is incomplete, not wrong — merge it first, then remediate on top. This prevents orphaning the original worktree when implement re-runs. dirty_tree routes to commit_guard_pre_remediation to auto-commit before retrying merge. dirty_main_repo routes to main_repo_guard_pre_remediation to stash. test_gate, rebase, and path_validation route to remediate — the remediation plan will address these. path_validation means the worktree was already merged in a prior session. Only hard errors escalate to release_issue_failure.\n"
+      "note": "Merges the current worktree before the remediation cycle creates a new one. Audit NO GO means the implementation is incomplete, not wrong — merge it first, then remediate on top. This prevents orphaning the original worktree when implement re-runs. A local-ahead ref_coherence mismatch uses the shared ref_push_count budget and pre-remediation push recovery; genuine divergence or indeterminate ancestry escalates. dirty_tree routes to commit_guard_pre_remediation to auto-commit before retrying merge. dirty_main_repo routes to main_repo_guard_pre_remediation to stash. test_gate, rebase, and path_validation route to remediate — the remediation plan will address these. path_validation means the worktree was already merged in a prior session. Only hard errors escalate to release_issue_failure.\n"
     },
     "commit_guard_pre_remediation": {
       "tool": "run_python",
@@ -1090,8 +1131,12 @@
           "route": "check_dirty_main_retry"
         },
         {
-          "when": "result.failed_step == 'ref_coherence'",
+          "when": "result.failed_step == 'ref_coherence' and result.remote_is_ancestor == true",
           "route": "check_ref_push_loop"
+        },
+        {
+          "when": "result.failed_step == 'ref_coherence'",
+          "route": "release_issue_failure"
         },
         {
           "when": "result.error",
@@ -1102,7 +1147,7 @@
         }
       ],
       "on_failure": "release_issue_failure",
-      "note": "After merge, route to inter_part_push to sync the remote branch, then next_or_done to process remaining parts before pushing.\n"
+      "note": "After merge, route to inter_part_push to sync the remote branch, then next_or_done to process remaining parts before pushing. Local-ahead ref_coherence mismatches use bounded push recovery; genuine divergence or indeterminate ancestry escalates.\n"
     },
     "inter_part_push": {
       "tool": "push_to_remote",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -632,7 +632,40 @@ steps:
     on_failure: pre_remediation_merge
     note: >-
       Resets ref_push_count to 0 so each audit-remediation cycle gets a
-      fresh ref-push budget.
+      fresh ref-push budget shared by normal and pre-remediation recovery.
+
+  check_ref_push_loop_pre_remediation:
+    tool: run_python
+    with:
+      callable: autoskillit.smoke_utils.check_loop_iteration
+      current_iteration: ${{ context.ref_push_count }}
+      max_iterations: '2'
+    capture:
+      ref_push_count: ${{ result.next_iteration }}
+    on_result:
+    - when: ${{ result.max_exceeded }} == true
+      route: release_issue_failure
+    - route: ref_push_pre_remediation
+    on_failure: release_issue_failure
+    optional_context_refs:
+    - ref_push_count
+    note: >
+      Pre-remediation ref-coherence recovery guard. Shares ref_push_count
+      (max 2) with check_ref_push_loop. Routes to ref_push_pre_remediation,
+      then commit_guard_pre_remediation and pre_remediation_merge.
+
+  ref_push_pre_remediation:
+    tool: push_to_remote
+    with:
+      clone_path: ${{ context.work_dir }}
+      remote_url: ${{ context.remote_url }}
+      branch: ${{ context.merge_target }}
+      force: 'true'
+    on_success: commit_guard_pre_remediation
+    on_failure: release_issue_failure
+    note: >
+      Pushes the feature branch when the remote ref is an ancestor of the
+      local ref, then retries pre_remediation_merge through its commit guard.
 
   pre_remediation_merge:
     tool: merge_worktree
@@ -654,8 +687,10 @@ steps:
       route: remediate
     - when: result.failed_step == 'dirty_main_repo'
       route: main_repo_guard_pre_remediation
+    - when: result.failed_step == 'ref_coherence' and result.remote_is_ancestor == true
+      route: check_ref_push_loop_pre_remediation
     - when: result.failed_step == 'ref_coherence'
-      route: remediate
+      route: release_issue_failure
     - when: result.failed_step == 'path_validation'
       route: remediate
     - when: result.error
@@ -666,10 +701,12 @@ steps:
       Merges the current worktree before the remediation cycle creates a new
       one. Audit NO GO means the implementation is incomplete, not wrong —
       merge it first, then remediate on top. This prevents orphaning the
-      original worktree when implement re-runs. dirty_tree routes to
-      commit_guard_pre_remediation to auto-commit before retrying merge.
-      dirty_main_repo routes to main_repo_guard_pre_remediation to stash.
-      test_gate, rebase, and path_validation route to remediate — the
+      original worktree when implement re-runs. A local-ahead ref_coherence
+      mismatch uses the shared ref_push_count budget and pre-remediation push
+      recovery; genuine divergence or indeterminate ancestry escalates.
+      dirty_tree routes to commit_guard_pre_remediation to auto-commit before
+      retrying merge. dirty_main_repo routes to main_repo_guard_pre_remediation
+      to stash. test_gate, rebase, and path_validation route to remediate — the
       remediation plan will address these. path_validation means the worktree
       was already merged in a prior session. Only hard errors escalate to
       release_issue_failure.
@@ -968,14 +1005,17 @@ steps:
       route: check_merge_rebase_loop
     - when: result.failed_step == 'dirty_main_repo'
       route: check_dirty_main_retry
-    - when: result.failed_step == 'ref_coherence'
+    - when: result.failed_step == 'ref_coherence' and result.remote_is_ancestor == true
       route: check_ref_push_loop
+    - when: result.failed_step == 'ref_coherence'
+      route: release_issue_failure
     - when: result.error
       route: release_issue_failure
     - route: inter_part_push
     on_failure: release_issue_failure
     note: 'After merge, route to inter_part_push to sync the remote branch, then next_or_done
-      to process remaining parts before pushing.
+      to process remaining parts before pushing. Local-ahead ref_coherence mismatches
+      use bounded push recovery; genuine divergence or indeterminate ancestry escalates.
 
       '
   inter_part_push:

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -680,11 +680,11 @@ steps:
     - when: result.failed_step == 'dirty_tree'
       route: commit_guard_pre_remediation
     - when: result.failed_step == 'test_gate'
-      route: remediate
+      route: release_issue_failure
     - when: result.failed_step == 'post_rebase_test_gate'
-      route: remediate
+      route: release_issue_failure
     - when: result.failed_step == 'rebase'
-      route: remediate
+      route: release_issue_failure
     - when: result.failed_step == 'dirty_main_repo'
       route: main_repo_guard_pre_remediation
     - when: result.failed_step == 'ref_coherence' and result.remote_is_ancestor == true
@@ -706,10 +706,11 @@ steps:
       recovery; genuine divergence or indeterminate ancestry escalates.
       dirty_tree routes to commit_guard_pre_remediation to auto-commit before
       retrying merge. dirty_main_repo routes to main_repo_guard_pre_remediation
-      to stash. test_gate, rebase, and path_validation route to remediate — the
-      remediation plan will address these. path_validation means the worktree
-      was already merged in a prior session. Only hard errors escalate to
-      release_issue_failure.
+      to stash. test_gate, post_rebase_test_gate, and rebase escalate to
+      release_issue_failure — leaving the worktree live and retrying from a
+      remediation cycle would orphan the original worktree. path_validation
+      means the worktree was already merged in a prior session and routes to
+      remediate.
   commit_guard_pre_remediation:
     tool: run_python
     with:
@@ -998,11 +999,11 @@ steps:
     - when: result.failed_step == 'dirty_tree'
       route: check_merge_fix_loop
     - when: result.failed_step == 'test_gate'
-      route: check_merge_fix_loop
+      route: release_issue_failure
     - when: result.failed_step == 'post_rebase_test_gate'
-      route: check_merge_fix_loop
+      route: release_issue_failure
     - when: result.failed_step == 'rebase'
-      route: check_merge_rebase_loop
+      route: release_issue_failure
     - when: result.failed_step == 'dirty_main_repo'
       route: check_dirty_main_retry
     - when: result.failed_step == 'ref_coherence' and result.remote_is_ancestor == true

--- a/src/autoskillit/server/git.py
+++ b/src/autoskillit/server/git.py
@@ -112,6 +112,7 @@ async def _verify_merge_target(
         ["git", "rev-parse", expected_branch], main_repo, 10, runner
     )
     if sha_rc != 0:
+        # Local SHA resolution failed, so ancestry cannot be evaluated.
         return {
             "error": (f"Failed to resolve SHA of '{expected_branch}' in '{main_repo}'."),
             "failed_step": MergeFailedStep.REF_COHERENCE,
@@ -440,6 +441,7 @@ async def perform_merge(
         runner,
     )
     if remote_rc != 0:
+        # The remote SHA is unavailable, so the required ancestry pair is incomplete.
         return {
             "error": f"Could not resolve {remote}/{base_branch} after fetch: {remote_stderr}",
             "failed_step": MergeFailedStep.REF_COHERENCE,
@@ -449,17 +451,38 @@ async def perform_merge(
     local_sha = target.sha
     remote_sha = remote_sha_out.strip()
     if local_sha != remote_sha:
+        ancestry_rc, _, ancestry_stderr = await _run_git(
+            ["git", "merge-base", "--is-ancestor", remote_sha, local_sha],
+            worktree_path,
+            10,
+            runner,
+        )
+        if ancestry_rc not in (0, 1):
+            return {
+                "error": (
+                    f"Could not determine ancestry between local '{base_branch}' "
+                    f"({local_sha[:12]}) and '{remote}/{base_branch}' "
+                    f"({remote_sha[:12]}): {ancestry_stderr}"
+                ),
+                "failed_step": MergeFailedStep.REF_COHERENCE,
+                "state": MergeState.WORKTREE_INTACT_REF_DIVERGED,
+                "stderr": ancestry_stderr,
+                "worktree_path": worktree_path,
+                "local_sha": local_sha,
+                "remote_sha": remote_sha,
+            }
+        remote_is_ancestor = ancestry_rc == 0
         return {
             "error": (
-                f"Local '{base_branch}' ({local_sha[:12]}) has diverged from "
-                f"'{remote}/{base_branch}' ({remote_sha[:12]}). "
-                f"Push the local branch or pull the remote before merging."
+                f"Local '{base_branch}' ({local_sha[:12]}) does not match "
+                f"'{remote}/{base_branch}' ({remote_sha[:12]})."
             ),
             "failed_step": MergeFailedStep.REF_COHERENCE,
             "state": MergeState.WORKTREE_INTACT_REF_DIVERGED,
             "worktree_path": worktree_path,
             "local_sha": local_sha,
             "remote_sha": remote_sha,
+            "remote_is_ancestor": remote_is_ancestor,
         }
 
     # 7.6 Pre-merge dirty check — reject if main repo has uncommitted changes

--- a/src/autoskillit/server/tools/_types.py
+++ b/src/autoskillit/server/tools/_types.py
@@ -130,6 +130,9 @@ class MergeWorktreeResult(TypedDict, total=False):
     abort_failed: bool
     abort_stderr: str
     poisoned_installs: list[str]
+    local_sha: str
+    remote_sha: str
+    remote_is_ancestor: bool
 
 
 class TokenSummaryResult(TypedDict, total=False):

--- a/tests/recipe/test_rules_integration_predicate.py
+++ b/tests/recipe/test_rules_integration_predicate.py
@@ -44,15 +44,15 @@ class TestRecipeIntegrationPredicateRouting:
 
         cond1 = step.on_result.conditions[1]
         assert cond1.when == "result.failed_step == 'test_gate'"
-        assert cond1.route == "check_merge_fix_loop"
+        assert cond1.route == "release_issue_failure"
 
         cond2 = step.on_result.conditions[2]
         assert cond2.when == "result.failed_step == 'post_rebase_test_gate'"
-        assert cond2.route == "check_merge_fix_loop"
+        assert cond2.route == "release_issue_failure"
 
         cond3 = step.on_result.conditions[3]
         assert cond3.when == "result.failed_step == 'rebase'"
-        assert cond3.route == "check_merge_rebase_loop"
+        assert cond3.route == "release_issue_failure"
 
         cond4 = step.on_result.conditions[4]
         assert cond4.when == "result.failed_step == 'dirty_main_repo'"
@@ -249,18 +249,31 @@ class TestLoopBudgetSeparation:
             "check_dirty_main_retry",
         }
         guard_steps = merge_fix_guard_steps | {"check_ref_push_loop"}
+        terminal_steps = {"release_issue_failure"}
         for cond in merge_step.on_result.conditions:
             if not cond.when or "failed_step" not in cond.when:
                 continue
             if "ref_coherence" in cond.when and "remote_is_ancestor" not in cond.when:
                 assert cond.route == "release_issue_failure"
+            elif recipe_name == "remediation" and cond.when in (
+                "result.failed_step == 'test_gate'",
+                "result.failed_step == 'post_rebase_test_gate'",
+                "result.failed_step == 'rebase'",
+            ):
+                # After PART B step 5, remediation.yaml's pre_remediation_merge
+                # routes these to terminal escalation so live-worktree merge
+                # failures no longer orphan the next worktree creator.
+                assert cond.route in terminal_steps, (
+                    f"{cond.when} routes to {cond.route}, expected a terminal escalation"
+                )
             else:
                 assert cond.route in guard_steps, (
                     f"{cond.when} routes to {cond.route}, expected a guard step"
                 )
         for name in merge_fix_guard_steps:
-            step = recipe.steps[name]
-            assert step.with_args.get("current_iteration") == "${{ context.merge_fix_count }}"
+            if name in recipe.steps:
+                step = recipe.steps[name]
+                assert step.with_args.get("current_iteration") == "${{ context.merge_fix_count }}"
 
     @pytest.mark.parametrize("recipe_name", RECIPE_NAMES)
     def test_loop_budget_ingredients_exist(self, recipe_name: str) -> None:

--- a/tests/recipe/test_rules_integration_predicate.py
+++ b/tests/recipe/test_rules_integration_predicate.py
@@ -36,7 +36,7 @@ class TestRecipeIntegrationPredicateRouting:
         """The merge step in remediation.yaml has predicate on_result."""
         step = self.if_recipe.steps["merge"]
         assert step.on_result is not None
-        assert len(step.on_result.conditions) == 8
+        assert len(step.on_result.conditions) == 9
 
         cond0 = step.on_result.conditions[0]
         assert cond0.when == "result.failed_step == 'dirty_tree'"
@@ -59,16 +59,23 @@ class TestRecipeIntegrationPredicateRouting:
         assert cond4.route == "check_dirty_main_retry"
 
         cond5 = step.on_result.conditions[5]
-        assert cond5.when == "result.failed_step == 'ref_coherence'"
+        assert (
+            cond5.when
+            == "result.failed_step == 'ref_coherence' and result.remote_is_ancestor == true"
+        )
         assert cond5.route == "check_ref_push_loop"
 
         cond6 = step.on_result.conditions[6]
-        assert cond6.when == "result.error"
+        assert cond6.when == "result.failed_step == 'ref_coherence'"
         assert cond6.route == "release_issue_failure"
 
         cond7 = step.on_result.conditions[7]
-        assert cond7.when is None
-        assert cond7.route == "inter_part_push"
+        assert cond7.when == "result.error"
+        assert cond7.route == "release_issue_failure"
+
+        cond8 = step.on_result.conditions[8]
+        assert cond8.when is None
+        assert cond8.route == "inter_part_push"
 
     def test_investigate_first_merge_step_captures_worktree_path(self) -> None:
         """The merge step captures worktree_path from result.worktree_path."""
@@ -80,7 +87,7 @@ class TestRecipeIntegrationPredicateRouting:
         """The merge step in implementation.yaml has predicate on_result."""
         step = self.ip_recipe.steps["merge"]
         assert step.on_result is not None
-        assert len(step.on_result.conditions) == 8
+        assert len(step.on_result.conditions) == 9
 
         cond0 = step.on_result.conditions[0]
         assert cond0.when == "result.failed_step == 'dirty_tree'"
@@ -103,16 +110,23 @@ class TestRecipeIntegrationPredicateRouting:
         assert cond4.route == "check_dirty_main_retry"
 
         cond5 = step.on_result.conditions[5]
-        assert cond5.when == "result.failed_step == 'ref_coherence'"
+        assert (
+            cond5.when
+            == "result.failed_step == 'ref_coherence' and result.remote_is_ancestor == true"
+        )
         assert cond5.route == "check_ref_push_loop"
 
         cond6 = step.on_result.conditions[6]
-        assert cond6.when == "result.error"
+        assert cond6.when == "result.failed_step == 'ref_coherence'"
         assert cond6.route == "release_issue_failure"
 
         cond7 = step.on_result.conditions[7]
-        assert cond7.when is None
-        assert cond7.route == "inter_part_push"
+        assert cond7.when == "result.error"
+        assert cond7.route == "release_issue_failure"
+
+        cond8 = step.on_result.conditions[8]
+        assert cond8.when is None
+        assert cond8.route == "inter_part_push"
 
     def test_implementation_pipeline_merge_step_captures_worktree_path(self) -> None:
         """The merge step in implementation.yaml captures worktree_path."""
@@ -143,6 +157,48 @@ class TestRecipeIntegrationPredicateRouting:
             assert errors == [], f"{name} has ERROR-severity semantic findings: " + str(
                 [(f.rule, f.step_name, f.message) for f in errors]
             )
+
+
+class TestPreRemediationMergePredicateRouting:
+    @pytest.fixture(scope="class", autouse=True)
+    def _load_recipe(self, request) -> None:
+        request.cls.recipe = load_recipe(builtin_recipes_dir() / "remediation.yaml")
+
+    def test_ref_coherence_routes_by_ancestry_before_fallback(self) -> None:
+        step = self.recipe.steps["pre_remediation_merge"]
+        assert step.on_result is not None
+
+        ancestry_indexes = [
+            index
+            for index, condition in enumerate(step.on_result.conditions)
+            if condition.when
+            and "ref_coherence" in condition.when
+            and "remote_is_ancestor" in condition.when
+        ]
+        fallback_indexes = [
+            index
+            for index, condition in enumerate(step.on_result.conditions)
+            if condition.when
+            and "ref_coherence" in condition.when
+            and "remote_is_ancestor" not in condition.when
+        ]
+
+        assert len(ancestry_indexes) == 1
+        assert len(fallback_indexes) == 1
+        ancestry_index = ancestry_indexes[0]
+        fallback_index = fallback_indexes[0]
+        assert ancestry_index < fallback_index
+        assert (
+            step.on_result.conditions[ancestry_index].route
+            == "check_ref_push_loop_pre_remediation"
+        )
+        assert step.on_result.conditions[fallback_index].route == "release_issue_failure"
+
+    def test_ref_push_returns_to_pre_remediation_guard(self) -> None:
+        assert (
+            self.recipe.steps["ref_push_pre_remediation"].on_success
+            == "commit_guard_pre_remediation"
+        )
 
 
 class TestLoopBudgetSeparation:
@@ -194,7 +250,11 @@ class TestLoopBudgetSeparation:
         }
         guard_steps = merge_fix_guard_steps | {"check_ref_push_loop"}
         for cond in merge_step.on_result.conditions:
-            if cond.when and "failed_step" in cond.when:
+            if not cond.when or "failed_step" not in cond.when:
+                continue
+            if "ref_coherence" in cond.when and "remote_is_ancestor" not in cond.when:
+                assert cond.route == "release_issue_failure"
+            else:
                 assert cond.route in guard_steps, (
                     f"{cond.when} routes to {cond.route}, expected a guard step"
                 )

--- a/tests/recipe/test_rules_merge.py
+++ b/tests/recipe/test_rules_merge.py
@@ -852,14 +852,21 @@ def test_bundled_recipes_push_between_parts(recipe_name: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _push_recovery_subgraph(steps: dict, terminal: str = "done") -> dict:
+def _push_recovery_subgraph(terminal: str = "done", *, prefix: str = "") -> dict:
     """Build a subgraph whose ancestry arm reaches a real push_to_remote step.
 
     check_ref_push_loop -> check_loop_iteration guard -> ref_push (push_to_remote)
     -> retry the merge barrier. This satisfies _classify_recovery_class == "push_recovery".
+
+    When *prefix* is provided, step names and successor references are prefixed
+    (e.g. ``"a"`` -> ``"check_ref_push_loop_a"``, ``"ref_push_a"``) so the same
+    subgraph can be reused for both merge sites in a single recipe.
     """
+    loop_name = f"check_ref_push_loop{prefix}"
+    push_name = f"ref_push{prefix}"
+    retry_name = f"retry_merge{prefix}"
     return {
-        "check_ref_push_loop": RecipeStep(
+        loop_name: RecipeStep(
             tool="run_python",
             with_args={
                 "callable": "autoskillit.smoke_utils.check_loop_iteration",
@@ -874,20 +881,20 @@ def _push_recovery_subgraph(steps: dict, terminal: str = "done") -> dict:
                     ),
                 ]
             ),
-            on_success="ref_push",
+            on_success=push_name,
             on_failure="release_issue_failure",
         ),
-        "ref_push": RecipeStep(
+        push_name: RecipeStep(
             tool="push_to_remote",
             with_args={
                 "clone_path": "${{ context.work_dir }}",
                 "remote_url": "${{ context.remote_url }}",
                 "branch": "${{ context.merge_target }}",
             },
-            on_success="retry_merge",
+            on_success=retry_name,
             on_failure="release_issue_failure",
         ),
-        "retry_merge": RecipeStep(
+        retry_name: RecipeStep(
             tool="merge_worktree",
             with_args={
                 "worktree_path": "${{ context.implementation_ref }}",
@@ -900,13 +907,18 @@ def _push_recovery_subgraph(steps: dict, terminal: str = "done") -> dict:
     }
 
 
-def _direct_remediation_subgraph(terminal: str = "done") -> dict:
+def _direct_remediation_subgraph(terminal: str = "done", *, prefix: str = "") -> dict:
     """Build a subgraph whose ancestry arm reaches make-plan (direct_remediate).
 
     check_loop_iteration -> make-plan (autoskillit skill) -> terminal.
+
+    When *prefix* is provided, step names and successor references are prefixed
+    (e.g. ``"a"`` -> ``"check_direct_loop_a"``, ``"make_plan_a"``).
     """
+    loop_name = f"check_direct_loop{prefix}"
+    plan_name = f"make_plan{prefix}"
     return {
-        "check_direct_loop": RecipeStep(
+        loop_name: RecipeStep(
             tool="run_python",
             with_args={
                 "callable": "autoskillit.smoke_utils.check_loop_iteration",
@@ -921,10 +933,10 @@ def _direct_remediation_subgraph(terminal: str = "done") -> dict:
                     ),
                 ]
             ),
-            on_success="make_plan",
+            on_success=plan_name,
             on_failure="release_issue_failure",
         ),
-        "make_plan": RecipeStep(
+        plan_name: RecipeStep(
             tool="run_skill",
             with_args={
                 "skill_command": "/autoskillit:make-plan plan.md",
@@ -944,14 +956,14 @@ def _two_merge_recipe(*, site_a_class: str, site_b_class: str) -> Recipe:
     ref_coherence arm at each site reaches: "push" or "direct".
     """
     site_a = (
-        _push_recovery_subgraph({}, terminal="retry_merge_b")
+        _push_recovery_subgraph(terminal="retry_merge_b", prefix="_a")
         if site_a_class == "push"
-        else _direct_remediation_subgraph("retry_merge_b")
+        else _direct_remediation_subgraph("retry_merge_b", prefix="_a")
     )
     site_b = (
-        _push_recovery_subgraph({}, terminal="done")
+        _push_recovery_subgraph(terminal="done", prefix="_b")
         if site_b_class == "push"
-        else _direct_remediation_subgraph("done")
+        else _direct_remediation_subgraph("done", prefix="_b")
     )
 
     common = {
@@ -1053,62 +1065,29 @@ def _two_merge_recipe(*, site_a_class: str, site_b_class: str) -> Recipe:
         "done": RecipeStep(action="stop", message="done"),
     }
 
-    # Wire per-site guard names to the matching subgraph
+    # Wire per-site guard names to the matching subgraph. The subgraph helpers
+    # already produced prefixed step names when called with prefix="_a"/"_b".
     if site_a_class == "push":
         site_a_subgraph = {
-            "check_ref_push_loop_a": site_a["check_ref_push_loop"],
-            "ref_push_a": RecipeStep(
-                tool="push_to_remote",
-                with_args={
-                    "clone_path": "${{ context.work_dir }}",
-                    "remote_url": "${{ context.remote_url }}",
-                    "branch": "main",
-                },
-                on_success="retry_merge_a",
-                on_failure="release_issue_failure",
-            ),
-            "retry_merge_a": RecipeStep(
-                tool="merge_worktree",
-                with_args={
-                    "worktree_path": "${{ context.implementation_ref }}",
-                    "base_branch": "main",
-                },
-                on_success="merge_b",
-                on_failure="release_issue_failure",
-            ),
+            "check_ref_push_loop_a": site_a["check_ref_push_loop_a"],
+            "ref_push_a": site_a["ref_push_a"],
+            "retry_merge_a": site_a["retry_merge_a"],
         }
     else:
         site_a_subgraph = {
-            "check_direct_loop_a": site_a["check_direct_loop"],
-            "make_plan_a": site_a["make_plan"],
+            "check_direct_loop_a": site_a["check_direct_loop_a"],
+            "make_plan_a": site_a["make_plan_a"],
         }
     if site_b_class == "push":
         site_b_subgraph = {
-            "check_ref_push_loop_b": site_b["check_ref_push_loop"],
-            "ref_push_b": RecipeStep(
-                tool="push_to_remote",
-                with_args={
-                    "clone_path": "${{ context.work_dir }}",
-                    "remote_url": "${{ context.remote_url }}",
-                    "branch": "main",
-                },
-                on_success="retry_merge_b",
-                on_failure="release_issue_failure",
-            ),
-            "retry_merge_b": RecipeStep(
-                tool="merge_worktree",
-                with_args={
-                    "worktree_path": "${{ context.implementation_ref }}",
-                    "base_branch": "main",
-                },
-                on_success="done",
-                on_failure="release_issue_failure",
-            ),
+            "check_ref_push_loop_b": site_b["check_ref_push_loop_b"],
+            "ref_push_b": site_b["ref_push_b"],
+            "retry_merge_b": site_b["retry_merge_b"],
         }
     else:
         site_b_subgraph = {
-            "check_direct_loop_b": site_b["check_direct_loop"],
-            "make_plan_b": site_b["make_plan"],
+            "check_direct_loop_b": site_b["check_direct_loop_b"],
+            "make_plan_b": site_b["make_plan_b"],
         }
 
     steps = {**common, **site_a_subgraph, **site_b_subgraph}

--- a/tests/recipe/test_rules_merge.py
+++ b/tests/recipe/test_rules_merge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.core import Severity
+from autoskillit.recipe._analysis import _build_step_graph, bfs_reachable
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.rules.rules_merge import _RECOVERABLE_FAILED_STEPS, _TERMINAL_FAILED_STEPS
@@ -101,7 +102,6 @@ def test_bundled_recipes_pass_merge_routing_incomplete(recipe_name: str) -> None
 @pytest.mark.parametrize("recipe_name", ["implementation", "remediation", "implementation-groups"])
 def test_bundled_recipes_route_ref_coherence(recipe_name: str) -> None:
     """All bundled recipes must route REF_COHERENCE in their merge_worktree on_result."""
-    from autoskillit.core.types import MergeFailedStep
 
     recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
 
@@ -113,18 +113,44 @@ def test_bundled_recipes_route_ref_coherence(recipe_name: str) -> None:
     assert merge_steps, f"{recipe_name}: no merge_worktree step found"
 
     for step_name, step in merge_steps.items():
-        if step.on_result is None:
-            continue
-        matched = set()
-        for cond in step.on_result.conditions:
-            if cond.when is None:
-                continue
-            if "ref_coherence" in cond.when.lower():
-                matched.add(MergeFailedStep.REF_COHERENCE)
-        assert MergeFailedStep.REF_COHERENCE in matched, (
-            f"{recipe_name}: merge_worktree step '{step_name}' does not route "
-            f"REF_COHERENCE in on_result."
+        assert step.on_result is not None
+        conditions = step.on_result.conditions
+        ancestry_matches = [
+            (index, condition)
+            for index, condition in enumerate(conditions)
+            if condition.when
+            and "ref_coherence" in condition.when.lower()
+            and "remote_is_ancestor" in condition.when.lower()
+        ]
+        fallback_matches = [
+            (index, condition)
+            for index, condition in enumerate(conditions)
+            if condition.when
+            and "ref_coherence" in condition.when.lower()
+            and "remote_is_ancestor" not in condition.when.lower()
+        ]
+
+        assert len(ancestry_matches) == 1, (
+            f"{recipe_name}: merge_worktree step '{step_name}' must have exactly one "
+            "ancestry-aware REF_COHERENCE arm"
         )
+        assert len(fallback_matches) == 1, (
+            f"{recipe_name}: merge_worktree step '{step_name}' must have exactly one "
+            "REF_COHERENCE fallback arm"
+        )
+
+        ancestry_index, ancestry_condition = ancestry_matches[0]
+        fallback_index, fallback_condition = fallback_matches[0]
+        assert ancestry_index < fallback_index
+        assert fallback_condition.route == "release_issue_failure"
+
+        graph = _build_step_graph(recipe)
+        reachable = bfs_reachable(graph, ancestry_condition.route) | {ancestry_condition.route}
+        assert any(
+            recipe.steps[step_name].tool == "push_to_remote"
+            for step_name in reachable
+            if step_name in recipe.steps
+        ), f"{recipe_name}: route {ancestry_condition.route} cannot reach push_to_remote"
 
 
 def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:

--- a/tests/recipe/test_rules_merge.py
+++ b/tests/recipe/test_rules_merge.py
@@ -845,3 +845,494 @@ def test_bundled_recipes_push_between_parts(recipe_name: str) -> None:
             f"{step_name} success route {success_route} must be a push_to_remote step, "
             f"got tool={getattr(push_step, 'tool', None)}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Step 1a: merge-routing-cross-site-consistency rule tests
+# ---------------------------------------------------------------------------
+
+
+def _push_recovery_subgraph(steps: dict, terminal: str = "done") -> dict:
+    """Build a subgraph whose ancestry arm reaches a real push_to_remote step.
+
+    check_ref_push_loop -> check_loop_iteration guard -> ref_push (push_to_remote)
+    -> retry the merge barrier. This satisfies _classify_recovery_class == "push_recovery".
+    """
+    return {
+        "check_ref_push_loop": RecipeStep(
+            tool="run_python",
+            with_args={
+                "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                "current_iteration": "${{ context.ref_push_count }}",
+                "max_iterations": "3",
+            },
+            on_result=StepResultRoute(
+                conditions=[
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="${{ result.max_exceeded }} == true",
+                    ),
+                ]
+            ),
+            on_success="ref_push",
+            on_failure="release_issue_failure",
+        ),
+        "ref_push": RecipeStep(
+            tool="push_to_remote",
+            with_args={
+                "clone_path": "${{ context.work_dir }}",
+                "remote_url": "${{ context.remote_url }}",
+                "branch": "${{ context.merge_target }}",
+            },
+            on_success="retry_merge",
+            on_failure="release_issue_failure",
+        ),
+        "retry_merge": RecipeStep(
+            tool="merge_worktree",
+            with_args={
+                "worktree_path": "${{ context.implementation_ref }}",
+                "base_branch": "${{ context.merge_target }}",
+            },
+            on_success=terminal,
+            on_failure="release_issue_failure",
+        ),
+        "release_issue_failure": RecipeStep(action="stop", message="failed"),
+    }
+
+
+def _direct_remediation_subgraph(terminal: str = "done") -> dict:
+    """Build a subgraph whose ancestry arm reaches make-plan (direct_remediate).
+
+    check_loop_iteration -> make-plan (autoskillit skill) -> terminal.
+    """
+    return {
+        "check_direct_loop": RecipeStep(
+            tool="run_python",
+            with_args={
+                "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                "current_iteration": "${{ context.direct_count }}",
+                "max_iterations": "3",
+            },
+            on_result=StepResultRoute(
+                conditions=[
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="${{ result.max_exceeded }} == true",
+                    ),
+                ]
+            ),
+            on_success="make_plan",
+            on_failure="release_issue_failure",
+        ),
+        "make_plan": RecipeStep(
+            tool="run_skill",
+            with_args={
+                "skill_command": "/autoskillit:make-plan plan.md",
+                "cwd": "${{ context.worktree_path }}",
+            },
+            on_success=terminal,
+            on_failure="release_issue_failure",
+        ),
+        "release_issue_failure": RecipeStep(action="stop", message="failed"),
+    }
+
+
+def _two_merge_recipe(*, site_a_class: str, site_b_class: str) -> Recipe:
+    """Build a recipe with two merge_worktree steps.
+
+    site_a_class and site_b_class pick which recovery subgraph the ancestry-aware
+    ref_coherence arm at each site reaches: "push" or "direct".
+    """
+    site_a = (
+        _push_recovery_subgraph({}, terminal="retry_merge_b")
+        if site_a_class == "push"
+        else _direct_remediation_subgraph("retry_merge_b")
+    )
+    site_b = (
+        _push_recovery_subgraph({}, terminal="done")
+        if site_b_class == "push"
+        else _direct_remediation_subgraph("done")
+    )
+
+    common = {
+        "merge_a": RecipeStep(
+            tool="merge_worktree",
+            with_args={
+                "worktree_path": "${{ context.implementation_ref }}",
+                "base_branch": "main",
+            },
+            on_result=StepResultRoute(
+                conditions=[
+                    StepResultCondition(
+                        route="check_ref_push_loop_a"
+                        if site_a_class == "push"
+                        else "check_direct_loop_a",
+                        when=(
+                            "result.failed_step == 'ref_coherence' "
+                            "and result.remote_is_ancestor == true"
+                        ),
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'ref_coherence'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'dirty_tree'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'test_gate'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'post_rebase_test_gate'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'rebase'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'dirty_main_repo'",
+                    ),
+                    StepResultCondition(route="done", when=None),
+                ]
+            ),
+            on_success="done",
+            on_failure="release_issue_failure",
+        ),
+        "merge_b": RecipeStep(
+            tool="merge_worktree",
+            with_args={
+                "worktree_path": "${{ context.implementation_ref }}",
+                "base_branch": "main",
+            },
+            on_result=StepResultRoute(
+                conditions=[
+                    StepResultCondition(
+                        route="check_ref_push_loop_b"
+                        if site_b_class == "push"
+                        else "check_direct_loop_b",
+                        when=(
+                            "result.failed_step == 'ref_coherence' "
+                            "and result.remote_is_ancestor == true"
+                        ),
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'ref_coherence'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'dirty_tree'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'test_gate'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'post_rebase_test_gate'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'rebase'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'dirty_main_repo'",
+                    ),
+                    StepResultCondition(route="done", when=None),
+                ]
+            ),
+            on_success="done",
+            on_failure="release_issue_failure",
+        ),
+        "release_issue_failure": RecipeStep(action="stop", message="failed"),
+        "done": RecipeStep(action="stop", message="done"),
+    }
+
+    # Wire per-site guard names to the matching subgraph
+    if site_a_class == "push":
+        site_a_subgraph = {
+            "check_ref_push_loop_a": site_a["check_ref_push_loop"],
+            "ref_push_a": RecipeStep(
+                tool="push_to_remote",
+                with_args={
+                    "clone_path": "${{ context.work_dir }}",
+                    "remote_url": "${{ context.remote_url }}",
+                    "branch": "main",
+                },
+                on_success="retry_merge_a",
+                on_failure="release_issue_failure",
+            ),
+            "retry_merge_a": RecipeStep(
+                tool="merge_worktree",
+                with_args={
+                    "worktree_path": "${{ context.implementation_ref }}",
+                    "base_branch": "main",
+                },
+                on_success="merge_b",
+                on_failure="release_issue_failure",
+            ),
+        }
+    else:
+        site_a_subgraph = {
+            "check_direct_loop_a": site_a["check_direct_loop"],
+            "make_plan_a": site_a["make_plan"],
+        }
+    if site_b_class == "push":
+        site_b_subgraph = {
+            "check_ref_push_loop_b": site_b["check_ref_push_loop"],
+            "ref_push_b": RecipeStep(
+                tool="push_to_remote",
+                with_args={
+                    "clone_path": "${{ context.work_dir }}",
+                    "remote_url": "${{ context.remote_url }}",
+                    "branch": "main",
+                },
+                on_success="retry_merge_b",
+                on_failure="release_issue_failure",
+            ),
+            "retry_merge_b": RecipeStep(
+                tool="merge_worktree",
+                with_args={
+                    "worktree_path": "${{ context.implementation_ref }}",
+                    "base_branch": "main",
+                },
+                on_success="done",
+                on_failure="release_issue_failure",
+            ),
+        }
+    else:
+        site_b_subgraph = {
+            "check_direct_loop_b": site_b["check_direct_loop"],
+            "make_plan_b": site_b["make_plan"],
+        }
+
+    steps = {**common, **site_a_subgraph, **site_b_subgraph}
+    return _make_recipe(steps)
+
+
+def test_cross_site_consistency_drifts_between_merge_worktree_sites() -> None:
+    """Two merge_worktree steps with ancestry arms reaching different recovery
+    classes (push vs direct) trigger exactly one cross-site finding.
+
+    The finding must identify both merge steps, their routes, and the observed classes.
+    """
+    recipe = _two_merge_recipe(site_a_class="push", site_b_class="direct")
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "merge-routing-cross-site-consistency"]
+    assert len(flagged) == 1, f"Expected exactly 1 finding, got: {flagged}"
+    msg = flagged[0].message
+    assert "merge_a" in msg and "merge_b" in msg, (
+        f"Finding message must identify both merge steps, got: {msg}"
+    )
+    assert "push_recovery" in msg and "direct_remediate" in msg, (
+        f"Finding message must identify both recovery classes, got: {msg}"
+    )
+
+
+def test_cross_site_consistency_matching_arms_is_clean() -> None:
+    """Two merge_worktree steps whose ancestry arms reach the same recovery class
+    (push) emit no cross-site finding."""
+    recipe = _two_merge_recipe(site_a_class="push", site_b_class="push")
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "merge-routing-cross-site-consistency"]
+    assert flagged == [], f"Expected no finding, got: {flagged}"
+
+
+def test_cross_site_consistency_classified_vs_unclassified_is_mismatch() -> None:
+    """A classified-vs-unclassified pair is a mismatch, not silently equivalent.
+
+    site_a reaches push_recovery (classified); site_b has the ancestry arm route
+    going to a non-recovery target (unclassified). Different unclassified routes
+    at multiple sites also constitute a mismatch.
+    """
+    # site_b uses an unclassified terminal target for its ancestry arm
+    steps = {
+        "merge_a": RecipeStep(
+            tool="merge_worktree",
+            with_args={
+                "worktree_path": "${{ context.implementation_ref }}",
+                "base_branch": "main",
+            },
+            on_result=StepResultRoute(
+                conditions=[
+                    StepResultCondition(
+                        route="check_ref_push_loop_a",
+                        when=(
+                            "result.failed_step == 'ref_coherence' "
+                            "and result.remote_is_ancestor == true"
+                        ),
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'ref_coherence'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'dirty_tree'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'test_gate'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'post_rebase_test_gate'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'rebase'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'dirty_main_repo'",
+                    ),
+                    StepResultCondition(route="done", when=None),
+                ]
+            ),
+            on_success="done",
+            on_failure="release_issue_failure",
+        ),
+        "merge_b": RecipeStep(
+            tool="merge_worktree",
+            with_args={
+                "worktree_path": "${{ context.implementation_ref }}",
+                "base_branch": "main",
+            },
+            on_result=StepResultRoute(
+                conditions=[
+                    StepResultCondition(
+                        route="merge_b_recovery",
+                        when=(
+                            "result.failed_step == 'ref_coherence' "
+                            "and result.remote_is_ancestor == true"
+                        ),
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'ref_coherence'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'dirty_tree'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'test_gate'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'post_rebase_test_gate'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'rebase'",
+                    ),
+                    StepResultCondition(
+                        route="release_issue_failure",
+                        when="result.failed_step == 'dirty_main_repo'",
+                    ),
+                    StepResultCondition(route="done", when=None),
+                ]
+            ),
+            on_success="done",
+            on_failure="release_issue_failure",
+        ),
+        "check_ref_push_loop_a": RecipeStep(
+            tool="run_python",
+            with_args={
+                "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                "current_iteration": "${{ context.ref_push_count }}",
+                "max_iterations": "3",
+            },
+            on_success="ref_push_a",
+            on_failure="release_issue_failure",
+        ),
+        "ref_push_a": RecipeStep(
+            tool="push_to_remote",
+            with_args={
+                "clone_path": "${{ context.work_dir }}",
+                "remote_url": "${{ context.remote_url }}",
+                "branch": "main",
+            },
+            on_success="retry_a",
+            on_failure="release_issue_failure",
+        ),
+        "retry_a": RecipeStep(
+            tool="merge_worktree",
+            with_args={
+                "worktree_path": "${{ context.implementation_ref }}",
+                "base_branch": "main",
+            },
+            on_success="done",
+            on_failure="release_issue_failure",
+        ),
+        # unclassified recovery — bare route step, no recovery signature
+        "merge_b_recovery": RecipeStep(
+            tool="run_python",
+            with_args={"callable": "autoskillit.recipe._cmd_rpc.compute_branch"},
+            on_success="done",
+            on_failure="release_issue_failure",
+        ),
+        "release_issue_failure": RecipeStep(action="stop", message="failed"),
+        "done": RecipeStep(action="stop", message="done"),
+    }
+    recipe = _make_recipe(steps)
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "merge-routing-cross-site-consistency"]
+    assert len(flagged) >= 1, (
+        f"Expected mismatch finding when classified vs unclassified arms diverge, got: {flagged}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 6: _classify_recovery_class integration check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("recipe_name", ["implementation", "remediation", "implementation-groups"])
+def test_bundled_recipes_ancestry_arm_classifies_as_push_recovery(
+    recipe_name: str,
+) -> None:
+    """The ancestry-aware ref_coherence arm must classify as 'push_recovery' for
+    every bundled merge_worktree step.
+
+    Supplements test_bundled_recipes_route_ref_coherence with a behavioral
+    classification assertion rather than only structural reachability.
+    """
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.rules import rules_merge
+
+    recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+    ctx = make_validation_context(recipe)
+
+    merge_steps = {
+        name: step
+        for name, step in recipe.steps.items()
+        if getattr(step, "tool", None) == "merge_worktree"
+    }
+    assert merge_steps, f"{recipe_name}: no merge_worktree step found"
+
+    for step_name, step in merge_steps.items():
+        assert step.on_result is not None
+        ancestry_condition = None
+        for condition in step.on_result.conditions:
+            if (
+                condition.when
+                and "ref_coherence" in condition.when.lower()
+                and "remote_is_ancestor" in condition.when.lower()
+            ):
+                ancestry_condition = condition
+                break
+        assert ancestry_condition is not None, (
+            f"{recipe_name}: merge_worktree '{step_name}' missing ancestry arm"
+        )
+        cls = rules_merge._classify_recovery_class(ancestry_condition.route, ctx)
+        assert cls == "push_recovery", (
+            f"{recipe_name}: merge '{step_name}' ancestry arm route "
+            f"'{ancestry_condition.route}' classified as {cls!r}, expected 'push_recovery'"
+        )

--- a/tests/recipe/test_rules_merge_failure_domain.py
+++ b/tests/recipe/test_rules_merge_failure_domain.py
@@ -181,6 +181,12 @@ class TestBundledRecipesPassFailureDomainCheck:
         for cond in merge_step.on_result.conditions:
             if cond.when and "rebase" in cond.when and "post_rebase" not in cond.when:
                 found_rebase = True
+                # After PART B step 5, the pre-remediation/merge rebase arm
+                # routes to terminal escalation (release_issue_failure) instead
+                # of the resolve-merge-conflicts skill, so live-worktree merge
+                # failures no longer orphan the next worktree creator.
+                if cond.route == "release_issue_failure":
+                    continue
                 target_step = recipe.steps[cond.route]
                 skill_cmd = (target_step.with_args or {}).get("skill_command", "")
                 if not skill_cmd and target_step.tool == "run_python" and target_step.on_result:

--- a/tests/recipe/test_rules_merge_failure_domain.py
+++ b/tests/recipe/test_rules_merge_failure_domain.py
@@ -196,3 +196,232 @@ class TestBundledRecipesPassFailureDomainCheck:
                     f"'{skill_cmd}', expected resolve-merge-conflicts"
                 )
         assert found_rebase, f"{recipe_name}: no rebase condition found in merge step"
+
+
+# ---------------------------------------------------------------------------
+# Step 1b: REF_COHERENCE domain validation behavior tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.medium
+class TestRefCoherenceDomainValidation:
+    """REF_COHERENCE must be validated through recovery-class classification, not
+    exact skill matching. An ancestry-aware arm reaching push_to_remote is correct;
+    one reaching direct remediation is a mismatch."""
+
+    def test_ref_coherence_maps_to_push_recovery_domain(self):
+        """MergeFailedStep.REF_COHERENCE must be registered under the push_recovery domain."""
+        from autoskillit.core.types import MergeFailedStep
+        from autoskillit.recipe.rules import rules_merge
+
+        assert (
+            rules_merge._MERGE_FAILURE_DOMAINS.get(MergeFailedStep.REF_COHERENCE)
+            == "push_recovery"
+        ), "REF_COHERENCE must map to 'push_recovery' in _MERGE_FAILURE_DOMAINS"
+
+    def test_push_recovery_required_class_mapping_exists(self):
+        """_REQUIRED_RECOVERY_CLASS must declare push_recovery -> push_recovery."""
+        from autoskillit.recipe.rules import rules_merge
+
+        assert rules_merge._REQUIRED_RECOVERY_CLASS.get("push_recovery") == "push_recovery", (
+            "_REQUIRED_RECOVERY_CLASS must require push_recovery for the push_recovery domain"
+        )
+
+    def test_ancestry_arm_reaching_push_to_remote_is_clean(self):
+        """A ref_coherence ancestry arm that reaches push_to_remote via a guard
+        must NOT trigger merge-failure-skill-domain-mismatch."""
+        recipe = _make_workflow(
+            {
+                "merge": {
+                    "tool": "merge_worktree",
+                    "with": {"worktree_path": "/tmp/wt", "base_branch": "main"},
+                    "on_result": [
+                        {
+                            "when": (
+                                "result.failed_step == 'ref_coherence' "
+                                "and result.remote_is_ancestor == true"
+                            ),
+                            "route": "check_ref_push_loop",
+                        },
+                        {
+                            "when": "result.failed_step == 'ref_coherence'",
+                            "route": "release_issue_failure",
+                        },
+                        {"when": "result.error", "route": "release_issue_failure"},
+                        {"route": "done"},
+                    ],
+                },
+                "check_ref_push_loop": {
+                    "tool": "run_python",
+                    "with": {
+                        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                        "current_iteration": "${{ context.ref_push_count }}",
+                        "max_iterations": "3",
+                    },
+                    "on_result": [
+                        {
+                            "when": "${{ result.max_exceeded }} == true",
+                            "route": "release_issue_failure",
+                        }
+                    ],
+                    "on_success": "ref_push",
+                    "on_failure": "release_issue_failure",
+                },
+                "ref_push": {
+                    "tool": "push_to_remote",
+                    "with": {
+                        "clone_path": "${{ context.work_dir }}",
+                        "remote_url": "git@example.com",
+                        "branch": "main",
+                    },
+                    "on_success": "retry_merge",
+                    "on_failure": "release_issue_failure",
+                },
+                "retry_merge": {
+                    "tool": "merge_worktree",
+                    "with": {"worktree_path": "/tmp/wt", "base_branch": "main"},
+                    "on_success": "done",
+                    "on_failure": "release_issue_failure",
+                },
+                "release_issue_failure": {"action": "stop", "message": "Escalate."},
+                "done": {"action": "stop", "message": "Done."},
+            }
+        )
+        findings = run_semantic_rules(recipe)
+        errors = [f for f in findings if f.rule == "merge-failure-skill-domain-mismatch"]
+        assert errors == [], (
+            f"ref_coherence ancestry arm reaching push_to_remote must be clean, "
+            f"got: {[e.message for e in errors]}"
+        )
+
+    def test_ancestry_arm_reaching_direct_remediation_fires_mismatch(self):
+        """A ref_coherence ancestry arm reaching direct_remediate (make-plan) must
+        trigger exactly one mismatch finding naming expected push_recovery."""
+        recipe = _make_workflow(
+            {
+                "merge": {
+                    "tool": "merge_worktree",
+                    "with": {"worktree_path": "/tmp/wt", "base_branch": "main"},
+                    "on_result": [
+                        {
+                            "when": (
+                                "result.failed_step == 'ref_coherence' "
+                                "and result.remote_is_ancestor == true"
+                            ),
+                            "route": "check_direct_loop",
+                        },
+                        {
+                            "when": "result.failed_step == 'ref_coherence'",
+                            "route": "release_issue_failure",
+                        },
+                        {"when": "result.error", "route": "release_issue_failure"},
+                        {"route": "done"},
+                    ],
+                },
+                "check_direct_loop": {
+                    "tool": "run_python",
+                    "with": {
+                        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                        "current_iteration": "${{ context.direct_count }}",
+                        "max_iterations": "3",
+                    },
+                    "on_result": [
+                        {
+                            "when": "${{ result.max_exceeded }} == true",
+                            "route": "release_issue_failure",
+                        }
+                    ],
+                    "on_success": "make_plan",
+                    "on_failure": "release_issue_failure",
+                },
+                "make_plan": {
+                    "tool": "run_skill",
+                    "with": {
+                        "skill_command": "/autoskillit:make-plan /tmp/plan",
+                    },
+                    "on_success": "done",
+                    "on_failure": "release_issue_failure",
+                },
+                "release_issue_failure": {"action": "stop", "message": "Escalate."},
+                "done": {"action": "stop", "message": "Done."},
+            }
+        )
+        findings = run_semantic_rules(recipe)
+        errors = [f for f in findings if f.rule == "merge-failure-skill-domain-mismatch"]
+        ref_coherence_errors = [e for e in errors if "ref_coherence" in e.message]
+        assert len(ref_coherence_errors) == 1, (
+            f"Expected exactly 1 ref_coherence mismatch, got: "
+            f"{[e.message for e in ref_coherence_errors]}"
+        )
+        msg = ref_coherence_errors[0].message
+        assert "push_recovery" in msg and "direct_remediate" in msg, (
+            f"Mismatch message must report expected push_recovery and actual "
+            f"direct_remediate, got: {msg}"
+        )
+
+    def test_fallback_arm_is_not_misclassified_as_ancestry_arm(self):
+        """The fallback ref_coherence arm (without remote_is_ancestor) must not
+        be classified against the recovery-class requirement.
+
+        Recipe with ancestry arm reaching push_recovery AND fallback arm routing
+        to direct remediation: only the ancestry arm is validated; the fallback
+        arm is an escalation terminal and not a recovery mismatch."""
+        recipe = _make_workflow(
+            {
+                "merge": {
+                    "tool": "merge_worktree",
+                    "with": {"worktree_path": "/tmp/wt", "base_branch": "main"},
+                    "on_result": [
+                        {
+                            "when": (
+                                "result.failed_step == 'ref_coherence' "
+                                "and result.remote_is_ancestor == true"
+                            ),
+                            "route": "check_ref_push_loop",
+                        },
+                        # Fallback arm — direct remediation as escalation.
+                        # Per plan: fallback is intentional escalation terminal.
+                        {
+                            "when": "result.failed_step == 'ref_coherence'",
+                            "route": "release_issue_failure",
+                        },
+                        {"when": "result.error", "route": "release_issue_failure"},
+                        {"route": "done"},
+                    ],
+                },
+                "check_ref_push_loop": {
+                    "tool": "run_python",
+                    "with": {
+                        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                        "current_iteration": "${{ context.ref_push_count }}",
+                        "max_iterations": "3",
+                    },
+                    "on_success": "ref_push",
+                    "on_failure": "release_issue_failure",
+                },
+                "ref_push": {
+                    "tool": "push_to_remote",
+                    "with": {
+                        "clone_path": "${{ context.work_dir }}",
+                        "remote_url": "git@example.com",
+                        "branch": "main",
+                    },
+                    "on_success": "retry_merge",
+                    "on_failure": "release_issue_failure",
+                },
+                "retry_merge": {
+                    "tool": "merge_worktree",
+                    "with": {"worktree_path": "/tmp/wt", "base_branch": "main"},
+                    "on_success": "done",
+                    "on_failure": "release_issue_failure",
+                },
+                "release_issue_failure": {"action": "stop", "message": "Escalate."},
+                "done": {"action": "stop", "message": "Done."},
+            }
+        )
+        findings = run_semantic_rules(recipe)
+        errors = [f for f in findings if f.rule == "merge-failure-skill-domain-mismatch"]
+        assert errors == [], (
+            f"Fallback escalation arm must not be flagged when ancestry arm is correct, "
+            f"got: {[e.message for e in errors]}"
+        )

--- a/tests/recipe/test_rules_worktree.py
+++ b/tests/recipe/test_rules_worktree.py
@@ -1279,3 +1279,234 @@ def test_model_on_non_skill_clean() -> None:
     )
     findings = run_semantic_rules(wf)
     assert not any(f.rule == "model-on-non-skill-step" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# Step 1c: worktree-clobber-without-merge barrier-transparency tests
+# ---------------------------------------------------------------------------
+
+
+def _make_worktree_creator_cycle(
+    *,
+    fail_arm_route: str,
+    fail_arm_when: str = "result.failed_step == 'ref_coherence'",
+) -> Recipe:
+    """Build a recipe implementing the creator -> barrier -> creator cycle.
+
+    implement captures implementation_ref; barrier (merge_worktree) consumes that
+    variable. The fail arm on the barrier routes to *fail_arm_route*, which may
+    re-enter the creator (unsafe), go through a guard then back to the barrier
+    (safe retry), exit to terminal (safe), or go to a different creator (safe).
+    """
+    return _make_workflow(
+        {
+            "implement": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:implement-worktree-no-merge plan"},
+                "capture": {
+                    "implementation_ref": "${{ result.worktree_path }}",
+                    "worktree_path": "${{ result.worktree_path }}",
+                },
+                "retries": 0,
+                "on_success": "merge",
+                "on_failure": "fail_stop",
+            },
+            "merge": {
+                "tool": "merge_worktree",
+                "with": {
+                    "worktree_path": "${{ context.implementation_ref }}",
+                    "base_branch": "main",
+                },
+                "on_result": [
+                    {"when": "result.failed_step == 'dirty_tree'", "route": "implement"},
+                    {"when": fail_arm_when, "route": fail_arm_route},
+                    {"when": "result.error", "route": "fail_stop"},
+                    {"route": "done"},
+                ],
+                "on_success": "done",
+                "on_failure": "fail_stop",
+            },
+            "done": {"action": "stop", "message": "Done."},
+            "fail_stop": {"action": "stop", "message": "Fail."},
+        }
+    )
+
+
+def test_barrier_transparency_unsafe_reentry_to_creator_fires_error() -> None:
+    """When the merge barrier's explicit failure arm routes directly back to the
+    creator without revisiting the barrier, worktree-clobber-without-merge must fire.
+
+    The finding is owned by the worktree-creating step (the existing rule contract).
+    """
+    recipe = _make_worktree_creator_cycle(fail_arm_route="implement")
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "worktree-clobber-without-merge"]
+    assert len(flagged) == 1, (
+        f"Expected exactly 1 worktree-clobber-without-merge ERROR for unsafe "
+        f"re-entry, got: {flagged}"
+    )
+    assert flagged[0].step_name == "implement", (
+        f"Finding must be owned by the worktree creator, got: {flagged[0].step_name}"
+    )
+    assert "merge" in flagged[0].message.lower(), (
+        f"Finding message must identify the unsafe barrier, got: {flagged[0].message}"
+    )
+
+
+def test_barrier_transparency_safe_retry_via_guard_is_clean() -> None:
+    """When the failure arm routes through a check_loop_iteration guard then
+    returns to the merge barrier, worktree-clobber-without-merge must NOT fire.
+
+    The bounded retry path is enforced by merge-fix-cycle-without-iteration-guard;
+    barrier transparency treats a route that re-enters the barrier as safe.
+    """
+    recipe = _make_workflow(
+        {
+            "implement": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:implement-worktree-no-merge plan"},
+                "capture": {
+                    "implementation_ref": "${{ result.worktree_path }}",
+                    "worktree_path": "${{ result.worktree_path }}",
+                },
+                "retries": 0,
+                "on_success": "merge",
+                "on_failure": "fail_stop",
+            },
+            "merge": {
+                "tool": "merge_worktree",
+                "with": {
+                    "worktree_path": "${{ context.implementation_ref }}",
+                    "base_branch": "main",
+                },
+                "on_result": [
+                    {
+                        "when": "result.failed_step == 'ref_coherence'",
+                        "route": "check_ref_push_loop",
+                    },
+                    {"when": "result.error", "route": "fail_stop"},
+                    {"route": "done"},
+                ],
+                "on_success": "done",
+                "on_failure": "fail_stop",
+            },
+            "check_ref_push_loop": {
+                "tool": "run_python",
+                "with": {
+                    "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                    "current_iteration": "${{ context.ref_push_count }}",
+                    "max_iterations": "3",
+                },
+                "on_result": [
+                    {
+                        "when": "${{ result.max_exceeded }} == true",
+                        "route": "fail_stop",
+                    }
+                ],
+                "on_success": "ref_push",
+                "on_failure": "fail_stop",
+            },
+            "ref_push": {
+                "tool": "push_to_remote",
+                "with": {
+                    "clone_path": "${{ context.work_dir }}",
+                    "remote_url": "git@example.com",
+                    "branch": "main",
+                },
+                "on_success": "merge",
+                "on_failure": "fail_stop",
+            },
+            "done": {"action": "stop", "message": "Done."},
+            "fail_stop": {"action": "stop", "message": "Fail."},
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "worktree-clobber-without-merge"]
+    assert flagged == [], (
+        f"Bounded retry via guard must not trigger worktree-clobber-without-merge, got: {flagged}"
+    )
+
+
+def test_barrier_transparency_safe_terminal_exit_is_clean() -> None:
+    """When the failure arm reaches a terminal stop step, the barrier is safe."""
+    recipe = _make_worktree_creator_cycle(fail_arm_route="fail_stop")
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "worktree-clobber-without-merge"]
+    assert flagged == [], f"Terminal exit must not invalidate the barrier, got: {flagged}"
+
+
+def test_barrier_transparency_unrelated_creator_does_not_invalidate_barrier() -> None:
+    """A failure arm reaching a different worktree creator does NOT invalidate
+    the barrier for the current creator being analyzed."""
+    recipe = _make_workflow(
+        {
+            "implement_a": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:implement-worktree-no-merge plan_a"},
+                "capture": {
+                    "implementation_ref": "${{ result.worktree_path }}",
+                    "worktree_path": "${{ result.worktree_path }}",
+                },
+                "retries": 0,
+                "on_success": "merge_a",
+                "on_failure": "fail_stop",
+            },
+            "merge_a": {
+                "tool": "merge_worktree",
+                "with": {
+                    "worktree_path": "${{ context.implementation_ref }}",
+                    "base_branch": "main",
+                },
+                "on_result": [
+                    {
+                        "when": "result.failed_step == 'ref_coherence'",
+                        "route": "implement_b",
+                    },
+                    {"when": "result.error", "route": "fail_stop"},
+                    {"route": "done"},
+                ],
+                "on_success": "done",
+                "on_failure": "fail_stop",
+            },
+            "implement_b": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:implement-worktree-no-merge plan_b"},
+                "capture": {
+                    "implementation_ref": "${{ result.worktree_path }}",
+                    "worktree_path": "${{ result.worktree_path }}",
+                },
+                "retries": 0,
+                "on_success": "done",
+                "on_failure": "fail_stop",
+            },
+            "done": {"action": "stop", "message": "Done."},
+            "fail_stop": {"action": "stop", "message": "Fail."},
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "worktree-clobber-without-merge"]
+    assert flagged == [], (
+        f"A different worktree creator must not invalidate the barrier, got: {flagged}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 1d: bundled remediation remains semantically valid after barrier transparency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.medium
+def test_bundled_remediation_passes_worktree_clobber_after_transparency() -> None:
+    """Bundled remediation.yaml must not trigger worktree-clobber-without-merge after
+    barrier transparency routes live-worktree merge failures to terminal escalation.
+
+    This integration case guards against a new ERROR rule being registered while
+    the bundled recipe still violates it.
+    """
+    recipe = load_recipe(builtin_recipes_dir() / "remediation.yaml")
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "worktree-clobber-without-merge"]
+    assert flagged == [], (
+        f"Bundled remediation recipe must pass worktree-clobber-without-merge "
+        f"after barrier transparency, got: {[(f.step_name, f.message) for f in flagged]}"
+    )

--- a/tests/recipe/test_rules_worktree.py
+++ b/tests/recipe/test_rules_worktree.py
@@ -1318,7 +1318,7 @@ def _make_worktree_creator_cycle(
                     "base_branch": "main",
                 },
                 "on_result": [
-                    {"when": "result.failed_step == 'dirty_tree'", "route": "implement"},
+                    {"when": "result.failed_step == 'dirty_tree'", "route": "fail_stop"},
                     {"when": fail_arm_when, "route": fail_arm_route},
                     {"when": "result.error", "route": "fail_stop"},
                     {"route": "done"},

--- a/tests/server/test_git.py
+++ b/tests/server/test_git.py
@@ -940,6 +940,7 @@ async def test_perform_merge_rejects_diverged_local_branch(tmp_path):
     runner.push(
         _make_result(0, "bbbbbbbbbbbb\n", "")
     )  # step 7.5b: rev-parse remote SHA (different!)
+    runner.push(_make_result(1, "", ""))  # merge-base: remote is not an ancestor
 
     with patch(
         "autoskillit.server.git.resolve_main_worktree", return_value=Path("/nonexistent-main-repo")
@@ -952,7 +953,99 @@ async def test_perform_merge_rejects_diverged_local_branch(tmp_path):
     assert "remote_sha" in result
     assert result["local_sha"] == "aaaaaaaaaaaa"
     assert result["remote_sha"] == "bbbbbbbbbbbb"
-    assert "diverged" in result["error"]
+    assert result["remote_is_ancestor"] is False
+    merge_base_call = next(
+        args
+        for args in runner.call_args_list
+        if args[0][:3] == ["git", "merge-base", "--is-ancestor"]
+    )
+    assert merge_base_call[0] == [
+        "git",
+        "merge-base",
+        "--is-ancestor",
+        "bbbbbbbbbbbb",
+        "aaaaaaaaaaaa",
+    ]
+    assert merge_base_call[1] == Path(fake_wt)
+
+
+@pytest.mark.anyio
+async def test_perform_merge_reports_local_ahead_ref_coherence(tmp_path):
+    from autoskillit.config import SafetyConfig
+    from autoskillit.server.git import perform_merge
+
+    fake_wt = str(tmp_path)
+    config = AutomationConfig(safety=SafetyConfig(test_gate_on_merge=False))
+    runner = MockSubprocessRunner()
+    runner.push(_make_result(0, f"{fake_wt}/.git/worktrees/wt", ""))
+    runner.push(_make_result(0, "feature-branch\n", ""))
+    runner.push(_make_result(0, "", ""))
+    runner.push(_make_result(0, "", ""))
+    runner.push(_make_result(0, "", ""))
+    runner.push(_make_result(0, "abc123\n", ""))
+    runner.push(_make_result(0, "", ""))
+    runner.push(_make_result(0, "", ""))
+    runner.push(_make_result(0, "dev\n", ""))
+    runner.push(_make_result(0, "bbbbbbbbbbbb\n", ""))
+    runner.push(_make_result(0, "aaaaaaaaaaaa\n", ""))
+    runner.push(_make_result(0, "", ""))
+
+    with patch(
+        "autoskillit.server.git.resolve_main_worktree", return_value=Path("/nonexistent-main-repo")
+    ):
+        result = await perform_merge(fake_wt, "dev", config=config, runner=runner)
+
+    assert result["failed_step"] == MergeFailedStep.REF_COHERENCE
+    assert result["local_sha"] == "bbbbbbbbbbbb"
+    assert result["remote_sha"] == "aaaaaaaaaaaa"
+    assert result["remote_is_ancestor"] is True
+    merge_base_call = next(
+        args
+        for args in runner.call_args_list
+        if args[0][:3] == ["git", "merge-base", "--is-ancestor"]
+    )
+    assert merge_base_call[0] == [
+        "git",
+        "merge-base",
+        "--is-ancestor",
+        "aaaaaaaaaaaa",
+        "bbbbbbbbbbbb",
+    ]
+    assert merge_base_call[1] == Path(fake_wt)
+
+
+@pytest.mark.anyio
+async def test_perform_merge_reports_ancestry_operational_error(tmp_path):
+    from autoskillit.config import SafetyConfig
+    from autoskillit.server.git import perform_merge
+
+    fake_wt = str(tmp_path)
+    config = AutomationConfig(safety=SafetyConfig(test_gate_on_merge=False))
+    runner = MockSubprocessRunner()
+    runner.push(_make_result(0, f"{fake_wt}/.git/worktrees/wt", ""))
+    runner.push(_make_result(0, "feature-branch\n", ""))
+    runner.push(_make_result(0, "", ""))
+    runner.push(_make_result(0, "", ""))
+    runner.push(_make_result(0, "", ""))
+    runner.push(_make_result(0, "abc123\n", ""))
+    runner.push(_make_result(0, "", ""))
+    runner.push(_make_result(0, "", ""))
+    runner.push(_make_result(0, "dev\n", ""))
+    runner.push(_make_result(0, "aaaaaaaaaaaa\n", ""))
+    runner.push(_make_result(0, "bbbbbbbbbbbb\n", ""))
+    runner.push(_make_result(128, "", "fatal: invalid object name"))
+
+    with patch(
+        "autoskillit.server.git.resolve_main_worktree", return_value=Path("/nonexistent-main-repo")
+    ):
+        result = await perform_merge(fake_wt, "dev", config=config, runner=runner)
+
+    assert result["failed_step"] == MergeFailedStep.REF_COHERENCE
+    assert result["local_sha"] == "aaaaaaaaaaaa"
+    assert result["remote_sha"] == "bbbbbbbbbbbb"
+    assert result["stderr"] == "fatal: invalid object name"
+    assert "invalid object name" in result["error"]
+    assert "remote_is_ancestor" not in result
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_types_module.py
+++ b/tests/server/test_tools_types_module.py
@@ -41,7 +41,8 @@ class TestServerToolTypesImport:
     def test_merge_worktree_result_importable(self):
         from autoskillit.server.tools._types import MergeWorktreeResult
 
-        assert "merge_succeeded" in MergeWorktreeResult.__optional_keys__
+        expected = {"merge_succeeded", "local_sha", "remote_sha", "remote_is_ancestor"}
+        assert expected <= MergeWorktreeResult.__optional_keys__
 
 
 class TestServerToolTypesNotInCore:


### PR DESCRIPTION
## Summary

`pre_remediation_merge` in `remediation.yaml` routes `ref_coherence` failures directly to `remediate`, bypassing the bounded push-recovery loop and orphaning the audited worktree. The normal `merge` steps do reach `check_ref_push_loop → ref_push`, but they do so for every SHA mismatch, including genuinely diverged refs. This fix wires `pre_remediation_merge` to a pre-remediation-specific recovery chain, adds ancestry discrimination to the `ref_coherence` result contract, and updates every bundled implementation-family merge site so push recovery is attempted only when the remote ref is an ancestor of the local ref.

Closes #4228

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260714-072735-240828/.autoskillit/temp/rectify/rectify_ref_coherence_bypass_2026-07-14_074500_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| review_approach* | sonnet | 1 | 23.1k | 20.1k | 3.6M | 114.0k | 82 | 189.4k | 5m 51s |
| investigate* | opus | 1 | 13 | 5.5k | 384.4k | 98.1k | 31 | 8.8k | 6m 59s |
| rectify* | opus[1m] | 1 | 12 | 1.1k | 538.8k | 181.3k | 114 | 4.6k | 30m 45s |
| dry_walkthrough* | gpt-5.6-sol | 2 | 10.4M | 59.7k | 10.0M | 0 | 0 | 0 | 27m 41s |
| implement* | MiniMax-M3 | 2 | 330.2k | 82.9k | 20.1M | 0 | 339 | 0 | 57m 22s |
| retry_worktree* | MiniMax-M3 | 1 | 155.9k | 44.2k | 6.5M | 0 | 143 | 0 | 29m 30s |
| audit_impl* | opus[1m] | 1 | 10 | 2.7k | 116.0k | 116.0k | 36 | 421 | 13m 41s |
| prepare_pr* | MiniMax-M3 | 1 | 51.5k | 2.1k | 272.0k | 0 | 16 | 0 | 36s |
| compose_pr* | MiniMax-M3 | 1 | 43.0k | 4.0k | 256.5k | 0 | 15 | 0 | 1m 58s |
| **Total** | | | 11.0M | 222.3k | 41.8M | 181.3k | | 203.2k | 2h 54m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| review_approach | 0 | — | — | — |
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 1778 | 11312.0 | 0.0 | 46.6 |
| retry_worktree | 1364 | 4776.2 | 0.0 | 32.4 |
| audit_impl | 0 | — | — | — |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **3142** | 13304.6 | 64.7 | 70.7 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| sonnet | 1 | 23.1k | 20.1k | 3.6M | 189.4k | 5m 51s |
| opus | 1 | 13 | 5.5k | 384.4k | 8.8k | 6m 59s |
| opus[1m] | 2 | 22 | 3.8k | 654.8k | 5.0k | 44m 26s |
| gpt-5.6-sol | 1 | 10.4M | 59.7k | 10.0M | 0 | 27m 41s |
| MiniMax-M3 | 4 | 580.7k | 133.2k | 27.2M | 0 | 1h 29m |