### PR TITLE
Rectify: Codex Capacity Error Classification Immunity

### DIFF
--- a/src/autoskillit/execution/backends/_codex_parse.py
+++ b/src/autoskillit/execution/backends/_codex_parse.py
@@ -128,6 +128,13 @@ def _scan_codex_ndjson(stdout: str) -> _CodexParseAccumulator:
                 acc.error_message = str(error) if error else ""
             acc.saw_failure = True
             acc.success = False
+        elif event_type == CodexEventType.ERROR:
+            # Standalone ERROR events are FLAT: {"type": "error", "message": "..."}.
+            # There is no nested "error" object and no "code" field on this event shape.
+            # Extracted via obj.get("message", "") (NOT obj.get("error", {}).get("message")).
+            acc.error_message = obj.get("message", "")
+            acc.saw_failure = True
+            acc.success = False
     return acc
 
 
@@ -190,6 +197,7 @@ class CodexResultParser:
                 "mcp_tool_calls": acc.mcp_tool_calls,
                 "file_changes": acc.file_changes,
                 "error_code": acc.error_code,
+                "saw_failure": acc.saw_failure,
                 "ndjson_unknown_event_count": acc.ndjson_unknown_event_count,
                 "ndjson_unknown_item_count": acc.ndjson_unknown_item_count,
             },

--- a/src/autoskillit/execution/backends/_codex_parse.py
+++ b/src/autoskillit/execution/backends/_codex_parse.py
@@ -176,7 +176,7 @@ class CodexResultParser:
             subtype = CliSubtype.UNPARSEABLE.value
         is_error = subtype != CliSubtype.SUCCESS.value
         canonical_dict = None
-        if acc.last_usage is not None:
+        if acc.last_usage:
             canonical = CanonicalTokenUsage.from_codex_dict(acc.last_usage)
             canonical_dict = canonical.to_dict()
         return AgentSessionResult(

--- a/src/autoskillit/execution/headless/_headless_evidence.py
+++ b/src/autoskillit/execution/headless/_headless_evidence.py
@@ -86,6 +86,9 @@ def _apply_budget_guard(
 
 _CODEX_ERROR_CODE_API_STATUS: dict[str, int] = {
     "rate_limit_exceeded": 429,
+    "server_error": 500,
+    "insufficient_quota": 402,
+    "model_not_found": 404,
 }
 
 
@@ -99,6 +102,7 @@ def _adapt_agent_result(agent_result: AgentSessionResult) -> ClaudeSessionResult
     stop_reasons: list[str] = raw.get("stop_reasons", [])
 
     error_code: str = raw.get("error_code", "")
+    saw_failure: bool = raw.get("saw_failure", False)
 
     error_subtypes = {
         CliSubtype.ERROR_DURING_EXECUTION,
@@ -144,6 +148,7 @@ def _adapt_agent_result(agent_result: AgentSessionResult) -> ClaudeSessionResult
         stop_reasons=stop_reasons,
         has_thinking_only_turn=False,
         seen_block_types=frozenset(),
+        api_retry_exhausted=saw_failure and error_code != "",
         api_error_status=api_error_status,
         seen_ndjson_unknown_event_count=seen_ndjson_unknown_event_count,
         seen_ndjson_unknown_item_count=seen_ndjson_unknown_item_count,

--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -32,6 +32,7 @@ _CODEX_API_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bserver_error\b", re.IGNORECASE),
     re.compile(r"insufficient_quota", re.IGNORECASE),
     re.compile(r"model_not_found", re.IGNORECASE),
+    re.compile(r"at capacity", re.IGNORECASE),
 )
 
 _KNOWN_API_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = (

--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -134,4 +134,17 @@ def classify_infra_exit(
         return InfraExitCategory.API_ERROR
     if result.returncode is not None and is_signal_death_code(result.returncode):
         return InfraExitCategory.PROCESS_KILLED
+    # Observability: surface unrecognized error-bearing sessions so future pattern
+    # gaps produce visible telemetry instead of silently falling through to COMPLETED.
+    # Behaviour is unchanged (COMPLETED is still returned) — this is logging only.
+    if session.is_error or session.errors:
+        text_sources = _all_text_sources(session, result)
+        error_preview = text_sources[0][:200] if text_sources else ""
+        logger.warning(
+            "unclassified_infra_error",
+            is_error=session.is_error,
+            error_count=len(session.errors),
+            returncode=result.returncode,
+            error_preview=error_preview,
+        )
     return InfraExitCategory.COMPLETED

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -23,7 +23,7 @@ HEADLESS_SIZE_BUDGETS = {
     "headless/_headless_recovery.py": 370,
     "headless/_headless_path_tokens.py": 190,
     "headless/_headless_result.py": 920,
-    "headless/_headless_evidence.py": 310,
+    "headless/_headless_evidence.py": 315,
 }
 
 

--- a/tests/execution/backends/test_codex_fixtures.py
+++ b/tests/execution/backends/test_codex_fixtures.py
@@ -19,6 +19,7 @@ from tests.fixtures.codex import (
     MULTI_TURN_WITH_COMPACTION,
     SESSION_WITH_MCP_TOOL_CALL,
     SESSION_WITH_REASONING,
+    TURN_FAILED_CAPACITY_ERROR,
     TURN_FAILED_ERROR,
     fixture_path,
 )
@@ -34,6 +35,7 @@ ALL_FIXTURE_NAMES = [
     MARKER_DETECTION_V0136,
     MULTI_TURN_WITH_COMPACTION,
     TURN_FAILED_ERROR,
+    TURN_FAILED_CAPACITY_ERROR,
     SESSION_WITH_REASONING,
     SESSION_WITH_MCP_TOOL_CALL,
 ]
@@ -58,7 +60,7 @@ class TestCodexFixturePackage:
             assert fixture_path(name).is_file()
 
     def test_all_exports_count(self) -> None:
-        assert len(CODEX_ALL) == 10
+        assert len(CODEX_ALL) == 11
 
 
 class TestCodexFixtureValidity:

--- a/tests/execution/backends/test_codex_result_parser.py
+++ b/tests/execution/backends/test_codex_result_parser.py
@@ -194,6 +194,38 @@ class TestScanCodexNdjson:
         assert acc.ndjson_unknown_event_count == 1
         assert acc.ndjson_unknown_item_count == 1
 
+    def test_scan_standalone_error_event_populates_error_message(self) -> None:
+        """Standalone ERROR events (flat shape) populate error_message from obj['message'].
+
+        Shape is FLAT: {\"type\": \"error\", \"message\": \"...\"} with NO nested error
+        envelope and NO code field. Extraction must read obj['message'] directly,
+        NOT obj.get('error', {}).get('message') (which would silently produce '').
+        """
+        line = json.dumps({"type": "error", "message": "Connection failed"})
+        acc = _scan_codex_ndjson(line)
+        assert acc.error_message == "Connection failed"
+        assert acc.saw_failure is True
+        assert acc.success is False
+
+    def test_scan_standalone_error_event_empty_message(self) -> None:
+        """Standalone ERROR event with no message → empty error_message, still saw_failure."""
+        line = json.dumps({"type": "error"})
+        acc = _scan_codex_ndjson(line)
+        assert acc.error_message == ""
+        assert acc.saw_failure is True
+        assert acc.success is False
+
+    def test_scan_standalone_error_event_does_not_set_error_code(self) -> None:
+        """Standalone ERROR events have no 'code' field; error_code remains empty.
+
+        Confirms we do not invent an error_code from the FLAT shape — acc.error_code
+        stays as the default empty string. Only nested turn.failed events populate
+        error_code from obj['error']['code'].
+        """
+        line = json.dumps({"type": "error", "message": "Connection failed"})
+        acc = _scan_codex_ndjson(line)
+        assert acc.error_code == ""
+
 
 class TestCodexResultParserStdout:
     def test_parse_stdout_empty_returns_error(self) -> None:
@@ -724,6 +756,30 @@ def test_error_code_empty_when_no_failure() -> None:
     )
     result = CodexResultParser().parse_stdout(line)
     assert result.raw["error_code"] == ""
+
+
+def test_saw_failure_in_codex_raw_dict() -> None:
+    """Production wiring: parse_stdout copies acc.saw_failure into raw['saw_failure'].
+
+    Without this key, the structural api_retry_exhausted guard in
+    classify_infra_exit can never activate for real Codex sessions — Step 2A
+    threads the signal but only when it's actually present in the raw dict.
+    """
+    line = json.dumps(
+        {
+            "type": "turn.failed",
+            "error": {"message": "Token limit", "code": "context_length_exceeded"},
+        }
+    )
+    result = CodexResultParser().parse_stdout(line)
+    assert result.raw["saw_failure"] is True
+
+
+def test_saw_failure_false_when_no_failure() -> None:
+    """Production wiring: parse_stdout sets raw['saw_failure']=False on success path."""
+    line = json.dumps({"type": "turn.completed", "usage": {}})
+    result = CodexResultParser().parse_stdout(line)
+    assert result.raw["saw_failure"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_adapt_agent_result.py
+++ b/tests/execution/test_adapt_agent_result.py
@@ -377,14 +377,86 @@ def test_api_error_status_from_rate_limit_code() -> None:
     assert result.api_error_status == 429
 
 
-def test_api_error_status_none_for_non_rate_limit_code() -> None:
+def test_api_error_status_none_for_unmapped_error_code() -> None:
     result = _adapt_agent_result(
         _make_agent_result(
-            raw={"subtype": "error_during_execution", "error_code": "server_error"},
-            error="Internal server error",
+            raw={"subtype": "error_during_execution", "error_code": "unknown_provider_code"},
+            error="Some unknown error",
         )
     )
     assert result.api_error_status is None
+
+
+@pytest.mark.parametrize(
+    ("error_code", "expected_status"),
+    [
+        ("server_error", 500),
+        ("insufficient_quota", 402),
+        ("model_not_found", 404),
+    ],
+)
+def test_api_error_status_expanded_codex_mapping(error_code: str, expected_status: int) -> None:
+    """Defence-in-depth: known Codex error codes map to HTTP status codes.
+
+    Enables classify_infra_exit's ``api_error_status >= 400`` guard to fire even
+    when text-pattern matching misses (independent detection channel from the
+    saw_failure/api_retry_exhausted structural guard).
+    """
+    result = _adapt_agent_result(
+        _make_agent_result(
+            raw={"subtype": "error_during_execution", "error_code": error_code},
+            error=f"Codex error: {error_code}",
+        )
+    )
+    assert result.api_error_status == expected_status
+
+
+def test_saw_failure_with_error_code_populates_api_retry_exhausted() -> None:
+    """Architectural immunity: Codex turn.failed signal reaches api_retry_exhausted.
+
+    With raw={'saw_failure': True, 'error_code': <unknown code>} and no matching
+    pattern, _adapt_agent_result must still populate api_retry_exhausted=True so
+    classify_infra_exit's api_retry_exhausted guard (line 131-132) classifies the
+    session as API_ERROR rather than COMPLETED. This is the structural fallback
+    that makes future missing-pattern bugs retriable instead of silently permanent.
+    """
+    result = _adapt_agent_result(
+        _make_agent_result(
+            raw={
+                "subtype": "error_during_execution",
+                "saw_failure": True,
+                "error_code": "unknown_provider_code",
+            },
+            error="Totally new unrecognized provider failure",
+        )
+    )
+    assert result.api_retry_exhausted is True
+
+
+def test_saw_failure_without_error_code_does_not_populate_api_retry_exhausted() -> None:
+    """Structural guard requires both signals: saw_failure AND a structured error_code.
+
+    saw_failure=True alone (no error_code) does NOT populate api_retry_exhausted,
+    because bare failure events without a structured error.code are weaker signal
+    (text-pattern matching is the right detection path for those).
+    """
+    result = _adapt_agent_result(
+        _make_agent_result(
+            raw={
+                "subtype": "error_during_execution",
+                "saw_failure": True,
+                "error_code": "",
+            },
+            error="Some failure",
+        )
+    )
+    assert result.api_retry_exhausted is False
+
+
+def test_saw_failure_absent_does_not_populate_api_retry_exhausted() -> None:
+    """Default (no saw_failure in raw) leaves api_retry_exhausted=False."""
+    result = _adapt_agent_result(_make_agent_result())
+    assert result.api_retry_exhausted is False
 
 
 def test_classify_infra_exit_rate_limited_via_adapted_error_code() -> None:

--- a/tests/execution/test_api_error_signal_invariants.py
+++ b/tests/execution/test_api_error_signal_invariants.py
@@ -23,7 +23,10 @@ from autoskillit.core.types import (
 )
 from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.headless._headless_result import _build_skill_result
-from autoskillit.execution.session._exit_classification import classify_infra_exit
+from autoskillit.execution.session._exit_classification import (
+    _KNOWN_API_ERROR_PATTERNS,
+    classify_infra_exit,
+)
 from autoskillit.execution.session._session_model import ClaudeSessionResult, parse_session_result
 from tests.execution.conftest import (
     CODEX_API_ERROR_SIGNAL_STRINGS,
@@ -361,3 +364,56 @@ class TestApiErrorStatusChannelInvariance:
         assert sr.infra.exit_category == "rate_limited"
         assert sr.needs_retry is True
         assert sr.retry_reason == RetryReason.RATE_LIMITED
+
+
+# ---------------------------------------------------------------------------
+# Invariant 5: Independent curated error corpus — breaks circular derivation
+# ---------------------------------------------------------------------------
+#
+# Architectural immunity test. CODEX_API_ERROR_SIGNAL_STRINGS in tests/execution/
+# conftest.py is mechanically derived from _CODEX_API_ERROR_PATTERNS, so it can
+# only verify that existing patterns work — it can never detect that a pattern
+# is missing from the production list.
+#
+# KNOWN_PROVIDER_ERROR_STRINGS is independently maintained. Adding a real-world
+# error string here without adding a matching pattern in _KNOWN_API_ERROR_PATTERNS
+# will fail TestKnownProviderErrorsCovered, surfacing the gap before production
+# encounters it.
+#
+# Note on exact wording: patterns match snake_case error codes
+# (rate_limit_exceeded, \bserver_error\b, insufficient_quota) rather than
+# free-form prose. Use literal error.code values — which is also what Codex
+# surfaces via acc.error_code in production.
+
+KNOWN_PROVIDER_ERROR_STRINGS: list[str] = [
+    # OpenAI/Codex transient error codes (error.code values from the OpenAI API)
+    "Selected model is at capacity. Please try a different model.",
+    "rate_limit_exceeded",
+    "server_error",
+    "insufficient_quota",
+    # Network/connection errors
+    "overloaded",
+    "ECONNRESET",
+    "ECONNREFUSED",
+    "socket hang up",
+    "network error",
+    "connection reset",
+    "socket connection was closed",
+]
+
+
+class TestKnownProviderErrorsCovered:
+    """Each real-world error string must match at least one pattern in _KNOWN_API_ERROR_PATTERNS.
+
+    Independent of the production pattern list: if a new error string is added
+    to KNOWN_PROVIDER_ERROR_STRINGS but no matching pattern exists, this test
+    fails — proving the corpus breaks the circular test derivation.
+    """
+
+    @pytest.mark.parametrize("error_string", KNOWN_PROVIDER_ERROR_STRINGS)
+    def test_error_string_matches_at_least_one_pattern(self, error_string: str) -> None:
+        assert any(p.search(error_string) for p in _KNOWN_API_ERROR_PATTERNS), (
+            f"Error string {error_string!r} is not covered by any pattern in "
+            f"_KNOWN_API_ERROR_PATTERNS. Add a matching pattern or remove the "
+            f"string from KNOWN_PROVIDER_ERROR_STRINGS."
+        )

--- a/tests/execution/test_api_error_signal_invariants.py
+++ b/tests/execution/test_api_error_signal_invariants.py
@@ -54,6 +54,7 @@ API_ERROR_SIGNALS: list[str] = [
     "socket connection was closed",
     "Rate limited",
     "rate_limit_exceeded",
+    "at capacity",
     # OpenAI/Codex API error types
     *CODEX_API_ERROR_SIGNAL_STRINGS,
 ]

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 import pytest
+import structlog
 
 from autoskillit.core.types import (
     CLAUDE_CODE_CAPABILITIES,
@@ -676,6 +677,46 @@ def test_is_signal_death_code_boundary_cases(returncode: int, expected: bool) ->
 def test_codex_api_error_patterns_count() -> None:
     """Structural test: _CODEX_API_ERROR_PATTERNS has exactly 5 entries."""
     assert len(_CODEX_API_ERROR_PATTERNS) == 5
+
+
+def test_unclassified_infra_error_warning_emitted() -> None:
+    """Unrecognized error-bearing session produces a structured warning log.
+
+    Observability layer: future pattern gaps become visible via the
+    unclassified_infra_error warning rather than silently falling through to
+    COMPLETED. The session still classifies as COMPLETED (behaviour unchanged).
+    """
+    session = ClaudeSessionResult(
+        subtype=CliSubtype.EMPTY_OUTPUT,
+        is_error=True,
+        result="",
+        session_id="s1",
+        errors=["Some unknown API failure"],
+    )
+    result = _sr(returncode=1, stderr="")
+    with structlog.testing.capture_logs() as captured:
+        category = classify_infra_exit(session, result, capabilities=_CAPS)
+    assert category == InfraExitCategory.COMPLETED
+    warning_events = [e for e in captured if e.get("event") == "unclassified_infra_error"]
+    assert warning_events, f"Expected unclassified_infra_error warning, got: {captured}"
+    assert warning_events[0]["is_error"] is True
+    assert warning_events[0]["error_count"] == 1
+    assert warning_events[0]["returncode"] == 1
+
+
+def test_unclassified_infra_error_warning_not_emitted_on_clean_completed() -> None:
+    """Clean success session produces NO unclassified_infra_error warning."""
+    session = ClaudeSessionResult(
+        subtype=CliSubtype.SUCCESS,
+        is_error=False,
+        result="Done.",
+        session_id="s1",
+    )
+    result = _sr(returncode=0, stderr="")
+    with structlog.testing.capture_logs() as captured:
+        classify_infra_exit(session, result, capabilities=_CAPS)
+    warning_events = [e for e in captured if e.get("event") == "unclassified_infra_error"]
+    assert warning_events == []
 
 
 class TestCodexApiErrorClassification:

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -674,5 +674,26 @@ def test_is_signal_death_code_boundary_cases(returncode: int, expected: bool) ->
 
 
 def test_codex_api_error_patterns_count() -> None:
-    """Structural test: _CODEX_API_ERROR_PATTERNS has exactly 4 entries."""
-    assert len(_CODEX_API_ERROR_PATTERNS) == 4
+    """Structural test: _CODEX_API_ERROR_PATTERNS has exactly 5 entries."""
+    assert len(_CODEX_API_ERROR_PATTERNS) == 5
+
+
+class TestCodexApiErrorClassification:
+    """Capacity error patterns must classify as API_ERROR, not COMPLETED.
+
+    Regression guard for Codex "at capacity" misclassification (issue #4226).
+    Without the 'at capacity' pattern in _CODEX_API_ERROR_PATTERNS, the
+    classify_infra_exit cascade silently falls through to COMPLETED, and
+    Codex's exit_code_is_terminal=True makes the session non-retriable.
+    """
+
+    def test_turn_failed_capacity_error_classified_as_api_error(self) -> None:
+        ndjson = _turn_failed_ndjson(
+            "Selected model is at capacity. Please try a different model."
+        )
+        agent_result = CodexResultParser().parse_stdout(ndjson)
+        adapted = _adapt_agent_result(agent_result)
+        result = _sr(returncode=1)
+        assert (
+            classify_infra_exit(adapted, result, capabilities=_CAPS) == InfraExitCategory.API_ERROR
+        )

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -40,6 +40,7 @@ from tests.execution.conftest import _make_tool_use_line, _sr, _success_session_
 from tests.fixtures.codex import (
     HAPPY_PATH_SINGLE_TURN,
     HAPPY_PATH_V0136,
+    TURN_FAILED_CAPACITY_ERROR,
     TURN_FAILED_ERROR,
     fixture_path,
 )
@@ -1180,6 +1181,49 @@ class TestCodexPipelineTurnFailed:
     def test_failure_token_usage_none(self):
         sr = self._build()
         assert sr.token_usage is None
+
+
+class TestCodexCapacityErrorEndToEnd:
+    """Codex capacity error through full pipeline → needs_retry=True via API_ERROR override.
+
+    Regression guard for issue #4226: 'at capacity' messages were silently
+    falling through to COMPLETED. With exit_code_is_terminal=True (Codex),
+    this combination was a permanent failure with no retry path.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _patch_parse_stdout(self, monkeypatch):
+        from autoskillit.execution.headless import _headless_result
+
+        monkeypatch.setattr(_headless_result, "_parse_stdout", _make_codex_parse_stdout())
+        self._content = fixture_path(TURN_FAILED_CAPACITY_ERROR).read_text()
+        self._result = _codex_subprocess_result(
+            self._content,
+            returncode=1,
+            termination=TerminationReason.NATURAL_EXIT,
+            kill_reason=KillReason.NATURAL_EXIT,
+        )
+
+    def _build(self) -> SkillResult:
+        return _build_skill_result(
+            self._result, supports_claude_format_stdout=False, backend=CodexBackend()
+        )
+
+    def test_capacity_error_needs_retry(self):
+        sr = self._build()
+        assert sr.needs_retry is True
+
+    def test_capacity_error_retry_reason_is_resume(self):
+        sr = self._build()
+        assert sr.retry_reason == RetryReason.RESUME
+
+    def test_capacity_error_exit_category_is_api_error(self):
+        sr = self._build()
+        assert sr.infra.exit_category == "api_error"
+
+    def test_capacity_error_success_is_false(self):
+        sr = self._build()
+        assert sr.success is False
 
 
 class TestCodexPipelineTerminationBranches:

--- a/tests/fixtures/codex/__init__.py
+++ b/tests/fixtures/codex/__init__.py
@@ -12,6 +12,7 @@ HAPPY_PATH_V0136: str = "happy_path_v0136.ndjson"
 MARKER_DETECTION_V0136: str = "marker_detection_v0136.ndjson"
 MULTI_TURN_WITH_COMPACTION: str = "multi_turn_with_compaction_v0133.ndjson"
 TURN_FAILED_ERROR: str = "turn_failed_error_v0133.ndjson"
+TURN_FAILED_CAPACITY_ERROR: str = "turn_failed_capacity_error_v0133.ndjson"
 SESSION_WITH_REASONING: str = "session_with_reasoning_v0133.ndjson"
 SESSION_WITH_MCP_TOOL_CALL: str = "session_with_mcp_tool_call_v0133.ndjson"
 
@@ -30,6 +31,7 @@ __all__ = [
     "MULTI_TURN_WITH_COMPACTION",
     "SESSION_WITH_MCP_TOOL_CALL",
     "SESSION_WITH_REASONING",
+    "TURN_FAILED_CAPACITY_ERROR",
     "TURN_FAILED_ERROR",
     "fixture_path",
 ]

--- a/tests/fixtures/codex/turn_failed_capacity_error_v0133.ndjson
+++ b/tests/fixtures/codex/turn_failed_capacity_error_v0133.ndjson
@@ -1,0 +1,4 @@
+{"type":"thread.started","thread_id":"thread_capacity_001"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"type":"message","id":"msg_001","content":[]}}
+{"type":"turn.failed","error":{"message":"Selected model is at capacity. Please try a different model."}}


### PR DESCRIPTION
## Summary

The exit classification pipeline uses a closed allowlist of regex patterns (`_KNOWN_API_ERROR_PATTERNS`) to recognize transient API errors. Any error message not matching this allowlist silently falls through to `InfraExitCategory.COMPLETED`, which combined with Codex's `exit_code_is_terminal=True` produces a non-retriable permanent failure — a silent misclassification. The test suite mirrors the production pattern list via mechanical derivation (`CODEX_API_ERROR_SIGNAL_STRINGS = tuple(p.pattern.replace(...)  for p in _CODEX_API_ERROR_PATTERNS)`), making it structurally impossible for tests to detect that the production list is incomplete.

Closes #4226

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260715-072517-215223/.autoskillit/temp/rectify/rectify_codex_capacity_error_classification_immunity_2026-07-15_074500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
