### PR TITLE
Rectify backend pin bypasses and propagation hardening

### DIFF
--- a/src/autoskillit/cli/fleet/_fleet_session.py
+++ b/src/autoskillit/cli/fleet/_fleet_session.py
@@ -185,7 +185,9 @@ def _launch_fleet_session(
         if resume_metadata is not None:
             state = read_state(state_path)
             current_resume_spec = (
-                derive_orchestrator_resume_spec(state) if state is not None else NoResume()
+                derive_orchestrator_resume_spec(state, current_backend=cfg.agent_backend.backend)
+                if state is not None
+                else NoResume()
             )
         else:
             current_resume_spec = NoResume()

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -215,7 +215,6 @@ from .types import SESSION_TYPE_ORCHESTRATOR as SESSION_TYPE_ORCHESTRATOR
 from .types import SESSION_TYPE_SKILL as SESSION_TYPE_SKILL
 from .types import SKILL_ACTIVATE_DEPS_REQUIRED as SKILL_ACTIVATE_DEPS_REQUIRED
 from .types import SKILL_CAPABILITY_REGISTRY as SKILL_CAPABILITY_REGISTRY
-from .types import unsatisfied_backend_capabilities as unsatisfied_backend_capabilities
 from .types import SKILL_COMMAND_DISPLAY_MAX as SKILL_COMMAND_DISPLAY_MAX
 from .types import SKILL_COMMAND_PREFIX as SKILL_COMMAND_PREFIX
 from .types import SKILL_FILE_ADVISORY_MAP as SKILL_FILE_ADVISORY_MAP
@@ -286,6 +285,7 @@ from .types import FleetSessionEnv as FleetSessionEnv
 from .types import GateState as GateState
 from .types import GitHubApiLog as GitHubApiLog
 from .types import GitHubFetcher as GitHubFetcher
+from .types import HardCapabilityMismatch as HardCapabilityMismatch
 from .types import HeadlessExecutor as HeadlessExecutor
 from .types import InfraExitCategory as InfraExitCategory
 from .types import InfraOutcome as InfraOutcome
@@ -348,7 +348,6 @@ from .types import SessionTelemetry as SessionTelemetry
 from .types import SessionType as SessionType
 from .types import Severity as Severity
 from .types import SkillCapabilityDef as SkillCapabilityDef
-from .types import HardCapabilityMismatch as HardCapabilityMismatch
 from .types import SkillFamilyDef as SkillFamilyDef
 from .types import SkillLister as SkillLister
 from .types import SkillResolver as SkillResolver
@@ -393,4 +392,5 @@ from .types import resume_spec_from_cli as resume_spec_from_cli
 from .types import session_type as session_type
 from .types import strip_context_window_suffix as strip_context_window_suffix
 from .types import truncate_text as truncate_text
+from .types import unsatisfied_backend_capabilities as unsatisfied_backend_capabilities
 from .types import validate_label_transition as validate_label_transition

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -215,6 +215,7 @@ from .types import SESSION_TYPE_ORCHESTRATOR as SESSION_TYPE_ORCHESTRATOR
 from .types import SESSION_TYPE_SKILL as SESSION_TYPE_SKILL
 from .types import SKILL_ACTIVATE_DEPS_REQUIRED as SKILL_ACTIVATE_DEPS_REQUIRED
 from .types import SKILL_CAPABILITY_REGISTRY as SKILL_CAPABILITY_REGISTRY
+from .types import unsatisfied_backend_capabilities as unsatisfied_backend_capabilities
 from .types import SKILL_COMMAND_DISPLAY_MAX as SKILL_COMMAND_DISPLAY_MAX
 from .types import SKILL_COMMAND_PREFIX as SKILL_COMMAND_PREFIX
 from .types import SKILL_FILE_ADVISORY_MAP as SKILL_FILE_ADVISORY_MAP
@@ -347,6 +348,7 @@ from .types import SessionTelemetry as SessionTelemetry
 from .types import SessionType as SessionType
 from .types import Severity as Severity
 from .types import SkillCapabilityDef as SkillCapabilityDef
+from .types import HardCapabilityMismatch as HardCapabilityMismatch
 from .types import SkillFamilyDef as SkillFamilyDef
 from .types import SkillLister as SkillLister
 from .types import SkillResolver as SkillResolver

--- a/src/autoskillit/core/types/_type_checkpoint.py
+++ b/src/autoskillit/core/types/_type_checkpoint.py
@@ -19,6 +19,8 @@ class SessionCheckpoint:
     step_name: str = ""
     progress_pct: float = 0.0
     ts: str = ""
+    backend_name: str = ""
+    skill_name: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -26,6 +28,8 @@ class SessionCheckpoint:
             "step_name": self.step_name,
             "progress_pct": self.progress_pct,
             "ts": self.ts,
+            "backend_name": self.backend_name,
+            "skill_name": self.skill_name,
         }
 
     @classmethod
@@ -35,17 +39,26 @@ class SessionCheckpoint:
             step_name=str(data.get("step_name", "")),
             progress_pct=float(data.get("progress_pct", 0.0)),
             ts=str(data.get("ts", "")),
+            backend_name=str(data.get("backend_name", "")),
+            skill_name=str(data.get("skill_name", "")),
         )
 
     @classmethod
     def now(
-        cls, completed_items: list[str], step_name: str = "", progress_pct: float = 0.0
+        cls,
+        completed_items: list[str],
+        step_name: str = "",
+        progress_pct: float = 0.0,
+        backend_name: str = "",
+        skill_name: str = "",
     ) -> SessionCheckpoint:
         return cls(
             completed_items=completed_items,
             step_name=step_name,
             progress_pct=progress_pct,
             ts=datetime.now(tz=UTC).isoformat(),
+            backend_name=backend_name,
+            skill_name=skill_name,
         )
 
 

--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import NamedTuple
 
+from ._type_constants_registries import SKILL_CAPABILITY_REGISTRY
+
 __all__ = [
     "RETIRED_SKILL_NAMES",
     "RETIRED_AGENT_NAMES",
@@ -107,12 +109,22 @@ CAPABILITY_INGREDIENT_TO_SKIP_GUARD: dict[str, str] = {
 }
 
 # Maps worker_routable capabilities to the specific recipe ingredients they
-# authorize. Capabilities not in this map (e.g. agent_subagent, agent_model,
-# cross_skill_ref) trigger backend rerouting but do not flip any ingredient
-# — they are routed but not git-write-gated.
+# authorize. Derived from the authoritative capability definitions so recipe
+# admission cannot drift from dispatch-time hard-capability enforcement.
 CAPABILITY_INGREDIENT_MAP: dict[str, str] = {
-    "git_metadata_write": "backend_supports_git_write",
+    name: capability.required_recipe_ingredient
+    for name, capability in SKILL_CAPABILITY_REGISTRY.items()
+    if capability.required_recipe_ingredient is not None
 }
+
+_UNKNOWN_CAPABILITY_INGREDIENTS = (
+    frozenset(CAPABILITY_INGREDIENT_MAP.values()) - BACKEND_CAPABILITY_INGREDIENTS
+)
+if _UNKNOWN_CAPABILITY_INGREDIENTS:
+    raise RuntimeError(
+        "SKILL_CAPABILITY_REGISTRY references unknown backend capability ingredients: "
+        f"{sorted(_UNKNOWN_CAPABILITY_INGREDIENTS)}"
+    )
 
 # Bare (un-dotted) callable names whose run_python steps are capability gates.
 # Each entry corresponds to a callable in smoke_utils that reads a

--- a/src/autoskillit/core/types/_type_constants_registries.py
+++ b/src/autoskillit/core/types/_type_constants_registries.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 from dataclasses import dataclass, fields
 from typing import Literal, NamedTuple
 
+# _type_backend.py itself imports several other core/types siblings, but all
+# of them stay within core/ (IL-0) — importing BackendCapabilities here does
+# not introduce a circular or cross-layer dependency.
 from ._type_backend import BackendCapabilities
 from ._type_constants_env import AGENT_BACKEND_CLAUDE_CODE
 from ._type_enums import FleetErrorCode
@@ -411,7 +414,11 @@ for _cap_name, _cap_def in SKILL_CAPABILITY_REGISTRY.items():
 
 # Boot-time validation: every `required_backend_property` must name a real
 # field on `BackendCapabilities`. Catches typos in the registry at import
-# time rather than at first dispatch.
+# time rather than at first dispatch. This is the hard, dispatch-level
+# gating mechanism; the parallel `CAPABILITY_INGREDIENT_MAP` (in
+# `_type_constants.py`) drives soft, recipe-level ingredient gating — both
+# registries must be kept in sync when adding a new hard capability (see
+# the `required_backend_property` field docstring above for the full split).
 _BACKEND_CAPABILITIES_FIELDS = {f.name for f in fields(BackendCapabilities)}
 for _cap_name, _cap_def in SKILL_CAPABILITY_REGISTRY.items():
     if (

--- a/src/autoskillit/core/types/_type_constants_registries.py
+++ b/src/autoskillit/core/types/_type_constants_registries.py
@@ -41,7 +41,9 @@ __all__ = [
     "ALL_VISIBILITY_TAGS",
     "SERVE_SURFACES",
     "SkillCapabilityDef",
+    "HardCapabilityMismatch",
     "SKILL_CAPABILITY_REGISTRY",
+    "unsatisfied_backend_capabilities",
 ]
 
 # Native Claude Code tools that pipeline orchestrators must NEVER use directly.
@@ -342,6 +344,14 @@ class SkillCapabilityDef:
         return frozenset()
 
 
+class HardCapabilityMismatch(NamedTuple):
+    """A required backend capability property whose value is unsatisfied."""
+
+    capability: str
+    property_name: str
+    actual_value: object
+
+
 # Semantics divergence: fix-required has different enforcement in HOOK_REGISTRY vs
 # SKILL_CAPABILITY_REGISTRY. In HOOK_REGISTRY, fix-required triggers _check_backend_compat
 # to block dispatch on backends whose applicable_guards don't cover the hook's scripts.
@@ -429,3 +439,20 @@ for _cap_name, _cap_def in SKILL_CAPABILITY_REGISTRY.items():
             f"SKILL_CAPABILITY_REGISTRY[{_cap_name!r}].required_backend_property="
             f"{_cap_def.required_backend_property!r} is not a field on BackendCapabilities."
         )
+
+
+def unsatisfied_backend_capabilities(
+    uses_capabilities: frozenset[str],
+    backend_capabilities: BackendCapabilities,
+) -> tuple[HardCapabilityMismatch, ...]:
+    """Return hard capability requirements not satisfied by a backend."""
+    mismatches: list[HardCapabilityMismatch] = []
+    for capability in sorted(uses_capabilities):
+        capability_def = SKILL_CAPABILITY_REGISTRY.get(capability)
+        if capability_def is None or capability_def.required_backend_property is None:
+            continue
+        property_name = capability_def.required_backend_property
+        actual_value = getattr(backend_capabilities, property_name, None)
+        if not actual_value:
+            mismatches.append(HardCapabilityMismatch(capability, property_name, actual_value))
+    return tuple(mismatches)

--- a/src/autoskillit/core/types/_type_constants_registries.py
+++ b/src/autoskillit/core/types/_type_constants_registries.py
@@ -329,11 +329,11 @@ class SkillCapabilityDef:
     # (`_check_backend_compat`) gates if the backend's value is falsy —
     # independent of explicit backend pinning (REQ-RES-001).
     #
-    # The parallel `CAPABILITY_INGREDIENT_MAP` (in `_type_constants.py`)
-    # drives soft, recipe-level ingredient gating; this field drives hard,
-    # dispatch-level backend-property gating. Both registries must be kept
-    # in sync when adding a new hard capability.
+    # `required_recipe_ingredient` drives the corresponding soft,
+    # recipe-level gate. `CAPABILITY_INGREDIENT_MAP` is derived from this
+    # definition so admission and dispatch cannot drift apart.
     required_backend_property: str | None = None
+    required_recipe_ingredient: str | None = None
 
     @property
     def required_backends(self) -> frozenset[str]:
@@ -401,6 +401,7 @@ SKILL_CAPABILITY_REGISTRY: dict[str, SkillCapabilityDef] = {
         codex_status="not-applicable",
         worker_routable=True,
         required_backend_property="git_metadata_writable",
+        required_recipe_ingredient="backend_supports_git_write",
     ),
     "github_api_write": SkillCapabilityDef(
         description=(
@@ -424,13 +425,17 @@ for _cap_name, _cap_def in SKILL_CAPABILITY_REGISTRY.items():
 
 # Boot-time validation: every `required_backend_property` must name a real
 # field on `BackendCapabilities`. Catches typos in the registry at import
-# time rather than at first dispatch. This is the hard, dispatch-level
-# gating mechanism; the parallel `CAPABILITY_INGREDIENT_MAP` (in
-# `_type_constants.py`) drives soft, recipe-level ingredient gating — both
-# registries must be kept in sync when adding a new hard capability (see
-# the `required_backend_property` field docstring above for the full split).
+# time rather than at first dispatch. The recipe-level ingredient map is
+# derived from the same capability definitions in `_type_constants.py`.
 _BACKEND_CAPABILITIES_FIELDS = {f.name for f in fields(BackendCapabilities)}
 for _cap_name, _cap_def in SKILL_CAPABILITY_REGISTRY.items():
+    if (_cap_def.required_backend_property is None) != (
+        _cap_def.required_recipe_ingredient is None
+    ):
+        raise RuntimeError(
+            f"SKILL_CAPABILITY_REGISTRY[{_cap_name!r}] must define both "
+            "required_backend_property and required_recipe_ingredient, or neither."
+        )
     if (
         _cap_def.required_backend_property is not None
         and _cap_def.required_backend_property not in _BACKEND_CAPABILITIES_FIELDS

--- a/src/autoskillit/core/types/_type_constants_registries.py
+++ b/src/autoskillit/core/types/_type_constants_registries.py
@@ -1,13 +1,16 @@
 """Tool registries, pack registries, tool-to-tag mappings, visibility tags.
 
-Zero autoskillit imports — except sibling _type_constants_env for backend name constants.
+Zero autoskillit imports — except sibling `_type_constants_env` for backend name constants,
+sibling `_type_enums` for `FleetErrorCode`, and sibling `_type_backend` for the
+`BackendCapabilities` boot-time field check.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from typing import Literal, NamedTuple
 
+from ._type_backend import BackendCapabilities
 from ._type_constants_env import AGENT_BACKEND_CLAUDE_CODE
 from ._type_enums import FleetErrorCode
 
@@ -314,6 +317,18 @@ class SkillCapabilityDef:
     codex_status: Literal["works-as-is", "degraded", "fix-required", "not-applicable"]
     required_sandbox_overrides: frozenset[str] = frozenset()
     worker_routable: bool = False
+    # Name of a Boolean field on `BackendCapabilities` that must be True
+    # on the dispatch-target backend for this capability to be feasible.
+    # When set, `check_hard_capability_feasibility()` rejects the dispatch
+    # at both admission (`_check_dispatch_feasibility`) and dispatch-time
+    # (`_check_backend_compat`) gates if the backend's value is falsy —
+    # independent of explicit backend pinning (REQ-RES-001).
+    #
+    # The parallel `CAPABILITY_INGREDIENT_MAP` (in `_type_constants.py`)
+    # drives soft, recipe-level ingredient gating; this field drives hard,
+    # dispatch-level backend-property gating. Both registries must be kept
+    # in sync when adding a new hard capability.
+    required_backend_property: str | None = None
 
     @property
     def required_backends(self) -> frozenset[str]:
@@ -372,6 +387,7 @@ SKILL_CAPABILITY_REGISTRY: dict[str, SkillCapabilityDef] = {
         ),
         codex_status="not-applicable",
         worker_routable=True,
+        required_backend_property="git_metadata_writable",
     ),
     "github_api_write": SkillCapabilityDef(
         description=(
@@ -391,4 +407,18 @@ for _cap_name, _cap_def in SKILL_CAPABILITY_REGISTRY.items():
             f"SKILL_CAPABILITY_REGISTRY[{_cap_name!r}].codex_status="
             f"{_cap_def.codex_status!r} is not valid. "
             f"Must be one of {sorted(_VALID_CODEX_STATUSES)}."
+        )
+
+# Boot-time validation: every `required_backend_property` must name a real
+# field on `BackendCapabilities`. Catches typos in the registry at import
+# time rather than at first dispatch.
+_BACKEND_CAPABILITIES_FIELDS = {f.name for f in fields(BackendCapabilities)}
+for _cap_name, _cap_def in SKILL_CAPABILITY_REGISTRY.items():
+    if (
+        _cap_def.required_backend_property is not None
+        and _cap_def.required_backend_property not in _BACKEND_CAPABILITIES_FIELDS
+    ):
+        raise RuntimeError(
+            f"SKILL_CAPABILITY_REGISTRY[{_cap_name!r}].required_backend_property="
+            f"{_cap_def.required_backend_property!r} is not a field on BackendCapabilities."
         )

--- a/src/autoskillit/core/types/_type_protocols_recipe.py
+++ b/src/autoskillit/core/types/_type_protocols_recipe.py
@@ -9,7 +9,13 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 if TYPE_CHECKING:
     from autoskillit.recipe.schema import Recipe, RecipeInfo
 
+    from ._type_backend import BackendCapabilities
     from ._type_protocols_logging import SupportsDebug
+else:
+    # Re-exported at runtime so typing.get_type_hints() can resolve the string
+    # annotations in the RecipeRepository protocol below (from __future__ import
+    # annotations defers everything to strings).
+    from ._type_backend import BackendCapabilities  # noqa: F401
 
 from ._type_results import LoadResult
 
@@ -60,6 +66,7 @@ class RecipeRepository(Protocol):
         defer_unresolved: bool = False,
         backend_name: str | None = None,
         effective_backend_map: dict[str, str] | None = None,
+        backend_capabilities_map: dict[str, BackendCapabilities] | None = None,
     ) -> dict[str, Any]:
         """Load and validate a recipe.
 
@@ -75,6 +82,7 @@ class RecipeRepository(Protocol):
         backend_name: str | None = None,
         ingredient_overrides: dict[str, str] | None = None,
         effective_backend_map: dict[str, str] | None = None,
+        backend_capabilities_map: dict[str, BackendCapabilities] | None = None,
     ) -> dict[str, Any]: ...
 
     def list_all(

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -212,12 +212,18 @@ async def _execute_claude_headless(
     if not skip_clone_guard and is_git_main_checkout(Path(cwd)):
         _pre_sha = _clone_snapshot.head_sha if _clone_snapshot else ""
         try:
-            await validate_pre_session_index(
+            _was_dirty = await validate_pre_session_index(
                 cwd,
                 runner,
                 pre_session_sha=_pre_sha,
                 exclude_prefix=_derived_prefix or GUARD_EXCLUDE_PREFIX,
             )
+            if _was_dirty:
+                logger.warning(
+                    "pre_session_index_reset",
+                    dirty=True,
+                    pre_sha=_pre_sha,
+                )
         except Exception:
             logger.warning("validate_pre_session_index_failed", exc_info=True)
 

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -405,6 +405,7 @@ async def _run_dispatch(
         )
 
     _effective_backend = dispatch_backend if dispatch_backend is not None else tool_ctx.backend
+    _caller_backend_name = tool_ctx.backend.name if tool_ctx.backend is not None else ""
 
     try:
         _capability_overrides = provider_capability_overrides or _build_capability_overrides(
@@ -542,7 +543,13 @@ async def _run_dispatch(
                     campaign_id,
                     effective_name,
                     "",
-                    [DispatchRecord(name=effective_name, caller_session_id=caller_session_id)],
+                    [
+                        DispatchRecord(
+                            name=effective_name,
+                            caller_session_id=caller_session_id,
+                            caller_backend_name=_caller_backend_name,
+                        ),
+                    ],
                     recipe_snapshot,
                 )
             else:
@@ -587,7 +594,13 @@ async def _run_dispatch(
                 campaign_id,
                 effective_name,
                 "",
-                [DispatchRecord(name=effective_name, caller_session_id=caller_session_id)],
+                [
+                    DispatchRecord(
+                        name=effective_name,
+                        caller_session_id=caller_session_id,
+                        caller_backend_name=_caller_backend_name,
+                    ),
+                ],
                 recipe_snapshot,
             )
     else:
@@ -596,7 +609,13 @@ async def _run_dispatch(
             campaign_id,
             effective_name,
             "",
-            [DispatchRecord(name=effective_name, caller_session_id=caller_session_id)],
+            [
+                DispatchRecord(
+                    name=effective_name,
+                    caller_session_id=caller_session_id,
+                    caller_backend_name=_caller_backend_name,
+                ),
+            ],
             recipe_snapshot,
         )
 
@@ -1064,6 +1083,7 @@ async def _run_dispatch(
         dispatch_id=dispatch_id,
         campaign_id=campaign_id,
         caller_session_id=caller_session_id,
+        caller_backend_name=_caller_backend_name,
         dispatched_session_id=_dispatched_session_id[0]
         if _dispatched_session_id
         else skill_result.session_id,

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -953,7 +953,11 @@ async def _run_dispatch(
 
         sidecar_entries = read_sidecar_from_path(sidecar_file).entries
         if sidecar_entries:
-            dispatch_checkpoint = checkpoint_from_sidecar(sidecar_entries)
+            dispatch_checkpoint = checkpoint_from_sidecar(
+                sidecar_entries,
+                backend_name=_effective_backend.name if _effective_backend else "",
+                skill_name=recipe,
+            )
 
     tracker_checkpoint: SessionCheckpoint | None = None
     _tracker_path = (
@@ -968,7 +972,11 @@ async def _run_dispatch(
                 checkpoint_from_tracker,  # noqa: PLC0415
             )
 
-            tracker_checkpoint = checkpoint_from_tracker(_tracker_data)
+            tracker_checkpoint = checkpoint_from_tracker(
+                _tracker_data,
+                backend_name=_effective_backend.name if _effective_backend else "",
+                skill_name=recipe,
+            )
         except (OSError, ValueError, TypeError, AttributeError):
             logger.debug("tracker read failed for %s", dispatch_id, exc_info=True)
 

--- a/src/autoskillit/fleet/_checkpoint_bridge.py
+++ b/src/autoskillit/fleet/_checkpoint_bridge.py
@@ -13,7 +13,9 @@ from autoskillit.core import SessionCheckpoint
 from autoskillit.fleet.sidecar import IssueSidecarEntry
 
 
-def checkpoint_from_sidecar(entries: list[IssueSidecarEntry]) -> SessionCheckpoint:
+def checkpoint_from_sidecar(
+    entries: list[IssueSidecarEntry], *, backend_name: str, skill_name: str
+) -> SessionCheckpoint:
     completed = [e.issue_url for e in entries if e.status == "completed"]
     ts = entries[-1].ts if entries else ""
     return SessionCheckpoint(
@@ -21,10 +23,14 @@ def checkpoint_from_sidecar(entries: list[IssueSidecarEntry]) -> SessionCheckpoi
         step_name="fleet_dispatch",
         progress_pct=0.0,
         ts=ts,
+        backend_name=backend_name,
+        skill_name=skill_name,
     )
 
 
-def checkpoint_from_tracker(tracker_data: dict[str, Any] | None) -> SessionCheckpoint | None:
+def checkpoint_from_tracker(
+    tracker_data: dict[str, Any] | None, *, backend_name: str, skill_name: str
+) -> SessionCheckpoint | None:
     if tracker_data is None:
         return None
     steps = tracker_data.get("steps", {})
@@ -46,4 +52,6 @@ def checkpoint_from_tracker(tracker_data: dict[str, Any] | None) -> SessionCheck
         step_name=last_step_name,
         progress_pct=len(completed) / len(steps),
         ts=last_ts,
+        backend_name=backend_name,
+        skill_name=skill_name,
     )

--- a/src/autoskillit/fleet/_outcome.py
+++ b/src/autoskillit/fleet/_outcome.py
@@ -32,12 +32,7 @@ def _checkpoint_to_dict(cp: SessionCheckpoint | None) -> dict[str, Any]:
     """Convert SessionCheckpoint to a plain dict for DispatchRecord storage."""
     if cp is None:
         return {}
-    return {
-        "completed_items": list(cp.completed_items),
-        "step_name": cp.step_name,
-        "progress_pct": cp.progress_pct,
-        "ts": cp.ts,
-    }
+    return cp.to_dict()
 
 
 def classify_dispatch_outcome(

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -619,17 +619,49 @@ def find_dispatch_for_issue(
     return None
 
 
-def derive_orchestrator_resume_spec(state: CampaignState) -> NamedResume | NoResume:
+def derive_orchestrator_resume_spec(
+    state: CampaignState, *, current_backend: str = ""
+) -> NamedResume | NoResume:
     """Derive the correct ResumeSpec for the L3 orchestrator from campaign state.
 
     Priority:
     1. state.orchestrator_session_id (if non-empty) → NamedResume
     2. Latest dispatch's caller_session_id (fallback) → NamedResume
     3. No session ID available → NoResume
+
+    Backend-mismatch guard:
+        When ``current_backend`` is provided AND the source DispatchRecord's
+        ``backend_name`` is also set, the resume is rejected (returns
+        NoResume) if the two backends differ. This prevents a Codex
+        session_id from being passed to Claude's --resume flag (or vice versa),
+        which produces either an opaque CLI error or a silent fresh session
+        with stale resume context.
     """
     if state.orchestrator_session_id:
+        if current_backend:
+            for d in state.dispatches:
+                if (
+                    d.caller_session_id == state.orchestrator_session_id
+                    and d.backend_name
+                    and d.backend_name != current_backend
+                ):
+                    logger.warning(
+                        "resume_backend_mismatch",
+                        session_id=state.orchestrator_session_id,
+                        source_backend=d.backend_name,
+                        current_backend=current_backend,
+                    )
+                    return NoResume()
         return NamedResume(session_id=state.orchestrator_session_id)
     for d in reversed(state.dispatches):
         if d.caller_session_id:
+            if current_backend and d.backend_name and d.backend_name != current_backend:
+                logger.warning(
+                    "resume_backend_mismatch",
+                    session_id=d.caller_session_id,
+                    source_backend=d.backend_name,
+                    current_backend=current_backend,
+                )
+                return NoResume()
             return NamedResume(session_id=d.caller_session_id)
     return NoResume()

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -650,6 +650,15 @@ def derive_orchestrator_resume_spec(
     """
     if state.orchestrator_session_id:
         if current_backend:
+            if not state.dispatches:
+                # Truly legacy state with no dispatches — fail closed when backend
+                # provenance cannot be verified.
+                logger.warning(
+                    "resume_backend_provenance_missing",
+                    session_id=state.orchestrator_session_id,
+                    current_backend=current_backend,
+                )
+                return NoResume()
             source_record = next(
                 (
                     dispatch
@@ -658,13 +667,18 @@ def derive_orchestrator_resume_spec(
                 ),
                 None,
             )
-            source_backend = source_record.caller_backend_name if source_record else ""
-            if not _resume_backend_is_safe(
-                session_id=state.orchestrator_session_id,
-                source_backend=source_backend,
-                current_backend=current_backend,
-            ):
-                return NoResume()
+            if source_record is not None:
+                source_backend = source_record.caller_backend_name
+                if not _resume_backend_is_safe(
+                    session_id=state.orchestrator_session_id,
+                    source_backend=source_backend,
+                    current_backend=current_backend,
+                ):
+                    return NoResume()
+            # source_record is None: campaign has dispatches but none match the
+            # orchestrator session id — accept the orchestrator session id as
+            # authoritative since it was set via update_orchestrator_session_id
+            # (not derived from a dispatch).
         return NamedResume(session_id=state.orchestrator_session_id)
     for d in reversed(state.dispatches):
         if d.caller_session_id:

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -631,7 +631,7 @@ def derive_orchestrator_resume_spec(
 
     Backend-mismatch guard:
         When ``current_backend`` is provided AND the source DispatchRecord's
-        ``backend_name`` is also set, the resume is rejected (returns
+        ``caller_backend_name`` is also set, the resume is rejected (returns
         NoResume) if the two backends differ. This prevents a Codex
         session_id from being passed to Claude's --resume flag (or vice versa),
         which produces either an opaque CLI error or a silent fresh session
@@ -642,24 +642,28 @@ def derive_orchestrator_resume_spec(
             for d in state.dispatches:
                 if (
                     d.caller_session_id == state.orchestrator_session_id
-                    and d.backend_name
-                    and d.backend_name != current_backend
+                    and d.caller_backend_name
+                    and d.caller_backend_name != current_backend
                 ):
                     logger.warning(
                         "resume_backend_mismatch",
                         session_id=state.orchestrator_session_id,
-                        source_backend=d.backend_name,
+                        source_backend=d.caller_backend_name,
                         current_backend=current_backend,
                     )
                     return NoResume()
         return NamedResume(session_id=state.orchestrator_session_id)
     for d in reversed(state.dispatches):
         if d.caller_session_id:
-            if current_backend and d.backend_name and d.backend_name != current_backend:
+            if (
+                current_backend
+                and d.caller_backend_name
+                and d.caller_backend_name != current_backend
+            ):
                 logger.warning(
                     "resume_backend_mismatch",
                     session_id=d.caller_session_id,
-                    source_backend=d.backend_name,
+                    source_backend=d.caller_backend_name,
                     current_backend=current_backend,
                 )
                 return NoResume()

--- a/src/autoskillit/fleet/state_recovery.py
+++ b/src/autoskillit/fleet/state_recovery.py
@@ -619,6 +619,19 @@ def find_dispatch_for_issue(
     return None
 
 
+def _resume_backend_is_safe(*, session_id: str, source_backend: str, current_backend: str) -> bool:
+    if not current_backend or source_backend == current_backend:
+        return True
+    event = "resume_backend_mismatch" if source_backend else "resume_backend_provenance_missing"
+    logger.warning(
+        event,
+        session_id=session_id,
+        source_backend=source_backend,
+        current_backend=current_backend,
+    )
+    return False
+
+
 def derive_orchestrator_resume_spec(
     state: CampaignState, *, current_backend: str = ""
 ) -> NamedResume | NoResume:
@@ -629,43 +642,37 @@ def derive_orchestrator_resume_spec(
     2. Latest dispatch's caller_session_id (fallback) → NamedResume
     3. No session ID available → NoResume
 
-    Backend-mismatch guard:
-        When ``current_backend`` is provided AND the source DispatchRecord's
-        ``caller_backend_name`` is also set, the resume is rejected (returns
-        NoResume) if the two backends differ. This prevents a Codex
-        session_id from being passed to Claude's --resume flag (or vice versa),
-        which produces either an opaque CLI error or a silent fresh session
-        with stale resume context.
+    Backend-provenance guard:
+        When ``current_backend`` is provided, resume is allowed only when the
+        source DispatchRecord has the same ``caller_backend_name``. Missing or
+        mismatched provenance returns NoResume. This prevents a backend-specific
+        session ID from being passed to another backend's resume interface.
     """
     if state.orchestrator_session_id:
         if current_backend:
-            for d in state.dispatches:
-                if (
-                    d.caller_session_id == state.orchestrator_session_id
-                    and d.caller_backend_name
-                    and d.caller_backend_name != current_backend
-                ):
-                    logger.warning(
-                        "resume_backend_mismatch",
-                        session_id=state.orchestrator_session_id,
-                        source_backend=d.caller_backend_name,
-                        current_backend=current_backend,
-                    )
-                    return NoResume()
+            source_record = next(
+                (
+                    dispatch
+                    for dispatch in reversed(state.dispatches)
+                    if dispatch.caller_session_id == state.orchestrator_session_id
+                ),
+                None,
+            )
+            source_backend = source_record.caller_backend_name if source_record else ""
+            if not _resume_backend_is_safe(
+                session_id=state.orchestrator_session_id,
+                source_backend=source_backend,
+                current_backend=current_backend,
+            ):
+                return NoResume()
         return NamedResume(session_id=state.orchestrator_session_id)
     for d in reversed(state.dispatches):
         if d.caller_session_id:
-            if (
-                current_backend
-                and d.caller_backend_name
-                and d.caller_backend_name != current_backend
+            if not _resume_backend_is_safe(
+                session_id=d.caller_session_id,
+                source_backend=d.caller_backend_name,
+                current_backend=current_backend,
             ):
-                logger.warning(
-                    "resume_backend_mismatch",
-                    session_id=d.caller_session_id,
-                    source_backend=d.caller_backend_name,
-                    current_backend=current_backend,
-                )
                 return NoResume()
             return NamedResume(session_id=d.caller_session_id)
     return NoResume()

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -176,13 +176,18 @@ class DispatchRecord:
     def from_dict(cls, d: dict[str, Any]) -> DispatchRecord:
         pid_raw = d.get("dispatched_pid")
         ticks_raw = d.get("dispatched_starttime_ticks")
+        caller_backend_name = d.get("caller_backend_name", "")
+        if not isinstance(caller_backend_name, str):
+            raise TypeError(
+                f"caller_backend_name must be str, got {type(caller_backend_name).__name__!r}"
+            )
         return cls(
             name=d["name"],
             status=DispatchStatus(d.get("status", DispatchStatus.PENDING)),
             dispatch_id=d.get("dispatch_id", ""),
             campaign_id=d.get("campaign_id", ""),
             caller_session_id=d.get("caller_session_id", ""),
-            caller_backend_name=d.get("caller_backend_name", ""),
+            caller_backend_name=caller_backend_name,
             dispatched_session_id=(
                 d.get("dispatched_session_id")
                 or d.get("l3_session_id")

--- a/src/autoskillit/fleet/state_types.py
+++ b/src/autoskillit/fleet/state_types.py
@@ -22,6 +22,7 @@ _RETRY_IDENTITY_FIELDS: frozenset[str] = frozenset(
         "name",
         "campaign_id",
         "caller_session_id",
+        "caller_backend_name",
         "attempt_history",
         "session_chain",
         "resume_count",
@@ -105,6 +106,7 @@ class DispatchRecord:
     dispatch_id: str = ""
     campaign_id: str = ""
     caller_session_id: str = ""
+    caller_backend_name: str = ""
     dispatched_session_id: str = ""
     session_chain: list[str] = field(default_factory=list)
     dispatched_session_log_dir: str = ""
@@ -140,6 +142,7 @@ class DispatchRecord:
             "dispatch_id": self.dispatch_id,
             "campaign_id": self.campaign_id,
             "caller_session_id": self.caller_session_id,
+            "caller_backend_name": self.caller_backend_name,
             "dispatched_session_id": self.dispatched_session_id,
             "session_chain": list(self.session_chain),
             "dispatched_session_log_dir": self.dispatched_session_log_dir,
@@ -179,6 +182,7 @@ class DispatchRecord:
             dispatch_id=d.get("dispatch_id", ""),
             campaign_id=d.get("campaign_id", ""),
             caller_session_id=d.get("caller_session_id", ""),
+            caller_backend_name=d.get("caller_backend_name", ""),
             dispatched_session_id=(
                 d.get("dispatched_session_id")
                 or d.get("l3_session_id")

--- a/src/autoskillit/recipe/_analysis.py
+++ b/src/autoskillit/recipe/_analysis.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from autoskillit.core import SkillResolver
+    from autoskillit.core import BackendCapabilities, SkillResolver
 
 from autoskillit.recipe._analysis_bfs import _bfs_with_facts, bfs_reachable
 from autoskillit.recipe._analysis_blocks import extract_blocks
@@ -82,6 +82,7 @@ class ValidationContext:
     backend_name: str | None = None
     skill_resolver: SkillResolver | None = None
     effective_backend_map: dict[str, str] | None = None
+    backend_capabilities_map: dict[str, BackendCapabilities] | None = None
     blocks: tuple[RecipeBlock, ...] = field(default_factory=tuple)
     predecessors: dict[str, set[str]] = field(default_factory=dict)
 
@@ -135,6 +136,7 @@ def make_validation_context(
     backend_name: str | None = None,
     skill_resolver: SkillResolver | None = None,
     effective_backend_map: dict[str, str] | None = None,
+    backend_capabilities_map: dict[str, BackendCapabilities] | None = None,
 ) -> ValidationContext:
     """Build a ``ValidationContext`` from a recipe.
 
@@ -163,6 +165,7 @@ def make_validation_context(
         backend_name=backend_name,
         skill_resolver=skill_resolver,
         effective_backend_map=effective_backend_map,
+        backend_capabilities_map=backend_capabilities_map,
         blocks=extract_blocks(recipe, step_graph, predecessors=predecessors),
         predecessors=predecessors,
     )

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -268,7 +268,7 @@ def load_and_validate(
         _user_method_traditions_hash,
         backend_name,
         tuple(sorted(effective_backend_map.items())) if effective_backend_map else (),
-        tuple(sorted(backend_capabilities_map.keys()) if backend_capabilities_map else ()),
+        tuple(sorted(backend_capabilities_map.items())) if backend_capabilities_map else (),
         _manifest_mtime,
         _manifest_size,
         _budgets_mtime,

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -15,6 +15,7 @@ from typing import Any, cast
 from autoskillit.core import (
     BACKEND_CAPABILITY_INGREDIENTS,
     CAPABILITY_GATE_CALLABLES,
+    BackendCapabilities,
     ProcessStaleError,
     RecipeNotFoundError,
     RecipeSource,
@@ -199,6 +200,7 @@ def load_and_validate(
     defer_unresolved: bool = False,
     backend_name: str | None = None,
     effective_backend_map: dict[str, str] | None = None,
+    backend_capabilities_map: dict[str, BackendCapabilities] | None = None,
 ) -> LoadRecipeResult:
     """Load a recipe by name and run full validation.
 
@@ -266,6 +268,7 @@ def load_and_validate(
         _user_method_traditions_hash,
         backend_name,
         tuple(sorted(effective_backend_map.items())) if effective_backend_map else (),
+        tuple(sorted(backend_capabilities_map.keys()) if backend_capabilities_map else ()),
         _manifest_mtime,
         _manifest_size,
         _budgets_mtime,
@@ -394,6 +397,7 @@ def load_and_validate(
                 backend_name=backend_name,
                 skill_resolver=_skill_resolver,
                 effective_backend_map=effective_backend_map,
+                backend_capabilities_map=backend_capabilities_map,
             )
             _pre_prune_findings = run_semantic_rules(_pre_prune_val_ctx)
             _pre_prune_steps = dict(active_recipe.steps)
@@ -463,6 +467,7 @@ def load_and_validate(
                 skill_resolver=_skill_resolver,
                 backend_name=backend_name,
                 effective_backend_map=effective_backend_map,
+                backend_capabilities_map=backend_capabilities_map,
             )
             semantic_findings = run_semantic_rules(val_ctx)
             semantic_suggestions = findings_to_dicts(semantic_findings)

--- a/src/autoskillit/recipe/_api_listing.py
+++ b/src/autoskillit/recipe/_api_listing.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from autoskillit.core import LoadResult, SkillLister, YAMLError, get_logger, load_yaml
+from autoskillit.core import (
+    BackendCapabilities,
+    LoadResult,
+    SkillLister,
+    YAMLError,
+    get_logger,
+    load_yaml,
+)
 from autoskillit.recipe._analysis import make_validation_context
 from autoskillit.recipe._recipe_composition import _prune_skipped_steps
 from autoskillit.recipe._recipe_ingredients import RecipeListItem
@@ -79,6 +86,7 @@ def validate_from_path(
     backend_name: str | None = None,
     ingredient_overrides: dict[str, str] | None = None,
     effective_backend_map: dict[str, str] | None = None,
+    backend_capabilities_map: dict[str, BackendCapabilities] | None = None,
 ) -> dict[str, Any]:
     """Validate a recipe YAML file at the given path.
 
@@ -134,6 +142,7 @@ def validate_from_path(
             skill_resolver=_skill_resolver,
             backend_name=backend_name,
             effective_backend_map=effective_backend_map,
+            backend_capabilities_map=backend_capabilities_map,
         )
         _pre_prune_findings = run_semantic_rules(pre_prune_ctx)
         recipe, _skip_resolutions = _prune_skipped_steps(
@@ -151,6 +160,7 @@ def validate_from_path(
         skill_resolver=_skill_resolver,
         backend_name=backend_name,
         effective_backend_map=effective_backend_map,
+        backend_capabilities_map=backend_capabilities_map,
     )
     report = ctx.dataflow
     semantic_findings = run_semantic_rules(ctx)

--- a/src/autoskillit/recipe/_cmd_rpc_merge.py
+++ b/src/autoskillit/recipe/_cmd_rpc_merge.py
@@ -31,7 +31,7 @@ def queue_ejected_fix(
     if rebase.returncode == 0:
         return {"status": "clean"}
     run_git(["rebase", "--abort"], cwd=work_dir)
-    return {"status": "conflicts"}
+    return {"status": "conflicts", "stderr": rebase.stderr}
 
 
 def direct_merge_conflict_fix(
@@ -100,7 +100,7 @@ def attempt_cheap_rebase(
     if rebase.returncode == 0:
         return {"status": "clean"}
     run_git(["rebase", "--abort"], cwd=work_dir)
-    return {"status": "conflicts"}
+    return {"status": "conflicts", "stderr": rebase.stderr}
 
 
 def wait_for_review_pr_mergeability(
@@ -234,4 +234,4 @@ def proactive_rebase_next_pr(
     if rebase.returncode == 0:
         return {"status": "clean"}
     run_git(["rebase", "--abort"], cwd=work_dir)
-    return {"status": "conflicts"}
+    return {"status": "conflicts", "stderr": rebase.stderr}

--- a/src/autoskillit/recipe/repository.py
+++ b/src/autoskillit/recipe/repository.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
-    from autoskillit.core import LoadResult
+    from autoskillit.core import BackendCapabilities, LoadResult
     from autoskillit.recipe.schema import Recipe, RecipeInfo
 
 import autoskillit.recipe._api as _api
@@ -97,6 +97,7 @@ class DefaultRecipeRepository:
         defer_unresolved: bool = False,
         backend_name: str | None = None,
         effective_backend_map: dict[str, str] | None = None,
+        backend_capabilities_map: dict[str, BackendCapabilities] | None = None,
     ) -> dict[str, Any]:
         project_dir = Path(project_dir)
         result = self._get_list(project_dir)
@@ -116,6 +117,7 @@ class DefaultRecipeRepository:
                 defer_unresolved=defer_unresolved,
                 backend_name=backend_name,
                 effective_backend_map=effective_backend_map,
+                backend_capabilities_map=backend_capabilities_map,
             ),
         )
 
@@ -127,6 +129,7 @@ class DefaultRecipeRepository:
         backend_name: str | None = None,
         ingredient_overrides: dict[str, str] | None = None,
         effective_backend_map: dict[str, str] | None = None,
+        backend_capabilities_map: dict[str, BackendCapabilities] | None = None,
     ) -> dict[str, Any]:
         return _api.validate_from_path(
             script_path,
@@ -134,6 +137,7 @@ class DefaultRecipeRepository:
             backend_name=backend_name,
             ingredient_overrides=ingredient_overrides,
             effective_backend_map=effective_backend_map,
+            backend_capabilities_map=backend_capabilities_map,
         )
 
     def list_all(

--- a/src/autoskillit/recipe/rules/rules_backend_compat.py
+++ b/src/autoskillit/recipe/rules/rules_backend_compat.py
@@ -7,6 +7,7 @@ from autoskillit.core import (
     SKILL_CAPABILITY_REGISTRY,
     SKILL_TOOLS,
     Severity,
+    unsatisfied_backend_capabilities,
 )
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe._skill_helpers import _has_dynamic_skill_name
@@ -79,21 +80,17 @@ def _check_backend_incompatible_skill(ctx: ValidationContext) -> list[RuleFindin
         # diagnostic from backend_requirements — both findings surface together.
         step_backend_caps = (ctx.backend_capabilities_map or {}).get(step_backend)
         if step_backend_caps and uses_caps:
-            for _hc_cap in uses_caps:
-                _hc_cap_def = SKILL_CAPABILITY_REGISTRY.get(_hc_cap)
-                if _hc_cap_def and _hc_cap_def.required_backend_property:
-                    _hc_prop = _hc_cap_def.required_backend_property
-                    _hc_val = getattr(step_backend_caps, _hc_prop, None)
-                    if not _hc_val:
-                        findings.append(
-                            make_finding(
-                                rule_name="backend-incompatible-skill",
-                                step_name=step_name,
-                                message=(
-                                    f"step '{step_name}': skill '{skill_name}' requires "
-                                    f"{_hc_prop}=True (via capability '{_hc_cap}') but "
-                                    f"backend '{step_backend}' has {_hc_prop}={_hc_val!r}."
-                                ),
-                            )
-                        )
+            for mismatch in unsatisfied_backend_capabilities(uses_caps, step_backend_caps):
+                findings.append(
+                    make_finding(
+                        rule_name="backend-incompatible-skill",
+                        step_name=step_name,
+                        message=(
+                            f"step '{step_name}': skill '{skill_name}' requires "
+                            f"{mismatch.property_name}=True (via capability "
+                            f"'{mismatch.capability}') but backend '{step_backend}' has "
+                            f"{mismatch.property_name}={mismatch.actual_value!r}."
+                        ),
+                    )
+                )
     return findings

--- a/src/autoskillit/recipe/rules/rules_backend_compat.py
+++ b/src/autoskillit/recipe/rules/rules_backend_compat.py
@@ -52,8 +52,8 @@ def _check_backend_incompatible_skill(ctx: ValidationContext) -> list[RuleFindin
         )
         if step_backend is None:
             continue
+        uses_caps: frozenset[str] = getattr(skill_info, "uses_capabilities", frozenset())
         if skill_info.backend_requirements and step_backend not in skill_info.backend_requirements:
-            uses_caps: frozenset[str] = getattr(skill_info, "uses_capabilities", frozenset())
             cap_def = SKILL_CAPABILITY_REGISTRY.get(_GIT_METADATA_WRITE_CAP)
             _required = CLAUDE_CODE_CAPABILITIES.git_metadata_writable
             git_detail = (
@@ -72,4 +72,28 @@ def _check_backend_incompatible_skill(ctx: ValidationContext) -> list[RuleFindin
                     ),
                 )
             )
+        # Independent hard-capability property check (sibling if, not elif) —
+        # catches worker_routable skills whose backend_requirements are empty
+        # but require a backend property (e.g. git_metadata_write → requires
+        # git_metadata_writable=True on the pinned backend). Different actionable
+        # diagnostic from backend_requirements — both findings surface together.
+        step_backend_caps = (ctx.backend_capabilities_map or {}).get(step_backend)
+        if step_backend_caps and uses_caps:
+            for _hc_cap in uses_caps:
+                _hc_cap_def = SKILL_CAPABILITY_REGISTRY.get(_hc_cap)
+                if _hc_cap_def and _hc_cap_def.required_backend_property:
+                    _hc_prop = _hc_cap_def.required_backend_property
+                    _hc_val = getattr(step_backend_caps, _hc_prop, None)
+                    if not _hc_val:
+                        findings.append(
+                            make_finding(
+                                rule_name="backend-incompatible-skill",
+                                step_name=step_name,
+                                message=(
+                                    f"step '{step_name}': skill '{skill_name}' requires "
+                                    f"{_hc_prop}=True (via capability '{_hc_cap}') but "
+                                    f"backend '{step_backend}' has {_hc_prop}={_hc_val!r}."
+                                ),
+                            )
+                        )
     return findings

--- a/src/autoskillit/server/tools/AGENTS.md
+++ b/src/autoskillit/server/tools/AGENTS.md
@@ -10,6 +10,7 @@ MCP `@mcp.tool()` handlers registered on import (20 tool modules).
 | `_auto_overrides.py` | Shared `_build_auto_overrides()` factory for server-authoritative ingredient injection |
 | `_authority_feedback.py` | Authority-clobber warning builder and structured rejection envelope constructor for server-authoritative ingredient violations (single source of truth shared by open_kitchen, load_recipe, lock_ingredients) |
 | `_cancellation_shield.py` | `_cancellation_shield` decorator — catches `asyncio.CancelledError` at MCP tool boundary, returns structured JSON |
+| `_backend_compat.py` | Shared target resolution and fail-closed backend compatibility gate for direct headless executor callers |
 | `_types.py` | TypedDict definitions for server tool JSON responses (RunSkillResult, RunCmdResult, ToolFailureEnvelope, etc.) and failure envelope factory helpers |
 | `tools_kitchen.py` | `open_kitchen`, `close_kitchen` (gate lifecycle), `recipe://` MCP resource |
 | `tools_config.py` | `configure_fleet`, `configure_order` (session config overlay) |

--- a/src/autoskillit/server/tools/_backend_compat.py
+++ b/src/autoskillit/server/tools/_backend_compat.py
@@ -5,11 +5,99 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING
 
-from autoskillit.core import DISPATCH_ID_ENV_VAR, extract_skill_name, resolve_target_skill
-from autoskillit.server.tools.tools_execution import _check_backend_compat
+from autoskillit.core import (
+    DISPATCH_ID_ENV_VAR,
+    CodingAgentBackend,
+    SkillResult,
+    extract_skill_name,
+    resolve_target_skill,
+)
+from autoskillit.server.tools._preflight import (
+    _get_fix_required_hook_matchers,
+    check_hard_capability_feasibility,
+)
 
 if TYPE_CHECKING:
     from autoskillit.pipeline import ToolContext
+
+
+def _is_backend_incompatible(skill_info: object, effective_backend: str) -> bool:
+    """Return True if skill's backend_requirements exclude effective_backend."""
+    reqs = getattr(skill_info, "backend_requirements", None)
+    return bool(reqs and effective_backend not in reqs)
+
+
+def _check_backend_compat(
+    skill_command: str,
+    resolved_command: str,
+    effective_order_id: str,
+    target_name: str | None,
+    skill_info: object | None,
+    effective_backend_obj: CodingAgentBackend | None,
+    skill_resolver: object | None,
+) -> str | None:
+    """Fail closed when a skill is incompatible with its effective backend."""
+    if target_name is None:
+        return None
+    if skill_resolver is None:
+        return SkillResult.crashed(
+            exception=RuntimeError(
+                f"Cannot verify backend compatibility for skill {target_name!r}: "
+                "skill resolver is not available."
+            ),
+            skill_command=resolved_command,
+            order_id=effective_order_id,
+        ).to_json()
+    if effective_backend_obj is None:
+        return SkillResult.crashed(
+            exception=RuntimeError(
+                f"Cannot dispatch skill {target_name!r}: session backend is not configured."
+            ),
+            skill_command=resolved_command,
+            order_id=effective_order_id,
+        ).to_json()
+    if skill_info is None:
+        return None
+    effective_backend = effective_backend_obj.name
+    if _is_backend_incompatible(skill_info, effective_backend):
+        return SkillResult.crashed(
+            exception=RuntimeError(
+                f"Skill {target_name!r} requires backend "
+                f"{sorted(getattr(skill_info, 'backend_requirements', []))} but session "
+                f"backend is {effective_backend!r}."
+            ),
+            skill_command=resolved_command,
+            order_id=effective_order_id,
+        ).to_json()
+    skill_capabilities: frozenset[str] = getattr(skill_info, "uses_capabilities", frozenset())
+    if skill_capabilities:
+        hard_capability_error = check_hard_capability_feasibility(
+            skill_capabilities, effective_backend_obj
+        )
+        if hard_capability_error:
+            return SkillResult.crashed(
+                exception=RuntimeError(
+                    f"Skill {target_name!r} is not feasible on backend "
+                    f"{effective_backend!r}: {hard_capability_error}"
+                ),
+                skill_command=resolved_command,
+                order_id=effective_order_id,
+            ).to_json()
+    fix_required_matchers = _get_fix_required_hook_matchers(
+        effective_backend_obj.capabilities.applicable_guards,
+    )
+    if fix_required_matchers:
+        return SkillResult.crashed(
+            exception=RuntimeError(
+                f"Cannot dispatch skill {target_name!r} on backend "
+                f"{effective_backend!r}: HOOK_REGISTRY contains fix-required "
+                f"entries [{', '.join(fix_required_matchers)}] that cannot be "
+                f"enforced by this backend."
+            ),
+            skill_command=resolved_command,
+            order_id=effective_order_id,
+        ).to_json()
+    return None
 
 
 def _resolve_and_check_backend_compat(

--- a/src/autoskillit/server/tools/_backend_compat.py
+++ b/src/autoskillit/server/tools/_backend_compat.py
@@ -1,0 +1,39 @@
+"""Shared backend-compatibility setup for direct headless executor callers."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from autoskillit.core import DISPATCH_ID_ENV_VAR, extract_skill_name, resolve_target_skill
+from autoskillit.server.tools.tools_execution import _check_backend_compat
+
+if TYPE_CHECKING:
+    from autoskillit.pipeline import ToolContext
+
+
+def _resolve_and_check_backend_compat(
+    skill_command: str,
+    tool_ctx: ToolContext,
+) -> str | None:
+    """Resolve a direct skill invocation and run the fail-closed compatibility gate."""
+    resolved_command = skill_command
+    target_name = extract_skill_name(skill_command)
+    skill_info: object | None = None
+    if tool_ctx.skill_resolver is not None:
+        resolved_command, target_name = resolve_target_skill(
+            skill_command,
+            tool_ctx.skill_resolver,
+        )
+        if target_name is not None:
+            skill_info = tool_ctx.skill_resolver.resolve(target_name)
+
+    return _check_backend_compat(
+        skill_command=skill_command,
+        resolved_command=resolved_command,
+        effective_order_id=os.environ.get(DISPATCH_ID_ENV_VAR, ""),
+        target_name=target_name,
+        skill_info=skill_info,
+        effective_backend_obj=tool_ctx.backend,
+        skill_resolver=tool_ctx.skill_resolver,
+    )

--- a/src/autoskillit/server/tools/_preflight.py
+++ b/src/autoskillit/server/tools/_preflight.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from autoskillit.core import SKILL_CAPABILITY_REGISTRY, CodingAgentBackend
+from autoskillit.core import CodingAgentBackend, unsatisfied_backend_capabilities
 from autoskillit.hook_registry import HOOK_REGISTRY
 from autoskillit.server._misc import get_backend
 
@@ -34,23 +34,18 @@ def check_hard_capability_feasibility(
 ) -> str | None:
     """Return diagnostic string if any capability's required_backend_property is unsatisfied.
 
-    For each declared capability, looks up `SKILL_CAPABILITY_REGISTRY[cap]` and
-    checks the named `BackendCapabilities` field against the supplied backend.
-    Returns None when every capability is satisfied (or no capability declares
-    a `required_backend_property`).
+    Delegates registry lookup and BackendCapabilities evaluation to the shared
+    core predicate, then formats the first mismatch for server callers. Returns
+    None when every capability is satisfied.
     """
-    for cap_name in uses_capabilities:
-        cap_def = SKILL_CAPABILITY_REGISTRY.get(cap_name)
-        if cap_def is None or cap_def.required_backend_property is None:
-            continue
-        prop_name = cap_def.required_backend_property
-        prop_value = getattr(backend.capabilities, prop_name, None)
-        if not prop_value:
-            return (
-                f"Capability '{cap_name}' requires backend property "
-                f"'{prop_name}' to be True, but backend '{backend.name}' has "
-                f"{prop_name}={prop_value!r}."
-            )
+    mismatches = unsatisfied_backend_capabilities(uses_capabilities, backend.capabilities)
+    if mismatches:
+        mismatch = mismatches[0]
+        return (
+            f"Capability '{mismatch.capability}' requires backend property "
+            f"'{mismatch.property_name}' to be True, but backend '{backend.name}' has "
+            f"{mismatch.property_name}={mismatch.actual_value!r}."
+        )
     return None
 
 

--- a/src/autoskillit/server/tools/_preflight.py
+++ b/src/autoskillit/server/tools/_preflight.py
@@ -6,11 +6,13 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from autoskillit.core import SKILL_CAPABILITY_REGISTRY, CodingAgentBackend
 from autoskillit.hook_registry import HOOK_REGISTRY
 from autoskillit.server._misc import get_backend
 
 if TYPE_CHECKING:
     from autoskillit.config._config_dataclasses import AgentBackendConfig
+    from autoskillit.core import SkillResolver
 
 
 def _get_fix_required_hook_matchers(applicable_guards: frozenset[str]) -> list[str]:
@@ -24,6 +26,32 @@ def _get_fix_required_hook_matchers(applicable_guards: frozenset[str]) -> list[s
             or not frozenset(Path(s).stem for s in h.scripts).issubset(applicable_guards)
         )
     ]
+
+
+def check_hard_capability_feasibility(
+    uses_capabilities: frozenset[str],
+    backend: CodingAgentBackend,
+) -> str | None:
+    """Return diagnostic string if any capability's required_backend_property is unsatisfied.
+
+    For each declared capability, looks up `SKILL_CAPABILITY_REGISTRY[cap]` and
+    checks the named `BackendCapabilities` field against the supplied backend.
+    Returns None when every capability is satisfied (or no capability declares
+    a `required_backend_property`).
+    """
+    for cap_name in uses_capabilities:
+        cap_def = SKILL_CAPABILITY_REGISTRY.get(cap_name)
+        if cap_def is None or cap_def.required_backend_property is None:
+            continue
+        prop_name = cap_def.required_backend_property
+        prop_value = getattr(backend.capabilities, prop_name, None)
+        if not prop_value:
+            return (
+                f"Capability '{cap_name}' requires backend property "
+                f"'{prop_name}' to be True, but backend '{backend.name}' has "
+                f"{prop_name}={prop_value!r}."
+            )
+    return None
 
 
 def filter_steps_by_post_prune(
@@ -43,6 +71,7 @@ def _check_dispatch_feasibility(
     recipe_name: str = "",
     *,
     config_backend: AgentBackendConfig | None = None,
+    skill_resolver: SkillResolver | None,
 ) -> str | None:
     """Fail-closed dispatch-feasibility preflight.
 
@@ -50,6 +79,10 @@ def _check_dispatch_feasibility(
     recipe/backend combinations where HOOK_REGISTRY has fix-required entries
     that the current backend cannot enforce. Returns a JSON error envelope
     string on failure, None on pass.
+
+    `skill_resolver` is REQUIRED for explicit-pin hard-capability feasibility
+    checks. When omitted, the function fails closed for any pinned step: the
+    dispatch is refused as infeasible rather than silently bypassing the gate.
     """
     if backend is None:
         return None
@@ -76,19 +109,69 @@ def _check_dispatch_feasibility(
         # routing for preflight too (mirrors the dispatch path):
         # - pinned to claude-code: feasible regardless of orchestrator backend
         #   (effective backend enforces all fix-required hooks).
-        # - pinned to a non-claude backend: only feasible if its required
-        #   binary is on PATH; otherwise the step cannot run, so exclude it
-        #   from the feasibility check (preflight won't fire on its account).
+        # - pinned to a non-claude backend: subject to hard-capability
+        #   feasibility check — if the pinned backend lacks a required
+        #   BackendCapabilities property (e.g. git_metadata_writable=False
+        #   for git_metadata_write skills), dispatch is infeasible and the
+        #   gate refuses the recipe.
         if config_backend is not None:
             _explicit = _resolve_backend_override(step_name, recipe_name, config_backend)
             if _explicit is not None:
                 try:
-                    get_backend(_explicit)
+                    _pinned_backend = get_backend(_explicit)
                 except (ValueError, KeyError):
                     continue
-                # Any explicitly-overridden step is excluded from
-                # orchestrator-level feasibility — the step runs on the
-                # pinned backend, not the orchestrator's.
+                # Hard-capability feasibility: when an explicit pin targets a
+                # backend that lacks a BackendCapabilities property required
+                # by the step's skill (REQ-RES-001 suppression is structural,
+                # not opaque — capability feasibility still applies), refuse
+                # dispatch.
+                if skill_resolver is None:
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "kitchen": "preflight_failed",
+                            "user_visible_message": (
+                                f"Cannot verify capability feasibility for explicitly-pinned "
+                                f"step '{step_name}': skill resolver is not available."
+                            ),
+                            "error": "skill_resolver_unavailable_for_pinned_step",
+                            "stage": "dispatch_feasibility_preflight",
+                            "step": step_name,
+                        }
+                    )
+                _step_obj = active_recipe_steps.get(step_name)
+                _skill_name = (
+                    getattr(_step_obj, "skill_name", None) if _step_obj is not None else None
+                )
+                if _skill_name:
+                    _skill_info = skill_resolver.resolve(_skill_name)
+                    _skill_caps: frozenset[str] = (
+                        getattr(_skill_info, "uses_capabilities", frozenset())
+                        if _skill_info
+                        else frozenset()
+                    )
+                    if _skill_caps:
+                        hard_cap_err = check_hard_capability_feasibility(
+                            _skill_caps, _pinned_backend
+                        )
+                        if hard_cap_err:
+                            return json.dumps(
+                                {
+                                    "success": False,
+                                    "kitchen": "preflight_failed",
+                                    "user_visible_message": (
+                                        f"Cannot dispatch step '{step_name}': explicitly "
+                                        f"pinned to backend '{_explicit}' which lacks required "
+                                        f"capability. {hard_cap_err}"
+                                    ),
+                                    "error": hard_cap_err,
+                                    "stage": "dispatch_feasibility_preflight",
+                                    "backend": _explicit,
+                                    "step": step_name,
+                                    "override_source": "explicit_config",
+                                }
+                            )
                 continue
 
         step = active_recipe_steps.get(step_name)

--- a/src/autoskillit/server/tools/_preflight.py
+++ b/src/autoskillit/server/tools/_preflight.py
@@ -141,10 +141,24 @@ def _check_dispatch_feasibility(
                 )
                 if _skill_name:
                     _skill_info = skill_resolver.resolve(_skill_name)
-                    _skill_caps: frozenset[str] = (
-                        getattr(_skill_info, "uses_capabilities", frozenset())
-                        if _skill_info
-                        else frozenset()
+                    if _skill_info is None:
+                        return json.dumps(
+                            {
+                                "success": False,
+                                "kitchen": "preflight_failed",
+                                "user_visible_message": (
+                                    f"Cannot verify capability feasibility for explicitly-pinned "
+                                    f"step '{step_name}': skill '{_skill_name}' could not be "
+                                    "resolved."
+                                ),
+                                "error": "skill_not_found_for_pinned_step",
+                                "stage": "dispatch_feasibility_preflight",
+                                "step": step_name,
+                                "skill": _skill_name,
+                            }
+                        )
+                    _skill_caps: frozenset[str] = getattr(
+                        _skill_info, "uses_capabilities", frozenset()
                     )
                     if _skill_caps:
                         hard_cap_err = check_hard_capability_feasibility(

--- a/src/autoskillit/server/tools/_serve_helpers.py
+++ b/src/autoskillit/server/tools/_serve_helpers.py
@@ -23,28 +23,26 @@ def build_backend_capabilities_map(
 ) -> dict[str, BackendCapabilities]:
     """Build a backend-name → BackendCapabilities map for the static recipe rule.
 
-    Collects distinct backend names from the per-step effective backend map plus
-    the orchestrator's own backend, then resolves each via get_backend(). Names
-    that fail to resolve (e.g. test MagicMocks) are silently dropped — get_recipe,
-    load_recipe, and dispatch_food_truck must continue producing useful output
-    even when the test fixture substitutes non-real backend objects.
+    Uses the supplied orchestrator backend as the authority for its own name and
+    resolves every distinct per-step backend via get_backend(). Invalid names are
+    surfaced so admission cannot silently skip hard-capability diagnostics.
     """
     from autoskillit.server._misc import get_backend  # circular-break
 
-    distinct: set[str] = set()
-    for _v in (effective_backend_map or {}).values():
-        if isinstance(_v, str):
-            distinct.add(_v)
-    if orchestrator_backend is not None and isinstance(orchestrator_backend.name, str):
-        distinct.add(orchestrator_backend.name)
     out: dict[str, BackendCapabilities] = {}
-    for _name in distinct:
-        if not _name:
-            continue
-        try:
-            out[_name] = get_backend(_name).capabilities
-        except (KeyError, ValueError):
-            continue
+    if orchestrator_backend is not None:
+        orchestrator_name = orchestrator_backend.name
+        if not isinstance(orchestrator_name, str) or not orchestrator_name:
+            raise ValueError("orchestrator backend must have a non-empty string name")
+        out[orchestrator_name] = orchestrator_backend.capabilities
+
+    for step_name, backend_name in (effective_backend_map or {}).items():
+        if not isinstance(backend_name, str) or not backend_name:
+            raise ValueError(
+                f"effective backend for step {step_name!r} must be a non-empty string"
+            )
+        if backend_name not in out:
+            out[backend_name] = get_backend(backend_name).capabilities
     return out
 
 

--- a/src/autoskillit/server/tools/_serve_helpers.py
+++ b/src/autoskillit/server/tools/_serve_helpers.py
@@ -32,9 +32,8 @@ def build_backend_capabilities_map(
     out: dict[str, BackendCapabilities] = {}
     if orchestrator_backend is not None:
         orchestrator_name = orchestrator_backend.name
-        if not isinstance(orchestrator_name, str) or not orchestrator_name:
-            raise ValueError("orchestrator backend must have a non-empty string name")
-        out[orchestrator_name] = orchestrator_backend.capabilities
+        if isinstance(orchestrator_name, str) and orchestrator_name:
+            out[orchestrator_name] = orchestrator_backend.capabilities
 
     for step_name, backend_name in (effective_backend_map or {}).items():
         if not isinstance(backend_name, str) or not backend_name:

--- a/src/autoskillit/server/tools/_serve_helpers.py
+++ b/src/autoskillit/server/tools/_serve_helpers.py
@@ -13,7 +13,39 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from autoskillit.core import BackendCapabilities, CodingAgentBackend
     from autoskillit.pipeline.context import ToolContext
+
+
+def build_backend_capabilities_map(
+    effective_backend_map: dict[str, str] | None,
+    orchestrator_backend: CodingAgentBackend | None,
+) -> dict[str, BackendCapabilities]:
+    """Build a backend-name → BackendCapabilities map for the static recipe rule.
+
+    Collects distinct backend names from the per-step effective backend map plus
+    the orchestrator's own backend, then resolves each via get_backend(). Names
+    that fail to resolve (e.g. test MagicMocks) are silently dropped — get_recipe,
+    load_recipe, and dispatch_food_truck must continue producing useful output
+    even when the test fixture substitutes non-real backend objects.
+    """
+    from autoskillit.server._misc import get_backend  # circular-break
+
+    distinct: set[str] = set()
+    for _v in (effective_backend_map or {}).values():
+        if isinstance(_v, str):
+            distinct.add(_v)
+    if orchestrator_backend is not None and isinstance(orchestrator_backend.name, str):
+        distinct.add(orchestrator_backend.name)
+    out: dict[str, BackendCapabilities] = {}
+    for _name in distinct:
+        if not _name:
+            continue
+        try:
+            out[_name] = get_backend(_name).capabilities
+        except (KeyError, ValueError):
+            continue
+    return out
 
 
 def _build_serve_override_stack(
@@ -80,6 +112,7 @@ def serve_recipe(
     backend_name: str | None = None,
     temp_dir: Path | str | None = None,
     temp_dir_relpath: str | None = None,
+    backend_capabilities_map: dict[str, BackendCapabilities] | None = None,
 ) -> dict[str, Any]:
     """Unified recipe serve path. Only legal caller of load_and_validate in server/tools/."""
     ingredient_overrides = _build_serve_override_stack(
@@ -99,6 +132,8 @@ def serve_recipe(
         kwargs["resolved_defaults"] = resolved_defaults
     if effective_backend_map is not None:
         kwargs["effective_backend_map"] = effective_backend_map
+    if backend_capabilities_map is not None:
+        kwargs["backend_capabilities_map"] = backend_capabilities_map
     if suppressed is not None:
         kwargs["suppressed"] = suppressed
     if backend_name is not None:

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -78,7 +78,10 @@ from autoskillit.server.tools._execution_helpers import (
     resolve_relative_path_args,
     validate_path_arg_anchoring,
 )
-from autoskillit.server.tools._preflight import _get_fix_required_hook_matchers
+from autoskillit.server.tools._preflight import (
+    _get_fix_required_hook_matchers,
+    check_hard_capability_feasibility,
+)
 from autoskillit.server.tools._types import ToolFailureEnvelope
 
 logger = get_logger(__name__)
@@ -150,6 +153,23 @@ def _check_backend_compat(
             skill_command=resolved_command,
             order_id=effective_order_id,
         ).to_json()
+    # Hard-capability property check — runs AFTER override resolution so an
+    # explicit backend pin that targets an incapable backend is rejected.
+    # Catches the architectural gap where `worker_routable=True` capabilities
+    # (e.g. `git_metadata_write`) have empty `backend_requirements` and would
+    # otherwise bypass validation against the pinned backend.
+    _skill_caps: frozenset[str] = getattr(skill_info, "uses_capabilities", frozenset())
+    if _skill_caps:
+        hard_cap_err = check_hard_capability_feasibility(_skill_caps, effective_backend_obj)
+        if hard_cap_err:
+            return SkillResult.crashed(
+                exception=RuntimeError(
+                    f"Skill {target_name!r} is not feasible on backend "
+                    f"{effective_backend!r}: {hard_cap_err}"
+                ),
+                skill_command=resolved_command,
+                order_id=effective_order_id,
+            ).to_json()
     fix_required_matchers = _get_fix_required_hook_matchers(
         effective_backend_obj.capabilities.applicable_guards,
     )

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -70,6 +70,9 @@ from autoskillit.server._misc import (
 )
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._subprocess import _run_subprocess
+from autoskillit.server.tools._backend_compat import (
+    _check_backend_compat,
+)
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 from autoskillit.server.tools._execution_helpers import (
     _import_and_call,
@@ -77,10 +80,6 @@ from autoskillit.server.tools._execution_helpers import (
     propagate_session_deadline,
     resolve_relative_path_args,
     validate_path_arg_anchoring,
-)
-from autoskillit.server.tools._preflight import (
-    _get_fix_required_hook_matchers,
-    check_hard_capability_feasibility,
 )
 from autoskillit.server.tools._types import ToolFailureEnvelope
 
@@ -98,93 +97,6 @@ DEPENDENCY_DENY_PREFIX = "DEPENDENCY UNMET"
 def _is_absolute_path(path: str) -> bool:
     """Return True if path is an absolute filesystem path."""
     return Path(path).is_absolute()
-
-
-def _is_backend_incompatible(skill_info: object, effective_backend: str) -> bool:
-    """Return True if skill's backend_requirements exclude effective_backend."""
-    reqs = getattr(skill_info, "backend_requirements", None)
-    return bool(reqs and effective_backend not in reqs)
-
-
-def _check_backend_compat(
-    skill_command: str,
-    resolved_command: str,
-    effective_order_id: str,
-    target_name: str | None,
-    skill_info: object | None,
-    effective_backend_obj: CodingAgentBackend | None,
-    skill_resolver: object | None,
-) -> str | None:
-    """Fail-closed backend compatibility gate.
-
-    Returns crash JSON if the skill's backend_requirements exclude the effective
-    backend, or if the check cannot be conclusively performed (missing resolver
-    or backend). Returns None on pass.
-    """
-    if target_name is None:
-        return None
-    if skill_resolver is None:
-        return SkillResult.crashed(
-            exception=RuntimeError(
-                f"Cannot verify backend compatibility for skill {target_name!r}: "
-                "skill resolver is not available."
-            ),
-            skill_command=resolved_command,
-            order_id=effective_order_id,
-        ).to_json()
-    if effective_backend_obj is None:
-        return SkillResult.crashed(
-            exception=RuntimeError(
-                f"Cannot dispatch skill {target_name!r}: session backend is not configured."
-            ),
-            skill_command=resolved_command,
-            order_id=effective_order_id,
-        ).to_json()
-    if skill_info is None:
-        return None
-    effective_backend = effective_backend_obj.name
-    if _is_backend_incompatible(skill_info, effective_backend):
-        return SkillResult.crashed(
-            exception=RuntimeError(
-                f"Skill {target_name!r} requires backend "
-                f"{sorted(getattr(skill_info, 'backend_requirements', []))} but session "
-                f"backend is {effective_backend!r}."
-            ),
-            skill_command=resolved_command,
-            order_id=effective_order_id,
-        ).to_json()
-    # Hard-capability property check — runs AFTER override resolution so an
-    # explicit backend pin that targets an incapable backend is rejected.
-    # Catches the architectural gap where `worker_routable=True` capabilities
-    # (e.g. `git_metadata_write`) have empty `backend_requirements` and would
-    # otherwise bypass validation against the pinned backend.
-    _skill_caps: frozenset[str] = getattr(skill_info, "uses_capabilities", frozenset())
-    if _skill_caps:
-        hard_cap_err = check_hard_capability_feasibility(_skill_caps, effective_backend_obj)
-        if hard_cap_err:
-            return SkillResult.crashed(
-                exception=RuntimeError(
-                    f"Skill {target_name!r} is not feasible on backend "
-                    f"{effective_backend!r}: {hard_cap_err}"
-                ),
-                skill_command=resolved_command,
-                order_id=effective_order_id,
-            ).to_json()
-    fix_required_matchers = _get_fix_required_hook_matchers(
-        effective_backend_obj.capabilities.applicable_guards,
-    )
-    if fix_required_matchers:
-        return SkillResult.crashed(
-            exception=RuntimeError(
-                f"Cannot dispatch skill {target_name!r} on backend "
-                f"{effective_backend!r}: HOOK_REGISTRY contains fix-required "
-                f"entries [{', '.join(fix_required_matchers)}] that cannot be "
-                f"enforced by this backend."
-            ),
-            skill_command=resolved_command,
-            order_id=effective_order_id,
-        ).to_json()
-    return None
 
 
 def _check_ingredient_locks(step_name: str, order_id: str) -> str | None:

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -72,6 +72,7 @@ from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._subprocess import _run_subprocess
 from autoskillit.server.tools._backend_compat import (
     _check_backend_compat,
+    _is_backend_incompatible,  # noqa: F401  (re-exported for tests/arch/test_cross_registry_dispatch_sufficiency.py and tests/server/test_run_skill_backend_compat.py)
 )
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 from autoskillit.server.tools._execution_helpers import (
@@ -80,6 +81,9 @@ from autoskillit.server.tools._execution_helpers import (
     propagate_session_deadline,
     resolve_relative_path_args,
     validate_path_arg_anchoring,
+)
+from autoskillit.server.tools._preflight import (
+    _get_fix_required_hook_matchers,  # noqa: F401  (re-exported for tests/server/test_admission_dispatch_agreement.py)
 )
 from autoskillit.server.tools._types import ToolFailureEnvelope
 

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -60,6 +60,7 @@ from autoskillit.server.tools._preflight import (
     _check_dispatch_feasibility,
     filter_steps_by_post_prune,
 )
+from autoskillit.server.tools._serve_helpers import build_backend_capabilities_map
 
 logger = get_logger(__name__)
 
@@ -373,6 +374,9 @@ async def dispatch_food_truck(
                     skill_resolver=tool_ctx.skill_resolver,
                     config_backend=tool_ctx.config.agent_backend,
                 )
+                _preflight_backend_capabilities_map = build_backend_capabilities_map(
+                    _effective_backend_map, _override_backend
+                )
                 _fleet_load_result = tool_ctx.recipes.load_and_validate(
                     recipe,
                     tool_ctx.project_dir,
@@ -381,6 +385,7 @@ async def dispatch_food_truck(
                     temp_dir=tool_ctx.temp_dir,
                     backend_name=_override_backend.name if _override_backend else None,
                     effective_backend_map=_effective_backend_map,
+                    backend_capabilities_map=_preflight_backend_capabilities_map,
                 )
             except Exception:
                 logger.warning("dispatch_food_truck_preflight_load_failed", exc_info=True)
@@ -441,6 +446,7 @@ async def dispatch_food_truck(
                 config_providers=tool_ctx.config.providers,
                 recipe_name=recipe,
                 config_backend=tool_ctx.config.agent_backend,
+                skill_resolver=tool_ctx.skill_resolver,
             )
             if _preflight_err is not None:
                 return _preflight_err

--- a/src/autoskillit/server/tools/tools_github.py
+++ b/src/autoskillit/server/tools/tools_github.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -13,20 +12,14 @@ import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit.core import (
-    DISPATCH_ID_ENV_VAR,
-    atomic_write,
-    get_logger,
-    is_feature_enabled,
-    resolve_target_skill,
-)
+from autoskillit.core import atomic_write, get_logger, is_feature_enabled
 from autoskillit.pipeline import write_status
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import _extract_block, resolve_log_dir
 from autoskillit.server._notify import _notify, track_response_size
+from autoskillit.server.tools._backend_compat import _resolve_and_check_backend_compat
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
-from autoskillit.server.tools.tools_execution import _check_backend_compat
 
 if TYPE_CHECKING:
     from autoskillit.core import GitHubFetcher, HeadlessExecutor, WriteBehaviorSpec
@@ -277,27 +270,8 @@ async def report_bug(
                 f"Report output path: {report_path}"
             )
 
-            # Backend compatibility gate — must precede executor.run().
-            _resolved_command = skill_command
-            _target_name: str | None = None
-            if tool_ctx.skill_resolver is not None:
-                _resolved_command, _target_name = resolve_target_skill(
-                    skill_command, tool_ctx.skill_resolver
-                )
-            _skill_info = (
-                tool_ctx.skill_resolver.resolve(_target_name)
-                if tool_ctx.skill_resolver and _target_name
-                else None
-            )
-            if _compat_err := _check_backend_compat(
-                skill_command=skill_command,
-                resolved_command=_resolved_command,
-                effective_order_id=os.environ.get(DISPATCH_ID_ENV_VAR, ""),
-                target_name=_target_name,
-                skill_info=_skill_info,
-                effective_backend_obj=tool_ctx.backend,
-                skill_resolver=tool_ctx.skill_resolver,
-            ):
+            # Backend compatibility gate — must precede executor dispatch.
+            if _compat_err := _resolve_and_check_backend_compat(skill_command, tool_ctx):
                 return _compat_err
 
             log_dir = config.linux_tracing.log_dir if config.linux_tracing is not None else ""

--- a/src/autoskillit/server/tools/tools_github.py
+++ b/src/autoskillit/server/tools/tools_github.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -12,13 +13,15 @@ import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit.core import atomic_write, get_logger, is_feature_enabled
+from autoskillit.core import DISPATCH_ID_ENV_VAR, atomic_write, get_logger, is_feature_enabled
+from autoskillit.core.types._type_helpers import resolve_target_skill
 from autoskillit.pipeline import write_status
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import _extract_block, resolve_log_dir
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
+from autoskillit.server.tools.tools_execution import _check_backend_compat
 
 if TYPE_CHECKING:
     from autoskillit.core import GitHubFetcher, HeadlessExecutor, WriteBehaviorSpec
@@ -268,6 +271,29 @@ async def report_bug(
                 f"Error context:\n{error_context}\n\n"
                 f"Report output path: {report_path}"
             )
+
+            # Backend compatibility gate — must precede executor.run().
+            _resolved_command = skill_command
+            _target_name: str | None = None
+            if tool_ctx.skill_resolver is not None:
+                _resolved_command, _target_name = resolve_target_skill(
+                    skill_command, tool_ctx.skill_resolver
+                )
+            _skill_info = (
+                tool_ctx.skill_resolver.resolve(_target_name)
+                if tool_ctx.skill_resolver and _target_name
+                else None
+            )
+            if _compat_err := _check_backend_compat(
+                skill_command=skill_command,
+                resolved_command=_resolved_command,
+                effective_order_id=os.environ.get(DISPATCH_ID_ENV_VAR, ""),
+                target_name=_target_name,
+                skill_info=_skill_info,
+                effective_backend_obj=tool_ctx.backend,
+                skill_resolver=tool_ctx.skill_resolver,
+            ):
+                return _compat_err
 
             log_dir = config.linux_tracing.log_dir if config.linux_tracing is not None else ""
 

--- a/src/autoskillit/server/tools/tools_github.py
+++ b/src/autoskillit/server/tools/tools_github.py
@@ -13,8 +13,13 @@ import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit.core import DISPATCH_ID_ENV_VAR, atomic_write, get_logger, is_feature_enabled
-from autoskillit.core.types._type_helpers import resolve_target_skill
+from autoskillit.core import (
+    DISPATCH_ID_ENV_VAR,
+    atomic_write,
+    get_logger,
+    is_feature_enabled,
+    resolve_target_skill,
+)
 from autoskillit.pipeline import write_status
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled

--- a/src/autoskillit/server/tools/tools_issue_headless.py
+++ b/src/autoskillit/server/tools/tools_issue_headless.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from typing import TYPE_CHECKING, Any
 
 import regex as re
@@ -11,18 +10,13 @@ import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit.core import (
-    DISPATCH_ID_ENV_VAR,
-    RetryReason,
-    get_logger,
-    resolve_target_skill,
-)
+from autoskillit.core import RetryReason, get_logger
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import _extract_block
 from autoskillit.server._notify import _notify, track_response_size
+from autoskillit.server.tools._backend_compat import _resolve_and_check_backend_compat
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
-from autoskillit.server.tools.tools_execution import _check_backend_compat
 
 if TYPE_CHECKING:
     from autoskillit.core import SkillResult, WriteBehaviorSpec
@@ -322,26 +316,7 @@ async def prepare_issue(
                 write_spec = tool_ctx.write_expected_resolver(skill_command)
 
             # Backend compatibility gate — must precede executor.run().
-            _resolved_command = skill_command
-            _target_name: str | None = None
-            if tool_ctx.skill_resolver is not None:
-                _resolved_command, _target_name = resolve_target_skill(
-                    skill_command, tool_ctx.skill_resolver
-                )
-            _skill_info = (
-                tool_ctx.skill_resolver.resolve(_target_name)
-                if tool_ctx.skill_resolver and _target_name
-                else None
-            )
-            if _compat_err := _check_backend_compat(
-                skill_command=skill_command,
-                resolved_command=_resolved_command,
-                effective_order_id=os.environ.get(DISPATCH_ID_ENV_VAR, ""),
-                target_name=_target_name,
-                skill_info=_skill_info,
-                effective_backend_obj=tool_ctx.backend,
-                skill_resolver=tool_ctx.skill_resolver,
-            ):
+            if _compat_err := _resolve_and_check_backend_compat(skill_command, tool_ctx):
                 return _compat_err
 
             result = await tool_ctx.executor.run(
@@ -463,26 +438,7 @@ async def enrich_issues(
                 write_spec = tool_ctx.write_expected_resolver(skill_command)
 
             # Backend compatibility gate — must precede executor.run().
-            _resolved_command = skill_command
-            _target_name: str | None = None
-            if tool_ctx.skill_resolver is not None:
-                _resolved_command, _target_name = resolve_target_skill(
-                    skill_command, tool_ctx.skill_resolver
-                )
-            _skill_info = (
-                tool_ctx.skill_resolver.resolve(_target_name)
-                if tool_ctx.skill_resolver and _target_name
-                else None
-            )
-            if _compat_err := _check_backend_compat(
-                skill_command=skill_command,
-                resolved_command=_resolved_command,
-                effective_order_id=os.environ.get(DISPATCH_ID_ENV_VAR, ""),
-                target_name=_target_name,
-                skill_info=_skill_info,
-                effective_backend_obj=tool_ctx.backend,
-                skill_resolver=tool_ctx.skill_resolver,
-            ):
+            if _compat_err := _resolve_and_check_backend_compat(skill_command, tool_ctx):
                 return _compat_err
 
             result = await tool_ctx.executor.run(

--- a/src/autoskillit/server/tools/tools_issue_headless.py
+++ b/src/autoskillit/server/tools/tools_issue_headless.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import TYPE_CHECKING, Any
 
 import regex as re
@@ -10,12 +11,14 @@ import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit.core import RetryReason, get_logger
+from autoskillit.core import DISPATCH_ID_ENV_VAR, RetryReason, get_logger
+from autoskillit.core.types._type_helpers import resolve_target_skill
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import _extract_block
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
+from autoskillit.server.tools.tools_execution import _check_backend_compat
 
 if TYPE_CHECKING:
     from autoskillit.core import SkillResult, WriteBehaviorSpec
@@ -314,6 +317,29 @@ async def prepare_issue(
             if tool_ctx.write_expected_resolver:
                 write_spec = tool_ctx.write_expected_resolver(skill_command)
 
+            # Backend compatibility gate — must precede executor.run().
+            _resolved_command = skill_command
+            _target_name: str | None = None
+            if tool_ctx.skill_resolver is not None:
+                _resolved_command, _target_name = resolve_target_skill(
+                    skill_command, tool_ctx.skill_resolver
+                )
+            _skill_info = (
+                tool_ctx.skill_resolver.resolve(_target_name)
+                if tool_ctx.skill_resolver and _target_name
+                else None
+            )
+            if _compat_err := _check_backend_compat(
+                skill_command=skill_command,
+                resolved_command=_resolved_command,
+                effective_order_id=os.environ.get(DISPATCH_ID_ENV_VAR, ""),
+                target_name=_target_name,
+                skill_info=_skill_info,
+                effective_backend_obj=tool_ctx.backend,
+                skill_resolver=tool_ctx.skill_resolver,
+            ):
+                return _compat_err
+
             result = await tool_ctx.executor.run(
                 skill_command,
                 str(tool_ctx.project_dir),
@@ -431,6 +457,29 @@ async def enrich_issues(
             write_spec: WriteBehaviorSpec | None = None
             if tool_ctx.write_expected_resolver:
                 write_spec = tool_ctx.write_expected_resolver(skill_command)
+
+            # Backend compatibility gate — must precede executor.run().
+            _resolved_command = skill_command
+            _target_name: str | None = None
+            if tool_ctx.skill_resolver is not None:
+                _resolved_command, _target_name = resolve_target_skill(
+                    skill_command, tool_ctx.skill_resolver
+                )
+            _skill_info = (
+                tool_ctx.skill_resolver.resolve(_target_name)
+                if tool_ctx.skill_resolver and _target_name
+                else None
+            )
+            if _compat_err := _check_backend_compat(
+                skill_command=skill_command,
+                resolved_command=_resolved_command,
+                effective_order_id=os.environ.get(DISPATCH_ID_ENV_VAR, ""),
+                target_name=_target_name,
+                skill_info=_skill_info,
+                effective_backend_obj=tool_ctx.backend,
+                skill_resolver=tool_ctx.skill_resolver,
+            ):
+                return _compat_err
 
             result = await tool_ctx.executor.run(
                 skill_command,

--- a/src/autoskillit/server/tools/tools_issue_headless.py
+++ b/src/autoskillit/server/tools/tools_issue_headless.py
@@ -11,8 +11,12 @@ import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit.core import DISPATCH_ID_ENV_VAR, RetryReason, get_logger
-from autoskillit.core.types._type_helpers import resolve_target_skill
+from autoskillit.core import (
+    DISPATCH_ID_ENV_VAR,
+    RetryReason,
+    get_logger,
+    resolve_target_skill,
+)
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import _extract_block

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -78,7 +78,10 @@ from autoskillit.server.tools._preflight import (
     _check_dispatch_feasibility,
     filter_steps_by_post_prune,
 )
-from autoskillit.server.tools._serve_helpers import serve_recipe
+from autoskillit.server.tools._serve_helpers import (
+    build_backend_capabilities_map,
+    serve_recipe,
+)
 from autoskillit.server.tools._types import _validate_result
 
 logger = get_logger(__name__)
@@ -565,6 +568,9 @@ def get_recipe(name: str) -> str:
             skill_resolver=ctx.skill_resolver,
             config_backend=ctx.config.agent_backend,
         )
+        _backend_capabilities_map = build_backend_capabilities_map(
+            _effective_backend_map, ctx.backend
+        )
         _config_default = build_config_default_layer(_defaults)
         result = serve_recipe(
             ctx,
@@ -577,6 +583,7 @@ def get_recipe(name: str) -> str:
             resolved_defaults=_defaults,
             effective_backend_map=_effective_backend_map,
             backend_name=ctx.backend.name if ctx.backend else None,
+            backend_capabilities_map=_backend_capabilities_map,
         )
     except ProcessStaleError:
         logger.warning("get_recipe_failure", recipe=name, stage="process_stale", exc_info=True)
@@ -806,6 +813,9 @@ async def open_kitchen(
                 skill_resolver=tool_ctx.skill_resolver,
                 config_backend=tool_ctx.config.agent_backend,
             )
+            _backend_capabilities_map = build_backend_capabilities_map(
+                _effective_backend_map, tool_ctx.backend
+            )
             # Runtime enum check: output_mode must be validated before recipe loading
             if name == "research":
                 _om_value = (overrides or {}).get("output_mode")
@@ -831,6 +841,7 @@ async def open_kitchen(
                         suppressed=suppressed,
                         backend_name=tool_ctx.backend.name if tool_ctx.backend else None,
                         effective_backend_map=_effective_backend_map,
+                        backend_capabilities_map=_backend_capabilities_map,
                     )
                 except ProcessStaleError as exc:
                     logger.warning("open_kitchen_failure", stage="process_stale", exc_info=True)
@@ -895,6 +906,7 @@ async def open_kitchen(
                         config_providers=tool_ctx.config.providers,
                         recipe_name=name,
                         config_backend=tool_ctx.config.agent_backend,
+                        skill_resolver=tool_ctx.skill_resolver,
                     )
                     if _preflight_err is not None:
                         tool_ctx.gate.disable()
@@ -944,6 +956,7 @@ async def open_kitchen(
                     suppressed=suppressed,
                     backend_name=tool_ctx.backend.name if tool_ctx.backend else None,
                     effective_backend_map=_effective_backend_map,
+                    backend_capabilities_map=_backend_capabilities_map,
                 )
             except ProcessStaleError as exc:
                 logger.warning("open_kitchen_failure", stage="process_stale", exc_info=True)
@@ -1026,6 +1039,7 @@ async def open_kitchen(
                     config_providers=tool_ctx.config.providers,
                     recipe_name=name,
                     config_backend=tool_ctx.config.agent_backend,
+                    skill_resolver=tool_ctx.skill_resolver,
                 )
                 if _preflight_err is not None:
                     tool_ctx.gate.disable()

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -33,7 +33,10 @@ from autoskillit.server.tools._auto_overrides import (
     _provider_aware_capability_overrides,
 )
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
-from autoskillit.server.tools._serve_helpers import serve_recipe
+from autoskillit.server.tools._serve_helpers import (
+    build_backend_capabilities_map,
+    serve_recipe,
+)
 from autoskillit.server.tools._types import _validate_result
 
 logger = get_logger(__name__)
@@ -250,6 +253,9 @@ async def load_recipe(
                 skill_resolver=tool_ctx.skill_resolver,
                 config_backend=tool_ctx.config.agent_backend,
             )
+            _backend_capabilities_map = build_backend_capabilities_map(
+                _effective_backend_map, tool_ctx.backend
+            )
             result = serve_recipe(
                 tool_ctx,
                 name,
@@ -263,6 +269,7 @@ async def load_recipe(
                 temp_dir_relpath=temp_dir_display_str(tool_ctx.config.workspace.temp_dir),
                 backend_name=tool_ctx.backend.name if tool_ctx.backend else None,
                 effective_backend_map=_effective_backend_map,
+                backend_capabilities_map=_backend_capabilities_map,
             )
             recipe_info = _recipe_info_pre
             result = await _apply_triage_gate(result, name, recipe_info=recipe_info)
@@ -378,12 +385,16 @@ async def validate_recipe(script_path: str) -> str:
                 skill_resolver=tool_ctx.skill_resolver,
                 config_backend=tool_ctx.config.agent_backend,
             )
+            _validate_backend_capabilities_map = build_backend_capabilities_map(
+                _validate_effective_backend_map, tool_ctx.backend
+            )
             result = tool_ctx.recipes.validate_from_path(
                 Path(script_path),
                 temp_dir_relpath=temp_dir_display_str(tool_ctx.config.workspace.temp_dir),
                 backend_name=tool_ctx.backend.name if tool_ctx.backend else None,
                 ingredient_overrides=_cap_overrides,
                 effective_backend_map=_validate_effective_backend_map,
+                backend_capabilities_map=_validate_backend_capabilities_map,
             )
             return json.dumps(result)
     except Exception as exc:

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -234,7 +234,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
         }
     ),
     "_type_results_execution": frozenset({"core", "execution", "server", "pipeline"}),
-    "_type_backend": frozenset({"core", "execution", "cli", "recipe", "workspace"}),
+    "_type_backend": frozenset({"core", "execution", "cli", "recipe", "server", "workspace"}),
     "_type_dispatch_identity": frozenset({"core", "fleet", "execution"}),
     "_type_figure_spec": frozenset({"core", "report"}),
     "_type_session_env": frozenset({"core", "cli"}),

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -19,7 +19,7 @@ NEW_HEADLESS_MODULES = [
 HEADLESS_SIZE_BUDGETS = {
     "headless/__init__.py": 525,
     "headless/_headless_helpers.py": 220,
-    "headless/_headless_execute.py": 620,
+    "headless/_headless_execute.py": 630,
     "headless/_headless_recovery.py": 370,
     "headless/_headless_path_tokens.py": 190,
     "headless/_headless_result.py": 920,

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -309,6 +309,84 @@ def test_backend_compat_precedes_dispatch() -> None:
     )
 
 
+def test_direct_executor_callers_check_backend_compat() -> None:
+    """Every .executor.run() call outside run_skill must be preceded by a
+    _check_backend_compat call in the same enclosing function.
+
+    Mirrors the proven pattern from test_backend_compat_precedes_dispatch.
+    Scans tools_github.py (report_bug) and tools_issue_headless.py
+    (prepare_issue, enrich_issues) for direct executor.run() invocations
+    and verifies each is preceded by a _check_backend_compat call within
+    the same enclosing function. This is the structural guard for Defect 4
+    in the propagation-defect hardening plan.
+    """
+    target_files = [
+        SRC_ROOT / "server" / "tools" / "tools_github.py",
+        SRC_ROOT / "server" / "tools" / "tools_issue_headless.py",
+    ]
+
+    violations: list[str] = []
+
+    for py_file in target_files:
+        src = py_file.read_text()
+        tree = ast.parse(src)
+
+        # Walk top-level functions, then nested defs inside them, to get all
+        # enclosing functions (this matches the production scope at which
+        # tool_ctx.skill_resolver / tool_ctx.backend are in scope).
+        enclosing_funcs: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                enclosing_funcs.append(node)
+
+        # Only consider functions that call .executor.run() directly
+        for func_node in enclosing_funcs:
+            executor_run_linenos: list[int] = []
+            compat_lineno: int | None = None
+            for child in ast.walk(func_node):
+                if not isinstance(child, ast.Call):
+                    continue
+                call_func = child.func
+                is_executor_run = (
+                    isinstance(call_func, ast.Attribute)
+                    and call_func.attr == "run"
+                    and isinstance(call_func.value, ast.Attribute)
+                    and call_func.value.attr == "executor"
+                )
+                is_compat = (
+                    isinstance(call_func, ast.Name) and call_func.id == "_check_backend_compat"
+                )
+                if is_executor_run:
+                    executor_run_linenos.append(child.lineno)
+                if is_compat and compat_lineno is None:
+                    compat_lineno = child.lineno
+
+            if not executor_run_linenos:
+                continue
+            if compat_lineno is None:
+                rel = _rel(py_file)
+                for run_line in executor_run_linenos:
+                    violations.append(
+                        f"{rel}:{run_line} — function "
+                        f"{func_node.name!r} calls .executor.run() but has no "
+                        f"_check_backend_compat call"
+                    )
+                continue
+            for run_line in executor_run_linenos:
+                if run_line < compat_lineno:
+                    rel = _rel(py_file)
+                    violations.append(
+                        f"{rel}:{run_line} — .executor.run() in "
+                        f"{func_node.name!r} precedes _check_backend_compat "
+                        f"(line {compat_lineno})"
+                    )
+
+    assert not violations, (
+        "Direct executor callers must run _check_backend_compat before "
+        "executor.run():\n" + "\n".join(f"  {v}" for v in violations)
+    )
+
+
 def test_fleet_tools_call_require_fleet() -> None:
     """Every tool in FLEET_TOOLS (except batch_cleanup_clones) must call
     _require_fleet() before any non-guard await/return in its function body."""

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -311,19 +311,14 @@ def test_backend_compat_precedes_dispatch() -> None:
 
 def test_direct_executor_callers_check_backend_compat() -> None:
     """Every .executor.run() call outside run_skill must be preceded by a
-    _check_backend_compat call in the same enclosing function.
+    fail-closed backend compatibility call in the same enclosing function.
 
     Mirrors the proven pattern from test_backend_compat_precedes_dispatch.
-    Scans tools_github.py (report_bug) and tools_issue_headless.py
-    (prepare_issue, enrich_issues) for direct executor.run() invocations
-    and verifies each is preceded by a _check_backend_compat call within
-    the same enclosing function. This is the structural guard for Defect 4
-    in the propagation-defect hardening plan.
+    Discovers every server tool module so new direct executor callers cannot
+    silently escape the invariant.
     """
-    target_files = [
-        SRC_ROOT / "server" / "tools" / "tools_github.py",
-        SRC_ROOT / "server" / "tools" / "tools_issue_headless.py",
-    ]
+    target_files = sorted((SRC_ROOT / "server" / "tools").glob("*.py"))
+    compat_calls = {"_check_backend_compat", "_resolve_and_check_backend_compat"}
 
     violations: list[str] = []
 
@@ -341,6 +336,8 @@ def test_direct_executor_callers_check_backend_compat() -> None:
 
         # Only consider functions that call .executor.run() directly
         for func_node in enclosing_funcs:
+            if py_file.name == "tools_execution.py" and func_node.name == "run_skill":
+                continue
             executor_run_linenos: list[int] = []
             compat_lineno: int | None = None
             for child in ast.walk(func_node):
@@ -353,9 +350,7 @@ def test_direct_executor_callers_check_backend_compat() -> None:
                     and isinstance(call_func.value, ast.Attribute)
                     and call_func.value.attr == "executor"
                 )
-                is_compat = (
-                    isinstance(call_func, ast.Name) and call_func.id == "_check_backend_compat"
-                )
+                is_compat = isinstance(call_func, ast.Name) and call_func.id in compat_calls
                 if is_executor_run:
                     executor_run_linenos.append(child.lineno)
                 if is_compat and compat_lineno is None:
@@ -369,7 +364,7 @@ def test_direct_executor_callers_check_backend_compat() -> None:
                     violations.append(
                         f"{rel}:{run_line} — function "
                         f"{func_node.name!r} calls .executor.run() but has no "
-                        f"_check_backend_compat call"
+                        f"fail-closed backend compatibility call"
                     )
                 continue
             for run_line in executor_run_linenos:
@@ -377,12 +372,12 @@ def test_direct_executor_callers_check_backend_compat() -> None:
                     rel = _rel(py_file)
                     violations.append(
                         f"{rel}:{run_line} — .executor.run() in "
-                        f"{func_node.name!r} precedes _check_backend_compat "
+                        f"{func_node.name!r} precedes backend compatibility check "
                         f"(line {compat_lineno})"
                     )
 
     assert not violations, (
-        "Direct executor callers must run _check_backend_compat before "
+        "Direct executor callers must run a fail-closed backend compatibility check before "
         "executor.run():\n" + "\n".join(f"  {v}" for v in violations)
     )
 

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -309,6 +309,124 @@ def test_backend_compat_precedes_dispatch() -> None:
     )
 
 
+def _backend_compat_dominance_violations(
+    func_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    compat_calls: set[str],
+) -> list[int]:
+    """Return executor.run lines not dominated by a compat call in this scope."""
+    violations: list[int] = []
+
+    class _CurrentScopeCalls(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.calls: list[ast.Call] = []
+
+        def visit_Call(self, node: ast.Call) -> None:
+            self.calls.append(node)
+            self.generic_visit(node)
+
+        def visit_Lambda(self, node: ast.Lambda) -> None:
+            return
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            return
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            return
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            return
+
+    def scan_expression(node: ast.AST | None, compat_seen: bool) -> bool:
+        if node is None:
+            return compat_seen
+        visitor = _CurrentScopeCalls()
+        visitor.visit(node)
+        for call in visitor.calls:
+            call_func = call.func
+            is_executor_run = (
+                isinstance(call_func, ast.Attribute)
+                and call_func.attr == "run"
+                and isinstance(call_func.value, ast.Attribute)
+                and call_func.value.attr == "executor"
+            )
+            is_compat = isinstance(call_func, ast.Name) and call_func.id in compat_calls
+            if is_executor_run and not compat_seen:
+                violations.append(call.lineno)
+            if is_compat:
+                compat_seen = True
+        return compat_seen
+
+    def merge_paths(*states: bool | None) -> bool | None:
+        reachable = [state for state in states if state is not None]
+        return all(reachable) if reachable else None
+
+    def scan_block(statements: list[ast.stmt], compat_seen: bool) -> bool | None:
+        state: bool | None = compat_seen
+        for statement in statements:
+            if state is None:
+                break
+            state = scan_statement(statement, state)
+        return state
+
+    def scan_statement(statement: ast.stmt, compat_seen: bool) -> bool | None:
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            return compat_seen
+        if isinstance(statement, ast.If):
+            branch_state = scan_expression(statement.test, compat_seen)
+            body_state = scan_block(statement.body, branch_state)
+            else_state = (
+                scan_block(statement.orelse, branch_state) if statement.orelse else branch_state
+            )
+            return merge_paths(body_state, else_state)
+        if isinstance(statement, (ast.For, ast.AsyncFor)):
+            loop_state = scan_expression(statement.iter, compat_seen)
+            body_state = scan_block(statement.body, loop_state)
+            after_loop = merge_paths(loop_state, body_state)
+            if statement.orelse and after_loop is not None:
+                return scan_block(statement.orelse, after_loop)
+            return after_loop
+        if isinstance(statement, ast.While):
+            loop_state = scan_expression(statement.test, compat_seen)
+            body_state = scan_block(statement.body, loop_state)
+            after_loop = merge_paths(loop_state, body_state)
+            if statement.orelse and after_loop is not None:
+                return scan_block(statement.orelse, after_loop)
+            return after_loop
+        if isinstance(statement, (ast.With, ast.AsyncWith)):
+            body_state = compat_seen
+            for item in statement.items:
+                body_state = scan_expression(item.context_expr, body_state)
+                body_state = scan_expression(item.optional_vars, body_state)
+            return scan_block(statement.body, body_state)
+        if isinstance(statement, (ast.Try, ast.TryStar)):
+            body_state = scan_block(statement.body, compat_seen)
+            if statement.orelse and body_state is not None:
+                body_state = scan_block(statement.orelse, body_state)
+            handler_states = [
+                scan_block(handler.body, compat_seen) for handler in statement.handlers
+            ]
+            merged = merge_paths(body_state, *handler_states)
+            if statement.finalbody:
+                final_entry = merged if merged is not None else compat_seen
+                final_state = scan_block(statement.finalbody, final_entry)
+                return final_state if merged is not None else None
+            return merged
+        if isinstance(statement, ast.Match):
+            match_state = scan_expression(statement.subject, compat_seen)
+            case_states = [scan_block(case.body, match_state) for case in statement.cases]
+            return merge_paths(match_state, *case_states)
+        if isinstance(statement, (ast.Return, ast.Raise)):
+            value = statement.value if isinstance(statement, ast.Return) else statement.exc
+            scan_expression(value, compat_seen)
+            return None
+        if isinstance(statement, (ast.Break, ast.Continue)):
+            return None
+        return scan_expression(statement, compat_seen)
+
+    scan_block(func_node.body, False)
+    return violations
+
+
 def test_direct_executor_callers_check_backend_compat() -> None:
     """Every .executor.run() call outside run_skill must be preceded by a
     fail-closed backend compatibility call in the same enclosing function.
@@ -326,55 +444,17 @@ def test_direct_executor_callers_check_backend_compat() -> None:
         src = py_file.read_text()
         tree = ast.parse(src)
 
-        # Walk top-level functions, then nested defs inside them, to get all
-        # enclosing functions (this matches the production scope at which
-        # tool_ctx.skill_resolver / tool_ctx.backend are in scope).
-        enclosing_funcs: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
-        for node in ast.walk(tree):
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                enclosing_funcs.append(node)
-
-        # Only consider functions that call .executor.run() directly
-        for func_node in enclosing_funcs:
+        for func_node in ast.walk(tree):
+            if not isinstance(func_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
             if py_file.name == "tools_execution.py" and func_node.name == "run_skill":
                 continue
-            executor_run_linenos: list[int] = []
-            compat_lineno: int | None = None
-            for child in ast.walk(func_node):
-                if not isinstance(child, ast.Call):
-                    continue
-                call_func = child.func
-                is_executor_run = (
-                    isinstance(call_func, ast.Attribute)
-                    and call_func.attr == "run"
-                    and isinstance(call_func.value, ast.Attribute)
-                    and call_func.value.attr == "executor"
+            for run_line in _backend_compat_dominance_violations(func_node, compat_calls):
+                violations.append(
+                    f"{_rel(py_file)}:{run_line} — .executor.run() in "
+                    f"{func_node.name!r} is not control-flow dominated by a "
+                    "fail-closed backend compatibility call in the same lexical scope"
                 )
-                is_compat = isinstance(call_func, ast.Name) and call_func.id in compat_calls
-                if is_executor_run:
-                    executor_run_linenos.append(child.lineno)
-                if is_compat and compat_lineno is None:
-                    compat_lineno = child.lineno
-
-            if not executor_run_linenos:
-                continue
-            if compat_lineno is None:
-                rel = _rel(py_file)
-                for run_line in executor_run_linenos:
-                    violations.append(
-                        f"{rel}:{run_line} — function "
-                        f"{func_node.name!r} calls .executor.run() but has no "
-                        f"fail-closed backend compatibility call"
-                    )
-                continue
-            for run_line in executor_run_linenos:
-                if run_line < compat_lineno:
-                    rel = _rel(py_file)
-                    violations.append(
-                        f"{rel}:{run_line} — .executor.run() in "
-                        f"{func_node.name!r} precedes backend compatibility check "
-                        f"(line {compat_lineno})"
-                    )
 
     assert not violations, (
         "Direct executor callers must run a fail-closed backend compatibility check before "

--- a/tests/arch/test_pyright_suppression_allowlist.py
+++ b/tests/arch/test_pyright_suppression_allowlist.py
@@ -22,7 +22,7 @@ PRODUCTION_ALLOWLIST: dict[tuple[str, int], str] = {
         "recipe/__init__.py",
         274,
     ): "lazy-registry: method added by _register_rule_module() side effects",
-    ("recipe/_api.py", 282): "lazy-registry: RULE_REGISTRY_HASH set by _finalize_registry()",
+    ("recipe/_api.py", 285): "lazy-registry: RULE_REGISTRY_HASH set by _finalize_registry()",
 }
 
 TEST_ALLOWLIST: dict[tuple[str, int], str] = {

--- a/tests/arch/test_skill_capability_registry.py
+++ b/tests/arch/test_skill_capability_registry.py
@@ -156,12 +156,15 @@ def test_required_backend_property_on_git_metadata_write():
     and that property must exist as a field on BackendCapabilities (boot-time check).
     """
     from autoskillit.core.types._type_backend import BackendCapabilities
+    from autoskillit.core.types._type_constants import CAPABILITY_INGREDIENT_MAP
 
     cap = SKILL_CAPABILITY_REGISTRY["git_metadata_write"]
     assert cap.required_backend_property == "git_metadata_writable", (
         f"git_metadata_write.required_backend_property must be 'git_metadata_writable', "
         f"got {cap.required_backend_property!r}"
     )
+    assert cap.required_recipe_ingredient == "backend_supports_git_write"
+    assert CAPABILITY_INGREDIENT_MAP == {"git_metadata_write": "backend_supports_git_write"}
     # Boot-time validation: the property name must match a real BackendCapabilities field.
     fields_set = {f.name for f in __import__("dataclasses").fields(BackendCapabilities)}
     assert "git_metadata_writable" in fields_set, (
@@ -178,6 +181,14 @@ def test_required_backend_property_is_optional_on_unrouted_capabilities():
             f"{name}.required_backend_property must remain None (no hard property "
             f"requirement), got {cap.required_backend_property!r}"
         )
+        assert cap.required_recipe_ingredient is None
+
+
+def test_hard_backend_properties_and_recipe_ingredients_are_declared_together():
+    for name, capability in SKILL_CAPABILITY_REGISTRY.items():
+        assert (capability.required_backend_property is None) == (
+            capability.required_recipe_ingredient is None
+        ), f"{name} must define both hard-capability fields or neither"
 
 
 def test_headless_tools_not_marked_not_applicable():

--- a/tests/arch/test_skill_capability_registry.py
+++ b/tests/arch/test_skill_capability_registry.py
@@ -151,6 +151,35 @@ def test_required_backends_is_derived_property():
     assert "required_backends" not in SkillCapabilityDef.__dataclass_fields__
 
 
+def test_required_backend_property_on_git_metadata_write():
+    """git_metadata_write must declare required_backend_property=git_metadata_writable,
+    and that property must exist as a field on BackendCapabilities (boot-time check).
+    """
+    from autoskillit.core.types._type_backend import BackendCapabilities
+
+    cap = SKILL_CAPABILITY_REGISTRY["git_metadata_write"]
+    assert cap.required_backend_property == "git_metadata_writable", (
+        f"git_metadata_write.required_backend_property must be 'git_metadata_writable', "
+        f"got {cap.required_backend_property!r}"
+    )
+    # Boot-time validation: the property name must match a real BackendCapabilities field.
+    fields_set = {f.name for f in __import__("dataclasses").fields(BackendCapabilities)}
+    assert "git_metadata_writable" in fields_set, (
+        "BackendCapabilities must have a 'git_metadata_writable' field for "
+        "git_metadata_write.required_backend_property to be enforceable"
+    )
+
+
+def test_required_backend_property_is_optional_on_unrouted_capabilities():
+    """Caps without a hard property requirement must keep required_backend_property=None."""
+    for name in ("open_kitchen", "run_skill", "test_check", "claude_dir"):
+        cap = SKILL_CAPABILITY_REGISTRY[name]
+        assert cap.required_backend_property is None, (
+            f"{name}.required_backend_property must remain None (no hard property "
+            f"requirement), got {cap.required_backend_property!r}"
+        )
+
+
 def test_headless_tools_not_marked_not_applicable():
     from autoskillit.core.types._type_constants_registries import HEADLESS_TOOLS
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -881,8 +881,10 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "pipeline": 12,
         "fleet": 23,  # +_issue_url_helpers.py  # noqa: E501
         "recipe/rules": 54,  # +commit_guard_regression_route +rules_model +rules_gitignored_deliverable +rules_issue_scope_threading +rules_inventory_gate_bilateral +rules_verdict_context  # noqa: E501
-        "server/tools": 31,  # +_pipeline_deps.py +_ordering_telemetry.py (open_kitchen
+        "server/tools": 32,  # +_pipeline_deps.py +_ordering_telemetry.py (open_kitchen
         # auto-init dependency tracker + REVIEW_BEFORE_PLAN ordering telemetry)
+        # +_backend_compat.py (shared target-resolution + fail-closed compatibility gate
+        # for direct headless executor callers — report_bug, prepare_issue, enrich_issues)
         "hooks/guards": 32,  # +fleet_claim_guard, +reset_resume_gate, +recipe_read_guard
         "execution/backends": 12,  # +_composite_locator.py, +_probe_cache.py
     }

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1016,7 +1016,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "_effective_backend_map and tool_ctx.backend.name (+28 net lines)",
     ),
     "tools_execution.py": (
-        1700,
+        1600,
         "REQ-CNST-010-E8: execution tool handlers — run_cmd/run_python/run_skill are the "
         "three primary execution paths; fail-closed existence gate, empty-closure gate "
         "for fabricated skill name rejection, _check_backend_compat fail-closed gate "

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -979,7 +979,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "closure-scoped _spawn_error, and _write_pid fail-closed contract add ~33 lines",
     ),
     "tools_kitchen.py": (
-        1472,
+        1540,
         "REQ-CNST-010-E7: kitchen tool handlers — open_kitchen and lock_ingredients require "
         "inline validation helpers (_check_override_keys, _build_ingredient_key_suggestions) "
         "for ingredient key validation; splitting would cross import-layer boundaries; "
@@ -1010,10 +1010,13 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "(+53 net lines)"
         "; _auto_init_pipeline_tracker tool_ctx param typed as ToolContext under "
         "TYPE_CHECKING instead of Any, matching _active_order_ids_for_kitchen's "
-        "established pattern (+1 net line)",
+        "established pattern (+1 net line)"
+        "; serve_recipe backend_capabilities_map threading at get_recipe + deferred-recall + "
+        "normal open_kitchen paths with safe _distinct_backends extraction from "
+        "_effective_backend_map and tool_ctx.backend.name (+28 net lines)",
     ),
     "tools_execution.py": (
-        1580,
+        1700,
         "REQ-CNST-010-E8: execution tool handlers — run_cmd/run_python/run_skill are the "
         "three primary execution paths; fail-closed existence gate, empty-closure gate "
         "for fabricated skill name rejection, _check_backend_compat fail-closed gate "

--- a/tests/arch/test_subpackage_structure.py
+++ b/tests/arch/test_subpackage_structure.py
@@ -61,8 +61,8 @@ class TestCoreSubpackages:
         assert len(combined) == len(remaining) + len(env) + len(features) + len(registries), (
             "Duplicate symbols across split modules"
         )
-        assert len(combined) == 98, (
-            f"Expected 98 symbols total, got {len(combined)} "
+        assert len(combined) == 100, (
+            f"Expected 100 symbols total, got {len(combined)} "
             f"(remaining={len(remaining)}, env={len(env)}, "
             f"features={len(features)}, registries={len(registries)})"
         )

--- a/tests/core/test_session_checkpoint.py
+++ b/tests/core/test_session_checkpoint.py
@@ -27,6 +27,8 @@ class TestSessionCheckpoint:
         assert cp.step_name == ""
         assert cp.progress_pct == 0.0
         assert cp.ts == ""
+        assert cp.backend_name == ""
+        assert cp.skill_name == ""
 
     def test_from_dict_missing_fields_uses_defaults(self) -> None:
         cp = SessionCheckpoint.from_dict({})
@@ -44,6 +46,23 @@ class TestSessionCheckpoint:
         cp = SessionCheckpoint(completed_items=["x"])
         with pytest.raises(AttributeError):
             cp.step_name = "mutated"  # type: ignore[misc]
+
+    def test_session_checkpoint_round_trips_backend_name(self) -> None:
+        """SessionCheckpoint must preserve backend_name through serialization."""
+        cp = SessionCheckpoint.now(
+            completed_items=["step_a"],
+            step_name="step_b",
+            backend_name="codex",
+            skill_name="report-bug",
+        )
+        assert cp.backend_name == "codex"
+        assert cp.skill_name == "report-bug"
+        d = cp.to_dict()
+        assert d["backend_name"] == "codex"
+        assert d["skill_name"] == "report-bug"
+        cp2 = SessionCheckpoint.from_dict(d)
+        assert cp2.backend_name == "codex"
+        assert cp2.skill_name == "report-bug"
 
 
 class TestComputeRemaining:

--- a/tests/execution/test_headless_execute.py
+++ b/tests/execution/test_headless_execute.py
@@ -207,13 +207,18 @@ class TestPreSessionIndexSignaling:
 
         with (
             patch(
+                "autoskillit.execution.headless._headless_execute.is_git_main_checkout",
+                return_value=True,
+            ),
+            patch(
                 "autoskillit.execution.headless._headless_execute.validate_pre_session_index",
                 return_value=False,
-            ),
+            ) as validate_index,
             structlog.testing.capture_logs() as caplog,
         ):
             await run_headless_core("/test foo", str(tmp_path), minimal_ctx)
 
+        validate_index.assert_awaited_once()
         dirty_events = [e for e in caplog if e.get("event") == "pre_session_index_reset"]
         assert not dirty_events, (
             f"pre_session_index_reset must NOT be logged when clean; caplog={caplog}"

--- a/tests/execution/test_headless_execute.py
+++ b/tests/execution/test_headless_execute.py
@@ -167,6 +167,10 @@ class TestPreSessionIndexSignaling:
 
         with (
             patch(
+                "autoskillit.execution.headless._headless_execute.is_git_main_checkout",
+                return_value=True,
+            ),
+            patch(
                 "autoskillit.execution.headless._headless_execute.validate_pre_session_index",
                 return_value=True,
             ),

--- a/tests/execution/test_headless_execute.py
+++ b/tests/execution/test_headless_execute.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+import structlog
 
 from autoskillit.core import CmdSpec
 from autoskillit.core.types import SubprocessResult, TerminationReason
@@ -136,3 +138,79 @@ class TestProcessIdleTimeoutOverride:
         assert runner.call_args_list, "runner was never called"
         _cmd, _cwd, _timeout, kwargs = runner.call_args_list[0]
         assert kwargs.get("idle_output_timeout") == 30.0
+
+
+class TestPreSessionIndexSignaling:
+    """Tests that the caller logs the pre-session dirty-state signal."""
+
+    @pytest.mark.anyio
+    async def test_dirty_state_logged_with_structured_metadata(
+        self, minimal_ctx, tmp_path: Path, monkeypatch
+    ) -> None:
+        """When validate_pre_session_index returns True, the dirty-state
+        warning must be emitted with structured kwargs (dirty=True, pre_sha=...)."""
+        from autoskillit.execution.headless import run_headless_core
+        from tests.execution.conftest import _mock_backend
+        from tests.fakes import MockSubprocessRunner
+
+        monkeypatch.delenv("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", raising=False)
+        runner = MockSubprocessRunner()
+        runner.set_default(_success_result())
+        minimal_ctx.runner = runner
+        backend = _mock_backend(pty_required=True, channel_b_capable=True)
+        backend.build_skill_session_cmd.return_value = CmdSpec(
+            cmd=("claude", "-p", "test"),
+            env={},
+            process_idle_timeout_ms=30000,
+        )
+        minimal_ctx.backend = backend
+
+        with (
+            patch(
+                "autoskillit.execution.headless._headless_execute.validate_pre_session_index",
+                return_value=True,
+            ),
+            structlog.testing.capture_logs() as caplog,
+        ):
+            await run_headless_core("/test foo", str(tmp_path), minimal_ctx)
+
+        dirty_events = [e for e in caplog if e.get("event") == "pre_session_index_reset"]
+        assert dirty_events, f"pre_session_index_reset not logged; caplog={caplog}"
+        assert dirty_events[0].get("dirty") is True
+        assert "pre_sha" in dirty_events[0]
+
+    @pytest.mark.anyio
+    async def test_clean_state_does_not_log_dirty_warning(
+        self, minimal_ctx, tmp_path: Path, monkeypatch
+    ) -> None:
+        """When validate_pre_session_index returns False (clean state),
+        no pre_session_index_reset warning should be emitted."""
+        from autoskillit.execution.headless import run_headless_core
+        from tests.execution.conftest import _mock_backend
+        from tests.fakes import MockSubprocessRunner
+
+        monkeypatch.delenv("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", raising=False)
+        runner = MockSubprocessRunner()
+        runner.set_default(_success_result())
+        minimal_ctx.runner = runner
+        backend = _mock_backend(pty_required=True, channel_b_capable=True)
+        backend.build_skill_session_cmd.return_value = CmdSpec(
+            cmd=("claude", "-p", "test"),
+            env={},
+            process_idle_timeout_ms=30000,
+        )
+        minimal_ctx.backend = backend
+
+        with (
+            patch(
+                "autoskillit.execution.headless._headless_execute.validate_pre_session_index",
+                return_value=False,
+            ),
+            structlog.testing.capture_logs() as caplog,
+        ):
+            await run_headless_core("/test foo", str(tmp_path), minimal_ctx)
+
+        dirty_events = [e for e in caplog if e.get("event") == "pre_session_index_reset"]
+        assert not dirty_events, (
+            f"pre_session_index_reset must NOT be logged when clean; caplog={caplog}"
+        )

--- a/tests/fleet/test_checkpoint_bridge.py
+++ b/tests/fleet/test_checkpoint_bridge.py
@@ -9,6 +9,8 @@ from autoskillit.fleet.sidecar import IssueSidecarEntry
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
 
+_PROVENANCE = {"backend_name": "codex", "skill_name": "implementation"}
+
 
 class TestCheckpointFromSidecar:
     def test_extracts_completed_urls(self) -> None:
@@ -23,15 +25,17 @@ class TestCheckpointFromSidecar:
                 issue_url="https://github.com/o/r/issues/3", status="completed", ts="t3"
             ),
         ]
-        cp = checkpoint_from_sidecar(entries)
+        cp = checkpoint_from_sidecar(entries, **_PROVENANCE)
         assert cp.completed_items == [
             "https://github.com/o/r/issues/1",
             "https://github.com/o/r/issues/3",
         ]
         assert cp.step_name == "fleet_dispatch"
+        assert cp.backend_name == "codex"
+        assert cp.skill_name == "implementation"
 
     def test_empty_entries(self) -> None:
-        cp = checkpoint_from_sidecar([])
+        cp = checkpoint_from_sidecar([], **_PROVENANCE)
         assert cp.completed_items == []
         assert cp.ts == ""
 
@@ -40,14 +44,14 @@ class TestCheckpointFromSidecar:
             IssueSidecarEntry(issue_url="u1", status="completed", ts="2026-01-01"),
             IssueSidecarEntry(issue_url="u2", status="completed", ts="2026-05-04"),
         ]
-        cp = checkpoint_from_sidecar(entries)
+        cp = checkpoint_from_sidecar(entries, **_PROVENANCE)
         assert cp.ts == "2026-05-04"
 
     def test_produces_valid_checkpoint(self) -> None:
         entries = [
             IssueSidecarEntry(issue_url="u1", status="completed", ts="t"),
         ]
-        cp = checkpoint_from_sidecar(entries)
+        cp = checkpoint_from_sidecar(entries, **_PROVENANCE)
         d = cp.to_dict()
         from autoskillit.core.types._type_checkpoint import SessionCheckpoint
 
@@ -66,7 +70,7 @@ class TestCheckpointFromTracker:
                 "review-pr": {"status": "pending"},
             },
         }
-        checkpoint = checkpoint_from_tracker(tracker_data)
+        checkpoint = checkpoint_from_tracker(tracker_data, **_PROVENANCE)
         assert checkpoint is not None
         assert checkpoint.completed_items == [
             "plan",
@@ -75,6 +79,8 @@ class TestCheckpointFromTracker:
         ]  # sorted by completed_at
         assert checkpoint.step_name == "implement"
         assert checkpoint.progress_pct == pytest.approx(0.75)
+        assert checkpoint.backend_name == "codex"
+        assert checkpoint.skill_name == "implementation"
 
     def test_tracker_with_no_completed_steps_returns_none(self) -> None:
         tracker_data = {
@@ -84,7 +90,7 @@ class TestCheckpointFromTracker:
                 "verify": {"status": "pending"},
             },
         }
-        checkpoint = checkpoint_from_tracker(tracker_data)
+        checkpoint = checkpoint_from_tracker(tracker_data, **_PROVENANCE)
         assert checkpoint is None
 
     def test_tracker_empty_steps_returns_none(self) -> None:
@@ -92,11 +98,11 @@ class TestCheckpointFromTracker:
             "pipeline_id": "dispatch-123",
             "steps": {},
         }
-        checkpoint = checkpoint_from_tracker(tracker_data)
+        checkpoint = checkpoint_from_tracker(tracker_data, **_PROVENANCE)
         assert checkpoint is None
 
     def test_tracker_missing_file_returns_none(self) -> None:
-        checkpoint = checkpoint_from_tracker(None)
+        checkpoint = checkpoint_from_tracker(None, **_PROVENANCE)
         assert checkpoint is None
 
     def test_tracker_sorts_by_completed_at(self) -> None:
@@ -107,7 +113,7 @@ class TestCheckpointFromTracker:
                 "plan": {"status": "complete", "completed_at": "2026-06-01T00:00:00Z"},
             },
         }
-        checkpoint = checkpoint_from_tracker(tracker_data)
+        checkpoint = checkpoint_from_tracker(tracker_data, **_PROVENANCE)
         assert checkpoint is not None
         assert checkpoint.step_name == "implement"
         assert checkpoint.ts == "2026-06-01T00:02:00Z"
@@ -121,7 +127,7 @@ class TestCheckpointFromTracker:
                 "plan": {"status": "complete", "completed_at": "2026-06-01T00:00:00Z"},
             },
         }
-        checkpoint = checkpoint_from_tracker(tracker_data)
+        checkpoint = checkpoint_from_tracker(tracker_data, **_PROVENANCE)
         assert checkpoint is not None
         d = checkpoint.to_dict()
         restored = SessionCheckpoint.from_dict(d)
@@ -135,7 +141,7 @@ class TestCheckpointFromTracker:
                 "verify": "bad_data",
             },
         }
-        checkpoint = checkpoint_from_tracker(tracker_data)
+        checkpoint = checkpoint_from_tracker(tracker_data, **_PROVENANCE)
         assert checkpoint is not None
         assert checkpoint.completed_items == ["plan"]
         assert checkpoint.progress_pct == pytest.approx(0.5)

--- a/tests/fleet/test_dispatch_backend_override.py
+++ b/tests/fleet/test_dispatch_backend_override.py
@@ -147,6 +147,7 @@ class TestDispatchRecordPersistsBackendName:
 
         record = _read_dispatch_record(tool_ctx)
         assert record["backend_name"] == "codex"
+        assert record["caller_backend_name"] == "claude-code"
 
 
 class TestDispatchRecordBackendNameDefaultsEmptyWhenOmitted:
@@ -207,10 +208,17 @@ class TestDispatchBackendOverrideInvalidNameRaises:
 class TestDispatchBackendOverridePreservedAcrossRetry:
     def test_dispatch_backend_override_preserved_across_retry(self):
         assert "backend_name" in _RETRY_IDENTITY_FIELDS
+        assert "caller_backend_name" in _RETRY_IDENTITY_FIELDS
 
-        record = DispatchRecord(name="test", backend_name="codex")
+        record = DispatchRecord(
+            name="test",
+            backend_name="codex",
+            caller_backend_name="claude-code",
+        )
         d = record.to_dict()
         assert d["backend_name"] == "codex"
+        assert d["caller_backend_name"] == "claude-code"
 
         restored = DispatchRecord.from_dict(d)
         assert restored.backend_name == "codex"
+        assert restored.caller_backend_name == "claude-code"

--- a/tests/fleet/test_dispatch_failure_semantics.py
+++ b/tests/fleet/test_dispatch_failure_semantics.py
@@ -538,3 +538,5 @@ class TestTrackerBridgeIntegration:
         assert record["reason"] == "fleet_l3_no_result_block"
         assert record.get("resume_checkpoint") is not None
         assert "plan" in record["resume_checkpoint"]["completed_items"]
+        assert record["resume_checkpoint"]["backend_name"] == tool_ctx.backend.name
+        assert record["resume_checkpoint"]["skill_name"] == "test-recipe"

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -191,6 +191,13 @@ class TestDispatchRecordFromDict:
         assert rec.token_usage == {}
         assert rec.sidecar_path is None
 
+    @pytest.mark.parametrize("invalid_backend", [None, 7, ["codex"]])
+    def test_from_dict_rejects_non_string_caller_backend(self, invalid_backend: object) -> None:
+        with pytest.raises(TypeError, match="caller_backend_name must be str"):
+            DispatchRecord.from_dict(
+                {"name": "invalid-provenance", "caller_backend_name": invalid_backend}
+            )
+
     def test_from_dict_pid_zero_not_falsy(self) -> None:
         d = {"name": "t", "dispatched_pid": 0, "l3_pid": 999}
         rec = DispatchRecord.from_dict(d)

--- a/tests/fleet/test_state_recovery.py
+++ b/tests/fleet/test_state_recovery.py
@@ -152,6 +152,14 @@ class TestDeriveOrchestratorResumeSpec:
         mismatch_spec = derive_orchestrator_resume_spec(state, current_backend="codex")
         assert isinstance(mismatch_spec, NoResume)
 
+    def test_derive_rejects_orchestrator_session_without_backend_provenance(self) -> None:
+        from autoskillit.fleet.state_recovery import derive_orchestrator_resume_spec
+
+        state = _make_state(orchestrator_session_id="legacy-session", dispatches=[])
+
+        spec = derive_orchestrator_resume_spec(state, current_backend="claude-code")
+        assert isinstance(spec, NoResume)
+
     def test_derive_validates_backend_match_for_caller_session_id_fallback(self) -> None:
         """Fallback caller_session_id path must also reject mismatched backends."""
         from autoskillit.fleet.state_recovery import derive_orchestrator_resume_spec
@@ -189,8 +197,8 @@ class TestDeriveOrchestratorResumeSpec:
         assert isinstance(spec, NamedResume)
         assert spec.session_id == "claude-orchestrator-session"
 
-    def test_derive_passes_when_legacy_record_has_no_caller_backend_name(self) -> None:
-        """Legacy records cannot safely infer caller provenance from the worker backend."""
+    def test_derive_rejects_legacy_record_without_caller_backend_name(self) -> None:
+        """Legacy records without caller provenance must fail closed."""
         from autoskillit.fleet.state_recovery import derive_orchestrator_resume_spec
 
         dispatches = [
@@ -204,8 +212,7 @@ class TestDeriveOrchestratorResumeSpec:
         state = _make_state(orchestrator_session_id="", dispatches=dispatches)
 
         spec = derive_orchestrator_resume_spec(state, current_backend="claude-code")
-        assert isinstance(spec, NamedResume)
-        assert spec.session_id == "legacy-session"
+        assert isinstance(spec, NoResume)
 
 
 class TestResumeDecisionDispatchId:

--- a/tests/fleet/test_state_recovery.py
+++ b/tests/fleet/test_state_recovery.py
@@ -138,7 +138,7 @@ class TestDeriveOrchestratorResumeSpec:
         dispatches = [
             DispatchRecord(
                 name="dispatch-1",
-                backend_name="claude-code",
+                caller_backend_name="claude-code",
                 caller_session_id="claude-session-abc",
             ),
         ]
@@ -160,7 +160,7 @@ class TestDeriveOrchestratorResumeSpec:
             DispatchRecord(
                 name="dispatch-1",
                 status=DispatchStatus.SUCCESS,
-                backend_name="codex",
+                caller_backend_name="codex",
                 caller_session_id="codex-session-xyz",
             ),
         ]
@@ -170,8 +170,27 @@ class TestDeriveOrchestratorResumeSpec:
         mismatch_spec = derive_orchestrator_resume_spec(state, current_backend="claude-code")
         assert isinstance(mismatch_spec, NoResume)
 
-    def test_derive_passes_when_backend_name_missing(self) -> None:
-        """When dispatch record has no backend_name, fall through to NamedResume."""
+    def test_derive_uses_caller_backend_instead_of_dispatched_worker_backend(self) -> None:
+        """A heterogeneous worker backend must not invalidate the caller session."""
+        from autoskillit.fleet.state_recovery import derive_orchestrator_resume_spec
+
+        dispatches = [
+            DispatchRecord(
+                name="dispatch-1",
+                status=DispatchStatus.SUCCESS,
+                caller_session_id="claude-orchestrator-session",
+                caller_backend_name="claude-code",
+                backend_name="codex",
+            ),
+        ]
+        state = _make_state(orchestrator_session_id="", dispatches=dispatches)
+
+        spec = derive_orchestrator_resume_spec(state, current_backend="claude-code")
+        assert isinstance(spec, NamedResume)
+        assert spec.session_id == "claude-orchestrator-session"
+
+    def test_derive_passes_when_legacy_record_has_no_caller_backend_name(self) -> None:
+        """Legacy records cannot safely infer caller provenance from the worker backend."""
         from autoskillit.fleet.state_recovery import derive_orchestrator_resume_spec
 
         dispatches = [
@@ -179,11 +198,12 @@ class TestDeriveOrchestratorResumeSpec:
                 name="dispatch-1",
                 status=DispatchStatus.SUCCESS,
                 caller_session_id="legacy-session",
+                backend_name="codex",
             ),
         ]
         state = _make_state(orchestrator_session_id="", dispatches=dispatches)
 
-        spec = derive_orchestrator_resume_spec(state, current_backend="codex")
+        spec = derive_orchestrator_resume_spec(state, current_backend="claude-code")
         assert isinstance(spec, NamedResume)
         assert spec.session_id == "legacy-session"
 

--- a/tests/fleet/test_state_recovery.py
+++ b/tests/fleet/test_state_recovery.py
@@ -131,6 +131,62 @@ class TestDeriveOrchestratorResumeSpec:
         result = derive_orchestrator_resume_spec(state)
         assert result == NoResume()
 
+    def test_derive_validates_backend_match_for_orchestrator_session(self) -> None:
+        """Resume spec must reject session_id from a different backend."""
+        from autoskillit.fleet.state_recovery import derive_orchestrator_resume_spec
+
+        dispatches = [
+            DispatchRecord(
+                name="dispatch-1",
+                backend_name="claude-code",
+                caller_session_id="claude-session-abc",
+            ),
+        ]
+        state = _make_state(orchestrator_session_id="claude-session-abc", dispatches=dispatches)
+
+        # Same backend → NamedResume
+        same_spec = derive_orchestrator_resume_spec(state, current_backend="claude-code")
+        assert isinstance(same_spec, NamedResume)
+
+        # Different backend → NoResume
+        mismatch_spec = derive_orchestrator_resume_spec(state, current_backend="codex")
+        assert isinstance(mismatch_spec, NoResume)
+
+    def test_derive_validates_backend_match_for_caller_session_id_fallback(self) -> None:
+        """Fallback caller_session_id path must also reject mismatched backends."""
+        from autoskillit.fleet.state_recovery import derive_orchestrator_resume_spec
+
+        dispatches = [
+            DispatchRecord(
+                name="dispatch-1",
+                status=DispatchStatus.SUCCESS,
+                backend_name="codex",
+                caller_session_id="codex-session-xyz",
+            ),
+        ]
+        state = _make_state(orchestrator_session_id="", dispatches=dispatches)
+
+        # Mismatched backend → NoResume
+        mismatch_spec = derive_orchestrator_resume_spec(state, current_backend="claude-code")
+        assert isinstance(mismatch_spec, NoResume)
+
+    def test_derive_passes_when_backend_name_missing(self) -> None:
+        """When dispatch record has no backend_name, fall through to NamedResume."""
+        from autoskillit.fleet.state_recovery import derive_orchestrator_resume_spec
+
+        dispatches = [
+            DispatchRecord(
+                name="dispatch-1",
+                status=DispatchStatus.SUCCESS,
+                caller_session_id="legacy-session",
+            ),
+        ]
+        state = _make_state(orchestrator_session_id="", dispatches=dispatches)
+
+        spec = derive_orchestrator_resume_spec(state, current_backend="codex")
+        assert isinstance(spec, NamedResume)
+        assert spec.session_id == "legacy-session"
+
 
 class TestResumeDecisionDispatchId:
     def test_resume_decision_carries_dispatch_id(self) -> None:

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -369,6 +369,7 @@ class TestDispatchRecordToDict:
             "dispatch_id",
             "campaign_id",
             "caller_session_id",
+            "caller_backend_name",
             "dispatched_session_id",
             "session_chain",
             "dispatched_session_log_dir",

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -128,7 +128,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools/tools_status.py", 536),
     # tools_github.py — bug report dict (non-blocking report-bug status file)
-    ("src/autoskillit/server/tools/tools_github.py", 343),
+    ("src/autoskillit/server/tools/tools_github.py", 317),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 24),
     # _init_helpers.py — ~/.claude.json (co-owned)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -127,8 +127,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools/tools_status.py", 536),
-    # tools_github.py — bug report dict
-    ("src/autoskillit/server/tools/tools_github.py", 312),
+    # tools_github.py — bug report dict (non-blocking report-bug status file)
+    ("src/autoskillit/server/tools/tools_github.py", 338),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 24),
     # _init_helpers.py — ~/.claude.json (co-owned)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -128,7 +128,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools/tools_status.py", 536),
     # tools_github.py — bug report dict (non-blocking report-bug status file)
-    ("src/autoskillit/server/tools/tools_github.py", 338),
+    ("src/autoskillit/server/tools/tools_github.py", 343),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 24),
     # _init_helpers.py — ~/.claude.json (co-owned)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -119,10 +119,10 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 90),
     # tools_kitchen.py — hook config, quota guard, git_ops_policy, ingredient locks overlay
-    ("src/autoskillit/server/tools/tools_kitchen.py", 237),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 256),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 290),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 1261),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 240),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 259),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 293),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1275),
     # tools_pipeline_tracker.py — tracker_data dict
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 166),
     # tools_status.py — mcp_data dict

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -356,6 +356,7 @@ def test_load_and_validate_cache_key_includes_all_result_affecting_params(tmp_pa
         "_user_method_traditions_hash": 9,
         "backend_name": 10,
         "effective_backend_map": 11,
+        "backend_capabilities_map": 12,
     }
 
     missing_params: list[str] = []
@@ -464,6 +465,7 @@ def test_repository_load_and_validate_passes_recipe_info_to_api(monkeypatch):
         name,
         project_dir,
         *,
+        backend_capabilities_map=None,
         suppressed=None,
         recipe_info=None,
         recipe_list=None,
@@ -476,6 +478,7 @@ def test_repository_load_and_validate_passes_recipe_info_to_api(monkeypatch):
         effective_backend_map=None,
     ):
         captured["recipe_info"] = recipe_info
+        captured["backend_capabilities_map"] = locals().get("backend_capabilities_map")
         captured["recipe_list"] = recipe_list
         return real_fn(
             name,
@@ -490,6 +493,7 @@ def test_repository_load_and_validate_passes_recipe_info_to_api(monkeypatch):
             defer_unresolved=defer_unresolved,
             backend_name=backend_name,
             effective_backend_map=effective_backend_map,
+            backend_capabilities_map=backend_capabilities_map,
         )
 
     monkeypatch.setattr(api_mod, "load_and_validate", capturing_fn)

--- a/tests/recipe/test_cmd_rpc_merge.py
+++ b/tests/recipe/test_cmd_rpc_merge.py
@@ -111,3 +111,91 @@ def test_queue_ejected_fix_returns_fetch_error_on_network_failure():
 
     assert result["status"] == "fetch_error", f"Expected fetch_error, got: {result}"
     assert "Could not resolve host" in result.get("stderr", "")
+
+
+def test_queue_ejected_fix_returns_conflicts_with_stderr():
+    """Rebase failure must preserve stderr for downstream diagnostics."""
+    from autoskillit.recipe._cmd_rpc_merge import queue_ejected_fix
+
+    responses = [
+        _mock_result(0, "origin\n", ""),  # _detect_remote
+        _mock_result(0, "", ""),  # fetch
+        _mock_result(1, "", "CONFLICT (content): ..."),  # rebase (fails)
+        _mock_result(0, "", ""),  # rebase --abort
+    ]
+    fake = _fake_run_git_factory(responses=responses, call_log=[])
+
+    with patch("autoskillit.recipe._cmd_rpc_merge.run_git", side_effect=fake):
+        result = queue_ejected_fix(work_dir="/tmp/test", base_branch="main")
+
+    assert result["status"] == "conflicts"
+    assert "stderr" in result
+    assert "CONFLICT" in result["stderr"]
+
+
+def test_queue_ejected_fix_distinguishes_dirty_tree():
+    """Dirty-tree rebase rejection must still surface stderr for diagnostics."""
+    from autoskillit.recipe._cmd_rpc_merge import queue_ejected_fix
+
+    responses = [
+        _mock_result(0, "origin\n", ""),
+        _mock_result(0, "", ""),
+        _mock_result(1, "", "cannot rebase: you have unstaged changes"),
+        _mock_result(0, "", ""),
+    ]
+    fake = _fake_run_git_factory(responses=responses, call_log=[])
+
+    with patch("autoskillit.recipe._cmd_rpc_merge.run_git", side_effect=fake):
+        result = queue_ejected_fix(work_dir="/tmp/test", base_branch="main")
+
+    assert result["status"] == "conflicts"
+    assert "stderr" in result
+    assert "unstaged changes" in result["stderr"]
+
+
+def test_attempt_cheap_rebase_returns_conflicts_with_stderr():
+    """attempt_cheap_rebase must preserve stderr on rebase failure path."""
+    from autoskillit.recipe._cmd_rpc_merge import attempt_cheap_rebase
+
+    responses = [
+        _mock_result(0, "origin\n", ""),  # _detect_remote
+        _mock_result(0, "", ""),  # fetch ejected_pr_branch (check=True)
+        _mock_result(0, "", ""),  # fetch base_branch
+        _mock_result(0, "", ""),  # checkout ejected_pr_branch (check=True)
+        _mock_result(1, "", "CONFLICT (content): Merge conflict in x.py"),  # rebase fails
+        _mock_result(0, "", ""),  # rebase --abort
+    ]
+    fake = _fake_run_git_factory(responses=responses, call_log=[])
+
+    with patch("autoskillit.recipe._cmd_rpc_merge.run_git", side_effect=fake):
+        result = attempt_cheap_rebase(
+            work_dir="/tmp/test", ejected_pr_branch="pr-branch", base_branch="main"
+        )
+
+    assert result["status"] == "conflicts"
+    assert "stderr" in result
+    assert "CONFLICT" in result["stderr"]
+
+
+def test_proactive_rebase_next_pr_returns_conflicts_with_stderr():
+    """proactive_rebase_next_pr must preserve stderr on rebase failure path."""
+    from autoskillit.recipe._cmd_rpc_merge import proactive_rebase_next_pr
+
+    responses = [
+        _mock_result(0, "origin\n", ""),  # _detect_remote
+        _mock_result(0, "", ""),  # fetch next_pr_branch (check=True)
+        _mock_result(0, "", ""),  # fetch base_branch
+        _mock_result(0, "", ""),  # checkout -B (check=True)
+        _mock_result(1, "", "CONFLICT (content): Merge conflict in y.py"),  # rebase fails
+        _mock_result(0, "", ""),  # rebase --abort
+    ]
+    fake = _fake_run_git_factory(responses=responses, call_log=[])
+
+    with patch("autoskillit.recipe._cmd_rpc_merge.run_git", side_effect=fake):
+        result = proactive_rebase_next_pr(
+            work_dir="/tmp/test", next_pr_branch="next-pr", base_branch="main"
+        )
+
+    assert result["status"] == "conflicts"
+    assert "stderr" in result
+    assert "CONFLICT" in result["stderr"]

--- a/tests/recipe/test_repository.py
+++ b/tests/recipe/test_repository.py
@@ -176,6 +176,7 @@ def test_validate_from_path_delegates_to_api(tmp_path: Path) -> None:
         backend_name=None,
         ingredient_overrides=None,
         effective_backend_map=None,
+        backend_capabilities_map=None,
     )
 
 

--- a/tests/recipe/test_rules_backend_compat.py
+++ b/tests/recipe/test_rules_backend_compat.py
@@ -19,6 +19,7 @@ pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 def _make_skill_info(
     name: str = "investigate",
     backend_requirements: frozenset[str] = frozenset({"claude-code"}),
+    uses_capabilities: frozenset[str] = frozenset(),
 ) -> SimpleNamespace:
     return SimpleNamespace(
         name=name,
@@ -26,6 +27,7 @@ def _make_skill_info(
         path=Path("/nonexistent/SKILL.md"),
         categories=frozenset(),
         backend_requirements=backend_requirements,
+        uses_capabilities=uses_capabilities,
     )
 
 
@@ -117,6 +119,52 @@ class TestBackendIncompatibleSkillRule:
         findings = run_semantic_rules(ctx)
         compat_findings = [f for f in findings if f.rule == "backend-incompatible-skill"]
         assert len(compat_findings) == 0
+
+    def test_rules_backend_compat_fires_for_worker_routable_pinned_to_codex(self):
+        """A worker_routable skill (empty backend_requirements, only
+        uses_capabilities=frozenset({'git_metadata_write'})) explicitly pinned
+        via effective_backend_map to a codex backend that lacks the required
+        BackendCapabilities.git_metadata_writable property must fire the
+        backend-incompatible-skill rule."""
+        from autoskillit.core.types._type_backend import BackendCapabilities
+
+        # resolve-review declares uses_capabilities=[..., git_metadata_write, ...]
+        # but the /investigate fixture resolver returns a worker_routable
+        # skill with empty backend_requirements and only git_metadata_write
+        # capability — matches the architecturally interesting case.
+        skill_info = _make_skill_info(
+            name="resolve-review",
+            backend_requirements=frozenset(),
+            uses_capabilities=frozenset({"git_metadata_write"}),
+        )
+        steps = {
+            "run-skill-step": RecipeStep(
+                tool="run_skill",
+                with_args={"skill_command": "/resolve-review", "cwd": "/tmp"},
+            )
+        }
+        recipe = Recipe(name="test-recipe", description="test", steps=steps)
+        resolver = _mock_resolver(skill_info)
+        codex_caps = BackendCapabilities(git_metadata_writable=False)
+        ctx = make_validation_context(
+            recipe,
+            backend_name="claude-code",
+            skill_resolver=resolver,
+            effective_backend_map={"run-skill-step": "codex"},
+            backend_capabilities_map={"codex": codex_caps},
+            available_skills=frozenset({"resolve-review"}),
+        )
+        findings = run_semantic_rules(ctx)
+        compat_findings = [f for f in findings if f.rule == "backend-incompatible-skill"]
+        assert len(compat_findings) == 1, (
+            f"Expected one backend-incompatible-skill finding for worker_routable "
+            f"skill pinned to codex, got {compat_findings}"
+        )
+        msg = compat_findings[0].message
+        assert "git_metadata_writable" in msg, (
+            f"Finding must mention git_metadata_writable capability mismatch, got: {msg!r}"
+        )
+        assert "codex" in msg, f"Finding must reference the pinned codex backend, got: {msg!r}"
 
 
 _RECIPE_WITH_SKILL_STEP_YAML = """\

--- a/tests/recipe/test_rules_backend_compat.py
+++ b/tests/recipe/test_rules_backend_compat.py
@@ -256,6 +256,48 @@ class TestBackendNameThreadingAPI:
         cache = cache_mod._LOAD_CACHE
         assert len(cache._store) == 2
 
+    def test_cache_key_varies_by_backend_capability_values(self, tmp_path, monkeypatch):
+        import autoskillit.recipe._api as api_mod
+        import autoskillit.recipe._api_cache as cache_mod
+        from autoskillit.core import BackendCapabilities
+
+        monkeypatch.setattr(cache_mod, "_LOAD_CACHE", cache_mod.LoadCache())
+
+        recipes_dir = tmp_path / ".autoskillit" / "recipes"
+        recipes_dir.mkdir(parents=True)
+        (recipes_dir / "test-compat.yaml").write_text(_RECIPE_WITH_SKILL_STEP_YAML)
+
+        skill_info = _make_skill_info(
+            backend_requirements=frozenset(),
+            uses_capabilities=frozenset({"git_metadata_write"}),
+        )
+        resolver = _FakeSkillResolver(skill_info)
+
+        incapable = api_mod.load_and_validate(
+            "test-compat",
+            tmp_path,
+            backend_name="codex",
+            backend_capabilities_map={"codex": BackendCapabilities(git_metadata_writable=False)},
+            lister=resolver,
+        )
+        capable = api_mod.load_and_validate(
+            "test-compat",
+            tmp_path,
+            backend_name="codex",
+            backend_capabilities_map={"codex": BackendCapabilities(git_metadata_writable=True)},
+            lister=resolver,
+        )
+
+        assert any(
+            finding.get("rule") == "backend-incompatible-skill"
+            for finding in incapable["suggestions"]
+        )
+        assert not any(
+            finding.get("rule") == "backend-incompatible-skill"
+            for finding in capable["suggestions"]
+        )
+        assert len(cache_mod._LOAD_CACHE._store) == 2
+
 
 # ---------------------------------------------------------------------------
 # Backend-parameterized bundled recipe validation tests

--- a/tests/server/test_admission_dispatch_agreement.py
+++ b/tests/server/test_admission_dispatch_agreement.py
@@ -17,6 +17,7 @@ installed package. Filesystem access is required (no network).
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -611,59 +612,87 @@ def test_auto_overrides_git_ingredient_set_by_git_capability(
 # ---------------------------------------------------------------------------
 
 
-def test_admission_dispatch_agreement_with_explicit_pin(tmp_path: Path) -> None:
-    """Admission ↔ dispatch agreement when a single step is explicitly pinned
-    to a backend that cannot satisfy the step's hard capability.
+@pytest.mark.parametrize(
+    "config_backend_kwargs",
+    [
+        pytest.param(
+            {"recipe_overrides": {"test-explicit-pin": {"run-skill-step": "codex"}}},
+            id="recipe_overrides",
+        ),
+        pytest.param(
+            {"step_overrides": {"run-skill-step": "codex"}},
+            id="step_overrides",
+        ),
+    ],
+)
+def test_admission_dispatch_agreement_with_explicit_pin(
+    tmp_path: Path,
+    config_backend_kwargs: dict[str, Any],
+) -> None:
+    """Admission <-> dispatch agreement when a step is explicitly pinned via
+    config_backend (recipe_overrides or step_overrides) to a backend that
+    cannot satisfy the step's hard capability.
 
-    Construct a minimal recipe with one ``run_skill`` step whose skill
-    declares ``uses_capabilities={'git_metadata_write'}`` and
-    ``backend_requirements=frozenset()`` (the worker_routable shape). Pin
-    that step to codex via the ``effective_backend_map``, and supply codex
-    backend capabilities with ``git_metadata_writable=False``. Both
-    admission (``load_and_validate``) and dispatch
-    (``check_hard_capability_feasibility`` against the explicit-pin
-    effective backend) must agree: this step is infeasible on the pinned
-    backend due to the capability mismatch.
-
-    The agreement contract: if admission deems the recipe infeasible /
-    surfaces the capability mismatch, dispatch must produce the same
-    capability mismatch when called against the same effective pinned
-    backend.
+    Exercises three independent production code paths against the identical
+    pinned scenario and proves they all agree the step is infeasible:
+      * recipe-load-time semantic rule (rules_backend_compat.py, via
+        load_and_validate) — advisory finding at first validation.
+      * open_kitchen-time preflight gate (_check_dispatch_feasibility) — the
+        blocking admission gate this PART A fix added.
+      * run_skill-time dispatch gate (_check_backend_compat) — the final
+        enforcement point before a skill actually executes.
     """
     import json as _json
-    from unittest.mock import MagicMock
+    from unittest.mock import MagicMock, patch
 
+    from autoskillit.config._config_dataclasses import AgentBackendConfig, ProvidersConfig
     from autoskillit.core import BackendCapabilities
-    from autoskillit.server.tools._preflight import check_hard_capability_feasibility
+    from autoskillit.recipe.schema import RecipeStep
+    from autoskillit.server.tools._auto_overrides import _compute_effective_backend_map
+    from autoskillit.server.tools._preflight import _check_dispatch_feasibility
     from autoskillit.server.tools.tools_execution import _check_backend_compat
 
+    recipe_name = "test-explicit-pin"
     step_name = "run-skill-step"
     skill_command = "/autoskillit:resolve-review feature main"
     target_skill_name = "resolve-review"
 
-    # Skill resolver whose skill has empty backend_requirements and only the
-    # git_metadata_write capability — the worker_routable shape that bypasses
-    # the legacy backend_requirements mismatch gate.
     skill_info = MagicMock()
     skill_info.name = target_skill_name
     skill_info.backend_requirements = frozenset()
     skill_info.uses_capabilities = frozenset({"git_metadata_write"})
-    skill_info.path = Path(__file__).resolve()
     resolver = MagicMock()
     resolver.resolve.return_value = skill_info
-    resolver.list_all.return_value = [skill_info]
 
-    # Codex backend lacking git_metadata_writable — capability mismatch target.
     codex_caps = BackendCapabilities(git_metadata_writable=False)
     codex_backend = MagicMock()
     codex_backend.name = "codex"
     codex_backend.capabilities = codex_caps
 
-    # Persist the recipe to a temp location so load_and_validate can read it.
-    _recipes_dir = tmp_path / ".autoskillit" / "recipes"
-    _recipes_dir.mkdir(parents=True)
-    (_recipes_dir / "test-explicit-pin.yaml").write_text(
-        "name: test-explicit-pin\n"
+    orchestrator_backend = MagicMock()
+    orchestrator_backend.name = "claude-code"
+
+    step = RecipeStep(name=step_name, tool="run_skill", with_args={"skill_command": skill_command})
+    config_backend = AgentBackendConfig(backend="claude-code", **config_backend_kwargs)
+
+    # Derive effective_backend_map from the SAME config_backend production IL-3
+    # call sites use (_compute_effective_backend_map), instead of hand-
+    # constructing the map, so this test proves the whole resolution chain —
+    # not just the two downstream gates — agrees on the pinned backend.
+    effective_map = _compute_effective_backend_map(
+        {step_name: step},
+        "claude-code",
+        None,
+        recipe_name,
+        skill_resolver=resolver,
+        config_backend=config_backend,
+    )
+    assert effective_map == {step_name: "codex"}
+
+    recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    recipes_dir.mkdir(parents=True)
+    (recipes_dir / f"{recipe_name}.yaml").write_text(
+        f"name: {recipe_name}\n"
         "description: explicit-pin agreement test\n"
         'autoskillit_version: "0.2.0"\n'
         "steps:\n"
@@ -675,33 +704,46 @@ def test_admission_dispatch_agreement_with_explicit_pin(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    # Call admission with effective_backend_map pinning the step to codex.
+    # --- Leg 1: recipe-load-time semantic rule (rules_backend_compat.py) ---
     admission_result = load_and_validate(
-        "test-explicit-pin",
+        recipe_name,
         project_dir=tmp_path,
         backend_name="claude-code",
-        effective_backend_map={step_name: "codex"},
+        effective_backend_map=effective_map,
         backend_capabilities_map={"codex": codex_caps},
         lister=resolver,
     )
-
-    # --- ADMISSION side of the agreement ---
-    # Admission must surface the capability mismatch via one of:
-    #   * dispatch_feasible=False (refused outright)
-    #   * A suggestion/finding mentioning the git_metadata_writable mismatch
-    _admission_feasible = admission_result.get("dispatch_feasible", True)
-    _admission_findings = admission_result.get("suggestions", []) + admission_result.get(
+    admission_findings = admission_result.get("suggestions", []) + admission_result.get(
         "findings", []
     )
-    _admission_mentions_cap = any(
-        "git_metadata_writable" in str(f) or "git_metadata_write" in str(f)
-        for f in _admission_findings
+    assert any("git_metadata_writable" in str(f) for f in admission_findings), (
+        f"rules_backend_compat.py must surface the capability mismatch, got: {admission_findings}"
     )
 
-    # --- DISPATCH side of the agreement ---
-    # Dispatch is exercised by _check_backend_compat with the same
-    # effective pinned backend (codex, lacking the capability property).
-    _dispatch_err = _check_backend_compat(
+    # --- Leg 2: open_kitchen-time preflight gate (_check_dispatch_feasibility) ---
+    # get_backend("codex") is patched so the pinned-backend lookup resolves to
+    # the same codex_backend double used for the dispatch-side call below —
+    # keeps all three legs checking the identical capability state.
+    with patch("autoskillit.server.tools._preflight.get_backend", return_value=codex_backend):
+        preflight_err = _check_dispatch_feasibility(
+            post_prune_step_names=[step_name],
+            active_recipe_steps={step_name: step},
+            backend=orchestrator_backend,
+            config_providers=ProvidersConfig(),
+            recipe_name=recipe_name,
+            config_backend=config_backend,
+            skill_resolver=resolver,
+        )
+    assert preflight_err is not None, (
+        "_check_dispatch_feasibility must reject an explicit pin to a backend "
+        "lacking the required capability property"
+    )
+    preflight_parsed = _json.loads(preflight_err)
+    assert "git_metadata_writable" in preflight_parsed.get("error", "")
+    assert preflight_parsed.get("override_source") == "explicit_config"
+
+    # --- Leg 3: run_skill-time dispatch gate (_check_backend_compat) ---
+    dispatch_err = _check_backend_compat(
         skill_command=skill_command,
         resolved_command=target_skill_name,
         effective_order_id="test-order",
@@ -710,39 +752,9 @@ def test_admission_dispatch_agreement_with_explicit_pin(tmp_path: Path) -> None:
         effective_backend_obj=codex_backend,
         skill_resolver=resolver,
     )
-    # Direct hard-capability check on the same backend — the canonical
-    # capability-feasibility gate for worker_routable pinned steps.
-    _hard_cap_err = check_hard_capability_feasibility(
-        frozenset({"git_metadata_write"}),
-        codex_backend,
+    assert dispatch_err is not None, (
+        "_check_backend_compat must reject the same explicit pin at dispatch time"
     )
-
-    # Dispatch definitively rejects (returns diagnostic) — that's the
-    # canonical capability-feasibility gate.
-    assert _hard_cap_err is not None, (
-        "check_hard_capability_feasibility must report the capability "
-        "mismatch on a codex backend with git_metadata_writable=False"
-    )
-    assert "git_metadata_writable" in _hard_cap_err
-    assert _dispatch_err is not None, (
-        "_check_backend_compat must reject the explicit-pin to a backend "
-        "that lacks the required capability property"
-    )
-    _dispatch_parsed = _json.loads(_dispatch_err)
-    assert _dispatch_parsed.get("subtype") == "crashed", (
-        f"dispatch crash envelope subtype must be 'crashed', got {_dispatch_parsed}"
-    )
-
-    # The agreement: admission must NOT silently disagree with dispatch.
-    # If admission says feasible=True AND no capability finding exists,
-    # that is a structural disagreement — dispatch will fail at run_skill
-    # time even though admission admitted the pipeline.
-    admission_says_infeasible = _admission_feasible is False
-    admission_says_finding = _admission_mentions_cap
-    assert admission_says_infeasible or admission_says_finding, (
-        "Admission ↔ dispatch agreement violated: dispatch rejects "
-        f"({_hard_cap_err!r}) but admission reported dispatch_feasible="
-        f"{_admission_feasible!r} with no finding mentioning "
-        "git_metadata_writable/git_metadata_write. "
-        f"Admission findings: {_admission_findings!r}"
-    )
+    dispatch_parsed = _json.loads(dispatch_err)
+    assert dispatch_parsed.get("subtype") == "crashed"
+    assert "git_metadata_writable" in str(dispatch_parsed)

--- a/tests/server/test_admission_dispatch_agreement.py
+++ b/tests/server/test_admission_dispatch_agreement.py
@@ -604,3 +604,145 @@ def test_auto_overrides_git_ingredient_set_by_git_capability(
         "git_metadata_write must flip backend_supports_git_write"
     )
     assert detail.resolution_path == "capability_route"
+
+
+# ---------------------------------------------------------------------------
+# Explicit-pin admission ↔ dispatch agreement (REQ-RES-001 follow-up)
+# ---------------------------------------------------------------------------
+
+
+def test_admission_dispatch_agreement_with_explicit_pin(tmp_path: Path) -> None:
+    """Admission ↔ dispatch agreement when a single step is explicitly pinned
+    to a backend that cannot satisfy the step's hard capability.
+
+    Construct a minimal recipe with one ``run_skill`` step whose skill
+    declares ``uses_capabilities={'git_metadata_write'}`` and
+    ``backend_requirements=frozenset()`` (the worker_routable shape). Pin
+    that step to codex via the ``effective_backend_map``, and supply codex
+    backend capabilities with ``git_metadata_writable=False``. Both
+    admission (``load_and_validate``) and dispatch
+    (``check_hard_capability_feasibility`` against the explicit-pin
+    effective backend) must agree: this step is infeasible on the pinned
+    backend due to the capability mismatch.
+
+    The agreement contract: if admission deems the recipe infeasible /
+    surfaces the capability mismatch, dispatch must produce the same
+    capability mismatch when called against the same effective pinned
+    backend.
+    """
+    import json as _json
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import BackendCapabilities
+    from autoskillit.server.tools._preflight import check_hard_capability_feasibility
+    from autoskillit.server.tools.tools_execution import _check_backend_compat
+
+    step_name = "run-skill-step"
+    skill_command = "/autoskillit:resolve-review feature main"
+    target_skill_name = "resolve-review"
+
+    # Skill resolver whose skill has empty backend_requirements and only the
+    # git_metadata_write capability — the worker_routable shape that bypasses
+    # the legacy backend_requirements mismatch gate.
+    skill_info = MagicMock()
+    skill_info.name = target_skill_name
+    skill_info.backend_requirements = frozenset()
+    skill_info.uses_capabilities = frozenset({"git_metadata_write"})
+    skill_info.path = Path(__file__).resolve()
+    resolver = MagicMock()
+    resolver.resolve.return_value = skill_info
+    resolver.list_all.return_value = [skill_info]
+
+    # Codex backend lacking git_metadata_writable — capability mismatch target.
+    codex_caps = BackendCapabilities(git_metadata_writable=False)
+    codex_backend = MagicMock()
+    codex_backend.name = "codex"
+    codex_backend.capabilities = codex_caps
+
+    # Persist the recipe to a temp location so load_and_validate can read it.
+    _recipes_dir = tmp_path / ".autoskillit" / "recipes"
+    _recipes_dir.mkdir(parents=True)
+    (_recipes_dir / "test-explicit-pin.yaml").write_text(
+        "name: test-explicit-pin\n"
+        "description: explicit-pin agreement test\n"
+        'autoskillit_version: "0.2.0"\n'
+        "steps:\n"
+        f"  {step_name}:\n"
+        "    tool: run_skill\n"
+        "    with:\n"
+        f'      skill_command: "{skill_command}"\n'
+        "      cwd: /tmp\n",
+        encoding="utf-8",
+    )
+
+    # Call admission with effective_backend_map pinning the step to codex.
+    admission_result = load_and_validate(
+        "test-explicit-pin",
+        project_dir=tmp_path,
+        backend_name="claude-code",
+        effective_backend_map={step_name: "codex"},
+        backend_capabilities_map={"codex": codex_caps},
+        lister=resolver,
+    )
+
+    # --- ADMISSION side of the agreement ---
+    # Admission must surface the capability mismatch via one of:
+    #   * dispatch_feasible=False (refused outright)
+    #   * A suggestion/finding mentioning the git_metadata_writable mismatch
+    _admission_feasible = admission_result.get("dispatch_feasible", True)
+    _admission_findings = admission_result.get("suggestions", []) + admission_result.get(
+        "findings", []
+    )
+    _admission_mentions_cap = any(
+        "git_metadata_writable" in str(f) or "git_metadata_write" in str(f)
+        for f in _admission_findings
+    )
+
+    # --- DISPATCH side of the agreement ---
+    # Dispatch is exercised by _check_backend_compat with the same
+    # effective pinned backend (codex, lacking the capability property).
+    _dispatch_err = _check_backend_compat(
+        skill_command=skill_command,
+        resolved_command=target_skill_name,
+        effective_order_id="test-order",
+        target_name=target_skill_name,
+        skill_info=skill_info,
+        effective_backend_obj=codex_backend,
+        skill_resolver=resolver,
+    )
+    # Direct hard-capability check on the same backend — the canonical
+    # capability-feasibility gate for worker_routable pinned steps.
+    _hard_cap_err = check_hard_capability_feasibility(
+        frozenset({"git_metadata_write"}),
+        codex_backend,
+    )
+
+    # Dispatch definitively rejects (returns diagnostic) — that's the
+    # canonical capability-feasibility gate.
+    assert _hard_cap_err is not None, (
+        "check_hard_capability_feasibility must report the capability "
+        "mismatch on a codex backend with git_metadata_writable=False"
+    )
+    assert "git_metadata_writable" in _hard_cap_err
+    assert _dispatch_err is not None, (
+        "_check_backend_compat must reject the explicit-pin to a backend "
+        "that lacks the required capability property"
+    )
+    _dispatch_parsed = _json.loads(_dispatch_err)
+    assert _dispatch_parsed.get("subtype") == "crashed", (
+        f"dispatch crash envelope subtype must be 'crashed', got {_dispatch_parsed}"
+    )
+
+    # The agreement: admission must NOT silently disagree with dispatch.
+    # If admission says feasible=True AND no capability finding exists,
+    # that is a structural disagreement — dispatch will fail at run_skill
+    # time even though admission admitted the pipeline.
+    admission_says_infeasible = _admission_feasible is False
+    admission_says_finding = _admission_mentions_cap
+    assert admission_says_infeasible or admission_says_finding, (
+        "Admission ↔ dispatch agreement violated: dispatch rejects "
+        f"({_hard_cap_err!r}) but admission reported dispatch_feasible="
+        f"{_admission_feasible!r} with no finding mentioning "
+        "git_metadata_writable/git_metadata_write. "
+        f"Admission findings: {_admission_findings!r}"
+    )

--- a/tests/server/test_admission_dispatch_agreement.py
+++ b/tests/server/test_admission_dispatch_agreement.py
@@ -661,6 +661,10 @@ def test_admission_dispatch_agreement_with_explicit_pin(
     skill_info.name = target_skill_name
     skill_info.backend_requirements = frozenset()
     skill_info.uses_capabilities = frozenset({"git_metadata_write"})
+    # Path pointing at a non-existent file so the SKILL.md read in
+    # `_check_undefined_bash_placeholder` raises OSError (caught by the rule)
+    # instead of returning a MagicMock that crashes `extract_bash_blocks`.
+    skill_info.path = Path("/nonexistent/SKILL.md")
     resolver = MagicMock()
     resolver.resolve.return_value = skill_info
 

--- a/tests/server/test_backend_ingredient_injection.py
+++ b/tests/server/test_backend_ingredient_injection.py
@@ -54,6 +54,31 @@ class TestBackendCapabilityOverrides:
         assert _backend_capability_overrides(backend) == {"backend_supports_git_write": "false"}
 
 
+class TestBackendCapabilitiesMap:
+    def test_uses_supplied_orchestrator_backend_capabilities(self) -> None:
+        from autoskillit.server.tools._serve_helpers import build_backend_capabilities_map
+
+        backend = _make_backend_with_capability(False)
+        with patch("autoskillit.server._misc.get_backend") as resolve_backend:
+            result = build_backend_capabilities_map({"step": "codex"}, backend)
+
+        assert result == {"codex": backend.capabilities}
+        resolve_backend.assert_not_called()
+
+    def test_unknown_effective_backend_is_not_silently_dropped(self) -> None:
+        from autoskillit.server.tools._serve_helpers import build_backend_capabilities_map
+
+        backend = _make_backend_with_capability(True)
+        with (
+            patch(
+                "autoskillit.server._misc.get_backend",
+                side_effect=ValueError("unknown backend"),
+            ),
+            pytest.raises(ValueError, match="unknown backend"),
+        ):
+            build_backend_capabilities_map({"step": "codexx_typo"}, backend)
+
+
 # ---------------------------------------------------------------------------
 # open_kitchen injection
 # ---------------------------------------------------------------------------

--- a/tests/server/test_capability_admission_e2e.py
+++ b/tests/server/test_capability_admission_e2e.py
@@ -991,6 +991,7 @@ async def test_all_infeasibility_paths_have_escape_hatch(build_ctx_open: Any) ->
             preflight_backend,
             MagicMock(),
             recipe_name="implementation",
+            skill_resolver=MagicMock(),
         )
     assert preflight_result is not None
     parsed = json.loads(preflight_result)

--- a/tests/server/test_preflight_explicit_backend.py
+++ b/tests/server/test_preflight_explicit_backend.py
@@ -37,6 +37,20 @@ def _make_backend(**kwargs):
     return AgentBackendConfig(**kwargs)
 
 
+def _make_skill_resolver_with_no_caps() -> MagicMock:
+    """Return a MagicMock skill_resolver whose .resolve() returns a stub
+    with empty uses_capabilities — preserves existing tests' err is None behavior
+    because check_hard_capability_feasibility returns None for caps with no
+    required_backend_property.
+    """
+    resolver = MagicMock()
+    resolver.resolve.return_value = SimpleNamespace(
+        backend_requirements=frozenset(),
+        uses_capabilities=frozenset(),
+    )
+    return resolver
+
+
 class TestPreflightExplicitBackend:
     def test_explicit_override_to_missing_binary_excluded(self) -> None:
         """An explicit override pointing to a backend excludes that step from
@@ -64,6 +78,7 @@ class TestPreflightExplicitBackend:
                 config_providers=providers,
                 recipe_name="remediation",
                 config_backend=cfg,
+                skill_resolver=_make_skill_resolver_with_no_caps(),
             )
         assert err is None
 
@@ -93,6 +108,7 @@ class TestPreflightExplicitBackend:
                 config_providers=providers,
                 recipe_name="remediation",
                 config_backend=cfg,
+                skill_resolver=_make_skill_resolver_with_no_caps(),
             )
         assert err is None
 
@@ -121,5 +137,6 @@ class TestPreflightExplicitBackend:
                 config_providers=providers,
                 recipe_name="remediation",
                 config_backend=cfg,
+                skill_resolver=_make_skill_resolver_with_no_caps(),
             )
         assert err is None

--- a/tests/server/test_run_skill_backend_compat.py
+++ b/tests/server/test_run_skill_backend_compat.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
 from autoskillit.core import SkillSource
+from autoskillit.server.tools._preflight import check_hard_capability_feasibility
 from autoskillit.server.tools.tools_execution import _is_backend_incompatible
 from autoskillit.workspace.skills import SkillInfo
 
@@ -154,6 +157,103 @@ class TestBackendCompatGateFailClosed:
         )
         error_text = (parsed.get("error") or parsed.get("result") or "").lower()
         assert "backend" in error_text, f"Expected error mentioning missing backend, got: {parsed}"
+
+
+class TestHardCapabilityFeasibilityPredicate:
+    """Direct tests of `check_hard_capability_feasibility` (Step 2.2 / Tests 1a-1b).
+
+    Validates that the shared predicate correctly rejects backends whose
+    `BackendCapabilities` field is falsy for the capability's
+    `required_backend_property`, and passes when the field is True.
+    """
+
+    @staticmethod
+    def _make_backend(name: str, *, git_metadata_writable: bool) -> MagicMock:
+        """Build a mock backend with the given capability property values."""
+        from autoskillit.core import BackendCapabilities
+
+        caps = BackendCapabilities(git_metadata_writable=git_metadata_writable)
+        backend = MagicMock()
+        backend.name = name
+        backend.capabilities = caps
+        return backend
+
+    def test_rejects_incapable_backend_for_git_metadata_write(self):
+        """A backend with git_metadata_writable=False must be rejected for git_metadata_write."""
+        backend = self._make_backend("codex", git_metadata_writable=False)
+        result = check_hard_capability_feasibility(frozenset({"git_metadata_write"}), backend)
+        assert result is not None, "Expected rejection diagnostic"
+        assert "git_metadata_writable" in result
+        assert "codex" in result
+        assert "git_metadata_write" in result
+
+    def test_passes_capable_backend_for_git_metadata_write(self):
+        """A backend with git_metadata_writable=True must pass for git_metadata_write."""
+        backend = self._make_backend("claude-code", git_metadata_writable=True)
+        result = check_hard_capability_feasibility(frozenset({"git_metadata_write"}), backend)
+        assert result is None, f"Expected None for capable backend, got: {result}"
+
+    def test_unknown_capability_is_ignored(self):
+        """Capabilities not in SKILL_CAPABILITY_REGISTRY are silently skipped."""
+        backend = self._make_backend("claude-code", git_metadata_writable=True)
+        result = check_hard_capability_feasibility(frozenset({"unknown_capability"}), backend)
+        assert result is None
+
+    def test_capability_without_required_property_is_ignored(self):
+        """A capability without `required_backend_property` is silently passed."""
+        backend = self._make_backend("claude-code", git_metadata_writable=True)
+        # `open_kitchen` has required_backend_property=None.
+        result = check_hard_capability_feasibility(frozenset({"open_kitchen"}), backend)
+        assert result is None
+
+    def test_check_backend_compat_rejects_explicit_pin_to_incapable_backend(self):
+        """Test 1c: _check_backend_compat must reject when uses_capabilities requires
+        a BackendCapabilities property the backend lacks (the explicit-pin bypass)."""
+        import json
+
+        from autoskillit.server.tools.tools_execution import _check_backend_compat
+
+        skill_info = SimpleNamespace(
+            backend_requirements=frozenset(),
+            uses_capabilities=frozenset({"git_metadata_write"}),
+        )
+        backend = self._make_backend("codex", git_metadata_writable=False)
+        result = _check_backend_compat(
+            skill_command="/autoskillit:resolve-review ...",
+            resolved_command="resolve-review",
+            effective_order_id="test-order",
+            target_name="resolve-review",
+            skill_info=skill_info,
+            effective_backend_obj=backend,
+            skill_resolver=MagicMock(),
+        )
+        assert result is not None, "Expected crash JSON for incapable backend"
+        parsed = json.loads(result)
+        assert parsed["subtype"] == "crashed"
+        assert "git_metadata_writable" in parsed.get(
+            "result", ""
+        ) or "git_metadata_writable" in parsed.get("error", "")
+
+    def test_check_backend_compat_passes_pinned_claude_code_for_git_write(self):
+        """Sanity: _check_backend_compat must PASS when the chosen backend has the
+        capability property true (claude-code's `git_metadata_writable=True`)."""
+        from autoskillit.server.tools.tools_execution import _check_backend_compat
+
+        skill_info = SimpleNamespace(
+            backend_requirements=frozenset(),
+            uses_capabilities=frozenset({"git_metadata_write"}),
+        )
+        backend = self._make_backend("claude-code", git_metadata_writable=True)
+        result = _check_backend_compat(
+            skill_command="/autoskillit:resolve-review",
+            resolved_command="resolve-review",
+            effective_order_id="test-order",
+            target_name="resolve-review",
+            skill_info=skill_info,
+            effective_backend_obj=backend,
+            skill_resolver=MagicMock(),
+        )
+        assert result is None, f"Capable backend must pass — expected None, got: {result}"
 
     @pytest.mark.anyio
     async def test_provider_override_allows_skill_requiring_claude_code(

--- a/tests/server/test_tools_github_provider.py
+++ b/tests/server/test_tools_github_provider.py
@@ -6,9 +6,17 @@ import json
 
 import pytest
 
+from autoskillit.pipeline.gate import DefaultGateState
 from autoskillit.server.tools.tools_github import report_bug
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.fixture
+def tool_ctx_kitchen_open(tool_ctx):
+    """Open the gate while retaining production backend compatibility metadata."""
+    tool_ctx.gate = DefaultGateState(enabled=True)
+    return tool_ctx
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_integrations.py
+++ b/tests/server/test_tools_integrations.py
@@ -9,6 +9,7 @@ import pytest
 
 from autoskillit.core import SkillResult
 from autoskillit.core.types import RetryReason
+from autoskillit.pipeline.gate import DefaultGateState
 from autoskillit.server.tools.tools_issue_headless import (
     _PREPARE_RESULT_END,
     _PREPARE_RESULT_START,
@@ -25,6 +26,14 @@ from tests.conftest import _make_result
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 _CLAIM_HELPERS = "autoskillit.fleet"
+
+
+@pytest.fixture
+def tool_ctx_kitchen_open(tool_ctx):
+    """Open the gate while retaining production backend compatibility metadata."""
+    tool_ctx.gate = DefaultGateState(enabled=True)
+    return tool_ctx
+
 
 # ---------------------------------------------------------------------------
 # claim_issue / release_issue / prepare_issue / enrich_issues — gated tools

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from autoskillit.core import RetryReason, SkillResult
+from autoskillit.core import (
+    CLAUDE_CODE_CAPABILITIES,
+    BackendCapabilities,
+    RetryReason,
+    SkillResult,
+    SkillSource,
+)
 from autoskillit.pipeline.gate import DefaultGateState
 from autoskillit.server.tools.tools_issue_composite import claim_and_resolve_issue
 from autoskillit.server.tools.tools_issue_headless import (
@@ -28,6 +35,13 @@ from autoskillit.server.tools.tools_issue_labels import (
 )
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.fixture
+def tool_ctx_kitchen_open(tool_ctx):
+    """Open the gate while retaining production backend compatibility metadata."""
+    tool_ctx.gate = DefaultGateState(enabled=True)
+    return tool_ctx
 
 
 def _make_skill_result(
@@ -363,6 +377,71 @@ async def test_enrich_issues_success(tool_ctx_kitchen_open) -> None:
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("handler", "args"),
+    [
+        (prepare_issue, ("Title", "Body")),
+        (enrich_issues, ()),
+    ],
+    ids=("prepare-issue", "enrich-issues"),
+)
+async def test_issue_headless_handlers_reject_incompatible_backend_before_executor(
+    tool_ctx_kitchen_open,
+    handler,
+    args,
+) -> None:
+    """Direct lifecycle handlers must fail closed before executor dispatch."""
+    skill_info = SimpleNamespace(
+        source=SkillSource.BUNDLED_EXTENDED,
+        backend_requirements=frozenset({"required-backend"}),
+        uses_capabilities=frozenset(),
+    )
+    resolver = MagicMock()
+    resolver.resolve.return_value = skill_info
+    backend = MagicMock()
+    backend.name = "incompatible-backend"
+    backend.capabilities = BackendCapabilities(
+        applicable_guards=CLAUDE_CODE_CAPABILITIES.applicable_guards
+    )
+    tool_ctx_kitchen_open.skill_resolver = resolver
+    tool_ctx_kitchen_open.backend = backend
+    tool_ctx_kitchen_open.executor = AsyncMock()
+
+    result = json.loads(await handler(*args))
+
+    assert result["success"] is False
+    assert result["subtype"] == "crashed"
+    assert "required-backend" in result["result"]
+    tool_ctx_kitchen_open.executor.run.assert_not_awaited()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("handler", "args"),
+    [
+        (prepare_issue, ("Title", "Body")),
+        (enrich_issues, ()),
+    ],
+    ids=("prepare-issue", "enrich-issues"),
+)
+async def test_issue_headless_handlers_fail_closed_without_skill_resolver(
+    tool_ctx_kitchen_open,
+    handler,
+    args,
+) -> None:
+    """Missing resolution metadata must stop lifecycle dispatch before executor.run."""
+    tool_ctx_kitchen_open.skill_resolver = None
+    tool_ctx_kitchen_open.executor = AsyncMock()
+
+    result = json.loads(await handler(*args))
+
+    assert result["success"] is False
+    assert result["subtype"] == "crashed"
+    assert "resolver" in result["result"].lower()
+    tool_ctx_kitchen_open.executor.run.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_claim_issue_gate_closed(tool_ctx) -> None:
     """Gate disabled → gate error JSON."""
     tool_ctx.gate = DefaultGateState(enabled=False)
@@ -669,11 +748,14 @@ def _make_mock_tool_ctx_for_project_dir(project_dir):
     mock_ctx.config.github.check_labels_allowed = MagicMock(return_value=None)
     mock_ctx.output_pattern_resolver = MagicMock(return_value=[])
     mock_ctx.write_expected_resolver = MagicMock(return_value=None)
-    # Disable the backend-compat gate by leaving resolver/backend unset; the
-    # production gate fail-closes when these are missing, so set them to None
-    # so the gate short-circuits at `if target_name is None: return None`.
-    mock_ctx.skill_resolver = None
-    mock_ctx.backend = None
+    skill_info = SimpleNamespace(
+        source=SkillSource.BUNDLED_EXTENDED,
+        backend_requirements=frozenset(),
+        uses_capabilities=frozenset(),
+    )
+    mock_ctx.skill_resolver.resolve.return_value = skill_info
+    mock_ctx.backend.name = "claude-code"
+    mock_ctx.backend.capabilities = CLAUDE_CODE_CAPABILITIES
     return mock_ctx
 
 

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -669,6 +669,11 @@ def _make_mock_tool_ctx_for_project_dir(project_dir):
     mock_ctx.config.github.check_labels_allowed = MagicMock(return_value=None)
     mock_ctx.output_pattern_resolver = MagicMock(return_value=[])
     mock_ctx.write_expected_resolver = MagicMock(return_value=None)
+    # Disable the backend-compat gate by leaving resolver/backend unset; the
+    # production gate fail-closes when these are missing, so set them to None
+    # so the gate short-circuits at `if target_name is None: return None`.
+    mock_ctx.skill_resolver = None
+    mock_ctx.backend = None
     return mock_ctx
 
 

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -380,6 +380,7 @@ async def test_open_kitchen_smoke_test_renders_resolved_base_branch(monkeypatch)
     mock_ctx.project_dir = project_dir
     mock_ctx.enable_components = AsyncMock()
     mock_ctx.quota_refresh_task = None
+    mock_ctx.backend = None
     mock_ctx.recipes = DefaultRecipeRepository()
     mock_ctx.config.migration.suppressed = []
 
@@ -547,6 +548,7 @@ async def test_open_kitchen_with_config_authority_ingredient(monkeypatch):
     mock_ctx.project_dir = project_dir
     mock_ctx.enable_components = AsyncMock()
     mock_ctx.quota_refresh_task = None
+    mock_ctx.backend = None
     mock_ctx.recipes = DefaultRecipeRepository()
     mock_ctx.config.migration.suppressed = []
 

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -363,6 +363,7 @@ async def test_config_layer_keys_match_server_authoritative_ingredients(tmp_path
 @pytest.mark.anyio
 async def test_open_kitchen_smoke_test_renders_resolved_base_branch(monkeypatch):
     """T7: open_kitchen smoke-test renders the config-resolved base_branch value."""
+    monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
     import autoskillit.recipe._api_cache as cache_mod
     from autoskillit.core import pkg_root
     from autoskillit.recipe.repository import DefaultRecipeRepository
@@ -524,6 +525,7 @@ async def test_open_kitchen_emits_authority_clobber_warning(tmp_path, monkeypatc
 @pytest.mark.anyio
 async def test_open_kitchen_with_config_authority_ingredient(monkeypatch):
     """Full open_kitchen path: config value wins over caller override in rendered output."""
+    monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
     import autoskillit.recipe._api_cache as cache_mod
     from autoskillit.core import pkg_root
     from autoskillit.recipe.repository import DefaultRecipeRepository

--- a/tests/server/test_tools_kitchen_gate_features.py
+++ b/tests/server/test_tools_kitchen_gate_features.py
@@ -424,6 +424,7 @@ def test_recipe_resource_returns_composed_content():
         },
         defer_unresolved=True,
         resolved_defaults={},
+        backend_capabilities_map={},
     )
     assert result == ("name: test-recipe\nsteps:\n  stop:\n    action: stop\n    message: done\n")
     assert "optional: true" not in result

--- a/tests/server/test_tools_kitchen_preflight.py
+++ b/tests/server/test_tools_kitchen_preflight.py
@@ -214,6 +214,42 @@ class TestCheckDispatchFeasibilityUnit:
         assert parsed.get("stage") == "dispatch_feasibility_preflight"
         assert parsed.get("step") == "resolve_review"
 
+    def test_dispatch_feasibility_fails_closed_when_pinned_skill_is_unresolved(self) -> None:
+        """A valid explicit backend pin cannot turn an unknown skill into an
+        empty capability set.
+        """
+        from autoskillit.config._config_dataclasses import AgentBackendConfig
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
+
+        backend = _make_codex_backend()
+        active_steps: dict[str, Any] = {
+            "unknown_step": _make_recipe_step(
+                "unknown_step", tool="run_skill", skill_name="missing-skill"
+            ),
+        }
+        config_backend = AgentBackendConfig(
+            recipe_overrides={"test-recipe": {"unknown_step": "codex"}},
+        )
+        resolver = MagicMock()
+        resolver.resolve.return_value = None
+
+        with patch("autoskillit.server.tools._preflight.get_backend", return_value=backend):
+            result = _check_dispatch_feasibility(
+                post_prune_step_names=["unknown_step"],
+                active_recipe_steps=active_steps,
+                backend=backend,
+                config_providers=_DEFAULT_PROVIDERS,
+                recipe_name="test-recipe",
+                config_backend=config_backend,
+                skill_resolver=resolver,
+            )
+
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed.get("error") == "skill_not_found_for_pinned_step"
+        assert parsed.get("skill") == "missing-skill"
+        assert parsed.get("step") == "unknown_step"
+
     def test_incompatible_backend_fails(self) -> None:
         """Backend with empty applicable_guards returns error (1b)."""
         from autoskillit.server.tools._preflight import _check_dispatch_feasibility

--- a/tests/server/test_tools_kitchen_preflight.py
+++ b/tests/server/test_tools_kitchen_preflight.py
@@ -111,6 +111,7 @@ class TestCheckDispatchFeasibilityUnit:
                 active_recipe_steps=active_steps,
                 backend=backend,
                 config_providers=_DEFAULT_PROVIDERS,
+                skill_resolver=None,
             )
         assert result is None, f"Expected None, got: {result}"
 
@@ -129,6 +130,7 @@ class TestCheckDispatchFeasibilityUnit:
                 active_recipe_steps=active_steps,
                 backend=backend,
                 config_providers=_DEFAULT_PROVIDERS,
+                skill_resolver=None,
             )
         assert result is None, f"Expected None for compatible backend, got: {result}"
 
@@ -147,6 +149,7 @@ class TestCheckDispatchFeasibilityUnit:
                 active_recipe_steps=active_steps,
                 backend=backend,
                 config_providers=_DEFAULT_PROVIDERS,
+                skill_resolver=None,
             )
         assert result is not None
         parsed = json.loads(result)
@@ -165,6 +168,7 @@ class TestCheckDispatchFeasibilityUnit:
                 active_recipe_steps={},
                 backend=backend,
                 config_providers=_DEFAULT_PROVIDERS,
+                skill_resolver=None,
             )
         assert result is None
 
@@ -182,6 +186,7 @@ class TestCheckDispatchFeasibilityUnit:
                 active_recipe_steps=active_steps,
                 backend=backend,
                 config_providers=_DEFAULT_PROVIDERS,
+                skill_resolver=None,
             )
         assert result is None
 
@@ -200,6 +205,7 @@ class TestCheckDispatchFeasibilityUnit:
                 active_recipe_steps=active_steps,
                 backend=backend,
                 config_providers=_DEFAULT_PROVIDERS,
+                skill_resolver=None,
             )
         assert result is not None
         parsed = json.loads(result)
@@ -230,6 +236,7 @@ class TestCheckDispatchFeasibilityUnit:
                 active_recipe_steps=active_steps,
                 backend=backend,
                 config_providers=providers_config,
+                skill_resolver=None,
             )
         assert result is None, f"Provider override should exclude step from check, got: {result}"
 
@@ -248,6 +255,7 @@ class TestCheckDispatchFeasibilityUnit:
                 active_recipe_steps=active_steps,
                 backend=backend,
                 config_providers=_DEFAULT_PROVIDERS,
+                skill_resolver=None,
             )
         assert result is None
 
@@ -266,6 +274,7 @@ class TestCheckDispatchFeasibilityUnit:
                 active_recipe_steps=active_steps,
                 backend=backend,
                 config_providers=_DEFAULT_PROVIDERS,
+                skill_resolver=None,
             )
         assert result is not None
         parsed = json.loads(result)
@@ -288,6 +297,7 @@ class TestCheckDispatchFeasibilityUnit:
             active_recipe_steps=active_steps,
             backend=backend,
             config_providers=_DEFAULT_PROVIDERS,
+            skill_resolver=None,
         )
 
         has_unenforced = bool(

--- a/tests/server/test_tools_kitchen_preflight.py
+++ b/tests/server/test_tools_kitchen_preflight.py
@@ -13,6 +13,7 @@ itself and its integration into open_kitchen and dispatch_food_truck.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -59,13 +60,14 @@ def _make_dormancy_hook() -> Any:
     )
 
 
-def _make_codex_backend() -> MagicMock:
+def _make_codex_backend(git_metadata_writable: bool = True) -> MagicMock:
     """Create a mock codex backend with empty applicable_guards."""
     from autoskillit.core import BackendCapabilities
 
     caps = BackendCapabilities(
         applicable_guards=frozenset(),
         anthropic_provider_capable=False,
+        git_metadata_writable=git_metadata_writable,
     )
     backend = MagicMock()
     backend.name = "codex"
@@ -85,6 +87,16 @@ def _make_claude_backend() -> MagicMock:
     backend.name = AGENT_BACKEND_CLAUDE_CODE
     backend.capabilities = caps
     return backend
+
+
+def _make_skill_resolver_with_git_write() -> MagicMock:
+    """Resolver whose .resolve() returns a stub declaring git_metadata_write."""
+    resolver = MagicMock()
+    resolver.resolve.return_value = SimpleNamespace(
+        uses_capabilities=frozenset({"git_metadata_write"}),
+        backend_requirements=frozenset(),
+    )
+    return resolver
 
 
 # ---------------------------------------------------------------------------
@@ -133,6 +145,40 @@ class TestCheckDispatchFeasibilityUnit:
                 skill_resolver=None,
             )
         assert result is None, f"Expected None for compatible backend, got: {result}"
+
+    def test_dispatch_feasibility_rejects_pinned_step_to_incapable_backend(self) -> None:
+        """An explicit pin to a backend lacking a required BackendCapabilities
+        property is rejected at admission time (REQ-013/014/017/018/019)."""
+        from autoskillit.config._config_dataclasses import AgentBackendConfig
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
+
+        backend = _make_codex_backend(git_metadata_writable=False)
+        active_steps: dict[str, Any] = {
+            "resolve_review": _make_recipe_step(
+                "resolve_review", tool="run_skill", skill_name="resolve-review"
+            ),
+        }
+        config_backend = AgentBackendConfig(
+            recipe_overrides={"test-recipe": {"resolve_review": "codex"}},
+        )
+        # get_backend("codex") is patched to the same instance so the pinned-
+        # backend lookup inside _check_dispatch_feasibility deterministically
+        # observes git_metadata_writable=False, independent of whatever the
+        # real production Codex backend's default happens to be.
+        with patch("autoskillit.server.tools._preflight.get_backend", return_value=backend):
+            result = _check_dispatch_feasibility(
+                post_prune_step_names=["resolve_review"],
+                active_recipe_steps=active_steps,
+                backend=backend,
+                config_providers=_DEFAULT_PROVIDERS,
+                recipe_name="test-recipe",
+                config_backend=config_backend,
+                skill_resolver=_make_skill_resolver_with_git_write(),
+            )
+        assert result is not None
+        parsed = json.loads(result)
+        assert "git_metadata_writable" in parsed.get("error", "")
+        assert parsed.get("override_source") == "explicit_config"
 
     def test_incompatible_backend_fails(self) -> None:
         """Backend with empty applicable_guards returns error (1b)."""

--- a/tests/server/test_tools_kitchen_preflight.py
+++ b/tests/server/test_tools_kitchen_preflight.py
@@ -180,6 +180,40 @@ class TestCheckDispatchFeasibilityUnit:
         assert "git_metadata_writable" in parsed.get("error", "")
         assert parsed.get("override_source") == "explicit_config"
 
+    def test_dispatch_feasibility_fails_closed_when_skill_resolver_missing_for_pinned_step(
+        self,
+    ) -> None:
+        """An explicit pin that resolves to a valid backend, but with no
+        skill_resolver available, fails closed (REQ-018)."""
+        from autoskillit.config._config_dataclasses import AgentBackendConfig
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
+
+        backend = _make_codex_backend()
+        active_steps: dict[str, Any] = {
+            "resolve_review": _make_recipe_step(
+                "resolve_review", tool="run_skill", skill_name="resolve-review"
+            ),
+        }
+        config_backend = AgentBackendConfig(
+            recipe_overrides={"test-recipe": {"resolve_review": "codex"}},
+        )
+        with patch("autoskillit.server.tools._preflight.get_backend", return_value=backend):
+            result = _check_dispatch_feasibility(
+                post_prune_step_names=["resolve_review"],
+                active_recipe_steps=active_steps,
+                backend=backend,
+                config_providers=_DEFAULT_PROVIDERS,
+                recipe_name="test-recipe",
+                config_backend=config_backend,
+                skill_resolver=None,
+            )
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed.get("error") == "skill_resolver_unavailable_for_pinned_step"
+        assert parsed.get("success") is False
+        assert parsed.get("stage") == "dispatch_feasibility_preflight"
+        assert parsed.get("step") == "resolve_review"
+
     def test_incompatible_backend_fails(self) -> None:
         """Backend with empty applicable_guards returns error (1b)."""
         from autoskillit.server.tools._preflight import _check_dispatch_feasibility

--- a/tests/server/test_tools_label_validation.py
+++ b/tests/server/test_tools_label_validation.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from autoskillit.pipeline.gate import DefaultGateState
 from autoskillit.server.tools.tools_issue_headless import prepare_issue
 from autoskillit.server.tools.tools_issue_labels import (
     claim_issue,
@@ -14,6 +15,13 @@ from autoskillit.server.tools.tools_issue_labels import (
 )
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.fixture
+def tool_ctx_kitchen_open(tool_ctx):
+    """Open the gate while retaining production backend compatibility metadata."""
+    tool_ctx.gate = DefaultGateState(enabled=True)
+    return tool_ctx
 
 
 class TestClaimIssueWhitelist:

--- a/tests/server/test_tools_report_bug.py
+++ b/tests/server/test_tools_report_bug.py
@@ -12,6 +12,7 @@ import pytest
 from autoskillit.config import AutomationConfig
 from autoskillit.core import SkillResult
 from autoskillit.core.types import RetryReason
+from autoskillit.pipeline.gate import DefaultGateState
 from autoskillit.server._misc import _extract_block
 from autoskillit.server.tools.tools_github import (
     _FINGERPRINT_END,
@@ -30,6 +31,14 @@ from autoskillit.server.tools.tools_issue_headless import (
 from tests.server._helpers import _skill_fail, _skill_ok
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.fixture
+def tool_ctx_kitchen_open(tool_ctx):
+    """Open the gate while retaining production backend compatibility metadata."""
+    tool_ctx.gate = DefaultGateState(enabled=True)
+    return tool_ctx
+
 
 # ---------------------------------------------------------------------------
 # _parse_fingerprint unit tests
@@ -269,6 +278,21 @@ async def test_report_bug_no_executor(tool_ctx_kitchen_open, tmp_path):
     result = json.loads(await report_bug("error ctx", str(tmp_path)))
     assert result["success"] is False
     assert "executor" in result["error"].lower()
+
+
+@pytest.mark.anyio
+async def test_report_bug_fails_closed_without_skill_resolver(tool_ctx_kitchen_open, tmp_path):
+    """Missing resolution metadata must stop report dispatch before executor.run."""
+    tool_ctx_kitchen_open.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx_kitchen_open.skill_resolver = None
+    tool_ctx_kitchen_open.executor = AsyncMock()
+
+    result = json.loads(await report_bug("error ctx", str(tmp_path), severity="blocking"))
+
+    assert result["success"] is False
+    assert result["subtype"] == "crashed"
+    assert "resolver" in result["result"].lower()
+    tool_ctx_kitchen_open.executor.run.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/test_tools_session_diagnostics.py
+++ b/tests/server/test_tools_session_diagnostics.py
@@ -10,6 +10,7 @@ import pytest
 
 from autoskillit.core import SkillResult
 from autoskillit.core.types import RetryReason
+from autoskillit.pipeline.gate import DefaultGateState
 from autoskillit.server.tools.tools_github import (
     _format_diagnostics_section,
     _read_session_diagnostics,
@@ -17,6 +18,14 @@ from autoskillit.server.tools.tools_github import (
 )
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.fixture
+def tool_ctx_kitchen_open(tool_ctx):
+    """Open the gate while retaining production backend compatibility metadata."""
+    tool_ctx.gate = DefaultGateState(enabled=True)
+    return tool_ctx
+
 
 # ---------------------------------------------------------------------------
 # _read_session_diagnostics unit tests

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -166,7 +166,7 @@ class TestModuleCascadeCore:
 
     def test_type_backend_cascade(self) -> None:
         assert MODULE_CASCADE_CORE["_type_backend"] == frozenset(
-            {"core", "execution", "cli", "recipe", "workspace"}
+            {"core", "execution", "cli", "recipe", "server", "workspace"}
         )
 
     def test_type_dispatch_identity_cascade(self) -> None:


### PR DESCRIPTION
## Summary

Round 3 of `/audit-impl` identified a structural gap in capability validation: explicit backend pins (`REQ-RES-001`) suppressed rerouting, leaving no validation that the pinned backend satisfies hard capabilities. Part A closes that gap with a declarative `required_backend_property` field on `SkillCapabilityDef` and a shared post-resolution validation predicate — making the "pinned to incapable backend" state structurally unrepresentable at every admission and dispatch surface. Part B hardens four propagation defects that share a theme: identity and diagnostic information exists at write-time but is lost at read-time. The Part A test-gap closure adds direct unit tests for the admission-time hard-capability branch and the explicit-pin resolution path. A separate plan adds a missing regression test for `_check_dispatch_feasibility()`'s fail-closed branch when `skill_resolver is None` and an explicit pin resolves to a valid backend.

<details>
<summary>Individual Group Plans</summary>

### Group 1: Close `skill_resolver is None` + Resolved-Pin Fail-Closed Test Gap

Round 3 of `/audit-impl` found that `_check_dispatch_feasibility()` in
`src/autoskillit/server/tools/_preflight.py` already implements the fail-closed branch
required by REQ-018 correctly (returns a `"skill_resolver_unavailable_for_pinned_step"`
JSON error envelope when `skill_resolver is None` and an explicit pin resolves to a valid
backend), but no test in the diff exercises that exact combination. Every existing
`skill_resolver=None` call site either omits `config_backend` entirely or supplies an
empty `recipe_overrides`/`step_overrides` (so no pin resolves and the branch never fires);
every test that supplies a *resolving* pin instead supplies a mock `skill_resolver`.

This plan adds one regression test — `test_dispatch_feasibility_fails_closed_when_skill_resolver_missing_for_pinned_step`
in `tests/server/test_tools_kitchen_preflight.py`'s `TestCheckDispatchFeasibilityUnit`
class — that supplies both conditions simultaneously and asserts the exact fail-closed
error envelope. No production code changes: the fail-closed logic at `_preflight.py:129-142`
is already correct; this closes a coverage gap only.

### Group 2: Explicit Backend Pin Bypasses Capability Feasibility — Part A

The capability validation system has a compositional gap: `worker_routable=True` empties `required_backends` to allow rerouting instead of rejection, while explicit backend pins (`REQ-RES-001`) suppress the reroute — leaving no validation that the pinned backend satisfies hard capabilities. The architectural fix adds a declarative `required_backend_property` field to `SkillCapabilityDef` and a shared post-resolution validation predicate that runs after all override resolution, making the "pinned to incapable backend" state structurally unrepresentable at every admission and dispatch surface.

Part B will cover propagation defect hardening (rebase outcome discrimination, pre-session cleanup signaling, resume identity enrichment, direct executor centralization).

### Group 3: Explicit Backend Pin Bypasses Capability Feasibility — Part A Test-Gap Closure

The prior PART A implementation (commit `38153a615`) correctly added the
admission-time hard-capability branch to `_check_dispatch_feasibility()` in
`src/autoskillit/server/tools/_preflight.py` — REQ-013/014/017/018/019 are
all structurally present and correct. `/audit-impl` found four residual
gaps, all either missing tests or missing documentation comments; no
production logic is incorrect or missing: (1) **MISSING**
`test_dispatch_feasibility_rejects_pinned_step_to_incapable_backend`
(TEST-1d) — no direct unit test exercises the admission-time hard-capability
branch through `_check_dispatch_feasibility()`'s own call signature; (2)
**MISSING/incomplete** `test_admission_dispatch_agreement_with_explicit_pin`
(TEST-1e / REQ-026) — the existing test never constructs
`AgentBackendConfig(recipe_overrides=...)` or calls
`_check_dispatch_feasibility()`, so the real explicit-pin resolution path
(`config_backend.recipe_overrides` → `_resolve_backend_override` →
`_check_dispatch_feasibility`) is untested; (3) **MISSING** cross-reference
to `CAPABILITY_INGREDIENT_MAP` on the boot-time validation loop comment in
`src/autoskillit/core/types/_type_constants_registries.py` (REQ-004); (4)
**MISSING** documentation of why importing `BackendCapabilities` from
`_type_backend` does not introduce a circular/cross-layer dependency
(REQ-008).

This plan adds the two missing tests (closing the coverage gap against the
real production call paths, not synthetic stand-ins) and the two missing
comments. No behavioral/production code changes.

### Group 4: Propagation Defect Hardening — Part B

The investigation identified five propagation defects alongside the primary capability-bypass bug. These share a common architectural theme: **identity and diagnostic information exists at write-time but is lost or ignored at read-time.** This plan addresses four of them with structural fixes that make the information loss impossible.

Part A covered the primary capability-bypass fix (declarative `required_backend_property` + post-resolution validation predicate).

</details>

Closes #4268

## Implementation Plan

Plan files:
- `.autoskillit/temp/rectify/rectify_explicit_pin_capability_bypass_2026-07-16_081500.md`
- `.autoskillit/temp/make-plan/remediation_explicit_pin_capability_bypass_part_a_plan_2026-07-16_095617.md`
- `.autoskillit/temp/make-plan/explicit_pin_capability_bypass_test_gap_plan_2026-07-16_110500.md`
- `.autoskillit/temp/rectify/rectify_explicit_pin_capability_bypass_part_b_2026-07-16_081500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate* | opus | 1 | 16 | 7.1k | 585.2k | 94.4k | 61 | 35.9k | 8m 8s |
| rectify* | opus[1m] | 1 | 14 | 1.8k | 790.1k | 159.7k | 86 | 6.1k | 18m 16s |
| review_approach* | sonnet | 1 | 17.1k | 16.3k | 1.7M | 96.6k | 52 | 171.6k | 3m 36s |
| dry_walkthrough* | sonnet | 5 | 160.0k | 181.9k | 22.6M | 222.8k | 417 | 577.0k | 38m 58s |
| implement* | MiniMax-M3 | 4 | 566.2k | 62.8k | 12.1M | 0 | 312 | 0 | 22m 59s |
| retry_worktree* | MiniMax-M3 | 1 | 266.2k | 51.8k | 39.0M | 0 | 395 | 0 | 48m 16s |
| audit_impl* | sonnet | 5 | 87.4k | 85.2k | 7.2M | 224.0k | 404 | 295.2k | 1h 2m |
| make_plan* | sonnet | 2 | 97.0k | 133.0k | 20.6M | 304.4k | 244 | 450.0k | 22m 57s |
| assess* | MiniMax-M3 | 2 | 216.1k | 34.9k | 8.4M | 0 | 243 | 0 | 24m 6s |
| prepare_pr* | MiniMax-M3 | 1 | 68.7k | 4.9k | 212.5k | 0 | 20 | 0 | 1m 59s |
| compose_pr* | MiniMax-M3 | 1 | 38.7k | 4.1k | 181.0k | 0 | 13 | 0 | 38s |
| **Total** | | | 1.5M | 584.0k | 113.3M | 304.4k | | 1.5M | 4h 12m |

\* *Step used a non-Anthropic provider; caching behavior may differ.*

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| review_approach | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 1031 | 11751.7 | 0.0 | 60.9 |
| retry_worktree | 661 | 58979.0 | 0.0 | 78.4 |
| audit_impl | 0 | — | — | — |
| make_plan | 0 | — | — | — |
| assess | 36 | 232017.8 | 0.0 | 970.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **1728** | 65574.5 | 888.8 | 338.0 |

## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| opus | 1 | 16 | 7.1k | 585.2k | 35.9k | 8m 8s |
| opus[1m] | 1 | 14 | 1.8k | 790.1k | 6.1k | 18m 16s |
| sonnet | 4 | 361.5k | 416.5k | 52.1M | 1.5M | 2h 7m |
| MiniMax-M3 | 5 | 1.2M | 158.6k | 59.8M | 0 | 1h 37m |