### PR TITLE
Rectify: Inline Content in Subagent Prompts

### DIFF
--- a/src/autoskillit/execution/diff_annotator.py
+++ b/src/autoskillit/execution/diff_annotator.py
@@ -202,13 +202,18 @@ def filter_findings(
     """Partition findings into filtered (in-range) and unpostable (out-of-range).
 
     When valid_lines is provided, uses exact set-membership for validation instead
-    of hunk-span interval checking. When both are absent, all findings pass through.
+    of hunk-span interval checking. When both are absent, all findings pass through
+    except those with null/zero line numbers, which route to unpostable.
     Sets all_unpostable=True when total findings > 0 and filtered is empty.
     """
     if not findings:
         return FilterResult()
 
     if not valid_ranges and valid_lines is None:
+        good = [f for f in findings if f.get("line") and f["line"] != 0]
+        bad = [f for f in findings if not f.get("line") or f["line"] == 0]
+        if bad:
+            return FilterResult(filtered=good, unpostable=bad, all_unpostable=not good)
         return FilterResult(filtered=list(findings))
 
     filtered: list[dict] = []
@@ -216,7 +221,10 @@ def filter_findings(
 
     for finding in findings:
         file_path = finding.get("file", "")
-        line_num = finding.get("line", 0)
+        line_num = finding.get("line") or 0
+        if line_num == 0:
+            unpostable.append(finding)
+            continue
 
         if valid_lines is not None:
             valid_set = set(valid_lines.get(file_path, []))

--- a/src/autoskillit/recipe/AGENTS.md
+++ b/src/autoskillit/recipe/AGENTS.md
@@ -42,7 +42,7 @@ Sub-package: rules/ (see rules/AGENTS.md).
 | `_analysis_detectors.py` | Dead outputs + ref invalidations + implicit handoffs |
 | `_git_helpers.py` | Shared git-remote regex (`_GIT_REMOTE_COMMAND_RE`, `_LITERAL_ORIGIN_RE`) for lint rules |
 | `_skill_helpers.py` | Shared helpers for skill-related semantic rules |
-| `_skill_placeholder_parser.py` | SKILL.md structural analysis: bash placeholder extraction, step section parsing, section splitting, prose GraphQL detection, git command extraction |
+| `_skill_placeholder_parser.py` | SKILL.md structural analysis: bash placeholder extraction, step section parsing, section splitting, prose GraphQL detection, git command extraction, blockquote section extraction |
 | `identity.py` | Recipe identity hashing — content and composite fingerprints |
 | `schema.py` | `Recipe`, `RecipeStep`, `DataFlowWarning` |
 | `staleness_cache.py` | Staleness cache for contract and diagram freshness checks |

--- a/src/autoskillit/recipe/_skill_placeholder_parser.py
+++ b/src/autoskillit/recipe/_skill_placeholder_parser.py
@@ -215,3 +215,72 @@ def extract_validation_rule_block(content: str, rule_label: str) -> str | None:
         if m.group(1) == rule_label:
             return m.group(0).strip()
     return None
+
+
+_CONTENT_VAR_SIGNAL_RE = re.compile(r"\{[a-z_]+_content\}")
+
+
+def extract_blockquote_sections(content: str) -> list[tuple[str, str]]:
+    """Extract blockquote sections from SKILL.md content that are subagent prompts.
+
+    Returns ``(step_context, block_text)`` tuples where ``step_context`` is the
+    nearest ``### `` heading above the block and ``block_text`` is the joined
+    blockquote content with the ``> `` prefix stripped.
+
+    Inclusion criteria — a contiguous blockquote run is yielded if ANY of:
+
+    - It contains at least 3 contiguous ``> `` lines (likely a subagent prompt)
+    - It contains a ``{*_content}`` placeholder (content signal — even 1-2 line
+      blocks with these are subagent-prompt-shaped, not stylistic callouts)
+
+    Single-line ``>`` callouts without content signals (e.g., ``> **Note:**``)
+    are excluded — those are stylistic, not subagent prompts.
+
+    A trailing blockquote that runs to end of file is flushed (not silently
+    dropped).
+    """
+    sections: list[tuple[str, str]] = []
+    current_heading = ""
+    buf: list[str] = []
+
+    def flush() -> None:
+        if not buf:
+            return
+        joined = "\n".join(buf)
+        has_content_signal = bool(_CONTENT_VAR_SIGNAL_RE.search(joined))
+        if len(buf) >= 3 or has_content_signal:
+            sections.append((current_heading, joined))
+        buf.clear()
+
+    for line in content.splitlines():
+        heading_match = _STEP_RE.match(line)
+        if heading_match:
+            flush()
+            current_heading = heading_match.group(1)
+            continue
+        if line.startswith("> "):
+            buf.append(line[2:])
+        elif line.strip() == ">":
+            buf.append("")
+        elif line.startswith(">"):
+            # '>' without space (rare) — still blockquote, strip the '>'
+            buf.append(line[1:].lstrip())
+        else:
+            flush()
+
+    flush()  # trailing blockquote at EOF
+    return sections
+
+
+_BANNED_CONTENT_SUFFIX_RE = re.compile(r"\{([a-z_]+_content)\}")
+
+
+def extract_blockquote_placeholders(blockquote_text: str) -> set[str]:
+    """Extract ``{identifier}`` tokens from blockquote text matching ``*_content``.
+
+    The naming convention is the key signal: ``*_content`` in a subagent-facing
+    blockquote is always wrong — should be ``*_path`` with the subagent reading
+    the file. Other placeholder patterns (``*_path``, ``*_name``, etc.) are
+    intentionally excluded; those are valid.
+    """
+    return {m.group(1) for m in _BANNED_CONTENT_SUFFIX_RE.finditer(blockquote_text)}

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -17,6 +17,8 @@ from autoskillit.recipe._skill_placeholder_parser import (
     _VRULE_RE,
     extract_bash_blocks,
     extract_bash_placeholders,
+    extract_blockquote_placeholders,
+    extract_blockquote_sections,
     extract_declared_ingredients,
     extract_graphql_blocks,
     extract_python_blocks,
@@ -959,4 +961,73 @@ def _check_graphql_query_requires_shell_invocation(ctx: ValidationContext) -> li
                     )
                 )
 
+    return findings
+
+
+_BANNED_BLOCKQUOTE_VARS: frozenset[str] = frozenset(
+    {
+        "annotated_diff_content",
+        "diff_content",
+        "section_diff_content",
+    }
+)
+
+
+@semantic_rule(
+    name="inline-content-in-subagent-prompt",
+    description=(
+        "A SKILL.md blockquoted subagent prompt references a banned *_content "
+        "variable. Subagent prompts must use *_path variables and instruct the "
+        "subagent to Read the file, per the inline-content-in-subagent-prompt "
+        "architectural rule (PR #3651)."
+    ),
+)
+def _check_inline_content_in_subagent_prompt(ctx: ValidationContext) -> list[RuleFinding]:
+    """Fire WARNING when a run_skill step's SKILL.md uses banned *_content placeholders.
+
+    Detection scans blockquote subagent prompts for ``{*_content}`` variables
+    that are never defined as ingredients. The naming convention is wrong:
+    subagent prompts must reference content by PATH (``*_path``) with the
+    subagent reading the file. Inline content placeholders are dangling and
+    will be silently dropped by the recipe framework, leaving the subagent
+    prompt incomplete.
+    """
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        skill_cmd = step.with_args.get("skill_command", "")
+        if not skill_cmd:
+            continue
+        skill_name = resolve_skill_name(skill_cmd)
+        if skill_name is None:
+            continue
+        skill_md = _resolve_skill_md(skill_name, resolver=ctx.skill_resolver)
+        if skill_md is None:
+            continue  # unknown-skill-command rule handles missing skills
+        try:
+            content = skill_md.read_text(encoding="utf-8")
+        except OSError:
+            continue  # file deleted or unreadable between resolution and read
+
+        for step_context, block_text in extract_blockquote_sections(content):
+            banned_found = extract_blockquote_placeholders(block_text) & _BANNED_BLOCKQUOTE_VARS
+            if not banned_found:
+                continue
+            for banned_var in sorted(banned_found):
+                context_label = f"step {step_context!r}" if step_context else "no step heading"
+                findings.append(
+                    make_finding(
+                        rule_name="inline-content-in-subagent-prompt",
+                        step_name=step_name,
+                        message=(
+                            f"Skill '{skill_name}' blockquote subagent prompt in {context_label} "
+                            f"references banned {{placeholder}} {{{banned_var}}}. "
+                            f"Subagent prompts must use a *_path variable (e.g., "
+                            f"{{{banned_var.removesuffix('_content')}_path}}) and instruct the "
+                            f"subagent to Read the file. Inline content placeholders are "
+                            f"never populated and produce incomplete prompts."
+                        ),
+                    )
+                )
     return findings

--- a/src/autoskillit/skills_extended/audit-claims/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-claims/SKILL.md
@@ -51,6 +51,7 @@ comments and emits a verdict for recipe routing.
 - Generate findings for `experimental` claims — they are self-evidencing by definition
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
+- Embed diff content inline in subagent prompts — always pass by path and instruct subagents to Read
 
 **ALWAYS:**
 - Use the explicit `pr_url` argument instead of re-discovering via `gh pr list`
@@ -119,6 +120,14 @@ Do not output any prose between subagent dispatches. Immediately proceed to the 
 Divide the diff by top-level markdown section: `## Executive Summary`, `## Results`,
 `## Methodology`, `## Discussion`, `## Limitations`, and any other top-level `##` section.
 
+After dividing the diff by section, write each section's diff chunk to its own file at
+`{{AUTOSKILLIT_TEMP}}/audit-claims/section_diff_{section_slug}_{pr_number}.txt` where
+`{section_slug}` is the section name lowercased with spaces replaced by underscores (e.g.
+`executive_summary`, `results`, `methodology`). Use `jq -n` or the Write tool — do not use
+inline Python one-liners or heredoc scripts with `open()` (these are blocked by the sandbox,
+per the existing convention at Step 1 of this file). Then bind `{section_diff_path}` to that
+section's file path when building each subagent's prompt.
+
 Launch one subagent via `Agent(model="sonnet")` per section containing `+` diff lines.
 Each subagent returns a JSON array of extracted claims:
 
@@ -154,8 +163,7 @@ Subagent prompt template:
 > - comparative: compares to prior work, published results, or baselines
 >
 > If no claims found in this section, return an empty array [].
-> Diff content for section [{section_name}]:
-> {section_diff_content}
+> Read the section diff from: {section_diff_path}
 
 Aggregate all extracted claims from all subagents. Save to
 `{{AUTOSKILLIT_TEMP}}/audit-claims/claims_{pr_number}.json`. Use `jq -n` or the Write tool. If the file already exists from a prior retry, either read it first (to satisfy the Write tool guard) or use a Bash redirect (`jq -n ... > path`).
@@ -189,6 +197,12 @@ returns findings:
 - `comparative` — requires attribution; "comparable to state-of-the-art" without citation
   is `critical`
 
+When building each subagent's prompt, bind:
+- `{claims_json_path}` to `{{AUTOSKILLIT_TEMP}}/audit-claims/claims_{pr_number}.json`
+  (the file written in Phase 1 above)
+- `{diff_file_path}` to `{{AUTOSKILLIT_TEMP}}/audit-claims/diff_{pr_number}.txt`
+  (the file written in Step 2 above)
+
 Subagent prompt template:
 
 > You are checking citation evidence for [{claim_type}] claims in a GitHub PR diff.
@@ -203,13 +217,17 @@ Subagent prompt template:
 > remove claim).
 >
 > Evidence rules for [{claim_type}]:
-> {evidence_rules_for_type}
+> Apply the rule for your claim type as enumerated under "Evidence rules per claim type"
+> earlier in this skill (skipped entirely for `experimental` claims; warning for missing
+> `external` citations or for specific numeric comparisons in `external` claims being
+> critical; warning for missing `methodological` rationale; critical for unattributed
+> `comparative` claims such as "comparable to state-of-the-art" without citation).
 >
 > If all claims have adequate evidence, return an empty array [].
 > Claims to check:
-> {claims_json}
+> Read the claims file at: {claims_json_path}
 > Full PR diff:
-> {diff_content}
+> Read the diff file at: {diff_file_path}
 
 Save findings to `{{AUTOSKILLIT_TEMP}}/audit-claims/findings_{pr_number}.json`. Use `jq -n` or the Write tool. If the file already exists from a prior retry, either read it first (to satisfy the Write tool guard) or use a Bash redirect (`jq -n ... > path`).
 
@@ -410,6 +428,7 @@ Exit 1 only for unrecoverable tool-level errors.
 ```
 {{AUTOSKILLIT_TEMP}}/audit-claims/
 ├── diff_{pr_number}.txt
+├── section_diff_{section_slug}_{pr_number}.txt  (Phase 1 intermediate, one per section)
 ├── claims_{pr_number}.json          (Phase 1 output)
 ├── findings_{pr_number}.json        (Phase 2 output)
 └── summary_{pr_number}_{ts}.md

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -50,6 +50,7 @@ by the recipe pipeline after `open_pr_step` opens the PR.
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
 - Specify `subagent_type` when spawning audit subagents — these are ephemeral agents, not registered agent definitions. Use `Agent(model="sonnet")` exactly as shown, with no `subagent_type` parameter.
+- Embed diff content inline in subagent prompts — always pass by path and instruct subagents to Read
 
 **ALWAYS:**
 - Find the PR by feature branch at invocation time (not from a pre-captured URL)
@@ -410,8 +411,9 @@ Subagent prompt template (dimensions 1–6):
 > `+` or context line's marker in the same hunk.
 >
 > If no issues found, return an empty array [].
-> Annotated diff content (each line prefixed with [LNNN] markers):
-> {annotated_diff_content}
+> Read the annotated diff file at path: {annotated_diff_path}
+> Each line in the file is prefixed with [LNNN] markers indicating the GitHub diff line number.
+> Use the [LNNN] number as the `line` value in your findings JSON.
 >
 > Prior resolved findings (DO NOT RE-RAISE — these have been addressed by resolve-review):
 > {json_list_of_prior_resolved_findings or "[]"}
@@ -442,7 +444,11 @@ Subagent prompt template (dimensions 1–6):
 > are repetitive.
 
 Pass `prior_resolved_findings` and `prior_unresolved_findings` (both as JSON arrays) into each
-subagent prompt via template substitution, same as `annotated_diff_content`.
+subagent prompt via template substitution. The annotated diff is available at `annotated_diff_path`
+— instruct subagents to Read it. If `annotated_diff_path` is unset or the file does not exist,
+state "No annotated diff is available for this run — evaluate the diff without [LNNN] anchors and
+approximate `line` from context" instead of emitting a reference to a nonexistent path. This
+mirrors the existing graceful-degradation fallback for `DISPATCH_AGENTS` documented in Step 2.9.
 
 Subagent prompt template (dimension 7 — deletion_regression, only when `deletion_context` is non-null):
 
@@ -455,7 +461,7 @@ Subagent prompt template (dimension 7 — deletion_regression, only when `deleti
 > Deleted symbols: {deletion_context.deleted_symbols}
 >
 > PR diff:
-> {diff_content}
+> Read the raw diff file at path: {diff_file_path}
 >
 > Instructions:
 > - For each deleted file in the deletion context: check if the diff adds or recreates it

--- a/src/autoskillit/skills_extended/review-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-research-pr/SKILL.md
@@ -20,12 +20,13 @@ a summary verdict. Called by the recipe pipeline after `open_research_pr` opens 
 
 ## Arguments
 
-`/autoskillit:review-research-pr <worktree-path-or-feature-branch> <base-branch> [hunk_ranges_path=<path>] [valid_lines_path=<path>]`
+`/autoskillit:review-research-pr <worktree-path-or-feature-branch> <base-branch> [annotated_diff_path=<path>] [hunk_ranges_path=<path>] [valid_lines_path=<path>]`
 
 - **worktree-path-or-feature-branch** — Either an absolute path to the research worktree
   (preferred; skill derives the feature branch from `git rev-parse --abbrev-ref HEAD`)
   or the feature branch name directly
 - **base-branch** — The base branch the PR targets (e.g., "main")
+- **annotated_diff_path** (optional) — absolute path to a pre-computed annotated diff file (produced by `annotate_pr_diff` run_python step). When provided and present, read from file instead of running python3.
 - **hunk_ranges_path** (optional) — absolute path to a pre-computed hunk ranges JSON file (produced by `annotate_pr_diff` run_python step). When provided, loaded in Step 2.7 instead of parsing from the diff inline.
 - **valid_lines_path** (optional) — absolute path to a pre-computed valid lines JSON file (produced by `annotate_pr_diff` run_python step). Contains exact `{filepath: [line_numbers]}` set. When provided, enables exact set-membership validation in Step 4.
 
@@ -48,6 +49,7 @@ a summary verdict. Called by the recipe pipeline after `open_research_pr` opens 
   results are valid outcomes for research PRs (do not flag them)
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - Issue subagent Task calls sequentially — ALL must be in a single parallel message
+- Embed diff content inline in subagent prompts — always pass by path and instruct subagents to Read
 
 **ALWAYS:**
 - Find the PR by feature branch at invocation time (not from a pre-captured URL)
@@ -226,8 +228,12 @@ Subagent prompt template (all 8 dimensions):
 > `+` or context line's marker in the same hunk.
 >
 > If no issues found, return an empty array [].
-> Annotated diff content (each line prefixed with [LNNN] markers):
-> {annotated_diff_content}
+> Read the annotated diff file at path: {annotated_diff_path}
+> Each line is prefixed with [LNNN] markers. Use the [LNNN] number as the `line` value.
+
+If `annotated_diff_path` is unset or the file does not exist, state "No annotated diff is
+available for this run — evaluate the diff without [LNNN] anchors and approximate `line` from
+context" instead of emitting a reference to a nonexistent path.
 
 ### Step 4: Aggregate and Deduplicate Findings
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1091,6 +1091,23 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "; _register_agent_tomls session-config registration for generated roles "
         "(+39 net lines)",
     ),
+    "rules_skill_content.py": (
+        1200,
+        "REQ-CNST-010-E11: SKILL.md content validation rules registry — accumulating "
+        "semantic rules (undefined-bash-placeholder, hardcoded-origin-remote, "
+        "blind-git-add, no-interpreter-mediated-writes, no-autoskillit-import, "
+        "no-posix-char-class, no-grep-bre-alternation, output-section-no-markdown-directive, "
+        "no-gh-issue-comment, transition-boundary-anti-confirmation, "
+        "executable-field-content-validity, reviews-post-requires-input-flag, "
+        "source-attribution-directive, graphql-query-requires-shell-invocation, "
+        "inline-content-in-subagent-prompt) co-located to keep SKILL.md validation "
+        "discovery a single import; splitting into sub-modules per rule would fragment "
+        "the @semantic_rule registration surface and break the test filter cascade."
+        "; inline-content-in-subagent-prompt rule (#4289 manifestation, #3636 architectural): "
+        "extract_blockquote_sections + extract_blockquote_placeholders helpers co-located "
+        "in _skill_placeholder_parser.py and re-used by both rules_skill_content.py "
+        "and the tests/skills/ contract linters (+~60 net lines)",
+    ),
 }
 
 

--- a/tests/contracts/test_review_pr_diff_annotation.py
+++ b/tests/contracts/test_review_pr_diff_annotation.py
@@ -7,12 +7,8 @@ from pathlib import Path
 import pytest
 
 from autoskillit.core.io import load_yaml
+from autoskillit.recipe._skill_placeholder_parser import extract_blockquote_sections
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
-
-try:
-    from autoskillit.recipe._skill_placeholder_parser import extract_blockquote_sections
-except ImportError:
-    extract_blockquote_sections = None  # type: ignore[assignment,misc]
 
 pytestmark = [pytest.mark.layer("contracts"), pytest.mark.medium]
 
@@ -177,34 +173,24 @@ def test_review_pr_never_specify_subagent_type() -> None:
     )
 
 
-@pytest.mark.xfail(reason="SKILL.md NEVER block not yet updated (#3636 prerequisite)", strict=True)
 def test_review_pr_never_embed_inline_in_never_block() -> None:
     """review-pr NEVER block must prohibit inline diff embedding."""
     content = _SKILLS_EXTENDED.joinpath("review-pr", "SKILL.md").read_text()
     assert "Embed diff content inline" in content
 
 
-@pytest.mark.xfail(reason="SKILL.md NEVER block not yet updated (#3636 prerequisite)", strict=True)
 def test_review_research_pr_never_embed_inline_in_never_block() -> None:
     """review-research-pr NEVER block must prohibit inline diff embedding."""
     content = _SKILLS_EXTENDED.joinpath("review-research-pr", "SKILL.md").read_text()
     assert "Embed diff content inline" in content
 
 
-@pytest.mark.xfail(reason="SKILL.md NEVER block not yet updated (#3636 prerequisite)", strict=True)
 def test_audit_claims_never_embed_inline_in_never_block() -> None:
     """audit-claims NEVER block must prohibit inline diff embedding."""
     content = _SKILLS_EXTENDED.joinpath("audit-claims", "SKILL.md").read_text()
     assert "Embed diff content inline" in content
 
 
-@pytest.mark.skipif(
-    extract_blockquote_sections is None,
-    reason="extract_blockquote_sections not yet implemented (#3636 prerequisite)",
-)
-@pytest.mark.xfail(
-    reason="SKILL.md blockquote variables not yet migrated (#3636 prerequisite)", strict=True
-)
 def test_review_pr_blockquote_uses_path_not_content_var() -> None:
     """review-pr blockquotes must use path var, not content var."""
     content = _SKILLS_EXTENDED.joinpath("review-pr", "SKILL.md").read_text()
@@ -214,13 +200,6 @@ def test_review_pr_blockquote_uses_path_not_content_var() -> None:
     assert "{annotated_diff_content}" not in all_block_text
 
 
-@pytest.mark.skipif(
-    extract_blockquote_sections is None,
-    reason="extract_blockquote_sections not yet implemented (#3636 prerequisite)",
-)
-@pytest.mark.xfail(
-    reason="SKILL.md blockquote variables not yet migrated (#3636 prerequisite)", strict=True
-)
 def test_review_research_pr_blockquote_uses_path_not_content_var() -> None:
     """review-research-pr blockquotes must use path var, not content var."""
     content = _SKILLS_EXTENDED.joinpath("review-research-pr", "SKILL.md").read_text()
@@ -230,13 +209,6 @@ def test_review_research_pr_blockquote_uses_path_not_content_var() -> None:
     assert "{annotated_diff_content}" not in all_block_text
 
 
-@pytest.mark.skipif(
-    extract_blockquote_sections is None,
-    reason="extract_blockquote_sections not yet implemented (#3636 prerequisite)",
-)
-@pytest.mark.xfail(
-    reason="SKILL.md blockquote variables not yet migrated (#3636 prerequisite)", strict=True
-)
 def test_audit_claims_blockquote_uses_path_not_content_var() -> None:
     """audit-claims blockquotes must use path var, not content var."""
     content = _SKILLS_EXTENDED.joinpath("audit-claims", "SKILL.md").read_text()

--- a/tests/execution/test_diff_annotator.py
+++ b/tests/execution/test_diff_annotator.py
@@ -191,6 +191,62 @@ class TestFilterFindings:
         result = filter_findings([], {"f.py": [(10, 20)]})
         assert result.all_unpostable is False
 
+    def test_filter_findings_null_line_routes_to_unpostable(self):
+        """A finding with `"line": None` goes to `unpostable` and does not raise
+        (with non-empty `valid_ranges`)."""
+        ranges = {"f.py": [(10, 20)]}
+        findings = [{"file": "f.py", "line": None, "message": "null line"}]
+        result = filter_findings(findings, ranges)
+        assert len(result.filtered) == 0
+        assert len(result.unpostable) == 1
+        assert result.unpostable[0]["line"] is None
+        assert result.all_unpostable is True
+
+    def test_filter_findings_missing_line_key_routes_to_unpostable(self):
+        """A finding without a `line` key goes to `unpostable`."""
+        ranges = {"f.py": [(10, 20)]}
+        findings = [{"file": "f.py", "message": "missing line"}]
+        result = filter_findings(findings, ranges)
+        assert len(result.filtered) == 0
+        assert len(result.unpostable) == 1
+        assert "line" not in result.unpostable[0]
+
+    def test_filter_findings_zero_line_routes_to_unpostable(self):
+        """A finding with `"line": 0` goes to `unpostable` (valid lines start at 1)."""
+        ranges = {"f.py": [(10, 20)]}
+        findings = [{"file": "f.py", "line": 0, "message": "zero line"}]
+        result = filter_findings(findings, ranges)
+        assert len(result.filtered) == 0
+        assert len(result.unpostable) == 1
+        assert result.unpostable[0]["line"] == 0
+
+    def test_filter_findings_null_line_not_in_filtered_when_validation_absent(self):
+        """A finding with `"line": None` is NOT placed in `filtered` even when both
+        `valid_ranges={}` and `valid_lines=None` (the early-return branch)."""
+        findings = [
+            {"file": "f.py", "line": None, "message": "null line"},
+            {"file": "f.py", "line": 15, "message": "valid"},
+        ]
+        result = filter_findings(findings, {})
+        assert len(result.filtered) == 1
+        assert result.filtered[0]["line"] == 15
+        assert len(result.unpostable) == 1
+        assert result.unpostable[0]["line"] is None
+        assert result.all_unpostable is False
+
+    def test_filter_findings_null_line_hunk_range_branch_no_typeerror(self):
+        """A finding with `"line": None` against the hunk-range interval branch
+        (`valid_ranges={"f.py": [(10, 20)]}`, `valid_lines=None`) routes to
+        `unpostable` without raising `TypeError`. Exercises the
+        `start <= line_num <= end` comparison path that previously crashed on
+        `None`."""
+        ranges = {"f.py": [(10, 20)]}
+        findings = [{"file": "f.py", "line": None, "message": "null line"}]
+        result = filter_findings(findings, ranges)
+        assert len(result.filtered) == 0
+        assert len(result.unpostable) == 1
+        assert result.unpostable[0]["line"] is None
+
 
 # --- End-to-end ---
 

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -1052,8 +1052,8 @@ def test_canonical_recipe_responses_fit_independent_registry_ceilings(tmp_path, 
         for ingredients_only in (False, True)
     }
     assert maxima == {
-        "load_recipe": (182_759, "remediation", "all_truthy"),
-        "open_kitchen": (182_818, "remediation", "all_truthy"),
+        "load_recipe": (183_585, "remediation", "all_truthy"),
+        "open_kitchen": (183_644, "remediation", "all_truthy"),
     }
 
 

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -1052,8 +1052,8 @@ def test_canonical_recipe_responses_fit_independent_registry_ceilings(tmp_path, 
         for ingredients_only in (False, True)
     }
     assert maxima == {
-        "load_recipe": (183_585, "remediation", "all_truthy"),
-        "open_kitchen": (183_644, "remediation", "all_truthy"),
+        "load_recipe": (182_759, "remediation", "all_truthy"),
+        "open_kitchen": (182_818, "remediation", "all_truthy"),
     }
 
 

--- a/tests/recipe/test_inline_content_semantic_rule.py
+++ b/tests/recipe/test_inline_content_semantic_rule.py
@@ -52,10 +52,6 @@ def _make_skill_md_with_blockquote(var: str) -> str:
     )
 
 
-@pytest.mark.xfail(
-    reason="inline-content-in-subagent-prompt rule not yet implemented (#3636 prerequisite)",
-    strict=True,
-)
 @pytest.mark.parametrize(
     "banned_var",
     [

--- a/tests/recipe/test_skill_placeholder_parser.py
+++ b/tests/recipe/test_skill_placeholder_parser.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from autoskillit.recipe._skill_placeholder_parser import extract_validation_rule_block
+from autoskillit.recipe._skill_placeholder_parser import (
+    extract_blockquote_placeholders,
+    extract_blockquote_sections,
+    extract_validation_rule_block,
+)
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
@@ -55,3 +59,96 @@ def test_extract_validation_rule_block_different_rule() -> None:
     assert "V1" not in block
     assert "V2" in block
     assert "V3" not in block
+
+
+# --- extract_blockquote_sections ---
+
+
+def test_extract_blockquote_sections_identifies_contiguous_blocks() -> None:
+    """A 3+ line contiguous blockquote run is yielded with the nearest step heading."""
+    sample = (
+        "### Step 3: Dispatch subagent\n"
+        "\n"
+        "> Review the diff.\n"
+        "> Report findings.\n"
+        "> Be concise.\n"
+        "\n"
+        "Trailing prose.\n"
+    )
+    blocks = extract_blockquote_sections(sample)
+    assert len(blocks) == 1
+    heading, text = blocks[0]
+    assert heading == "Step 3"
+    assert "Review the diff." in text
+    assert "Report findings." in text
+    assert "Be concise." in text
+
+
+def test_extract_blockquote_sections_excludes_single_line_callouts() -> None:
+    """Single-line `>` callouts without content signals are stylistic, not prompts."""
+    sample = "### Step 1: Note\n\n> **Note:** This is a stylistic callout.\n\nBody prose.\n"
+    blocks = extract_blockquote_sections(sample)
+    assert blocks == []
+
+
+def test_extract_blockquote_sections_includes_two_line_prompt_with_banned_var() -> None:
+    """A 2-line blockquote containing a {*_content} placeholder IS returned (content signal)."""
+    sample = (
+        "### Step 2: Inline content\n\n> Review {annotated_diff_content}.\n> Report findings.\n"
+    )
+    blocks = extract_blockquote_sections(sample)
+    assert len(blocks) == 1
+    heading, text = blocks[0]
+    assert heading == "Step 2"
+    assert "{annotated_diff_content}" in text
+
+
+def test_extract_blockquote_sections_strips_prefix() -> None:
+    """Returned text has the `> ` prefix stripped from each line."""
+    sample = "### Step 4\n\n> First line.\n> Second line.\n> Third line.\n"
+    blocks = extract_blockquote_sections(sample)
+    assert len(blocks) == 1
+    _, text = blocks[0]
+    for line in text.splitlines():
+        assert not line.startswith(">"), f"Prefix not stripped: {line!r}"
+
+
+def test_extract_blockquote_sections_trailing_block_at_eof() -> None:
+    """A blockquote that runs to end of file is flushed, not silently dropped."""
+    sample = "### Step 5\n\n> Line one.\n> Line two.\n> Line three."
+    blocks = extract_blockquote_sections(sample)
+    assert len(blocks) == 1
+    heading, text = blocks[0]
+    assert heading == "Step 5"
+    assert "Line one." in text
+    assert "Line two." in text
+    assert "Line three." in text
+
+
+def test_extract_blockquote_sections_tuple_order_heading_first() -> None:
+    """First tuple element is the step heading, second is the body text."""
+    sample = "### Step 7\n\n> First.\n> Second.\n> Third.\n"
+    blocks = extract_blockquote_sections(sample)
+    assert len(blocks) == 1
+    heading, body = blocks[0]
+    assert heading == "Step 7"
+    assert isinstance(heading, str)
+    assert isinstance(body, str)
+    assert "First." in body
+
+
+# --- extract_blockquote_placeholders ---
+
+
+def test_extract_blockquote_placeholders_extracts_content_suffix_vars() -> None:
+    """Given a blockquote with {annotated_diff_content} and {diff_content}, return both names."""
+    text = "Review the following:\n{annotated_diff_content}\nand {diff_content} here.\n"
+    placeholders = extract_blockquote_placeholders(text)
+    assert placeholders == {"annotated_diff_content", "diff_content"}
+
+
+def test_extract_blockquote_placeholders_ignores_non_content_vars() -> None:
+    """A blockquote with only {*_path} vars (no {*_content}) returns an empty set."""
+    text = "Read {annotated_diff_path}.\nInspect {diff_path}.\n"
+    placeholders = extract_blockquote_placeholders(text)
+    assert placeholders == set()


### PR DESCRIPTION
## Summary

The `review-pr`, `review-research-pr`, and `audit-claims` SKILL.md files contain dangling template variables (`{annotated_diff_content}`, `{diff_content}`, `{section_diff_content}`) in blockquoted subagent prompts that are never populated. The existing `_skill_placeholder_parser.py` only validates `{placeholder}` tokens inside bash fenced blocks — blockquote/prose regions where subagent prompts live are structurally invisible to validation. The `inline-content-in-subagent-prompt` semantic rule was named and xfail-tested (#3636) but never implemented.

This PR implements the parser extension, the semantic rule, and `filter_findings()` null-safety (Part A), then migrates the three affected SKILL.md files to the architecturally correct `*_path` pattern, updates NEVER blocks to prohibit inline diff embedding, and un-xfails the remaining contract tests (Part B). After these changes, subagent prompts reference diff content by file path and instruct subagents to Read, in line with the architectural rule from PR #3651.

<details>
<summary>Individual Group Plans</summary>

### Part A: Parser extension, semantic rule, and null-safety

Implements `extract_blockquote_sections()` and `extract_blockquote_placeholders()` in `_skill_placeholder_parser.py`, adds the `inline-content-in-subagent-prompt` semantic rule in `rules_skill_content.py`, hardens `filter_findings()` against null/zero/missing `line` values (which currently crash with `TypeError` on `None in valid_set` and `start <= None <= end` comparisons), and un-xfails the gated semantic rule test.

### Part B: SKILL.md migration, NEVER blocks, and contract un-xfail

Migrates `review-pr`, `review-research-pr`, and `audit-claims` SKILL.md files from dangling `*_content` variables to the `*_path` pattern (subagent reads content from disk). Adds an explicit NEVER-block prohibition against inline diff embedding in all three skills. Adds the new `section_diff_path` file-writing step in `audit-claims` Phase 1 and declares `annotated_diff_path` in the `review-research-pr` Arguments section. Removes the `try/except ImportError` fallback for `extract_blockquote_sections` and the `skipif` guards that Part A makes obsolete, un-xfailing the six contract tests gating on SKILL.md content.

</details>

Closes #4289

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/remediation-20260718-171316-238004/.autoskillit/temp/rectify/rectify_inline_content_subagent_prompt_2026-07-18_172142_part_a.md`
- `/home/talon/projects/autoskillit-runs/remediation-20260718-171316-238004/.autoskillit/temp/rectify/rectify_inline_content_subagent_prompt_2026-07-18_172142_part_b.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
