### PR TITLE
Rectify: Codex CLI Limits Pin — From "Someone Looked" to "Here Is What They Found"

### DIFF
--- a/docs/decisions/0004-recipe-redelivery.md
+++ b/docs/decisions/0004-recipe-redelivery.md
@@ -77,5 +77,19 @@ page carrying `next_part`. They must not guess or repair a malformed continuatio
 - Future work relaxing `CODEX_AUTO_COMPACT_LIMIT` must add integration tests verifying
   `load_recipe` / `open_kitchen` / `get_recipe_section` re-delivery restores full
   pipeline execution capability, including envelope re-delivery plus per-step pulls.
-- `test_copied_config_has_auto_compact_limit` validates the primary defense path:
+- `test_snapshotted_config_has_auto_compact_limit` validates the primary defense path:
   `setup_session_dir` preserves the override in the copied `config.toml`.
+
+## Re-verification at codex-cli 0.145.0 (2026-07-26)
+
+Issue #4369 re-verified the primary defense against upstream `rust-v0.145.0`
+(commit `25af12f7e61572b0bc18ddb1008be543b91519b0`). `ModelInfo::auto_compact_token_limit()`
+clamps the configured `model_auto_compact_token_limit` to 90% of the resolved context
+window; for gpt-5.6-sol (`resolved_context_window = 272_000`) the clamped, effective
+threshold is **244,800** — not the configured `999_999_999`. **`CODEX_AUTO_COMPACT_LIMIT`
+is measurably neutralized upstream at this CLI version**: 34 compaction events were
+observed under 0.145.0. The forward obligation recorded above — testing the
+`load_recipe` / `open_kitchen` / `get_recipe_section` end-to-end recovery path — is
+therefore live, not hypothetical, and is owned by #4271. The finding is recorded
+machine-readably in `CODEX_LIMIT_VERIFICATION_REGISTRY["CODEX_AUTO_COMPACT_LIMIT"]`
+(`execution/backends/_codex_config.py`).

--- a/docs/decisions/0004-recipe-redelivery.md
+++ b/docs/decisions/0004-recipe-redelivery.md
@@ -15,7 +15,8 @@ Two defenses exist:
 1. **Primary — disable compaction**: `ensure_codex_mcp_registered` writes
    `model_auto_compact_token_limit = 999_999_999` (an unreachable threshold) to
    `~/.codex/config.toml`. `setup_session_dir` copies this config into each session
-   directory, ensuring every headless session inherits the setting.
+   directory, ensuring every headless session inherits the setting. *Re-verified at
+   codex-cli 0.145.0 and found neutralized upstream — see "Re-verification" below.*
 
 2. **Guard — block raw recipe reads**: The `recipe_read_guard.py` PreToolUse hook
    blocks `run_cmd`/`Bash` from reading recipe YAML, SKILL.md, or agent definition

--- a/docs/decisions/0005-output-budget-protocol.md
+++ b/docs/decisions/0005-output-budget-protocol.md
@@ -198,7 +198,13 @@ insertion control, not a measurement of remaining context.
   (`CODEX_HISTORY_RETENTION_TOKEN_LIMIT`), and auto-compact sentinel
   (`CODEX_AUTO_COMPACT_LIMIT`) against the upstream registry AND observed session
   windows, then bump `CODEX_LIMITS_LAST_VERIFIED_VERSION`. Doctor Check 39
-  (`codex_limits_verified`) mechanizes the reminder. Issue #4280's investigation
+  (`codex_limits_verified`) mechanizes the reminder. `CODEX_LIMIT_VERIFICATION_REGISTRY`
+  is the durable, machine-readable record of what was checked and found;
+  `CODEX_LIMITS_LAST_VERIFIED_VERSION` is derived from it as the minimum
+  `checked_at_cli_version` across its entries. At codex-cli 0.145.0,
+  `CODEX_AUTO_COMPACT_LIMIT` was found neutralized upstream:
+  `ModelInfo::auto_compact_token_limit()` clamps it to 90% of the resolved context
+  window, an effective threshold of 244,800 for gpt-5.6-sol. Issue #4280's investigation
   found upstream models.json (post-0.144.1) listing gpt-5.6-sol at 372,000 tokens
   vs 258,400 in cli 0.144.1, but the effective window is server/catalog-controlled
   and oscillated during July 2026 (openai/codex#31860, #32806) — re-verify, do not
@@ -212,10 +218,12 @@ insertion control, not a measurement of remaining context.
   files.
 - openai/codex#33881: agent-TOML `model`/`model_reasoning_effort` reportedly ignored
   on 0.144.5 — affects the pins `_generate_agent_tomls` writes.
-- Upstream auto-compact semantics are scope-dependent
-  (`model_auto_compact_token_limit` is consulted only under `BodyAfterPrefix` scope;
-  a separate full-context-window trigger ignores it) — re-verify
-  `CODEX_AUTO_COMPACT_LIMIT`'s disabling effect per upgrade.
+- Upstream auto-compact semantics: `model_auto_compact_token_limit` is consulted
+  directly only under the non-default `BodyAfterPrefix` scope; the default scope is
+  `Total`, under which the trigger uses `ModelInfo::auto_compact_token_limit()`, which
+  clamps the configured value to 90% of the resolved context window. The practical
+  mechanism is the clamp, not a separate trigger — re-verify `CODEX_AUTO_COMPACT_LIMIT`'s
+  disabling effect per upgrade.
 
 ## Consequences
 

--- a/docs/decisions/0005-output-budget-protocol.md
+++ b/docs/decisions/0005-output-budget-protocol.md
@@ -119,6 +119,17 @@ damage bound, not the current call's outer result selector, and does not make
 `develop`, not the repository's default branch, `main`. Closure must therefore be
 recorded explicitly in the issue body.
 
+Issue #4369 re-verified both governed limits against upstream `rust-v0.145.0` (see
+Forward Obligations, below). Two claims in the "Numeric Limits and Rationale" table
+above are superseded by that re-verification: `CODEX_HISTORY_RETENTION_TOKEN_LIMIT`'s
+"does not select the current outer result" framing incorrectly implied `tool_output_token_limit`
+only governs later-stored history — it also governs the current turn's tool output,
+per `CODEX_LIMIT_VERIFICATION_REGISTRY["CODEX_HISTORY_RETENTION_TOKEN_LIMIT"]`
+(`execution/backends/_codex_config.py`); and `CODEX_AUTO_COMPACT_LIMIT`'s "unreachable
+sentinel" framing no longer holds, since `ModelInfo::auto_compact_token_limit()` clamps
+it to 90% of the resolved context window (244,800 for gpt-5.6-sol), per
+`CODEX_LIMIT_VERIFICATION_REGISTRY["CODEX_AUTO_COMPACT_LIMIT"]`.
+
 ## Accepted Gaps
 
 1. Non-JSONL single-file searches and arbitrary shell verbs (`python -c` file dumps,

--- a/docs/decisions/0006-output-containment.md
+++ b/docs/decisions/0006-output-containment.md
@@ -32,7 +32,9 @@ output-boundary bounding on measured bytes:
    output through its owned fd. The bounded inline slice includes a provenance
    marker whose path is present only after marker-time identity verification. The
    ordinary outer-result limit remains the backstop for hook-failure paths. The
-   separately configured `CODEX_HISTORY_RETENTION_TOKEN_LIMIT` governs later history.
+   separately configured `CODEX_HISTORY_RETENTION_TOKEN_LIMIT` replaces the model's
+   `truncation_policy` outright, so it governs both the current-turn exec output sent
+   to the model and retained history — not later history alone.
 
 ### Sequencing Rule
 

--- a/src/autoskillit/cli/doctor/_doctor_runtime.py
+++ b/src/autoskillit/cli/doctor/_doctor_runtime.py
@@ -23,7 +23,11 @@ from autoskillit.core import (
     get_logger,
     is_valid_codex_model_id,
 )
-from autoskillit.execution import CODEX_LIMITS_LAST_VERIFIED_VERSION, QUOTA_CACHE_SCHEMA_VERSION
+from autoskillit.execution import (
+    CODEX_LIMITS_LAST_VERIFIED_VERSION,
+    QUOTA_CACHE_SCHEMA_VERSION,
+    CodexBackend,
+)
 
 from ._doctor_types import DoctorResult
 
@@ -94,23 +98,29 @@ def _check_codex_version(*, backend: CodingAgentBackend | None = None) -> Doctor
 
 def _check_codex_limits_verified(*, backend: CodingAgentBackend | None = None) -> DoctorResult:
     check_name = "codex_limits_verified"
+    # F3 guard: a Codex CLI limits pin is only ever meaningful for a Codex backend.
+    # Comparing it against whatever CLI a differently-configured backend names
+    # (e.g. `claude --version`) produces a factually false warning.
+    if not isinstance(backend, CodexBackend):
+        return DoctorResult(
+            Severity.OK, check_name, "Skipped (backend declares no CLI limits pin)"
+        )
     ver = _parse_codex_version(backend=backend)
     if ver.skip_reason is not None:
         return DoctorResult(Severity.OK, check_name, f"Skipped ({ver.skip_reason})")
     assert ver.parsed is not None
+    cur_str = ".".join(str(v) for v in ver.parsed)
     if ver.parsed > CODEX_LIMITS_LAST_VERIFIED_VERSION:
         pin_str = ".".join(str(v) for v in CODEX_LIMITS_LAST_VERIFIED_VERSION)
-        cur_str = ".".join(str(v) for v in ver.parsed)
         return DoctorResult(
             Severity.WARNING,
             check_name,
-            f"Codex CLI {cur_str} is newer than verified pin {pin_str}; "
-            "re-verify the recipe outer-result parser/protected evidence contract, "
-            "CODEX_HISTORY_RETENTION_TOKEN_LIMIT (later history only), and "
-            "CODEX_AUTO_COMPACT_LIMIT against upstream behavior, then bump "
-            "CODEX_LIMITS_LAST_VERIFIED_VERSION",
+            f"Codex CLI {cur_str} is newer than verified pin {pin_str}; re-verify "
+            "CODEX_HISTORY_RETENTION_TOKEN_LIMIT, CODEX_AUTO_COMPACT_LIMIT, and "
+            "CODEX_RECIPE_DELIVERY_BUDGET against upstream behavior and update "
+            "CODEX_LIMIT_VERIFICATION_REGISTRY, from which "
+            "CODEX_LIMITS_LAST_VERIFIED_VERSION is derived",
         )
-    cur_str = ".".join(str(v) for v in ver.parsed)
     return DoctorResult(Severity.OK, check_name, f"Codex CLI {cur_str} at or below verified pin")
 
 

--- a/src/autoskillit/execution/backends/AGENTS.md
+++ b/src/autoskillit/execution/backends/AGENTS.md
@@ -13,7 +13,7 @@ IL-1 backend abstraction layer — concrete `CodingAgentBackend` implementations
 | `claude.py` | `ClaudeCodeBackend` (incl. `validate_session_layout`), `ClaudeEnvPolicy`, `ClaudeSessionLocator`, `ClaudeStreamParser`, `ClaudeResultParser` (prompt utilities moved to `_claude_prompt.py`) |
 | `_claude_prompt.py` | Prompt injection utilities, session constants (`_ensure_skill_prefix`, `_inject_completion_directive`, `_compose_resume_prompt`, etc.), shared by claude + codex + commands |
 | `codex.py` | `CodexFlags`, `CodexBackend` (incl. `validate_session_layout`, `setup_session_dir` agent TOML generation and session-config registration), `CodexEnvPolicy`, `CodexSessionLocator`, `CodexStateReadinessProbe` (parse/config moved to `_codex_parse.py` / `_codex_config.py`) |
-| `_codex_config.py` | TOML serialization with `[[key]]` array-of-tables support, MCP registration (`ensure_codex_mcp_registered`, `_serialize_toml`) |
+| `_codex_config.py` | TOML serialization with `[[key]]` array-of-tables support, MCP registration (`ensure_codex_mcp_registered`, `_serialize_toml`), `CODEX_LIMIT_VERIFICATION_REGISTRY` (`CodexLimitVerificationDef`, `validate_codex_limit_verification`) |
 | `_codex_config_lock.py` | Canonical source-config advisory lock with timeout, ownership diagnostics, and non-reentrant lifecycle |
 | `_codex_hooks.py` | Codex config.toml hook generation, sync, and upsert (`generate_codex_hooks_config`, `sync_hooks_to_codex_config`) |
 | `_codex_parse.py` | `CodexStreamParser`, `CodexResultParser`, NDJSON scanning, and bounded persisted-rollout parsing |

--- a/src/autoskillit/execution/backends/_codex_config.py
+++ b/src/autoskillit/execution/backends/_codex_config.py
@@ -7,7 +7,7 @@ import json
 from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any
+from typing import Any, Literal, NamedTuple
 
 import regex as _re
 
@@ -150,14 +150,186 @@ CODEX_RECIPE_DELIVERY_CALLING_CONTRACT_DIGEST: str = hashlib.sha256(
 # loaded by `open_kitchen`, leaving the agent without the recipe steps it
 # needs to complete the pipeline. Defense-in-depth is provided by the
 # `recipe_read_guard.py` PreToolUse hook which prevents the agent from
-# re-reading recipe files via run_cmd/run_python after compaction.
+# re-reading recipe files via run_cmd/run_python after compaction. See the
+# "CODEX_AUTO_COMPACT_LIMIT" entry in CODEX_LIMIT_VERIFICATION_REGISTRY below
+# for the upstream-neutralization finding.
 CODEX_AUTO_COMPACT_LIMIT: int = 999_999_999
 
-# Codex CLI version against which the numeric limits above were last verified:
-# the history-retention requirement behind CODEX_HISTORY_RETENTION_TOKEN_LIMIT
-# and the context-window assumption behind CODEX_AUTO_COMPACT_LIMIT. The doctor
-# check `codex_limits_verified` warns when the installed CLI is newer.
-CODEX_LIMITS_LAST_VERIFIED_VERSION: tuple[int, int, int] = (0, 144, 1)
+CodexLimitVerificationStatus = Literal[
+    "upstream_honored", "upstream_neutralized", "locally_unreachable"
+]
+
+
+class CodexLimitVerificationDef(NamedTuple):
+    """Recorded outcome of verifying one governed limit against a pinned CLI revision."""
+
+    governed_symbol: str
+    checked_at_cli_version: tuple[int, int, int]
+    upstream_revision: str
+    upstream_sources: tuple[str, ...]
+    status: CodexLimitVerificationStatus
+    codex_config_key: str | None
+    configured_value: int | None
+    upstream_effective_value: int | None
+    finding: str
+
+
+def validate_codex_limit_verification(entry: CodexLimitVerificationDef, *, key: str) -> None:
+    """Raise ValueError if entry's declared status contradicts its recorded numbers."""
+    if entry.governed_symbol != key:
+        raise ValueError(
+            f"{key}: governed_symbol {entry.governed_symbol!r} must equal registry key {key!r}"
+        )
+    if len(entry.checked_at_cli_version) != 3 or not all(
+        isinstance(v, int) for v in entry.checked_at_cli_version
+    ):
+        raise ValueError(f"{key}: checked_at_cli_version must be a 3-tuple of ints")
+    if not entry.upstream_revision:
+        raise ValueError(f"{key}: upstream_revision must be non-empty")
+    if not entry.upstream_sources:
+        raise ValueError(f"{key}: upstream_sources must be non-empty")
+    if len(entry.finding) < 80:
+        raise ValueError(f"{key}: finding is too thin to act on")
+    if entry.codex_config_key is not None and entry.configured_value is None:
+        raise ValueError(f"{key}: codex_config_key is set but configured_value is None")
+    if entry.status == "upstream_honored":
+        honored = (
+            entry.configured_value is not None
+            and entry.upstream_effective_value == entry.configured_value
+        )
+        if not honored:
+            raise ValueError(
+                f"{key}: status upstream_honored requires "
+                "upstream_effective_value == configured_value"
+            )
+    elif entry.status == "upstream_neutralized":
+        neutralized = (
+            entry.configured_value is not None
+            and entry.upstream_effective_value is not None
+            and entry.upstream_effective_value != entry.configured_value
+        )
+        if not neutralized:
+            raise ValueError(
+                f"{key}: status upstream_neutralized requires configured_value and "
+                "upstream_effective_value to both be set and differ"
+            )
+    elif entry.status == "locally_unreachable":
+        if entry.upstream_effective_value is not None:
+            raise ValueError(
+                f"{key}: status locally_unreachable requires upstream_effective_value is None"
+            )
+
+
+CODEX_LIMIT_VERIFICATION_REGISTRY: Mapping[str, CodexLimitVerificationDef] = MappingProxyType(
+    {
+        "CODEX_HISTORY_RETENTION_TOKEN_LIMIT": CodexLimitVerificationDef(
+            governed_symbol="CODEX_HISTORY_RETENTION_TOKEN_LIMIT",
+            checked_at_cli_version=(0, 145, 0),
+            upstream_revision="25af12f7e61572b0bc18ddb1008be543b91519b0",
+            upstream_sources=(
+                "codex-rs/models-manager/src/model_info.rs::with_config_overrides",
+                "codex-rs/utils/string/src/truncate.rs::APPROX_BYTES_PER_TOKEN",
+                "codex-rs/core/src/tools/mod.rs::format_exec_output_for_model",
+                "codex-rs/core/src/context_manager/history.rs::record_items",
+            ),
+            status="upstream_honored",
+            codex_config_key="tool_output_token_limit",
+            configured_value=CODEX_HISTORY_RETENTION_TOKEN_LIMIT,
+            upstream_effective_value=CODEX_HISTORY_RETENTION_TOKEN_LIMIT,
+            finding=(
+                "tool_output_token_limit is applied verbatim: with_config_overrides replaces "
+                "ModelInfo.truncation_policy with no clamp (unlike model_context_window, which "
+                "is min()-clamped to max_context_window). APPROX_BYTES_PER_TOKEN is still 4. "
+                "The gpt-5.6-sol catalog default is {mode: tokens, limit: 10000}, so this "
+                "override is the only thing keeping recipe payloads intact. The same "
+                "truncation_policy field governs BOTH the current-turn exec output sent to "
+                "the model and retained history -- the earlier '(later history only)' "
+                "qualifier was factually wrong and is removed."
+            ),
+        ),
+        "CODEX_AUTO_COMPACT_LIMIT": CodexLimitVerificationDef(
+            governed_symbol="CODEX_AUTO_COMPACT_LIMIT",
+            checked_at_cli_version=(0, 145, 0),
+            upstream_revision="25af12f7e61572b0bc18ddb1008be543b91519b0",
+            upstream_sources=(
+                "codex-rs/protocol/src/openai_models.rs::ModelInfo::auto_compact_token_limit",
+                "codex-rs/protocol/src/config_types.rs::AutoCompactTokenLimitScope",
+                "codex-rs/core/src/session/context_window.rs",
+            ),
+            status="upstream_neutralized",
+            codex_config_key="model_auto_compact_token_limit",
+            configured_value=CODEX_AUTO_COMPACT_LIMIT,
+            upstream_effective_value=244_800,
+            finding=(
+                "ModelInfo::auto_compact_token_limit() returns "
+                "min(config, resolved_context_window * 9 / 10). AutoCompactTokenLimitScope "
+                "defaults to Total, under which the clamped accessor is used, and AutoSkillit "
+                "never writes model_auto_compact_token_limit_scope. gpt-5.6-sol's "
+                "resolved_context_window is 272_000, so the effective threshold is 244_800, "
+                "not the configured 999_999_999. Measured peak last_token_usage.total_tokens "
+                "before the first compaction across 26 compacted 0.145.0 rollouts was "
+                "244_865 (0.027 percent over 244_800); 34 compaction events occurred under "
+                "0.145.0. The sentinel does not disable auto-compaction and ADR-0004's "
+                "'primary defense' framing no longer holds; the recovery-path replacement is "
+                "owned by #4271."
+            ),
+        ),
+        "CODEX_RECIPE_DELIVERY_BUDGET": CodexLimitVerificationDef(
+            governed_symbol="CODEX_RECIPE_DELIVERY_BUDGET",
+            checked_at_cli_version=(0, 145, 0),
+            upstream_revision="25af12f7e61572b0bc18ddb1008be543b91519b0",
+            upstream_sources=(
+                "autoskillit: core/_delivery_bounds.py::resolve_recipe_delivery_decision",
+                "autoskillit: execution/backends/_codex_config.py"
+                "::SUPPORTED_CODEX_RECIPE_EVIDENCE_REGISTRY",
+            ),
+            status="locally_unreachable",
+            codex_config_key=None,
+            configured_value=None,
+            upstream_effective_value=None,
+            finding=(
+                "SUPPORTED_CODEX_RECIPE_EVIDENCE_REGISTRY is empty, so every caller reaches "
+                "resolve_recipe_delivery_decision with supported_evidence=None and the "
+                "ATTESTED_INLINE terminal branch is unreachable in the live call graph. The "
+                '// @exec: {"max_output_tokens": 56750} cell contract was emitted in 0 of '
+                "552 0.145.0 rollouts; zero AutoSkillit-launched Codex sessions have run "
+                "under 0.145.0. Positive verification requires the CODEX_SMOKE_TEST=1 live "
+                "probe suite; this pin does not certify upstream parser behavior for this "
+                "surface."
+            ),
+        ),
+    }
+)
+
+
+def _validate_codex_limit_verification_registry() -> tuple[int, int, int]:
+    if not CODEX_LIMIT_VERIFICATION_REGISTRY:
+        raise ValueError(
+            "CODEX_LIMIT_VERIFICATION_REGISTRY must not be empty: "
+            "CODEX_LIMITS_LAST_VERIFIED_VERSION is derived from it"
+        )
+    for key, entry in CODEX_LIMIT_VERIFICATION_REGISTRY.items():
+        validate_codex_limit_verification(entry, key=key)
+    return min(e.checked_at_cli_version for e in CODEX_LIMIT_VERIFICATION_REGISTRY.values())
+
+
+def _codex_limit_verification_registry_digest() -> str:
+    canonical = [
+        (key, entry._asdict()) for key, entry in sorted(CODEX_LIMIT_VERIFICATION_REGISTRY.items())
+    ]
+    payload = json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(payload.encode("ascii")).hexdigest()
+
+
+# Codex CLI version against which the numeric limits above were last verified,
+# derived as the minimum checked_at_cli_version over CODEX_LIMIT_VERIFICATION_REGISTRY --
+# the pin cannot be bumped without updating the evidence recorded alongside it. The
+# doctor check `codex_limits_verified` warns when the installed CLI is newer.
+CODEX_LIMITS_LAST_VERIFIED_VERSION: tuple[int, int, int] = (
+    _validate_codex_limit_verification_registry()
+)
+
+CODEX_LIMIT_VERIFICATION_REGISTRY_DIGEST: str = _codex_limit_verification_registry_digest()
 
 # Keys that must be present in the autoskillit MCP server entry for the Codex
 # backend. Validated against the entry dict actually written by

--- a/src/autoskillit/execution/backends/_codex_config.py
+++ b/src/autoskillit/execution/backends/_codex_config.py
@@ -214,9 +214,15 @@ def validate_codex_limit_verification(entry: CodexLimitVerificationDef, *, key: 
                 "upstream_effective_value to both be set and differ"
             )
     elif entry.status == "locally_unreachable":
-        if entry.upstream_effective_value is not None:
+        unreachable = (
+            entry.upstream_effective_value is None
+            and entry.configured_value is None
+            and entry.codex_config_key is None
+        )
+        if not unreachable:
             raise ValueError(
-                f"{key}: status locally_unreachable requires upstream_effective_value is None"
+                f"{key}: status locally_unreachable requires upstream_effective_value, "
+                "configured_value, and codex_config_key to all be None"
             )
 
 

--- a/src/autoskillit/execution/backends/_codex_config.py
+++ b/src/autoskillit/execution/backends/_codex_config.py
@@ -224,6 +224,8 @@ def validate_codex_limit_verification(entry: CodexLimitVerificationDef, *, key: 
                 f"{key}: status locally_unreachable requires upstream_effective_value, "
                 "configured_value, and codex_config_key to all be None"
             )
+    else:
+        raise ValueError(f"{key}: unrecognized status {entry.status!r}")
 
 
 CODEX_LIMIT_VERIFICATION_REGISTRY: Mapping[str, CodexLimitVerificationDef] = MappingProxyType(

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -140,6 +140,9 @@ _STRENUM_COMPARE_EXEMPT_FILES: frozenset[str] = frozenset(
         "test_sidecar_synthesis_terminal_guard.py",  # L3ParseResult.outcome: Literal[...]
         "test_verdict_dispatch_chain.py",  # L3ParseResult.outcome: Literal[...]
         "test_helpers_exports.py",  # L3ParseResult.outcome: Literal[...], not SessionOutcome
+        # CodexLimitVerificationDef.status: Literal[...], not StrEnum
+        "test_codex_limit_verification.py",
+        "test_codex_limit_findings_are_recorded.py",
     }
 )
 
@@ -155,6 +158,9 @@ _STRENUM_SRC_COMPARE_EXEMPT_PATHS: frozenset[str] = frozenset(
         "fleet/_checkpoint_bridge.py",  # IssueSidecarEntry.status: Literal[...], not StrEnum
         "fleet/_outcome.py",  # classify_dispatch_outcome: Literal comparisons
         "fleet/_sidecar_synthesis.py",  # L3ParseResult.outcome: Literal[...], not SessionOutcome
+        # CodexLimitVerificationDef.status: CodexLimitVerificationStatus = Literal[...],
+        # not StrEnum
+        "execution/backends/_codex_config.py",
     }
 )
 

--- a/tests/cli/test_doctor_runtime.py
+++ b/tests/cli/test_doctor_runtime.py
@@ -93,12 +93,72 @@ class TestCheckCodexLimitsVerified:
         monkeypatch.setattr(
             mod,
             "_parse_codex_version",
-            lambda *, backend=None: mod.CodexVersionResult(parsed=(0, 145, 0), skip_reason=None),
+            lambda *, backend=None: mod.CodexVersionResult(parsed=(0, 146, 0), skip_reason=None),
         )
         result = mod._check_codex_limits_verified(backend=CodexBackend())
         assert result.severity == Severity.WARNING
         assert "CODEX_HISTORY_RETENTION_TOKEN_LIMIT" in result.message
         assert "CODEX_AUTO_COMPACT_LIMIT" in result.message
+
+    def test_codex_limits_verified_skips_for_a_backend_without_a_limits_pin(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """F3 regression test: a non-Codex backend must never be version-compared
+        against the Codex pin, even when it exposes its own version_check_command."""
+        import autoskillit.cli.doctor._doctor_runtime as mod
+        from autoskillit.core import Severity
+        from autoskillit.execution.backends.claude import ClaudeCodeBackend
+
+        monkeypatch.setattr(
+            mod,
+            "_parse_codex_version",
+            lambda *, backend=None: mod.CodexVersionResult(parsed=(2, 1, 197), skip_reason=None),
+        )
+        result = mod._check_codex_limits_verified(backend=ClaudeCodeBackend())
+        assert result.severity == Severity.OK
+        assert "Skipped" in result.message
+
+    def test_codex_limits_verified_skips_when_no_backend_is_resolved(self) -> None:
+        import autoskillit.cli.doctor._doctor_runtime as mod
+        from autoskillit.core import Severity
+
+        result = mod._check_codex_limits_verified(backend=None)
+        assert result.severity == Severity.OK
+        assert "Skipped" in result.message
+
+    def test_codex_limits_verified_warning_names_every_governed_symbol(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import autoskillit.cli.doctor._doctor_runtime as mod
+        from autoskillit.core import Severity
+        from autoskillit.execution.backends._codex_config import (
+            CODEX_LIMIT_VERIFICATION_REGISTRY,
+        )
+        from autoskillit.execution.backends.codex import CodexBackend
+
+        monkeypatch.setattr(
+            mod,
+            "_parse_codex_version",
+            lambda *, backend=None: mod.CodexVersionResult(parsed=(0, 146, 0), skip_reason=None),
+        )
+        result = mod._check_codex_limits_verified(backend=CodexBackend())
+        assert result.severity == Severity.WARNING
+        for key in CODEX_LIMIT_VERIFICATION_REGISTRY:
+            assert key in result.message
+
+    def test_codex_limits_verified_warning_does_not_claim_later_history_only(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import autoskillit.cli.doctor._doctor_runtime as mod
+        from autoskillit.execution.backends.codex import CodexBackend
+
+        monkeypatch.setattr(
+            mod,
+            "_parse_codex_version",
+            lambda *, backend=None: mod.CodexVersionResult(parsed=(0, 146, 0), skip_reason=None),
+        )
+        result = mod._check_codex_limits_verified(backend=CodexBackend())
+        assert "later history only" not in result.message
 
     def test_codex_limits_verified_ok_at_pinned_version(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/docs/AGENTS.md
+++ b/tests/docs/AGENTS.md
@@ -26,3 +26,4 @@ Documentation integrity, link validity, and naming convention tests.
 | `test_recipe_redelivery_decision.py` | ADR-0004 recipe pull pagination identity and reconstruction contracts |
 | `test_check_sub_claude_md_script.py` | Unit and integration tests for the check_sub_claude_md.py pre-commit hook script |
 | `test_context_admission_decision.py` | Ratchet ADR-0007 context-admission authority, evidence, traceability, and downstream ownership |
+| `test_codex_limit_findings_are_recorded.py` | Ratchet: every upstream-neutralized Codex limit finding must be disclosed in ADR-0004 and ADR-0005 |

--- a/tests/docs/test_codex_limit_findings_are_recorded.py
+++ b/tests/docs/test_codex_limit_findings_are_recorded.py
@@ -1,0 +1,40 @@
+"""Ratchet: every upstream-neutralized Codex limit finding must be disclosed in the ADRs.
+
+Derived from CODEX_LIMIT_VERIFICATION_REGISTRY so a future verification that flips a
+status automatically requires — and self-checks — the corresponding ADR disclosure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.execution.backends._codex_config import CODEX_LIMIT_VERIFICATION_REGISTRY
+
+pytestmark = [pytest.mark.layer("docs"), pytest.mark.small]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_neutralized_limits_are_disclosed_in_the_governing_adrs() -> None:
+    adr_0004 = (REPO_ROOT / "docs/decisions/0004-recipe-redelivery.md").read_text()
+    adr_0005 = (REPO_ROOT / "docs/decisions/0005-output-budget-protocol.md").read_text()
+    neutralized = [
+        entry
+        for entry in CODEX_LIMIT_VERIFICATION_REGISTRY.values()
+        if entry.status == "upstream_neutralized"
+    ]
+    assert neutralized, "expected at least one upstream_neutralized entry to disclose"
+    for entry in neutralized:
+        value = entry.upstream_effective_value
+        assert value is not None
+        rendered = {str(value), f"{value:,}"}
+        for adr_name, adr_text in (("0004", adr_0004), ("0005", adr_0005)):
+            assert entry.governed_symbol in adr_text, (
+                f"ADR-{adr_name} does not disclose {entry.governed_symbol}"
+            )
+            assert any(r in adr_text for r in rendered), (
+                f"ADR-{adr_name} does not disclose the effective value "
+                f"({rendered}) for {entry.governed_symbol}"
+            )

--- a/tests/execution/backends/test_codex_limit_verification.py
+++ b/tests/execution/backends/test_codex_limit_verification.py
@@ -1,0 +1,121 @@
+"""Tests for the Codex CLI limit verification-record registry.
+
+The registry (`CODEX_LIMIT_VERIFICATION_REGISTRY`) is the durable, machine-readable
+record of what was checked against a pinned Codex CLI revision and what was found.
+`CODEX_LIMITS_LAST_VERIFIED_VERSION` is derived from it — it cannot be bumped
+without updating the evidence sitting alongside it in the same registry entry.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from autoskillit.execution.backends import ensure_codex_mcp_registered
+from autoskillit.execution.backends._codex_config import (
+    CODEX_AUTO_COMPACT_LIMIT,
+    CODEX_LIMIT_VERIFICATION_REGISTRY,
+    CODEX_LIMIT_VERIFICATION_REGISTRY_DIGEST,
+    CODEX_LIMITS_LAST_VERIFIED_VERSION,
+    CodexLimitVerificationDef,
+    _read_codex_config,
+    validate_codex_limit_verification,
+)
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+def test_pin_is_derived_from_the_verification_registry() -> None:
+    assert CODEX_LIMIT_VERIFICATION_REGISTRY
+    assert CODEX_LIMITS_LAST_VERIFIED_VERSION == min(
+        entry.checked_at_cli_version for entry in CODEX_LIMIT_VERIFICATION_REGISTRY.values()
+    )
+    for entry in CODEX_LIMIT_VERIFICATION_REGISTRY.values():
+        assert len(entry.checked_at_cli_version) == 3
+        assert all(isinstance(v, int) for v in entry.checked_at_cli_version)
+
+
+def test_every_top_level_codex_config_key_has_a_verification_record(tmp_path) -> None:
+    p = tmp_path / "config.toml"
+    ensure_codex_mcp_registered(config_path=p)
+    config = _read_codex_config(p).data
+    written = set(config) - {"mcp_servers"}
+    governed = {
+        entry.codex_config_key
+        for entry in CODEX_LIMIT_VERIFICATION_REGISTRY.values()
+        if entry.codex_config_key is not None
+    }
+    assert written >= governed, f"registry names keys the writer never wrote: {governed - written}"
+    assert written == governed, (
+        "top-level Codex config keys with no verification record: "
+        f"{written - governed} — add a CODEX_LIMIT_VERIFICATION_REGISTRY entry"
+    )
+    for entry in CODEX_LIMIT_VERIFICATION_REGISTRY.values():
+        if entry.codex_config_key is not None:
+            assert config[entry.codex_config_key] == entry.configured_value
+
+
+def test_declared_status_matches_the_recorded_numbers() -> None:
+    for key, entry in CODEX_LIMIT_VERIFICATION_REGISTRY.items():
+        validate_codex_limit_verification(entry, key=key)
+        assert entry.governed_symbol == key
+        assert entry.upstream_revision
+        assert entry.upstream_sources
+        assert len(entry.finding) >= 80
+        if entry.codex_config_key is not None:
+            assert entry.configured_value is not None
+
+
+def test_status_invariant_has_teeth() -> None:
+    inconsistent = CodexLimitVerificationDef(
+        governed_symbol="CODEX_AUTO_COMPACT_LIMIT",
+        checked_at_cli_version=(0, 145, 0),
+        upstream_revision="25af12f7e61572b0bc18ddb1008be543b91519b0",
+        upstream_sources=("codex-rs/protocol/src/openai_models.rs",),
+        status="upstream_honored",
+        codex_config_key="model_auto_compact_token_limit",
+        configured_value=999_999_999,
+        upstream_effective_value=244_800,
+        finding="x" * 100,
+    )
+    with pytest.raises(ValueError):
+        validate_codex_limit_verification(inconsistent, key="CODEX_AUTO_COMPACT_LIMIT")
+
+
+def test_auto_compact_sentinel_is_recorded_as_neutralized_at_the_clamped_threshold() -> None:
+    entry = CODEX_LIMIT_VERIFICATION_REGISTRY["CODEX_AUTO_COMPACT_LIMIT"]
+    assert entry.status == "upstream_neutralized"
+    assert entry.configured_value == CODEX_AUTO_COMPACT_LIMIT == 999_999_999
+    assert entry.upstream_effective_value == (272_000 * 9) // 10 == 244_800
+    assert entry.checked_at_cli_version == (0, 145, 0)
+    assert entry.upstream_revision == "25af12f7e61572b0bc18ddb1008be543b91519b0"
+    assert "auto_compact_token_limit" in entry.finding
+    assert "#4271" in entry.finding
+
+
+def test_unverifiable_surface_is_recorded_not_omitted() -> None:
+    entry = CODEX_LIMIT_VERIFICATION_REGISTRY["CODEX_RECIPE_DELIVERY_BUDGET"]
+    assert entry.status == "locally_unreachable"
+    assert entry.upstream_effective_value is None
+    assert "SUPPORTED_CODEX_RECIPE_EVIDENCE_REGISTRY" in entry.finding
+    assert "CODEX_SMOKE_TEST" in entry.finding
+
+
+def test_registry_digest_changes_when_a_finding_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    import autoskillit.execution.backends._codex_config as mod
+
+    key = "CODEX_HISTORY_RETENTION_TOKEN_LIMIT"
+    original = mod.CODEX_LIMIT_VERIFICATION_REGISTRY[key]
+    mutated_registry = dict(mod.CODEX_LIMIT_VERIFICATION_REGISTRY)
+    mutated_registry[key] = original._replace(finding=original.finding + " mutated")
+    monkeypatch.setattr(mod, "CODEX_LIMIT_VERIFICATION_REGISTRY", mutated_registry)
+
+    mutated_digest = mod._codex_limit_verification_registry_digest()
+
+    assert mutated_digest != CODEX_LIMIT_VERIFICATION_REGISTRY_DIGEST
+    # Sanity check that the helper is doing real canonicalisation, not returning a constant.
+    canonical = [(k, e._asdict()) for k, e in sorted(mutated_registry.items())]
+    payload = json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    assert mutated_digest == hashlib.sha256(payload.encode("ascii")).hexdigest()


### PR DESCRIPTION
## Summary

`CODEX_LIMITS_LAST_VERIFIED_VERSION = (0, 144, 1)` is a bare tuple with a prose comment. The installed CLI is `codex-cli 0.145.0`. Re-verification against upstream `rust-v0.145.0` (peeled commit `25af12f7e61572b0bc18ddb1008be543b91519b0`) is complete and produced one positive, one negative, and one unverifiable result. The deliverable is **verification, a pin bump, and durable recording of what was checked — including the negative findings**.

Closes #4369

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-4369-20260726-193308-115864/.autoskillit/temp/rectify/rectify_codex_limits_pin_verification_record_2026-07-26_211500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
