### PR TITLE
[FIX] Rectify: bridge_investigation Silently Truncates Investigation Content

### DIFF
--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -28,7 +28,7 @@ logger = get_logger(__name__)
 _ALL_TOOLS: frozenset[str] = frozenset(TOOL_REGISTRY)
 
 _RUN_PYTHON_PATH_LIKE_ARGS: frozenset[str] = frozenset(
-    {"output_dir", "workspace", "diagnostics_log_dir"}
+    {"output_dir", "workspace", "diagnostics_log_dir", "investigation_path"}
 )
 
 # Registry of context variables that are captured upstream and MUST be forwarded

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -3470,6 +3470,20 @@ callable_contracts:
     - name: variant_manifest
       type: str
       required: true
+  autoskillit.smoke_utils.extract_investigation:
+    inputs:
+    - name: investigation_path
+      type: str
+      required: false
+    - name: issue_number
+      type: str
+      required: false
+    - name: output_dir
+      type: str
+      required: false
+    outputs:
+    - name: investigation_report
+      type: str
 
 tool_output_contracts:
   wait_for_ci:

--- a/src/autoskillit/recipes/diagrams/remediation.md
+++ b/src/autoskillit/recipes/diagrams/remediation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:50563764cff7f70774acd59398c6a6aed515a4018c778210a08b0e2b6618aa0c -->
+<!-- autoskillit-recipe-hash: sha256:170f67eec5f0e24d77574080e27c43a301dfcb46ce0ee23e500b943c91a87f3c -->
 <!-- autoskillit-diagram-format: v7 -->
 ## remediation
 

--- a/src/autoskillit/recipes/remediation.json
+++ b/src/autoskillit/recipes/remediation.json
@@ -249,11 +249,13 @@
       "note": "ISSUE CONTEXT: If inputs.issue_url is a non-empty string, append it to the skill_command so the investigate skill can detect and fetch the issue itself: \"/autoskillit:investigate {task}\\n\\nGitHub Issue: {inputs.issue_url}\" The skill detects the URL pattern and calls fetch_github_issue internally. DEPTH: When inputs.depth == 'deep', passes --depth deep flag and sets model to opus[1m] for the main skill session. Subagents within the skill always use model: sonnet regardless of depth setting.\n"
     },
     "bridge_investigation": {
-      "tool": "run_cmd",
+      "tool": "run_python",
       "with": {
-        "cmd": "[ -n \"${{ context.investigation_path }}\" ] && [ -f \"${{ context.investigation_path }}\" ] && echo \"investigation_report=${{ context.investigation_path }}\" || { mkdir -p \"{{AUTOSKILLIT_TEMP}}/investigate\" && gh issue view ${{ context.issue_number }} --json body -q .body | tr -d '\\r' | awk '/^## Investigation/{p=1;next} p && /^## /{p=0} p{print}' > \"{{AUTOSKILLIT_TEMP}}/investigate/investigation_from_issue.md\" && test -s \"{{AUTOSKILLIT_TEMP}}/investigate/investigation_from_issue.md\" && echo \"investigation_report={{AUTOSKILLIT_TEMP}}/investigate/investigation_from_issue.md\"; }",
-        "cwd": "${{ context.work_dir }}",
-        "step_name": "bridge_investigation"
+        "callable": "autoskillit.smoke_utils.extract_investigation",
+        "investigation_path": "${{ context.investigation_path }}",
+        "issue_number": "${{ context.issue_number }}",
+        "output_dir": "{{AUTOSKILLIT_TEMP}}/investigate",
+        "work_dir": "${{ context.work_dir }}"
       },
       "capture": {
         "effective_investigation_path": {
@@ -262,8 +264,8 @@
         }
       },
       "on_success": "rectify",
-      "on_failure": "rectify",
-      "note": "Resolves the effective investigation path for rectify. When investigate ran, context.investigation_path contains the report path — pass it through. When investigate was skipped (pruned by skip_when_false), investigation_path is empty — extract the ## Investigation section from the issue body instead. The effective_investigation_path context variable replaces investigation_path for consumption by rectify."
+      "on_failure": "release_issue_failure",
+      "note": "Resolves the effective investigation path for rectify. When investigate ran, context.investigation_path contains the report path — pass it through. When investigate was skipped (pruned by skip_when_false), investigation_path is empty — extract the ## Investigation section from the issue body instead. Validates extracted content contains the ## Recommendations heading (structural completeness, not just non-empty)."
     },
     "rectify": {
       "tool": "run_skill",

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -260,30 +260,26 @@ steps:
 
       '
   bridge_investigation:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >-
-        [ -n "${{ context.investigation_path }}" ] && [ -f "${{ context.investigation_path }}" ] &&
-        echo "investigation_report=${{ context.investigation_path }}" ||
-        { mkdir -p "{{AUTOSKILLIT_TEMP}}/investigate" &&
-        gh issue view ${{ context.issue_number }} --json body -q .body | tr -d '\r' | awk '/^## Investigation/{p=1;next} p && /^## /{p=0} p{print}' > "{{AUTOSKILLIT_TEMP}}/investigate/investigation_from_issue.md" &&
-        test -s "{{AUTOSKILLIT_TEMP}}/investigate/investigation_from_issue.md" &&
-        echo "investigation_report={{AUTOSKILLIT_TEMP}}/investigate/investigation_from_issue.md"; }
-      cwd: ${{ context.work_dir }}
-      step_name: bridge_investigation
+      callable: autoskillit.smoke_utils.extract_investigation
+      investigation_path: ${{ context.investigation_path }}
+      issue_number: ${{ context.issue_number }}
+      output_dir: "{{AUTOSKILLIT_TEMP}}/investigate"
+      work_dir: ${{ context.work_dir }}
     capture:
       effective_investigation_path:
         from: ${{ result.investigation_report }}
         type: path
     on_success: rectify
-    on_failure: rectify
+    on_failure: release_issue_failure
     note: >-
       Resolves the effective investigation path for rectify. When investigate ran,
       context.investigation_path contains the report path — pass it through. When
       investigate was skipped (pruned by skip_when_false), investigation_path is
       empty — extract the ## Investigation section from the issue body instead.
-      The effective_investigation_path context variable replaces investigation_path
-      for consumption by rectify.
+      Validates extracted content contains the ## Recommendations heading
+      (structural completeness, not just non-empty).
 
   rectify:
     tool: run_skill

--- a/src/autoskillit/server/tools/_execution_helpers.py
+++ b/src/autoskillit/server/tools/_execution_helpers.py
@@ -65,7 +65,9 @@ if TYPE_CHECKING:
     from autoskillit.core import SkillResult
     from autoskillit.pipeline import ToolContext
 
-_PATH_LIKE_ARGS: frozenset[str] = frozenset({"output_dir", "workspace", "diagnostics_log_dir"})
+_PATH_LIKE_ARGS: frozenset[str] = frozenset(
+    {"output_dir", "workspace", "diagnostics_log_dir", "investigation_path"}
+)
 
 
 @dataclasses.dataclass(slots=True)

--- a/src/autoskillit/smoke_utils/AGENTS.md
+++ b/src/autoskillit/smoke_utils/AGENTS.md
@@ -8,6 +8,7 @@ Utility callables for smoke-test pipeline `run_python` steps (decomposed from mo
 |------|---------|
 | `__init__.py` | Re-export facade — 28 public names via `__all__` |
 | `_helpers.py` | Shared JSON loading helpers (`_load_json`, `try_load_json`) |
+| `_investigation.py` | Investigation report extraction and completeness validation for remediation |
 | `_merge_gate_diagnosis.py` | Merge gate test failure diagnosis file writer |
 | `_review.py` | PR diff annotation, review loop guards, diff context enrichment, dimension selection, verdict aggregation |
 | `_eval.py` | Eval manifest parsing, context building, scorecard compilation |

--- a/src/autoskillit/smoke_utils/__init__.py
+++ b/src/autoskillit/smoke_utils/__init__.py
@@ -23,6 +23,7 @@ from autoskillit.smoke_utils._git import (
     gate_backend_write,
 )
 from autoskillit.smoke_utils._helpers import try_load_json
+from autoskillit.smoke_utils._investigation import extract_investigation
 from autoskillit.smoke_utils._merge_gate_diagnosis import diagnose_merge_gate
 from autoskillit.smoke_utils._review import (
     LOCAL_ROUND_EXEMPT_VERDICTS,
@@ -61,6 +62,7 @@ __all__ = [
     "detect_zero_changes",
     "diagnose_merge_gate",
     "enrich_diff_context",
+    "extract_investigation",
     "fetch_merge_queue_data",
     "gate_backend_write",
     "init_counter",

--- a/src/autoskillit/smoke_utils/_investigation.py
+++ b/src/autoskillit/smoke_utils/_investigation.py
@@ -1,0 +1,68 @@
+"""Investigation extraction for the remediation bridge_investigation step."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from autoskillit.core import atomic_write, run_gh
+
+_INVESTIGATION_HEADING = "## Investigation"
+_RECOMMENDATIONS_HEADING = "## Recommendations"
+
+
+def extract_investigation(
+    investigation_path: str = "",
+    issue_number: str = "",
+    output_dir: str = "",
+) -> dict[str, str]:
+    """Resolve the effective investigation path for rectify.
+
+    Called by run_python from the bridge_investigation step in remediation.yaml.
+    When investigation_path points to a complete report, validates and returns it.
+    Otherwise, fetches the issue body and extracts the ``## Investigation`` section
+    to end-of-body, validating that the section contains the ``## Recommendations``
+    heading (the guaranteed-last section of an investigation report).
+    """
+    if investigation_path and Path(investigation_path).is_file():
+        content = Path(investigation_path).read_text()
+        if _RECOMMENDATIONS_HEADING not in content:
+            raise ValueError(
+                f"investigation_path file lacks '{_RECOMMENDATIONS_HEADING}' heading: "
+                f"{investigation_path}"
+            )
+        return {"investigation_report": str(investigation_path)}
+
+    if not issue_number:
+        raise ValueError("issue_number must be non-empty when investigation_path is absent")
+    if not output_dir:
+        raise ValueError("output_dir must be non-empty")
+    if not Path(output_dir).is_absolute():
+        raise ValueError(f"output_dir must be absolute, got {output_dir!r}")
+
+    gh_result = run_gh(
+        ["issue", "view", issue_number, "--json", "body", "-q", ".body"],
+        timeout=60,
+    )
+    if gh_result.returncode != 0:
+        raise ValueError(
+            f"gh issue view failed for issue {issue_number}: {gh_result.stderr.strip()}"
+        )
+
+    body = gh_result.stdout
+    idx = body.find(_INVESTIGATION_HEADING)
+    if idx < 0:
+        raise ValueError(
+            f"no '{_INVESTIGATION_HEADING}' section found in issue {issue_number} body"
+        )
+
+    extracted = body[idx + len(_INVESTIGATION_HEADING) :]
+
+    if _RECOMMENDATIONS_HEADING not in extracted:
+        raise ValueError(
+            f"extracted '{_INVESTIGATION_HEADING}' section lacks "
+            f"'{_RECOMMENDATIONS_HEADING}' heading — investigation report is truncated"
+        )
+
+    out_path = Path(output_dir) / "investigation_from_issue.md"
+    atomic_write(out_path, extracted)
+    return {"investigation_report": str(out_path)}

--- a/src/autoskillit/smoke_utils/_investigation.py
+++ b/src/autoskillit/smoke_utils/_investigation.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import regex as re
+
 from autoskillit.core import atomic_write, run_gh
 
 _INVESTIGATION_HEADING = "## Investigation"
 _RECOMMENDATIONS_HEADING = "## Recommendations"
+_INVESTIGATION_HEADING_RE = re.compile(r"^" + re.escape(_INVESTIGATION_HEADING), re.MULTILINE)
+_RECOMMENDATIONS_HEADING_RE = re.compile(r"^" + re.escape(_RECOMMENDATIONS_HEADING), re.MULTILINE)
 
 
 def extract_investigation(
@@ -25,7 +29,7 @@ def extract_investigation(
     """
     if investigation_path and Path(investigation_path).is_file():
         content = Path(investigation_path).read_text()
-        if _RECOMMENDATIONS_HEADING not in content:
+        if _RECOMMENDATIONS_HEADING_RE.search(content) is None:
             raise ValueError(
                 f"investigation_path file lacks '{_RECOMMENDATIONS_HEADING}' heading: "
                 f"{investigation_path}"
@@ -49,15 +53,15 @@ def extract_investigation(
         )
 
     body = gh_result.stdout
-    idx = body.find(_INVESTIGATION_HEADING)
-    if idx < 0:
+    heading_match = _INVESTIGATION_HEADING_RE.search(body)
+    if heading_match is None:
         raise ValueError(
             f"no '{_INVESTIGATION_HEADING}' section found in issue {issue_number} body"
         )
 
-    extracted = body[idx + len(_INVESTIGATION_HEADING) :]
+    extracted = body[heading_match.end() :]
 
-    if _RECOMMENDATIONS_HEADING not in extracted:
+    if _RECOMMENDATIONS_HEADING_RE.search(extracted) is None:
         raise ValueError(
             f"extracted '{_INVESTIGATION_HEADING}' section lacks "
             f"'{_RECOMMENDATIONS_HEADING}' heading — investigation report is truncated"

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -168,7 +168,7 @@ _CORE_UNIVERSAL_EXCLUSIONS: dict[str, frozenset[str]] = {
 }
 
 MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
-    "_cmd_runner": frozenset({"cli", "core", "recipe", "_probe_canary"}),
+    "_cmd_runner": frozenset({"cli", "core", "recipe", "smoke_utils", "_probe_canary"}),
     "_json": frozenset({"core", "execution", "pipeline", "recipe", "server"}),
     "feature_flags": frozenset(
         {"core", "cli", "config", "execution", "recipe", "server", "workspace"}

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -1091,8 +1091,8 @@ def test_canonical_recipe_responses_fit_independent_registry_ceilings(tmp_path, 
         for ingredients_only in (False, True)
     }
     assert maxima == {
-        "load_recipe": (168_499, "remediation", "all_truthy"),
-        "open_kitchen": (168_552, "remediation", "all_truthy"),
+        "load_recipe": (168_348, "remediation", "all_truthy"),
+        "open_kitchen": (168_401, "remediation", "all_truthy"),
     }
 
 

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -1091,8 +1091,8 @@ def test_canonical_recipe_responses_fit_independent_registry_ceilings(tmp_path, 
         for ingredients_only in (False, True)
     }
     assert maxima == {
-        "load_recipe": (168_782, "remediation", "all_truthy"),
-        "open_kitchen": (168_835, "remediation", "all_truthy"),
+        "load_recipe": (168_499, "remediation", "all_truthy"),
+        "open_kitchen": (168_552, "remediation", "all_truthy"),
     }
 
 

--- a/tests/recipe/test_callable_contracts.py
+++ b/tests/recipe/test_callable_contracts.py
@@ -49,3 +49,17 @@ def test_review_path_rebase_contract_inputs_and_outputs():
             assert inp.required is True, f"{inp.name} must be required"
     output_names = {out.name for out in contract.outputs}
     assert "status" in output_names
+
+
+def test_extract_investigation_callable_contract():
+    """extract_investigation must be declared in callable_contracts."""
+    from autoskillit.recipe.contracts import get_callable_contract
+
+    contract = get_callable_contract("autoskillit.smoke_utils.extract_investigation")
+    assert contract is not None, "extract_investigation must be declared in callable_contracts"
+    input_names = {inp.name for inp in contract.inputs}
+    assert "investigation_path" in input_names
+    assert "issue_number" in input_names
+    assert "output_dir" in input_names
+    output_names = {out.name for out in contract.outputs}
+    assert "investigation_report" in output_names

--- a/tests/recipe/test_remediation_recipe.py
+++ b/tests/recipe/test_remediation_recipe.py
@@ -295,8 +295,9 @@ def test_remediation_has_investigate_ingredient(recipe) -> None:
 
 # T9: bridge_investigation step exists and routes to rectify
 def test_remediation_has_bridge_investigation_step(recipe) -> None:
-    """remediation recipe must have a bridge_investigation step that routes to rectify."""
+    """remediation recipe must have a bridge_investigation step that uses run_python."""
     step = recipe.steps["bridge_investigation"]
+    assert step.tool == "run_python"
     assert step.on_success == "rectify"
 
 
@@ -310,10 +311,17 @@ def test_remediation_bridge_investigation_capture_is_path_typed(recipe) -> None:
     assert entry.value_type == "path"
 
 
-def test_remediation_bridge_investigation_cmd_has_nonempty_guard(recipe) -> None:
-    """bridge_investigation cmd must contain a non-empty file guard (test -s or [ -s)."""
-    cmd = recipe.steps["bridge_investigation"].with_args["cmd"]
-    assert "test -s" in cmd or "[ -s" in cmd
+def test_remediation_bridge_investigation_uses_extract_investigation_callable(recipe) -> None:
+    """bridge_investigation must invoke autoskillit.smoke_utils.extract_investigation."""
+    step = recipe.steps["bridge_investigation"]
+    callable_name = step.with_args["callable"]
+    assert callable_name == "autoskillit.smoke_utils.extract_investigation"
+
+
+def test_remediation_bridge_investigation_on_failure_halts(recipe) -> None:
+    """bridge_investigation must halt the pipeline on failure rather than passing garbage."""
+    step = recipe.steps["bridge_investigation"]
+    assert step.on_failure == "release_issue_failure"
 
 
 def test_remediation_investigate_routes_to_bridge(recipe) -> None:

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -3680,7 +3680,7 @@ def test_check_review_posted_in_smoke_utils_all():
 
 
 # ---------------------------------------------------------------------------
-# T_EI1–T_EI6: extract_investigation
+# T_EI1–T_EI8: extract_investigation
 # ---------------------------------------------------------------------------
 
 
@@ -3803,4 +3803,51 @@ def test_extract_investigation_gh_failure_raises(mock_run_gh, tmp_path: Path) ->
             investigation_path="",
             issue_number="42",
             output_dir=str(tmp_path),
+        )
+
+
+@patch("autoskillit.smoke_utils._investigation.run_gh")
+def test_extract_investigation_ignores_h3_investigation_decoy(mock_run_gh, tmp_path: Path) -> None:
+    """A decoy '### Investigation' subsection must not be mistaken for the real heading."""
+
+    body = (
+        "Preamble.\n"
+        "### Investigation\n"
+        "Decoy sub-subsection text, not the real heading.\n"
+        "\n"
+        "## Investigation\n"
+        "## Summary\n"
+        "Summary content.\n"
+        "## Recommendations\n"
+        "Recommendation content.\n"
+    )
+    mock_run_gh.return_value = subprocess.CompletedProcess([], 0, body, "")
+    out_dir = tmp_path / "investigate"
+    result = extract_investigation(
+        investigation_path="",
+        issue_number="42",
+        output_dir=str(out_dir),
+    )
+    written = Path(result["investigation_report"]).read_text()
+    assert "Decoy sub-subsection text" not in written
+    assert "## Summary" in written
+    assert "Summary content." in written
+
+
+def test_extract_investigation_passthrough_rejects_h3_recommendations_decoy(
+    tmp_path: Path,
+) -> None:
+    """A decoy '### Recommendations' heading must not satisfy the completeness check."""
+
+    truncated = tmp_path / "investigation_truncated.md"
+    truncated.write_text(
+        "<!-- investigation_complete: true -->\n"
+        "> Prior investigation completed interactively.\n"
+        "### Recommendations for future work (not a real section)\n"
+    )
+    with pytest.raises(ValueError, match="Recommendations"):
+        extract_investigation(
+            investigation_path=str(truncated),
+            issue_number="42",
+            output_dir=str(tmp_path / "unused"),
         )

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -22,6 +22,7 @@ from autoskillit.smoke_utils import (
     compile_eval_scorecard,
     consolidate_health_reports,
     enrich_diff_context,
+    extract_investigation,
     gate_backend_write,
     init_counter,
     parse_agent_eval_manifests,
@@ -2745,6 +2746,7 @@ def test_smoke_utils_all_exports_complete() -> None:
         "detect_zero_changes",
         "diagnose_merge_gate",
         "enrich_diff_context",
+        "extract_investigation",
         "fetch_merge_queue_data",
         "gate_backend_write",
         "init_counter",
@@ -2780,6 +2782,7 @@ def test_smoke_utils_all_exports_complete() -> None:
         "detect_zero_changes",
         "diagnose_merge_gate",
         "enrich_diff_context",
+        "extract_investigation",
         "fetch_merge_queue_data",
         "gate_backend_write",
         "init_counter",
@@ -3674,3 +3677,130 @@ def test_check_review_posted_in_smoke_utils_all():
 
     assert "check_review_posted" in sm.__all__
     assert callable(sm.check_review_posted)
+
+
+# ---------------------------------------------------------------------------
+# T_EI1–T_EI6: extract_investigation
+# ---------------------------------------------------------------------------
+
+
+_ISSUE_BODY_WITH_INVESTIGATION = (
+    "Some preamble not in the investigation section.\n"
+    "\n"
+    "## Investigation\n"
+    "<!-- investigation_complete: true -->\n"
+    "> Prior investigation completed interactively. See below for root cause analysis.\n"
+    "\n"
+    "# Investigation: Topic\n"
+    "## Summary\n"
+    "Summary content here.\n"
+    "## Root Cause\n"
+    "Root cause content here.\n"
+    "## Evidence\n"
+    "Evidence content here.\n"
+    "## Recommendations\n"
+    "Recommendation content here.\n"
+)
+
+
+@patch("autoskillit.smoke_utils._investigation.run_gh")
+def test_extract_investigation_full_content(mock_run_gh, tmp_path: Path) -> None:
+    """Extraction must retain all ## subsections inside ## Investigation."""
+
+    mock_run_gh.return_value = subprocess.CompletedProcess(
+        [], 0, _ISSUE_BODY_WITH_INVESTIGATION, ""
+    )
+    out_dir = tmp_path / "investigate"
+    result = extract_investigation(
+        investigation_path="",
+        issue_number="42",
+        output_dir=str(out_dir),
+    )
+    assert result["investigation_report"] == str(out_dir / "investigation_from_issue.md")
+    written = Path(result["investigation_report"]).read_text()
+    assert "## Summary" in written
+    assert "## Root Cause" in written
+    assert "## Evidence" in written
+    assert "## Recommendations" in written
+    assert "Summary content here." in written
+    assert "Root cause content here." in written
+    assert "Evidence content here." in written
+    assert "Recommendation content here." in written
+
+
+def test_extract_investigation_passthrough(tmp_path: Path) -> None:
+    """When investigation_path is set, file exists, and content is complete, return it."""
+
+    report = tmp_path / "investigation_full.md"
+    report.write_text(
+        "# Investigation: Topic\n"
+        "## Summary\n"
+        "Summary content.\n"
+        "## Recommendations\n"
+        "Recommendations content.\n"
+    )
+    result = extract_investigation(
+        investigation_path=str(report),
+        issue_number="42",
+        output_dir=str(tmp_path / "unused"),
+    )
+    assert result["investigation_report"] == str(report)
+
+
+def test_extract_investigation_passthrough_truncated_raises(tmp_path: Path) -> None:
+    """When investigation_path points to a truncated file (no ## subsections), callable raises."""
+
+    truncated = tmp_path / "investigation_truncated.md"
+    truncated.write_text(
+        "<!-- investigation_complete: true -->\n"
+        "> Prior investigation completed interactively. See below for root cause analysis.\n"
+    )
+    with pytest.raises(ValueError, match="Recommendations"):
+        extract_investigation(
+            investigation_path=str(truncated),
+            issue_number="42",
+            output_dir=str(tmp_path / "unused"),
+        )
+
+
+@patch("autoskillit.smoke_utils._investigation.run_gh")
+def test_extract_investigation_no_section_raises(mock_run_gh, tmp_path: Path) -> None:
+    """When issue body has no ## Investigation section, callable raises."""
+
+    mock_run_gh.return_value = subprocess.CompletedProcess(
+        [], 0, "Body without the investigation section.\n## Other\n", ""
+    )
+    with pytest.raises(ValueError, match="## Investigation"):
+        extract_investigation(
+            investigation_path="",
+            issue_number="42",
+            output_dir=str(tmp_path),
+        )
+
+
+@patch("autoskillit.smoke_utils._investigation.run_gh")
+def test_extract_investigation_empty_body_raises(mock_run_gh, tmp_path: Path) -> None:
+    """When ## Investigation section is empty, callable raises."""
+
+    mock_run_gh.return_value = subprocess.CompletedProcess(
+        [], 0, "## Investigation\n\n## Next Section\n", ""
+    )
+    with pytest.raises(ValueError, match="Recommendations"):
+        extract_investigation(
+            investigation_path="",
+            issue_number="42",
+            output_dir=str(tmp_path),
+        )
+
+
+@patch("autoskillit.smoke_utils._investigation.run_gh")
+def test_extract_investigation_gh_failure_raises(mock_run_gh, tmp_path: Path) -> None:
+    """When gh issue view fails, callable raises ValueError."""
+
+    mock_run_gh.return_value = subprocess.CompletedProcess([], 1, "", "gh: not authenticated")
+    with pytest.raises(ValueError, match="gh issue view failed"):
+        extract_investigation(
+            investigation_path="",
+            issue_number="42",
+            output_dir=str(tmp_path),
+        )


### PR DESCRIPTION
## Summary

The `bridge_investigation` step in `remediation.yaml` uses an inline awk command to extract investigation content from GitHub issue bodies. The awk terminates at the first `## ` heading inside the section being extracted, discarding 96-100% of the investigation report. This is the third manifestation of defects on the same awk line (#3195, #3324, #4381). The `test -s` guard and `type: path` capture validation catch only 0-byte files, not truncation. All four existing tests are structural (check string presence and routing) — none execute the command against realistic data.

The architectural immunity replaces the untestable inline awk with a `run_python` callable in `smoke_utils/`, following the project's established pattern for complex recipe step logic. This makes the extraction unit-testable, structurally validatable, and heading-level-correct by construction.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/fix-4381-20260727-070041-148642/.autoskillit/temp/rectify/rectify_bridge_investigation_truncation_2026-07-27_072500.md`

Closes #4381

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->