### PR TITLE
Rectify: Test Conftest Feature Resolution — Fail-Open Silent Skip Immunity

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,11 +119,7 @@ jobs:
       - name: Run tests
         env:
           AUTOSKILLIT_FILTER_STATS_FILE: ${{ github.workspace }}/.autoskillit/temp/filter-stats.json
-          AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED: >-
-            ${{
-              (github.event_name == 'pull_request' && github.base_ref == 'develop')
-              || (github.event_name == 'merge_group' && contains(github.ref, '/develop/'))
-            }}
+          AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED: "true"
         run: |
           mkdir -p .autoskillit/temp
           if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "develop" ]]; then

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,7 @@ tasks:
       PYTHONDONTWRITEBYTECODE: "1"
       OMP_NUM_THREADS: "1"
       TMPDIR: "{{.PYTEST_TMPDIR}}"
+      AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED: "true"
     cmds:
       - |
         mkdir -p temp
@@ -54,6 +55,7 @@ tasks:
       PYTHONDONTWRITEBYTECODE: "1"
       OMP_NUM_THREADS: "1"
       TMPDIR: "{{.PYTEST_TMPDIR}}"
+      AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED: "true"
     cmds:
       - |
         mkdir -p temp

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -154,6 +154,15 @@ class CoreRunConfig:
     def __post_init__(self) -> None:
         if not self.default_model:
             raise ValueError("CoreRunConfig.default_model must not be empty")
+        # Coerce None recipe_overrides entries to empty dicts. YAML sections with
+        # all children commented out (or otherwise empty) parse to None; treating
+        # them as empty matches user intent and avoids spurious validation errors
+        # during collection when a user-level ~/.autoskillit/config.yaml contains
+        # such a section.
+        self.recipe_overrides = {
+            recipe: (overrides if overrides is not None else {})
+            for recipe, overrides in self.recipe_overrides.items()
+        }
         for step, model_val in self.step_overrides.items():
             if not isinstance(model_val, str):
                 raise ValueError(

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -547,6 +547,15 @@ class ProvidersConfig:
                         f"profiles[{name!r}][{k!r}] must be a string or null, "
                         f"got {type(v).__name__!r}"
                     )
+        # Coerce None recipe_overrides entries to empty dicts. YAML sections with
+        # all children commented out (or otherwise empty) parse to None; treating
+        # them as empty matches user intent and avoids spurious validation errors
+        # during collection when a user-level ~/.autoskillit/config.yaml contains
+        # such a section.
+        self.recipe_overrides = {
+            recipe: (overrides if overrides is not None else {})
+            for recipe, overrides in self.recipe_overrides.items()
+        }
         for recipe, overrides in self.recipe_overrides.items():
             if not isinstance(overrides, dict):
                 raise ValueError(
@@ -649,6 +658,16 @@ class AgentBackendConfig:
                     backend=override_backend,
                     valid_names=sorted(KNOWN_BACKEND_NAMES),
                 )
+
+        # Coerce None recipe_overrides entries to empty dicts. YAML sections with
+        # all children commented out (or otherwise empty) parse to None; treating
+        # them as empty matches user intent and avoids spurious validation errors
+        # during collection when a user-level ~/.autoskillit/config.yaml contains
+        # such a section.
+        self.recipe_overrides = {
+            recipe: (overrides if overrides is not None else {})
+            for recipe, overrides in self.recipe_overrides.items()
+        }
 
         # Validate recipe_overrides shape: outer values are dicts, inner values are strings.
         for recipe_name, recipe_map in self.recipe_overrides.items():

--- a/tests/config/test_agent_backend_config.py
+++ b/tests/config/test_agent_backend_config.py
@@ -167,6 +167,12 @@ class TestAgentBackendConfigOverrides:
         with pytest.raises(ValueError, match="recipe_overrides"):
             AgentBackendConfig(recipe_overrides={"remediation": {"foo": 123}})  # type: ignore[dict-item]
 
+    def test_recipe_overrides_none_entry_coerced_to_empty_dict(self) -> None:
+        from autoskillit.config.settings import AgentBackendConfig
+
+        cfg = AgentBackendConfig(recipe_overrides={"remediation": None})  # type: ignore[dict-item]
+        assert cfg.recipe_overrides == {"remediation": {}}
+
     def test_unknown_backend_in_recipe_overrides_warns(self) -> None:
         import structlog.testing
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -119,6 +119,12 @@ class TestModelStepOverrides:
         cfg = CoreRunConfig(recipe_overrides={"impl": {"plan": "opus"}})
         assert cfg.recipe_overrides == {"impl": {"plan": "opus"}}
 
+    def test_recipe_overrides_none_entry_coerced_to_empty_dict(self):
+        from autoskillit.config import CoreRunConfig
+
+        cfg = CoreRunConfig(recipe_overrides={"impl": None})  # type: ignore[dict-item]
+        assert cfg.recipe_overrides == {"impl": {}}
+
     def test_yaml_loads_step_overrides(self, tmp_path):
         config_dir = tmp_path / ".autoskillit"
         config_dir.mkdir()

--- a/tests/config/test_providers_config.py
+++ b/tests/config/test_providers_config.py
@@ -121,6 +121,12 @@ class TestProvidersConfig:
         with pytest.raises(ValueError, match=r"recipe_overrides\[.+\] must be a dict"):
             ProvidersConfig(recipe_overrides={"remediation": "not_a_dict"})  # type: ignore[arg-type]
 
+    def test_recipe_overrides_none_entry_coerced_to_empty_dict(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        cfg = ProvidersConfig(recipe_overrides={"remediation": None})  # type: ignore[dict-item]
+        assert cfg.recipe_overrides == {"remediation": {}}
+
     def test_providers_config_profiles_none_value_accepted(self) -> None:
         from autoskillit.config.settings import ProvidersConfig
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -658,8 +658,8 @@ def _resolve_test_config() -> "AutomationConfig":
     """
     from pathlib import Path
 
+    from autoskillit.config import load_config
     from autoskillit.config.settings import AutomationConfig as _AutomationConfig
-    from autoskillit.config.settings import load_config
 
     # Anchor to repo root via this file's known location (tests/conftest.py)
     # rather than Path.cwd(), which varies across IDE runners and monkeypatch.chdir.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,11 +71,13 @@ _filter_mode_key = pytest.StashKey[str | None]()
 _selected_count_key = pytest.StashKey[int | None]()
 _deselected_count_key = pytest.StashKey[int | None]()
 _full_run_reason_key = pytest.StashKey[str | None]()
+_feature_scope_key = pytest.StashKey[dict[str, bool] | None]()
 
 # Module-level accumulator for xdist worker-to-controller IPC.
 # Populated by pytest_testnodedown (controller); cleared by pytest_configure
 # at session start so in-process pytester reruns don't leak stale data.
 _worker_filter_counts: dict[str, int | None] = {}
+_worker_feature_scope: dict[str, bool] = {}
 
 
 class TimeoutTier:
@@ -557,10 +559,12 @@ def pytest_configure(config: pytest.Config) -> None:
 
     # Reset xdist IPC accumulator so in-process pytester reruns don't leak counts.
     _worker_filter_counts.clear()
+    _worker_feature_scope.clear()
 
     config.stash[_scope_key] = None
     config.stash[_filter_mode_key] = None
     config.stash[_full_run_reason_key] = None
+    config.stash[_feature_scope_key] = None
 
     cli_mode = config.getoption("--filter-mode", default=None)
     env_val = os.environ.get("AUTOSKILLIT_TEST_FILTER", "")
@@ -738,6 +742,18 @@ def pytest_collection_modifyitems(
 
     # Feature gate pass — orthogonal to layer/size, runs on every worker
     _test_features_env = os.environ.get("AUTOSKILLIT_TEST_FEATURES")
+    # Stash the full feature scope for all registered features (not just those
+    # encountered on items) so pytest_terminal_summary can emit a single line
+    # describing the test run's effective feature scope. Under xdist
+    # (-n 4 --dist worksteal) this is populated on each worker, then
+    # transferred to the controller via workeroutput in pytest_sessionfinish.
+    from autoskillit.core import FEATURE_REGISTRY
+
+    _feature_scope: dict[str, bool] = {
+        name: _is_test_feature_enabled(name, env_val=_test_features_env)
+        for name in FEATURE_REGISTRY
+    }
+    config.stash[_feature_scope_key] = _feature_scope
     for item in items:
         marker = item.get_closest_marker("feature")
         if marker and marker.args:
@@ -750,16 +766,20 @@ def pytest_collection_modifyitems(
                 )
                 continue
             if not _is_test_feature_enabled(feature_name, env_val=_test_features_env):
-                env_display = _test_features_env or ""
-                item.add_marker(
-                    pytest.mark.skip(
-                        reason=(
-                            f"feature '{feature_name}' disabled"
-                            f" (AUTOSKILLIT_TEST_FEATURES='{env_display}'"
-                            f" does not include '{feature_name}')"
-                        )
+                # Step 2E: split skip reason by gating mechanism. Whitelist
+                # mode (AUTOSKILLIT_TEST_FEATURES set) names the env var;
+                # config-resolution mode uses a dedicated message so users
+                # can tell at a glance which path actually disabled the test.
+                if _test_features_env is not None:
+                    env_display = _test_features_env or ""
+                    reason = (
+                        f"feature '{feature_name}' disabled"
+                        f" (AUTOSKILLIT_TEST_FEATURES='{env_display}'"
+                        f" does not include '{feature_name}')"
                     )
-                )
+                else:
+                    reason = f"feature '{feature_name}' disabled via config resolution"
+                item.add_marker(pytest.mark.skip(reason=reason))
 
     scope: set[_Path] | None = config.stash.get(_scope_key, None)
     if scope is None:
@@ -862,6 +882,12 @@ def pytest_sessionfinish(session, exitstatus):
         session.config.workeroutput["filter_deselected"] = session.config.stash.get(
             _deselected_count_key, None
         )
+        # Step 2D: feature-scope propagation. Must happen BEFORE the early
+        # return — the controller only receives data via workeroutput, and
+        # any write after `return` is dead code on workers.
+        session.config.workeroutput["feature_scope"] = session.config.stash.get(
+            _feature_scope_key, None
+        )
         return
     out_path = os.environ.get("AUTOSKILLIT_FILTER_STATS_FILE")
     if not out_path:
@@ -912,3 +938,34 @@ def pytest_testnodedown(node, error):
     if selected is not None and deselected is not None:
         _worker_filter_counts["selected"] = selected
         _worker_filter_counts["deselected"] = deselected
+    # Step 2D: feature-scope aggregation from the first reporting worker.
+    # All workers run pytest_collection_modifyitems over the full pre-distribution
+    # item list (identical resolution across workers under --dist worksteal), so
+    # any single worker's scope is representative. "First worker wins" avoids
+    # pathological cases where a worker's scope is unexpectedly empty.
+    if not _worker_feature_scope:
+        scope = wo.get("feature_scope")
+        if scope:
+            _worker_feature_scope.update(scope)
+
+
+def pytest_terminal_summary(terminalreporter, config: pytest.Config) -> None:
+    """Emit a single ``Feature scope:`` line so the test run's effective feature
+    gate state is visible regardless of ``--disable-warnings``.
+
+    Fallback order: stash first (in-process / non-xdist runs where
+    ``pytest_collection_modifyitems`` populated it), then the
+    ``_worker_feature_scope`` accumulator (xdist runs where data was
+    transferred via ``workeroutput`` -> ``pytest_testnodedown``). If both are
+    empty, no summary is emitted.
+    """
+    scope = config.stash.get(_feature_scope_key, None)
+    if scope is None:
+        scope = _worker_feature_scope or None
+    if not scope:
+        return
+    parts = " ".join(
+        f"{name}=enabled" if enabled else f"{name}=disabled"
+        for name, enabled in sorted(scope.items())
+    )
+    terminalreporter.write_line(f"Feature scope: {parts}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -635,34 +635,35 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 @functools.lru_cache(maxsize=1)
-def _resolve_test_config() -> "AutomationConfig | None":
+def _resolve_test_config() -> "AutomationConfig":
     """Resolve full config for test collection via full config resolution.
 
     Uses the same dynaconf chain as production: defaults.yaml → project config → env vars.
-    Returns None on any failure (fail-open: individual features fall back to
-    FEATURE_REGISTRY[name].default_enabled).
+
+    Fail-closed: any exception raised by ``load_config`` (or a type mismatch in
+    the returned value) propagates to the caller. Since this function runs at
+    pytest collection time inside ``pytest_collection_modifyitems``, an unhandled
+    exception aborts collection with a clear error rather than silently
+    downgrading the test scope to per-feature ``default_enabled`` (which is
+    ``False`` for every currently-registered feature — see
+    ``FEATURE_REGISTRY`` in
+    ``src/autoskillit/core/types/_type_constants_features.py:42-100``).
+
+    ``lru_cache`` only caches successful returns; a transient failure will
+    retry on the next call.
     """
-    try:
-        from pathlib import Path
+    from pathlib import Path
 
-        from autoskillit.config.settings import AutomationConfig as _AutomationConfig
-        from autoskillit.config.settings import load_config
+    from autoskillit.config.settings import AutomationConfig as _AutomationConfig
+    from autoskillit.config.settings import load_config
 
-        # Anchor to repo root via this file's known location (tests/conftest.py)
-        # rather than Path.cwd(), which varies across IDE runners and monkeypatch.chdir.
-        repo_root = Path(__file__).resolve().parent.parent
-        cfg = load_config(repo_root)
-        if not isinstance(cfg, _AutomationConfig):
-            raise TypeError(f"load_config returned {type(cfg)!r}, expected AutomationConfig")
-        return cfg
-    except Exception as exc:
-        import warnings
-
-        warnings.warn(
-            f"Feature flag config resolution failed, falling back to defaults: {exc}",
-            stacklevel=1,
-        )
-        return None
+    # Anchor to repo root via this file's known location (tests/conftest.py)
+    # rather than Path.cwd(), which varies across IDE runners and monkeypatch.chdir.
+    repo_root = Path(__file__).resolve().parent.parent
+    cfg = load_config(repo_root)
+    if not isinstance(cfg, _AutomationConfig):
+        raise TypeError(f"load_config returned {type(cfg)!r}, expected AutomationConfig")
+    return cfg
 
 
 def _is_test_feature_enabled(feature_name: str, *, env_val: str | None) -> bool:
@@ -674,7 +675,6 @@ def _is_test_feature_enabled(feature_name: str, *, env_val: str | None) -> bool:
     2. If unset, resolve via full config chain (defaults.yaml → project config
        → env vars) using load_config().  This respects experimental_enabled and
        per-feature config overrides.
-    3. If config resolution fails, fall back to FEATURE_REGISTRY[name].default_enabled.
        Unknown feature names return True (fail-open).
 
     Args:
@@ -700,9 +700,6 @@ def _is_test_feature_enabled(feature_name: str, *, env_val: str | None) -> bool:
         return True
 
     cfg = _resolve_test_config()
-    if cfg is None:
-        return defn.default_enabled
-
     return is_feature_enabled(
         feature_name, cfg.features, experimental_enabled=cfg.experimental_enabled
     )

--- a/tests/infra/test_ci_dev_config.py
+++ b/tests/infra/test_ci_dev_config.py
@@ -400,10 +400,14 @@ class TestCIWorkflowExpressions:
             "Run tests step env block"
         )
 
-        exp_str = str(exp_val)
-        assert "merge_group" in exp_str, (
-            "AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED expression must "
-            "handle merge_group events. Current expression: " + exp_str
+        # Issue #4385: the env var is set unconditionally to "true" across all
+        # event types (pull_request, merge_group, push) so the test suite has a
+        # single deterministic feature scope. The previous conditional
+        # expression was the source of install-type-dependent test scope.
+        exp_str = str(exp_val).strip().strip('"').strip("'").lower()
+        assert exp_str == "true", (
+            "AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED must be set to "
+            "unconditional 'true' (issue #4385). Current expression: " + exp_str
         )
 
 

--- a/tests/infra/test_taskfile.py
+++ b/tests/infra/test_taskfile.py
@@ -174,6 +174,39 @@ class TestTaskfile:
         assert "CODEX_SMOKE_TEST" in preconditions
         assert "CLAUDE_CODE_SMOKE_TEST" in preconditions
 
+    def test_test_check_sets_experimental_enabled(self):
+        """T16 — test-check must set AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED to "true".
+
+        Guards against accidental removal of the env var. Without it, the test
+        suite falls back to is_dev_install() (config/settings.py:513) and silently
+        skips all EXPERIMENTAL-lifecycle tests on non-editable installs — a
+        fail-open hidden in feature-gate resolution (issue #4385).
+        """
+        data = self._load()
+        env = data["tasks"]["test-check"].get("env", {})
+        assert "AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED" in env, (
+            "test-check.env must set AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED "
+            "so the test scope matches CI regardless of install type"
+        )
+        assert env["AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED"] == "true", (
+            "test-check.env AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED must be 'true'"
+        )
+
+    def test_test_all_sets_experimental_enabled(self):
+        """T17 — test-all must set AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED to "true".
+
+        Mirrors the test-check guard. Both test entry points must request the
+        same feature scope, otherwise local runs diverge from each other.
+        """
+        data = self._load()
+        env = data["tasks"]["test-all"].get("env", {})
+        assert "AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED" in env, (
+            "test-all.env must set AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED"
+        )
+        assert env["AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED"] == "true", (
+            "test-all.env AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED must be 'true'"
+        )
+
 
 def test_taskfile_pytest_paths_exist() -> None:
     """All pytest file paths in Taskfile.yml must exist."""

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -358,10 +358,11 @@ def test_resolve_test_config_raises_on_load_failure(monkeypatch):
     """
     from tests.conftest import _resolve_test_config
 
-    def _broken_load_config():
+    def _broken_load_config(*args, **kwargs):
+        del args, kwargs
         raise RuntimeError("broken")
 
-    monkeypatch.setattr("autoskillit.config.settings.load_config", _broken_load_config)
+    monkeypatch.setattr("autoskillit.config.load_config", _broken_load_config)
     _resolve_test_config.cache_clear()
     try:
         with pytest.raises(RuntimeError, match="broken"):

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -344,3 +344,27 @@ def test_resolve_test_config_cache_persists_across_calls():
         assert info.hits >= 1, "Expected at least 1 cache hit"
     finally:
         _resolve_test_config.cache_clear()
+
+
+def test_resolve_test_config_raises_on_load_failure(monkeypatch):
+    """_resolve_test_config must raise on config-resolution failure (fail-closed).
+
+    Previously the function caught Exception, emitted a warnings.warn (suppressed
+    by --disable-warnings under task test-check), and returned None. The fail-open
+    direction silently downgraded the test scope to per-feature default_enabled,
+    which is False for every registered feature (FEATURE_REGISTRY at
+    autoskillit/core/types/_type_constants_features.py:42-100). After the fix, a
+    broken config aborts collection instead of silently skipping 100+ tests.
+    """
+    from tests.conftest import _resolve_test_config
+
+    def _broken_load_config():
+        raise RuntimeError("broken")
+
+    monkeypatch.setattr("autoskillit.config.settings.load_config", _broken_load_config)
+    _resolve_test_config.cache_clear()
+    try:
+        with pytest.raises(RuntimeError, match="broken"):
+            _resolve_test_config()
+    finally:
+        _resolve_test_config.cache_clear()

--- a/tests/test_conftest_feature_summary.py
+++ b/tests/test_conftest_feature_summary.py
@@ -1,0 +1,231 @@
+"""Tests for tests/conftest.py feature-scope summary (issue #4385).
+
+The shadow-conftest pattern mirrors tests/test_test_filter_plugin.py: a hardcoded
+source string is written via pytester.makeconftest(...) so the feature-gate
+summary can be exercised in isolation without importing the real conftest.py
+(which depends on autoskillit.core and autoskillit.config.settings that do not
+resolve inside pytester's throwaway tmp_path).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+pytestmark = [pytest.mark.medium]
+
+
+# ---------------------------------------------------------------------------
+# Shadow conftest source — must stay in sync with tests/conftest.py:
+#   - _feature_scope_key StashKey
+#   - _worker_feature_scope module-level accumulator
+#   - pytest_collection_modifyitems: feature-scope stash write
+#   - pytest_sessionfinish: workeroutput["feature_scope"] BEFORE the early return
+#   - pytest_testnodedown: controller-side aggregation
+#   - pytest_terminal_summary: stash-then-accumulator fallback, terminal write
+# ---------------------------------------------------------------------------
+
+_CONFTEST_FEATURE_SCOPE_SOURCE = """
+import os
+
+import pytest
+
+# Match real conftest.py StashKey naming.
+_feature_scope_key = pytest.StashKey[dict | None]()
+
+# Module-level accumulator for xdist worker-to-controller IPC.
+_worker_feature_scope: dict[str, bool] = {}
+
+
+def pytest_configure(config):
+    _worker_feature_scope.clear()
+    config.stash[_feature_scope_key] = None
+
+
+def pytest_collection_modifyitems(items, config):
+    import os
+
+    # Feature gate pass — emulate the real conftest: stash the full feature
+    # scope dict for all registered features (not just those encountered on items).
+    scope = {"fleet": False, "planner": False, "providers": False}
+    config.stash[_feature_scope_key] = scope
+    test_features_env = os.environ.get("AUTOSKILLIT_TEST_FEATURES")
+    for item in items:
+        marker = item.get_closest_marker("feature")
+        if marker and marker.args:
+            feature_name = marker.args[0]
+            if not isinstance(feature_name, str):
+                continue
+            if feature_name in scope and not scope[feature_name]:
+                # Step 2E: split skip reason by mechanism — whitelist mode
+                # (AUTOSKILLIT_TEST_FEATURES set) keeps the env-var reference;
+                # config-resolution mode uses the dedicated message.
+                if test_features_env is not None:
+                    env_display = test_features_env or ""
+                    reason = (
+                        f"feature '{feature_name}' disabled"
+                        f" (AUTOSKILLIT_TEST_FEATURES='{env_display}'"
+                        f" does not include '{feature_name}')"
+                    )
+                else:
+                    reason = f"feature '{feature_name}' disabled via config resolution"
+                item.add_marker(pytest.mark.skip(reason=reason))
+
+
+def pytest_sessionfinish(session, exitstatus):
+    if hasattr(session.config, "workerinput"):
+        # CRITICAL: stash write MUST happen before the early return, or the
+        # controller never sees it. The early return below is the dead-code
+        # failure mode the structural sync guard catches.
+        session.config.workeroutput["feature_scope"] = session.config.stash.get(
+            _feature_scope_key, None
+        )
+        return
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_testnodedown(node, error):
+    if _worker_feature_scope:
+        return
+    wo = getattr(node, "workeroutput", {})
+    scope = wo.get("feature_scope")
+    if scope and not _worker_feature_scope:
+        _worker_feature_scope.update(scope)
+
+
+def pytest_terminal_summary(terminalreporter, config):
+    # Fallback order: stash first (in-process run), then accumulator (xdist).
+    scope = config.stash.get(_feature_scope_key, None)
+    if scope is None:
+        scope = _worker_feature_scope or None
+    if scope is None:
+        return
+    parts = " ".join(f"{name}=enabled" if enabled else f"{name}=disabled"
+                     for name, enabled in sorted(scope.items()))
+    terminalreporter.write_line(f"Feature scope: {parts}")
+"""
+
+
+# ---------------------------------------------------------------------------
+# Structural sync guard
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_conftest_has_feature_scope_summary() -> None:
+    """Shadow conftest must define pytest_terminal_summary and workeroutput["feature_scope"].
+
+    Mirrors test_shadow_conftest_has_workeroutput_propagation in
+    tests/test_test_filter_plugin.py:391-417. Without this guard the shadow
+    could silently lose the IPC pathway, causing pytester-based xdist tests
+    to pass against stale shadow code that does not match production behavior.
+    """
+    import ast
+
+    tree = ast.parse(_CONFTEST_FEATURE_SCOPE_SOURCE)
+    func_names = {node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)}
+    assert "pytest_terminal_summary" in func_names, (
+        "Shadow conftest is missing pytest_terminal_summary hook — "
+        "feature-scope summary will not be emitted"
+    )
+    assert "pytest_testnodedown" in func_names, (
+        "Shadow conftest is missing pytest_testnodedown hook — "
+        "xdist worker-to-controller aggregation not present"
+    )
+    # Verify pytest_sessionfinish writes workeroutput["feature_scope"] BEFORE the early return.
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "pytest_sessionfinish":
+            func_src = ast.unparse(node)
+            assert "feature_scope" in func_src, (
+                "pytest_sessionfinish in shadow conftest must write "
+                "workeroutput['feature_scope'] — xdist IPC channel missing"
+            )
+            # workeroutput assignment must precede the return statement
+            assert func_src.index("workeroutput") < func_src.rindex("return"), (
+                "workeroutput assignment in pytest_sessionfinish must be "
+                "BEFORE the early return (otherwise it is dead code on workers)"
+            )
+            break
+    else:
+        raise AssertionError("pytest_sessionfinish not found in shadow conftest")
+
+
+# ---------------------------------------------------------------------------
+# Pytester integration tests — feature-scope summary appears in terminal output
+# ---------------------------------------------------------------------------
+
+
+class TestConftestFeatureScopeSummary:
+    """Verify Feature scope: line is emitted via pytest_terminal_summary.
+
+    The summary must bypass --disable-warnings (it goes through
+    terminalreporter.write_line, not warnings.warn).
+    """
+
+    def test_feature_scope_summary_appears_without_xdist(self, pytester: pytest.Pytester) -> None:
+        """In-process run: stash path. Feature scope line appears in stdout."""
+        pytester.makeconftest(_CONFTEST_FEATURE_SCOPE_SOURCE)
+        pytester.makepyfile(
+            test_a="def test_one(): pass",
+            test_b="def test_two(): pass",
+        )
+        result = pytester.runpytest("-q", "--disable-warnings")
+        result.stdout.fnmatch_lines(["*Feature scope:*=enabled*"])
+
+    def test_feature_scope_summary_appears_with_xdist(self, pytester: pytest.Pytester) -> None:
+        """xdist run (-n 2): worker-to-controller IPC path via workeroutput.
+
+        This is the critical variant: under -n 2 the controller never runs
+        pytest_collection_modifyitems directly, so the stash path is dead and
+        the only way the summary can appear is through pytest_testnodedown →
+        _worker_feature_scope → pytest_terminal_summary.
+        """
+        pytester.makeconftest(_CONFTEST_FEATURE_SCOPE_SOURCE)
+        pytester.makepyfile(
+            test_a="def test_one(): pass",
+            test_b="def test_two(): pass",
+        )
+        result = pytester.runpytest("-q", "--disable-warnings", "-n", "2")
+        result.stdout.fnmatch_lines(["*Feature scope:*=enabled*"])
+
+
+# ---------------------------------------------------------------------------
+# Skip reason distinction — config-resolution vs whitelist mode
+# ---------------------------------------------------------------------------
+
+
+class TestConftestFeatureScopeSkipReason:
+    """Verify the skip reason names the actual gating mechanism (issue #4385).
+
+    Previously both modes produced the same ``AUTOSKILLIT_TEST_FEATURES=...``
+    message, which mis-attributed config-resolution skips to the env-var path.
+    After the fix, the two mechanisms produce distinct messages.
+    """
+
+    def test_skip_reason_uses_config_resolution_message(
+        self,
+        pytester: pytest.Pytester,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When AUTOSKILLIT_TEST_FEATURES is unset, skip says 'disabled via config resolution'."""
+        monkeypatch.delenv("AUTOSKILLIT_TEST_FEATURES", raising=False)
+        pytester.makeconftest(_CONFTEST_FEATURE_SCOPE_SOURCE)
+        pytester.makepyfile(
+            test_a=("import pytest\n\n@pytest.mark.feature('fleet')\ndef test_one(): pass\n"),
+        )
+        result = pytester.runpytest("-rs")
+        result.stdout.fnmatch_lines(["*SKIPPED*disabled via config resolution*"])
+
+    def test_skip_reason_references_env_var_in_whitelist_mode(
+        self,
+        pytester: pytest.Pytester,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When AUTOSKILLIT_TEST_FEATURES is set, skip references the env var name."""
+        monkeypatch.setenv("AUTOSKILLIT_TEST_FEATURES", "")
+        pytester.makeconftest(_CONFTEST_FEATURE_SCOPE_SOURCE)
+        pytester.makepyfile(
+            test_a=("import pytest\n\n@pytest.mark.feature('fleet')\ndef test_one(): pass\n"),
+        )
+        result = pytester.runpytest("-rs")
+        result.stdout.fnmatch_lines(["*SKIPPED*AUTOSKILLIT_TEST_FEATURES*"])

--- a/tests/test_conftest_feature_summary.py
+++ b/tests/test_conftest_feature_summary.py
@@ -48,7 +48,7 @@ def pytest_collection_modifyitems(items, config):
 
     # Feature gate pass — emulate the real conftest: stash the full feature
     # scope dict for all registered features (not just those encountered on items).
-    scope = {"fleet": False, "planner": False, "providers": False}
+    scope = {"fleet": False, "planner": False, "providers": True}
     config.stash[_feature_scope_key] = scope
     test_features_env = os.environ.get("AUTOSKILLIT_TEST_FEATURES")
     for item in items:


### PR DESCRIPTION
## Summary

The test feature gate in `tests/conftest.py` silently skips feature-gated tests when config resolution fails or when `experimental_enabled` resolves differently than expected. Two cooperating root causes drive this behavior: local-vs-CI feature scope delta and fail-open config resolution.

The architectural fix explicitly sets the experimental feature environment variable for `test-check`, makes config resolution fail closed, and emits a feature-scope summary through the terminal writer so diagnostics remain visible even with warnings disabled.

Closes #4385

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/fix-4385-20260727-070042-106829/.autoskillit/temp/rectify/rectify_conftest_feature_resolution_2026-07-27_071500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
