### PR TITLE
[FIX] Rectify: Sessions That Completed Successfully Return Failure Envelopes

### DIFF
--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -77,6 +77,8 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+_EVIDENCE_RECOVERABLE_SUBTYPES: frozenset[str] = frozenset({"adjudicated_failure", "unparseable"})
+
 __all__ = [
     "_build_skill_result",
     "_make_terminated_result",
@@ -700,16 +702,18 @@ def _build_skill_result(
             f"TIMED_OUT session produced subtype={normalized_subtype!r}, expected {expected!r}"
         )
 
-    # For adjudicated_failure + write evidence: record as retriable so the consecutive
-    # chain is intact for the CONTRACT_RECOVERY budget guard (genuinely retriable).
+    # For evidence-recoverable subtypes (adjudicated_failure, unparseable) + write evidence:
+    # record as retriable so the consecutive chain is intact for the CONTRACT_RECOVERY
+    # budget guard (genuinely retriable).
     _audit_needs_retry = needs_retry
     _audit_retry_reason = retry_reason
     if (
         not success
         and not needs_retry
-        and normalized_subtype == "adjudicated_failure"
+        and normalized_subtype in _EVIDENCE_RECOVERABLE_SUBTYPES
         and _has_write_evidence
         and not readonly_skill
+        and (normalized_subtype == "adjudicated_failure" or returncode == 0)
     ):
         _audit_needs_retry = True
         _audit_retry_reason = RetryReason.CONTRACT_RECOVERY
@@ -848,17 +852,19 @@ def _build_skill_result(
         )
     sr = _apply_budget_guard(sr, skill_command, audit, max_consecutive_retries)
 
-    # CONTRACT_RECOVERY gate: when the session was classified as adjudicated_failure but
-    # write evidence exists, the model wrote the artifact but omitted the structured output
-    # token — promote to RETRIABLE(CONTRACT_RECOVERY). Re-apply budget_guard after
-    # promoting so budget exhaustion can still cap CONTRACT_RECOVERY retries.
+    # CONTRACT_RECOVERY gate: when the session was classified as a terminal failure
+    # (adjudicated_failure or unparseable) but write evidence exists and the process
+    # exited cleanly, the model wrote the artifact but the structured output token was
+    # missing or the stdout stream was truncated — promote to RETRIABLE(CONTRACT_RECOVERY).
+    # Re-apply budget_guard after promoting so budget exhaustion can still cap retries.
     # The first _apply_budget_guard skips this case because needs_retry is False then.
     if (
         not sr.success
         and not sr.needs_retry
-        and sr.subtype == "adjudicated_failure"
+        and sr.subtype in _EVIDENCE_RECOVERABLE_SUBTYPES
         and _has_write_evidence
         and not readonly_skill
+        and (sr.subtype == "adjudicated_failure" or returncode == 0)
     ):
         sr = dataclasses.replace(
             sr,

--- a/src/autoskillit/server/tools/tools_issue_headless.py
+++ b/src/autoskillit/server/tools/tools_issue_headless.py
@@ -360,9 +360,16 @@ async def prepare_issue(
             if parsed.get("error") in _BLOCK_PARSE_ERRORS:
                 extra = _extract_partial_issue_data(result.result)
                 return json.dumps(
-                    _build_headless_error_response(
-                        result, error=parsed["error"], extra_fields=extra
-                    )
+                    {
+                        "success": True,
+                        "status": "degraded",
+                        "warning": parsed["error"],
+                        "session_id": result.session_id,
+                        "stderr": result.stderr or "",
+                        "subtype": result.subtype or "",
+                        "exit_code": result.exit_code if result.exit_code is not None else -1,
+                        **extra,
+                    }
                 )
 
             # Block parsed successfully. result.success=True is the authoritative signal —
@@ -488,9 +495,16 @@ async def enrich_issues(
             if parsed.get("error") in _BLOCK_PARSE_ERRORS:
                 extra = _extract_partial_enrich_data(result.result)
                 return json.dumps(
-                    _build_headless_error_response(
-                        result, error=parsed["error"], extra_fields=extra
-                    )
+                    {
+                        "success": True,
+                        "status": "degraded",
+                        "warning": parsed["error"],
+                        "session_id": result.session_id,
+                        "stderr": result.stderr or "",
+                        "subtype": result.subtype or "",
+                        "exit_code": result.exit_code if result.exit_code is not None else -1,
+                        **extra,
+                    }
                 )
 
             return json.dumps(

--- a/src/autoskillit/server/tools/tools_issue_headless.py
+++ b/src/autoskillit/server/tools/tools_issue_headless.py
@@ -38,10 +38,10 @@ _BLOCK_PARSE_ERRORS: frozenset[str] = frozenset(
     {"no result block found", "result block contained invalid JSON"}
 )
 
-# Canonical 7 fields of the headless error envelope. extra_fields cannot overwrite
+# Canonical fields of the headless response envelope. extra_fields cannot overwrite
 # any of these — see _build_headless_error_response for the contract.
 _CANONICAL_KEYS: frozenset[str] = frozenset(
-    {"success", "status", "error", "session_id", "stderr", "subtype", "exit_code"}
+    {"success", "status", "error", "warning", "session_id", "stderr", "subtype", "exit_code"}
 )
 
 # Regex for partial-issue-data extraction: a GitHub issue URL anywhere in the
@@ -60,31 +60,37 @@ _ENRICHED_ISSUE_RE: re.Pattern[str] = re.compile(r"Enriched issue #(\d+)")
 def _build_headless_error_response(
     result: SkillResult,
     *,
-    error: str,
+    error: str | None = None,
+    warning: str | None = None,
     status: str = "failed",
+    success: bool = False,
     extra_fields: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Canonical error response for tools that invoke headless sessions.
+    """Canonical response envelope for tools that invoke headless sessions.
 
-    Every failure path that derives a response from a SkillResult MUST use this
-    builder. Do not hand-roll error dicts — that pattern caused silent omission of
+    Every path that derives a response from a SkillResult MUST use this builder —
+    including degraded-success paths (``success=True``, ``status="degraded"``). Do
+    not hand-roll response dicts — that pattern caused silent omission of
     diagnostic fields (issue #384). Adding a field here propagates to all paths
     automatically.
 
     Callers may pass ``extra_fields`` to attach partial-result evidence (e.g.,
     ``partial_issue_url`` when a headless session created an issue but failed to
     emit a parseable result block). ``extra_fields`` is filtered against
-    ``_CANONICAL_KEYS`` — it cannot overwrite any of the 7 canonical fields.
+    ``_CANONICAL_KEYS`` — it cannot overwrite any canonical field.
     """
     resp: dict[str, Any] = {
-        "success": False,
+        "success": success,
         "status": status,
-        "error": error,
         "session_id": result.session_id,
         "stderr": result.stderr or "",
         "subtype": result.subtype or "",
         "exit_code": result.exit_code if result.exit_code is not None else -1,
     }
+    if error is not None:
+        resp["error"] = error
+    if warning is not None:
+        resp["warning"] = warning
     if extra_fields:
         resp.update({k: v for k, v in extra_fields.items() if k not in _CANONICAL_KEYS})
     return resp
@@ -360,16 +366,13 @@ async def prepare_issue(
             if parsed.get("error") in _BLOCK_PARSE_ERRORS:
                 extra = _extract_partial_issue_data(result.result)
                 return json.dumps(
-                    {
-                        "success": True,
-                        "status": "degraded",
-                        "warning": parsed["error"],
-                        "session_id": result.session_id,
-                        "stderr": result.stderr or "",
-                        "subtype": result.subtype or "",
-                        "exit_code": result.exit_code if result.exit_code is not None else -1,
-                        **extra,
-                    }
+                    _build_headless_error_response(
+                        result,
+                        warning=parsed["error"],
+                        status="degraded",
+                        success=True,
+                        extra_fields=extra,
+                    )
                 )
 
             # Block parsed successfully. result.success=True is the authoritative signal —
@@ -495,16 +498,13 @@ async def enrich_issues(
             if parsed.get("error") in _BLOCK_PARSE_ERRORS:
                 extra = _extract_partial_enrich_data(result.result)
                 return json.dumps(
-                    {
-                        "success": True,
-                        "status": "degraded",
-                        "warning": parsed["error"],
-                        "session_id": result.session_id,
-                        "stderr": result.stderr or "",
-                        "subtype": result.subtype or "",
-                        "exit_code": result.exit_code if result.exit_code is not None else -1,
-                        **extra,
-                    }
+                    _build_headless_error_response(
+                        result,
+                        warning=parsed["error"],
+                        status="degraded",
+                        success=True,
+                        extra_fields=extra,
+                    )
                 )
 
             return json.dumps(

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -938,6 +938,78 @@ def make_build_skill_result_kwargs():
 
 
 class TestContractRecoveryGate:
+    def _unparseable_with_write_evidence(self, returncode: int = 0) -> SubprocessResult:
+        stdout = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Write",
+                            "id": "t1",
+                            "input": {"file_path": "/tmp/plan.md"},
+                        }
+                    ]
+                },
+            }
+        )
+        return SubprocessResult(
+            returncode=returncode,
+            stdout=stdout,
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+            channel_confirmation=ChannelConfirmation.CHANNEL_A,
+        )
+
+    def test_unparseable_with_clean_exit_and_write_evidence_becomes_retriable(self):
+        sr = _build_skill_result(
+            self._unparseable_with_write_evidence(),
+            completion_marker="%%ORDER_UP%%",
+            expected_output_patterns=[r"plan_path\s*=\s*/. +".replace(" ", "")],
+            backend=ClaudeCodeBackend(),
+        )
+        assert sr.success is False
+        assert sr.needs_retry is True
+        assert sr.retry_reason == RetryReason.CONTRACT_RECOVERY
+        assert sr.subtype == "unparseable"
+
+    def test_unparseable_with_crashed_process_is_not_contract_recovery(self):
+        sr = _build_skill_result(
+            self._unparseable_with_write_evidence(returncode=1),
+            completion_marker="%%ORDER_UP%%",
+            expected_output_patterns=[r"plan_path\s*=\s*/. +".replace(" ", "")],
+            backend=ClaudeCodeBackend(),
+        )
+        assert sr.retry_reason != RetryReason.CONTRACT_RECOVERY
+
+    def test_unparseable_contract_recovery_respects_budget_guard(self):
+        audit = DefaultAuditLog()
+        skill_command = "/autoskillit:make-plan"
+        for _ in range(4):
+            audit.record_failure(
+                FailureRecord(
+                    timestamp="2026-01-01T00:00:00+00:00",
+                    skill_command=skill_command,
+                    exit_code=0,
+                    subtype="unparseable",
+                    needs_retry=True,
+                    retry_reason=RetryReason.CONTRACT_RECOVERY.value,
+                    stderr="",
+                )
+            )
+        sr = _build_skill_result(
+            self._unparseable_with_write_evidence(),
+            completion_marker="%%ORDER_UP%%",
+            expected_output_patterns=[r"plan_path\s*=\s*/. +".replace(" ", "")],
+            skill_command=skill_command,
+            audit=audit,
+            backend=ClaudeCodeBackend(),
+        )
+        assert sr.needs_retry is False
+        assert sr.retry_reason == RetryReason.BUDGET_EXHAUSTED
+
     def test_adjudicated_failure_with_write_evidence_becomes_retriable(
         self, make_build_skill_result_kwargs
     ):

--- a/tests/server/test_tools_integrations.py
+++ b/tests/server/test_tools_integrations.py
@@ -479,7 +479,7 @@ class TestPrepareIssueTool:
 
     @pytest.mark.anyio
     async def test_prepare_issue_no_result_block_includes_stderr(self, tool_ctx_kitchen_open):
-        """success=True + non-empty result + no delimiters → stderr surfaced."""
+        """success=True + non-empty result + no delimiters → degraded success."""
         mock_executor = AsyncMock()
         mock_executor.run.return_value = SkillResult(
             success=True,
@@ -494,9 +494,10 @@ class TestPrepareIssueTool:
         )
         tool_ctx_kitchen_open.executor = mock_executor
         response = json.loads(await prepare_issue("Test Issue", ""))
-        assert response["success"] is False
-        assert response["error"] == "no result block found"
-        assert "stderr" in response, "stderr must be in block-parse-failure response"
+        assert response["success"] is True
+        assert response["status"] == "degraded"
+        assert response["warning"] == "no result block found"
+        assert "stderr" in response, "stderr must be in degraded-success response"
         assert response["stderr"] == "ImportError: cannot import x from autoskillit"
         assert response["session_id"] == "abc-123"
 
@@ -648,11 +649,43 @@ class TestEnrichIssuesTool:
         )
         tool_ctx_kitchen_open.executor = mock_executor
         response = json.loads(await enrich_issues())
-        assert response["success"] is False
-        assert response["error"] == "no result block found"
-        assert "stderr" in response, "stderr must be in block-parse-failure response"
+        assert response["success"] is True
+        assert response["status"] == "degraded"
+        assert response["warning"] == "no result block found"
+        assert "stderr" in response, "stderr must be in degraded-success response"
         assert response["stderr"] == "Warning: contract stale"
         assert response["session_id"] == "enrich-123"
+
+    @pytest.mark.anyio
+    async def test_enrich_issues_invalid_result_block_returns_degraded_success(
+        self, tool_ctx_kitchen_open
+    ):
+        """success=True + malformed block preserves success and partial diagnostics."""
+        mock_executor = AsyncMock()
+        mock_executor.run.return_value = SkillResult(
+            success=True,
+            result=(
+                "Enriched issue #42.\n"
+                "---enrich-issues-result---\n"
+                "{bad json\n"
+                "---/enrich-issues-result---"
+            ),
+            session_id="enrich-invalid",
+            stderr="Warning: malformed result",
+            subtype="success",
+            is_error=False,
+            exit_code=0,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+        )
+        tool_ctx_kitchen_open.executor = mock_executor
+        response = json.loads(await enrich_issues())
+        assert response["success"] is True
+        assert response["status"] == "degraded"
+        assert "invalid JSON" in response["warning"]
+        assert response["partial_issues_enriched"] == [42]
+        assert response["session_id"] == "enrich-invalid"
+        assert response["stderr"] == "Warning: malformed result"
 
     @pytest.mark.anyio
     async def test_enrich_issues_contract_recovery_includes_partial_enriched(
@@ -718,21 +751,6 @@ _HEADLESS_FAILURE_SCENARIOS = [
         id="prepare_issue-drain_race",
     ),
     pytest.param(
-        "prepare_issue",
-        dict(
-            success=True,
-            result="prose without delimiters",
-            session_id="s3",
-            stderr="e3",
-            subtype="success",
-            exit_code=0,
-            needs_retry=False,
-            is_error=False,
-            retry_reason=RetryReason.NONE,
-        ),
-        id="prepare_issue-block_parse_error",
-    ),
-    pytest.param(
         "enrich_issues",
         dict(
             success=False,
@@ -761,21 +779,6 @@ _HEADLESS_FAILURE_SCENARIOS = [
             retry_reason=RetryReason.NONE,
         ),
         id="enrich_issues-drain_race",
-    ),
-    pytest.param(
-        "enrich_issues",
-        dict(
-            success=True,
-            result="prose without delimiters",
-            session_id="s6",
-            stderr="e6",
-            subtype="success",
-            exit_code=0,
-            needs_retry=False,
-            is_error=False,
-            retry_reason=RetryReason.NONE,
-        ),
-        id="enrich_issues-block_parse_error",
     ),
 ]
 
@@ -860,10 +863,12 @@ async def test_prepare_issue_block_parse_error_propagates_partial_url(
     tool_ctx_kitchen_open.executor = mock_executor
 
     response = json.loads(await prepare_issue("Title", "Body"))
-    # Canonical contract preserved.
-    missing = _REQUIRED_FAILURE_KEYS - set(response.keys())
-    assert not missing, f"missing failure response keys: {missing}"
-    assert response["success"] is False
+    # Degraded-success contract preserves adjudication authority and diagnostics.
+    assert response["success"] is True
+    assert response["status"] == "degraded"
+    assert "invalid JSON" in response["warning"]
+    assert response["session_id"] == "s-parse"
+    assert response["stderr"] == "e-parse"
     # Partial-result propagation.
     assert response["partial_issue_url"] == "https://github.com/owner/repo/issues/42"
     assert response["partial_issue_number"] == 42

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -287,14 +287,15 @@ async def test_prepare_issue_empty_output(tool_ctx_kitchen_open) -> None:
 
 @pytest.mark.anyio
 async def test_prepare_issue_block_parse_error(tool_ctx_kitchen_open) -> None:
-    """success=True, output present, but no delimiters → 'no result block found' error."""
+    """success=True with no delimiters → degraded-success warning."""
     skill_result = _make_skill_result(success=True, result="some output without delimiters")
     tool_ctx_kitchen_open.executor = AsyncMock()
     tool_ctx_kitchen_open.executor.run = AsyncMock(return_value=skill_result)
 
     result = json.loads(await prepare_issue("Title", "Body"))
-    assert result["success"] is False
-    assert result["error"] == "no result block found"
+    assert result["success"] is True
+    assert result["status"] == "degraded"
+    assert result["warning"] == "no result block found"
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -145,6 +145,46 @@ def test_build_headless_error_response_extra_fields_cannot_override_canonical() 
     assert resp["success"] is False
 
 
+def test_build_headless_error_response_degraded_success_fields() -> None:
+    """success=True, status='degraded' → warning key set, no error key."""
+    result = _make_skill_result(success=True, session_id="abc", subtype="success", exit_code=0)
+    resp = _build_headless_error_response(
+        result, warning="no result block found", status="degraded", success=True
+    )
+    assert resp["success"] is True
+    assert resp["status"] == "degraded"
+    assert resp["warning"] == "no result block found"
+    assert "error" not in resp
+    assert resp["session_id"] == "abc"
+    assert resp["subtype"] == "success"
+    assert resp["exit_code"] == 0
+
+
+def test_build_headless_error_response_degraded_extra_fields_cannot_override_canonical() -> None:
+    """In degraded-success mode, extra_fields still cannot overwrite canonical keys."""
+    result = _make_skill_result(
+        success=True, session_id="real-session", subtype="success", exit_code=0
+    )
+    resp = _build_headless_error_response(
+        result,
+        warning="real warning",
+        status="degraded",
+        success=True,
+        extra_fields={
+            "warning": "injected",
+            "session_id": "spoofed",
+            "status": "spoofed",
+            "success": False,
+            "partial_issue_url": "https://github.com/owner/repo/issues/42",
+        },
+    )
+    assert resp["warning"] == "real warning"
+    assert resp["session_id"] == "real-session"
+    assert resp["status"] == "degraded"
+    assert resp["success"] is True
+    assert resp["partial_issue_url"] == "https://github.com/owner/repo/issues/42"
+
+
 def test_retry_reason_to_error_uses_enum_value() -> None:
     """Non-NONE RetryReason → returns its .value string."""
     result = _make_skill_result(success=False, retry_reason=RetryReason.STALE)


### PR DESCRIPTION
## Summary

The session adjudication pipeline has two independent structural gaps, each allowing completed work to be reported as failed through a different failure mode:

1. **CONTRACT_RECOVERY gate uses a hardcoded string predicate** (`sr.subtype == "adjudicated_failure"` at `_headless_result.py:859`) that structurally excludes UNPARSEABLE sessions from evidence-based recovery, even when `returncode == 0` and write evidence proves the work was done. This produces a hard failure (`needs_retry=False`) instead of a retriable failure at the headless level.
2. **Tool-level parsers independently override adjudication** — when the headless level returns `result.success=True` but the result block's JSON is malformed or absent, `_parse_prepare_result` / `_parse_enrich_result` (`tools_issue_headless.py:209-217`, `:239-247`) return an error dict, and the handler code at lines 360-366 / 488-494 returns a failure envelope via `_build_headless_error_response`, overriding the headless-level success determination.

These are independent failure modes on independent control-flow branches. Root Cause A affects the headless adjudication layer (all session types). Root Cause B affects the tool-level result handling layer (only `prepare_issue` / `enrich_issues`, only when headless adjudication already succeeded).

The immunity approach: (a) replace the single-string gate — at both the sr-mutating site (line 856) AND the parallel audit-log site (line 707) — with a set-based predicate guarded by `returncode == 0` for non-adjudicated_failure subtypes, making the gate self-documenting and trivially extensible; (b) make tool-level result handling produce a degraded-success envelope (not a failure envelope) when `result.success is True` but block parsing fails (covering both "invalid JSON" and "no result block found" sentinels in `_BLOCK_PARSE_ERRORS`).

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/fix-4377-20260727-070043-055029/.autoskillit/temp/rectify/rectify_successful_sessions_returning_failure_envelopes_2026-07-27_070500.md`

Closes #4377

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->