### PR TITLE
Fix: completeness gate proxied on a heading name — restore 16 of 34 blocked investigations (#4392)

### DIFF
--- a/src/autoskillit/smoke_utils/_investigation.py
+++ b/src/autoskillit/smoke_utils/_investigation.py
@@ -9,9 +9,23 @@ import regex as re
 from autoskillit.core import atomic_write, run_gh
 
 _INVESTIGATION_HEADING = "## Investigation"
-_RECOMMENDATIONS_HEADING = "## Recommendations"
 _INVESTIGATION_HEADING_RE = re.compile(r"^" + re.escape(_INVESTIGATION_HEADING), re.MULTILINE)
-_RECOMMENDATIONS_HEADING_RE = re.compile(r"^" + re.escape(_RECOMMENDATIONS_HEADING), re.MULTILINE)
+# A structured report carries at least one ``## `` subsection. This is a property of the
+# content, not of any particular heading vocabulary — see _is_structured.
+_SUBSECTION_RE = re.compile(r"^## ", re.MULTILINE)
+
+
+def _is_structured(text: str) -> bool:
+    """Whether ``text`` looks like a structured report rather than a bare stub.
+
+    The defect this guards (#4381) produced a preamble of a few lines — a marker plus a
+    one-line note — with no subsections at all. Requiring at least one ``## `` subsection
+    rejects exactly that shape while remaining agnostic about which headings a report
+    uses. An earlier revision required a literal ``## Recommendations`` heading; that
+    proxied completeness on one vocabulary and rejected 16 of 34 real investigations
+    (#4392).
+    """
+    return _SUBSECTION_RE.search(text) is not None
 
 
 def extract_investigation(
@@ -22,17 +36,25 @@ def extract_investigation(
     """Resolve the effective investigation path for rectify.
 
     Called by run_python from the bridge_investigation step in remediation.yaml.
-    When investigation_path points to a complete report, validates and returns it.
-    Otherwise, fetches the issue body and extracts the ``## Investigation`` section
-    to end-of-body, validating that the section contains the ``## Recommendations``
-    heading (the guaranteed-last section of an investigation report).
+    When investigation_path points to a structured report, validates and returns it.
+
+    Otherwise, fetches the issue body and extracts the ``## Investigation`` section to
+    end-of-body. Because extraction runs to end-of-body, the section itself cannot be
+    truncated; what must still be established is that it *carries* the analysis.
+
+    Two shapes occur in practice. Most issues put the report under the heading, and the
+    extracted section is handed to rectify. A sizeable minority use the heading as an
+    attestation — "prior investigation completed interactively … included above" — with
+    the analysis earlier in the body. Failing those would halt the pipeline over a
+    formatting convention, so the whole body is handed over instead: it demonstrably
+    contains the analysis, and rectify is better served by more context than by none.
     """
     if investigation_path and Path(investigation_path).is_file():
         content = Path(investigation_path).read_text()
-        if _RECOMMENDATIONS_HEADING_RE.search(content) is None:
+        if not _is_structured(content):
             raise ValueError(
-                f"investigation_path file lacks '{_RECOMMENDATIONS_HEADING}' heading: "
-                f"{investigation_path}"
+                f"investigation_path file has no '## ' subsections, so it carries no "
+                f"structured investigation: {investigation_path}"
             )
         return {"investigation_report": str(investigation_path)}
 
@@ -61,12 +83,22 @@ def extract_investigation(
 
     extracted = body[heading_match.end() :]
 
-    if _RECOMMENDATIONS_HEADING_RE.search(extracted) is None:
+    if _is_structured(extracted):
+        payload = extracted
+    elif _is_structured(body[: heading_match.start()]):
+        # Attestation-style section: the heading records that an investigation happened
+        # and the analysis sits *above* it. Hand rectify the whole body rather than a
+        # three-line note, and rather than halting the pipeline (#4392). The test is
+        # deliberately against the text preceding the heading — testing the whole body
+        # would match the ``## Investigation`` heading itself and always pass.
+        payload = body
+    else:
         raise ValueError(
-            f"extracted '{_INVESTIGATION_HEADING}' section lacks "
-            f"'{_RECOMMENDATIONS_HEADING}' heading — investigation report is truncated"
+            f"issue {issue_number} has a '{_INVESTIGATION_HEADING}' heading but neither "
+            f"the section nor the text above it contains any '## ' subsections — there "
+            f"is no investigation to hand to rectify"
         )
 
     out_path = Path(output_dir) / "investigation_from_issue.md"
-    atomic_write(out_path, extracted)
+    atomic_write(out_path, payload)
     return {"investigation_report": str(out_path)}

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -3755,7 +3755,7 @@ def test_extract_investigation_passthrough_truncated_raises(tmp_path: Path) -> N
         "<!-- investigation_complete: true -->\n"
         "> Prior investigation completed interactively. See below for root cause analysis.\n"
     )
-    with pytest.raises(ValueError, match="Recommendations"):
+    with pytest.raises(ValueError, match="no '## ' subsections"):
         extract_investigation(
             investigation_path=str(truncated),
             issue_number="42",
@@ -3780,17 +3780,53 @@ def test_extract_investigation_no_section_raises(mock_run_gh, tmp_path: Path) ->
 
 @patch("autoskillit.smoke_utils._investigation.run_gh")
 def test_extract_investigation_empty_body_raises(mock_run_gh, tmp_path: Path) -> None:
-    """When ## Investigation section is empty, callable raises."""
+    """When neither the section nor the body carries any ## subsection, callable raises."""
 
     mock_run_gh.return_value = subprocess.CompletedProcess(
-        [], 0, "## Investigation\n\n## Next Section\n", ""
+        [], 0, "Preamble with no structure.\n## Investigation\n\n", ""
     )
-    with pytest.raises(ValueError, match="Recommendations"):
+    with pytest.raises(ValueError, match="no investigation to hand to rectify"):
         extract_investigation(
             investigation_path="",
             issue_number="42",
             output_dir=str(tmp_path),
         )
+
+
+@patch("autoskillit.smoke_utils._investigation.run_gh")
+def test_extract_investigation_attestation_section_falls_back_to_body(
+    mock_run_gh, tmp_path: Path
+) -> None:
+    """An attestation-style section hands rectify the whole body, not a three-line note.
+
+    Regression test for #4392. A sizeable minority of issues use ``## Investigation`` to
+    record *that* an investigation happened, with the analysis written above the heading.
+    Requiring a ``## Recommendations`` heading rejected 16 of 34 such issues and — because
+    bridge_investigation now halts on failure — stopped the pipeline outright.
+    """
+
+    body = (
+        "## Problem\n"
+        "The real analysis lives up here, above the attestation.\n"
+        "## Root cause\n"
+        "Detailed root cause content.\n"
+        "\n"
+        "## Investigation\n"
+        "<!-- investigation_complete: true -->\n"
+        "> Prior investigation completed interactively; analysis included above.\n"
+    )
+    mock_run_gh.return_value = subprocess.CompletedProcess([], 0, body, "")
+    out_dir = tmp_path / "investigate"
+    result = extract_investigation(
+        investigation_path="",
+        issue_number="42",
+        output_dir=str(out_dir),
+    )
+    written = Path(result["investigation_report"]).read_text()
+    # The whole body is handed over, so the analysis above the heading survives.
+    assert "The real analysis lives up here" in written
+    assert "Detailed root cause content." in written
+    assert "## Problem" in written
 
 
 @patch("autoskillit.smoke_utils._investigation.run_gh")
@@ -3834,10 +3870,10 @@ def test_extract_investigation_ignores_h3_investigation_decoy(mock_run_gh, tmp_p
     assert "Summary content." in written
 
 
-def test_extract_investigation_passthrough_rejects_h3_recommendations_decoy(
+def test_extract_investigation_passthrough_rejects_h3_subsection_decoy(
     tmp_path: Path,
 ) -> None:
-    """A decoy '### Recommendations' heading must not satisfy the completeness check."""
+    """A '### ' heading is not a '## ' subsection and must not satisfy the check."""
 
     truncated = tmp_path / "investigation_truncated.md"
     truncated.write_text(
@@ -3845,9 +3881,36 @@ def test_extract_investigation_passthrough_rejects_h3_recommendations_decoy(
         "> Prior investigation completed interactively.\n"
         "### Recommendations for future work (not a real section)\n"
     )
-    with pytest.raises(ValueError, match="Recommendations"):
+    with pytest.raises(ValueError, match="no '## ' subsections"):
         extract_investigation(
             investigation_path=str(truncated),
             issue_number="42",
             output_dir=str(tmp_path / "unused"),
         )
+
+
+def test_extract_investigation_accepts_report_without_recommendations(
+    tmp_path: Path,
+) -> None:
+    """Completeness must not be proxied on one heading name (#4392).
+
+    A structured report using a different terminal section is complete. The prior
+    revision rejected this shape, which is what halted 16 of 34 real investigations.
+    """
+
+    report = tmp_path / "investigation_no_recs.md"
+    report.write_text(
+        "# Investigation: Topic\n"
+        "## Summary\n"
+        "Summary content.\n"
+        "## Root Cause\n"
+        "Root cause content.\n"
+        "## Scope Boundary\n"
+        "Scope content — no Recommendations heading anywhere.\n"
+    )
+    result = extract_investigation(
+        investigation_path=str(report),
+        issue_number="42",
+        output_dir=str(tmp_path / "unused"),
+    )
+    assert result["investigation_report"] == str(report)


### PR DESCRIPTION
Closes #4392.

Follow-up to #4381 (PR #4388), found by running that issue's own acceptance test
immediately after it merged.

## What was wrong

#4381 shipped a completeness gate requiring a literal `## Recommendations` heading.
Replayed against the live issue corpus, it rejected **16 of 34** real investigations.
Because #4381 also — correctly — changed `bridge_investigation`'s `on_failure` from
`rectify` to `release_issue_failure`, that is not a warning: those issues can no longer
enter the remediation pipeline at all.

## Two findings that changed the fix

**1. The heading test was never guarding extraction.** Extraction already runs from
`## Investigation` to end-of-body, so the section *cannot* be truncated. The check was
demanding one report vocabulary, not measuring completeness. This also rules out the
byte-ratio check #4381 proposed as remediation — with end-of-body extraction, extracted
always equals heading-to-end-of-body, so the ratio is always 100% and the check is vacuous.

**2. The remaining failures are not truncated reports.** The issues that fail even a
generic structural check use `## Investigation` as an *attestation* — "prior investigation
completed interactively … included **above**" — with the analysis written above the
heading. Extracting downward from the heading gets a three-line note; the content is
upward. Rejecting them was wrong, and so was extracting from the heading down.

## What this does

- Completeness is now **"the section contains at least one `## ` subsection"** — agnostic
  to heading vocabulary, and still rejecting the original defect shape (marker plus a
  one-line note, no subsections).
- An attestation-style section **falls back to handing rectify the whole issue body**,
  which demonstrably contains the analysis. This is exactly what the programme's machinery
  notes already instructed operators to do by hand.
- A hard failure is kept only when neither the section **nor the text above it** carries
  any structure.

The fallback deliberately tests the text *preceding* the heading. Testing the whole body
matches the `## Investigation` heading itself and always passes — caught by a failing test
during development.

## Verification

Acceptance re-measured on the live corpus, which is what #4381 asked for and what this PR
is answerable to:

```
marked issues with an ## Investigation heading : 34
failing / empty  — before this change          : 16
failing / empty  — after  this change          :  0
```

- 11/11 `extract_investigation` unit tests pass, including three new ones: the attestation
  fallback, a structured report with no `## Recommendations` heading, and a `### ` decoy.
- Full suite: **33,024 passed**, 625 skipped, 26 xfailed.
- `pre-commit run --all-files` clean.

## Scope flags

None. Single callable plus its tests; no sibling-ticket surfaces touched. Specifically
does **not** touch `server/_recipe_delivery.py` or `server/tools/tools_recipe.py` (#4362,
actively in progress), `tools_issue_labels.py` (#4386), or the audit-cycle verifier (#4387).

Does **not** revert #4381 — halting loudly is strictly better than the silent truncation it
replaced, and reverting would restore the worse behaviour.
