### PR TITLE
Rectify: Generation-Bound Bounded Recipe Initialization

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a
 multi-level orchestrator. The bundled recipes implement issue → plan → worktree
-→ tests → PR → merge pipelines using 60 MCP tools and 142 bundled skills.
+→ tests → PR → merge pipelines using 61 MCP tools and 142 bundled skills.
 
 ## Start here
 

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -4,7 +4,7 @@ How AutoSkillit runs a recipe end to end: orchestrator, kitchen gating, clone an
 
 ## Overview
 
-AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 60 MCP tools and 142 bundled skills, organized into a gated visibility system.
+AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 61 MCP tools and 142 bundled skills, organized into a gated visibility system.
 
 ## Core Concepts
 
@@ -23,12 +23,12 @@ AutoSkillit uses a three-tier tool visibility model:
 
 - **Free-range (4 tools)**: Always visible — `open_kitchen`, `close_kitchen`, `disable_quota_guard`, `reload_session`
 - **Headless tools (2 tools)**: Revealed in headless sessions via `mcp.enable({'headless'})` — `test_check`, `unlock_agent_pack`
-- **Kitchen-tagged tools (41 tools total)**: Gated behind `open_kitchen` — `run_skill`,
-  `run_cmd`, `run_python`, `merge_worktree`, `clone_repo`, `push_to_remote`, and 34 more.
+- **Kitchen-tagged tools (42 tools total)**: Gated behind `open_kitchen` — `run_skill`,
+  `run_cmd`, `run_python`, `merge_worktree`, `clone_repo`, `push_to_remote`, and 35 more.
   Two kitchen tools (`test_check`, `unlock_agent_pack`) also carry the `headless` tag and are
   additionally pre-enabled in headless sessions.
 
-When you call `open_kitchen` (automatically done by `order`), all 41 kitchen-tagged tools become
+When you call `open_kitchen` (automatically done by `order`), all 42 kitchen-tagged tools become
 available for that session. This keeps normal Claude Code sessions clean — no pipeline tools
 cluttering the tool list.
 
@@ -60,7 +60,7 @@ AutoSkillit supports four session modes with different tool and skill visibility
 
 - **`$ claude` (plugin, no kitchen)**: Regular Claude Code session with the AutoSkillit plugin
   loaded. Sees 4 Free Range MCP tools (`open_kitchen`, `close_kitchen`, `disable_quota_guard`, `reload_session`) and Tier 1 skills only
-  (`open-kitchen`, `close-kitchen`). After calling `/open-kitchen`, all 41 kitchen-tagged MCP
+  (`open-kitchen`, `close-kitchen`). After calling `/open-kitchen`, all 42 kitchen-tagged MCP
   tools become available.
 
 - **`$ autoskillit cook`**: Interactive development session. Sees all three skill tiers
@@ -68,7 +68,7 @@ AutoSkillit supports four session modes with different tool and skill visibility
   `$ claude`); `/open-kitchen` reveals kitchen tools.
 
 - **`$ autoskillit order`**: Pipeline orchestrator session. Kitchen is pre-opened at startup —
-  all 60 MCP tools are available immediately. All skill tiers are accessible. The orchestrator
+  all 61 MCP tools are available immediately. All skill tiers are accessible. The orchestrator
   delegates work through `run_skill` (headless sessions) and `run_cmd` (shell commands).
 
 - **`run_skill` (headless)**: Worker sessions launched by the orchestrator. Sees 4 Free Range

--- a/docs/execution/tool-access.md
+++ b/docs/execution/tool-access.md
@@ -1,6 +1,6 @@
 # MCP Tool Access Control
 
-AutoSkillit provides 60 MCP tools organized into three access levels that control which
+AutoSkillit provides 61 MCP tools organized into three access levels that control which
 session types can see each tool.
 
 ## Three Access Levels
@@ -61,7 +61,7 @@ Server startup sequence:
 
 ```
 1. mcp.disable(tags={"kitchen"})
-   → hides 41 kitchen-tagged tools (including the 2 headless-tagged tools)
+   → hides 42 kitchen-tagged tools (including the 2 headless-tagged tools)
 
 2. mcp.disable(tags={subset}) for each entry in config.subsets.disabled
    → e.g. hides all github-tagged tools if "github" is disabled
@@ -92,7 +92,7 @@ missing kitchen visibility.
 
 ## Complete MCP Tool Access Control Map
 
-All 60 tools with their access level, tags, source file, and functional category.
+All 61 tools with their access level, tags, source file, and functional category.
 
 **Tag abbreviations**: AS = `autoskillit`, K = `kitchen`, HL = `headless`,
 GH = `github`, CI = `ci`, CL = `clone`, TL = `telemetry`, FL = `fleet`
@@ -209,6 +209,7 @@ GH = `github`, CI = `ci`, CL = `clone`, TL = `telemetry`, FL = `fleet`
 |------|------|-------------|
 | `list_recipes` | AS, K | `server/tools_recipe.py` |
 | `load_recipe` | AS, K | `server/tools_recipe.py` |
+| `complete_recipe_initialization` | AS, K | `server/tools_recipe.py` |
 | `validate_recipe` | AS, K | `server/tools_recipe.py` |
 | `migrate_recipe` | AS, K | `server/tools_recipe.py` |
 

--- a/docs/skills/catalog.md
+++ b/docs/skills/catalog.md
@@ -8,7 +8,7 @@ you need an exhaustive listing; this catalog groups by purpose.
 
 Plugin-scanned at `src/autoskillit/skills/`:
 
-- `open-kitchen` — reveals the 41 kitchen MCP tools
+- `open-kitchen` — reveals the 42 kitchen MCP tools
 - `close-kitchen` — re-hides them
 
 ## Tier 2 — interactive cook + headless (106 configured)

--- a/docs/skills/subsets.md
+++ b/docs/skills/subsets.md
@@ -84,7 +84,7 @@ Custom tags behave like built-in categories for filtering purposes: disabling
 ## FastMCP Mechanics: Why `open_kitchen` Re-Disables Subsets
 
 FastMCP session rules override server rules. When `open_kitchen` calls
-`ctx.enable_components(tags={"kitchen"})` to reveal the 41 kitchen-tagged tools, this
+`ctx.enable_components(tags={"kitchen"})` to reveal the 42 kitchen-tagged tools, this
 operation overwrites the server-level `mcp.disable(tags={"github"})` mark applied at
 startup. As a result, `open_kitchen` must immediately re-call
 `ctx.disable_components(tags={subset})` for each configured disabled subset to restore

--- a/src/autoskillit/cli/_mcp_names.py
+++ b/src/autoskillit/cli/_mcp_names.py
@@ -20,13 +20,6 @@ __all__ = [
 ]
 
 
-def resolve_tool_name(short_name: str, prefix: str | None = None) -> str:
-    """Return the fully-qualified MCP tool name for the given short name.
-
-    If prefix is None, detect_autoskillit_mcp_prefix() is called. Pass
-    prefix explicitly when it has already been resolved for a session to
-    avoid re-reading the filesystem.
-    """
-    if prefix is None:
-        prefix = detect_autoskillit_mcp_prefix()
+def resolve_tool_name(short_name: str, prefix: str) -> str:
+    """Return a tool name using the prefix already resolved for this backend."""
     return f"{prefix}{short_name}"

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -27,12 +27,27 @@ from autoskillit.workspace import (
 # ── Shared helpers (used by sibling _prompts_*.py modules) ──────────────
 
 _MCP_RETRY_INSTRUCTION: str = (
-    "If calling open_kitchen produces ANY error — including"
-    ' "No such tool available", a tool_use_error, or any is_error response —'
-    " retry the call once immediately. Do not explain the error or suggest"
-    " troubleshooting steps to the user. Just retry silently.\n"
-    'If the retry also fails, output "AutoSkillit MCP server did not start — ending session."'
-    " and end."
+    "RECIPE STARTUP RESULT ORDER — evaluate these cases in order:\n"
+    "1. A pre-dispatch symbol-resolution error (for example, No such tool or an "
+    "AutoSkillit-generated bad symbol) requires runtime tool discovery, then one "
+    "dispatch using the discovered symbol.\n"
+    "2. A discovery, transport, unavailable, tool_use_error, or isError:true "
+    "failure requires one silent retry. Only if that retry also fails at transport "
+    'may you output "AutoSkillit MCP server did not start — ending session." and end.\n'
+    "3. An isError:false MCP response is a structured application result, including "
+    "when its JSON contains success:false. Parse it before applying failure rules.\n"
+    "4. If the application result contains a recovery manifest, process it before "
+    "any generic success:false branch: preserve recipe_pull, recipe_flow, "
+    "initialization_id, required_sections, page-plan and pagination identities; "
+    "pull every flow_records page in order, then the entrypoint named-step pages. "
+    "Forward every advertised immutable identity plus initialization_id, "
+    "page_plan_sha256, part, and continuation; reject mismatched versions, digests, "
+    "sizes, records, skipped parts, or changed bindings. After exact reconstruction, "
+    "call complete_recipe_initialization(initialization_id) and require its receipt "
+    "before the first execution or mutation tool.\n"
+    "5. Only a structured, nonrecoverable application error is terminal. Print its "
+    "user_visible_message verbatim (or the raw application result if absent), do "
+    "not call AskUserQuestion, and do not diagnose it as MCP startup failure."
 )
 
 

--- a/src/autoskillit/cli/_prompts_orchestrator.py
+++ b/src/autoskillit/cli/_prompts_orchestrator.py
@@ -164,25 +164,6 @@ FAILURE PREDICATES — when to follow on_failure:
 - run_skill: "success: False" in output
 - classify_fix: "error:" line present in output
 
-FAILURE PREDICATE — open_kitchen:
-  If the open_kitchen response contains `"success": false` OR `"ingredients_table"`: null
-  (field absent or null in the JSON response):
-    1. Extract and print the value of "user_visible_message" from the
-       JSON response verbatim (fall back to the raw response text if
-       parsing fails).
-    2. DO NOT call AskUserQuestion.
-    3. End the session with a final text response.
-
-FAILURE PREDICATE — DEGRADED TOOL RESPONSE:
-  If ANY tool response contains `"success": false` AND the `content` field is
-  absent, null, or an empty string — this is a degraded state.
-    1. Extract and print the value of "user_visible_message" from the
-       response (fall back to the raw response text if the field is missing).
-    2. DO NOT call AskUserQuestion.
-    3. Do not improvise a recovery path. Do not route to on_failure.
-       Do not retry the tool without explicit instructions from the recipe step.
-    4. End the session with a final text response.
-
 CONTEXT LIMIT ROUTING — run_skill only (check BEFORE on_failure):
 - When run_skill returns "success: False" AND "needs_retry: true" AND "retry_reason: resume":
   - Check "subtype" to discriminate the termination cause:

--- a/src/autoskillit/cli/fleet/_fleet_run.py
+++ b/src/autoskillit/cli/fleet/_fleet_run.py
@@ -94,11 +94,9 @@ async def _execute_fleet_run(
     )
 
     effective_backend = dispatch_backend or ctx.backend
-    has_ufa = (
-        effective_backend.capabilities.has_unguarded_filesystem_access
-        if effective_backend
-        else False
-    )
+    if effective_backend is None:
+        raise RuntimeError("Fleet dispatch requires a configured backend.")
+    has_ufa = effective_backend.capabilities.has_unguarded_filesystem_access
     sous_chef = None
     if ctx.skill_resolver is not None:
         orchestrator_catalog = ctx.skill_resolver.list_effective(
@@ -116,9 +114,7 @@ async def _execute_fleet_run(
                 cwd=ctx.project_dir.resolve(),
                 catalog=orchestrator_catalog,
                 backend=effective_backend,
-                conventions=(
-                    effective_backend.conventions if effective_backend is not None else None
-                ),
+                conventions=effective_backend.conventions,
                 gating=False,
             ),
         ).content
@@ -127,7 +123,7 @@ async def _execute_fleet_run(
     )
     prompt_builder = functools.partial(
         _build_food_truck_prompt,
-        mcp_prefix=detect_autoskillit_mcp_prefix(),
+        mcp_prefix=detect_autoskillit_mcp_prefix(effective_backend.capabilities),
         has_unguarded_filesystem_access=has_ufa,
         projected_sous_chef=projected_sous_chef,
     )
@@ -139,11 +135,7 @@ async def _execute_fleet_run(
     else:
         from autoskillit.execution import check_and_sleep_if_needed
 
-        _supports_quota = (
-            effective_backend.capabilities.anthropic_provider_capable
-            if effective_backend
-            else True
-        )
+        _supports_quota = effective_backend.capabilities.anthropic_provider_capable
 
         async def quota_checker(_cfg: object) -> dict[str, object]:
             return await check_and_sleep_if_needed(

--- a/src/autoskillit/cli/fleet/_fleet_session.py
+++ b/src/autoskillit/cli/fleet/_fleet_session.py
@@ -52,8 +52,6 @@ def _launch_fleet_session(
         _run_interactive_session,
     )
 
-    mcp_prefix = detect_autoskillit_mcp_prefix()
-
     project_dir = Path.cwd()
 
     from autoskillit.config import load_config  # noqa: PLC0415
@@ -62,7 +60,9 @@ def _launch_fleet_session(
 
     from autoskillit.execution import get_backend  # noqa: PLC0415
 
-    _backend_caps = get_backend(cfg.agent_backend.backend).capabilities
+    _backend = get_backend(cfg.agent_backend.backend)
+    _backend_caps = _backend.capabilities
+    mcp_prefix = detect_autoskillit_mcp_prefix(_backend_caps)
 
     if campaign_recipe is None:
         # Ad-hoc mode: no campaign, no state, bare kitchen open
@@ -93,6 +93,7 @@ def _launch_fleet_session(
                 resume_spec=current_resume_spec,
                 project_dir=project_dir,
                 required_env=FLEET_SESSION_REQUIRED_ENV,
+                backend=_backend,
             )
             if session_signal is None:
                 break
@@ -202,6 +203,7 @@ def _launch_fleet_session(
                 resume_spec=current_resume_spec,
                 project_dir=project_dir,
                 required_env=FLEET_SESSION_REQUIRED_ENV,
+                backend=_backend,
             )
             if session_signal is None:
                 break

--- a/src/autoskillit/cli/session/_session_launch.py
+++ b/src/autoskillit/cli/session/_session_launch.py
@@ -100,7 +100,7 @@ def _run_interactive_session(
     _project_dir = project_dir if project_dir is not None else Path.cwd()
     plugin_source: PluginSource | None
     if backend.capabilities.skill_injection_capable:
-        if detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX:
+        if detect_autoskillit_mcp_prefix(backend.capabilities) == MARKETPLACE_PREFIX:
             plugin_source = None
         else:
             from autoskillit.workspace import project_default_plugin_source

--- a/src/autoskillit/cli/session/_session_order.py
+++ b/src/autoskillit/cli/session/_session_order.py
@@ -183,8 +183,6 @@ def order(
         )
         return
 
-    mcp_prefix = detect_autoskillit_mcp_prefix()
-
     from autoskillit.cli.ui._timed_input import timed_prompt
 
     if recipe is None:
@@ -218,6 +216,7 @@ def order(
             _cfg_early = _load_config_early(Path.cwd())
             _backend_early = _get_backend_early(_cfg_early.agent_backend.backend)
             _caps_early = _backend_early.capabilities
+            mcp_prefix = detect_autoskillit_mcp_prefix(_caps_early)
             _launch_cook_session(
                 _build_open_kitchen_prompt(
                     mcp_prefix=mcp_prefix,
@@ -231,6 +230,7 @@ def order(
                 project_dir=Path.cwd(),
                 extra_env=_write_order_entry(Path.cwd(), None),
                 required_env=ORDER_INTERACTIVE_REQUIRED_ENV,
+                backend=_backend_early,
                 skill_catalog=skill_catalog,
             )
             return
@@ -351,6 +351,7 @@ def order(
 
     _backend = get_backend(_cfg.agent_backend.backend)
     _backend_caps = _backend.capabilities
+    mcp_prefix = detect_autoskillit_mcp_prefix(_backend_caps)
     _launch_cook_session(
         _build_orchestrator_prompt(
             recipe,
@@ -366,5 +367,6 @@ def order(
         resume_spec=resume_spec,
         project_dir=Path.cwd(),
         required_env=ORDER_INTERACTIVE_REQUIRED_ENV,
+        backend=_backend,
         skill_catalog=skill_catalog,
     )

--- a/src/autoskillit/config/ingredient_defaults.py
+++ b/src/autoskillit/config/ingredient_defaults.py
@@ -35,7 +35,14 @@ _DISPLAY_CATEGORIES: tuple[tuple[str, tuple[str, ...]], ...] = (
     ),
     (
         "Recipes",
-        ("migrate_recipe", "list_recipes", "load_recipe", "validate_recipe", "get_recipe_section"),
+        (
+            "migrate_recipe",
+            "list_recipes",
+            "load_recipe",
+            "validate_recipe",
+            "get_recipe_section",
+            "complete_recipe_initialization",
+        ),
     ),
     ("Agents", ("unlock_agent_pack",)),
     (

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -9,6 +9,9 @@ from ._delivery_bounds import (
     resolve_general_output_token_limit as resolve_general_output_token_limit,
 )
 from ._delivery_bounds import resolve_recipe_delivery_decision as resolve_recipe_delivery_decision
+from ._delivery_bounds import (
+    resolve_recipe_envelope_byte_limit as resolve_recipe_envelope_byte_limit,
+)
 from ._execution_marker import execution_marker as execution_marker
 from ._install_detect import DirectUrlInfo as DirectUrlInfo
 from ._install_detect import _is_release_tag as _is_release_tag
@@ -297,11 +300,18 @@ from .types import QUOTA_GUARD_DENY_TRIGGER as QUOTA_GUARD_DENY_TRIGGER
 from .types import QUOTA_POST_BUDGET_EXCEEDED_TRIGGER as QUOTA_POST_BUDGET_EXCEEDED_TRIGGER
 from .types import QUOTA_POST_WARNING_TRIGGER as QUOTA_POST_WARNING_TRIGGER
 from .types import READING_TOKEN_PATTERN as READING_TOKEN_PATTERN
+from .types import RECIPE_ARTIFACT_DESCRIPTOR_VERSION as RECIPE_ARTIFACT_DESCRIPTOR_VERSION
+from .types import RECIPE_ARTIFACT_MAX_BLOB_BYTES as RECIPE_ARTIFACT_MAX_BLOB_BYTES
+from .types import (
+    RECIPE_ARTIFACT_MAX_DESCRIPTOR_BYTES as RECIPE_ARTIFACT_MAX_DESCRIPTOR_BYTES,
+)
+from .types import RECIPE_ARTIFACT_SCHEMA_VERSION as RECIPE_ARTIFACT_SCHEMA_VERSION
 from .types import RECIPE_DELIVERY_ATTESTATION_AUDIENCE as RECIPE_DELIVERY_ATTESTATION_AUDIENCE
 from .types import RECIPE_DELIVERY_SURFACE_REGISTRY as RECIPE_DELIVERY_SURFACE_REGISTRY
 from .types import (
     RECIPE_DELIVERY_SURFACE_REGISTRY_DIGEST as RECIPE_DELIVERY_SURFACE_REGISTRY_DIGEST,
 )
+from .types import RECIPE_FLOW_SCHEMA_VERSION as RECIPE_FLOW_SCHEMA_VERSION
 from .types import RECIPE_PACK_REGISTRY as RECIPE_PACK_REGISTRY
 from .types import RECIPE_PACK_TAGS as RECIPE_PACK_TAGS
 from .types import (
@@ -492,6 +502,7 @@ from .types import FailureRecord as FailureRecord
 from .types import FeatureDef as FeatureDef
 from .types import FeatureLifecycle as FeatureLifecycle
 from .types import FigureSpec as FigureSpec
+from .types import FinalizedRecipeProjection as FinalizedRecipeProjection
 from .types import FleetErrorCode as FleetErrorCode
 from .types import FleetLock as FleetLock
 from .types import FleetSessionEnv as FleetSessionEnv
@@ -581,6 +592,7 @@ from .types import QuotaRefreshTask as QuotaRefreshTask
 from .types import ReadinessProbe as ReadinessProbe
 from .types import ReadingToken as ReadingToken
 from .types import ReadOnlyResolver as ReadOnlyResolver
+from .types import RecipeArtifactGeneration as RecipeArtifactGeneration
 from .types import RecipeBindingProjection as RecipeBindingProjection
 from .types import RecipeDeliveryAttestation as RecipeDeliveryAttestation
 from .types import RecipeDeliveryBudgetDef as RecipeDeliveryBudgetDef
@@ -592,6 +604,8 @@ from .types import RecipeDeliverySurfaceDef as RecipeDeliverySurfaceDef
 from .types import RecipeExecutionFactory as RecipeExecutionFactory
 from .types import RecipeExecutionLock as RecipeExecutionLock
 from .types import RecipeExecutionSnapshot as RecipeExecutionSnapshot
+from .types import RecipeFlowEdge as RecipeFlowEdge
+from .types import RecipeFlowGeneration as RecipeFlowGeneration
 from .types import RecipeIdentity as RecipeIdentity
 from .types import RecipeLoadError as RecipeLoadError
 from .types import RecipeNotFoundError as RecipeNotFoundError
@@ -690,6 +704,7 @@ from .types import TokenizerIdentity as TokenizerIdentity
 from .types import TokenLog as TokenLog
 from .types import ToolCallId as ToolCallId
 from .types import ToolDef as ToolDef
+from .types import ToolInitializationOperation as ToolInitializationOperation
 from .types import ToolParamDef as ToolParamDef
 from .types import ToolWireType as ToolWireType
 from .types import TraditionManifest as TraditionManifest

--- a/src/autoskillit/core/_delivery_bounds.py
+++ b/src/autoskillit/core/_delivery_bounds.py
@@ -48,6 +48,11 @@ def resolve_general_output_token_limit(caps: BackendCapabilities) -> int:
     return caps.unnegotiated_tool_result_token_limit
 
 
+def resolve_recipe_envelope_byte_limit(capabilities: BackendCapabilities) -> int:
+    """Return the conservative UTF-8 byte ceiling for an ordinary recipe envelope."""
+    return resolve_general_output_token_limit(capabilities)
+
+
 def resolve_recipe_delivery_decision(
     *,
     capabilities: BackendCapabilities,

--- a/src/autoskillit/core/_plugin_ids.py
+++ b/src/autoskillit/core/_plugin_ids.py
@@ -11,6 +11,10 @@ from __future__ import annotations
 import functools
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .types import BackendCapabilities
 
 # The key written to installed_plugins.json by `autoskillit install`
 _AUTOSKILLIT_PLUGIN_KEY = "autoskillit@autoskillit-local"
@@ -65,17 +69,19 @@ def registered_install_paths() -> tuple[Path, ...]:
     return tuple(paths)
 
 
-@functools.lru_cache(maxsize=1)
-def detect_autoskillit_mcp_prefix() -> str:
+@functools.lru_cache(maxsize=2)
+def detect_autoskillit_mcp_prefix(capabilities: BackendCapabilities) -> str:
     """Return the MCP prefix that autoskillit tools will use in a spawned session.
 
-    Reads ~/.claude/plugins/installed_plugins.json to determine whether
-    autoskillit is marketplace-installed. When it is, the marketplace
-    prefix takes precedence even when --plugin-dir is also passed.
+    Backends that cannot consume Claude marketplace tool names always use the
+    direct/runtime prefix without reading Claude registry state. Capable backends
+    read ``installed_plugins.json`` and prefer the marketplace prefix when present.
 
     Falls back to DIRECT_PREFIX if the file is absent, unreadable, or
     does not contain the autoskillit key.
     """
+    if not capabilities.claude_marketplace_tool_prefix_capable:
+        return DIRECT_PREFIX
     try:
         data = json.loads(_installed_plugins_path().read_text())
         if _AUTOSKILLIT_PLUGIN_KEY in data.get("plugins", {}):

--- a/src/autoskillit/core/tool_registry.py
+++ b/src/autoskillit/core/tool_registry.py
@@ -12,7 +12,12 @@ from types import MappingProxyType
 
 from .closure_hashing import compute_canonical_hash
 from .types._type_constants_registries import HEADLESS_TOOLS
-from .types._type_recipe_binding import ToolDef, ToolParamDef, ToolWireType
+from .types._type_recipe_binding import (
+    ToolDef,
+    ToolInitializationOperation,
+    ToolParamDef,
+    ToolWireType,
+)
 
 __all__ = [
     "TOOL_REGISTRY",
@@ -23,6 +28,85 @@ __all__ = [
 ]
 
 _TOOL_CONTRACT_IDENTITY_DOMAIN = "autoskillit:tool-contract:v1:sha256"
+
+_INSPECTION_TOOLS = frozenset(
+    {
+        "analyze_tool_sequences",
+        "check_pr_mergeable",
+        "check_repo_merge_state",
+        "fetch_github_issue",
+        "get_ci_status",
+        "get_issue_title",
+        "get_pipeline_report",
+        "get_pr_reviews",
+        "get_quota_events",
+        "get_timing_summary",
+        "get_token_summary",
+        "kitchen_status",
+        "list_recipes",
+        "load_recipe",
+        "read_db",
+        "validate_recipe",
+    }
+)
+_LIFECYCLE_CONTROL_TOOLS = frozenset({"close_kitchen", "open_kitchen"})
+_RECOVERY_TOOLS = frozenset({"complete_recipe_initialization", "get_recipe_section"})
+_EXECUTION_TOOLS = frozenset({"run_cmd", "run_python", "run_skill", "test_check"})
+_MUTATION_TOOLS = frozenset(
+    {
+        "batch_cleanup_clones",
+        "bootstrap_clone",
+        "bulk_close_issues",
+        "claim_and_resolve_issue",
+        "claim_issue",
+        "classify_fix",
+        "clone_repo",
+        "commit_files",
+        "configure_fleet",
+        "configure_order",
+        "create_and_publish_branch",
+        "create_unique_branch",
+        "disable_quota_guard",
+        "dispatch_food_truck",
+        "enqueue_pr",
+        "enrich_issues",
+        "lock_ingredients",
+        "merge_worktree",
+        "migrate_recipe",
+        "prepare_issue",
+        "push_to_remote",
+        "record_gate_dispatch",
+        "record_pipeline_step",
+        "register_clone_status",
+        "release_issue",
+        "reload_session",
+        "remove_clone",
+        "report_bug",
+        "reset_dispatch",
+        "reset_test_dir",
+        "reset_workspace",
+        "set_commit_status",
+        "toggle_auto_merge",
+        "unlock_agent_pack",
+        "wait_for_ci",
+        "wait_for_merge_queue",
+        "write_telemetry_files",
+    }
+)
+
+
+def _initialization_operation(name: str) -> ToolInitializationOperation:
+    if name in _RECOVERY_TOOLS:
+        return ToolInitializationOperation.RECOVERY
+    if name in _INSPECTION_TOOLS:
+        return ToolInitializationOperation.INSPECTION
+    if name in _LIFECYCLE_CONTROL_TOOLS:
+        return ToolInitializationOperation.LIFECYCLE_CONTROL
+    if name in _EXECUTION_TOOLS:
+        return ToolInitializationOperation.EXECUTION
+    if name in _MUTATION_TOOLS:
+        return ToolInitializationOperation.MUTATION
+    raise ValueError(f"Tool {name!r} has no initialization-time operation class")
 
 
 def _tool(
@@ -44,6 +128,7 @@ def _tool(
             )
             for param in params
         ),
+        initialization_operation=_initialization_operation(name),
     )
 
 
@@ -93,7 +178,11 @@ def _run_skill() -> ToolDef:
             handler_parameter=True,
         )
     )
-    return ToolDef(name="run_skill", params=tuple(params))
+    return ToolDef(
+        name="run_skill",
+        params=tuple(params),
+        initialization_operation=_initialization_operation("run_skill"),
+    )
 
 
 _TOOL_DEFS = (
@@ -377,7 +466,14 @@ _TOOL_DEFS = (
             "artifact_blob_size_bytes",
             "body_sha256",
             "body_size_bytes",
+            "flow_schema_version",
+            "flow_sha256",
+            "flow_size_bytes",
+            "flow_record_count",
             "part",
+            "initialization_id",
+            "page_plan_sha256",
+            "continuation",
         ),
         required=(
             "section",
@@ -390,7 +486,17 @@ _TOOL_DEFS = (
             "artifact_blob_size_bytes",
             "body_sha256",
             "body_size_bytes",
+            "flow_schema_version",
+            "flow_sha256",
+            "flow_size_bytes",
+            "flow_record_count",
         ),
+    ),
+    _tool(
+        "complete_recipe_initialization",
+        ("initialization_id",),
+        required=("initialization_id",),
+        wire_types={"initialization_id": ToolWireType.STRING},
     ),
     _tool("validate_recipe", ("script_path",), required=("script_path",)),
     _tool("migrate_recipe", ("name",), required=("name",)),
@@ -439,6 +545,7 @@ def compute_tool_contract_identity(tool_def: ToolDef) -> str:
     return compute_canonical_hash(
         {
             "name": tool_def.name,
+            "initialization_operation": tool_def.initialization_operation.value,
             "params": [
                 {
                     "handler_parameter": param.handler_parameter,

--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -141,6 +141,9 @@ class BackendCapabilities:
     anthropic_provider_capable: bool = field(default=False)
     # True when backend supports Claude plugin install/list CLI
     plugin_install_capable: bool = field(default=False)
+    # True when MCP tool names may use Claude marketplace registration state.
+    # Backends without this capability always use the direct/runtime prefix.
+    claude_marketplace_tool_prefix_capable: bool = field(default=False)
     # True when backend supports Health Inspector LLM-callback idle detection
     inspector_capable: bool = field(default=False)
     # True when backend CLI natively understands context-window suffixes like [1m]
@@ -312,6 +315,7 @@ CLAUDE_CODE_CAPABILITIES: BackendCapabilities = BackendCapabilities(
     record_capable=True,
     anthropic_provider_capable=True,
     plugin_install_capable=True,
+    claude_marketplace_tool_prefix_capable=True,
     inspector_capable=False,
     supports_context_window_suffix=True,
     has_unguarded_filesystem_access=False,

--- a/src/autoskillit/core/types/_type_constants_registries.py
+++ b/src/autoskillit/core/types/_type_constants_registries.py
@@ -138,6 +138,7 @@ GATED_TOOLS: frozenset[str] = frozenset(
         "record_pipeline_step",
         "reset_dispatch",
         "get_recipe_section",
+        "complete_recipe_initialization",
     }
 )
 
@@ -204,6 +205,7 @@ class RecipeDeliverySurfaceDef(NamedTuple):
     negotiation_eligible: bool
     pull_eligible: bool
     recreation_eligible: bool
+    initialization_activating: bool
     response_exemption_tool: str | None
     response_exemption: ResponseBackstopExemptionDef | None
 
@@ -218,6 +220,7 @@ RECIPE_DELIVERY_SURFACE_REGISTRY: Mapping[str, RecipeDeliverySurfaceDef] = Mappi
             negotiation_eligible=True,
             pull_eligible=True,
             recreation_eligible=True,
+            initialization_activating=True,
             response_exemption_tool="open_kitchen",
             response_exemption=ResponseBackstopExemptionDef(
                 max_chars=_RECIPE_RESPONSE_MAX_UTF8_BYTES,
@@ -231,6 +234,7 @@ RECIPE_DELIVERY_SURFACE_REGISTRY: Mapping[str, RecipeDeliverySurfaceDef] = Mappi
             negotiation_eligible=True,
             pull_eligible=True,
             recreation_eligible=True,
+            initialization_activating=True,
             response_exemption_tool="open_kitchen",
             response_exemption=None,
         ),
@@ -240,6 +244,7 @@ RECIPE_DELIVERY_SURFACE_REGISTRY: Mapping[str, RecipeDeliverySurfaceDef] = Mappi
             negotiation_eligible=True,
             pull_eligible=True,
             recreation_eligible=False,
+            initialization_activating=False,
             response_exemption_tool="load_recipe",
             response_exemption=ResponseBackstopExemptionDef(
                 max_chars=_RECIPE_RESPONSE_MAX_UTF8_BYTES,
@@ -253,6 +258,7 @@ RECIPE_DELIVERY_SURFACE_REGISTRY: Mapping[str, RecipeDeliverySurfaceDef] = Mappi
             negotiation_eligible=False,
             pull_eligible=True,
             recreation_eligible=True,
+            initialization_activating=False,
             response_exemption_tool=None,
             response_exemption=None,
         ),
@@ -409,6 +415,17 @@ RECIPE_SECTION_REGISTRY: Mapping[str, RecipeSectionDef] = _validated_recipe_sect
             has_default=True,
             default_value=(),
         ),
+        "flow_records": RecipeSectionDef(
+            name="flow_records",
+            value_kind="array",
+            element_kind="string",
+            missing_behavior="invalid",
+            none_behavior="invalid",
+            section_strategy="array",
+            range_unit="elements",
+            ordinary_content_format="json-array-page",
+            oversized_content_format="json-element-fragment",
+        ),
         "warnings": RecipeSectionDef(
             name="warnings",
             value_kind="array",
@@ -437,7 +454,7 @@ DYNAMIC_RECIPE_SECTION_DEF = RecipeSectionDef(
     oversized_content_format=None,
 )
 
-RECIPE_SECTION_PAGINATION_VERSION = 1
+RECIPE_SECTION_PAGINATION_VERSION = 2
 _RECIPE_SECTION_CANONICAL_JSON_ENSURE_ASCII = False
 _RECIPE_SECTION_CANONICAL_JSON_SEPARATORS = (",", ":")
 _RECIPE_SECTION_CANONICAL_JSON_SORT_KEYS = True
@@ -570,6 +587,9 @@ RECIPE_SECTION_PAGINATION_POLICY_DIGEST = _qualified_registry_digest(
 
 RECIPE_SECTION_MANDATORY_FAILURE_CODES: tuple[str, ...] = (
     "invalid_recipe_artifact_identity",
+    "invalid_recipe_initialization_identity",
+    "invalid_recipe_page_plan_identity",
+    "invalid_recipe_section_continuation",
     "invalid_recipe_section_part",
     "recipe_artifact_identity_required",
     "recipe_artifact_parse_failed",
@@ -737,6 +757,7 @@ TOOL_SUBSET_TAGS: dict[str, frozenset[str]] = {
     "unlock_agent_pack": frozenset({"kitchen-core"}),
     "record_pipeline_step": frozenset({"kitchen-core"}),
     "get_recipe_section": frozenset({"kitchen-core"}),
+    "complete_recipe_initialization": frozenset({"kitchen-core"}),
 }
 
 ALL_VISIBILITY_TAGS: frozenset[str] = frozenset(

--- a/src/autoskillit/core/types/_type_protocols_recipe.py
+++ b/src/autoskillit/core/types/_type_protocols_recipe.py
@@ -70,7 +70,7 @@ class RecipeRepository(Protocol):
         effective_backend_map: dict[str, str] | None = None,
         backend_capabilities_map: dict[str, BackendCapabilities] | None = None,
         backend_origin_map: dict[str, str] | None = None,
-        include_compiled_bindings: bool = False,
+        include_finalized_projection: bool = False,
     ) -> dict[str, Any]:
         """Load and validate a recipe.
 

--- a/src/autoskillit/core/types/_type_recipe_binding.py
+++ b/src/autoskillit/core/types/_type_recipe_binding.py
@@ -23,8 +23,11 @@ __all__ = [
     "BoundValue",
     "BoundValueOrigin",
     "BoundValueState",
+    "FinalizedRecipeProjection",
     "RecipeBindingProjection",
+    "RecipeFlowEdge",
     "ToolDef",
+    "ToolInitializationOperation",
     "ToolParamDef",
     "ToolWireType",
 ]
@@ -45,6 +48,16 @@ class ToolWireType(StrEnum):
     ARRAY = "array"
 
 
+class ToolInitializationOperation(StrEnum):
+    """Operation class used by the recipe-initialization admission boundary."""
+
+    RECOVERY = "recovery"
+    INSPECTION = "inspection"
+    LIFECYCLE_CONTROL = "lifecycle_control"
+    EXECUTION = "execution"
+    MUTATION = "mutation"
+
+
 @dataclass(frozen=True, slots=True)
 class ToolParamDef:
     """Static definition of one public MCP handler parameter."""
@@ -62,8 +75,14 @@ class ToolDef:
 
     name: str
     params: tuple[ToolParamDef, ...]
+    initialization_operation: ToolInitializationOperation
 
     def __post_init__(self) -> None:
+        if not isinstance(self.initialization_operation, ToolInitializationOperation):
+            raise TypeError(
+                f"ToolDef {self.name!r} initialization_operation must be "
+                "a ToolInitializationOperation"
+            )
         params = tuple(self.params)
         for index, param in enumerate(params):
             if not isinstance(param, ToolParamDef):
@@ -278,3 +297,68 @@ class RecipeBindingProjection:
         return tuple(
             failure for invocation in self.invocations.values() for failure in invocation.failures
         )
+
+
+@dataclass(frozen=True, slots=True)
+class RecipeFlowEdge:
+    """One ordered route in a finalized recipe graph."""
+
+    source: str
+    edge_type: str
+    target: str
+    condition: str | None
+    result_field: str | None
+
+    def __post_init__(self) -> None:
+        for field_name in ("source", "edge_type", "target"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"RecipeFlowEdge.{field_name} must be a non-empty string")
+        for field_name in ("condition", "result_field"):
+            value = getattr(self, field_name)
+            if value is not None and not isinstance(value, str):
+                raise TypeError(f"RecipeFlowEdge.{field_name} must be a string or None")
+
+
+@dataclass(frozen=True, slots=True)
+class FinalizedRecipeProjection:
+    """Immutable execution projection of one fully finalized recipe."""
+
+    binding_projection: RecipeBindingProjection
+    ordered_step_names: tuple[str, ...]
+    entrypoint: str
+    ordered_flow_edges: tuple[RecipeFlowEdge, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.binding_projection, RecipeBindingProjection):
+            raise TypeError(
+                "FinalizedRecipeProjection.binding_projection must be a RecipeBindingProjection"
+            )
+
+        ordered_step_names = tuple(self.ordered_step_names)
+        if not ordered_step_names:
+            raise ValueError("FinalizedRecipeProjection requires at least one ordered step")
+        if any(not isinstance(name, str) or not name for name in ordered_step_names):
+            raise ValueError(
+                "FinalizedRecipeProjection.ordered_step_names must contain non-empty strings"
+            )
+        if len(ordered_step_names) != len(set(ordered_step_names)):
+            raise ValueError("FinalizedRecipeProjection.ordered_step_names contains duplicates")
+        if not isinstance(self.entrypoint, str) or not self.entrypoint:
+            raise ValueError("FinalizedRecipeProjection.entrypoint must be a non-empty string")
+        if self.entrypoint != ordered_step_names[0]:
+            raise ValueError("FinalizedRecipeProjection.entrypoint must be the first ordered step")
+
+        ordered_flow_edges = tuple(self.ordered_flow_edges)
+        if any(not isinstance(edge, RecipeFlowEdge) for edge in ordered_flow_edges):
+            raise TypeError(
+                "FinalizedRecipeProjection.ordered_flow_edges must contain RecipeFlowEdge entries"
+            )
+        step_names = frozenset(ordered_step_names)
+        if any(edge.source not in step_names for edge in ordered_flow_edges):
+            raise ValueError(
+                "FinalizedRecipeProjection flow-edge sources must be finalized step names"
+            )
+
+        object.__setattr__(self, "ordered_step_names", ordered_step_names)
+        object.__setattr__(self, "ordered_flow_edges", ordered_flow_edges)

--- a/src/autoskillit/core/types/_type_recipe_delivery.py
+++ b/src/autoskillit/core/types/_type_recipe_delivery.py
@@ -67,9 +67,10 @@ class RecipeFlowGeneration:
     def __post_init__(self) -> None:
         if self.schema_version != RECIPE_FLOW_SCHEMA_VERSION:
             raise ValueError("unsupported recipe flow schema version")
-        if not self.records:
+        records = tuple(self.records)
+        if not records:
             raise ValueError("recipe flow generation must contain records")
-        for record in self.records:
+        for record in records:
             if not isinstance(record, str):
                 raise TypeError("recipe flow records must be strings")
             try:
@@ -84,10 +85,10 @@ class RecipeFlowGeneration:
             )
             if not isinstance(parsed, dict) or canonical != record:
                 raise ValueError("recipe flow record is not canonical")
-        generated = _flow_generation_bytes(self.records)
+        generated = _flow_generation_bytes(records)
         expected_digest = _qualified_sha256(b"autoskillit.recipe-flow.v1\0" + generated)
         expected_size = len(generated)
-        expected_count = len(self.records)
+        expected_count = len(records)
         for supplied, expected, label in (
             (self.flow_sha256, expected_digest, "flow digest"),
             (self.flow_size_bytes, expected_size, "flow size"),
@@ -95,6 +96,7 @@ class RecipeFlowGeneration:
         ):
             if supplied not in ("", 0) and supplied != expected:
                 raise ValueError(f"{label} mismatch")
+        object.__setattr__(self, "records", records)
         object.__setattr__(self, "flow_sha256", expected_digest)
         object.__setattr__(self, "flow_size_bytes", expected_size)
         object.__setattr__(self, "record_count", expected_count)

--- a/src/autoskillit/core/types/_type_recipe_delivery.py
+++ b/src/autoskillit/core/types/_type_recipe_delivery.py
@@ -45,6 +45,16 @@ def _qualified_sha256(data: bytes) -> str:
     return f"sha256:{hashlib.sha256(data).hexdigest()}"
 
 
+def _is_sha256_identity(value: object) -> bool:
+    prefix = "sha256:"
+    return (
+        isinstance(value, str)
+        and value.startswith(prefix)
+        and len(value) == len(prefix) + 64
+        and all(character in "0123456789abcdef" for character in value[len(prefix) :])
+    )
+
+
 def _flow_generation_bytes(records: tuple[str, ...]) -> bytes:
     generated = bytearray()
     for record in records:
@@ -127,6 +137,45 @@ class RecipeArtifactGeneration:
     flow_sha256: str
     flow_size_bytes: int
     flow_record_count: int
+
+    def __post_init__(self) -> None:
+        for field_name in ("producer_tool", "recipe_name"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"{field_name} must be a non-empty string")
+        for field_name, expected in (
+            ("descriptor_version", RECIPE_ARTIFACT_DESCRIPTOR_VERSION),
+            ("schema_version", RECIPE_ARTIFACT_SCHEMA_VERSION),
+            ("flow_schema_version", RECIPE_FLOW_SCHEMA_VERSION),
+        ):
+            value = getattr(self, field_name)
+            if isinstance(value, bool) or not isinstance(value, int) or value != expected:
+                raise ValueError(f"unsupported {field_name}")
+        for field_name in (
+            "payload_sha256",
+            "artifact_blob_sha256",
+            "body_sha256",
+            "flow_sha256",
+        ):
+            if not _is_sha256_identity(getattr(self, field_name)):
+                raise ValueError(f"{field_name} must be an algorithm-qualified sha256 digest")
+        for field_name in (
+            "artifact_blob_size_bytes",
+            "body_size_bytes",
+            "flow_size_bytes",
+            "flow_record_count",
+        ):
+            value = getattr(self, field_name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError(f"{field_name} must be an integer")
+        if not 0 < self.artifact_blob_size_bytes <= RECIPE_ARTIFACT_MAX_BLOB_BYTES:
+            raise ValueError("artifact_blob_size_bytes is outside supported bounds")
+        if not 0 <= self.body_size_bytes <= self.artifact_blob_size_bytes:
+            raise ValueError("body_size_bytes must fit within the artifact blob")
+        if not 0 < self.flow_size_bytes <= self.artifact_blob_size_bytes:
+            raise ValueError("flow_size_bytes must fit within the artifact blob")
+        if self.flow_record_count <= 0:
+            raise ValueError("flow_record_count must be positive")
 
     def has_valid_read_bounds(self) -> bool:
         """Return whether caller-provided sizes stay within server ceilings."""

--- a/src/autoskillit/core/types/_type_recipe_delivery.py
+++ b/src/autoskillit/core/types/_type_recipe_delivery.py
@@ -172,8 +172,8 @@ class RecipeArtifactGeneration:
             raise ValueError("artifact_blob_size_bytes is outside supported bounds")
         if not 0 <= self.body_size_bytes <= self.artifact_blob_size_bytes:
             raise ValueError("body_size_bytes must fit within the artifact blob")
-        if not 0 < self.flow_size_bytes <= self.artifact_blob_size_bytes:
-            raise ValueError("flow_size_bytes must fit within the artifact blob")
+        if self.flow_size_bytes <= 0:
+            raise ValueError("flow_size_bytes must be positive")
         if self.flow_record_count <= 0:
             raise ValueError("flow_record_count must be positive")
 

--- a/src/autoskillit/core/types/_type_recipe_delivery.py
+++ b/src/autoskillit/core/types/_type_recipe_delivery.py
@@ -2,21 +2,35 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import NamedTuple
 
 __all__ = [
     "RECIPE_DELIVERY_ATTESTATION_AUDIENCE",
+    "RECIPE_ARTIFACT_DESCRIPTOR_VERSION",
+    "RECIPE_ARTIFACT_MAX_BLOB_BYTES",
+    "RECIPE_ARTIFACT_MAX_DESCRIPTOR_BYTES",
+    "RECIPE_ARTIFACT_SCHEMA_VERSION",
+    "RECIPE_FLOW_SCHEMA_VERSION",
+    "RecipeArtifactGeneration",
     "RecipeDeliveryAttestation",
     "RecipeDeliveryBudgetDef",
     "RecipeDeliveryDecision",
     "RecipeDeliveryEvidenceDef",
     "RecipeDeliveryMode",
     "RecipeDeliveryRequest",
+    "RecipeFlowGeneration",
 ]
 
 RECIPE_DELIVERY_ATTESTATION_AUDIENCE = "autoskillit.recipe-delivery"
+RECIPE_ARTIFACT_DESCRIPTOR_VERSION = 2
+RECIPE_ARTIFACT_SCHEMA_VERSION = 2
+RECIPE_ARTIFACT_MAX_BLOB_BYTES = 1_000_000
+RECIPE_ARTIFACT_MAX_DESCRIPTOR_BYTES = 16_384
+RECIPE_FLOW_SCHEMA_VERSION = 1
 
 
 class RecipeDeliveryMode(StrEnum):
@@ -25,6 +39,122 @@ class RecipeDeliveryMode(StrEnum):
     ORDINARY_INLINE = "ordinary_inline"
     ATTESTED_INLINE = "attested_inline"
     ENVELOPE = "envelope"
+
+
+def _qualified_sha256(data: bytes) -> str:
+    return f"sha256:{hashlib.sha256(data).hexdigest()}"
+
+
+def _flow_generation_bytes(records: tuple[str, ...]) -> bytes:
+    generated = bytearray()
+    for record in records:
+        encoded = record.encode("utf-8")
+        generated.extend(len(encoded).to_bytes(8, "big"))
+        generated.extend(encoded)
+    return bytes(generated)
+
+
+@dataclass(frozen=True, slots=True)
+class RecipeFlowGeneration:
+    """Canonical, ordered recipe-flow records with derived immutable identity."""
+
+    schema_version: int
+    records: tuple[str, ...]
+    flow_sha256: str = ""
+    flow_size_bytes: int = 0
+    record_count: int = 0
+
+    def __post_init__(self) -> None:
+        if self.schema_version != RECIPE_FLOW_SCHEMA_VERSION:
+            raise ValueError("unsupported recipe flow schema version")
+        if not self.records:
+            raise ValueError("recipe flow generation must contain records")
+        for record in self.records:
+            if not isinstance(record, str):
+                raise TypeError("recipe flow records must be strings")
+            try:
+                parsed = json.loads(record)
+            except json.JSONDecodeError as exc:
+                raise ValueError("recipe flow record is not valid JSON") from exc
+            canonical = json.dumps(
+                parsed,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            if not isinstance(parsed, dict) or canonical != record:
+                raise ValueError("recipe flow record is not canonical")
+        generated = _flow_generation_bytes(self.records)
+        expected_digest = _qualified_sha256(b"autoskillit.recipe-flow.v1\0" + generated)
+        expected_size = len(generated)
+        expected_count = len(self.records)
+        for supplied, expected, label in (
+            (self.flow_sha256, expected_digest, "flow digest"),
+            (self.flow_size_bytes, expected_size, "flow size"),
+            (self.record_count, expected_count, "flow record count"),
+        ):
+            if supplied not in ("", 0) and supplied != expected:
+                raise ValueError(f"{label} mismatch")
+        object.__setattr__(self, "flow_sha256", expected_digest)
+        object.__setattr__(self, "flow_size_bytes", expected_size)
+        object.__setattr__(self, "record_count", expected_count)
+
+    def identity(self) -> dict[str, str | int]:
+        return {
+            "flow_schema_version": self.schema_version,
+            "flow_sha256": self.flow_sha256,
+            "flow_size_bytes": self.flow_size_bytes,
+            "flow_record_count": self.record_count,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RecipeArtifactGeneration:
+    """Exact identities for one immutable canonical recipe payload."""
+
+    producer_tool: str
+    recipe_name: str
+    descriptor_version: int
+    schema_version: int
+    payload_sha256: str
+    artifact_blob_sha256: str
+    artifact_blob_size_bytes: int
+    body_sha256: str
+    body_size_bytes: int
+    flow_schema_version: int
+    flow_sha256: str
+    flow_size_bytes: int
+    flow_record_count: int
+
+    def has_valid_read_bounds(self) -> bool:
+        """Return whether caller-provided sizes stay within server ceilings."""
+        return (
+            self.descriptor_version == RECIPE_ARTIFACT_DESCRIPTOR_VERSION
+            and self.schema_version == RECIPE_ARTIFACT_SCHEMA_VERSION
+            and self.flow_schema_version == RECIPE_FLOW_SCHEMA_VERSION
+            and 0 < self.artifact_blob_size_bytes <= RECIPE_ARTIFACT_MAX_BLOB_BYTES
+            and 0 <= self.body_size_bytes <= self.artifact_blob_size_bytes
+            and self.flow_size_bytes > 0
+            and self.flow_record_count > 0
+        )
+
+    def pull_identity(self) -> dict[str, str | int]:
+        return {
+            "producer_tool": self.producer_tool,
+            "recipe_name": self.recipe_name,
+            "descriptor_version": self.descriptor_version,
+            "schema_version": self.schema_version,
+            "payload_sha256": self.payload_sha256,
+            "artifact_blob_sha256": self.artifact_blob_sha256,
+            "artifact_blob_size_bytes": self.artifact_blob_size_bytes,
+            "body_sha256": self.body_sha256,
+            "body_size_bytes": self.body_size_bytes,
+            "flow_schema_version": self.flow_schema_version,
+            "flow_sha256": self.flow_sha256,
+            "flow_size_bytes": self.flow_size_bytes,
+            "flow_record_count": self.flow_record_count,
+            "pull_tool": "get_recipe_section",
+        }
 
 
 class RecipeDeliveryBudgetDef(NamedTuple):

--- a/src/autoskillit/execution/backends/_codex_config.py
+++ b/src/autoskillit/execution/backends/_codex_config.py
@@ -135,7 +135,15 @@ def codex_recipe_delivery_calling_contract(*, mcp_prefix: str = "") -> str:
                 "If protected host values are unavailable, omit delivery_request and use "
                 "the bounded recipe_pull path."
             ),
-            ("- ingredients_only calls and recipe resources are not eligible for the exception."),
+            (
+                "- isError:false: keep recipe_pull, recipe_flow, initialization_id; "
+                "validate flow_records then entrypoint."
+            ),
+            (
+                "- Require complete_recipe_initialization(initialization_id) before "
+                "execution/mutation."
+            ),
+            "- No ingredients_only/resource exception.",
         )
     )
 

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -1029,6 +1029,7 @@ class CodexBackend(BackendCmdBuilderBase):
             record_capable=False,
             anthropic_provider_capable=False,
             plugin_install_capable=False,
+            claude_marketplace_tool_prefix_capable=False,
             inspector_capable=False,
             supports_context_window_suffix=False,
             has_unguarded_filesystem_access=True,

--- a/src/autoskillit/hooks/formatters/_fmt_recipe.py
+++ b/src/autoskillit/hooks/formatters/_fmt_recipe.py
@@ -1,12 +1,8 @@
-"""Recipe-tool formatters for the pretty_output split.
-
-Hosts the per-tool formatters for ``load_recipe``, ``open_kitchen``, and
-``list_recipes`` along with their field-coverage contracts. Stdlib-only at
-runtime.
-"""
+"""Recipe-tool formatters and field-coverage contracts."""
 
 from __future__ import annotations
 
+import json
 import sys
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
@@ -29,7 +25,6 @@ else:
     from _recipe_delivery_framing import is_attested_recipe_delivery
 
 
-# Field coverage contract for _fmt_load_recipe ↔ LoadRecipeResult
 _FMT_LOAD_RECIPE_RENDERED: frozenset[str] = frozenset(
     {
         "valid",
@@ -39,6 +34,15 @@ _FMT_LOAD_RECIPE_RENDERED: frozenset[str] = frozenset(
         "diagram",
         "ingredients_table",
         "orchestration_rules",
+        "finalized_recipe_projection",
+        "flow_records",
+        "recipe_execution",
+        "recipe_flow",
+        "recipe_pull",
+        "delivery_bound_spill",
+        "initialization_id",
+        "recovery",
+        "required_sections",
         "warnings",
     }
 )
@@ -58,34 +62,18 @@ _FMT_LOAD_RECIPE_SUPPRESSED: frozenset[str] = frozenset(
         "post_prune_routing_edges",  # internal preflight field; not displayed to agent
         "dispatch_feasible",  # internal admission control signal; surfaced via refusal envelopes
         "infeasible_steps",  # internal admission control detail; surfaced via refusal envelopes
-        "_compiled_bindings",  # internal host-attested invocation carrier
+        "_finalized_projection",  # internal host-attested finalized recipe carrier
     }
 )
 
-# Maps derived-display field name → source field name in LoadRecipeResult.
-# When a derived field is present in a response, the formatter strips its
-# corresponding source block from the source field to prevent duplicate display.
-# All entries must map to "content" — only content-derived fields require
-# ingredients-block stripping. Non-content source fields are not supported here.
-#
-# HOW TO USE: When adding a new field to _FMT_LOAD_RECIPE_RENDERED, ask:
-#   "Is this field a re-rendering of content already in another RENDERED field?"
-# If yes, add an entry here: {new_derived_field: "content"}.
-# The augmented field coverage test will enforce this declaration.
+# Derived displays strip their source block to avoid duplicate rendering.
 _LOAD_RECIPE_CONTENT_DERIVED_FROM: dict[str, str] = {
     "ingredients_table": "content",  # GFM table derived from the ingredients: block in content
 }
 
 
 def _strip_yaml_ingredients_block(yaml_text: str) -> str:
-    """Remove the top-level `ingredients:` block from YAML text.
-
-    Called by _fmt_recipe_body() when ingredients_table is present, so the
-    RECIPE block does not repeat the TABLE block. Operates line-by-line:
-    drops the `ingredients:` key and all its indented children until a
-    non-indented line signals the next top-level key. Preserves all other
-    top-level keys (steps, kitchen_rules, description, etc.) unchanged.
-    """
+    """Remove the top-level ``ingredients`` block from YAML text."""
     lines = yaml_text.splitlines(keepends=True)
     result: list[str] = []
     in_ingredients = False
@@ -95,23 +83,15 @@ def _strip_yaml_ingredients_block(yaml_text: str) -> str:
             continue
         if in_ingredients:
             if line and not line[0].isspace():
-                # First non-indented non-empty line = next top-level key
                 in_ingredients = False
                 result.append(line)
-            # else: still inside the ingredients block — skip
         else:
             result.append(line)
     return "".join(result)
 
 
 def _fmt_recipe_body(data: Mapping[str, Any]) -> list[str]:
-    """Shared recipe content rendering for load_recipe and open_kitchen+recipe.
-
-    Renders STEP FLOW (structured summary) before FLOW DIAGRAM before RECIPE
-    so the step-ordering chain survives even if only the first ~2KB of the
-    response is delivered (see issue #4253). load_recipe and named-recipe
-    open_kitchen intentionally share this same head ordering.
-    """
+    """Render flow before content so bounded heads preserve step ordering."""
     lines: list[str] = []
     summary = data.get("summary")
     if summary:
@@ -125,8 +105,6 @@ def _fmt_recipe_body(data: Mapping[str, Any]) -> list[str]:
         lines.append("--- END DIAGRAM ---")
     content = data.get("content")
     if content:
-        # When a derived field is present, strip its source block from content
-        # to prevent duplicate display. The derivation map drives this automatically.
         display_content = content
         for derived_field in _LOAD_RECIPE_CONTENT_DERIVED_FROM:
             if data.get(derived_field):
@@ -135,6 +113,29 @@ def _fmt_recipe_body(data: Mapping[str, Any]) -> list[str]:
         lines.append("\n--- RECIPE ---")
         lines.append(display_content)
         lines.append("--- END RECIPE ---")
+    initialization_fields = (
+        "finalized_recipe_projection",
+        "flow_records",
+        "recipe_execution",
+        "recipe_flow",
+        "recipe_pull",
+        "delivery_bound_spill",
+        "initialization_id",
+        "recovery",
+        "required_sections",
+    )
+    initialization = {key: data[key] for key in initialization_fields if data.get(key) is not None}
+    if initialization:
+        lines.append("\n--- RECIPE INITIALIZATION ---")
+        lines.append(
+            json.dumps(
+                initialization,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
+        lines.append("--- END RECIPE INITIALIZATION ---")
     ing_table = data.get("ingredients_table")
     if ing_table:
         lines.append("\n--- INGREDIENTS TABLE (display this verbatim to the user) ---")
@@ -171,7 +172,6 @@ def _fmt_load_recipe(data: LoadRecipeResult, pipeline: bool) -> str:
     return "\n".join(lines)
 
 
-# Field coverage contract for _fmt_list_recipes ↔ ListRecipesResult
 _FMT_LIST_RECIPES_RENDERED: frozenset[str] = frozenset(
     {
         "recipes",
@@ -181,7 +181,6 @@ _FMT_LIST_RECIPES_RENDERED: frozenset[str] = frozenset(
 )
 _FMT_LIST_RECIPES_SUPPRESSED: frozenset[str] = frozenset()
 
-# Field coverage contract for per-item recipe entries ↔ RecipeListItem
 _FMT_RECIPE_LIST_ITEM_RENDERED: frozenset[str] = frozenset(
     {
         "name",
@@ -192,7 +191,6 @@ _FMT_RECIPE_LIST_ITEM_RENDERED: frozenset[str] = frozenset(
 )
 _FMT_RECIPE_LIST_ITEM_SUPPRESSED: frozenset[str] = frozenset()
 
-# Field coverage contract for _fmt_open_kitchen ↔ OpenKitchenResult
 _FMT_OPEN_KITCHEN_RENDERED: frozenset[str] = frozenset(
     {
         "valid",
@@ -202,6 +200,15 @@ _FMT_OPEN_KITCHEN_RENDERED: frozenset[str] = frozenset(
         "diagram",
         "ingredients_table",
         "orchestration_rules",
+        "finalized_recipe_projection",
+        "flow_records",
+        "recipe_execution",
+        "recipe_flow",
+        "recipe_pull",
+        "delivery_bound_spill",
+        "initialization_id",
+        "recovery",
+        "required_sections",
         "version",
         "warnings",
     }

--- a/src/autoskillit/hooks/formatters/_fmt_recipe.py
+++ b/src/autoskillit/hooks/formatters/_fmt_recipe.py
@@ -25,6 +25,18 @@ else:
     from _recipe_delivery_framing import is_attested_recipe_delivery
 
 
+_RECIPE_INITIALIZATION_FIELDS: tuple[str, ...] = (
+    "finalized_recipe_projection",
+    "flow_records",
+    "recipe_execution",
+    "recipe_flow",
+    "recipe_pull",
+    "delivery_bound_spill",
+    "initialization_id",
+    "recovery",
+    "required_sections",
+)
+
 _FMT_LOAD_RECIPE_RENDERED: frozenset[str] = frozenset(
     {
         "valid",
@@ -34,18 +46,9 @@ _FMT_LOAD_RECIPE_RENDERED: frozenset[str] = frozenset(
         "diagram",
         "ingredients_table",
         "orchestration_rules",
-        "finalized_recipe_projection",
-        "flow_records",
-        "recipe_execution",
-        "recipe_flow",
-        "recipe_pull",
-        "delivery_bound_spill",
-        "initialization_id",
-        "recovery",
-        "required_sections",
         "warnings",
     }
-)
+).union(_RECIPE_INITIALIZATION_FIELDS)
 _FMT_LOAD_RECIPE_SUPPRESSED: frozenset[str] = frozenset(
     {
         "greeting",  # delivered via positional CLI arg, not MCP response
@@ -113,18 +116,9 @@ def _fmt_recipe_body(data: Mapping[str, Any]) -> list[str]:
         lines.append("\n--- RECIPE ---")
         lines.append(display_content)
         lines.append("--- END RECIPE ---")
-    initialization_fields = (
-        "finalized_recipe_projection",
-        "flow_records",
-        "recipe_execution",
-        "recipe_flow",
-        "recipe_pull",
-        "delivery_bound_spill",
-        "initialization_id",
-        "recovery",
-        "required_sections",
-    )
-    initialization = {key: data[key] for key in initialization_fields if data.get(key) is not None}
+    initialization = {
+        key: data[key] for key in _RECIPE_INITIALIZATION_FIELDS if data.get(key) is not None
+    }
     if initialization:
         lines.append("\n--- RECIPE INITIALIZATION ---")
         lines.append(
@@ -200,19 +194,10 @@ _FMT_OPEN_KITCHEN_RENDERED: frozenset[str] = frozenset(
         "diagram",
         "ingredients_table",
         "orchestration_rules",
-        "finalized_recipe_projection",
-        "flow_records",
-        "recipe_execution",
-        "recipe_flow",
-        "recipe_pull",
-        "delivery_bound_spill",
-        "initialization_id",
-        "recovery",
-        "required_sections",
         "version",
         "warnings",
     }
-)
+).union(_RECIPE_INITIALIZATION_FIELDS)
 _FMT_OPEN_KITCHEN_SUPPRESSED: frozenset[str] = frozenset(
     {
         "success",  # metadata — model infers success from formatted output

--- a/src/autoskillit/hooks/formatters/_fmt_recipe.py
+++ b/src/autoskillit/hooks/formatters/_fmt_recipe.py
@@ -47,8 +47,9 @@ _FMT_LOAD_RECIPE_RENDERED: frozenset[str] = frozenset(
         "ingredients_table",
         "orchestration_rules",
         "warnings",
+        *_RECIPE_INITIALIZATION_FIELDS,
     }
-).union(_RECIPE_INITIALIZATION_FIELDS)
+)
 _FMT_LOAD_RECIPE_SUPPRESSED: frozenset[str] = frozenset(
     {
         "greeting",  # delivered via positional CLI arg, not MCP response
@@ -196,8 +197,9 @@ _FMT_OPEN_KITCHEN_RENDERED: frozenset[str] = frozenset(
         "orchestration_rules",
         "version",
         "warnings",
+        *_RECIPE_INITIALIZATION_FIELDS,
     }
-).union(_RECIPE_INITIALIZATION_FIELDS)
+)
 _FMT_OPEN_KITCHEN_SUPPRESSED: frozenset[str] = frozenset(
     {
         "success",  # metadata — model infers success from formatted output

--- a/src/autoskillit/hooks/formatters/pretty_output_hook.py
+++ b/src/autoskillit/hooks/formatters/pretty_output_hook.py
@@ -202,6 +202,7 @@ _UNFORMATTED_TOOLS: frozenset[str] = frozenset(
         "record_pipeline_step",  # structured init/status result
         "reset_dispatch",  # JSON cleanup report, generic renders correctly
         "get_recipe_section",  # bounded section content with continuation
+        "complete_recipe_initialization",  # simple completion receipt
     }
 )
 

--- a/src/autoskillit/pipeline/AGENTS.md
+++ b/src/autoskillit/pipeline/AGENTS.md
@@ -15,6 +15,7 @@ IL-1 pipeline state — per-tool-call state containers, gate logic, audit log, t
 | `gate.py` | `DefaultGateState`, `gate_error_result` |
 | `github_api_log.py` | `DefaultGitHubApiLog` — session-scoped GitHub API request accumulator |
 | `mcp_response.py` | Per-tool response size tracking |
+| `recipe_initialization.py` | Pure typed reducer for named-recipe INITIALIZING/READY lifecycle state |
 | `telemetry_fmt.py` | Canonical token/timing display |
 | `timings.py` | `DefaultTimingLog` |
 | `tokens.py` | `DefaultTokenLog` |

--- a/src/autoskillit/pipeline/__init__.py
+++ b/src/autoskillit/pipeline/__init__.py
@@ -37,6 +37,19 @@ from autoskillit.pipeline.pr_gates import (
     is_review_passing,
     partition_prs,
 )
+from autoskillit.pipeline.recipe_initialization import (
+    InitializingRecipe,
+    NoActiveRecipe,
+    ReadyRecipe,
+    RecipeInitializationProgress,
+    RecipeInitializationRequirement,
+    RecipeInitializationState,
+    initialization_is_complete,
+    record_initialization_page,
+    replace_ready_execution,
+    start_recipe_initialization,
+    transition_recipe_ready,
+)
 from autoskillit.pipeline.telemetry_fmt import TelemetryFormatter
 from autoskillit.pipeline.timings import DefaultTimingLog, TimingEntry
 from autoskillit.pipeline.tokens import DefaultTokenLog, TokenEntry, canonical_step_name
@@ -81,4 +94,16 @@ __all__ = [
     "is_ci_passing",
     "is_review_passing",
     "partition_prs",
+    # recipe initialization
+    "InitializingRecipe",
+    "NoActiveRecipe",
+    "ReadyRecipe",
+    "RecipeInitializationProgress",
+    "RecipeInitializationRequirement",
+    "RecipeInitializationState",
+    "initialization_is_complete",
+    "record_initialization_page",
+    "replace_ready_execution",
+    "start_recipe_initialization",
+    "transition_recipe_ready",
 ]

--- a/src/autoskillit/pipeline/context.py
+++ b/src/autoskillit/pipeline/context.py
@@ -30,7 +30,6 @@ from autoskillit.core import (
     GitHubFetcher,
     HeadlessExecutor,
     InputContractResolver,
-    InstalledRecipeExecution,
     McpResponseLog,
     MergeQueueWatcher,
     MigrationService,
@@ -58,6 +57,10 @@ from autoskillit.core import (
 )
 from autoskillit.pipeline.background import DefaultBackgroundSupervisor
 from autoskillit.pipeline.mcp_response import DefaultMcpResponseLog
+from autoskillit.pipeline.recipe_initialization import (
+    NoActiveRecipe,
+    RecipeInitializationState,
+)
 
 __all__ = ["ToolContext", "current_step_name", "current_order_id"]
 
@@ -138,8 +141,8 @@ class ToolContext:
     active_recipe_ingredients: frozenset[str] | None — ingredient keys declared by the loaded
                           recipe (frozenset() when kitchen open but no recipe loaded; None when
                           closed)
-    active_recipe_execution: atomically installed compiled execution snapshot, runtime
-                          binding digests, trusted audit heads, and verified input resolver.
+    recipe_initialization_state: sole INITIALIZING/READY authority for the active
+                          generation, its staged snapshot, progress, and installed execution.
     recipe_execution_lock: RecipeExecutionLock — serializes installation, lookup, and
                           cleanup of the active compiled execution state.
     temp_dir:             Resolved temp directory for this project. Sentinel-guarded: raises
@@ -205,7 +208,7 @@ class ToolContext:
     fleet_lock: FleetLock | None = field(default=None)
     build_protected_campaign_ids: CampaignProtector | None = field(default=None)
     ephemeral_root: Path | None = field(default_factory=lambda: None)
-    active_recipe_execution: InstalledRecipeExecution | None = field(default_factory=lambda: None)
+    recipe_initialization_state: RecipeInitializationState = field(default_factory=NoActiveRecipe)
     recipe_execution_lock: RecipeExecutionLock = field(
         default_factory=threading.RLock,
         repr=False,

--- a/src/autoskillit/pipeline/recipe_initialization.py
+++ b/src/autoskillit/pipeline/recipe_initialization.py
@@ -1,0 +1,240 @@
+"""Pure kitchen-scoped recipe initialization lifecycle."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import TypeAlias
+
+from autoskillit.core import (
+    InstalledRecipeExecution,
+    RecipeArtifactGeneration,
+    RecipeExecutionSnapshot,
+    RecipeFlowGeneration,
+)
+
+__all__ = [
+    "InitializingRecipe",
+    "NoActiveRecipe",
+    "ReadyRecipe",
+    "RecipeInitializationProgress",
+    "RecipeInitializationRequirement",
+    "RecipeInitializationState",
+    "initialization_is_complete",
+    "record_initialization_page",
+    "replace_ready_execution",
+    "start_recipe_initialization",
+    "transition_recipe_ready",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class RecipeInitializationRequirement:
+    """One immutable section page plan required before READY."""
+
+    section: str
+    page_plan_sha256: str
+    total_parts: int
+
+    def __post_init__(self) -> None:
+        if not self.section or not self.page_plan_sha256:
+            raise ValueError("recipe initialization requirement identity is incomplete")
+        if type(self.total_parts) is not int or self.total_parts <= 0:
+            raise ValueError("recipe initialization requirement must have positive parts")
+
+
+@dataclass(frozen=True, slots=True)
+class RecipeInitializationProgress:
+    """Committed in-order progress for one required page plan."""
+
+    section: str
+    page_plan_sha256: str
+    next_part: int
+    total_parts: int
+
+    def __post_init__(self) -> None:
+        if not self.section or not self.page_plan_sha256:
+            raise ValueError("recipe initialization progress identity is incomplete")
+        if (
+            type(self.next_part) is not int
+            or type(self.total_parts) is not int
+            or not 0 <= self.next_part <= self.total_parts
+            or self.total_parts <= 0
+        ):
+            raise ValueError("recipe initialization progress range is invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class NoActiveRecipe:
+    """No named recipe currently owns execution authority."""
+
+
+@dataclass(frozen=True, slots=True)
+class InitializingRecipe:
+    """A generation delivered successfully but not yet reconstructed."""
+
+    kitchen_id: str
+    recipe_name: str
+    artifact_generation: RecipeArtifactGeneration
+    flow_generation: RecipeFlowGeneration
+    initialization_id: str
+    staged_snapshot: RecipeExecutionSnapshot
+    requirements: tuple[RecipeInitializationRequirement, ...]
+    progress: tuple[RecipeInitializationProgress, ...]
+    generation_store_key: str
+    completion_receipt: str | None = None
+
+    def __post_init__(self) -> None:
+        if not all(
+            isinstance(value, str) and value
+            for value in (
+                self.kitchen_id,
+                self.recipe_name,
+                self.initialization_id,
+                self.generation_store_key,
+            )
+        ):
+            raise ValueError("recipe initialization identity is incomplete")
+        requirements = tuple(self.requirements)
+        progress = tuple(self.progress)
+        if len(requirements) != len(progress):
+            raise ValueError("recipe initialization requirements and progress differ")
+        requirement_keys = tuple((item.section, item.page_plan_sha256) for item in requirements)
+        progress_keys = tuple((item.section, item.page_plan_sha256) for item in progress)
+        if (
+            len(requirement_keys) != len(set(requirement_keys))
+            or requirement_keys != progress_keys
+            or any(
+                requirement.total_parts != current.total_parts
+                for requirement, current in zip(requirements, progress, strict=True)
+            )
+        ):
+            raise ValueError("recipe initialization page-plan identities differ")
+        object.__setattr__(self, "requirements", requirements)
+        object.__setattr__(self, "progress", progress)
+
+
+@dataclass(frozen=True, slots=True)
+class ReadyRecipe:
+    """The sole authority for executing one immutable recipe generation."""
+
+    kitchen_id: str
+    recipe_name: str
+    artifact_generation: RecipeArtifactGeneration
+    flow_generation: RecipeFlowGeneration
+    initialization_id: str
+    installed_execution: InstalledRecipeExecution
+    generation_store_key: str
+    completion_receipt: str
+
+
+RecipeInitializationState: TypeAlias = NoActiveRecipe | InitializingRecipe | ReadyRecipe
+
+
+def start_recipe_initialization(
+    *,
+    kitchen_id: str,
+    recipe_name: str,
+    artifact_generation: RecipeArtifactGeneration,
+    flow_generation: RecipeFlowGeneration,
+    initialization_id: str,
+    staged_snapshot: RecipeExecutionSnapshot,
+    requirements: tuple[RecipeInitializationRequirement, ...],
+    generation_store_key: str,
+) -> InitializingRecipe:
+    """Start a fresh generation and discard all prior authority."""
+    progress = tuple(
+        RecipeInitializationProgress(
+            section=requirement.section,
+            page_plan_sha256=requirement.page_plan_sha256,
+            next_part=0,
+            total_parts=requirement.total_parts,
+        )
+        for requirement in requirements
+    )
+    return InitializingRecipe(
+        kitchen_id=kitchen_id,
+        recipe_name=recipe_name,
+        artifact_generation=artifact_generation,
+        flow_generation=flow_generation,
+        initialization_id=initialization_id,
+        staged_snapshot=staged_snapshot,
+        requirements=requirements,
+        progress=progress,
+        generation_store_key=generation_store_key,
+    )
+
+
+def record_initialization_page(
+    state: RecipeInitializationState,
+    *,
+    initialization_id: str,
+    section: str,
+    page_plan_sha256: str,
+    part: int,
+) -> RecipeInitializationState:
+    """Commit one exact in-order page; exact replay is idempotent."""
+    if not isinstance(state, InitializingRecipe):
+        raise ValueError("recipe initialization is not active")
+    if initialization_id != state.initialization_id:
+        raise ValueError("recipe initialization ID is stale or altered")
+    progress = list(state.progress)
+    index = next(
+        (
+            offset
+            for offset, item in enumerate(progress)
+            if item.section == section and item.page_plan_sha256 == page_plan_sha256
+        ),
+        None,
+    )
+    if index is None:
+        raise ValueError("recipe initialization page plan is not required")
+    current = progress[index]
+    if part < current.next_part:
+        return state
+    if part != current.next_part or part >= current.total_parts:
+        raise ValueError("recipe initialization page is skipped or out of order")
+    progress[index] = replace(current, next_part=current.next_part + 1)
+    return replace(state, progress=tuple(progress))
+
+
+def initialization_is_complete(state: RecipeInitializationState) -> bool:
+    return isinstance(state, InitializingRecipe) and all(
+        item.next_part == item.total_parts for item in state.progress
+    )
+
+
+def transition_recipe_ready(
+    state: InitializingRecipe,
+    *,
+    installed_execution: InstalledRecipeExecution,
+    completion_receipt: str,
+) -> ReadyRecipe:
+    """Transition a completely reconstructed generation to READY."""
+    if not initialization_is_complete(state):
+        raise ValueError("recipe initialization reconstruction is incomplete")
+    if installed_execution.snapshot != state.staged_snapshot:
+        raise ValueError("installed recipe snapshot differs from staged generation")
+    if not completion_receipt:
+        raise ValueError("recipe initialization completion receipt is required")
+    return ReadyRecipe(
+        kitchen_id=state.kitchen_id,
+        recipe_name=state.recipe_name,
+        artifact_generation=state.artifact_generation,
+        flow_generation=state.flow_generation,
+        initialization_id=state.initialization_id,
+        installed_execution=installed_execution,
+        generation_store_key=state.generation_store_key,
+        completion_receipt=completion_receipt,
+    )
+
+
+def replace_ready_execution(
+    state: RecipeInitializationState,
+    installed_execution: InstalledRecipeExecution,
+) -> RecipeInitializationState:
+    """Replace runtime-only execution metadata without changing generation identity."""
+    if not isinstance(state, ReadyRecipe):
+        raise ValueError("recipe execution is not READY")
+    if installed_execution.snapshot != state.installed_execution.snapshot:
+        raise ValueError("replacement recipe execution crosses generations")
+    return replace(state, installed_execution=installed_execution)

--- a/src/autoskillit/pipeline/recipe_initialization.py
+++ b/src/autoskillit/pipeline/recipe_initialization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import TypeAlias
 
 from autoskillit.core import (
@@ -25,6 +25,8 @@ __all__ = [
     "start_recipe_initialization",
     "transition_recipe_ready",
 ]
+
+_READY_RECIPE_TRANSITION_TOKEN = object()
 
 
 @dataclass(frozen=True, slots=True)
@@ -125,6 +127,34 @@ class ReadyRecipe:
     installed_execution: InstalledRecipeExecution
     generation_store_key: str
     completion_receipt: str
+    _transition_token: object = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self._transition_token is not _READY_RECIPE_TRANSITION_TOKEN:
+            raise ValueError("ready recipe requires a completed initialization transition")
+        if not all(
+            isinstance(value, str) and value
+            for value in (
+                self.kitchen_id,
+                self.recipe_name,
+                self.initialization_id,
+                self.generation_store_key,
+                self.completion_receipt,
+            )
+        ):
+            raise ValueError("ready recipe identity and completion receipt must be non-empty")
+        if (
+            self.artifact_generation.recipe_name != self.recipe_name
+            or self.installed_execution.snapshot.recipe_name != self.recipe_name
+        ):
+            raise ValueError("ready recipe generation identity differs from installed snapshot")
+        if (
+            self.artifact_generation.flow_schema_version != self.flow_generation.schema_version
+            or self.artifact_generation.flow_sha256 != self.flow_generation.flow_sha256
+            or self.artifact_generation.flow_size_bytes != self.flow_generation.flow_size_bytes
+            or self.artifact_generation.flow_record_count != self.flow_generation.record_count
+        ):
+            raise ValueError("ready recipe artifact and flow generation differ")
 
 
 RecipeInitializationState: TypeAlias = NoActiveRecipe | InitializingRecipe | ReadyRecipe
@@ -225,6 +255,7 @@ def transition_recipe_ready(
         installed_execution=installed_execution,
         generation_store_key=state.generation_store_key,
         completion_receipt=completion_receipt,
+        _transition_token=_READY_RECIPE_TRANSITION_TOKEN,
     )
 
 

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -16,7 +16,9 @@ from autoskillit.core import (
     BACKEND_CAPABILITY_INGREDIENTS,
     CAPABILITY_GATE_CALLABLES,
     BackendCapabilities,
+    FinalizedRecipeProjection,
     ProcessStaleError,
+    RecipeFlowEdge,
     RecipeNotFoundError,
     RecipeSource,
     SkillLister,
@@ -205,7 +207,7 @@ def load_and_validate(
     effective_backend_map: dict[str, str] | None = None,
     backend_capabilities_map: dict[str, BackendCapabilities] | None = None,
     backend_origin_map: dict[str, str] | None = None,
-    include_compiled_bindings: bool = False,
+    include_finalized_projection: bool = False,
 ) -> LoadRecipeResult:
     """Load a recipe by name and run full validation.
 
@@ -274,7 +276,7 @@ def load_and_validate(
         backend_name,
         tuple(sorted(effective_backend_map.items())) if effective_backend_map else (),
         tuple(sorted(backend_capabilities_map.items())) if backend_capabilities_map else (),
-        include_compiled_bindings,
+        include_finalized_projection,
         _manifest_mtime,
         _manifest_size,
         _budgets_mtime,
@@ -335,6 +337,7 @@ def load_and_validate(
     _skip_resolutions: dict[str, bool | None] = {}
     _pre_prune_steps: dict[str, Any] = {}
     _post_prune_bindings = None
+    _finalized_projection = None
     _dispatch_feasible = True
     _infeasible_steps: list[str] = []
 
@@ -481,6 +484,30 @@ def load_and_validate(
                 active_recipe,
                 ingredient_values=ingredient_overrides,
             )
+            if include_finalized_projection:
+                _ordered_step_names = tuple(active_recipe.steps)
+                _finalized_projection = FinalizedRecipeProjection(
+                    binding_projection=_post_prune_bindings,
+                    ordered_step_names=_ordered_step_names,
+                    entrypoint=next(iter(_ordered_step_names), ""),
+                    ordered_flow_edges=tuple(
+                        RecipeFlowEdge(
+                            source=step_name,
+                            edge_type=edge.edge_type,
+                            target=edge.target,
+                            condition=edge.condition,
+                            result_field=(
+                                step.on_result.field
+                                if edge.edge_type == "result_condition"
+                                and step.on_result is not None
+                                and step.on_result.field
+                                else None
+                            ),
+                        )
+                        for step_name, step in active_recipe.steps.items()
+                        for edge in _extract_routing_edges(step)
+                    ),
+                )
             val_ctx = make_validation_context(
                 active_recipe,
                 available_recipes=known,
@@ -691,8 +718,8 @@ def load_and_validate(
     if _deferred_guard_list:
         result["deferred_guards"] = _deferred_guard_list
     if active_recipe is not None:
-        if include_compiled_bindings and _post_prune_bindings is not None:
-            result["_compiled_bindings"] = _post_prune_bindings
+        if include_finalized_projection and _finalized_projection is not None:
+            result["_finalized_projection"] = _finalized_projection
         result["post_prune_step_names"] = list(active_recipe.steps.keys())
         _step_names_set = set(active_recipe.steps)
         result["post_prune_routing_edges"] = sorted(

--- a/src/autoskillit/recipe/_recipe_ingredients.py
+++ b/src/autoskillit/recipe/_recipe_ingredients.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, NotRequired, TypedDict
 
 from autoskillit.core import (
-    RecipeBindingProjection,
+    FinalizedRecipeProjection,
     TerminalColumn,
     _render_gfm_table,
 )
@@ -132,10 +132,19 @@ class LoadRecipeResult(TypedDict, total=False):
     post_prune_routing_edges: list[str]
     dispatch_feasible: bool
     infeasible_steps: list[str]
+    finalized_recipe_projection: dict[str, Any]
+    flow_records: list[str]
+    recipe_flow: dict[str, str | int]
+    recipe_execution: dict[str, Any]
+    recipe_pull: dict[str, str | int]
+    initialization_id: str
+    delivery_bound_spill: bool
+    required_sections: list[dict[str, Any]]
+    recovery: dict[str, Any]
     warnings: NotRequired[list[str]]
     # Internal-only. Recipe API callers receive this only when they explicitly
     # request the attested server-delivery carrier.
-    _compiled_bindings: RecipeBindingProjection
+    _finalized_projection: FinalizedRecipeProjection
 
 
 class OpenKitchenResult(TypedDict, total=False):
@@ -144,7 +153,7 @@ class OpenKitchenResult(TypedDict, total=False):
     Extends LoadRecipeResult with four post-return keys injected by the handler.
     """
 
-    # Inherited from LoadRecipeResult (20 keys)
+    # Inherited from LoadRecipeResult
     content: str
     errors: list[str]
     diagram: str | None
@@ -166,6 +175,15 @@ class OpenKitchenResult(TypedDict, total=False):
     post_prune_routing_edges: list[str]
     dispatch_feasible: bool
     infeasible_steps: list[str]
+    finalized_recipe_projection: dict[str, Any]
+    flow_records: list[str]
+    recipe_flow: dict[str, str | int]
+    recipe_execution: dict[str, Any]
+    recipe_pull: dict[str, str | int]
+    initialization_id: str
+    delivery_bound_spill: bool
+    required_sections: list[dict[str, Any]]
+    recovery: dict[str, Any]
     warnings: NotRequired[list[str]]
     # Post-return keys injected by open_kitchen handler (4 keys)
     success: bool

--- a/src/autoskillit/recipe/repository.py
+++ b/src/autoskillit/recipe/repository.py
@@ -99,7 +99,7 @@ class DefaultRecipeRepository:
         effective_backend_map: dict[str, str] | None = None,
         backend_capabilities_map: dict[str, BackendCapabilities] | None = None,
         backend_origin_map: dict[str, str] | None = None,
-        include_compiled_bindings: bool = False,
+        include_finalized_projection: bool = False,
     ) -> dict[str, Any]:
         project_dir = Path(project_dir)
         result = self._get_list(project_dir)
@@ -121,7 +121,7 @@ class DefaultRecipeRepository:
                 effective_backend_map=effective_backend_map,
                 backend_capabilities_map=backend_capabilities_map,
                 backend_origin_map=backend_origin_map,
-                include_compiled_bindings=include_compiled_bindings,
+                include_finalized_projection=include_finalized_projection,
             ),
         )
 

--- a/src/autoskillit/server/AGENTS.md
+++ b/src/autoskillit/server/AGENTS.md
@@ -17,6 +17,8 @@ Sub-package: tools/ (see tools/AGENTS.md).
 | `_response_budget.py` | Lossless response spill, exact canonical projection finalization, measured exemptions, and privacy-safe budget telemetry |
 | `_response_conformance.py` | Post-FastMCP-conversion conformance gate for registered string tool responses |
 | `_recipe_delivery.py` | Unified recipe finalization, content-addressed generations, pull integrity, and receipt completion |
+| `_recipe_generation.py` | Bounded kitchen-scoped LRU for canonical compile generations and exact artifact replay |
+| `_recipe_initialization.py` | Post-enforcement recipe page and completion transactions for INITIALIZING/READY lifecycle state |
 | `_recipe_execution.py` | Compiled execution snapshot lifecycle, trusted audit-head ledger, runtime binding, and input preflight |
 | `_recipe_section_pagination.py` | Typed recipe-section selection, deterministic byte-bounded page planning, rendering, and verified-plan caching |
 | `recipe_section/__init__.py` | Package marker for focused recipe-section planning support |

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -61,6 +61,9 @@ from autoskillit.hook_registry import (
 )
 from autoskillit.pipeline import create_background_task
 from autoskillit.server._guards import _backend_supports_quota
+from autoskillit.server._recipe_generation import (
+    activate_kitchen as activate_recipe_generation,
+)
 from autoskillit.server._state import _get_ctx_or_none, deferred_initialize
 from autoskillit.workspace import verify_install_state
 
@@ -321,6 +324,7 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
         register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
     except Exception:
         logger.warning("fleet_auto_gate_boot_registry_failed", exc_info=True)
+    activate_recipe_generation(ctx.kitchen_id)
 
     _campaign_state_paths: list[Path] = []
     try:
@@ -372,6 +376,7 @@ async def _pre_reveal_kitchen(ctx: Any) -> None:
     for tag in _collect_disabled_feature_tags(ctx.config.features, experimental_enabled=False):
         _mcp.disable(tags={tag})
     register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
+    activate_recipe_generation(ctx.kitchen_id)
     _write_hook_config()
     _supports_quota = _backend_supports_quota(ctx)
     await _prime_quota_cache(supports_quota_check=_supports_quota)
@@ -456,6 +461,7 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
         register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
     except Exception:
         logger.warning("food_truck_auto_gate_boot_registry_failed", exc_info=True)
+    activate_recipe_generation(ctx.kitchen_id)
 
     try:
         _campaign_state_paths = discover_campaign_state_files(ctx.project_dir)
@@ -557,6 +563,7 @@ async def _skill_auto_gate_boot(ctx: Any) -> None:
         register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
     except Exception:
         logger.warning("skill_auto_gate_boot_registry_failed", exc_info=True)
+    activate_recipe_generation(ctx.kitchen_id)
 
 
 _LIFESPAN_BOOT_REGISTRY: dict[SessionType, Callable[[Any], Awaitable[None]] | None] = {

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -98,15 +98,10 @@ def run_startup_drift_check() -> None:
         logger.exception("startup_drift_check_failed")
 
 
-def _register_active_recipe_kitchen(
-    kitchen_id: str,
-    pid: int,
-    project_path: str,
-) -> None:
-    """Publish one kitchen to both process and recipe-generation lifecycles."""
-    from autoskillit.server._recipe_generation import activate_kitchen
+def _activate_recipe_kitchen(kitchen_id: str) -> None:
+    """Publish one kitchen to the recipe-generation lifecycle."""
+    from autoskillit.server._recipe_generation import activate_kitchen  # circular-break
 
-    register_active_kitchen(kitchen_id, pid, project_path)
     activate_kitchen(kitchen_id)
 
 
@@ -330,11 +325,8 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
         logger.warning("fleet_auto_gate_boot_quota_refresh_failed", exc_info=True)
 
     try:
-        _register_active_recipe_kitchen(
-            ctx.kitchen_id,
-            os.getpid(),
-            str(ctx.project_dir),
-        )
+        register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
+        _activate_recipe_kitchen(ctx.kitchen_id)
     except Exception:
         logger.warning("fleet_auto_gate_boot_registry_failed", exc_info=True)
 
@@ -387,11 +379,8 @@ async def _pre_reveal_kitchen(ctx: Any) -> None:
         _mcp.disable(tags={subset})
     for tag in _collect_disabled_feature_tags(ctx.config.features, experimental_enabled=False):
         _mcp.disable(tags={tag})
-    _register_active_recipe_kitchen(
-        ctx.kitchen_id,
-        os.getpid(),
-        str(ctx.project_dir),
-    )
+    register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
+    _activate_recipe_kitchen(ctx.kitchen_id)
     _write_hook_config()
     _supports_quota = _backend_supports_quota(ctx)
     await _prime_quota_cache(supports_quota_check=_supports_quota)
@@ -473,11 +462,8 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
         logger.warning("food_truck_auto_gate_boot_refresh_loop_failed", exc_info=True)
 
     try:
-        _register_active_recipe_kitchen(
-            ctx.kitchen_id,
-            os.getpid(),
-            str(ctx.project_dir),
-        )
+        register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
+        _activate_recipe_kitchen(ctx.kitchen_id)
     except Exception:
         logger.warning("food_truck_auto_gate_boot_registry_failed", exc_info=True)
 
@@ -578,11 +564,8 @@ async def _skill_auto_gate_boot(ctx: Any) -> None:
         logger.warning("skill_auto_gate_boot_quota_cache_failed", exc_info=True)
 
     try:
-        _register_active_recipe_kitchen(
-            ctx.kitchen_id,
-            os.getpid(),
-            str(ctx.project_dir),
-        )
+        register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
+        _activate_recipe_kitchen(ctx.kitchen_id)
     except Exception:
         logger.warning("skill_auto_gate_boot_registry_failed", exc_info=True)
 

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -61,9 +61,6 @@ from autoskillit.hook_registry import (
 )
 from autoskillit.pipeline import create_background_task
 from autoskillit.server._guards import _backend_supports_quota
-from autoskillit.server._recipe_generation import (
-    activate_kitchen as activate_recipe_generation,
-)
 from autoskillit.server._state import _get_ctx_or_none, deferred_initialize
 from autoskillit.workspace import verify_install_state
 
@@ -99,6 +96,18 @@ def run_startup_drift_check() -> None:
             logger.info("startup_drift_check_ok")
     except Exception:
         logger.exception("startup_drift_check_failed")
+
+
+def _register_active_recipe_kitchen(
+    kitchen_id: str,
+    pid: int,
+    project_path: str,
+) -> None:
+    """Publish one kitchen to both process and recipe-generation lifecycles."""
+    from autoskillit.server._recipe_generation import activate_kitchen
+
+    register_active_kitchen(kitchen_id, pid, project_path)
+    activate_kitchen(kitchen_id)
 
 
 def run_startup_hook_health_check() -> list[str]:
@@ -321,10 +330,13 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
         logger.warning("fleet_auto_gate_boot_quota_refresh_failed", exc_info=True)
 
     try:
-        register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
+        _register_active_recipe_kitchen(
+            ctx.kitchen_id,
+            os.getpid(),
+            str(ctx.project_dir),
+        )
     except Exception:
         logger.warning("fleet_auto_gate_boot_registry_failed", exc_info=True)
-    activate_recipe_generation(ctx.kitchen_id)
 
     _campaign_state_paths: list[Path] = []
     try:
@@ -375,8 +387,11 @@ async def _pre_reveal_kitchen(ctx: Any) -> None:
         _mcp.disable(tags={subset})
     for tag in _collect_disabled_feature_tags(ctx.config.features, experimental_enabled=False):
         _mcp.disable(tags={tag})
-    register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
-    activate_recipe_generation(ctx.kitchen_id)
+    _register_active_recipe_kitchen(
+        ctx.kitchen_id,
+        os.getpid(),
+        str(ctx.project_dir),
+    )
     _write_hook_config()
     _supports_quota = _backend_supports_quota(ctx)
     await _prime_quota_cache(supports_quota_check=_supports_quota)
@@ -458,10 +473,13 @@ async def _food_truck_auto_gate_boot(ctx: Any) -> None:
         logger.warning("food_truck_auto_gate_boot_refresh_loop_failed", exc_info=True)
 
     try:
-        register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
+        _register_active_recipe_kitchen(
+            ctx.kitchen_id,
+            os.getpid(),
+            str(ctx.project_dir),
+        )
     except Exception:
         logger.warning("food_truck_auto_gate_boot_registry_failed", exc_info=True)
-    activate_recipe_generation(ctx.kitchen_id)
 
     try:
         _campaign_state_paths = discover_campaign_state_files(ctx.project_dir)
@@ -560,10 +578,13 @@ async def _skill_auto_gate_boot(ctx: Any) -> None:
         logger.warning("skill_auto_gate_boot_quota_cache_failed", exc_info=True)
 
     try:
-        register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
+        _register_active_recipe_kitchen(
+            ctx.kitchen_id,
+            os.getpid(),
+            str(ctx.project_dir),
+        )
     except Exception:
         logger.warning("skill_auto_gate_boot_registry_failed", exc_info=True)
-    activate_recipe_generation(ctx.kitchen_id)
 
 
 _LIFESPAN_BOOT_REGISTRY: dict[SessionType, Callable[[Any], Awaitable[None]] | None] = {

--- a/src/autoskillit/server/_misc.py
+++ b/src/autoskillit/server/_misc.py
@@ -15,7 +15,6 @@ from autoskillit._llm_triage import triage_staleness
 from autoskillit.core import (
     DIRECT_INSTALL_CACHE_SUBDIR,
     MARKETPLACE_PREFIX,
-    detect_autoskillit_mcp_prefix,
     ensure_project_temp,
     get_logger,
 )
@@ -176,7 +175,9 @@ def _extract_block(text: str, start_delim: str, end_delim: str) -> list[str]:
     return []
 
 
-def _build_hook_diagnostic_warning() -> str | None:
+def _build_hook_diagnostic_warning(
+    mcp_prefix: str,
+) -> str | None:
     """Run hook health and drift checks. Return a warning string if issues are found."""
 
     issues: list[str] = []
@@ -192,7 +193,7 @@ def _build_hook_diagnostic_warning() -> str | None:
                 f"{drift.orphaned} orphaned hook entry(ies) in settings.json are not in "
                 f"HOOK_REGISTRY — every matching tool call will be denied with ENOENT."
             )
-        if drift.missing > 0 and detect_autoskillit_mcp_prefix() != MARKETPLACE_PREFIX:
+        if drift.missing > 0 and mcp_prefix != MARKETPLACE_PREFIX:
             issues.append(
                 f"{drift.missing} hook(s) from HOOK_REGISTRY are not deployed in settings.json."
             )

--- a/src/autoskillit/server/_notify.py
+++ b/src/autoskillit/server/_notify.py
@@ -22,6 +22,12 @@ from autoskillit.server._recipe_delivery import (
     FinalizedRecipeResponse,
     complete_finalized_recipe_response,
 )
+from autoskillit.server._recipe_initialization import (
+    FinalizedRecipeInitializationResponse,
+    FinalizedRecipeSectionResponse,
+    complete_initialization_response,
+    complete_section_response,
+)
 from autoskillit.server._response_budget import (
     bounded_response_budget_failure,
     enforce_response_budget,
@@ -113,7 +119,25 @@ def track_response_size(
                 )
                 logger.exception("track_response_size_handler_failed", tool_name=tool_name)
             finalized = result if isinstance(result, FinalizedRecipeResponse) else None
-            response_value = finalized.rendered if finalized is not None else result
+            finalized_section = (
+                result if isinstance(result, FinalizedRecipeSectionResponse) else None
+            )
+            finalized_initialization = (
+                result if isinstance(result, FinalizedRecipeInitializationResponse) else None
+            )
+            response_value = (
+                finalized.rendered
+                if finalized is not None
+                else (
+                    finalized_section.rendered
+                    if finalized_section is not None
+                    else (
+                        finalized_initialization.rendered
+                        if finalized_initialization is not None
+                        else result
+                    )
+                )
+            )
             ctx = _get_ctx_or_none()
             try:
                 response_str = (
@@ -206,6 +230,10 @@ def track_response_size(
                     )
             if finalized is not None:
                 result = complete_finalized_recipe_response(finalized, result)
+            elif finalized_section is not None:
+                result = complete_section_response(finalized_section, result)
+            elif finalized_initialization is not None:
+                result = complete_initialization_response(finalized_initialization, result)
             return result
 
         return wrapper

--- a/src/autoskillit/server/_recipe_delivery.py
+++ b/src/autoskillit/server/_recipe_delivery.py
@@ -703,7 +703,9 @@ def build_recipe_envelope(
         ],
         "recovery": {
             "completion_required": completion_required,
-            "ordered_sections": ["flow_records", entrypoint],
+            "ordered_sections": [
+                requirement.section for requirement in initialization_requirements
+            ],
             "pagination_version": RECIPE_SECTION_PAGINATION_VERSION,
             "section_registry_sha256": RECIPE_SECTION_REGISTRY_DIGEST,
             "pull_tool": "get_recipe_section",

--- a/src/autoskillit/server/_recipe_delivery.py
+++ b/src/autoskillit/server/_recipe_delivery.py
@@ -7,10 +7,9 @@ import hashlib
 import json
 import shutil
 import time
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass, fields, is_dataclass, replace
-from enum import Enum
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
@@ -64,6 +63,7 @@ from autoskillit.server._recipe_execution import (
 from autoskillit.server._recipe_generation import (
     RecipeGenerationError,
     RecipeGenerationRecord,
+    generation_json_primitive,
     get_recipe_generation_store,
 )
 from autoskillit.server._recipe_initialization import stage_recipe_initialization
@@ -155,41 +155,10 @@ def _canonical_flow_record(record: dict[str, Any]) -> str:
     )
 
 
-def _generation_json_primitive(value: object) -> object:
-    """Convert immutable compile values to a deterministic JSON primitive tree."""
-    if isinstance(value, Enum):
-        return _generation_json_primitive(value.value)
-    if value is None or isinstance(value, (str, bool, int, float)):
-        return value
-    if isinstance(value, Mapping):
-        if any(not isinstance(key, str) for key in value):
-            raise TypeError("recipe generation mappings require string keys")
-        return {key: _generation_json_primitive(value[key]) for key in sorted(value)}
-    if isinstance(value, (list, tuple)):
-        return [_generation_json_primitive(item) for item in value]
-    if isinstance(value, (set, frozenset)):
-        converted = [_generation_json_primitive(item) for item in value]
-        return sorted(
-            converted,
-            key=lambda item: json.dumps(
-                item,
-                ensure_ascii=False,
-                separators=(",", ":"),
-                sort_keys=True,
-            ),
-        )
-    if is_dataclass(value) and not isinstance(value, type):
-        return {
-            item.name: _generation_json_primitive(getattr(value, item.name))
-            for item in fields(value)
-        }
-    raise TypeError(f"recipe generation contains unsupported value {type(value).__name__}")
-
-
 def _finalized_projection_payload(
     projection: FinalizedRecipeProjection,
 ) -> dict[str, Any]:
-    primitive = _generation_json_primitive(projection)
+    primitive = generation_json_primitive(projection)
     if not isinstance(primitive, dict):
         raise TypeError("finalized recipe projection did not serialize to a mapping")
     return primitive
@@ -311,7 +280,7 @@ def prepare_recipe_delivery_generation(
         "recipe_name": recipe_name,
         "content_hash": source_payload.get("content_hash"),
         "composite_hash": source_payload.get("composite_hash"),
-        "source_payload": _generation_json_primitive(source_payload),
+        "source_payload": generation_json_primitive(source_payload),
         "finalized_projection": _finalized_projection_payload(finalized_projection),
         "flow_generation": flow_generation.identity(),
     }
@@ -330,8 +299,8 @@ def prepare_recipe_delivery_generation(
             raise RecipeGenerationError(
                 "normalized compile generation resolved to different canonical outputs"
             )
-        artifact_payload = _generation_json_primitive(existing.artifact_payload)
-        compile_inputs_copy = _generation_json_primitive(existing.compile_inputs)
+        artifact_payload = generation_json_primitive(existing.artifact_payload)
+        compile_inputs_copy = generation_json_primitive(existing.compile_inputs)
         if not isinstance(artifact_payload, dict) or not isinstance(compile_inputs_copy, dict):
             raise RecipeGenerationError("stored recipe generation did not reconstruct to mappings")
         expected_payload = build_canonical_recipe_artifact_payload(
@@ -387,8 +356,8 @@ def prepare_recipe_delivery_generation(
             compile_inputs=compile_inputs,
         )
     )
-    admitted_payload = _generation_json_primitive(admitted.artifact_payload)
-    admitted_inputs = _generation_json_primitive(admitted.compile_inputs)
+    admitted_payload = generation_json_primitive(admitted.artifact_payload)
+    admitted_inputs = generation_json_primitive(admitted.compile_inputs)
     if not isinstance(admitted_payload, dict) or not isinstance(admitted_inputs, dict):
         raise RecipeGenerationError("admitted recipe generation is not reconstructable")
     return PreparedRecipeGeneration(

--- a/src/autoskillit/server/_recipe_delivery.py
+++ b/src/autoskillit/server/_recipe_delivery.py
@@ -129,6 +129,23 @@ class PreparedRecipeGeneration:
     compile_inputs: dict[str, Any]
 
 
+_RECIPE_GENERATION_SOURCE_EXCLUDED_FIELDS = frozenset(
+    {
+        "_finalized_projection",
+        "delivery_bound_spill",
+        "hook_warning",
+        "initialization_id",
+        "kitchen",
+        "recipe_pull",
+        "recovery",
+        "required_sections",
+        "success",
+        "version",
+        "warnings",
+    }
+)
+
+
 def _qualified_sha256(data: bytes) -> str:
     return f"sha256:{hashlib.sha256(data).hexdigest()}"
 
@@ -162,6 +179,15 @@ def _finalized_projection_payload(
     if not isinstance(primitive, dict):
         raise TypeError("finalized recipe projection did not serialize to a mapping")
     return primitive
+
+
+def _recipe_generation_source_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Project caller payload fields shared by compile identity and persistence."""
+    return {
+        key: value
+        for key, value in payload.items()
+        if key not in _RECIPE_GENERATION_SOURCE_EXCLUDED_FIELDS
+    }
 
 
 def build_recipe_flow_generation(
@@ -214,24 +240,7 @@ def build_canonical_recipe_artifact_payload(
     execution_snapshot: RecipeExecutionSnapshot,
 ) -> dict[str, Any]:
     """Return the primitive, generation-bound canonical artifact payload."""
-    candidate_payload = {
-        key: value
-        for key, value in payload.items()
-        if key
-        not in {
-            "_finalized_projection",
-            "delivery_bound_spill",
-            "hook_warning",
-            "initialization_id",
-            "kitchen",
-            "recipe_pull",
-            "recovery",
-            "required_sections",
-            "success",
-            "version",
-            "warnings",
-        }
-    }
+    candidate_payload = _recipe_generation_source_payload(payload)
     candidate_payload["finalized_recipe_projection"] = _finalized_projection_payload(
         finalized_projection
     )
@@ -258,24 +267,7 @@ def prepare_recipe_delivery_generation(
     )
 
     flow_generation = build_recipe_flow_generation(finalized_projection)
-    source_payload = {
-        key: value
-        for key, value in payload.items()
-        if key
-        not in {
-            "_finalized_projection",
-            "delivery_bound_spill",
-            "hook_warning",
-            "initialization_id",
-            "kitchen",
-            "recipe_pull",
-            "recovery",
-            "required_sections",
-            "success",
-            "version",
-            "warnings",
-        }
-    }
+    source_payload = _recipe_generation_source_payload(payload)
     compile_inputs = {
         "recipe_name": recipe_name,
         "content_hash": source_payload.get("content_hash"),

--- a/src/autoskillit/server/_recipe_delivery.py
+++ b/src/autoskillit/server/_recipe_delivery.py
@@ -7,11 +7,13 @@ import hashlib
 import json
 import shutil
 import time
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, fields, is_dataclass, replace
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 from autoskillit._recipe_delivery_framing import (
     RECIPE_BODY_END,
@@ -21,17 +23,31 @@ from autoskillit._recipe_delivery_framing import (
 from autoskillit.config import OutputBudgetConfig
 from autoskillit.core import (
     CLAUDE_CODE_CAPABILITIES,
+    RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+    RECIPE_ARTIFACT_MAX_BLOB_BYTES,
+    RECIPE_ARTIFACT_MAX_DESCRIPTOR_BYTES,
+    RECIPE_ARTIFACT_SCHEMA_VERSION,
     RECIPE_DELIVERY_SURFACE_REGISTRY,
+    RECIPE_FLOW_SCHEMA_VERSION,
+    RECIPE_SECTION_PAGINATION_VERSION,
+    RECIPE_SECTION_REGISTRY_DIGEST,
     RESPONSE_BACKSTOP_EXEMPTION_REGISTRY,
     BackendCapabilities,
+    FinalizedRecipeProjection,
+    RecipeArtifactGeneration,
     RecipeDeliveryAttestation,
     RecipeDeliveryDecision,
     RecipeDeliveryMode,
     RecipeDeliveryRequest,
+    RecipeExecutionSnapshot,
+    RecipeFlowGeneration,
     atomic_write,
+    fast_dumps,
     get_logger,
+    load_yaml,
     resolve_general_output_token_limit,
     resolve_recipe_delivery_decision,
+    resolve_recipe_envelope_byte_limit,
     validate_recipe_artifact_sections,
 )
 from autoskillit.execution import (
@@ -39,23 +55,31 @@ from autoskillit.execution import (
     RecipeReceiptHandle,
     codex_recipe_delivery_calling_contract,
 )
-from autoskillit.recipe import _extract_routing_edges, step_byte_ranges_from_yaml
+from autoskillit.pipeline import InitializingRecipe, RecipeInitializationRequirement
+from autoskillit.server._recipe_execution import (
+    clear_recipe_execution,
+    install_recipe_execution,
+    prepare_recipe_execution,
+)
+from autoskillit.server._recipe_generation import (
+    RecipeGenerationError,
+    RecipeGenerationRecord,
+    get_recipe_generation_store,
+)
+from autoskillit.server._recipe_initialization import stage_recipe_initialization
+from autoskillit.server._recipe_section_pagination import (
+    get_or_build_recipe_section_page_plan,
+    select_recipe_section,
+)
 from autoskillit.server._response_budget import enforce_response_budget
 from autoskillit.server.recipe_section._lifecycle import notify_kitchen_retired
 
 if TYPE_CHECKING:
     from autoskillit.core import (
-        RecipeBindingProjection,
         RecipeDeliveryBudgetDef,
         RecipeDeliveryEvidenceDef,
-        RecipeExecutionSnapshot,
     )
     from autoskillit.pipeline import ToolContext
-
-RECIPE_ARTIFACT_DESCRIPTOR_VERSION = 1
-RECIPE_ARTIFACT_SCHEMA_VERSION = 1
-RECIPE_ARTIFACT_MAX_BLOB_BYTES = 1_000_000
-RECIPE_ARTIFACT_MAX_DESCRIPTOR_BYTES = 16_384
 
 
 def document_recipe_delivery_contract(function: Any) -> Any:
@@ -74,44 +98,6 @@ class RecipeArtifactSchemaError(RecipeArtifactError):
 
 
 @dataclass(frozen=True, slots=True)
-class RecipeArtifactGeneration:
-    """Exact identities for one immutable canonical recipe payload."""
-
-    producer_tool: str
-    recipe_name: str
-    descriptor_version: int
-    schema_version: int
-    payload_sha256: str
-    artifact_blob_sha256: str
-    artifact_blob_size_bytes: int
-    body_sha256: str
-    body_size_bytes: int
-
-    def has_valid_read_bounds(self) -> bool:
-        """Return whether caller-provided sizes stay within server ceilings."""
-        return (
-            self.descriptor_version > 0
-            and self.schema_version > 0
-            and 0 < self.artifact_blob_size_bytes <= RECIPE_ARTIFACT_MAX_BLOB_BYTES
-            and 0 <= self.body_size_bytes <= self.artifact_blob_size_bytes
-        )
-
-    def pull_identity(self) -> dict[str, str | int]:
-        return {
-            "producer_tool": self.producer_tool,
-            "recipe_name": self.recipe_name,
-            "descriptor_version": self.descriptor_version,
-            "schema_version": self.schema_version,
-            "payload_sha256": self.payload_sha256,
-            "artifact_blob_sha256": self.artifact_blob_sha256,
-            "artifact_blob_size_bytes": self.artifact_blob_size_bytes,
-            "body_sha256": self.body_sha256,
-            "body_size_bytes": self.body_size_bytes,
-            "pull_tool": "get_recipe_section",
-        }
-
-
-@dataclass(frozen=True, slots=True)
 class FinalizedRecipeResponse:
     """Internal carrier consumed before FastMCP result conversion."""
 
@@ -120,8 +106,27 @@ class FinalizedRecipeResponse:
     receipt_handle: RecipeReceiptHandle | None = None
     receipt_ledger: RecipeDeliveryReceiptLedger | None = None
     artifact_generation: RecipeArtifactGeneration | None = None
+    finalized_projection: FinalizedRecipeProjection | None = None
+    flow_generation: RecipeFlowGeneration | None = None
     execution_snapshot: RecipeExecutionSnapshot | None = None
+    normalized_compile_key: str | None = None
     tool_ctx: ToolContext | None = None
+    recipe_name: str | None = None
+    initialization_activating: bool = False
+    initialization_id: str | None = None
+    initialization_requirements: tuple[RecipeInitializationRequirement, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedRecipeGeneration:
+    """Canonical compile outputs shared by every delivery surface."""
+
+    finalized_projection: FinalizedRecipeProjection
+    flow_generation: RecipeFlowGeneration
+    canonical_artifact_payload: dict[str, Any]
+    execution_snapshot: RecipeExecutionSnapshot
+    normalized_compile_key: str
+    compile_inputs: dict[str, Any]
 
 
 def _qualified_sha256(data: bytes) -> str:
@@ -139,6 +144,283 @@ def _canonical_payload(payload: dict[str, Any]) -> bytes:
         sort_keys=True,
         separators=(",", ":"),
     ).encode("utf-8")
+
+
+def _canonical_flow_record(record: dict[str, Any]) -> str:
+    return json.dumps(
+        record,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _generation_json_primitive(value: object) -> object:
+    """Convert immutable compile values to a deterministic JSON primitive tree."""
+    if isinstance(value, Enum):
+        return _generation_json_primitive(value.value)
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    if isinstance(value, Mapping):
+        if any(not isinstance(key, str) for key in value):
+            raise TypeError("recipe generation mappings require string keys")
+        return {key: _generation_json_primitive(value[key]) for key in sorted(value)}
+    if isinstance(value, (list, tuple)):
+        return [_generation_json_primitive(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        converted = [_generation_json_primitive(item) for item in value]
+        return sorted(
+            converted,
+            key=lambda item: json.dumps(
+                item,
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+        )
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            item.name: _generation_json_primitive(getattr(value, item.name))
+            for item in fields(value)
+        }
+    raise TypeError(f"recipe generation contains unsupported value {type(value).__name__}")
+
+
+def _finalized_projection_payload(
+    projection: FinalizedRecipeProjection,
+) -> dict[str, Any]:
+    primitive = _generation_json_primitive(projection)
+    if not isinstance(primitive, dict):
+        raise TypeError("finalized recipe projection did not serialize to a mapping")
+    return primitive
+
+
+def build_recipe_flow_generation(
+    projection: FinalizedRecipeProjection,
+) -> RecipeFlowGeneration:
+    """Build the immutable record stream from one finalized recipe projection."""
+    records = [
+        _canonical_flow_record(
+            {
+                "kind": "entrypoint",
+                "name": projection.entrypoint,
+            }
+        )
+    ]
+    records.extend(
+        _canonical_flow_record(
+            {
+                "index": index,
+                "kind": "step",
+                "name": name,
+            }
+        )
+        for index, name in enumerate(projection.ordered_step_names)
+    )
+    records.extend(
+        _canonical_flow_record(
+            {
+                "condition": edge.condition,
+                "edge_type": edge.edge_type,
+                "index": index,
+                "kind": "edge",
+                "result_field": edge.result_field,
+                "source": edge.source,
+                "target": edge.target,
+            }
+        )
+        for index, edge in enumerate(projection.ordered_flow_edges)
+    )
+    return RecipeFlowGeneration(
+        schema_version=RECIPE_FLOW_SCHEMA_VERSION,
+        records=tuple(records),
+    )
+
+
+def build_canonical_recipe_artifact_payload(
+    payload: dict[str, Any],
+    *,
+    finalized_projection: FinalizedRecipeProjection,
+    flow_generation: RecipeFlowGeneration,
+    execution_snapshot: RecipeExecutionSnapshot,
+) -> dict[str, Any]:
+    """Return the primitive, generation-bound canonical artifact payload."""
+    candidate_payload = {
+        key: value
+        for key, value in payload.items()
+        if key
+        not in {
+            "_finalized_projection",
+            "delivery_bound_spill",
+            "hook_warning",
+            "initialization_id",
+            "kitchen",
+            "recipe_pull",
+            "recovery",
+            "required_sections",
+            "success",
+            "version",
+            "warnings",
+        }
+    }
+    candidate_payload["finalized_recipe_projection"] = _finalized_projection_payload(
+        finalized_projection
+    )
+    candidate_payload["flow_records"] = list(flow_generation.records)
+    candidate_payload["recipe_flow"] = flow_generation.identity()
+    candidate_payload["recipe_execution"] = {
+        "execution_id": execution_snapshot.execution_id,
+        "invocation_template_digests": dict(execution_snapshot.template_digests),
+        "snapshot_digest": execution_snapshot.snapshot_digest,
+    }
+    return candidate_payload
+
+
+def prepare_recipe_delivery_generation(
+    payload: dict[str, Any],
+    *,
+    recipe_name: str,
+    tool_ctx: ToolContext,
+    finalized_projection: FinalizedRecipeProjection,
+) -> PreparedRecipeGeneration:
+    """Build or reuse one server-owned canonical compile generation."""
+    from autoskillit.server._recipe_execution import (  # circular-break
+        build_recipe_execution_snapshot,
+    )
+
+    flow_generation = build_recipe_flow_generation(finalized_projection)
+    source_payload = {
+        key: value
+        for key, value in payload.items()
+        if key
+        not in {
+            "_finalized_projection",
+            "delivery_bound_spill",
+            "hook_warning",
+            "initialization_id",
+            "kitchen",
+            "recipe_pull",
+            "recovery",
+            "required_sections",
+            "success",
+            "version",
+            "warnings",
+        }
+    }
+    compile_inputs = {
+        "recipe_name": recipe_name,
+        "content_hash": source_payload.get("content_hash"),
+        "composite_hash": source_payload.get("composite_hash"),
+        "source_payload": _generation_json_primitive(source_payload),
+        "finalized_projection": _finalized_projection_payload(finalized_projection),
+        "flow_generation": flow_generation.identity(),
+    }
+    normalized_compile_key = _domain_sha256(
+        "autoskillit.recipe-compile-generation.v1",
+        _canonical_payload(compile_inputs),
+    )
+    store = get_recipe_generation_store()
+    existing = store.lookup_compile(tool_ctx.kitchen_id, normalized_compile_key)
+    if existing is not None:
+        if (
+            existing.recipe_name != recipe_name
+            or existing.finalized_projection != finalized_projection
+            or existing.flow_generation != flow_generation
+        ):
+            raise RecipeGenerationError(
+                "normalized compile generation resolved to different canonical outputs"
+            )
+        artifact_payload = _generation_json_primitive(existing.artifact_payload)
+        compile_inputs_copy = _generation_json_primitive(existing.compile_inputs)
+        if not isinstance(artifact_payload, dict) or not isinstance(compile_inputs_copy, dict):
+            raise RecipeGenerationError("stored recipe generation did not reconstruct to mappings")
+        expected_payload = build_canonical_recipe_artifact_payload(
+            payload,
+            finalized_projection=finalized_projection,
+            flow_generation=flow_generation,
+            execution_snapshot=existing.execution_snapshot,
+        )
+        if artifact_payload != expected_payload:
+            raise RecipeGenerationError(
+                "normalized compile replay changed the canonical artifact payload"
+            )
+        return PreparedRecipeGeneration(
+            finalized_projection=existing.finalized_projection,
+            flow_generation=existing.flow_generation,
+            canonical_artifact_payload=artifact_payload,
+            execution_snapshot=existing.execution_snapshot,
+            normalized_compile_key=existing.normalized_compile_key,
+            compile_inputs=compile_inputs_copy,
+        )
+
+    try:
+        execution_snapshot = build_recipe_execution_snapshot(
+            recipe_name=recipe_name,
+            content_hash=str(source_payload.get("content_hash", "")),
+            composite_hash=str(source_payload.get("composite_hash", "")),
+            projection=finalized_projection.binding_projection,
+        )
+    except (TypeError, ValueError) as exc:
+        get_logger(__name__).warning(
+            "recipe_execution_compilation_failed",
+            recipe_name=recipe_name,
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
+        raise RecipeGenerationError("recipe execution snapshot compilation failed") from exc
+    artifact_payload = build_canonical_recipe_artifact_payload(
+        payload,
+        finalized_projection=finalized_projection,
+        flow_generation=flow_generation,
+        execution_snapshot=execution_snapshot,
+    )
+    admitted = store.put(
+        RecipeGenerationRecord(
+            kitchen_id=tool_ctx.kitchen_id,
+            normalized_compile_key=normalized_compile_key,
+            recipe_name=recipe_name,
+            finalized_projection=finalized_projection,
+            flow_generation=flow_generation,
+            artifact_payload=artifact_payload,
+            execution_snapshot=execution_snapshot,
+            execution_id=execution_snapshot.execution_id,
+            compile_inputs=compile_inputs,
+        )
+    )
+    admitted_payload = _generation_json_primitive(admitted.artifact_payload)
+    admitted_inputs = _generation_json_primitive(admitted.compile_inputs)
+    if not isinstance(admitted_payload, dict) or not isinstance(admitted_inputs, dict):
+        raise RecipeGenerationError("admitted recipe generation is not reconstructable")
+    return PreparedRecipeGeneration(
+        finalized_projection=admitted.finalized_projection,
+        flow_generation=admitted.flow_generation,
+        canonical_artifact_payload=admitted_payload,
+        execution_snapshot=admitted.execution_snapshot,
+        normalized_compile_key=admitted.normalized_compile_key,
+        compile_inputs=admitted_inputs,
+    )
+
+
+def _flow_generation_from_payload(payload: dict[str, Any]) -> RecipeFlowGeneration:
+    records = payload.get("flow_records")
+    identity = payload.get("recipe_flow")
+    if (
+        not isinstance(records, list)
+        or not records
+        or any(not isinstance(record, str) for record in records)
+        or not isinstance(identity, dict)
+    ):
+        raise RecipeArtifactSchemaError("recipe flow generation is unavailable")
+    try:
+        return RecipeFlowGeneration(
+            schema_version=int(identity["flow_schema_version"]),
+            records=tuple(records),
+            flow_sha256=str(identity["flow_sha256"]),
+            flow_size_bytes=int(identity["flow_size_bytes"]),
+            record_count=int(identity["flow_record_count"]),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RecipeArtifactSchemaError("recipe flow generation is invalid") from exc
 
 
 def _validate_recipe_artifact_schema(payload: dict[str, Any]) -> None:
@@ -223,6 +505,7 @@ def _generation_from_payload(
     recipe_name: str,
     blob: bytes,
     payload: dict[str, Any],
+    flow_generation: RecipeFlowGeneration,
     descriptor_version: int | None = None,
     schema_version: int | None = None,
 ) -> RecipeArtifactGeneration:
@@ -244,6 +527,10 @@ def _generation_from_payload(
         artifact_blob_size_bytes=len(blob),
         body_sha256=_qualified_sha256(body_bytes),
         body_size_bytes=len(body_bytes),
+        flow_schema_version=flow_generation.schema_version,
+        flow_sha256=flow_generation.flow_sha256,
+        flow_size_bytes=flow_generation.flow_size_bytes,
+        flow_record_count=flow_generation.record_count,
     )
 
 
@@ -254,9 +541,14 @@ def persist_recipe_artifact(
     producer_tool: str,
     recipe_name: str,
     payload: dict[str, Any],
+    flow_generation: RecipeFlowGeneration | None = None,
 ) -> RecipeArtifactGeneration:
     """Publish an immutable canonical payload and its generation descriptor."""
     _validate_recipe_artifact_schema(payload)
+    canonical_flow_generation = _flow_generation_from_payload(payload)
+    if flow_generation is not None and canonical_flow_generation != flow_generation:
+        raise RecipeArtifactSchemaError("recipe flow generation does not match payload")
+    flow_generation = canonical_flow_generation
     blob = _canonical_payload(payload)
     if len(blob) > RECIPE_ARTIFACT_MAX_BLOB_BYTES:
         raise RecipeArtifactError("recipe artifact blob exceeds persistence limit")
@@ -265,6 +557,7 @@ def persist_recipe_artifact(
         recipe_name=recipe_name,
         blob=blob,
         payload=payload,
+        flow_generation=flow_generation,
     )
     directory = _generation_dir(
         temp_dir,
@@ -357,6 +650,7 @@ def load_recipe_artifact(
         recipe_name=identity.recipe_name,
         blob=blob,
         payload=payload,
+        flow_generation=_flow_generation_from_payload(payload),
         descriptor_version=identity.descriptor_version,
         schema_version=identity.schema_version,
     )
@@ -420,262 +714,50 @@ def recipe_recreation_producers() -> frozenset[str]:
     )
 
 
-def _step_one_line_summary(step: Any) -> str:
-    """Return a compact single-line summary for one recipe step."""
-    description = getattr(step, "description", "") or ""
-    if description.strip():
-        return description.strip().splitlines()[0][:160]
-    message = getattr(step, "message", None)
-    if isinstance(message, str) and message.strip():
-        return message.strip().splitlines()[0][:160]
-    tool = getattr(step, "tool", None)
-    action = getattr(step, "action", None)
-    if tool:
-        return f"tool={tool}"
-    if action:
-        return f"action={action}"
-    return ""
-
-
-def _compute_step_byte_ranges(content: str) -> dict[str, tuple[int, int]]:
-    """Return UTF-8 step-body offsets from the canonical YAML helper."""
-    return step_byte_ranges_from_yaml(content)
-
-
-def extract_step_skeleton(
-    post_prune_step_names: list[str],
-    routing_edges_by_step: dict[str, list[tuple[str, str]]],
-    step_summaries: dict[str, str] | None = None,
-    byte_ranges: dict[str, tuple[int, int]] | None = None,
-) -> dict[str, Any]:
-    """Build the compact routing and byte-range index carried by an envelope."""
-    skeleton: list[dict[str, Any]] = []
-    for name in post_prune_step_names:
-        entry: dict[str, Any] = {
-            "name": name,
-            "edges": [
-                {"type": edge_type, "target": target}
-                for edge_type, target in routing_edges_by_step.get(name) or []
-                if target
-            ],
-        }
-        summary = (step_summaries or {}).get(name) or ""
-        if summary:
-            entry["summary"] = summary
-        span = (byte_ranges or {}).get(name)
-        if span is not None:
-            entry["byte_range"] = list(span)
-        skeleton.append(entry)
-    return {"step_count": len(skeleton), "steps": skeleton}
-
-
-def _safe_utf8_truncate(data: bytes) -> str:
-    """Decode a byte prefix without retaining a partial UTF-8 codepoint."""
-    while data:
-        try:
-            return data.decode("utf-8")
-        except UnicodeDecodeError as exc:
-            data = data[: exc.start]
-    return ""
-
-
-def build_step_summaries(active_recipe_steps: Any) -> dict[str, str]:
-    """Build step-name to one-line-summary metadata from parsed recipe steps."""
-    if not isinstance(active_recipe_steps, dict) or not active_recipe_steps:
-        return {}
-    return {
-        name: _step_one_line_summary(step)
-        for name, step in active_recipe_steps.items()
-        if isinstance(name, str) and name
-    }
-
-
-def build_routing_edges_by_step(
-    active_recipe_steps: Any,
-    *,
-    edge_extractor: Any = _extract_routing_edges,
-) -> dict[str, list[tuple[str, str]]]:
-    """Build outgoing routing-edge metadata from parsed recipe steps."""
-    if not isinstance(active_recipe_steps, dict) or not active_recipe_steps:
-        return {}
-    edges_by_step: dict[str, list[tuple[str, str]]] = {}
-    for name, step in active_recipe_steps.items():
-        if not isinstance(name, str) or not name:
-            continue
-        extracted = edge_extractor(step) if edge_extractor is not None else []
-        edges_by_step[name] = [
-            (edge.edge_type, edge.target)
-            for edge in (extracted or [])
-            if getattr(edge, "target", None)
-        ]
-    return edges_by_step
-
-
 def build_recipe_envelope(
     payload: dict[str, Any],
     *,
     recipe_name: str,
     generation: RecipeArtifactGeneration,
-    skeleton_source: ToolContext,
+    flow_generation: RecipeFlowGeneration,
+    entrypoint: str,
     bound_bytes: int,
+    initialization_id: str | None = None,
+    initialization_requirements: tuple[RecipeInitializationRequirement, ...] = (),
+    completion_required: bool = False,
 ) -> dict[str, Any]:
     """Build the bounded pull envelope used by every recipe delivery surface."""
-    post_prune_raw = payload.get("post_prune_step_names") or []
-    if not isinstance(post_prune_raw, list):
-        post_prune_raw = []
-    post_prune_names = [name for name in post_prune_raw if isinstance(name, str)]
-    active_recipe_steps: dict[str, Any] | None = None
-    if getattr(skeleton_source, "recipe_name", "") == recipe_name:
-        active_recipe_steps = skeleton_source.active_recipe_steps
-    summaries = build_step_summaries(active_recipe_steps)
-    edges = build_routing_edges_by_step(active_recipe_steps)
-    byte_ranges = _compute_step_byte_ranges(payload.get("content") or "")
-    skeleton = extract_step_skeleton(
-        post_prune_names,
-        edges,
-        summaries,
-        byte_ranges=byte_ranges,
-    )
-    pull_identity = generation.pull_identity()
-
-    def _pullable_skeleton_size(candidate: dict[str, Any]) -> int:
-        pullable = {
-            "success": payload.get("success", True),
-            "step_flow_skeleton": candidate,
-            "recipe_pull": pull_identity,
-            "delivery_bound_spill": True,
-        }
-        return len(json.dumps(pullable, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
-
-    if _pullable_skeleton_size(skeleton) > bound_bytes:
-        for summary_limit in (120, 80, 64, 48, 32, 24, 16, 8, 0):
-            bounded_summaries = (
-                {name: summary[:summary_limit] for name, summary in summaries.items()}
-                if summary_limit
-                else {}
-            )
-            skeleton = extract_step_skeleton(
-                post_prune_names,
-                edges,
-                bounded_summaries,
-                byte_ranges=byte_ranges,
-            )
-            if _pullable_skeleton_size(skeleton) <= bound_bytes:
-                break
-
-    envelope: dict[str, Any] = {"success": payload.get("success", True)}
-    envelope_bytes = len(json.dumps(envelope["success"]).encode("utf-8"))
-    for key in (
-        "kitchen",
-        "version",
-        "valid",
-        "dispatch_feasible",
-        "errors",
-        "warnings",
-        "hooks",
-        "post_prune_step_names",
-        "post_prune_routing_edges",
-        "requires_packs",
-        "requires_features",
-    ):
-        if key in payload and payload[key] is not None:
-            envelope[key] = payload[key]
-            envelope_bytes += len(
-                json.dumps({key: payload[key]}, ensure_ascii=False).encode("utf-8")
-            )
-
-    skeleton_overhead = len(
-        json.dumps({"step_flow_skeleton": skeleton}, ensure_ascii=False).encode("utf-8")
-    )
-    pull_overhead = len(
-        json.dumps(
-            {"recipe_pull": pull_identity, "delivery_bound_spill": True},
-            ensure_ascii=False,
-        ).encode("utf-8")
-    )
-    remaining = max(
-        0,
-        bound_bytes - skeleton_overhead - pull_overhead - envelope_bytes - 64,
-    )
-
-    def _project_priority_strings(keys: tuple[str, ...]) -> None:
-        nonlocal remaining
-        candidates = [
-            key for key in keys if isinstance(payload.get(key), str) and payload.get(key)
-        ]
-        overhead = {
-            key: len(json.dumps({key: ""}, ensure_ascii=False).encode("utf-8"))
-            for key in candidates
-        }
-        present: list[str] = []
-        budget = remaining
-        for key in candidates:
-            if overhead[key] < budget:
-                present.append(key)
-                budget -= overhead[key]
-        if not present:
-            return
-
-        lengths = {key: len(payload[key].encode("utf-8")) for key in present}
-        allocation: dict[str, int] = dict.fromkeys(present, 0)
-        active = list(present)
-        pool = remaining - sum(overhead[key] for key in present)
-        while active and pool > 0:
-            share, extra = divmod(pool, len(active))
-            still_active: list[str] = []
-            for index, key in enumerate(active):
-                give = share + (1 if index < extra else 0)
-                take = min(give, lengths[key] - allocation[key], pool)
-                allocation[key] += take
-                pool -= take
-                if allocation[key] < lengths[key]:
-                    still_active.append(key)
-            active = still_active
-
-        for key in present:
-            take = allocation[key]
-            if take <= 0:
-                continue
-            value_bytes = payload[key].encode("utf-8")
-            if len(value_bytes) <= take:
-                envelope[key] = payload[key]
-                remaining -= len(value_bytes) + overhead[key]
-            else:
-                envelope[key] = _safe_utf8_truncate(value_bytes[:take])
-                remaining -= take + overhead[key]
-                get_logger(__name__).warning(
-                    "recipe_envelope_priority_field_truncated",
-                    recipe_name=recipe_name,
-                    field=key,
-                    alloc_bytes=take,
-                )
-
-    _project_priority_strings(("orchestration_rules", "stop_step_semantics"))
-    for key in ("ingredients_table", "suggestions"):
-        value = payload.get(key)
-        if value is None:
-            continue
-        serialized_value = json.dumps(value, ensure_ascii=False).encode("utf-8")
-        if len(serialized_value) + 32 <= remaining:
-            envelope[key] = value
-            remaining -= len(serialized_value) + 32
-
-    envelope["step_flow_skeleton"] = skeleton
-    envelope["recipe_pull"] = pull_identity
-    envelope["delivery_bound_spill"] = True
+    manifest = {
+        "success": True,
+        "delivery_bound_spill": True,
+        "recipe_pull": generation.pull_identity(),
+        "recipe_flow": flow_generation.identity(),
+        "required_sections": [
+            {
+                "page_plan_sha256": requirement.page_plan_sha256,
+                "section": requirement.section,
+                "total_parts": requirement.total_parts,
+            }
+            for requirement in initialization_requirements
+        ],
+        "recovery": {
+            "completion_required": completion_required,
+            "ordered_sections": ["flow_records", entrypoint],
+            "pagination_version": RECIPE_SECTION_PAGINATION_VERSION,
+            "section_registry_sha256": RECIPE_SECTION_REGISTRY_DIGEST,
+            "pull_tool": "get_recipe_section",
+        },
+    }
+    if initialization_id is not None:
+        manifest["initialization_id"] = initialization_id
     if (
-        len(json.dumps(envelope, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+        len(json.dumps(manifest, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
         <= bound_bytes
     ):
-        return envelope
+        return manifest
+    pull_identity = generation.pull_identity()
 
     fallback_candidates: tuple[dict[str, Any], ...] = (
-        {
-            "success": payload.get("success", True),
-            "step_flow_skeleton": skeleton,
-            "recipe_pull": pull_identity,
-            "delivery_bound_spill": True,
-        },
         {
             "success": False,
             "error": "recipe_envelope_exceeds_delivery_bound",
@@ -691,6 +773,54 @@ def build_recipe_envelope(
         ):
             return fallback
     raise ValueError("delivery bound is too small for a JSON object")
+
+
+def _initialization_requirements(
+    *,
+    tool_ctx: ToolContext,
+    generation: RecipeArtifactGeneration,
+    payload: dict[str, Any],
+    entrypoint: str,
+    bound_bytes: int,
+    initialization_id: str | None,
+) -> tuple[RecipeInitializationRequirement, ...]:
+    """Build the exact flow and entrypoint page plans advertised by a manifest."""
+
+    def _entrypoint_content(step_name: str) -> str:
+        content = payload.get("content")
+        parsed = load_yaml(content) if isinstance(content, str) else None
+        steps = parsed.get("steps") if isinstance(parsed, dict) else None
+        step = steps.get(step_name) if isinstance(steps, dict) else None
+        if not isinstance(step, dict):
+            raise RecipeArtifactSchemaError("recipe entrypoint definition is unavailable")
+        return fast_dumps({step_name: step})
+
+    requirements: list[RecipeInitializationRequirement] = []
+    for section in ("flow_records", entrypoint):
+        selected = select_recipe_section(
+            payload,
+            section,
+            dynamic_content_loader=_entrypoint_content,
+        )
+        selected = replace(selected, initialization_id=initialization_id)
+        if not selected.present:
+            raise RecipeArtifactSchemaError(
+                f"required recipe initialization section is absent: {section}"
+            )
+        page_plan = get_or_build_recipe_section_page_plan(
+            kitchen_id=tool_ctx.kitchen_id,
+            generation=generation,
+            selected=selected,
+            recipe_section_bound_bytes=bound_bytes,
+        )
+        requirements.append(
+            RecipeInitializationRequirement(
+                section=section,
+                page_plan_sha256=page_plan.page_plan_sha256,
+                total_parts=page_plan.total_parts,
+            )
+        )
+    return tuple(requirements)
 
 
 def _conservative_token_upper_bound(rendered: str) -> int:
@@ -756,66 +886,18 @@ def finalize_recipe_delivery(
     surface: str,
     recipe_name: str,
     tool_ctx: ToolContext,
+    finalized_projection: FinalizedRecipeProjection,
+    flow_generation: RecipeFlowGeneration,
+    canonical_artifact_payload: dict[str, Any],
+    execution_snapshot: RecipeExecutionSnapshot,
+    normalized_compile_key: str,
     delivery_request: RecipeDeliveryRequest | None = None,
     attestation: RecipeDeliveryAttestation | None = None,
     supported_evidence: RecipeDeliveryEvidenceDef | None = None,
     receipt_ledger: RecipeDeliveryReceiptLedger | None = None,
     now_unix: int | None = None,
-    compiled_bindings: RecipeBindingProjection | None = None,
 ) -> FinalizedRecipeResponse:
     """Persist, decide, shape, and transactionally reserve one recipe response."""
-    execution_snapshot = None
-    candidate_payload = dict(payload)
-    # ORDINARY_INLINE rendered output is the authoritative recipe payload serialized
-    # to JSON. Some callers (e.g. load_recipe) pass a payload without a `success`
-    # field; tests and downstream consumers require success=True on the wire shape.
-    # Open_kitchen callers already inject success=True via build_open_kitchen_recipe_payload
-    # so this is a no-op for that surface. Inject once here so ORDINARY_INLINE always
-    # carries the success indicator.
-    if "success" not in candidate_payload:
-        candidate_payload["success"] = True
-    if compiled_bindings is not None:
-        from autoskillit.server._recipe_execution import (  # circular-break
-            build_recipe_execution_snapshot,
-        )
-
-        try:
-            execution_snapshot = build_recipe_execution_snapshot(
-                recipe_name=recipe_name,
-                content_hash=str(candidate_payload.get("content_hash", "")),
-                composite_hash=str(candidate_payload.get("composite_hash", "")),
-                projection=compiled_bindings,
-            )
-        except (TypeError, ValueError) as exc:
-            get_logger(__name__).warning(
-                "recipe_execution_compilation_failed",
-                recipe_name=recipe_name,
-                surface=surface,
-                error_type=type(exc).__name__,
-                exc_info=True,
-            )
-            decision = _failure_decision(
-                producer=RECIPE_DELIVERY_SURFACE_REGISTRY[surface].producer_tool,
-                reason="recipe_execution_compilation_failed",
-                selected_limit=resolve_general_output_token_limit(
-                    tool_ctx.backend.capabilities
-                    if tool_ctx.backend is not None
-                    else CLAUDE_CODE_CAPABILITIES
-                ),
-                contract_digest="",
-            )
-            return FinalizedRecipeResponse(
-                rendered=json.dumps(
-                    {"success": False, "error": "recipe_execution_unavailable"},
-                    separators=(",", ":"),
-                ),
-                decision=decision,
-            )
-        candidate_payload["recipe_execution"] = {
-            "execution_id": execution_snapshot.execution_id,
-            "invocation_template_digests": dict(execution_snapshot.template_digests),
-            "snapshot_digest": execution_snapshot.snapshot_digest,
-        }
     surface_definition = RECIPE_DELIVERY_SURFACE_REGISTRY[surface]
     candidate_capabilities = (
         getattr(tool_ctx.backend, "capabilities", None) if tool_ctx.backend is not None else None
@@ -834,6 +916,32 @@ def finalize_recipe_delivery(
     )
     delivery_budget = capabilities.recipe_delivery_budget
     ordinary_limit = resolve_general_output_token_limit(capabilities)
+    envelope_byte_limit = resolve_recipe_envelope_byte_limit(capabilities)
+    if (
+        not isinstance(finalized_projection, FinalizedRecipeProjection)
+        or not isinstance(flow_generation, RecipeFlowGeneration)
+        or not isinstance(execution_snapshot, RecipeExecutionSnapshot)
+        or not isinstance(normalized_compile_key, str)
+        or not normalized_compile_key
+    ):
+        raise TypeError("finalize_recipe_delivery requires a complete prepared generation")
+    candidate_payload = dict(canonical_artifact_payload)
+    if (
+        candidate_payload.get("flow_records") != list(flow_generation.records)
+        or candidate_payload.get("recipe_flow") != flow_generation.identity()
+    ):
+        raise ValueError("canonical artifact payload does not match prepared flow generation")
+    surface_payload = dict(payload)
+    if "success" not in surface_payload:
+        surface_payload["success"] = True
+    for generation_field in (
+        "finalized_recipe_projection",
+        "flow_records",
+        "recipe_execution",
+        "recipe_flow",
+    ):
+        surface_payload[generation_field] = candidate_payload[generation_field]
+    initialization_id = uuid4().hex if surface_definition.initialization_activating else None
     try:
         generation = persist_recipe_artifact(
             tool_ctx.temp_dir,
@@ -841,8 +949,21 @@ def finalize_recipe_delivery(
             producer_tool=surface_definition.producer_tool,
             recipe_name=recipe_name,
             payload=candidate_payload,
+            flow_generation=flow_generation,
         )
-    except (OSError, RecipeArtifactError, TypeError, ValueError):
+        get_recipe_generation_store().bind_surface(
+            tool_ctx.kitchen_id,
+            normalized_compile_key,
+            surface,
+            generation,
+        )
+    except (
+        OSError,
+        RecipeArtifactError,
+        RecipeGenerationError,
+        TypeError,
+        ValueError,
+    ):
         decision = _failure_decision(
             producer=surface_definition.producer_tool,
             reason="recipe_artifact_persistence_failed",
@@ -857,8 +978,24 @@ def finalize_recipe_delivery(
             decision=decision,
         )
 
+    surface_payload["recipe_pull"] = generation.pull_identity()
+    if initialization_id is None:
+        with tool_ctx.recipe_execution_lock:
+            current_initialization = tool_ctx.recipe_initialization_state
+        if (
+            isinstance(current_initialization, InitializingRecipe)
+            and current_initialization.recipe_name == recipe_name
+            and current_initialization.artifact_generation.payload_sha256
+            == generation.payload_sha256
+            and current_initialization.artifact_generation.artifact_blob_sha256
+            == generation.artifact_blob_sha256
+            and current_initialization.flow_generation == flow_generation
+        ):
+            initialization_id = current_initialization.initialization_id
+    if initialization_id is not None:
+        surface_payload["initialization_id"] = initialization_id
     ordinary_rendered = json.dumps(
-        candidate_payload,
+        surface_payload,
         ensure_ascii=False,
         separators=(",", ":"),
     )
@@ -867,7 +1004,7 @@ def finalize_recipe_delivery(
     candidate_request = delivery_request if surface_definition.negotiation_eligible else None
     high_rendered = (
         _attested_render(
-            candidate_payload,
+            surface_payload,
             generation,
             budget=delivery_budget,
             evidence_identity=(
@@ -987,36 +1124,67 @@ def finalize_recipe_delivery(
                 receipt_status="not_required",
             )
 
+    initialization_requirements: tuple[RecipeInitializationRequirement, ...] = ()
     if decision.mode is RecipeDeliveryMode.ORDINARY_INLINE:
         rendered = ordinary_rendered
     elif decision.mode is RecipeDeliveryMode.ATTESTED_INLINE:
         rendered = high_rendered
     else:
-        envelope_bound_bytes = ordinary_limit
+        envelope_bound_bytes = envelope_byte_limit
         if (
             surface_definition.response_exemption_tool is None
             and response_ceiling_bytes is not None
         ):
             envelope_bound_bytes = min(envelope_bound_bytes, response_ceiling_bytes)
-        rendered = json.dumps(
-            build_recipe_envelope(
-                candidate_payload,
-                recipe_name=recipe_name,
+        try:
+            initialization_requirements = _initialization_requirements(
+                tool_ctx=tool_ctx,
                 generation=generation,
-                skeleton_source=tool_ctx,
+                payload=candidate_payload,
+                entrypoint=finalized_projection.entrypoint,
                 bound_bytes=envelope_bound_bytes,
-            ),
-            ensure_ascii=False,
-            separators=(",", ":"),
-        )
+                initialization_id=initialization_id,
+            )
+            rendered = json.dumps(
+                build_recipe_envelope(
+                    candidate_payload,
+                    recipe_name=recipe_name,
+                    generation=generation,
+                    flow_generation=flow_generation,
+                    entrypoint=finalized_projection.entrypoint,
+                    bound_bytes=envelope_bound_bytes,
+                    initialization_id=initialization_id,
+                    initialization_requirements=initialization_requirements,
+                    completion_required=(surface_definition.initialization_activating),
+                ),
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+        except Exception:
+            get_logger(__name__).error(
+                "recipe initialization manifest planning failed",
+                recipe_name=recipe_name,
+                exc_info=True,
+            )
+            rendered = json.dumps(
+                {"success": False, "error": "recipe_initialization_plan_failed"},
+                separators=(",", ":"),
+            )
     return FinalizedRecipeResponse(
         rendered=rendered,
         decision=decision,
         receipt_handle=receipt_handle,
         receipt_ledger=receipt_ledger if receipt_handle is not None else None,
         artifact_generation=generation,
+        finalized_projection=finalized_projection,
+        flow_generation=flow_generation,
         execution_snapshot=execution_snapshot,
+        normalized_compile_key=normalized_compile_key,
         tool_ctx=tool_ctx if execution_snapshot is not None else None,
+        recipe_name=recipe_name,
+        initialization_activating=surface_definition.initialization_activating,
+        initialization_id=initialization_id,
+        initialization_requirements=initialization_requirements,
     )
 
 
@@ -1026,52 +1194,128 @@ def complete_finalized_recipe_response(
     *,
     now_unix: int | None = None,
 ) -> Any:
-    """Commit and install an exact enforced response; otherwise preserve prior state."""
+    """Commit receipt and lifecycle state only for exact enforced response bytes."""
     handle = finalized.receipt_handle
     ledger = finalized.receipt_ledger
-    prepared_execution = None
-    if enforced == finalized.rendered:
-        if finalized.execution_snapshot is not None and finalized.tool_ctx is not None:
+    parsed: dict[str, Any] | None = None
+    prepared_execution: Any = None
+    if enforced == finalized.rendered and finalized.initialization_activating:
+        required_values = (
+            finalized.tool_ctx,
+            finalized.recipe_name,
+            finalized.artifact_generation,
+            finalized.flow_generation,
+            finalized.execution_snapshot,
+            finalized.normalized_compile_key,
+            finalized.initialization_id,
+        )
+        if any(value is None or value == "" for value in required_values):
+            enforced = json.dumps(
+                {"success": False, "error": "recipe_initialization_identity_missing"},
+                separators=(",", ":"),
+            )
+        else:
+            assert finalized.tool_ctx is not None
+            assert finalized.execution_snapshot is not None
             try:
-                from autoskillit.server._recipe_execution import (  # circular-break
-                    prepare_recipe_execution,
+                candidate = (
+                    json.loads(finalized.rendered)
+                    if finalized.decision.mode is not RecipeDeliveryMode.ATTESTED_INLINE
+                    else {"success": True}
                 )
-
-                prepared_execution = prepare_recipe_execution(
-                    finalized.tool_ctx,
-                    snapshot=finalized.execution_snapshot,
-                )
-            except Exception:
-                get_logger(__name__).error(
-                    "recipe execution snapshot installation failed",
-                    exc_info=True,
-                )
+            except json.JSONDecodeError:
+                candidate = {"success": False}
+            if not isinstance(candidate, dict) or candidate.get("success") is False:
                 enforced = json.dumps(
-                    {"success": False, "error": "recipe_execution_install_failed"},
+                    {"success": False, "error": "recipe_initialization_failed"},
                     separators=(",", ":"),
                 )
+            else:
+                parsed = candidate
+                if parsed.get("delivery_bound_spill") is not True:
+                    try:
+                        prepared_execution = prepare_recipe_execution(
+                            finalized.tool_ctx,
+                            snapshot=finalized.execution_snapshot,
+                        )
+                    except Exception:
+                        get_logger(__name__).error(
+                            "recipe execution snapshot installation failed",
+                            initialization_id=finalized.initialization_id,
+                            exc_info=True,
+                        )
+                        enforced = json.dumps(
+                            {
+                                "success": False,
+                                "error": "recipe_execution_install_failed",
+                            },
+                            separators=(",", ":"),
+                        )
+    if enforced == finalized.rendered:
+        if handle is not None and (
+            ledger is None
+            or not ledger.commit(
+                handle,
+                now_unix=int(time.time()) if now_unix is None else now_unix,
+            )
+        ):
+            enforced = json.dumps(
+                {"success": False, "error": "recipe_delivery_receipt_commit_failed"},
+                separators=(",", ":"),
+            )
+        elif handle is not None:
+            handle = None
+        if enforced == finalized.rendered and finalized.initialization_activating:
+            assert finalized.tool_ctx is not None
+            assert finalized.recipe_name is not None
+            assert finalized.artifact_generation is not None
+            assert finalized.flow_generation is not None
+            assert finalized.execution_snapshot is not None
+            assert finalized.normalized_compile_key is not None
+            assert finalized.initialization_id is not None
+            assert parsed is not None
+            staged = stage_recipe_initialization(
+                finalized.tool_ctx,
+                recipe_name=finalized.recipe_name,
+                artifact_generation=finalized.artifact_generation,
+                flow_generation=finalized.flow_generation,
+                initialization_id=finalized.initialization_id,
+                staged_snapshot=finalized.execution_snapshot,
+                requirements=(
+                    finalized.initialization_requirements
+                    if parsed.get("delivery_bound_spill") is True
+                    else ()
+                ),
+                generation_store_key=finalized.normalized_compile_key,
+            )
+            if parsed.get("delivery_bound_spill") is not True:
+                try:
+                    assert prepared_execution is not None
+                    install_recipe_execution(
+                        finalized.tool_ctx,
+                        prepared_execution=prepared_execution,
+                        completion_receipt=_qualified_sha256(
+                            (
+                                finalized.initialization_id
+                                + finalized.artifact_generation.payload_sha256
+                            ).encode("utf-8")
+                        ),
+                    )
+                except Exception:
+                    clear_recipe_execution(finalized.tool_ctx)
+                    get_logger(__name__).error(
+                        "recipe execution snapshot installation failed",
+                        initialization_id=staged.initialization_id,
+                        exc_info=True,
+                    )
+                    enforced = json.dumps(
+                        {
+                            "success": False,
+                            "error": "recipe_execution_install_failed",
+                        },
+                        separators=(",", ":"),
+                    )
         if enforced == finalized.rendered:
-            if handle is not None and (
-                ledger is None
-                or not ledger.commit(
-                    handle,
-                    now_unix=int(time.time()) if now_unix is None else now_unix,
-                )
-            ):
-                enforced = json.dumps(
-                    {"success": False, "error": "recipe_delivery_receipt_commit_failed"},
-                    separators=(",", ":"),
-                )
-        if enforced == finalized.rendered:
-            if prepared_execution is not None and finalized.tool_ctx is not None:
-                from autoskillit.server._recipe_execution import (  # circular-break
-                    install_recipe_execution,
-                )
-
-                install_recipe_execution(
-                    finalized.tool_ctx,
-                    prepared_execution=prepared_execution,
-                )
             return enforced
     if handle is not None and (ledger is None or not ledger.abort(handle)):
         return json.dumps(
@@ -1111,6 +1355,7 @@ def enforce_recipe_resource_response(
 
 __all__ = [
     "FinalizedRecipeResponse",
+    "PreparedRecipeGeneration",
     "RECIPE_ARTIFACT_DESCRIPTOR_VERSION",
     "RECIPE_ARTIFACT_SCHEMA_VERSION",
     "RECIPE_BODY_END",
@@ -1124,6 +1369,7 @@ __all__ = [
     "finalize_recipe_delivery",
     "load_recipe_artifact",
     "persist_recipe_artifact",
+    "prepare_recipe_delivery_generation",
     "recipe_pull_producers",
     "retire_recipe_artifacts",
 ]

--- a/src/autoskillit/server/_recipe_delivery.py
+++ b/src/autoskillit/server/_recipe_delivery.py
@@ -69,6 +69,7 @@ from autoskillit.server._recipe_generation import (
 from autoskillit.server._recipe_initialization import stage_recipe_initialization
 from autoskillit.server._recipe_section_pagination import (
     get_or_build_recipe_section_page_plan,
+    resolve_recipe_section_bound_bytes,
     select_recipe_section,
 )
 from autoskillit.server._response_budget import enforce_response_budget
@@ -1001,6 +1002,14 @@ def finalize_recipe_delivery(
         if isinstance(response_max_bytes, int) and response_max_bytes > 0
         else None
     )
+    section_response_bound_bytes = resolve_recipe_section_bound_bytes(
+        (
+            response_ceiling_bytes
+            if response_ceiling_bytes is not None
+            else OutputBudgetConfig().response_max_bytes
+        ),
+        ordinary_limit,
+    )
     if (
         decision.mode is RecipeDeliveryMode.ORDINARY_INLINE
         and surface_definition.response_exemption_tool is None
@@ -1105,7 +1114,7 @@ def finalize_recipe_delivery(
                 generation=generation,
                 payload=candidate_payload,
                 entrypoint=finalized_projection.entrypoint,
-                bound_bytes=envelope_bound_bytes,
+                bound_bytes=section_response_bound_bytes,
                 initialization_id=initialization_id,
             )
             rendered = json.dumps(

--- a/src/autoskillit/server/_recipe_delivery.py
+++ b/src/autoskillit/server/_recipe_delivery.py
@@ -56,7 +56,6 @@ from autoskillit.execution import (
 )
 from autoskillit.pipeline import InitializingRecipe, RecipeInitializationRequirement
 from autoskillit.server._recipe_execution import (
-    clear_recipe_execution,
     install_recipe_execution,
     prepare_recipe_execution,
 )
@@ -1171,6 +1170,7 @@ def complete_finalized_recipe_response(
     ledger = finalized.receipt_ledger
     parsed: dict[str, Any] | None = None
     prepared_execution: Any = None
+    previous_initialization_state: Any = None
     if enforced == finalized.rendered and finalized.initialization_activating:
         required_values = (
             finalized.tool_ctx,
@@ -1223,30 +1223,19 @@ def complete_finalized_recipe_response(
                             },
                             separators=(",", ":"),
                         )
-    if enforced == finalized.rendered:
-        if handle is not None and (
-            ledger is None
-            or not ledger.commit(
-                handle,
-                now_unix=int(time.time()) if now_unix is None else now_unix,
-            )
-        ):
-            enforced = json.dumps(
-                {"success": False, "error": "recipe_delivery_receipt_commit_failed"},
-                separators=(",", ":"),
-            )
-        elif handle is not None:
-            handle = None
-        if enforced == finalized.rendered and finalized.initialization_activating:
-            assert finalized.tool_ctx is not None
-            assert finalized.recipe_name is not None
-            assert finalized.artifact_generation is not None
-            assert finalized.flow_generation is not None
-            assert finalized.execution_snapshot is not None
-            assert finalized.normalized_compile_key is not None
-            assert finalized.initialization_id is not None
-            assert parsed is not None
-            staged = stage_recipe_initialization(
+    if enforced == finalized.rendered and finalized.initialization_activating:
+        assert finalized.tool_ctx is not None
+        assert finalized.recipe_name is not None
+        assert finalized.artifact_generation is not None
+        assert finalized.flow_generation is not None
+        assert finalized.execution_snapshot is not None
+        assert finalized.normalized_compile_key is not None
+        assert finalized.initialization_id is not None
+        assert parsed is not None
+        with finalized.tool_ctx.recipe_execution_lock:
+            previous_initialization_state = finalized.tool_ctx.recipe_initialization_state
+        try:
+            stage_recipe_initialization(
                 finalized.tool_ctx,
                 recipe_name=finalized.recipe_name,
                 artifact_generation=finalized.artifact_generation,
@@ -1261,34 +1250,57 @@ def complete_finalized_recipe_response(
                 generation_store_key=finalized.normalized_compile_key,
             )
             if parsed.get("delivery_bound_spill") is not True:
-                try:
-                    assert prepared_execution is not None
-                    install_recipe_execution(
-                        finalized.tool_ctx,
-                        prepared_execution=prepared_execution,
-                        completion_receipt=_qualified_sha256(
-                            (
-                                finalized.initialization_id
-                                + finalized.artifact_generation.payload_sha256
-                            ).encode("utf-8")
-                        ),
-                    )
-                except Exception:
-                    clear_recipe_execution(finalized.tool_ctx)
-                    get_logger(__name__).error(
-                        "recipe execution snapshot installation failed",
-                        initialization_id=staged.initialization_id,
-                        exc_info=True,
-                    )
-                    enforced = json.dumps(
-                        {
-                            "success": False,
-                            "error": "recipe_execution_install_failed",
-                        },
-                        separators=(",", ":"),
-                    )
-        if enforced == finalized.rendered:
-            return enforced
+                assert prepared_execution is not None
+                install_recipe_execution(
+                    finalized.tool_ctx,
+                    prepared_execution=prepared_execution,
+                    completion_receipt=_qualified_sha256(
+                        (
+                            finalized.initialization_id
+                            + finalized.artifact_generation.payload_sha256
+                        ).encode("utf-8")
+                    ),
+                )
+        except Exception:
+            with finalized.tool_ctx.recipe_execution_lock:
+                finalized.tool_ctx.recipe_initialization_state = previous_initialization_state
+            get_logger(__name__).error(
+                "recipe execution snapshot installation failed",
+                initialization_id=finalized.initialization_id,
+                exc_info=True,
+            )
+            enforced = json.dumps(
+                {
+                    "success": False,
+                    "error": "recipe_execution_install_failed",
+                },
+                separators=(",", ":"),
+            )
+    if enforced == finalized.rendered and handle is not None:
+        try:
+            receipt_committed = ledger is not None and ledger.commit(
+                handle,
+                now_unix=int(time.time()) if now_unix is None else now_unix,
+            )
+        except Exception:
+            receipt_committed = False
+            get_logger(__name__).error(
+                "recipe delivery receipt commit failed",
+                exc_info=True,
+            )
+        if not receipt_committed:
+            if finalized.initialization_activating:
+                assert finalized.tool_ctx is not None
+                with finalized.tool_ctx.recipe_execution_lock:
+                    finalized.tool_ctx.recipe_initialization_state = previous_initialization_state
+            enforced = json.dumps(
+                {"success": False, "error": "recipe_delivery_receipt_commit_failed"},
+                separators=(",", ":"),
+            )
+        else:
+            handle = None
+    if enforced == finalized.rendered:
+        return enforced
     if handle is not None and (ledger is None or not ledger.abort(handle)):
         return json.dumps(
             {"success": False, "error": "recipe_delivery_receipt_abort_failed"},

--- a/src/autoskillit/server/_recipe_execution.py
+++ b/src/autoskillit/server/_recipe_execution.py
@@ -36,6 +36,13 @@ from autoskillit.core import (
     get_logger,
     get_tool_def,
 )
+from autoskillit.pipeline import (
+    InitializingRecipe,
+    NoActiveRecipe,
+    ReadyRecipe,
+    replace_ready_execution,
+    transition_recipe_ready,
+)
 from autoskillit.recipe import (
     RecipeStep,
     RuntimeBindingError,
@@ -353,7 +360,8 @@ def build_recipe_execution_snapshot(
 
 def get_recipe_execution(tool_ctx: ToolContext) -> InstalledRecipeExecution | None:
     with tool_ctx.recipe_execution_lock:
-        return tool_ctx.active_recipe_execution
+        state = tool_ctx.recipe_initialization_state
+        return state.installed_execution if isinstance(state, ReadyRecipe) else None
 
 
 def prepare_recipe_execution(
@@ -376,6 +384,7 @@ def install_recipe_execution(
     *,
     snapshot: RecipeExecutionSnapshot | None = None,
     prepared_execution: InstalledRecipeExecution | None = None,
+    completion_receipt: str | None = None,
 ) -> InstalledRecipeExecution:
     """Atomically install a snapshot, empty runtime map, and empty head ledger."""
     if (snapshot is None) == (prepared_execution is None):
@@ -386,8 +395,21 @@ def install_recipe_execution(
         assert snapshot is not None
         installed = prepare_recipe_execution(tool_ctx, snapshot=snapshot)
     with tool_ctx.recipe_execution_lock:
-        previous = tool_ctx.active_recipe_execution
-        tool_ctx.active_recipe_execution = installed
+        state = tool_ctx.recipe_initialization_state
+        previous = state.installed_execution if isinstance(state, ReadyRecipe) else None
+        if isinstance(state, InitializingRecipe):
+            tool_ctx.recipe_initialization_state = transition_recipe_ready(
+                state,
+                installed_execution=installed,
+                completion_receipt=completion_receipt or state.completion_receipt or "",
+            )
+        elif isinstance(state, ReadyRecipe):
+            tool_ctx.recipe_initialization_state = replace_ready_execution(state, installed)
+        else:
+            raise RecipeExecutionAdmissionError(
+                "recipe_initialization_not_active",
+                "recipe execution cannot install before initialization is staged",
+            )
     if previous is not None and previous is not installed:
         try:
             previous.audit_cycle_heads.clear_generation(previous.snapshot.execution_id)
@@ -402,8 +424,9 @@ def install_recipe_execution(
 def clear_recipe_execution(tool_ctx: ToolContext) -> None:
     """Clear the complete active attestation generation in one locked transition."""
     with tool_ctx.recipe_execution_lock:
-        previous = tool_ctx.active_recipe_execution
-        tool_ctx.active_recipe_execution = None
+        state = tool_ctx.recipe_initialization_state
+        previous = state.installed_execution if isinstance(state, ReadyRecipe) else None
+        tool_ctx.recipe_initialization_state = NoActiveRecipe()
     if previous is not None:
         previous.audit_cycle_heads.clear_generation(previous.snapshot.execution_id)
 
@@ -416,17 +439,24 @@ def record_runtime_binding_digest(
     digest: str,
 ) -> None:
     with tool_ctx.recipe_execution_lock:
-        installed = tool_ctx.active_recipe_execution
-        if installed is None or installed.snapshot.execution_id != execution_id:
+        state = tool_ctx.recipe_initialization_state
+        if (
+            not isinstance(state, ReadyRecipe)
+            or state.installed_execution.snapshot.execution_id != execution_id
+        ):
             raise RecipeExecutionAdmissionError(
                 "recipe_execution_replaced",
                 "active recipe execution changed before runtime binding was recorded",
             )
+        installed = state.installed_execution
         updated = dict(installed.runtime_binding_digests)
         updated[step_name] = digest
-        tool_ctx.active_recipe_execution = replace(
-            installed,
-            runtime_binding_digests=MappingProxyType(updated),
+        tool_ctx.recipe_initialization_state = replace_ready_execution(
+            state,
+            replace(
+                installed,
+                runtime_binding_digests=MappingProxyType(updated),
+            ),
         )
 
 
@@ -628,7 +658,8 @@ def _publish_loaded_audit_cycle(
         verifier.verify_artifact_ref(authority.remediation_ref)
     manifest = load_bundled_manifest()
     with tool_ctx.recipe_execution_lock:
-        if tool_ctx.active_recipe_execution is not installed:
+        state = tool_ctx.recipe_initialization_state
+        if not isinstance(state, ReadyRecipe) or state.installed_execution is not installed:
             raise AuditCycleHeadConflict(
                 "active recipe execution changed while publishing audit authority"
             )
@@ -651,9 +682,12 @@ def _publish_loaded_audit_cycle(
                 and contract.input_preflight == PreflightKind.AUDIT_CYCLE_INVENTORY.value
             ):
                 preflight_identities[step_name] = expected_identity
-        tool_ctx.active_recipe_execution = replace(
-            installed,
-            preflight_identities=preflight_identities,
+        tool_ctx.recipe_initialization_state = replace_ready_execution(
+            state,
+            replace(
+                installed,
+                preflight_identities=preflight_identities,
+            ),
         )
     return head
 

--- a/src/autoskillit/server/_recipe_generation.py
+++ b/src/autoskillit/server/_recipe_generation.py
@@ -34,6 +34,7 @@ __all__ = [
     "RecipeGenerationRecord",
     "RecipeGenerationRetiredError",
     "RecipeGenerationStore",
+    "generation_json_primitive",
     "get_recipe_generation_store",
     "recipe_generation_weight_bytes",
     "retire_kitchen",
@@ -89,34 +90,34 @@ def _freeze_primitive_mapping(
     return cast(Mapping[str, object], frozen)
 
 
-def _weight_primitive(value: object) -> object:
+def generation_json_primitive(value: object) -> object:
     """Convert retained immutable values to a deterministic JSON primitive tree."""
     if isinstance(value, Enum):
-        return _weight_primitive(value.value)
+        return generation_json_primitive(value.value)
     if value is None or isinstance(value, (str, bool, int)):
         return value
     if isinstance(value, float):
         if not math.isfinite(value):
-            raise ValueError("generation weight input contains a non-finite float")
+            raise ValueError("recipe generation contains a non-finite float")
         return value
     if isinstance(value, Mapping):
         if any(not isinstance(key, str) for key in value):
-            raise TypeError("generation weight mapping keys must be strings")
+            raise TypeError("recipe generation mapping keys must be strings")
         result: dict[str, object] = {}
         for key in sorted(value):
-            result[key] = _weight_primitive(value[key])
+            result[key] = generation_json_primitive(value[key])
         return result
     if isinstance(value, (list, tuple)):
-        return [_weight_primitive(item) for item in value]
+        return [generation_json_primitive(item) for item in value]
     if isinstance(value, (set, frozenset)):
-        converted = [_weight_primitive(item) for item in value]
+        converted = [generation_json_primitive(item) for item in value]
         return sorted(converted, key=_canonical_json)
     if is_dataclass(value) and not isinstance(value, type):
         return {
-            item.name: _weight_primitive(getattr(value, item.name))
+            item.name: generation_json_primitive(getattr(value, item.name))
             for item in fields(cast(Any, value))
         }
-    raise TypeError(f"generation weight input contains unsupported value {type(value).__name__}")
+    raise TypeError(f"recipe generation contains unsupported value {type(value).__name__}")
 
 
 def _canonical_json(value: object) -> str:
@@ -192,7 +193,7 @@ def recipe_generation_weight_bytes(record: RecipeGenerationRecord) -> int:
     """Return the exact UTF-8 size of the canonical retained-record projection."""
     if not isinstance(record, RecipeGenerationRecord):
         raise TypeError("record must be a RecipeGenerationRecord")
-    primitive = _weight_primitive(record)
+    primitive = generation_json_primitive(record)
     return len(_canonical_json(primitive).encode("utf-8"))
 
 
@@ -200,7 +201,7 @@ def thaw_recipe_generation_mapping(
     value: Mapping[str, object],
 ) -> dict[str, object]:
     """Return a mutable JSON-primitive copy of one retained mapping."""
-    primitive = _weight_primitive(value)
+    primitive = generation_json_primitive(value)
     if not isinstance(primitive, dict):
         raise TypeError("recipe generation mapping did not thaw to a JSON object")
     return primitive

--- a/src/autoskillit/server/_recipe_generation.py
+++ b/src/autoskillit/server/_recipe_generation.py
@@ -149,8 +149,8 @@ class RecipeGenerationRecord:
     surface_bindings: Mapping[str, RecipeArtifactGeneration] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not isinstance(self.kitchen_id, str):
-            raise TypeError("RecipeGenerationRecord.kitchen_id must be a string")
+        if not isinstance(self.kitchen_id, str) or not self.kitchen_id:
+            raise ValueError("RecipeGenerationRecord.kitchen_id must be a non-empty string")
         for field_name in ("normalized_compile_key", "recipe_name", "execution_id"):
             value = getattr(self, field_name)
             if not isinstance(value, str) or not value:

--- a/src/autoskillit/server/_recipe_generation.py
+++ b/src/autoskillit/server/_recipe_generation.py
@@ -185,6 +185,14 @@ class RecipeGenerationRecord:
                 raise TypeError("surface bindings must contain RecipeArtifactGeneration values")
             if generation.recipe_name != self.recipe_name:
                 raise ValueError("surface artifact generation must match the record recipe_name")
+            artifact_identity = generation.pull_identity()
+            if any(
+                artifact_identity[field_name] != expected
+                for field_name, expected in self.flow_generation.identity().items()
+            ):
+                raise ValueError(
+                    "surface artifact generation must match the record flow generation"
+                )
             bindings[surface] = generation
 
         object.__setattr__(self, "artifact_payload", artifact_payload)

--- a/src/autoskillit/server/_recipe_generation.py
+++ b/src/autoskillit/server/_recipe_generation.py
@@ -24,16 +24,19 @@ from autoskillit.server.recipe_section._lifecycle import (
 
 RECIPE_GENERATION_STORE_MAX_ENTRIES = 8
 RECIPE_GENERATION_STORE_MAX_BYTES = 32 * 1024 * 1024
+RECIPE_GENERATION_STORE_MAX_RETIRED_KITCHENS = 1_024
 
 __all__ = [
     "RECIPE_GENERATION_STORE_MAX_BYTES",
     "RECIPE_GENERATION_STORE_MAX_ENTRIES",
+    "RECIPE_GENERATION_STORE_MAX_RETIRED_KITCHENS",
     "RecipeGenerationCapacityError",
     "RecipeGenerationConflictError",
     "RecipeGenerationError",
     "RecipeGenerationRecord",
     "RecipeGenerationRetiredError",
     "RecipeGenerationStore",
+    "activate_kitchen",
     "generation_json_primitive",
     "get_recipe_generation_store",
     "recipe_generation_weight_bytes",
@@ -245,17 +248,23 @@ class RecipeGenerationStore:
         *,
         max_entries: int = RECIPE_GENERATION_STORE_MAX_ENTRIES,
         max_bytes: int = RECIPE_GENERATION_STORE_MAX_BYTES,
+        max_retired_kitchens: int = RECIPE_GENERATION_STORE_MAX_RETIRED_KITCHENS,
     ) -> None:
         if max_entries < 0:
             raise ValueError("generation store max_entries must not be negative")
         if max_bytes < 0:
             raise ValueError("generation store max_bytes must not be negative")
+        if max_retired_kitchens < 0:
+            raise ValueError("generation store max_retired_kitchens must not be negative")
         self._max_entries = max_entries
         self._max_bytes = max_bytes
+        self._max_retired_kitchens = max_retired_kitchens
         self._compile_index: OrderedDict[_CompileIndexKey, RecipeGenerationRecord] = OrderedDict()
         self._artifact_index: dict[_ArtifactIndexKey, _CompileIndexKey] = {}
         self._weight_bytes = 0
-        self._retired_kitchens: set[str] = set()
+        self._retired_kitchens: OrderedDict[str, None] = OrderedDict()
+        self._active_kitchens: set[str] = set()
+        self._lifecycle_authoritative = False
         self._lock = RLock()
 
     @property
@@ -268,8 +277,24 @@ class RecipeGenerationStore:
         with self._lock:
             return self._weight_bytes
 
+    @property
+    def retired_kitchen_count(self) -> int:
+        with self._lock:
+            return len(self._retired_kitchens)
+
+    def activate_kitchen(self, kitchen_id: str) -> None:
+        """Mark one current lifecycle identity active without retaining history."""
+        if not isinstance(kitchen_id, str) or not kitchen_id:
+            raise ValueError("kitchen_id must be a non-empty string")
+        with self._lock:
+            self._lifecycle_authoritative = True
+            self._active_kitchens.add(kitchen_id)
+            self._retired_kitchens.pop(kitchen_id, None)
+
     def _require_active_locked(self, kitchen_id: str) -> None:
-        if kitchen_id in self._retired_kitchens:
+        if (self._lifecycle_authoritative and kitchen_id not in self._active_kitchens) or (
+            not self._lifecycle_authoritative and kitchen_id in self._retired_kitchens
+        ):
             raise RecipeGenerationRetiredError(
                 f"recipe generation kitchen is retired: {kitchen_id}"
             )
@@ -439,7 +464,12 @@ class RecipeGenerationStore:
         if not isinstance(kitchen_id, str) or not kitchen_id:
             raise ValueError("kitchen_id must be a non-empty string")
         with self._lock:
-            self._retired_kitchens.add(kitchen_id)
+            self._active_kitchens.discard(kitchen_id)
+            if self._max_retired_kitchens > 0:
+                self._retired_kitchens[kitchen_id] = None
+                self._retired_kitchens.move_to_end(kitchen_id)
+                while len(self._retired_kitchens) > self._max_retired_kitchens:
+                    self._retired_kitchens.popitem(last=False)
             keys = [key for key in self._compile_index if key[0] == kitchen_id]
             for key in keys:
                 self._remove_locked(key)
@@ -451,6 +481,8 @@ class RecipeGenerationStore:
             self._artifact_index.clear()
             self._weight_bytes = 0
             self._retired_kitchens.clear()
+            self._active_kitchens.clear()
+            self._lifecycle_authoritative = False
 
 
 _RECIPE_GENERATION_STORE: RecipeGenerationStore | None = None
@@ -464,6 +496,11 @@ def get_recipe_generation_store() -> RecipeGenerationStore:
         if _RECIPE_GENERATION_STORE is None:
             _RECIPE_GENERATION_STORE = RecipeGenerationStore()
         return _RECIPE_GENERATION_STORE
+
+
+def activate_kitchen(kitchen_id: str) -> None:
+    """Activate generation state for one current kitchen lifecycle."""
+    get_recipe_generation_store().activate_kitchen(kitchen_id)
 
 
 def retire_kitchen(kitchen_id: str) -> None:

--- a/src/autoskillit/server/_recipe_generation.py
+++ b/src/autoskillit/server/_recipe_generation.py
@@ -1,0 +1,473 @@
+"""Kitchen-scoped ownership of compiled and persisted recipe generations."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections import OrderedDict
+from collections.abc import Mapping
+from dataclasses import dataclass, field, fields, is_dataclass, replace
+from enum import Enum
+from threading import Lock, RLock
+from types import MappingProxyType
+from typing import Any, cast
+
+from autoskillit.core import (
+    FinalizedRecipeProjection,
+    RecipeArtifactGeneration,
+    RecipeExecutionSnapshot,
+    RecipeFlowGeneration,
+)
+from autoskillit.server.recipe_section._lifecycle import (
+    register_kitchen_retirement_callback,
+)
+
+RECIPE_GENERATION_STORE_MAX_ENTRIES = 8
+RECIPE_GENERATION_STORE_MAX_BYTES = 32 * 1024 * 1024
+
+__all__ = [
+    "RECIPE_GENERATION_STORE_MAX_BYTES",
+    "RECIPE_GENERATION_STORE_MAX_ENTRIES",
+    "RecipeGenerationCapacityError",
+    "RecipeGenerationConflictError",
+    "RecipeGenerationError",
+    "RecipeGenerationRecord",
+    "RecipeGenerationRetiredError",
+    "RecipeGenerationStore",
+    "get_recipe_generation_store",
+    "recipe_generation_weight_bytes",
+    "retire_kitchen",
+    "thaw_recipe_generation_mapping",
+]
+
+
+class RecipeGenerationError(RuntimeError):
+    """Base error for generation-store admission and binding failures."""
+
+
+class RecipeGenerationConflictError(RecipeGenerationError):
+    """An existing exact generation disagrees with a replay."""
+
+
+class RecipeGenerationCapacityError(RecipeGenerationError):
+    """A single generation cannot fit within the configured store bounds."""
+
+
+class RecipeGenerationRetiredError(RecipeGenerationError):
+    """A write targeted a kitchen whose generation namespace is retired."""
+
+
+def _freeze_primitive(value: object, *, path: str) -> object:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{path} contains a non-finite float")
+        return value
+    if isinstance(value, Mapping):
+        if any(not isinstance(key, str) for key in value):
+            raise TypeError(f"{path} object keys must be strings")
+        copied: dict[str, object] = {}
+        for key in sorted(value):
+            copied[key] = _freeze_primitive(value[key], path=f"{path}.{key}")
+        return MappingProxyType(copied)
+    if isinstance(value, (list, tuple)):
+        return tuple(
+            _freeze_primitive(item, path=f"{path}[{index}]") for index, item in enumerate(value)
+        )
+    raise TypeError(f"{path} contains unsupported value {type(value).__name__}")
+
+
+def _freeze_primitive_mapping(
+    value: Mapping[str, object],
+    *,
+    field_name: str,
+) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{field_name} must be a mapping")
+    frozen = _freeze_primitive(value, path=field_name)
+    return cast(Mapping[str, object], frozen)
+
+
+def _weight_primitive(value: object) -> object:
+    """Convert retained immutable values to a deterministic JSON primitive tree."""
+    if isinstance(value, Enum):
+        return _weight_primitive(value.value)
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("generation weight input contains a non-finite float")
+        return value
+    if isinstance(value, Mapping):
+        if any(not isinstance(key, str) for key in value):
+            raise TypeError("generation weight mapping keys must be strings")
+        result: dict[str, object] = {}
+        for key in sorted(value):
+            result[key] = _weight_primitive(value[key])
+        return result
+    if isinstance(value, (list, tuple)):
+        return [_weight_primitive(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        converted = [_weight_primitive(item) for item in value]
+        return sorted(converted, key=_canonical_json)
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            item.name: _weight_primitive(getattr(value, item.name))
+            for item in fields(cast(Any, value))
+        }
+    raise TypeError(f"generation weight input contains unsupported value {type(value).__name__}")
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class RecipeGenerationRecord:
+    """One immutable compile generation and its exact persisted surface bindings."""
+
+    kitchen_id: str
+    normalized_compile_key: str
+    recipe_name: str
+    finalized_projection: FinalizedRecipeProjection
+    flow_generation: RecipeFlowGeneration
+    artifact_payload: Mapping[str, object]
+    execution_snapshot: RecipeExecutionSnapshot
+    execution_id: str
+    compile_inputs: Mapping[str, object]
+    surface_bindings: Mapping[str, RecipeArtifactGeneration] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kitchen_id, str):
+            raise TypeError("RecipeGenerationRecord.kitchen_id must be a string")
+        for field_name in ("normalized_compile_key", "recipe_name", "execution_id"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"RecipeGenerationRecord.{field_name} must be a non-empty string")
+        if not isinstance(self.finalized_projection, FinalizedRecipeProjection):
+            raise TypeError("finalized_projection must be a FinalizedRecipeProjection")
+        if not isinstance(self.flow_generation, RecipeFlowGeneration):
+            raise TypeError("flow_generation must be a RecipeFlowGeneration")
+        if not isinstance(self.execution_snapshot, RecipeExecutionSnapshot):
+            raise TypeError("execution_snapshot must be a RecipeExecutionSnapshot")
+        if self.execution_id != self.execution_snapshot.execution_id:
+            raise ValueError("execution_id must match execution_snapshot.execution_id")
+        if self.recipe_name != self.execution_snapshot.recipe_name:
+            raise ValueError("recipe_name must match execution_snapshot.recipe_name")
+
+        artifact_payload = _freeze_primitive_mapping(
+            self.artifact_payload,
+            field_name="artifact_payload",
+        )
+        compile_inputs = _freeze_primitive_mapping(
+            self.compile_inputs,
+            field_name="compile_inputs",
+        )
+        bindings: dict[str, RecipeArtifactGeneration] = {}
+        if not isinstance(self.surface_bindings, Mapping):
+            raise TypeError("surface_bindings must be a mapping")
+        for surface in sorted(self.surface_bindings):
+            generation = self.surface_bindings[surface]
+            if not isinstance(surface, str) or not surface:
+                raise ValueError("surface binding names must be non-empty strings")
+            if not isinstance(generation, RecipeArtifactGeneration):
+                raise TypeError("surface bindings must contain RecipeArtifactGeneration values")
+            if generation.recipe_name != self.recipe_name:
+                raise ValueError("surface artifact generation must match the record recipe_name")
+            bindings[surface] = generation
+
+        object.__setattr__(self, "artifact_payload", artifact_payload)
+        object.__setattr__(self, "compile_inputs", compile_inputs)
+        object.__setattr__(self, "surface_bindings", MappingProxyType(bindings))
+
+
+def recipe_generation_weight_bytes(record: RecipeGenerationRecord) -> int:
+    """Return the exact UTF-8 size of the canonical retained-record projection."""
+    if not isinstance(record, RecipeGenerationRecord):
+        raise TypeError("record must be a RecipeGenerationRecord")
+    primitive = _weight_primitive(record)
+    return len(_canonical_json(primitive).encode("utf-8"))
+
+
+def thaw_recipe_generation_mapping(
+    value: Mapping[str, object],
+) -> dict[str, object]:
+    """Return a mutable JSON-primitive copy of one retained mapping."""
+    primitive = _weight_primitive(value)
+    if not isinstance(primitive, dict):
+        raise TypeError("recipe generation mapping did not thaw to a JSON object")
+    return primitive
+
+
+def _copy_record(record: RecipeGenerationRecord) -> RecipeGenerationRecord:
+    return replace(
+        record,
+        artifact_payload=dict(record.artifact_payload),
+        compile_inputs=dict(record.compile_inputs),
+        surface_bindings=dict(record.surface_bindings),
+    )
+
+
+def _same_compile_generation(
+    left: RecipeGenerationRecord,
+    right: RecipeGenerationRecord,
+) -> bool:
+    return (
+        left.kitchen_id == right.kitchen_id
+        and left.normalized_compile_key == right.normalized_compile_key
+        and left.recipe_name == right.recipe_name
+        and left.finalized_projection == right.finalized_projection
+        and left.flow_generation == right.flow_generation
+        and left.artifact_payload == right.artifact_payload
+        and left.execution_snapshot == right.execution_snapshot
+        and left.execution_id == right.execution_id
+        and left.compile_inputs == right.compile_inputs
+    )
+
+
+_CompileIndexKey = tuple[str, str]
+_ArtifactIndexKey = tuple[str, RecipeArtifactGeneration]
+
+
+class RecipeGenerationStore:
+    """Bounded thread-safe LRU with compile and exact-artifact indexes."""
+
+    def __init__(
+        self,
+        *,
+        max_entries: int = RECIPE_GENERATION_STORE_MAX_ENTRIES,
+        max_bytes: int = RECIPE_GENERATION_STORE_MAX_BYTES,
+    ) -> None:
+        if max_entries < 0:
+            raise ValueError("generation store max_entries must not be negative")
+        if max_bytes < 0:
+            raise ValueError("generation store max_bytes must not be negative")
+        self._max_entries = max_entries
+        self._max_bytes = max_bytes
+        self._compile_index: OrderedDict[_CompileIndexKey, RecipeGenerationRecord] = OrderedDict()
+        self._artifact_index: dict[_ArtifactIndexKey, _CompileIndexKey] = {}
+        self._weight_bytes = 0
+        self._retired_kitchens: set[str] = set()
+        self._lock = RLock()
+
+    @property
+    def entry_count(self) -> int:
+        with self._lock:
+            return len(self._compile_index)
+
+    @property
+    def weight_bytes(self) -> int:
+        with self._lock:
+            return self._weight_bytes
+
+    def _require_active_locked(self, kitchen_id: str) -> None:
+        if kitchen_id in self._retired_kitchens:
+            raise RecipeGenerationRetiredError(
+                f"recipe generation kitchen is retired: {kitchen_id}"
+            )
+
+    def _deindex_artifacts_locked(
+        self,
+        key: _CompileIndexKey,
+        record: RecipeGenerationRecord,
+    ) -> None:
+        for generation in record.surface_bindings.values():
+            artifact_key = (record.kitchen_id, generation)
+            if self._artifact_index.get(artifact_key) == key:
+                self._artifact_index.pop(artifact_key)
+
+    def _remove_locked(self, key: _CompileIndexKey) -> None:
+        record = self._compile_index.pop(key)
+        self._deindex_artifacts_locked(key, record)
+        self._weight_bytes -= recipe_generation_weight_bytes(record)
+
+    def _validate_artifact_owners_locked(
+        self,
+        key: _CompileIndexKey,
+        record: RecipeGenerationRecord,
+    ) -> None:
+        for generation in record.surface_bindings.values():
+            owner = self._artifact_index.get((record.kitchen_id, generation))
+            if owner is not None and owner != key:
+                raise RecipeGenerationConflictError(
+                    "exact artifact generation is already bound to another compile generation"
+                )
+
+    def _replace_locked(
+        self,
+        key: _CompileIndexKey,
+        record: RecipeGenerationRecord,
+        *,
+        weight: int,
+    ) -> None:
+        if key in self._compile_index:
+            self._remove_locked(key)
+        self._compile_index[key] = record
+        self._weight_bytes += weight
+        for generation in record.surface_bindings.values():
+            self._artifact_index[(record.kitchen_id, generation)] = key
+        while len(self._compile_index) > self._max_entries or self._weight_bytes > self._max_bytes:
+            oldest_key = next(iter(self._compile_index))
+            self._remove_locked(oldest_key)
+
+    def put(self, record: RecipeGenerationRecord) -> RecipeGenerationRecord:
+        """Admit a compile generation or accept an exact idempotent replay."""
+        if not isinstance(record, RecipeGenerationRecord):
+            raise TypeError("record must be a RecipeGenerationRecord")
+        candidate = _copy_record(record)
+        key = (candidate.kitchen_id, candidate.normalized_compile_key)
+        with self._lock:
+            self._require_active_locked(candidate.kitchen_id)
+            existing = self._compile_index.get(key)
+            if existing is not None:
+                if not _same_compile_generation(existing, candidate):
+                    raise RecipeGenerationConflictError(
+                        "normalized compile generation replay does not match"
+                    )
+                merged_bindings = dict(existing.surface_bindings)
+                for surface, generation in candidate.surface_bindings.items():
+                    bound = merged_bindings.get(surface)
+                    if bound is not None and bound != generation:
+                        raise RecipeGenerationConflictError(
+                            f"surface {surface!r} already has another exact generation"
+                        )
+                    merged_bindings[surface] = generation
+                candidate = replace(existing, surface_bindings=merged_bindings)
+            self._validate_artifact_owners_locked(key, candidate)
+            weight = recipe_generation_weight_bytes(candidate)
+            if self._max_entries == 0 or weight > self._max_bytes:
+                raise RecipeGenerationCapacityError(
+                    "recipe generation exceeds store entry or byte capacity"
+                )
+            self._replace_locked(key, candidate, weight=weight)
+            return _copy_record(candidate)
+
+    def bind_surface(
+        self,
+        kitchen_id: str,
+        normalized_compile_key: str,
+        surface: str,
+        generation: RecipeArtifactGeneration,
+    ) -> RecipeGenerationRecord:
+        """Atomically bind one surface to an exact persisted generation."""
+        if not isinstance(kitchen_id, str):
+            raise TypeError("kitchen_id must be a string")
+        for name, value in (
+            ("normalized_compile_key", normalized_compile_key),
+            ("surface", surface),
+        ):
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"{name} must be a non-empty string")
+        if not isinstance(generation, RecipeArtifactGeneration):
+            raise TypeError("generation must be a RecipeArtifactGeneration")
+
+        key = (kitchen_id, normalized_compile_key)
+        with self._lock:
+            self._require_active_locked(kitchen_id)
+            existing = self._compile_index.get(key)
+            if existing is None:
+                raise KeyError("normalized compile generation is not present for this kitchen")
+            if generation.recipe_name != existing.recipe_name:
+                raise RecipeGenerationConflictError(
+                    "artifact generation recipe_name does not match compile generation"
+                )
+            bound = existing.surface_bindings.get(surface)
+            if bound is not None:
+                if bound != generation:
+                    raise RecipeGenerationConflictError(
+                        f"surface {surface!r} already has another exact generation"
+                    )
+                self._compile_index.move_to_end(key)
+                return _copy_record(existing)
+            owner = self._artifact_index.get((kitchen_id, generation))
+            if owner is not None and owner != key:
+                raise RecipeGenerationConflictError(
+                    "exact artifact generation is already bound to another compile generation"
+                )
+
+            bindings = dict(existing.surface_bindings)
+            bindings[surface] = generation
+            candidate = replace(existing, surface_bindings=bindings)
+            weight = recipe_generation_weight_bytes(candidate)
+            if weight > self._max_bytes:
+                raise RecipeGenerationCapacityError(
+                    "surface binding exceeds generation store byte capacity"
+                )
+            self._replace_locked(key, candidate, weight=weight)
+            return _copy_record(candidate)
+
+    def lookup_compile(
+        self,
+        kitchen_id: str,
+        normalized_compile_key: str,
+    ) -> RecipeGenerationRecord | None:
+        """Return an immutable defensive copy for a normalized compile key."""
+        key = (kitchen_id, normalized_compile_key)
+        with self._lock:
+            record = self._compile_index.get(key)
+            if record is None:
+                return None
+            self._compile_index.move_to_end(key)
+            return _copy_record(record)
+
+    def lookup_artifact(
+        self,
+        kitchen_id: str,
+        generation: RecipeArtifactGeneration,
+    ) -> RecipeGenerationRecord | None:
+        """Return the compile record owning one exact artifact descriptor."""
+        with self._lock:
+            key = self._artifact_index.get((kitchen_id, generation))
+            if key is None:
+                return None
+            record = self._compile_index.get(key)
+            if record is None:
+                raise RuntimeError("artifact generation index has no compile owner")
+            self._compile_index.move_to_end(key)
+            return _copy_record(record)
+
+    def retire_kitchen(self, kitchen_id: str) -> None:
+        """Permanently reject writes and remove all entries for one kitchen."""
+        if not isinstance(kitchen_id, str) or not kitchen_id:
+            raise ValueError("kitchen_id must be a non-empty string")
+        with self._lock:
+            self._retired_kitchens.add(kitchen_id)
+            keys = [key for key in self._compile_index if key[0] == kitchen_id]
+            for key in keys:
+                self._remove_locked(key)
+
+    def clear(self) -> None:
+        """Clear all indexes and retirement markers."""
+        with self._lock:
+            self._compile_index.clear()
+            self._artifact_index.clear()
+            self._weight_bytes = 0
+            self._retired_kitchens.clear()
+
+
+_RECIPE_GENERATION_STORE: RecipeGenerationStore | None = None
+_RECIPE_GENERATION_STORE_LOCK = Lock()
+
+
+def get_recipe_generation_store() -> RecipeGenerationStore:
+    """Return the process-local bounded generation store."""
+    global _RECIPE_GENERATION_STORE
+    with _RECIPE_GENERATION_STORE_LOCK:
+        if _RECIPE_GENERATION_STORE is None:
+            _RECIPE_GENERATION_STORE = RecipeGenerationStore()
+        return _RECIPE_GENERATION_STORE
+
+
+def retire_kitchen(kitchen_id: str) -> None:
+    """Retire generation state when the owning kitchen artifact is retired."""
+    get_recipe_generation_store().retire_kitchen(kitchen_id)
+
+
+register_kitchen_retirement_callback(retire_kitchen)

--- a/src/autoskillit/server/_recipe_initialization.py
+++ b/src/autoskillit/server/_recipe_initialization.py
@@ -1,0 +1,307 @@
+"""Server translation and post-enforcement commits for recipe initialization."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from autoskillit.core import (
+    RecipeArtifactGeneration,
+    RecipeExecutionSnapshot,
+    RecipeFlowGeneration,
+    ToolInitializationOperation,
+    get_tool_def,
+)
+from autoskillit.pipeline import (
+    InitializingRecipe,
+    ReadyRecipe,
+    RecipeInitializationRequirement,
+    initialization_is_complete,
+    record_initialization_page,
+    start_recipe_initialization,
+)
+from autoskillit.server._recipe_execution import (
+    RecipeExecutionAdmissionError,
+    install_recipe_execution,
+    prepare_recipe_execution,
+)
+from autoskillit.server._state import _get_ctx_or_none
+
+if TYPE_CHECKING:
+    from autoskillit.pipeline import ToolContext
+
+__all__ = [
+    "FinalizedRecipeInitializationResponse",
+    "FinalizedRecipeSectionResponse",
+    "admit_registered_tool_during_initialization",
+    "build_completion_response",
+    "complete_initialization_response",
+    "complete_section_response",
+    "matches_recipe_initialization_requirement",
+    "stage_recipe_initialization",
+]
+
+
+def _receipt(initialization_id: str, artifact: RecipeArtifactGeneration) -> str:
+    material = json.dumps(
+        {
+            "artifact": artifact.pull_identity(),
+            "initialization_id": initialization_id,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return (
+        "sha256:"
+        + hashlib.sha256(b"autoskillit.recipe-initialization-receipt.v1\0" + material).hexdigest()
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class FinalizedRecipeSectionResponse:
+    """A rendered page whose lifecycle credit awaits response enforcement."""
+
+    rendered: str
+    tool_ctx: ToolContext
+    initialization_id: str
+    artifact_generation: RecipeArtifactGeneration
+    section: str
+    page_plan_sha256: str
+    part: int
+
+
+@dataclass(frozen=True, slots=True)
+class FinalizedRecipeInitializationResponse:
+    """A completion receipt whose READY transition awaits enforcement."""
+
+    rendered: str
+    tool_ctx: ToolContext
+    initialization_id: str
+    artifact_generation: RecipeArtifactGeneration
+    staged_snapshot: RecipeExecutionSnapshot
+    completion_receipt: str
+
+
+def stage_recipe_initialization(
+    tool_ctx: ToolContext,
+    *,
+    recipe_name: str,
+    artifact_generation: RecipeArtifactGeneration,
+    flow_generation: RecipeFlowGeneration,
+    initialization_id: str,
+    staged_snapshot: RecipeExecutionSnapshot,
+    requirements: tuple[RecipeInitializationRequirement, ...],
+    generation_store_key: str,
+) -> InitializingRecipe:
+    """Replace all prior recipe authority with one immutable INITIALIZING state."""
+    candidate = start_recipe_initialization(
+        kitchen_id=tool_ctx.kitchen_id,
+        recipe_name=recipe_name,
+        artifact_generation=artifact_generation,
+        flow_generation=flow_generation,
+        initialization_id=initialization_id,
+        staged_snapshot=staged_snapshot,
+        requirements=requirements,
+        generation_store_key=generation_store_key,
+    )
+    with tool_ctx.recipe_execution_lock:
+        tool_ctx.recipe_initialization_state = candidate
+    return candidate
+
+
+def admit_registered_tool_during_initialization(tool_name: str) -> str | None:
+    """Deny execution/mutation before any registered handler side effect."""
+    tool_ctx = _get_ctx_or_none()
+    if tool_ctx is None:
+        return None
+    with tool_ctx.recipe_execution_lock:
+        state = tool_ctx.recipe_initialization_state
+    if not isinstance(state, InitializingRecipe):
+        return None
+    definition = get_tool_def(tool_name)
+    if definition is None:
+        return json.dumps(
+            {
+                "success": False,
+                "error": "recipe_initialization_unknown_operation",
+            },
+            separators=(",", ":"),
+        )
+    if definition.initialization_operation in {
+        ToolInitializationOperation.RECOVERY,
+        ToolInitializationOperation.INSPECTION,
+        ToolInitializationOperation.LIFECYCLE_CONTROL,
+    }:
+        return None
+    return json.dumps(
+        {
+            "success": False,
+            "error": "recipe_initialization_incomplete",
+            "initialization_id": state.initialization_id,
+            "recipe_name": state.recipe_name,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def matches_recipe_initialization_requirement(
+    state: object,
+    *,
+    initialization_id: str,
+    artifact_generation: RecipeArtifactGeneration,
+    section: str,
+    page_plan_sha256: str,
+) -> bool:
+    """Return whether a page belongs to the active immutable initialization."""
+    return (
+        isinstance(state, InitializingRecipe)
+        and state.initialization_id == initialization_id
+        and state.artifact_generation == artifact_generation
+        and any(
+            requirement.section == section and requirement.page_plan_sha256 == page_plan_sha256
+            for requirement in state.requirements
+        )
+    )
+
+
+def complete_section_response(
+    finalized: FinalizedRecipeSectionResponse,
+    enforced: Any,
+) -> Any:
+    """Credit a page only when the exact rendered bytes survived enforcement."""
+    if enforced != finalized.rendered:
+        return enforced
+    tool_ctx = finalized.tool_ctx
+    with tool_ctx.recipe_execution_lock:
+        state = tool_ctx.recipe_initialization_state
+        if (
+            not isinstance(state, InitializingRecipe)
+            or state.initialization_id != finalized.initialization_id
+            or state.artifact_generation != finalized.artifact_generation
+        ):
+            return json.dumps(
+                {"success": False, "error": "recipe_initialization_stale"},
+                separators=(",", ":"),
+            )
+        try:
+            tool_ctx.recipe_initialization_state = record_initialization_page(
+                state,
+                initialization_id=finalized.initialization_id,
+                section=finalized.section,
+                page_plan_sha256=finalized.page_plan_sha256,
+                part=finalized.part,
+            )
+        except ValueError:
+            return json.dumps(
+                {"success": False, "error": "recipe_initialization_page_rejected"},
+                separators=(",", ":"),
+            )
+    return enforced
+
+
+def complete_initialization_response(
+    finalized: FinalizedRecipeInitializationResponse,
+    enforced: Any,
+) -> Any:
+    """Install the staged snapshot and READY state after exact enforcement."""
+    if enforced != finalized.rendered:
+        return enforced
+    tool_ctx = finalized.tool_ctx
+    try:
+        prepared = prepare_recipe_execution(
+            tool_ctx,
+            snapshot=finalized.staged_snapshot,
+        )
+    except RecipeExecutionAdmissionError:
+        return json.dumps(
+            {"success": False, "error": "recipe_execution_install_failed"},
+            separators=(",", ":"),
+        )
+    with tool_ctx.recipe_execution_lock:
+        state = tool_ctx.recipe_initialization_state
+        if (
+            not isinstance(state, InitializingRecipe)
+            or state.initialization_id != finalized.initialization_id
+            or state.artifact_generation != finalized.artifact_generation
+            or not initialization_is_complete(state)
+        ):
+            return json.dumps(
+                {"success": False, "error": "recipe_initialization_incomplete"},
+                separators=(",", ":"),
+            )
+        try:
+            install_recipe_execution(
+                tool_ctx,
+                prepared_execution=prepared,
+                completion_receipt=finalized.completion_receipt,
+            )
+        except RecipeExecutionAdmissionError:
+            return json.dumps(
+                {"success": False, "error": "recipe_execution_install_failed"},
+                separators=(",", ":"),
+            )
+    return enforced
+
+
+def build_completion_response(
+    tool_ctx: ToolContext,
+    initialization_id: str,
+) -> FinalizedRecipeInitializationResponse | str:
+    """Validate server-owned completion state and build its exact receipt."""
+    with tool_ctx.recipe_execution_lock:
+        state = tool_ctx.recipe_initialization_state
+        if isinstance(state, ReadyRecipe):
+            if state.initialization_id != initialization_id:
+                return json.dumps(
+                    {"success": False, "error": "recipe_initialization_stale"},
+                    separators=(",", ":"),
+                )
+            rendered = json.dumps(
+                {
+                    "success": True,
+                    "initialization_id": initialization_id,
+                    "completion_receipt": state.completion_receipt,
+                    "recipe_name": state.recipe_name,
+                    "recipe_pull": state.artifact_generation.pull_identity(),
+                    "recipe_flow": state.flow_generation.identity(),
+                },
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            return rendered
+        if (
+            not isinstance(state, InitializingRecipe)
+            or state.initialization_id != initialization_id
+            or not initialization_is_complete(state)
+        ):
+            return json.dumps(
+                {"success": False, "error": "recipe_initialization_incomplete"},
+                separators=(",", ":"),
+            )
+        completion_receipt = _receipt(initialization_id, state.artifact_generation)
+        rendered = json.dumps(
+            {
+                "success": True,
+                "initialization_id": initialization_id,
+                "completion_receipt": completion_receipt,
+                "recipe_name": state.recipe_name,
+                "recipe_pull": state.artifact_generation.pull_identity(),
+                "recipe_flow": state.flow_generation.identity(),
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        return FinalizedRecipeInitializationResponse(
+            rendered=rendered,
+            tool_ctx=tool_ctx,
+            initialization_id=initialization_id,
+            artifact_generation=state.artifact_generation,
+            staged_snapshot=state.staged_snapshot,
+            completion_receipt=completion_receipt,
+        )

--- a/src/autoskillit/server/_recipe_initialization.py
+++ b/src/autoskillit/server/_recipe_initialization.py
@@ -12,6 +12,7 @@ from autoskillit.core import (
     RecipeExecutionSnapshot,
     RecipeFlowGeneration,
     ToolInitializationOperation,
+    get_logger,
     get_tool_def,
 )
 from autoskillit.pipeline import (
@@ -31,6 +32,8 @@ from autoskillit.server._state import _get_ctx_or_none
 
 if TYPE_CHECKING:
     from autoskillit.pipeline import ToolContext
+
+logger = get_logger(__name__)
 
 __all__ = [
     "FinalizedRecipeInitializationResponse",
@@ -216,7 +219,8 @@ def complete_initialization_response(
             tool_ctx,
             snapshot=finalized.staged_snapshot,
         )
-    except RecipeExecutionAdmissionError:
+    except Exception:
+        logger.error("recipe execution preparation failed", exc_info=True)
         return json.dumps(
             {"success": False, "error": "recipe_execution_install_failed"},
             separators=(",", ":"),

--- a/src/autoskillit/server/_recipe_section_pagination.py
+++ b/src/autoskillit/server/_recipe_section_pagination.py
@@ -12,20 +12,18 @@ from threading import Event, Lock, RLock
 
 from autoskillit.core import (
     DYNAMIC_RECIPE_SECTION_DEF,
+    RECIPE_ARTIFACT_MAX_BLOB_BYTES,
     RECIPE_SECTION_PAGINATION_POLICY_DIGEST,
     RECIPE_SECTION_PAGINATION_VERSION,
     RECIPE_SECTION_REGISTRY,
     RECIPE_SECTION_REGISTRY_DIGEST,
+    RecipeArtifactGeneration,
     RecipeSectionDef,
     canonical_recipe_section_json,
     get_logger,
     recipe_section_digest,
     recipe_section_element_digest,
     recipe_section_plan_digest,
-)
-from autoskillit.server._recipe_delivery import (
-    RECIPE_ARTIFACT_MAX_BLOB_BYTES,
-    RecipeArtifactGeneration,
 )
 from autoskillit.server.recipe_section._contracts import (
     PlannedRecipeSectionPage,
@@ -76,6 +74,7 @@ __all__ = [
     "get_or_build_recipe_section_page_plan",
     "render_recipe_section_failure",
     "render_recipe_section_page",
+    "recipe_section_continuation_binding",
     "resolve_recipe_section_definition",
     "resolve_recipe_section_bound_bytes",
     "select_recipe_section",
@@ -86,6 +85,7 @@ __all__ = [
 class _PagePlanCacheKey:
     kitchen_id: str
     generation: RecipeArtifactGeneration
+    initialization_id: str | None
     section: str
     section_sha256: str
     recipe_section_bound_bytes: int
@@ -344,28 +344,68 @@ def _render_candidate(
     terminal: bool,
 ) -> str:
     body: dict[str, object] = {
-        "body_sha256": generation.body_sha256,
         "content": page.content,
         "content_format": page.descriptor.content_format,
         "has_more": not terminal,
         "page_plan_sha256": page_plan_sha256,
+        "pagination_policy_sha256": RECIPE_SECTION_PAGINATION_POLICY_DIGEST,
         "pagination_version": RECIPE_SECTION_PAGINATION_VERSION,
         "part": part,
-        "payload_sha256": generation.payload_sha256,
         "section": selected.section,
         "section_registry_sha256": RECIPE_SECTION_REGISTRY_DIGEST,
         "section_sha256": section_sha256,
         "success": True,
         "total_parts": total_parts,
     }
+    body.update(generation.pull_identity())
+    body.pop("pull_tool")
+    if selected.initialization_id is not None:
+        body["initialization_id"] = selected.initialization_id
     if not terminal:
         body["next_part"] = part + 1
+        body["continuation"] = recipe_section_continuation_binding(
+            generation=generation,
+            initialization_id=selected.initialization_id,
+            section=selected.section,
+            section_sha256=section_sha256,
+            page_plan_sha256=page_plan_sha256,
+            next_part=part + 1,
+        )
     body.update(page.descriptor.wire_ranges())
     return json.dumps(
         body,
         ensure_ascii=False,
         separators=(",", ":"),
         sort_keys=True,
+    )
+
+
+def recipe_section_continuation_binding(
+    *,
+    generation: RecipeArtifactGeneration,
+    initialization_id: str | None,
+    section: str,
+    section_sha256: str,
+    page_plan_sha256: str,
+    next_part: int,
+) -> str:
+    """Bind the next part to the complete immutable request without a cursor."""
+    material = json.dumps(
+        {
+            "generation": generation.pull_identity(),
+            "initialization_id": initialization_id,
+            "next_part": next_part,
+            "page_plan_sha256": page_plan_sha256,
+            "section": section,
+            "section_sha256": section_sha256,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return (
+        "sha256:"
+        + hashlib.sha256(b"autoskillit.recipe-section-continuation.v1\0" + material).hexdigest()
     )
 
 
@@ -863,6 +903,7 @@ def build_recipe_section_page_plan(
         section_registry_sha256=RECIPE_SECTION_REGISTRY_DIGEST,
         pagination_policy_sha256=RECIPE_SECTION_PAGINATION_POLICY_DIGEST,
         generation=generation,
+        initialization_id=selected.initialization_id,
         section=selected.section,
         section_strategy=selected.definition.section_strategy,
         section_sha256=section_sha256,
@@ -891,6 +932,7 @@ def build_recipe_section_page_plan(
         page_plan_sha256=page_plan_sha256,
         bound_bytes=recipe_section_bound_bytes,
         pagination_version=RECIPE_SECTION_PAGINATION_VERSION,
+        pagination_policy_sha256=RECIPE_SECTION_PAGINATION_POLICY_DIGEST,
         section_registry_sha256=RECIPE_SECTION_REGISTRY_DIGEST,
         section_sha256=section_sha256,
     )
@@ -915,6 +957,7 @@ def _cache_key(
     return _PagePlanCacheKey(
         kitchen_id=kitchen_id,
         generation=generation,
+        initialization_id=selected.initialization_id,
         section=selected.section,
         section_sha256=_selected_section_sha256(selected),
         recipe_section_bound_bytes=recipe_section_bound_bytes,

--- a/src/autoskillit/server/recipe_section/_contracts.py
+++ b/src/autoskillit/server/recipe_section/_contracts.py
@@ -8,9 +8,9 @@ from typing import Literal
 from autoskillit.core import (
     RECIPE_SECTION_CONTENT_FORMAT_REGISTRY,
     RECIPE_SECTION_RESPONSE_FLOOR_BYTES,
+    RecipeArtifactGeneration,
     RecipeSectionDef,
 )
-from autoskillit.server._recipe_delivery import RecipeArtifactGeneration
 
 RecipeSectionContentFormat = Literal[
     "raw-text",
@@ -87,6 +87,7 @@ class SelectedRecipeSection:
     definition: RecipeSectionDef
     value: object
     present: bool
+    initialization_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -193,6 +194,7 @@ class RecipeSectionPlanManifest:
     section_registry_sha256: str
     pagination_policy_sha256: str
     generation: RecipeArtifactGeneration
+    initialization_id: str | None
     section: str
     section_strategy: str
     section_sha256: str

--- a/src/autoskillit/server/recipe_section/_verification.py
+++ b/src/autoskillit/server/recipe_section/_verification.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 
-from autoskillit.core import recipe_section_element_digest
-from autoskillit.server._recipe_delivery import RecipeArtifactGeneration
+from autoskillit.core import RecipeArtifactGeneration, recipe_section_element_digest
 from autoskillit.server.recipe_section._contracts import (
     RECIPE_SECTION_PAGE_RANGE_FIELDS,
     PlannedRecipeSectionPage,
@@ -255,6 +254,7 @@ def verify_finalized_recipe_section_plan(
     page_plan_sha256: str,
     bound_bytes: int,
     pagination_version: int,
+    pagination_policy_sha256: str,
     section_registry_sha256: str,
     section_sha256: str,
 ) -> None:
@@ -287,12 +287,25 @@ def verify_finalized_recipe_section_plan(
         _require(
             response.get("success") is True
             and response.get("pagination_version") == pagination_version
+            and response.get("pagination_policy_sha256") == pagination_policy_sha256
             and response.get("section_registry_sha256") == section_registry_sha256
             and response.get("section") == selected.section
             and response.get("section_sha256") == section_sha256
             and response.get("page_plan_sha256") == page_plan_sha256
+            and response.get("producer_tool") == generation.producer_tool
+            and response.get("recipe_name") == generation.recipe_name
+            and response.get("descriptor_version") == generation.descriptor_version
+            and response.get("schema_version") == generation.schema_version
             and response.get("payload_sha256") == generation.payload_sha256
+            and response.get("artifact_blob_sha256") == generation.artifact_blob_sha256
+            and response.get("artifact_blob_size_bytes") == generation.artifact_blob_size_bytes
             and response.get("body_sha256") == generation.body_sha256
+            and response.get("body_size_bytes") == generation.body_size_bytes
+            and response.get("flow_schema_version") == generation.flow_schema_version
+            and response.get("flow_sha256") == generation.flow_sha256
+            and response.get("flow_size_bytes") == generation.flow_size_bytes
+            and response.get("flow_record_count") == generation.flow_record_count
+            and response.get("initialization_id") == selected.initialization_id
             and response.get("part") == part
             and response.get("total_parts") == len(pages)
             and response.get("has_more") is not terminal
@@ -306,8 +319,12 @@ def verify_finalized_recipe_section_plan(
             "recipe section page content digest changed",
         )
         _require(
-            (response.get("next_part") == part + 1)
+            (
+                response.get("next_part") == part + 1
+                and isinstance(response.get("continuation"), str)
+                and response["continuation"].startswith("sha256:")
+            )
             if not terminal
-            else "next_part" not in response,
+            else "next_part" not in response and "continuation" not in response,
             "recipe section continuation metadata is inconsistent",
         )

--- a/src/autoskillit/server/tools/_cancellation_shield.py
+++ b/src/autoskillit/server/tools/_cancellation_shield.py
@@ -18,6 +18,9 @@ from typing import Any, Literal, TypeVar, cast, overload
 import anyio
 
 from autoskillit.core import FleetErrorCode, fleet_error, get_logger
+from autoskillit.server._recipe_initialization import (
+    admit_registered_tool_during_initialization,
+)
 
 logger = get_logger(__name__)
 
@@ -84,6 +87,8 @@ def _cancellation_shield(
     def decorator(fn: F) -> F:
         @wraps(fn)
         async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            if (denial := admit_registered_tool_during_initialization(fn.__name__)) is not None:
+                return denial
             if typed_mode:
                 typed_state_factory = cast(Callable[[], Any], state_factory)
                 typed_context_var = cast(ContextVar[Any], state_context_var)

--- a/src/autoskillit/server/tools/_serve_helpers.py
+++ b/src/autoskillit/server/tools/_serve_helpers.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 from autoskillit.core import (
     RESPONSE_BACKSTOP_EXEMPTION_REGISTRY,
     RESPONSE_BACKSTOP_EXEMPTION_REGISTRY_DIGEST,
-    RecipeBindingProjection,
+    FinalizedRecipeProjection,
     SkillExecutionRole,
 )
 from autoskillit.server._misc import SkillProjectionContext, project_agent_skill_document
@@ -110,16 +110,20 @@ def response_backstop_tool_meta(
 def render_served_response(payload: dict[str, Any]) -> str:
     """Render the authoritative pre-backstop response used by recipe serve tools."""
     public_payload = dict(payload)
-    public_payload.pop("_compiled_bindings", None)
+    public_payload.pop("_finalized_projection", None)
     return json.dumps(public_payload, ensure_ascii=False, separators=(",", ":"))
 
 
-def pop_compiled_bindings(
+def pop_finalized_recipe_projection(
     payload: dict[str, Any],
-) -> RecipeBindingProjection | None:
-    """Remove and return the internal post-prune carrier before serialization."""
-    candidate = payload.pop("_compiled_bindings", None)
-    return candidate if isinstance(candidate, RecipeBindingProjection) else None
+) -> FinalizedRecipeProjection | None:
+    """Remove the finalized projection for a later fail-closed finalization gate."""
+    candidate = payload.pop("_finalized_projection", None)
+    if candidate is None:
+        return None
+    if not isinstance(candidate, FinalizedRecipeProjection):
+        raise RuntimeError("served recipe response has an invalid _finalized_projection carrier")
+    return candidate
 
 
 def build_open_kitchen_recipe_payload(result: dict[str, Any], *, version: str) -> dict[str, Any]:
@@ -238,6 +242,6 @@ def serve_recipe(
     return ctx.recipes.load_and_validate(
         name,
         ctx.project_dir,
-        include_compiled_bindings=True,
+        include_finalized_projection=True,
         **kwargs,
     )

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -151,12 +151,13 @@ def _write_dispatch_to_campaign_state(
 
 
 def _get_food_truck_prompt_builder(
+    backend: CodingAgentBackend,
     has_unguarded_filesystem_access: bool = False,
     projected_sous_chef: str = "",
 ) -> Callable[..., str]:
     """Return the food truck prompt builder with mcp_prefix pre-bound."""
 
-    mcp_prefix = detect_autoskillit_mcp_prefix()
+    mcp_prefix = detect_autoskillit_mcp_prefix(backend.capabilities)
     return functools.partial(
         _build_food_truck_prompt,
         mcp_prefix=mcp_prefix,
@@ -495,6 +496,12 @@ async def dispatch_food_truck(
             _override_backend is not None
             and _override_backend.capabilities.anthropic_provider_capable
         )
+        effective_dispatch_backend = _override_backend or tool_ctx.backend
+        if effective_dispatch_backend is None:
+            return fleet_error(
+                FleetErrorCode.FLEET_INVALID_BACKEND,
+                "Fleet dispatch requires a configured backend.",
+            )
         try:
             with anyio.fail_after(tool_ctx.config.run_skill.mcp_tool_timeout_sec):
                 result = await execute_dispatch(
@@ -505,14 +512,13 @@ async def dispatch_food_truck(
                     dispatch_name=dispatch_name,
                     timeout_sec=timeout_sec,
                     prompt_builder=_get_food_truck_prompt_builder(
+                        effective_dispatch_backend,
                         has_unguarded_filesystem_access=(
-                            _override_backend.capabilities.has_unguarded_filesystem_access
-                            if _override_backend
-                            else False
+                            effective_dispatch_backend.capabilities.has_unguarded_filesystem_access
                         ),
                         projected_sous_chef=_project_food_truck_sous_chef(
                             tool_ctx,
-                            _override_backend,
+                            effective_dispatch_backend,
                         ),
                     ),
                     quota_checker=lambda cfg: check_and_sleep_if_needed(

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -33,6 +33,7 @@ from autoskillit.core import (
     _collect_disabled_feature_tags,
     atomic_write,
     clear_kitchens_for_pid,
+    detect_autoskillit_mcp_prefix,
     fast_dumps,
     find_latest_session_id,
     get_logger,
@@ -71,9 +72,13 @@ from autoskillit.server._recipe_delivery import (
     document_recipe_delivery_contract,
     enforce_recipe_resource_response,
     finalize_recipe_delivery,
+    prepare_recipe_delivery_generation,
     retire_recipe_artifacts,
 )
 from autoskillit.server._recipe_execution import clear_recipe_execution
+from autoskillit.server._recipe_generation import (
+    retire_kitchen as retire_recipe_generation,
+)
 from autoskillit.server.tools._authority_feedback import (
     build_authority_clobber_warnings,
     build_authority_rejection_envelope,
@@ -92,7 +97,7 @@ from autoskillit.server.tools._preflight import (
 from autoskillit.server.tools._serve_helpers import (
     build_backend_capabilities_map,
     build_open_kitchen_recipe_payload,
-    pop_compiled_bindings,
+    pop_finalized_recipe_projection,
     project_orchestrator_guidance,
     render_served_response,
     response_backstop_tool_meta,
@@ -456,7 +461,7 @@ def _auto_init_pipeline_tracker(tool_ctx: ToolContext) -> None:
         logger.warning("pipeline_tracker_auto_init_write_failed", exc_info=True)
 
 
-async def _open_kitchen_handler() -> str | None:
+async def _open_kitchen_handler(*, preserve_active_recipe: bool = False) -> str | None:
     """Set the tools-enabled flag. Extracted for testability.
 
     Returns ``None`` on success, or a JSON failure envelope string on error.
@@ -466,11 +471,12 @@ async def _open_kitchen_handler() -> str | None:
     ctx = _get_ctx()
     ctx.gate.enable()
     ctx.kitchen_id = resolve_kitchen_id()
-    ctx.active_recipe_packs = frozenset()
-    ctx.active_recipe_features = frozenset()
-    ctx.active_recipe_steps = {}
-    ctx.active_recipe_ingredients = frozenset()
-    clear_recipe_execution(ctx)
+    if not preserve_active_recipe:
+        ctx.active_recipe_packs = frozenset()
+        ctx.active_recipe_features = frozenset()
+        ctx.active_recipe_steps = {}
+        ctx.active_recipe_ingredients = frozenset()
+        clear_recipe_execution(ctx)
     logger.info("open_kitchen", gate_state="open", kitchen_id=ctx.kitchen_id)
     _supports_quota = _backend_supports_quota(ctx)
 
@@ -582,13 +588,16 @@ def _close_kitchen_handler() -> None:
         unregister_active_kitchen(ctx.kitchen_id)
     except Exception:
         logger.warning("close_kitchen_registry_failed", exc_info=True)
-    if (
-        isinstance(ctx.temp_dir, Path)
-        and isinstance(ctx.kitchen_id, str)
-        and ctx.kitchen_id
-        and not retire_recipe_artifacts(ctx.temp_dir, kitchen_id=ctx.kitchen_id)
-    ):
-        logger.warning("close_kitchen_recipe_artifact_retirement_failed")
+    if isinstance(ctx.kitchen_id, str) and ctx.kitchen_id:
+        if isinstance(ctx.temp_dir, Path) and not retire_recipe_artifacts(
+            ctx.temp_dir,
+            kitchen_id=ctx.kitchen_id,
+        ):
+            logger.warning("close_kitchen_recipe_artifact_retirement_failed")
+        try:
+            retire_recipe_generation(ctx.kitchen_id)
+        except Exception:
+            logger.warning("close_kitchen_recipe_generation_retirement_failed", exc_info=True)
     ctx.active_recipe_packs = None
     ctx.active_recipe_features = None
     ctx.active_recipe_steps = None
@@ -724,7 +733,9 @@ def get_recipe(name: str) -> str:
             backend_capabilities_map=_backend_capabilities_map,
             backend_origin_map=_backend_origin_map,
         )
-        _resource_compiled_bindings = pop_compiled_bindings(result)
+        _resource_finalized_projection = (
+            pop_finalized_recipe_projection(result) if result.get("valid", False) else None
+        )
     except ProcessStaleError:
         logger.warning("get_recipe_failure", recipe=name, stage="process_stale", exc_info=True)
         return json.dumps({"error": f"Recipe '{name}' composition failed — process stale."})
@@ -740,6 +751,8 @@ def get_recipe(name: str) -> str:
                 "suggestions": result.get("suggestions", []),
             }
         )
+    if _resource_finalized_projection is None:
+        return json.dumps({"error": f"Recipe '{name}' has no finalized projection."})
     if not result.get("dispatch_feasible", True):
         return json.dumps(
             {
@@ -748,12 +761,22 @@ def get_recipe(name: str) -> str:
                 "infeasible_steps": result.get("infeasible_steps", []),
             }
         )
+    prepared_generation = prepare_recipe_delivery_generation(
+        result,
+        recipe_name=name,
+        tool_ctx=ctx,
+        finalized_projection=_resource_finalized_projection,
+    )
     finalized = finalize_recipe_delivery(
         result,
         surface="get_recipe",
         recipe_name=name,
         tool_ctx=ctx,
-        compiled_bindings=_resource_compiled_bindings,
+        finalized_projection=_resource_finalized_projection,
+        flow_generation=prepared_generation.flow_generation,
+        canonical_artifact_payload=prepared_generation.canonical_artifact_payload,
+        execution_snapshot=prepared_generation.execution_snapshot,
+        normalized_compile_key=prepared_generation.normalized_compile_key,
     )
     return enforce_recipe_resource_response(finalized, tool_ctx=ctx)
 
@@ -853,7 +876,9 @@ async def open_kitchen(
         tool_ctx = _get_ctx()
 
         if not _skip_handler:
-            handler_err = await _open_kitchen_handler()
+            handler_err = await _open_kitchen_handler(
+                preserve_active_recipe=ingredients_only,
+            )
             if handler_err is not None:
                 return handler_err
         else:
@@ -1004,7 +1029,11 @@ async def open_kitchen(
                         backend_capabilities_map=_backend_capabilities_map,
                         backend_origin_map=_backend_origin_map,
                     )
-                    _deferred_compiled_bindings = pop_compiled_bindings(result)
+                    _deferred_finalized_projection = (
+                        pop_finalized_recipe_projection(result)
+                        if result.get("valid", False)
+                        else None
+                    )
                 except ProcessStaleError as exc:
                     logger.warning("open_kitchen_failure", stage="process_stale", exc_info=True)
                     return _kitchen_failure_envelope(exc, stage="process_stale")
@@ -1013,6 +1042,19 @@ async def open_kitchen(
                         "open_kitchen_failure", stage="load_and_validate", exc_info=True
                     )
                     return _kitchen_failure_envelope(exc, stage="load_and_validate")
+                if ingredients_only:
+                    inspection = build_open_kitchen_recipe_payload(result, version=__version__)
+                    inspection = strip_ingredients_only_keys(inspection)
+                    if _raw_recipe is not None:
+                        warnings = _check_override_keys(
+                            overrides,
+                            frozenset(_raw_recipe.ingredients.keys()),
+                            set(_session_overrides.keys()),
+                            _config_layer,
+                        )
+                        if warnings:
+                            inspection["warnings"] = warnings
+                    return render_served_response(inspection)
                 tool_ctx.active_recipe_packs = frozenset(result.get("requires_packs", []))
                 tool_ctx.active_recipe_features = frozenset(result.get("requires_features", []))
                 tool_ctx.recipe_content_hash = result.get("content_hash", "")
@@ -1103,6 +1145,14 @@ async def open_kitchen(
                     tool_ctx.session_serve_overrides = dict(overrides)
                     tool_ctx.session_serve_defer_unresolved = not bool(overrides)
                 if not ingredients_only:
+                    if _deferred_finalized_projection is None:
+                        return _recipe_validation_error_response(name, result)
+                    _prepared_generation = prepare_recipe_delivery_generation(
+                        result,
+                        recipe_name=name,
+                        tool_ctx=tool_ctx,
+                        finalized_projection=_deferred_finalized_projection,
+                    )
                     return cast(
                         str,
                         finalize_recipe_delivery(
@@ -1110,8 +1160,14 @@ async def open_kitchen(
                             surface="open_kitchen_deferred_recall",
                             recipe_name=name,
                             tool_ctx=tool_ctx,
+                            finalized_projection=_deferred_finalized_projection,
+                            flow_generation=_prepared_generation.flow_generation,
+                            canonical_artifact_payload=(
+                                _prepared_generation.canonical_artifact_payload
+                            ),
+                            execution_snapshot=(_prepared_generation.execution_snapshot),
+                            normalized_compile_key=(_prepared_generation.normalized_compile_key),
                             delivery_request=delivery_request,
-                            compiled_bindings=_deferred_compiled_bindings,
                         ),
                     )
                 return render_served_response(result)
@@ -1130,13 +1186,28 @@ async def open_kitchen(
                     backend_capabilities_map=_backend_capabilities_map,
                     backend_origin_map=_backend_origin_map,
                 )
-                _normal_compiled_bindings = pop_compiled_bindings(result)
+                _normal_finalized_projection = (
+                    pop_finalized_recipe_projection(result) if result.get("valid", False) else None
+                )
             except ProcessStaleError as exc:
                 logger.warning("open_kitchen_failure", stage="process_stale", exc_info=True)
                 return _kitchen_failure_envelope(exc, stage="process_stale")
             except Exception as exc:
                 logger.warning("open_kitchen_failure", stage="load_and_validate", exc_info=True)
                 return _kitchen_failure_envelope(exc, stage="load_and_validate")
+            if ingredients_only:
+                inspection = build_open_kitchen_recipe_payload(result, version=__version__)
+                inspection = strip_ingredients_only_keys(inspection)
+                if _raw_recipe is not None:
+                    warnings = _check_override_keys(
+                        overrides,
+                        frozenset(_raw_recipe.ingredients.keys()),
+                        set(_session_overrides.keys()),
+                        _config_layer,
+                    )
+                    if warnings:
+                        inspection["warnings"] = warnings
+                return render_served_response(inspection)
 
             tool_ctx.active_recipe_packs = frozenset(result.get("requires_packs", []))
             tool_ctx.active_recipe_features = frozenset(result.get("requires_features", []))
@@ -1247,7 +1318,13 @@ async def open_kitchen(
                     result["warnings"] = _override_warnings
 
             try:
-                warning = _build_hook_diagnostic_warning()
+                warning = (
+                    _build_hook_diagnostic_warning(
+                        detect_autoskillit_mcp_prefix(tool_ctx.backend.capabilities)
+                    )
+                    if tool_ctx.backend is not None
+                    else None
+                )
             except Exception as exc:
                 logger.warning("open_kitchen_failure", stage="hook_diagnostic", exc_info=True)
                 return _kitchen_failure_envelope(exc, stage="hook_diagnostic")
@@ -1269,6 +1346,14 @@ async def open_kitchen(
                 return _validation_err
 
             if not ingredients_only:
+                if _normal_finalized_projection is None:
+                    return _recipe_validation_error_response(name, result)
+                _prepared_generation = prepare_recipe_delivery_generation(
+                    result,
+                    recipe_name=name,
+                    tool_ctx=tool_ctx,
+                    finalized_projection=_normal_finalized_projection,
+                )
                 return cast(
                     str,
                     finalize_recipe_delivery(
@@ -1276,8 +1361,14 @@ async def open_kitchen(
                         surface="open_kitchen",
                         recipe_name=name,
                         tool_ctx=tool_ctx,
+                        finalized_projection=_normal_finalized_projection,
+                        flow_generation=_prepared_generation.flow_generation,
+                        canonical_artifact_payload=(
+                            _prepared_generation.canonical_artifact_payload
+                        ),
+                        execution_snapshot=_prepared_generation.execution_snapshot,
+                        normalized_compile_key=(_prepared_generation.normalized_compile_key),
                         delivery_request=delivery_request,
-                        compiled_bindings=_normal_compiled_bindings,
                     ),
                 )
 
@@ -1316,7 +1407,13 @@ async def open_kitchen(
             )
 
         try:
-            warning = _build_hook_diagnostic_warning()
+            warning = (
+                _build_hook_diagnostic_warning(
+                    detect_autoskillit_mcp_prefix(tool_ctx.backend.capabilities)
+                )
+                if tool_ctx.backend is not None
+                else None
+            )
         except Exception as exc:
             logger.warning("open_kitchen_failure", stage="hook_diagnostic", exc_info=True)
             return _kitchen_failure_envelope(exc, stage="hook_diagnostic")

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -1774,7 +1774,7 @@ def _register_active_recipe_kitchen(
     project_path: str,
 ) -> None:
     """Publish one kitchen to both process and recipe-generation lifecycles."""
-    from autoskillit.server._recipe_generation import activate_kitchen
+    from autoskillit.server._recipe_generation import activate_kitchen  # circular-break
 
     register_active_kitchen(kitchen_id, pid, project_path)
     activate_kitchen(kitchen_id)

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -813,6 +813,30 @@ def _check_override_keys(
     return warnings
 
 
+def _render_ingredients_only_response(
+    result: dict[str, Any],
+    *,
+    declared_ingredients: frozenset[str] | None,
+    overrides: dict[str, str] | None,
+    session_keys: set[str],
+    config_layer: dict[str, str],
+) -> str:
+    """Build the canonical ingredients-only inspection response."""
+    inspection = strip_ingredients_only_keys(
+        build_open_kitchen_recipe_payload(result, version=__version__)
+    )
+    if declared_ingredients is not None:
+        warnings = _check_override_keys(
+            overrides,
+            declared_ingredients,
+            session_keys,
+            config_layer,
+        )
+        if warnings:
+            inspection["warnings"] = warnings
+    return render_served_response(inspection)
+
+
 @mcp.tool(
     tags={"autoskillit"},
     annotations={"readOnlyHint": True},
@@ -1043,18 +1067,15 @@ async def open_kitchen(
                     )
                     return _kitchen_failure_envelope(exc, stage="load_and_validate")
                 if ingredients_only:
-                    inspection = build_open_kitchen_recipe_payload(result, version=__version__)
-                    inspection = strip_ingredients_only_keys(inspection)
-                    if _raw_recipe is not None:
-                        warnings = _check_override_keys(
-                            overrides,
-                            frozenset(_raw_recipe.ingredients.keys()),
-                            set(_session_overrides.keys()),
-                            _config_layer,
-                        )
-                        if warnings:
-                            inspection["warnings"] = warnings
-                    return render_served_response(inspection)
+                    return _render_ingredients_only_response(
+                        result,
+                        declared_ingredients=(
+                            frozenset(_raw_recipe.ingredients) if _raw_recipe is not None else None
+                        ),
+                        overrides=overrides,
+                        session_keys=set(_session_overrides),
+                        config_layer=_config_layer,
+                    )
                 tool_ctx.active_recipe_packs = frozenset(result.get("requires_packs", []))
                 tool_ctx.active_recipe_features = frozenset(result.get("requires_features", []))
                 tool_ctx.recipe_content_hash = result.get("content_hash", "")
@@ -1196,18 +1217,15 @@ async def open_kitchen(
                 logger.warning("open_kitchen_failure", stage="load_and_validate", exc_info=True)
                 return _kitchen_failure_envelope(exc, stage="load_and_validate")
             if ingredients_only:
-                inspection = build_open_kitchen_recipe_payload(result, version=__version__)
-                inspection = strip_ingredients_only_keys(inspection)
-                if _raw_recipe is not None:
-                    warnings = _check_override_keys(
-                        overrides,
-                        frozenset(_raw_recipe.ingredients.keys()),
-                        set(_session_overrides.keys()),
-                        _config_layer,
-                    )
-                    if warnings:
-                        inspection["warnings"] = warnings
-                return render_served_response(inspection)
+                return _render_ingredients_only_response(
+                    result,
+                    declared_ingredients=(
+                        frozenset(_raw_recipe.ingredients) if _raw_recipe is not None else None
+                    ),
+                    overrides=overrides,
+                    session_keys=set(_session_overrides),
+                    config_layer=_config_layer,
+                )
 
             tool_ctx.active_recipe_packs = frozenset(result.get("requires_packs", []))
             tool_ctx.active_recipe_features = frozenset(result.get("requires_features", []))

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -877,7 +877,7 @@ async def open_kitchen(
 
         if not _skip_handler:
             handler_err = await _open_kitchen_handler(
-                preserve_active_recipe=ingredients_only,
+                preserve_active_recipe=ingredients_only and _ctx_pre.gate.enabled,
             )
             if handler_err is not None:
                 return handler_err

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -77,6 +77,9 @@ from autoskillit.server._recipe_delivery import (
 )
 from autoskillit.server._recipe_execution import clear_recipe_execution
 from autoskillit.server._recipe_generation import (
+    activate_kitchen as activate_recipe_generation,
+)
+from autoskillit.server._recipe_generation import (
     retire_kitchen as retire_recipe_generation,
 )
 from autoskillit.server.tools._authority_feedback import (
@@ -518,6 +521,7 @@ async def _open_kitchen_handler(*, preserve_active_recipe: bool = False) -> str 
         register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
     except Exception:
         logger.warning("open_kitchen_registry_failed", exc_info=True)
+    activate_recipe_generation(ctx.kitchen_id)
 
     try:
         prune_stale_kitchen_state(ctx.project_dir, ctx.kitchen_id)

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -77,9 +77,6 @@ from autoskillit.server._recipe_delivery import (
 )
 from autoskillit.server._recipe_execution import clear_recipe_execution
 from autoskillit.server._recipe_generation import (
-    activate_kitchen as activate_recipe_generation,
-)
-from autoskillit.server._recipe_generation import (
     retire_kitchen as retire_recipe_generation,
 )
 from autoskillit.server.tools._authority_feedback import (
@@ -518,10 +515,9 @@ async def _open_kitchen_handler(*, preserve_active_recipe: bool = False) -> str 
         logger.warning("open_kitchen_clear_pid_failed", exc_info=True)
 
     try:
-        register_active_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
+        _register_active_recipe_kitchen(ctx.kitchen_id, os.getpid(), str(ctx.project_dir))
     except Exception:
         logger.warning("open_kitchen_registry_failed", exc_info=True)
-    activate_recipe_generation(ctx.kitchen_id)
 
     try:
         prune_stale_kitchen_state(ctx.project_dir, ctx.kitchen_id)
@@ -1770,3 +1766,15 @@ async def reload_session() -> str:
     except Exception as exc:
         logger.error("reload_session unhandled exception", exc_info=True)
         return json.dumps({"status": "error", "error": f"{type(exc).__name__}: {exc}"})
+
+
+def _register_active_recipe_kitchen(
+    kitchen_id: str,
+    pid: int,
+    project_path: str,
+) -> None:
+    """Publish one kitchen to both process and recipe-generation lifecycles."""
+    from autoskillit.server._recipe_generation import activate_kitchen
+
+    register_active_kitchen(kitchen_id, pid, project_path)
+    activate_kitchen(kitchen_id)

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -457,19 +457,9 @@ async def load_recipe(
                     stage="validate_result",
                 )
                 return _validation_err
-            if not ingredients_only:
+            if not ingredients_only and result.get("valid", False):
                 if _finalized_projection is None:
-                    logger.error(
-                        "load_recipe_fail_closed",
-                        tool="load_recipe",
-                        stage="finalized_projection",
-                    )
-                    return json.dumps(
-                        {
-                            "success": False,
-                            "error": f"Recipe '{name}' has no finalized projection.",
-                        }
-                    )
+                    raise RuntimeError("valid recipe is missing its finalized projection")
                 _prepared_generation = prepare_recipe_delivery_generation(
                     result,
                     recipe_name=name,
@@ -591,22 +581,24 @@ async def get_recipe_section(
             artifact_dir = getattr(tool_ctx, "temp_dir", None)
             if not isinstance(artifact_dir, Path):
                 return _recipe_section_failure("invalid_recipe_artifact_identity")
-
-            identity = RecipeArtifactGeneration(
-                producer_tool=producer_tool,
-                recipe_name=requested_recipe_name,
-                descriptor_version=descriptor_version,
-                schema_version=schema_version,
-                payload_sha256=payload_sha256,
-                artifact_blob_sha256=artifact_blob_sha256,
-                artifact_blob_size_bytes=artifact_blob_size_bytes,
-                body_sha256=body_sha256,
-                body_size_bytes=body_size_bytes,
-                flow_schema_version=flow_schema_version,
-                flow_sha256=flow_sha256,
-                flow_size_bytes=flow_size_bytes,
-                flow_record_count=flow_record_count,
-            )
+            try:
+                identity = RecipeArtifactGeneration(
+                    producer_tool=producer_tool,
+                    recipe_name=requested_recipe_name,
+                    descriptor_version=descriptor_version,
+                    schema_version=schema_version,
+                    payload_sha256=payload_sha256,
+                    artifact_blob_sha256=artifact_blob_sha256,
+                    artifact_blob_size_bytes=artifact_blob_size_bytes,
+                    body_sha256=body_sha256,
+                    body_size_bytes=body_size_bytes,
+                    flow_schema_version=flow_schema_version,
+                    flow_sha256=flow_sha256,
+                    flow_size_bytes=flow_size_bytes,
+                    flow_record_count=flow_record_count,
+                )
+            except (TypeError, ValueError):
+                return _recipe_section_failure("invalid_recipe_artifact_identity")
             if not identity.has_valid_read_bounds():
                 return _recipe_section_failure("invalid_recipe_artifact_identity")
             if part < 0:

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -459,7 +459,17 @@ async def load_recipe(
                 return _validation_err
             if not ingredients_only:
                 if _finalized_projection is None:
-                    return render_served_response(result)
+                    logger.error(
+                        "load_recipe_fail_closed",
+                        tool="load_recipe",
+                        stage="finalized_projection",
+                    )
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "error": f"Recipe '{name}' has no finalized projection.",
+                        }
+                    )
                 _prepared_generation = prepare_recipe_delivery_generation(
                     result,
                     recipe_name=name,

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 from collections.abc import Mapping
 from contextvars import ContextVar
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
 
@@ -13,7 +14,6 @@ import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit import __version__
 from autoskillit.config import (
     build_config_authoritative_layer,
     build_config_default_layer,
@@ -21,6 +21,7 @@ from autoskillit.config import (
 )
 from autoskillit.core import (
     BackendCapabilities,
+    RecipeArtifactGeneration,
     RecipeDeliveryRequest,
     fast_dumps,
     get_logger,
@@ -28,7 +29,11 @@ from autoskillit.core import (
     resolve_general_output_token_limit,
     temp_dir_display_str,
 )  # noqa: F401
-from autoskillit.pipeline import GATED_TOOLS, UNGATED_TOOLS  # noqa: F401
+from autoskillit.pipeline import (  # noqa: F401
+    GATED_TOOLS,
+    UNGATED_TOOLS,
+    InitializingRecipe,
+)
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import (
@@ -39,22 +44,31 @@ from autoskillit.server._misc import (
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._recipe_delivery import (
     RecipeArtifactError,
-    RecipeArtifactGeneration,
     RecipeArtifactSchemaError,
     document_recipe_delivery_contract,
     finalize_recipe_delivery,
     load_recipe_artifact,
     persist_recipe_artifact,
+    prepare_recipe_delivery_generation,
     recipe_pull_producers,
     recipe_recreation_producers,
 )
-from autoskillit.server._recipe_execution import get_recipe_execution
+from autoskillit.server._recipe_generation import (
+    get_recipe_generation_store,
+    thaw_recipe_generation_mapping,
+)
+from autoskillit.server._recipe_initialization import (
+    FinalizedRecipeSectionResponse,
+    build_completion_response,
+    matches_recipe_initialization_requirement,
+)
 from autoskillit.server._recipe_section_pagination import (
     RecipeSectionBoundError,
     RecipeSectionNonConvergenceError,
     RecipeSectionPaginationError,
     RecipeSectionRequestState,
     get_or_build_recipe_section_page_plan,
+    recipe_section_continuation_binding,
     render_recipe_section_failure,
     render_recipe_section_page,
     resolve_recipe_section_bound_bytes,
@@ -70,8 +84,7 @@ from autoskillit.server.tools._auto_overrides import (
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 from autoskillit.server.tools._serve_helpers import (
     build_backend_capabilities_map,
-    build_open_kitchen_recipe_payload,
-    pop_compiled_bindings,
+    pop_finalized_recipe_projection,
     render_served_response,
     response_backstop_tool_meta,
     serve_recipe,
@@ -391,7 +404,9 @@ async def load_recipe(
                 backend_capabilities_map=_backend_capabilities_map,
                 backend_origin_map=_backend_origin_map,
             )
-            _compiled_bindings = pop_compiled_bindings(result)
+            _finalized_projection = (
+                pop_finalized_recipe_projection(result) if result.get("valid", False) else None
+            )
             recipe_info = _recipe_info_pre
             result = await _apply_triage_gate(result, name, recipe_info=recipe_info)
             if not result.get("valid", False):
@@ -443,6 +458,14 @@ async def load_recipe(
                 )
                 return _validation_err
             if not ingredients_only:
+                if _finalized_projection is None:
+                    return render_served_response(result)
+                _prepared_generation = prepare_recipe_delivery_generation(
+                    result,
+                    recipe_name=name,
+                    tool_ctx=tool_ctx,
+                    finalized_projection=_finalized_projection,
+                )
                 return cast(
                     str,
                     finalize_recipe_delivery(
@@ -450,10 +473,14 @@ async def load_recipe(
                         surface="load_recipe",
                         recipe_name=name,
                         tool_ctx=tool_ctx,
-                        delivery_request=delivery_request,
-                        compiled_bindings=(
-                            _compiled_bindings if result.get("valid", False) else None
+                        finalized_projection=_finalized_projection,
+                        flow_generation=_prepared_generation.flow_generation,
+                        canonical_artifact_payload=(
+                            _prepared_generation.canonical_artifact_payload
                         ),
+                        execution_snapshot=_prepared_generation.execution_snapshot,
+                        normalized_compile_key=(_prepared_generation.normalized_compile_key),
+                        delivery_request=delivery_request,
                     ),
                 )
             return render_served_response(result)
@@ -480,7 +507,14 @@ async def get_recipe_section(
     artifact_blob_size_bytes: int,
     body_sha256: str,
     body_size_bytes: int,
+    flow_schema_version: int,
+    flow_sha256: str,
+    flow_size_bytes: int,
+    flow_record_count: int,
     part: int = 0,
+    initialization_id: str | None = None,
+    page_plan_sha256: str | None = None,
+    continuation: str | None = None,
 ) -> str:
     """Retrieve a recipe step or section from the persisted recipe artifact.
 
@@ -515,6 +549,10 @@ async def get_recipe_section(
         artifact_blob_size_bytes: Exact persisted blob byte size.
         body_sha256: Digest of the recipe body bytes.
         body_size_bytes: Exact recipe body byte size.
+        flow_schema_version: Exact flow-record schema version.
+        flow_sha256: Digest of the complete ordered flow generation.
+        flow_size_bytes: Exact length-prefixed flow-generation byte size.
+        flow_record_count: Exact number of canonical flow records.
 
     Returns:
         A versioned JSON page. Nonterminal pages include ``next_part``;
@@ -554,6 +592,10 @@ async def get_recipe_section(
                 artifact_blob_size_bytes=artifact_blob_size_bytes,
                 body_sha256=body_sha256,
                 body_size_bytes=body_size_bytes,
+                flow_schema_version=flow_schema_version,
+                flow_sha256=flow_sha256,
+                flow_size_bytes=flow_size_bytes,
+                flow_record_count=flow_record_count,
             )
             if not identity.has_valid_read_bounds():
                 return _recipe_section_failure("invalid_recipe_artifact_identity")
@@ -576,99 +618,38 @@ async def get_recipe_section(
             except RecipeArtifactError:
                 if producer_tool not in recipe_recreation_producers():
                     return _recipe_section_failure("recipe_artifact_unavailable")
-                # Recreation path: re-invoke the same serve pipeline that
-                # built the artifact originally. This handles the case
-                # where the artifact was pruned/garbage-collected between
-                # open_kitchen and get_recipe_section calls. Use the
-                # session_serve_overrides snapshot to preserve idempotence
-                # — re-serving with the same overrides must produce the
-                # same content (issue #4208 hardening).
-                _recreate_envelope_err = None
+                generation_record = get_recipe_generation_store().lookup_artifact(
+                    tool_ctx.kitchen_id,
+                    identity,
+                )
+                if generation_record is None:
+                    return _recipe_section_failure("invalid_recipe_artifact_identity")
                 try:
-                    _defaults = resolve_ingredient_defaults(tool_ctx.project_dir)
-                    _config_layer = build_config_authoritative_layer(_defaults)
-                    _config_default = build_config_default_layer(_defaults)
-                    _session_overrides: dict[str, str] = {
-                        "kitchen_id": tool_ctx.kitchen_id,
-                        "diagnostics_log_dir": str(
-                            resolve_log_dir(tool_ctx.config.linux_tracing.log_dir)
-                        ),
-                    }
-                    _caller_overrides = (
-                        dict(tool_ctx.session_serve_overrides)
-                        if tool_ctx.session_serve_overrides is not None
-                        else None
+                    recreated_payload = thaw_recipe_generation_mapping(
+                        generation_record.artifact_payload
                     )
-                    _recreate = serve_recipe(
-                        tool_ctx,
-                        requested_recipe_name,
-                        caller_overrides=_caller_overrides,
-                        config_default=_config_default,
-                        session_overrides=_session_overrides,
-                        config_layer=_config_layer,
-                        resolved_defaults=_defaults,
-                        ingredients_only=False,
-                    )
-                    pop_compiled_bindings(_recreate)
-                    if not _recreate.get("valid", False):
-                        return _recipe_section_failure(
-                            "recipe_artifact_unavailable",
-                            context={"detail": "recreation returned invalid recipe"},
-                        )
-                    if producer_tool == "open_kitchen":
-                        _recreate = build_open_kitchen_recipe_payload(
-                            _recreate, version=__version__
-                        )
-                    installed_execution = get_recipe_execution(tool_ctx)
-                    if (
-                        installed_execution is not None
-                        and installed_execution.snapshot.recipe_name == requested_recipe_name
-                        and installed_execution.snapshot.content_hash
-                        == _recreate.get("content_hash")
-                        and installed_execution.snapshot.composite_hash
-                        == _recreate.get("composite_hash")
-                    ):
-                        snapshot = installed_execution.snapshot
-                        _recreate["recipe_execution"] = {
-                            "execution_id": snapshot.execution_id,
-                            "invocation_template_digests": dict(snapshot.template_digests),
-                            "snapshot_digest": snapshot.snapshot_digest,
-                        }
-
-                    try:
-                        recreated_generation = persist_recipe_artifact(
-                            artifact_dir,
-                            kitchen_id=tool_ctx.kitchen_id,
-                            producer_tool=producer_tool,
-                            recipe_name=requested_recipe_name,
-                            payload=_recreate,
-                        )
-                    except RecipeArtifactSchemaError as exc:
-                        logger.warning(
-                            "get_recipe_section_schema_mismatch",
-                            stage="recreate_persist",
-                            detail=str(exc),
-                        )
-                        return _recipe_section_failure("recipe_artifact_schema_mismatch")
-                    except (OSError, RecipeArtifactError):
-                        return _recipe_section_failure(
-                            "recipe_artifact_unavailable",
-                            context={"detail": "recreation write failed"},
-                        )
-                    if recreated_generation != identity:
-                        return _recipe_section_failure("invalid_recipe_artifact_identity")
-                except Exception:
-                    logger.warning(
-                        "get_recipe_section_recreate_failed",
+                    recreated_generation = persist_recipe_artifact(
+                        artifact_dir,
+                        kitchen_id=tool_ctx.kitchen_id,
+                        producer_tool=producer_tool,
                         recipe_name=requested_recipe_name,
-                        exc_info=True,
+                        payload=recreated_payload,
+                        flow_generation=generation_record.flow_generation,
                     )
-                    _recreate_envelope_err = "recreation failed"
-                if _recreate_envelope_err is not None:
+                except RecipeArtifactSchemaError as exc:
+                    logger.warning(
+                        "get_recipe_section_schema_mismatch",
+                        stage="recreate_persist",
+                        detail=str(exc),
+                    )
+                    return _recipe_section_failure("recipe_artifact_schema_mismatch")
+                except (OSError, RecipeArtifactError, TypeError):
                     return _recipe_section_failure(
                         "recipe_artifact_unavailable",
-                        context={"detail": _recreate_envelope_err},
+                        context={"detail": "recreation write failed"},
                     )
+                if recreated_generation != identity:
+                    return _recipe_section_failure("invalid_recipe_artifact_identity")
 
                 try:
                     persisted = load_recipe_artifact(
@@ -705,6 +686,7 @@ async def get_recipe_section(
                 )
             except _RecipeSectionError as exc:
                 return _recipe_section_failure(exc.code)
+            selected = replace(selected, initialization_id=initialization_id)
             if not selected.present:
                 return _recipe_section_failure(
                     "section_not_found",
@@ -730,10 +712,90 @@ async def get_recipe_section(
                     "invalid_recipe_section_part",
                     context={"total_parts": page_plan.total_parts},
                 )
-            return render_recipe_section_page(page_plan, part)
+            if page_plan_sha256 is not None and (page_plan_sha256 != page_plan.page_plan_sha256):
+                return _recipe_section_failure("invalid_recipe_page_plan_identity")
+            active_initialization: InitializingRecipe | None = None
+            if initialization_id is not None:
+                with tool_ctx.recipe_execution_lock:
+                    state = tool_ctx.recipe_initialization_state
+                if not matches_recipe_initialization_requirement(
+                    state,
+                    initialization_id=initialization_id,
+                    artifact_generation=identity,
+                    section=section,
+                    page_plan_sha256=page_plan.page_plan_sha256,
+                ):
+                    return _recipe_section_failure("invalid_recipe_initialization_identity")
+                assert isinstance(state, InitializingRecipe)
+                active_initialization = state
+                if page_plan_sha256 != page_plan.page_plan_sha256:
+                    return _recipe_section_failure("invalid_recipe_page_plan_identity")
+            expected_continuation = (
+                None
+                if part == 0
+                else recipe_section_continuation_binding(
+                    generation=identity,
+                    initialization_id=initialization_id,
+                    section=section,
+                    section_sha256=page_plan.manifest.section_sha256,
+                    page_plan_sha256=page_plan.page_plan_sha256,
+                    next_part=part,
+                )
+            )
+            if continuation != expected_continuation:
+                return _recipe_section_failure("invalid_recipe_section_continuation")
+            rendered = render_recipe_section_page(page_plan, part)
+            if active_initialization is None:
+                return rendered
+            return cast(
+                str,
+                FinalizedRecipeSectionResponse(
+                    rendered=rendered,
+                    tool_ctx=tool_ctx,
+                    initialization_id=active_initialization.initialization_id,
+                    artifact_generation=identity,
+                    section=section,
+                    page_plan_sha256=page_plan.page_plan_sha256,
+                    part=part,
+                ),
+            )
     except Exception:
         logger.error("get_recipe_section unhandled exception", exc_info=True)
         return _recipe_section_failure("recipe_section_internal_error")
+
+
+@mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
+@track_response_size("complete_recipe_initialization")
+@_cancellation_shield()
+async def complete_recipe_initialization(initialization_id: str) -> str:
+    """Complete the current server-owned recipe initialization.
+
+    The opaque initialization ID is the only caller value. Generation identities,
+    reconstruction coverage, the staged snapshot, and the completion receipt are
+    resolved from current kitchen state. The READY transition occurs only after the
+    universal response boundary preserves the exact completion response.
+
+    Never raises.
+    """
+    if (gate := _require_enabled()) is not None:
+        return gate
+    try:
+        tool_ctx = _get_ctx_or_none()
+        if tool_ctx is None:
+            return json.dumps(
+                {"success": False, "error": "kitchen not open"},
+                separators=(",", ":"),
+            )
+        return cast(str, build_completion_response(tool_ctx, initialization_id))
+    except Exception:
+        logger.error(
+            "complete_recipe_initialization unhandled exception",
+            exc_info=True,
+        )
+        return json.dumps(
+            {"success": False, "error": "recipe_initialization_internal_error"},
+            separators=(",", ":"),
+        )
 
 
 def _extract_step_body_from_persisted(persisted: dict[str, Any], step_name: str) -> str:

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -971,19 +971,30 @@ resolved state. The `load_recipe` tool is the ONLY authoritative source of recip
 it runs the full composition pipeline (sub-recipe merging, skip-guard resolution, hidden
 ingredient interpolation) before serving content to you.
 
-When `load_recipe`/`open_kitchen` return a bounded envelope (large recipes exceeding
-the backend's delivery bound), the envelope omits full step bodies. Call
-`get_recipe_section(section=<step_name>)` to pull the body of a specific step on
-demand — this is still the authoritative channel (backed by the same persisted
-artifact `load_recipe` wrote), not a raw-file read. For sections spanning multiple
-pages, require one known `pagination_version` and stable `section_registry_sha256`,
-`section_sha256`, and `page_plan_sha256`; reject an unknown pagination_version or
-unknown content_format and do not guess. Reconstruct `raw-text` by concatenating
-contiguous byte ranges. For `json-array-page`, call `json.loads` on every page and
-extend in order. For `json-scalar-page`, call `json.loads` and concatenate decoded
-strings. For `json-element-fragment`, call `json.loads` on each string fragment,
-concatenate and verify the canonical element, then parse it once. Follow
-`has_more`/`next_part`; a terminal page must omit `next_part`.
+When `load_recipe`/`open_kitchen` return a bounded recovery manifest, process it
+before any generic `success:false` rule. Preserve `recipe_pull`, `recipe_flow`,
+`initialization_id`, `required_sections`, page-plan identity, and pagination-policy
+identity. Retrieve every `flow_records` part first, then every part of the
+entrypoint named-step descriptor. Forward all advertised producer, recipe, descriptor,
+artifact, flow, section-registry, pagination, digest, size, record-count,
+`initialization_id`, `page_plan_sha256`, `part`, and `continuation` fields unchanged.
+This includes `descriptor_version`, `schema_version`, `flow_schema_version`,
+`section_registry_sha256`, `pagination_version`, `pagination_policy_sha256`,
+`section_sha256`, `content_format`, `has_more`, and `next_part`.
+Part zero has no continuation; each later request uses the prior response's binding.
+Reject an unknown pagination_version or unknown content_format, changed request fields,
+mismatched identities,
+skips, out-of-order parts, conflicting duplicates, or cross-generation pages.
+
+Reconstruct `raw-text` from contiguous ranges. For `json-array-page`, use `json.loads`
+to decode every page and extend in order. For `json-scalar-page`, decode and concatenate
+strings. For `json-element-fragment`, decode each string fragment, concatenate and
+verify the canonical element, then parse it once. Verify the complete flow digest, byte size,
+and record count plus the entrypoint section digest. Then call
+`complete_recipe_initialization(initialization_id=<server-issued ID>)` without
+caller-supplied generation selectors and require its completion receipt before the
+first execution or mutation tool. Random-access pulls without the matching
+initialization ID never establish readiness.
 
 Similarly, NEVER read SKILL.md files directly from the filesystem. Use the Skill tool
 to load skill instructions — it applies runtime transformations (namespace rewriting,

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -240,7 +240,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     ),
     "_type_results_execution": frozenset({"core", "execution", "server", "pipeline"}),
     "_type_backend": frozenset({"core", "execution", "cli", "recipe", "server", "workspace"}),
-    "_type_recipe_delivery": frozenset({"core", "execution", "server"}),
+    "_type_recipe_delivery": frozenset({"core", "execution", "pipeline", "server"}),
     "_type_recipe_sections": frozenset({"core", "execution", "server"}),
     "_type_context_admission": frozenset({"core", "pipeline", "server"}),
     "_type_context_admission_persistence": frozenset({"core", "pipeline", "server"}),

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -829,7 +829,7 @@ def test_no_is_plugin_installed_in_session_launch() -> None:
 
     _is_plugin_installed runs 'claude plugin list' as a subprocess (up to 10s).
     This pre-launch delay widens the MCP first-call race window.
-    Replacement: detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX (µs filesystem read).
+    Replacement: backend-aware prefix detection against MARKETPLACE_PREFIX.
     """
     source = Path("src/autoskillit/cli/session/_session_launch.py").read_text()
     tree = ast.parse(source)
@@ -840,7 +840,7 @@ def test_no_is_plugin_installed_in_session_launch() -> None:
     ]
     assert "_is_plugin_installed" not in calls, (
         "_session_launch.py calls _is_plugin_installed — replace with "
-        "detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX"
+        "detect_autoskillit_mcp_prefix(backend.capabilities) == MARKETPLACE_PREFIX"
     )
 
 
@@ -858,7 +858,7 @@ def test_no_is_plugin_installed_in_cook() -> None:
     ]
     assert "_is_plugin_installed" not in calls, (
         "_session_cook.py calls _is_plugin_installed — replace with "
-        "detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX"
+        "detect_autoskillit_mcp_prefix(backend.capabilities) == MARKETPLACE_PREFIX"
     )
 
 

--- a/tests/arch/test_pyright_suppression_allowlist.py
+++ b/tests/arch/test_pyright_suppression_allowlist.py
@@ -22,7 +22,7 @@ PRODUCTION_ALLOWLIST: dict[tuple[str, int], str] = {
         "recipe/__init__.py",
         289,
     ): "lazy-registry: method added by _register_rule_module() side effects",
-    ("recipe/_api.py", 291): "lazy-registry: RULE_REGISTRY_HASH set by _finalize_registry()",
+    ("recipe/_api.py", 293): "lazy-registry: RULE_REGISTRY_HASH set by _finalize_registry()",
 }
 
 TEST_ALLOWLIST: dict[tuple[str, int], str] = {

--- a/tests/arch/test_recipe_section_registry.py
+++ b/tests/arch/test_recipe_section_registry.py
@@ -17,6 +17,7 @@ _FIXED_SECTION_NAMES = {
     "orchestration_rules",
     "stop_step_semantics",
     "errors",
+    "flow_records",
     "warnings",
 }
 
@@ -132,6 +133,15 @@ def test_recipe_section_definition_rejects_contradictory_construction(
             "json-array-page",
             "json-element-fragment",
         ),
+        (
+            "flow_records",
+            "array",
+            "string",
+            "array",
+            "elements",
+            "json-array-page",
+            "json-element-fragment",
+        ),
     ],
 )
 def test_recipe_section_strategy_and_format_combinations_are_pinned(
@@ -167,6 +177,7 @@ def test_recipe_section_presence_and_default_semantics_are_explicit() -> None:
         "orchestration_rules": ("absent", "invalid", False, None),
         "stop_step_semantics": ("absent", "invalid", False, None),
         "errors": ("default", "invalid", True, ()),
+        "flow_records": ("invalid", "invalid", False, None),
         "warnings": ("default", "invalid", True, ()),
         "$dynamic": ("absent", "invalid", False, None),
     }
@@ -189,14 +200,14 @@ def test_recipe_section_registry_identity_is_stable_and_qualified() -> None:
         RECIPE_SECTION_REGISTRY_DIGEST,
     )
 
-    assert RECIPE_SECTION_PAGINATION_VERSION == 1
+    assert RECIPE_SECTION_PAGINATION_VERSION == 2
     assert (
         RECIPE_SECTION_REGISTRY_DIGEST
-        == "sha256:d2b8a9f404b264dc3963850712f7d69b0fdfcea5433331b0c4b6ea9400e1e4a1"
+        == "sha256:f0cee935bfda7cf138a9a2ac8cdbe290eb95afe13c2e014766b4663d6a90ee79"
     )
     assert (
         RECIPE_SECTION_PAGINATION_POLICY_DIGEST
-        == "sha256:c65ec6cec7cd4af15aa8247d67cf7fe7540bc7ee0df727e3e8a9da46dcd96c92"
+        == "sha256:cd7105407037f155c3156ab5c4e550e0690a01c12084cc2f65ccc1bef8a9a173"
     )
     for digest in (
         RECIPE_SECTION_REGISTRY_DIGEST,
@@ -224,6 +235,7 @@ def test_pullable_sections_match_public_result_schemas() -> None:
         assert hints["stop_step_semantics"] is str
         assert hints["errors"] == list[str]
         assert hints["warnings"] == list[str]
+        assert hints["flow_records"] == list[str]
         assert hints["post_prune_step_names"] == list[str]
 
     assert set(RECIPE_SECTION_REGISTRY) == _FIXED_SECTION_NAMES

--- a/tests/arch/test_serve_surface_registry.py
+++ b/tests/arch/test_serve_surface_registry.py
@@ -104,3 +104,17 @@ def test_recipe_recreation_policy_is_registry_owned() -> None:
     }
 
     assert eligible == {"open_kitchen", "open_kitchen_deferred_recall", "get_recipe"}
+
+
+def test_recipe_initialization_activation_is_registry_owned() -> None:
+    from autoskillit.core import RECIPE_DELIVERY_SURFACE_REGISTRY
+
+    assert {
+        surface
+        for surface, definition in RECIPE_DELIVERY_SURFACE_REGISTRY.items()
+        if definition.initialization_activating
+    } == {"open_kitchen", "open_kitchen_deferred_recall"}
+    assert all(
+        type(definition.initialization_activating) is bool
+        for definition in RECIPE_DELIVERY_SURFACE_REGISTRY.values()
+    )

--- a/tests/arch/test_startup_budget.py
+++ b/tests/arch/test_startup_budget.py
@@ -204,7 +204,7 @@ def test_no_subprocess_in_serve() -> None:
         "serve() transitively uses subprocess on the MCP transport critical path "
         "(REQ-STARTUP-001):\n"
         + "\n".join(f"  {v}" for v in violations)
-        + "\nReplace with a filesystem-based alternative (e.g. detect_autoskillit_mcp_prefix())."
+        + "\nReplace with backend-aware detect_autoskillit_mcp_prefix(capabilities)."
     )
 
 
@@ -254,7 +254,7 @@ def test_serve_pre_anyio_no_denylist_calls() -> None:
         "serve() calls denylist function(s) before anyio.run() — violates REQ-STARTUP-001.\n"
         "These block the MCP transport critical path:\n"
         + "\n".join(f"  {v}" for v in violations)
-        + "\nReplace with a filesystem-based alternative (e.g. detect_autoskillit_mcp_prefix())."
+        + "\nReplace with backend-aware detect_autoskillit_mcp_prefix(capabilities)."
     )
 
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -921,7 +921,9 @@ def test_no_subpackage_exceeds_10_files() -> None:
             Exempt at 32 files.
           pipeline/ — REQ-CNST-003-E7: pipeline/ added github_api_log.py for session-scoped
             GitHub API request tracking (DefaultGitHubApiLog accumulator + GitHubApiEntry).
-            Exempt at 12 files.
+            context_admission_ledger.py adds crash-safe shadow accounting, and
+            recipe_initialization.py adds the pure named-recipe lifecycle reducer.
+            Exempt at 14 files.
           fleet/ — REQ-CNST-003-E8: fleet/ added _semaphore.py for FleetSemaphore, the
             configurable asyncio.BoundedSemaphore implementation of the FleetLock protocol.
             Placed in fleet/ rather than server/ to preserve conservative test-filter cascade
@@ -931,7 +933,8 @@ def test_no_subpackage_exceeds_10_files() -> None:
             logic on DispatchRecord.from_dict. Exempt at 15 files.
     """
     EXEMPTIONS: dict[str, int] = {
-        "server": 17,  # +_recipe_section_pagination planner +_recipe_execution attestation
+        # +generation-bound replay store and post-enforcement initialization commits.
+        "server": 19,
         "recipe": 42,  # was 33; +9 from CI/graph/dataflow splits
         "execution": 18,
         "core": 28,  # +context admission +audit-cycle verifier/tool registry
@@ -942,7 +945,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         # replacing nine ad-hoc repairs) +_projection_cache (asset inventory, cache-key
         # record, and orphan sweep — split out so staleness cannot drift from projection)
         "hooks": 18,  # +recipe_confirmed_post_hook, +quota_guard_state_post_hook, +_policy_event, +shell_capture_hook (#4286), +_capture_artifacts.py  # noqa: E501
-        "pipeline": 13,  # +context_admission_ledger crash-safe shadow accounting
+        "pipeline": 14,  # +context admission ledger +recipe initialization reducer
         "fleet": 23,  # +_issue_url_helpers.py  # noqa: E501
         "recipe/rules": 55,  # +commit_guard_regression_route +rules_model +rules_gitignored_deliverable +rules_issue_scope_threading +rules_inventory_gate_bilateral +rules_verdict_context +rules_contract_recovery  # noqa: E501
         "server/tools": 32,  # +_pipeline_deps.py +_ordering_telemetry.py (open_kitchen
@@ -1048,17 +1051,19 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "closure-scoped _spawn_error, and _write_pid fail-closed contract add ~33 lines",
     ),
     "server/_recipe_delivery.py": (
-        1150,
+        1450,
         "REQ-CNST-010-E12: immutable recipe generation persistence, host-attested delivery "
         "selection, receipt reservation, and compiled-execution publication form one "
         "transactional authority boundary; the snapshot carrier keeps installation before "
-        "durable delivery commit without introducing a second finalization path. "
-        "Bumped to 1150 for #4399: exemption-aware ENVELOPE→ORDINARY_INLINE override "
-        "(scope-check + byte budget + decision.replace; +18 net lines) and success=True "
-        "injection on candidate_payload before serialization (+8 net lines).",
+        "durable delivery commit without introducing a second finalization path; "
+        "generation-bound flow records, bounded recovery manifests, exact-replay "
+        "provenance, and activating/non-activating lifecycle staging remain in that same "
+        "finalizer transaction so no second wire authority can drift; #4399's exemption-aware "
+        "ordinary-inline override and success-shaped surface payload preserve complete bodies "
+        "for registered non-protected surfaces.",
     ),
     "tools_kitchen.py": (
-        1700,
+        1800,
         "REQ-CNST-010-E7: kitchen tool handlers — open_kitchen and lock_ingredients require "
         "inline validation helpers (_check_override_keys, _build_ingredient_key_suggestions) "
         "for ingredient key validation; splitting would cross import-layer boundaries; "
@@ -1104,7 +1109,10 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "; compiled recipe binding publication and execution-lifecycle cleanup across "
         "recipe load, kitchen open, and kitchen close (+13 net lines)"
         "; #4399 close→open visibility restore: mcp.enable() refresh in open_kitchen's "
-        "_skip_notify branch to override prior global mcp.disable() from close_kitchen (+2 lines)",
+        "_skip_notify branch to override prior global mcp.disable() from close_kitchen (+2 lines)"
+        "; finalized projection/flow generation and explicit activating-surface delivery "
+        "are threaded through normal, deferred, and resource paths while named-open "
+        "replacement clears stale readiness before every early return",
     ),
     "tools_execution.py": (
         1800,
@@ -1396,6 +1404,7 @@ def test_tool_context_service_fields_use_protocol_types() -> None:
     Exempt fields:
     - plugin_source: PluginSource discriminated union (value type, not a service interface)
     - config: AutomationConfig dataclass (configuration container, not a service interface)
+    - recipe_initialization_state: lifecycle value union, not a service interface
     """
     AUTOSKILLIT_ROOT = SRC_ROOT
 
@@ -1439,7 +1448,7 @@ def test_tool_context_service_fields_use_protocol_types() -> None:
         "active_recipe_features",
         "active_recipe_steps",
         "active_recipe_ingredients",
-        "active_recipe_execution",
+        "recipe_initialization_state",
         "temp_dir",
         "project_dir",
         "ephemeral_root",

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -33,7 +33,10 @@ def _stub_detect_mcp_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
     """Stub detect_autoskillit_mcp_prefix for deterministic PLUGIN_DIR behavior."""
     from autoskillit.core._plugin_ids import DIRECT_PREFIX
 
-    monkeypatch.setattr("autoskillit.core.detect_autoskillit_mcp_prefix", lambda: DIRECT_PREFIX)
+    monkeypatch.setattr(
+        "autoskillit.core.detect_autoskillit_mcp_prefix",
+        lambda _capabilities: DIRECT_PREFIX,
+    )
 
 
 _SCRIPT_YAML = """\

--- a/tests/cli/test_cook_order_command.py
+++ b/tests/cli/test_cook_order_command.py
@@ -193,7 +193,7 @@ class TestCLIOrderCommand:
 
         monkeypatch.setattr(
             "autoskillit.core.detect_autoskillit_mcp_prefix",
-            lambda: MARKETPLACE_PREFIX,
+            lambda _capabilities: MARKETPLACE_PREFIX,
         )
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
@@ -223,7 +223,8 @@ class TestCLIOrderCommand:
         from autoskillit.core._plugin_ids import DIRECT_PREFIX
 
         monkeypatch.setattr(
-            "autoskillit.core.detect_autoskillit_mcp_prefix", lambda: DIRECT_PREFIX
+            "autoskillit.core.detect_autoskillit_mcp_prefix",
+            lambda _capabilities: DIRECT_PREFIX,
         )
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""

--- a/tests/cli/test_cook_order_picker.py
+++ b/tests/cli/test_cook_order_picker.py
@@ -520,6 +520,7 @@ class TestOrderResumeParsing:
             project_dir=None,
             required_env=None,
             skill_catalog=None,
+            backend=None,
         ):
             captured["resume_spec"] = resume_spec
 
@@ -564,6 +565,7 @@ class TestOrderResumeParsing:
             resume_spec=NoResume(),
             required_env=None,
             skill_catalog=None,
+            backend=None,
         ):
             captured["resume_spec"] = resume_spec
 
@@ -598,6 +600,7 @@ class TestOrderResumeParsing:
             resume_spec=NoResume(),
             required_env=None,
             skill_catalog=None,
+            backend=None,
         ):
             captured["resume_spec"] = resume_spec
 

--- a/tests/cli/test_fleet_run.py
+++ b/tests/cli/test_fleet_run.py
@@ -69,6 +69,16 @@ def _mock_rejected_result():
     )
 
 
+def _mock_backend() -> MagicMock:
+    backend = MagicMock()
+    backend.name = "codex"
+    backend.conventions = None
+    backend.capabilities.claude_marketplace_tool_prefix_capable = False
+    backend.capabilities.has_unguarded_filesystem_access = False
+    backend.capabilities.anthropic_provider_capable = False
+    return backend
+
+
 class TestFleetRunGates:
     def test_fleet_run_blocks_in_leaf_session(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
@@ -379,7 +389,7 @@ class TestFleetRunDispatch:
         )
 
         fake_ctx = MagicMock()
-        fake_ctx.backend = None
+        fake_ctx.backend = _mock_backend()
         fake_ctx.config = MagicMock()
         monkeypatch.setattr(
             "autoskillit.server.make_context",
@@ -445,7 +455,7 @@ class TestFleetRunDispatch:
         )
         make_context_calls: list[object] = []
         fake_ctx = MagicMock()
-        fake_ctx.backend = None
+        fake_ctx.backend = _mock_backend()
         fake_ctx.config = MagicMock()
         fake_ctx.fleet_lock = MagicMock()
 

--- a/tests/cli/test_mcp_names.py
+++ b/tests/cli/test_mcp_names.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,7 @@ from autoskillit.cli._mcp_names import (
     MARKETPLACE_PREFIX,
     detect_autoskillit_mcp_prefix,
 )
+from autoskillit.core import CLAUDE_CODE_CAPABILITIES
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
@@ -33,7 +35,7 @@ class TestDetectAutoskillitMcpPrefix:
         f = tmp_path / "installed_plugins.json"
         f.write_text(json.dumps({"version": 2, "plugins": {_PLUGIN_KEY: []}}))
         monkeypatch.setattr("autoskillit.core._plugin_ids._installed_plugins_path", lambda: f)
-        assert detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX
+        assert detect_autoskillit_mcp_prefix(CLAUDE_CODE_CAPABILITIES) == MARKETPLACE_PREFIX
 
     def test_returns_direct_prefix_when_file_absent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -42,7 +44,7 @@ class TestDetectAutoskillitMcpPrefix:
             "autoskillit.core._plugin_ids._installed_plugins_path",
             lambda: tmp_path / "no_such_file.json",
         )
-        assert detect_autoskillit_mcp_prefix() == DIRECT_PREFIX
+        assert detect_autoskillit_mcp_prefix(CLAUDE_CODE_CAPABILITIES) == DIRECT_PREFIX
 
     def test_returns_direct_prefix_when_autoskillit_key_absent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -50,7 +52,7 @@ class TestDetectAutoskillitMcpPrefix:
         f = tmp_path / "installed_plugins.json"
         f.write_text(json.dumps({"version": 2, "plugins": {"other@other-local": []}}))
         monkeypatch.setattr("autoskillit.core._plugin_ids._installed_plugins_path", lambda: f)
-        assert detect_autoskillit_mcp_prefix() == DIRECT_PREFIX
+        assert detect_autoskillit_mcp_prefix(CLAUDE_CODE_CAPABILITIES) == DIRECT_PREFIX
 
     def test_returns_direct_prefix_on_malformed_json(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -58,7 +60,24 @@ class TestDetectAutoskillitMcpPrefix:
         f = tmp_path / "installed_plugins.json"
         f.write_text("not valid json {{{")
         monkeypatch.setattr("autoskillit.core._plugin_ids._installed_plugins_path", lambda: f)
-        assert detect_autoskillit_mcp_prefix() == DIRECT_PREFIX
+        assert detect_autoskillit_mcp_prefix(CLAUDE_CODE_CAPABILITIES) == DIRECT_PREFIX
+
+    def test_non_marketplace_backend_does_not_read_claude_registry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        capabilities = replace(
+            CLAUDE_CODE_CAPABILITIES,
+            claude_marketplace_tool_prefix_capable=False,
+        )
+
+        def fail_if_read() -> Path:
+            raise AssertionError("Claude marketplace state must not be read")
+
+        monkeypatch.setattr(
+            "autoskillit.core._plugin_ids._installed_plugins_path",
+            fail_if_read,
+        )
+        assert detect_autoskillit_mcp_prefix(capabilities) == DIRECT_PREFIX
 
     def test_direct_prefix_ends_with_double_underscore(self) -> None:
         assert DIRECT_PREFIX.endswith("__")

--- a/tests/cli/test_orchestrator_prompt_contract.py
+++ b/tests/cli/test_orchestrator_prompt_contract.py
@@ -16,80 +16,50 @@ def _get_prompt() -> str:
     return _build_orchestrator_prompt("demo", "mcp__autoskillit__")
 
 
-class TestOpenKitchenFailurePredicate:
-    """Guards for the FAILURE PREDICATE — open_kitchen block in the orchestrator prompt."""
+class TestOrderedRecipeStartupContract:
+    """Startup distinguishes dispatch, transport, recovery, and application errors."""
 
-    def test_prompt_contains_open_kitchen_failure_predicate(self):
+    @pytest.mark.parametrize(
+        ("case_number", "required_phrases"),
+        [
+            (1, ("pre-dispatch", "runtime tool discovery", "bad symbol")),
+            (2, ("transport", "isError:true", "silent retry")),
+            (3, ("isError:false", "structured application result", "success:false")),
+            (4, ("recovery manifest", "flow_records", "entrypoint", "continuation")),
+            (5, ("nonrecoverable application error", "user_visible_message")),
+        ],
+    )
+    def test_cases_are_present_and_ordered(
+        self, case_number: int, required_phrases: tuple[str, ...]
+    ) -> None:
         prompt = _get_prompt()
-        assert "FAILURE PREDICATE — open_kitchen" in prompt
-
-    def test_prompt_open_kitchen_predicate_mentions_success_false_substring(self):
-        prompt = _get_prompt()
-        # Find the open_kitchen predicate section
-        idx = prompt.index("FAILURE PREDICATE — open_kitchen")
-        section = prompt[idx : idx + 500]
-        assert '"success": false' in section
-
-    def test_prompt_open_kitchen_predicate_mentions_user_visible_message(self):
-        prompt = _get_prompt()
-        idx = prompt.index("FAILURE PREDICATE — open_kitchen")
-        section = prompt[idx : idx + 500]
-        assert "user_visible_message" in section
-
-    def test_prompt_open_kitchen_predicate_forbids_askuserquestion(self):
-        prompt = _get_prompt()
-        idx = prompt.index("FAILURE PREDICATE — open_kitchen")
-        section = prompt[idx : idx + 500]
-        assert "DO NOT call AskUserQuestion" in section
-
-    def test_open_kitchen_predicate_uses_json_field_not_substring(self):
-        """The predicate block must use JSON-field check, not substring marker."""
-        prompt = _get_prompt()
-        idx = prompt.index("FAILURE PREDICATE — open_kitchen")
-        section = prompt[idx : idx + 500]
-        assert "--- INGREDIENTS TABLE ---" not in section
-        assert "ingredients_table" in section
-
-
-class TestDegradedToolResponsePredicate:
-    """Guards for the FAILURE PREDICATE — DEGRADED TOOL RESPONSE block."""
-
-    def _get_section(self) -> str:
-        prompt = _get_prompt()
-        start = prompt.index("FAILURE PREDICATE — DEGRADED TOOL RESPONSE")
-        end = prompt.index("CONTEXT LIMIT ROUTING", start)
-        return prompt[start:end]
-
-    def test_prompt_contains_degraded_tool_response_section(self):
-        prompt = _get_prompt()
-        ok_idx = prompt.index("FAILURE PREDICATE — open_kitchen")
-        deg_idx = prompt.index("FAILURE PREDICATE — DEGRADED TOOL RESPONSE")
-        ctx_idx = prompt.index("CONTEXT LIMIT ROUTING")
-        assert ok_idx < deg_idx < ctx_idx, (
-            "Degraded predicate must appear after open_kitchen and before CONTEXT LIMIT ROUTING"
+        start = prompt.index("RECIPE STARTUP RESULT ORDER")
+        end = prompt.index("During pipeline execution", start)
+        section = prompt[start:end]
+        case_positions = [section.index(f"{number}.") for number in range(1, 6)]
+        assert case_positions == sorted(case_positions)
+        case_start = section.index(f"{case_number}.")
+        case_end = (
+            section.index(f"{case_number + 1}.", case_start) if case_number < 5 else len(section)
         )
+        case_text = section[case_start:case_end]
+        assert all(phrase in case_text for phrase in required_phrases)
 
-    def test_degraded_predicate_covers_success_false_empty_content(self):
-        section = self._get_section()
-        assert "success" in section
-        assert "false" in section
-        assert any(word in section for word in ("absent", "null", "empty")), (
-            "Section must reference absent, null, or empty content"
+    def test_recovery_precedes_generic_success_false_rules(self) -> None:
+        prompt = _get_prompt()
+        start = prompt.index("RECIPE STARTUP RESULT ORDER")
+        end = prompt.index("During pipeline execution", start)
+        section = prompt[start:end]
+        assert section.index("recovery manifest") < section.index(
+            "nonrecoverable application error"
         )
+        assert "complete_recipe_initialization(initialization_id)" in section
+        assert "before the first execution or mutation tool" in section
 
-    def test_degraded_predicate_prohibits_improvisation(self):
-        section = self._get_section()
-        lower = section.lower()
-        assert any(
-            phrase in lower
-            for phrase in (
-                "do not improvise",
-                "do not retry",
-                "do not attempt",
-                "never",
-                "halt",
-            )
-        ), "Section must prohibit improvisation or retry"
+    def test_old_conflicting_termination_blocks_are_removed(self) -> None:
+        prompt = _get_prompt()
+        assert "FAILURE PREDICATE — open_kitchen" not in prompt
+        assert "FAILURE PREDICATE — DEGRADED TOOL RESPONSE" not in prompt
 
 
 class TestStep0ToolPredicateCoverage:
@@ -114,9 +84,11 @@ class TestStep0ToolPredicateCoverage:
 
         # Each tool must appear in a FAILURE PREDICATE section
         for tool in tool_names:
-            assert f"FAILURE PREDICATE — {tool}" in prompt or f"- {tool}:" in prompt, (
-                f"Tool '{tool}' in STEP 0 has no failure predicate or shared rule"
-            )
+            assert (
+                f"FAILURE PREDICATE — {tool}" in prompt
+                or f"- {tool}:" in prompt
+                or (tool == "open_kitchen" and "RECIPE STARTUP RESULT ORDER" in prompt)
+            ), f"Tool '{tool}' in STEP 0 has no failure predicate or shared rule"
 
 
 class TestFirstActionAskUserQuestionProhibition:

--- a/tests/cli/test_plugin_source_authority.py
+++ b/tests/cli/test_plugin_source_authority.py
@@ -101,7 +101,12 @@ class TestDanglingInstallPathIsHarmless:
         _seed_dangling_registry(tmp_path)
         _plugin_ids.detect_autoskillit_mcp_prefix.cache_clear()
         try:
-            assert _plugin_ids.detect_autoskillit_mcp_prefix() == _plugin_ids.MARKETPLACE_PREFIX
+            from autoskillit.core import CLAUDE_CODE_CAPABILITIES
+
+            assert (
+                _plugin_ids.detect_autoskillit_mcp_prefix(CLAUDE_CODE_CAPABILITIES)
+                == _plugin_ids.MARKETPLACE_PREFIX
+            )
         finally:
             _plugin_ids.detect_autoskillit_mcp_prefix.cache_clear()
 

--- a/tests/cli/test_reload_loop.py
+++ b/tests/cli/test_reload_loop.py
@@ -379,6 +379,7 @@ def test_fleet_reload_relaunches_without_resume(
         project_dir=None,
         initial_message=None,
         required_env=None,
+        backend=None,
     ):
         call_count[0] += 1
         captured_resume_specs.append(resume_spec)
@@ -390,7 +391,10 @@ def test_fleet_reload_relaunches_without_resume(
         "autoskillit.cli.session._session_launch._run_interactive_session",
         fake_run_interactive_session,
     )
-    monkeypatch.setattr("autoskillit.cli.detect_autoskillit_mcp_prefix", lambda: "autoskillit")
+    monkeypatch.setattr(
+        "autoskillit.cli.detect_autoskillit_mcp_prefix",
+        lambda _capabilities: "autoskillit",
+    )
     monkeypatch.setattr(
         "autoskillit.cli._prompts._build_fleet_dispatch_prompt",
         lambda mcp_prefix, **kw: "test-prompt",

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -77,7 +77,10 @@ def _stub_plugin_installed(monkeypatch: pytest.MonkeyPatch, *, installed: bool =
     from autoskillit.core._plugin_ids import DIRECT_PREFIX, MARKETPLACE_PREFIX
 
     prefix = MARKETPLACE_PREFIX if installed else DIRECT_PREFIX
-    monkeypatch.setattr("autoskillit.core.detect_autoskillit_mcp_prefix", lambda: prefix)
+    monkeypatch.setattr(
+        "autoskillit.core.detect_autoskillit_mcp_prefix",
+        lambda _capabilities: prefix,
+    )
 
 
 def _stub_codex_pre_launch(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/test_sous_chef_content.py
+++ b/tests/cli/test_sous_chef_content.py
@@ -27,10 +27,23 @@ def test_sous_chef_documents_exhaustive_recipe_section_reconstruction() -> None:
     content = _read_full_sous_chef()
 
     for required in (
+        "recipe_pull",
+        "recipe_flow",
+        "initialization_id",
+        "required_sections",
+        "flow_records",
+        "entrypoint",
+        "complete_recipe_initialization",
+        "completion receipt",
+        "descriptor_version",
+        "schema_version",
+        "flow_schema_version",
         "pagination_version",
         "section_registry_sha256",
+        "pagination_policy_sha256",
         "section_sha256",
         "page_plan_sha256",
+        "continuation",
         "raw-text",
         "json-array-page",
         "json-scalar-page",
@@ -41,5 +54,5 @@ def test_sous_chef_documents_exhaustive_recipe_section_reconstruction() -> None:
         assert required in content
     assert "unknown pagination_version" in content
     assert "unknown content_format" in content
-    assert "do not guess" in content.lower()
-    assert "terminal" in content.lower() and "omit" in content.lower()
+    assert content.index("flow_records") < content.index("entrypoint named-step")
+    assert content.index("entrypoint named-step") < content.index("complete_recipe_initialization")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -471,6 +471,7 @@ def tool_ctx_kitchen_open(tool_ctx):
     from autoskillit.pipeline.gate import DefaultGateState
 
     tool_ctx.gate = DefaultGateState(enabled=True)
+    tool_ctx.kitchen_id = "test-kitchen"
     return tool_ctx
 
 

--- a/tests/contracts/test_delivery_bound_fitness.py
+++ b/tests/contracts/test_delivery_bound_fitness.py
@@ -16,28 +16,31 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, cast
+from typing import Any, cast
 
 import pytest
-
-if TYPE_CHECKING:
-    from autoskillit.pipeline import ToolContext
 
 from autoskillit.config import OutputBudgetConfig
 from autoskillit.core import (
     RECIPE_SECTION_RESPONSE_FLOOR_BYTES,
     RESPONSE_BACKSTOP_EXEMPTION_REGISTRY,
     BackendCapabilities,
+    FinalizedRecipeProjection,
     resolve_general_output_token_limit,
+    resolve_recipe_envelope_byte_limit,
 )
 from autoskillit.execution.backends import BACKEND_REGISTRY, CODEX_HISTORY_RETENTION_TOKEN_LIMIT
 from autoskillit.recipe import (
+    NON_INTERACTIVE_KINDS,
     all_validated_recipe_names,
-    find_recipe_by_name,
+    list_recipes,
     load_and_validate,
-    load_recipe,
 )
-from autoskillit.server._recipe_delivery import build_recipe_envelope, persist_recipe_artifact
+from autoskillit.server._recipe_delivery import (
+    finalize_recipe_delivery,
+    prepare_recipe_delivery_generation,
+)
+from autoskillit.server._recipe_generation import RecipeGenerationStore
 from autoskillit.server._response_budget import (
     RESPONSE_SPILL_METADATA_KEY,
     enforce_response_budget,
@@ -56,12 +59,21 @@ def _recipe_names() -> list[str]:
     return sorted(all_validated_recipe_names(_PROJECT_ROOT))
 
 
+def _delivery_recipe_names() -> list[str]:
+    result = list_recipes(
+        _PROJECT_ROOT,
+        exclude_kinds=NON_INTERACTIVE_KINDS,
+        exclude_dispatch_only=True,
+    )
+    return sorted(recipe.name for recipe in result.items)
+
+
 def _backend_capabilities():
     return {name: cls().capabilities for name, cls in BACKEND_REGISTRY.items()}
 
 
-def _effective_bound_bytes(bound_tokens: int) -> int:
-    """Convert effective delivery token bound to UTF-8 byte ceiling (4 bytes/token)."""
+def _generic_backstop_bound_bytes(bound_tokens: int) -> int:
+    """Convert a generic response backstop token limit to its UTF-8 byte ceiling."""
     return bound_tokens * 4
 
 
@@ -102,7 +114,26 @@ def _full_open_kitchen_payload(recipe_name: str) -> dict[str, object]:
     return build_open_kitchen_recipe_payload(dict(result), version="0.0.0")
 
 
-@pytest.mark.parametrize("recipe_name", _recipe_names(), ids=lambda n: n)
+def _full_open_kitchen_generation(
+    recipe_name: str,
+) -> tuple[dict[str, object], FinalizedRecipeProjection]:
+    """Build one production payload together with its hidden finalized projection."""
+    result = load_and_validate(
+        recipe_name,
+        project_dir=_PROJECT_ROOT,
+        ingredient_overrides={
+            "task": "test task",
+            "issue_url": "https://github.com/test/test/issues/1",
+            "source_dir": str(_PROJECT_ROOT),
+        },
+        include_finalized_projection=True,
+    )
+    projection = result.pop("_finalized_projection", None)
+    assert isinstance(projection, FinalizedRecipeProjection)
+    return build_open_kitchen_recipe_payload(dict(result), version="0.0.0"), projection
+
+
+@pytest.mark.parametrize("recipe_name", _delivery_recipe_names(), ids=lambda n: n)
 @pytest.mark.parametrize("backend_name", sorted(_backend_capabilities().keys()), ids=lambda n: n)
 def test_bundled_recipe_open_kitchen_envelope_fits_per_backend(
     recipe_name: str,
@@ -111,60 +142,65 @@ def test_bundled_recipe_open_kitchen_envelope_fits_per_backend(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """System-level fitness contract (issue #4304 Part B REQ-B-T7): the bounded
-    envelope built unconditionally for every bundled recipe via
-    ``build_recipe_envelope`` must fit every registered backend's effective
-    delivery bound by construction — independent of whether the raw
-    ``open_kitchen`` payload itself happens to fit today.
-
-    This test mirrors the unit-level invariant already exercised by
-    ``test_envelope_fits_every_backend_by_construction`` in
-    ``tests/server/test_tools_recipe_pull.py`` at the contracts layer: the
-    two layers overlap in scope by design (test-pyramid convention) and the
-    envelope-fit-by-construction guarantee is the post-#4304-Part-B invariant
-    that this file exists to defend.
+    response produced through the real generation preparation and finalizer path
+    must fit every registered backend's effective delivery bound. Each response
+    contains either complete inline flow or a successful bounded recovery manifest.
     """
     from autoskillit.recipe import _api_cache
     from autoskillit.recipe._api_cache import LoadCache
 
     monkeypatch.setattr(_api_cache, "_LOAD_CACHE", LoadCache())
-    payload = _full_open_kitchen_payload(recipe_name)
-    generation = persist_recipe_artifact(
-        tmp_path,
-        kitchen_id="fitness-kitchen",
-        producer_tool="open_kitchen",
+    from autoskillit.server import _recipe_generation
+
+    monkeypatch.setattr(
+        _recipe_generation,
+        "_RECIPE_GENERATION_STORE",
+        RecipeGenerationStore(),
+    )
+    payload, projection = _full_open_kitchen_generation(recipe_name)
+    tool_ctx = cast(
+        Any,
+        SimpleNamespace(
+            backend=BACKEND_REGISTRY[backend_name](),
+            kitchen_id=f"fitness-{backend_name}-{recipe_name}",
+            temp_dir=tmp_path,
+        ),
+    )
+    prepared = prepare_recipe_delivery_generation(
+        payload,
         recipe_name=recipe_name,
-        payload=payload,
+        tool_ctx=tool_ctx,
+        finalized_projection=projection,
+    )
+    finalized = finalize_recipe_delivery(
+        payload,
+        surface="open_kitchen",
+        recipe_name=recipe_name,
+        tool_ctx=tool_ctx,
+        finalized_projection=projection,
+        flow_generation=prepared.flow_generation,
+        canonical_artifact_payload=prepared.canonical_artifact_payload,
+        execution_snapshot=prepared.execution_snapshot,
+        normalized_compile_key=prepared.normalized_compile_key,
     )
 
     caps = _backend_capabilities()[backend_name]
-    bound_tokens = resolve_general_output_token_limit(caps)
-    bound_bytes = _effective_bound_bytes(bound_tokens)
-    recipe_info = find_recipe_by_name(recipe_name, _PROJECT_ROOT)
-    assert recipe_info is not None
-    recipe = load_recipe(recipe_info.path)
-    envelope = build_recipe_envelope(
-        payload,
-        recipe_name=recipe_name,
-        generation=generation,
-        skeleton_source=cast(
-            "ToolContext",
-            SimpleNamespace(recipe_name=recipe_name, active_recipe_steps=recipe.steps),
-        ),
-        bound_bytes=bound_bytes,
-    )
-    serialized = json.dumps(envelope, ensure_ascii=False, separators=(",", ":"))
-    assert len(serialized.encode("utf-8")) <= bound_bytes, (
+    bound_bytes = resolve_recipe_envelope_byte_limit(caps)
+    envelope = json.loads(finalized.rendered)
+    assert len(finalized.rendered.encode("utf-8")) <= bound_bytes, (
         f"{backend_name}: envelope for {recipe_name} exceeds "
         f"{bound_bytes} bytes (effective delivery bound)"
     )
     assert envelope["recipe_pull"]["pull_tool"] == "get_recipe_section"
-    skeleton_steps = envelope["step_flow_skeleton"]["steps"]
-    expected_step_names = set(payload.get("post_prune_step_names") or [])
-    assert {step["name"] for step in skeleton_steps} == expected_step_names
-    if expected_step_names:
-        assert any(step.get("summary") or step["edges"] for step in skeleton_steps)
+    assert envelope["success"] is True
+    assert envelope["recipe_flow"] == prepared.flow_generation.identity()
+    if envelope.get("delivery_bound_spill") is True:
+        assert [item["section"] for item in envelope["required_sections"]] == [
+            "flow_records",
+            projection.entrypoint,
+        ]
     else:
-        assert not recipe.steps, "step-bearing recipes must expose production skeleton metadata"
+        assert envelope["flow_records"] == list(prepared.flow_generation.records)
 
 
 @pytest.mark.parametrize("recipe_name", _recipe_names(), ids=lambda n: n)
@@ -190,7 +226,7 @@ def test_bundled_recipe_open_kitchen_raw_spill_projection_fits_per_backend(
     serialized_bytes = len(serialized.encode("utf-8"))
     for backend_name, caps in _backend_capabilities().items():
         bound_tokens = resolve_general_output_token_limit(caps)
-        bound_bytes = _effective_bound_bytes(bound_tokens)
+        bound_bytes = _generic_backstop_bound_bytes(bound_tokens)
         if serialized_bytes <= bound_bytes:
             continue
         result = enforce_response_budget(
@@ -222,7 +258,7 @@ def test_non_exempted_oversized_payload_spills_within_delivery_bound(tmp_path) -
     config = OutputBudgetConfig()
     for backend_name, caps in _backend_capabilities().items():
         bound_tokens = resolve_general_output_token_limit(caps)
-        bound_bytes = _effective_bound_bytes(bound_tokens)
+        bound_bytes = _generic_backstop_bound_bytes(bound_tokens)
         assert len(serialized.encode("utf-8")) > bound_bytes, (
             f"{backend_name}: payload does not exceed bound ({bound_bytes} bytes)"
         )
@@ -283,7 +319,7 @@ def test_delivery_bound_summary_carries_all_step_names(
     ]
     for backend_name, caps in _backend_capabilities().items():
         bound_tokens = resolve_general_output_token_limit(caps)
-        bound_bytes = _effective_bound_bytes(bound_tokens)
+        bound_bytes = _generic_backstop_bound_bytes(bound_tokens)
         if serialized_bytes <= bound_bytes:
             continue
         result = enforce_response_budget(

--- a/tests/contracts/test_delivery_bound_fitness.py
+++ b/tests/contracts/test_delivery_bound_fitness.py
@@ -185,7 +185,11 @@ def test_bundled_recipe_open_kitchen_envelope_fits_per_backend(
     )
 
     caps = _backend_capabilities()[backend_name]
-    bound_bytes = resolve_recipe_envelope_byte_limit(caps)
+    if finalized.decision.reason == "exemption_overrides_envelope":
+        assert caps.recipe_delivery_budget is None
+        bound_bytes = RESPONSE_BACKSTOP_EXEMPTION_REGISTRY["open_kitchen"].max_utf8_bytes
+    else:
+        bound_bytes = resolve_recipe_envelope_byte_limit(caps)
     envelope = json.loads(finalized.rendered)
     assert len(finalized.rendered.encode("utf-8")) <= bound_bytes, (
         f"{backend_name}: envelope for {recipe_name} exceeds "

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -107,6 +107,7 @@ def test_backend_capabilities_field_count():
         "supports_model_invocation_gating",
         "github_api_callable",
         "protected_recipe_delivery_capable",
+        "claude_marketplace_tool_prefix_capable",
     }
     assert frozenset_fields == {
         "completion_record_types",
@@ -184,6 +185,7 @@ def test_backend_capabilities_field_names_locked():
         "github_api_callable",
         "unnegotiated_tool_result_token_limit",
         "protected_recipe_delivery_capable",
+        "claude_marketplace_tool_prefix_capable",
         "recipe_delivery_budget",
         "hook_trust_policy",
     }
@@ -203,6 +205,7 @@ def test_claude_code_capabilities_field_values():
     assert CLAUDE_CODE_CAPABILITIES.supports_claude_format_stdout is True
     assert CLAUDE_CODE_CAPABILITIES.exit_code_is_terminal is False
     assert CLAUDE_CODE_CAPABILITIES.mcp_config_capable is False
+    assert CLAUDE_CODE_CAPABILITIES.claude_marketplace_tool_prefix_capable is True
     assert CLAUDE_CODE_CAPABILITIES.food_truck_capable is True
     assert CLAUDE_CODE_CAPABILITIES.completion_record_types == frozenset({"result"})
     assert CLAUDE_CODE_CAPABILITIES.session_record_types == frozenset({"assistant"})

--- a/tests/core/test_recipe_delivery_contract.py
+++ b/tests/core/test_recipe_delivery_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+from typing import cast
 
 import pytest
 
@@ -10,6 +11,7 @@ from autoskillit.core import (
     AGENT_BACKEND_CLAUDE_CODE,
     AGENT_BACKEND_CODEX,
     RECIPE_DELIVERY_ATTESTATION_AUDIENCE,
+    RECIPE_FLOW_SCHEMA_VERSION,
     BackendCapabilities,
     RecipeDeliveryAttestation,
     RecipeDeliveryBudgetDef,
@@ -17,6 +19,7 @@ from autoskillit.core import (
     RecipeDeliveryEvidenceDef,
     RecipeDeliveryMode,
     RecipeDeliveryRequest,
+    RecipeFlowGeneration,
     recipe_delivery_request_digest,
     resolve_general_output_token_limit,
     resolve_recipe_delivery_decision,
@@ -361,3 +364,18 @@ def test_history_retention_never_becomes_selected_outer_result() -> None:
 def test_negative_required_tokens_fail_closed() -> None:
     decision = _resolve(required=-1)
     assert decision.mode is RecipeDeliveryMode.ENVELOPE
+
+
+def test_flow_generation_owns_an_immutable_record_tuple() -> None:
+    caller_records = ['{"kind":"entrypoint","name":"step"}']
+
+    generation = RecipeFlowGeneration(
+        schema_version=RECIPE_FLOW_SCHEMA_VERSION,
+        records=cast(tuple[str, ...], caller_records),
+    )
+    original_identity = generation.identity()
+    caller_records.append('{"kind":"step","name":"later"}')
+
+    assert generation.records == ('{"kind":"entrypoint","name":"step"}',)
+    assert generation.record_count == 1
+    assert generation.identity() == original_identity

--- a/tests/core/test_recipe_delivery_contract.py
+++ b/tests/core/test_recipe_delivery_contract.py
@@ -10,9 +10,12 @@ import pytest
 from autoskillit.core import (
     AGENT_BACKEND_CLAUDE_CODE,
     AGENT_BACKEND_CODEX,
+    RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+    RECIPE_ARTIFACT_SCHEMA_VERSION,
     RECIPE_DELIVERY_ATTESTATION_AUDIENCE,
     RECIPE_FLOW_SCHEMA_VERSION,
     BackendCapabilities,
+    RecipeArtifactGeneration,
     RecipeDeliveryAttestation,
     RecipeDeliveryBudgetDef,
     RecipeDeliveryDecision,
@@ -379,3 +382,44 @@ def test_flow_generation_owns_an_immutable_record_tuple() -> None:
     assert generation.records == ('{"kind":"entrypoint","name":"step"}',)
     assert generation.record_count == 1
     assert generation.identity() == original_identity
+
+
+def _artifact_generation(**changes: object) -> RecipeArtifactGeneration:
+    values: dict[str, object] = {
+        "producer_tool": "open_kitchen",
+        "recipe_name": "demo",
+        "descriptor_version": RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+        "schema_version": RECIPE_ARTIFACT_SCHEMA_VERSION,
+        "payload_sha256": f"sha256:{'1' * 64}",
+        "artifact_blob_sha256": f"sha256:{'2' * 64}",
+        "artifact_blob_size_bytes": 100,
+        "body_sha256": f"sha256:{'3' * 64}",
+        "body_size_bytes": 50,
+        "flow_schema_version": RECIPE_FLOW_SCHEMA_VERSION,
+        "flow_sha256": f"sha256:{'4' * 64}",
+        "flow_size_bytes": 25,
+        "flow_record_count": 1,
+    }
+    values.update(changes)
+    return RecipeArtifactGeneration(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"producer_tool": ""}, "producer_tool"),
+        ({"recipe_name": ""}, "recipe_name"),
+        ({"descriptor_version": 0}, "descriptor_version"),
+        ({"payload_sha256": "not-a-digest"}, "payload_sha256"),
+        ({"artifact_blob_size_bytes": 0}, "artifact_blob_size_bytes"),
+        ({"body_size_bytes": 101}, "body_size_bytes"),
+        ({"flow_size_bytes": 101}, "flow_size_bytes"),
+        ({"flow_record_count": 0}, "flow_record_count"),
+    ],
+)
+def test_artifact_generation_rejects_malformed_identity_at_construction(
+    changes: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _artifact_generation(**changes)

--- a/tests/core/test_recipe_delivery_contract.py
+++ b/tests/core/test_recipe_delivery_contract.py
@@ -413,7 +413,7 @@ def _artifact_generation(**changes: object) -> RecipeArtifactGeneration:
         ({"payload_sha256": "not-a-digest"}, "payload_sha256"),
         ({"artifact_blob_size_bytes": 0}, "artifact_blob_size_bytes"),
         ({"body_size_bytes": 101}, "body_size_bytes"),
-        ({"flow_size_bytes": 101}, "flow_size_bytes"),
+        ({"flow_size_bytes": 0}, "flow_size_bytes"),
         ({"flow_record_count": 0}, "flow_record_count"),
     ],
 )

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -207,9 +207,9 @@ def _count_semantic_rule_files() -> int:
 # ----- tests ------------------------------------------------------------------
 
 
-def test_kitchen_tagged_tool_count_is_41() -> None:
+def test_kitchen_tagged_tool_count_is_42() -> None:
     count = _count_kitchen_tools()
-    assert count == 41, f"Expected 41 kitchen-tagged tools; found {count}"
+    assert count == 42, f"Expected 42 kitchen-tagged tools; found {count}"
 
 
 def test_free_range_tool_count_is_17() -> None:
@@ -302,8 +302,8 @@ def _assert_doc_states_number(doc: Path, label: str, expected: int) -> None:
         DOCS_DIR / "execution" / "tool-access.md",
     ],
 )
-def test_docs_state_60_mcp_tools(doc_path: Path) -> None:
-    _assert_doc_states_number(doc_path, "MCP tools", 60)
+def test_docs_state_61_mcp_tools(doc_path: Path) -> None:
+    _assert_doc_states_number(doc_path, "MCP tools", 61)
 
 
 @pytest.mark.parametrize(
@@ -313,8 +313,8 @@ def test_docs_state_60_mcp_tools(doc_path: Path) -> None:
         DOCS_DIR / "execution" / "tool-access.md",
     ],
 )
-def test_docs_state_41_kitchen_tools(doc_path: Path) -> None:
-    _assert_doc_states_number(doc_path, "kitchen tools", 41)
+def test_docs_state_42_kitchen_tools(doc_path: Path) -> None:
+    _assert_doc_states_number(doc_path, "kitchen tools", 42)
 
 
 def test_skill_visibility_states_142_skills() -> None:

--- a/tests/execution/backends/test_coding_agent_backend_conformance.py
+++ b/tests/execution/backends/test_coding_agent_backend_conformance.py
@@ -44,6 +44,7 @@ CAPABILITY_CLASSIFICATION: dict[str, Literal["REQUIRED", "OPTIONAL"]] = {
     "applicable_guards": "REQUIRED",
     "anthropic_provider_capable": "OPTIONAL",
     "channel_b_capable": "OPTIONAL",
+    "claude_marketplace_tool_prefix_capable": "REQUIRED",
     "completion_record_types": "REQUIRED",
     "default_skill_sandbox_mode": "REQUIRED",
     "unnegotiated_tool_result_token_limit": "REQUIRED",
@@ -113,6 +114,13 @@ class TestCodingAgentBackendConformance(BackendContractBase):
         """BackendCapabilities.process_name — backend name from identity field."""
         assert isinstance(self.backend.name, str)
         assert len(self.backend.name) > 0
+
+    def test_marketplace_tool_prefix_capability_is_bool(self) -> None:
+        """BackendCapabilities.claude_marketplace_tool_prefix_capable is boolean."""
+        assert isinstance(
+            self.backend.capabilities.claude_marketplace_tool_prefix_capable,
+            bool,
+        )
 
     def test_capabilities_returns_backend_capabilities(self) -> None:
         """BackendCapabilities contract — exercises multiple fields.

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -14,8 +14,10 @@ if TYPE_CHECKING:
     from autoskillit.recipe._recipe_ingredients import OpenKitchenResult
 
 from autoskillit.core import (
+    RECIPE_FLOW_SCHEMA_VERSION,
     RESPONSE_BACKSTOP_EXEMPTION_REGISTRY,
     RESPONSE_BACKSTOP_EXEMPTION_REGISTRY_DIGEST,
+    RecipeFlowGeneration,
 )
 from autoskillit.execution import CODEX_RECIPE_DELIVERY_BUDGET
 from autoskillit.hooks.formatters.pretty_output_hook import _format_response
@@ -27,6 +29,27 @@ from tests.infra._pretty_output_helpers import (
 )
 
 pytestmark = [pytest.mark.layer("infra"), pytest.mark.medium]
+
+
+def _simple_flow_generation(name: str) -> RecipeFlowGeneration:
+    records = (
+        json.dumps(
+            {"kind": "entrypoint", "name": name},
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ),
+        json.dumps(
+            {"index": 0, "kind": "step", "name": name},
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ),
+    )
+    return RecipeFlowGeneration(
+        schema_version=RECIPE_FLOW_SCHEMA_VERSION,
+        records=records,
+    )
 
 
 def test_response_backstop_tool_metadata_comes_from_registry() -> None:
@@ -466,12 +489,16 @@ def test_attested_recipe_delivery_region_is_preserved_byte_for_byte(
         "errors": [],
         "warnings": [],
     }
+    flow_generation = _simple_flow_generation("impl")
+    payload["flow_records"] = list(flow_generation.records)
+    payload["recipe_flow"] = flow_generation.identity()
     generation = persist_recipe_artifact(
         tmp_path,
         kitchen_id="formatter-contract",
         producer_tool=tool_name,
         recipe_name="remediation",
         payload=payload,
+        flow_generation=flow_generation,
     )
     protected = _attested_render(
         payload,
@@ -947,6 +974,8 @@ _COMPACT_TEST_OVERRIDES = {
     "default": {
         "task": "test task",
         "issue_url": "https://github.com/test/test/issues/1",
+        "max_issues_per_l2": "6",
+        "model_context_window": "200000",
     },
     "all_truthy": {
         "task": "test task",
@@ -954,6 +983,8 @@ _COMPACT_TEST_OVERRIDES = {
         "is_fleet_dispatch": "true",
         "adversarial_review_level": "true",
         "local_review_rounds": "true",
+        "max_issues_per_l2": "6",
+        "model_context_window": "200000",
         "base_branch": "true",
         "pipeline_health": "true",
     },
@@ -968,10 +999,12 @@ def _served_content(
     from autoskillit.recipe._api_cache import LoadCache
 
     monkeypatch.setattr(_api_cache, "_LOAD_CACHE", LoadCache())
+    resolved = dict(overrides, source_dir=str(project_root))
     result = load_and_validate(
         recipe_name,
         project_dir=project_root,
-        ingredient_overrides=dict(overrides, source_dir=str(project_root)),
+        ingredient_overrides=resolved,
+        resolved_defaults=resolved,
         temp_dir=tmp_path,
     )
     return result.get("content")
@@ -1014,10 +1047,9 @@ def test_compact_recipe_display_preserves_execution_semantics(tmp_path, monkeypa
 
 def test_canonical_recipe_responses_fit_independent_registry_ceilings(tmp_path, monkeypatch):
     """Measure the same pre-backstop string in characters and UTF-8 bytes."""
-    from types import SimpleNamespace
 
     from autoskillit import __version__
-    from autoskillit.recipe import _api_cache, all_validated_recipe_names
+    from autoskillit.recipe import _api_cache, all_validated_recipe_names, load_and_validate
     from autoskillit.recipe._api_cache import LoadCache
     from autoskillit.recipe.io import _SCRIPTS_PLACEHOLDER, builtin_scripts_dir
     from autoskillit.recipe.repository import DefaultRecipeRepository
@@ -1045,13 +1077,25 @@ def test_canonical_recipe_responses_fit_independent_registry_ceilings(tmp_path, 
                 session_serve_overrides=None,
                 session_serve_defer_unresolved=False,
             )
+            resolved = dict(overrides, source_dir=str(project_root))
+            preview = load_and_validate(
+                recipe_name,
+                project_dir=project_root,
+                ingredient_overrides=resolved,
+                resolved_defaults=resolved,
+                temp_dir=tmp_path,
+            )
+            if not preview.get("post_prune_step_names"):
+                continue
+            monkeypatch.setattr(_api_cache, "_LOAD_CACHE", LoadCache())
             result = serve_recipe(
                 tool_ctx,
                 recipe_name,
-                caller_overrides=dict(overrides, source_dir=str(project_root)),
-                config_default={},
-                session_overrides={},
-                config_layer={},
+                caller_overrides=resolved,
+                config_default=resolved,
+                session_overrides=resolved,
+                config_layer=resolved,
+                resolved_defaults=resolved,
                 temp_dir=tmp_path,
             )
 
@@ -1092,8 +1136,8 @@ def test_canonical_recipe_responses_fit_independent_registry_ceilings(tmp_path, 
         for ingredients_only in (False, True)
     }
     assert maxima == {
-        "load_recipe": (168_348, "remediation", "all_truthy"),
-        "open_kitchen": (168_401, "remediation", "all_truthy"),
+        "load_recipe": (168_523, "remediation", "all_truthy"),
+        "open_kitchen": (168_576, "remediation", "all_truthy"),
     }
 
 
@@ -1114,7 +1158,11 @@ def test_rendered_open_kitchen_payload_under_budget(tmp_path, monkeypatch):
     Ceiling accommodates growth from issue #4274 Part B (the new
     ``inter_part_push_pre_remediation`` / ``verify_ref_push_exhaustion`` steps in
     ``remediation.yaml`` legitimately grew the rendered payload)."""
-    from autoskillit.core import resolve_general_output_token_limit
+    from autoskillit.core import (
+        RECIPE_FLOW_SCHEMA_VERSION,
+        RecipeFlowGeneration,
+        resolve_recipe_envelope_byte_limit,
+    )
     from autoskillit.execution.backends import BACKEND_REGISTRY
     from autoskillit.hooks.formatters import _fmt_recipe_compact
     from autoskillit.hooks.formatters.pretty_output_hook import (
@@ -1129,45 +1177,77 @@ def test_rendered_open_kitchen_payload_under_budget(tmp_path, monkeypatch):
     ceiling = RESPONSE_BACKSTOP_EXEMPTION_REGISTRY["open_kitchen"].max_utf8_bytes
     # Smallest backend's effective delivery bound across the registry — the
     # conservative ceiling a payload of arbitrary size must fit. Mirrors
-    # `_smallest_bound_tokens()` in tests/server/test_tools_recipe_pull.py and
+    # The recipe envelope uses the strictest registered backend byte ceiling.
+    # This mirrors the production resolver and
     # `test_capability_default_uses_conservative_bound` in this directory's
     # sibling test file. Computed inline because this test lives in tests/infra/
     # and does not have a full `ToolContext` fixture available; replicates the
     # fits/build-envelope decision directly rather than depending on
-    # `maybe_envelope_recipe_response`, which receives its bound as a
-    # caller-supplied parameter (selected_result_token_limit) derived from
-    # the single active session's backend, not computed via `min()`.
+    # `maybe_envelope_recipe_response`, which receives a single active session's
+    # bound instead of computing the registry minimum.
     backend_caps = {name: cls().capabilities for name, cls in BACKEND_REGISTRY.items()}
-    smallest_bound_tokens = min(
-        resolve_general_output_token_limit(caps) for caps in backend_caps.values()
+    smallest_bound_bytes = min(
+        resolve_recipe_envelope_byte_limit(caps) for caps in backend_caps.values()
     )
-    smallest_bound_bytes = smallest_bound_tokens * 4
     over_budget: list[str] = []
     maximum: tuple[int, str, str] = (0, "", "")
 
     for recipe_name in all_validated_recipe_names(project_root):
         for mode_name, overrides in _COMPACT_TEST_OVERRIDES.items():
             monkeypatch.setattr(_api_cache, "_LOAD_CACHE", LoadCache())
+            resolved = dict(overrides, source_dir=str(project_root))
             result = load_and_validate(
                 recipe_name,
                 project_dir=project_root,
-                ingredient_overrides=dict(overrides, source_dir=str(project_root)),
+                ingredient_overrides=resolved,
+                resolved_defaults=resolved,
                 temp_dir=tmp_path,
             )
+            payload = dict(result)
+            step_names = [
+                name
+                for name in payload.get("post_prune_step_names") or []
+                if isinstance(name, str)
+            ]
+            if not step_names:
+                continue
+            flow_records = [
+                json.dumps(
+                    {"kind": "entrypoint", "name": step_names[0]},
+                    ensure_ascii=False,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ),
+                *[
+                    json.dumps(
+                        {"index": index, "kind": "step", "name": name},
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    )
+                    for index, name in enumerate(step_names)
+                ],
+            ]
+            flow_generation = RecipeFlowGeneration(
+                schema_version=RECIPE_FLOW_SCHEMA_VERSION,
+                records=tuple(flow_records),
+            )
+            payload["flow_records"] = list(flow_generation.records)
+            payload["recipe_flow"] = flow_generation.identity()
             generation = persist_recipe_artifact(
                 tmp_path,
                 kitchen_id="pretty-output",
                 producer_tool="open_kitchen",
                 recipe_name=recipe_name,
-                payload=dict(result),
+                payload=payload,
+                flow_generation=flow_generation,
             )
             envelope = build_recipe_envelope(
-                dict(result),
+                payload,
                 recipe_name=recipe_name,
                 generation=generation,
-                skeleton_source=cast(
-                    "ToolContext", SimpleNamespace(recipe_name="", active_recipe_steps=None)
-                ),
+                flow_generation=flow_generation,
+                entrypoint=step_names[0],
                 bound_bytes=smallest_bound_bytes,
             )
             rendered = _fmt_open_kitchen(envelope, pipeline=False)

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
 if TYPE_CHECKING:
-    from autoskillit.pipeline import ToolContext
     from autoskillit.recipe._recipe_ingredients import OpenKitchenResult
 
 from autoskillit.core import (

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -119,10 +119,10 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 90),
     # tools_kitchen.py — hook config, quota guard, git_ops_policy, ingredient locks overlay
-    ("src/autoskillit/server/tools/tools_kitchen.py", 285),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 304),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 338),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 1460),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 290),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 309),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 343),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1557),
     # tools_pipeline_tracker.py — tracker_data dict (init) and mark_step_complete write
     # (same tracker file schema as init — not a new format, grandfathered alongside it)
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 256),

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -122,7 +122,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools/tools_kitchen.py", 290),
     ("src/autoskillit/server/tools/tools_kitchen.py", 309),
     ("src/autoskillit/server/tools/tools_kitchen.py", 343),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 1557),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1575),
     # tools_pipeline_tracker.py — tracker_data dict (init) and mark_step_complete write
     # (same tracker file schema as init — not a new format, grandfathered alongside it)
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 256),

--- a/tests/pipeline/AGENTS.md
+++ b/tests/pipeline/AGENTS.md
@@ -15,6 +15,7 @@ Audit log, gate state, token tracking, and PR-gate tests.
 | `test_github_api_log.py` | GitHub API log tests |
 | `test_mcp_response.py` | Tests for autoskillit.pipeline.mcp_response — MCP tool response size tracking |
 | `test_pr_gates.py` | Tests for analyze-prs PR eligibility gate logic (CI gate + review gate) |
+| `test_recipe_initialization.py` | Pure INITIALIZING/READY lifecycle, page ordering, replay, and generation-identity tests |
 | `test_telemetry_formatter.py` | Tests for TelemetryFormatter — canonical telemetry formatting |
 | `test_timings.py` | Tests for autoskillit.pipeline.timings — pipeline step timing |
 | `test_tokens_core.py` | Tests for pipeline.tokens — TokenEntry, DefaultTokenLog core, and log-dir loading |

--- a/tests/pipeline/test_gate.py
+++ b/tests/pipeline/test_gate.py
@@ -60,6 +60,7 @@ def test_gated_tools_contains_expected_names():
         "record_pipeline_step",
         "reset_dispatch",
         "get_recipe_section",
+        "complete_recipe_initialization",
     }
     assert GATED_TOOLS == expected
 

--- a/tests/pipeline/test_recipe_initialization.py
+++ b/tests/pipeline/test_recipe_initialization.py
@@ -25,6 +25,7 @@ from autoskillit.pipeline import (
     RecipeInitializationRequirement,
     initialization_is_complete,
     record_initialization_page,
+    replace_ready_execution,
     start_recipe_initialization,
     transition_recipe_ready,
 )
@@ -241,3 +242,38 @@ def test_ready_recipe_rejects_direct_construction_without_transition_authority()
             completion_receipt=_hash("receipt"),
             _transition_token=object(),
         )
+
+
+def test_ready_execution_replacement_rejects_cross_generation_without_mutation() -> None:
+    state = _initializing()
+    for requirement in state.requirements:
+        for part in range(requirement.total_parts):
+            state = cast(
+                InitializingRecipe,
+                record_initialization_page(
+                    state,
+                    initialization_id=state.initialization_id,
+                    section=requirement.section,
+                    page_plan_sha256=requirement.page_plan_sha256,
+                    part=part,
+                ),
+            )
+    installed = InstalledRecipeExecution(
+        snapshot=state.staged_snapshot,
+        runtime_binding_digests={},
+        audit_cycle_heads=cast(Any, object()),
+        input_preflight_resolver=cast(Any, object()),
+    )
+    ready = transition_recipe_ready(
+        state,
+        installed_execution=installed,
+        completion_receipt=_hash("receipt"),
+    )
+    original = ready
+    replacement = replace(installed, snapshot=_snapshot("execution-b"))
+
+    with pytest.raises(ValueError, match="crosses generations"):
+        replace_ready_execution(ready, replacement)
+
+    assert ready == original
+    assert ready.installed_execution is installed

--- a/tests/pipeline/test_recipe_initialization.py
+++ b/tests/pipeline/test_recipe_initialization.py
@@ -1,0 +1,219 @@
+"""Focused contracts for the named-recipe initialization lifecycle."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+from typing import Any, cast
+
+import pytest
+
+from autoskillit.core import (
+    RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+    RECIPE_ARTIFACT_SCHEMA_VERSION,
+    RECIPE_FLOW_SCHEMA_VERSION,
+    InstalledRecipeExecution,
+    RecipeArtifactGeneration,
+    RecipeExecutionSnapshot,
+    RecipeFlowGeneration,
+    compute_recipe_execution_snapshot_digest,
+)
+from autoskillit.pipeline import (
+    InitializingRecipe,
+    RecipeInitializationRequirement,
+    initialization_is_complete,
+    record_initialization_page,
+    start_recipe_initialization,
+    transition_recipe_ready,
+)
+
+pytestmark = [pytest.mark.layer("pipeline"), pytest.mark.small]
+
+
+def _hash(seed: str) -> str:
+    return f"sha256:{hashlib.sha256(seed.encode()).hexdigest()}"
+
+
+def _snapshot(execution_id: str = "execution-a") -> RecipeExecutionSnapshot:
+    recipe_name = "recipe"
+    content_hash = _hash(f"{execution_id}:content")
+    composite_hash = _hash(f"{execution_id}:composite")
+    snapshot_digest = compute_recipe_execution_snapshot_digest(
+        execution_id=execution_id,
+        recipe_name=recipe_name,
+        content_hash=content_hash,
+        composite_hash=composite_hash,
+        templates={},
+        dynamic_skill_step_names=frozenset(),
+    )
+    return RecipeExecutionSnapshot(
+        execution_id=execution_id,
+        recipe_name=recipe_name,
+        content_hash=content_hash,
+        composite_hash=composite_hash,
+        templates={},
+        snapshot_digest=snapshot_digest,
+        dynamic_skill_step_names=frozenset(),
+    )
+
+
+def _flow() -> RecipeFlowGeneration:
+    return RecipeFlowGeneration(
+        schema_version=RECIPE_FLOW_SCHEMA_VERSION,
+        records=(
+            json.dumps(
+                {"kind": "entrypoint", "name": "step"},
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+        ),
+    )
+
+
+def _artifact(flow: RecipeFlowGeneration) -> RecipeArtifactGeneration:
+    return RecipeArtifactGeneration(
+        producer_tool="open_kitchen",
+        recipe_name="recipe",
+        descriptor_version=RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+        schema_version=RECIPE_ARTIFACT_SCHEMA_VERSION,
+        payload_sha256=_hash("payload"),
+        artifact_blob_sha256=_hash("blob"),
+        artifact_blob_size_bytes=10,
+        body_sha256=_hash("body"),
+        body_size_bytes=5,
+        flow_schema_version=flow.schema_version,
+        flow_sha256=flow.flow_sha256,
+        flow_size_bytes=flow.flow_size_bytes,
+        flow_record_count=flow.record_count,
+    )
+
+
+def _initializing() -> InitializingRecipe:
+    flow = _flow()
+    return start_recipe_initialization(
+        kitchen_id="kitchen",
+        recipe_name="recipe",
+        artifact_generation=_artifact(flow),
+        flow_generation=flow,
+        initialization_id="initialization",
+        staged_snapshot=_snapshot(),
+        requirements=(
+            RecipeInitializationRequirement(
+                section="flow_records",
+                page_plan_sha256=_hash("flow-plan"),
+                total_parts=2,
+            ),
+            RecipeInitializationRequirement(
+                section="step",
+                page_plan_sha256=_hash("step-plan"),
+                total_parts=1,
+            ),
+        ),
+        generation_store_key="compile-key",
+    )
+
+
+def test_start_initialization_creates_zero_progress_for_each_requirement() -> None:
+    state = _initializing()
+
+    assert tuple(item.next_part for item in state.progress) == (0, 0)
+    assert initialization_is_complete(state) is False
+
+
+def test_page_progress_is_in_order_and_exact_replay_is_idempotent() -> None:
+    state = _initializing()
+    first = record_initialization_page(
+        state,
+        initialization_id="initialization",
+        section="flow_records",
+        page_plan_sha256=_hash("flow-plan"),
+        part=0,
+    )
+
+    assert first != state
+    assert (
+        record_initialization_page(
+            first,
+            initialization_id="initialization",
+            section="flow_records",
+            page_plan_sha256=_hash("flow-plan"),
+            part=0,
+        )
+        is first
+    )
+
+
+@pytest.mark.parametrize(
+    ("initialization_id", "section", "page_plan_sha256", "part"),
+    [
+        ("stale", "flow_records", _hash("flow-plan"), 0),
+        ("initialization", "other", _hash("flow-plan"), 0),
+        ("initialization", "flow_records", _hash("other-plan"), 0),
+        ("initialization", "flow_records", _hash("flow-plan"), 1),
+    ],
+)
+def test_page_progress_rejects_stale_changed_or_skipped_requests(
+    initialization_id: str,
+    section: str,
+    page_plan_sha256: str,
+    part: int,
+) -> None:
+    with pytest.raises(ValueError):
+        record_initialization_page(
+            _initializing(),
+            initialization_id=initialization_id,
+            section=section,
+            page_plan_sha256=page_plan_sha256,
+            part=part,
+        )
+
+
+def test_ready_requires_complete_coverage_and_the_staged_snapshot() -> None:
+    state = _initializing()
+    installed = InstalledRecipeExecution(
+        snapshot=state.staged_snapshot,
+        runtime_binding_digests={},
+        audit_cycle_heads=cast(Any, object()),
+        input_preflight_resolver=cast(Any, object()),
+    )
+
+    with pytest.raises(ValueError, match="incomplete"):
+        transition_recipe_ready(
+            state,
+            installed_execution=installed,
+            completion_receipt=_hash("receipt"),
+        )
+
+    for section, page_plan_sha256, parts in (
+        ("flow_records", _hash("flow-plan"), range(2)),
+        ("step", _hash("step-plan"), range(1)),
+    ):
+        for part in parts:
+            state = cast(
+                InitializingRecipe,
+                record_initialization_page(
+                    state,
+                    initialization_id="initialization",
+                    section=section,
+                    page_plan_sha256=page_plan_sha256,
+                    part=part,
+                ),
+            )
+
+    mismatched = replace(installed, snapshot=_snapshot("execution-b"))
+    with pytest.raises(ValueError, match="differs"):
+        transition_recipe_ready(
+            state,
+            installed_execution=mismatched,
+            completion_receipt=_hash("receipt"),
+        )
+
+    ready = transition_recipe_ready(
+        state,
+        installed_execution=installed,
+        completion_receipt=_hash("receipt"),
+    )
+    assert ready.initialization_id == state.initialization_id
+    assert ready.artifact_generation == state.artifact_generation
+    assert ready.flow_generation == state.flow_generation

--- a/tests/pipeline/test_recipe_initialization.py
+++ b/tests/pipeline/test_recipe_initialization.py
@@ -21,6 +21,7 @@ from autoskillit.core import (
 )
 from autoskillit.pipeline import (
     InitializingRecipe,
+    ReadyRecipe,
     RecipeInitializationRequirement,
     initialization_is_complete,
     record_initialization_page,
@@ -217,3 +218,26 @@ def test_ready_requires_complete_coverage_and_the_staged_snapshot() -> None:
     assert ready.initialization_id == state.initialization_id
     assert ready.artifact_generation == state.artifact_generation
     assert ready.flow_generation == state.flow_generation
+
+
+def test_ready_recipe_rejects_direct_construction_without_transition_authority() -> None:
+    state = _initializing()
+    installed = InstalledRecipeExecution(
+        snapshot=state.staged_snapshot,
+        runtime_binding_digests={},
+        audit_cycle_heads=cast(Any, object()),
+        input_preflight_resolver=cast(Any, object()),
+    )
+
+    with pytest.raises(ValueError, match="completed initialization transition"):
+        ReadyRecipe(
+            kitchen_id=state.kitchen_id,
+            recipe_name=state.recipe_name,
+            artifact_generation=state.artifact_generation,
+            flow_generation=state.flow_generation,
+            initialization_id=state.initialization_id,
+            installed_execution=installed,
+            generation_store_key=state.generation_store_key,
+            completion_receipt=_hash("receipt"),
+            _transition_token=object(),
+        )

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -261,10 +261,10 @@ def test_finalized_projection_preserves_ordered_steps_entrypoint_and_routes(tmp_
 def test_finalized_projection_rejects_an_empty_entrypoint() -> None:
     from autoskillit.core import FinalizedRecipeProjection, RecipeBindingProjection
 
-    with pytest.raises(ValueError, match="at least one ordered step"):
+    with pytest.raises(ValueError, match="entrypoint must be a non-empty string"):
         FinalizedRecipeProjection(
             binding_projection=RecipeBindingProjection(invocations={}),
-            ordered_step_names=(),
+            ordered_step_names=("step",),
             entrypoint="",
             ordered_flow_edges=(),
         )

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -192,6 +192,11 @@ steps:
       cmd: "echo test"
     on_success: step_b
     on_failure: step_c
+    on_result:
+      field: status
+      routes:
+        ok: step_b
+        retry: step_c
   step_b:
     action: stop
     message: B
@@ -214,6 +219,55 @@ def test_load_recipe_result_has_post_prune_routing_edges(tmp_path):
         "post_prune_routing_edges must be in LoadRecipeResult"
     )
     assert set(result["post_prune_routing_edges"]) == {"step_b", "step_c"}
+
+
+def test_finalized_projection_preserves_ordered_steps_entrypoint_and_routes(tmp_path):
+    """The internal carrier is one exact projection of the finalized recipe."""
+    from autoskillit.core import FinalizedRecipeProjection
+    from autoskillit.recipe._api import load_and_validate
+
+    _setup_project_recipe(tmp_path, "test-recipe-routing", _RECIPE_WITH_ROUTING_EDGES)
+    result = load_and_validate(
+        name="test-recipe-routing",
+        project_dir=tmp_path,
+        include_finalized_projection=True,
+    )
+
+    projection = result["_finalized_projection"]
+    assert isinstance(projection, FinalizedRecipeProjection)
+    assert projection.ordered_step_names == ("step_a", "step_b", "step_c")
+    assert projection.entrypoint == "step_a"
+    assert tuple(
+        (
+            edge.source,
+            edge.edge_type,
+            edge.target,
+            edge.condition,
+            edge.result_field,
+        )
+        for edge in projection.ordered_flow_edges
+    ) == (
+        ("step_a", "success", "step_b", None, None),
+        ("step_a", "failure", "step_c", None, None),
+        ("step_a", "exhausted", "escalate", None, None),
+        ("step_a", "result_condition", "step_b", "ok", "status"),
+        ("step_a", "result_condition", "step_c", "retry", "status"),
+        ("step_b", "exhausted", "escalate", None, None),
+        ("step_c", "exhausted", "escalate", None, None),
+    )
+    assert tuple(projection.binding_projection.invocations) == ("step_a",)
+
+
+def test_finalized_projection_rejects_an_empty_entrypoint() -> None:
+    from autoskillit.core import FinalizedRecipeProjection, RecipeBindingProjection
+
+    with pytest.raises(ValueError, match="at least one ordered step"):
+        FinalizedRecipeProjection(
+            binding_projection=RecipeBindingProjection(invocations={}),
+            ordered_step_names=(),
+            entrypoint="",
+            ordered_flow_edges=(),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -265,7 +319,7 @@ def test_load_and_validate_returns_cached_result_on_second_call(tmp_path, monkey
     assert len(calls) == 1  # validate_recipe called only once across two loads
 
 
-def test_default_cache_excludes_server_only_compiled_bindings(tmp_path, monkeypatch):
+def test_default_cache_excludes_server_only_finalized_projection(tmp_path, monkeypatch):
     import autoskillit.recipe._api as api_mod
     import autoskillit.recipe._api_cache as cache_mod
 
@@ -277,18 +331,18 @@ def test_default_cache_excludes_server_only_compiled_bindings(tmp_path, monkeypa
 
     default_result = api_mod.load_and_validate("myrecipe", tmp_path)
 
-    assert "_compiled_bindings" not in default_result
+    assert "_finalized_projection" not in default_result
     assert len(cache._store) == 1
     default_entry = next(iter(cache._store.values()))
-    assert "_compiled_bindings" not in default_entry.result
+    assert "_finalized_projection" not in default_entry.result
 
     server_result = api_mod.load_and_validate(
         "myrecipe",
         tmp_path,
-        include_compiled_bindings=True,
+        include_finalized_projection=True,
     )
 
-    assert "_compiled_bindings" in server_result
+    assert "_finalized_projection" in server_result
     assert len(cache._store) == 2
 
 
@@ -427,7 +481,7 @@ def test_load_and_validate_cache_key_includes_all_result_affecting_params(tmp_pa
         "backend_name": 10,
         "effective_backend_map": 11,
         "backend_capabilities_map": 12,
-        "include_compiled_bindings": 13,
+        "include_finalized_projection": 13,
     }
 
     missing_params: list[str] = []
@@ -548,7 +602,7 @@ def test_repository_load_and_validate_passes_recipe_info_to_api(monkeypatch):
         backend_name=None,
         effective_backend_map=None,
         backend_origin_map=None,
-        include_compiled_bindings=False,
+        include_finalized_projection=False,
     ):
         captured["recipe_info"] = recipe_info
         captured["backend_capabilities_map"] = locals().get("backend_capabilities_map")
@@ -568,7 +622,7 @@ def test_repository_load_and_validate_passes_recipe_info_to_api(monkeypatch):
             effective_backend_map=effective_backend_map,
             backend_capabilities_map=backend_capabilities_map,
             backend_origin_map=backend_origin_map,
-            include_compiled_bindings=include_compiled_bindings,
+            include_finalized_projection=include_finalized_projection,
         )
 
     monkeypatch.setattr(api_mod, "load_and_validate", capturing_fn)

--- a/tests/server/AGENTS.md
+++ b/tests/server/AGENTS.md
@@ -37,6 +37,8 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_notify_module.py` | Contract tests: server._notify module |
 | `test_response_backstop.py` | Universal response-budget spill, exact projection, exemption, fail-closed, and telemetry contracts |
 | `test_recipe_section_pagination.py` | Pure schema-driven recipe-section pagination, rendering, digest, and cache contracts |
+| `test_recipe_generation.py` | Bounded kitchen-scoped compile-generation store, replay, eviction, retirement, and concurrency contracts |
+| `test_recipe_initialization.py` | Server-owned completion receipt and post-enforcement INITIALIZING-to-READY transaction contracts |
 | `test_perform_merge_editable_guard.py` | Integration tests verifying perform_merge() aborts before cleanup on poisoned installs |
 | `test_profile_to_env.py` | Tests for _profile_to_env — ProviderProfileDef to env dict conversion in _guards.py |
 | `test_quota_refresh_loop.py` | Tests for _quota_refresh_loop in server/_misc.py |

--- a/tests/server/_helpers.py
+++ b/tests/server/_helpers.py
@@ -8,6 +8,8 @@ from typing import Any
 from autoskillit.core import (
     RECIPE_SECTION_PAGINATION_VERSION,
     RECIPE_SECTION_REGISTRY_DIGEST,
+    FinalizedRecipeProjection,
+    RecipeBindingProjection,
     SkillResult,
     recipe_section_digest,
     recipe_section_element_digest,
@@ -16,6 +18,30 @@ from autoskillit.core.types import RetryReason
 from tests.fleet._helpers import _make_recipe_info as _fleet_make_recipe_info
 
 _HOOK_CONFIG_OVERLAY_RELPATH = (".autoskillit", "temp", ".hook_config_overlay.json")
+
+
+def _with_finalized_projection(
+    result: dict[str, Any],
+    *,
+    binding_projection: RecipeBindingProjection | None = None,
+) -> dict[str, Any]:
+    """Attach the server-only projection required by a successful serve fixture."""
+    for key, fill in (("content_hash", "a"), ("composite_hash", "b")):
+        digest = result.get(key)
+        if not isinstance(digest, str) or not digest.startswith("sha256:") or len(digest) != 71:
+            result[key] = "sha256:" + (fill * 64)
+    names = tuple(
+        name for name in result.get("post_prune_step_names", ()) if isinstance(name, str) and name
+    )
+    if not names:
+        names = ("fixture-entrypoint",)
+    result["_finalized_projection"] = FinalizedRecipeProjection(
+        binding_projection=binding_projection or RecipeBindingProjection(invocations={}),
+        ordered_step_names=names,
+        entrypoint=names[0],
+        ordered_flow_edges=(),
+    )
+    return result
 
 
 async def _resolve_recipe_section(result: dict[str, Any], *, section: str = "content") -> Any:
@@ -45,8 +71,18 @@ async def _resolve_recipe_section(result: dict[str, Any], *, section: str = "con
     expected_total_parts: int | None = None
     expected_section_total: int | None = None
     part = 0
+    page_plan_sha256: str | None = None
+    continuation: str | None = None
     while True:
-        response = json.loads(await get_recipe_section(section=section, part=part, **identity))
+        response = json.loads(
+            await get_recipe_section(
+                section=section,
+                part=part,
+                page_plan_sha256=page_plan_sha256,
+                continuation=continuation,
+                **identity,
+            )
+        )
         assert response.get("success") is True, f"get_recipe_section returned error: {response}"
         assert response["pagination_version"] == RECIPE_SECTION_PAGINATION_VERSION
         assert response["section_registry_sha256"] == RECIPE_SECTION_REGISTRY_DIGEST
@@ -72,6 +108,7 @@ async def _resolve_recipe_section(result: dict[str, Any], *, section: str = "con
         if shared_identity is None:
             shared_identity = page_identity
             expected_total_parts = response["total_parts"]
+            page_plan_sha256 = response["page_plan_sha256"]
         else:
             assert page_identity == shared_identity
             assert response["total_parts"] == expected_total_parts
@@ -252,6 +289,7 @@ async def _resolve_recipe_section(result: dict[str, Any], *, section: str = "con
             assert response["next_part"] == part + 1
             assert part + 1 < response["total_parts"]
             part = response["next_part"]
+            continuation = response["continuation"]
             continue
 
         assert "next_part" not in response

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -31,12 +31,15 @@ def _reset_server_state():
     because the previous value may itself be leaked state from an earlier test.
     """
     from autoskillit.server import _state
+    from autoskillit.server._recipe_generation import get_recipe_generation_store
 
     _state._ctx = None
     _state._startup_ready = None
+    get_recipe_generation_store().clear()
     yield
     _state._ctx = None
     _state._startup_ready = None
+    get_recipe_generation_store().clear()
 
 
 @pytest.fixture(autouse=True)
@@ -117,7 +120,11 @@ def assert_no_timing(timing_log: DefaultTimingLog) -> None:
 
 def _make_mock_ctx() -> MagicMock:
     """Return a minimal mock ToolContext with a gate."""
-    from autoskillit.config import OutputBudgetConfig
+    from threading import RLock
+
+    from autoskillit.config import OutputBudgetConfig, QuotaGuardConfig
+    from autoskillit.pipeline import NoActiveRecipe
+    from autoskillit.server._factory import make_recipe_execution
 
     gate = MagicMock()
     gate.enabled = False
@@ -129,9 +136,13 @@ def _make_mock_ctx() -> MagicMock:
     )
     ctx.kitchen_id = f"test-{uuid4().hex}"
     ctx.config.output_budget = OutputBudgetConfig()
+    ctx.config.quota_guard = QuotaGuardConfig()
     ctx.config.subsets.disabled = []  # REQ-VIS-008: no subsets disabled by default
     ctx.active_recipe_ingredients = None
     ctx.gate_infrastructure_ready = False
+    ctx.recipe_execution_lock = RLock()
+    ctx.recipe_initialization_state = NoActiveRecipe()
+    ctx.recipe_execution_factory = make_recipe_execution
     return ctx
 
 

--- a/tests/server/test_audit_cycle_delivery_integration.py
+++ b/tests/server/test_audit_cycle_delivery_integration.py
@@ -467,6 +467,49 @@ def test_failed_execution_preparation_aborts_receipt_before_commit(
     assert get_recipe_execution(minimal_ctx) is None
 
 
+def test_failed_execution_installation_aborts_receipt_before_commit(
+    minimal_ctx,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire_recipe_execution_factory(minimal_ctx)
+    finalized = _finalize_recipe_delivery(
+        {
+            "content": "name: demo\n",
+            "content_hash": _HASH_A,
+            "composite_hash": _HASH_B,
+            "valid": True,
+        },
+        surface="open_kitchen",
+        recipe_name="demo",
+        tool_ctx=minimal_ctx,
+        finalized_projection=_finalized_projection(),
+    )
+    handle = MagicMock()
+    ledger = MagicMock()
+    ledger.commit.return_value = True
+    ledger.abort.return_value = True
+    finalized = replace(
+        finalized,
+        receipt_handle=handle,
+        receipt_ledger=ledger,
+    )
+    monkeypatch.setattr(
+        recipe_delivery_module,
+        "install_recipe_execution",
+        MagicMock(side_effect=RuntimeError("install failed")),
+    )
+
+    result = json.loads(complete_finalized_recipe_response(finalized, finalized.rendered))
+
+    assert result == {
+        "success": False,
+        "error": "recipe_execution_install_failed",
+    }
+    ledger.commit.assert_not_called()
+    ledger.abort.assert_called_once_with(handle)
+    assert get_recipe_execution(minimal_ctx) is None
+
+
 def test_receipt_commit_failure_preserves_previous_execution(
     tool_ctx_kitchen_open,
 ) -> None:

--- a/tests/server/test_audit_cycle_delivery_integration.py
+++ b/tests/server/test_audit_cycle_delivery_integration.py
@@ -6,6 +6,7 @@ import json
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -23,6 +24,9 @@ import autoskillit.recipe._binding as binding_module
 import autoskillit.server._recipe_delivery as recipe_delivery_module
 import autoskillit.server._recipe_execution as recipe_execution_module
 from autoskillit.core import (
+    RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+    RECIPE_ARTIFACT_SCHEMA_VERSION,
+    RECIPE_FLOW_SCHEMA_VERSION,
     AdmissionReason,
     AdmissionStatus,
     ArtifactRef,
@@ -38,6 +42,7 @@ from autoskillit.core import (
     BoundValue,
     BoundValueOrigin,
     BoundValueState,
+    FinalizedRecipeProjection,
     InputPreflightResolver,
     InventoryAdmissionDecision,
     InventoryAdmissionEvaluator,
@@ -45,8 +50,10 @@ from autoskillit.core import (
     PlanDispositionReport,
     PlanDispositionRow,
     PreflightEvidence,
+    RecipeArtifactGeneration,
     RecipeBindingProjection,
     RecipeExecutionSnapshot,
+    RecipeFlowGeneration,
     RetryReason,
     SkillResult,
     VerifiedInputPreflightRequest,
@@ -59,6 +66,7 @@ from autoskillit.server._recipe_delivery import (
     complete_finalized_recipe_response,
     finalize_recipe_delivery,
     load_recipe_artifact,
+    prepare_recipe_delivery_generation,
 )
 from autoskillit.server._recipe_execution import (
     AuditCycleHeadConflict,
@@ -75,6 +83,8 @@ from autoskillit.server._recipe_execution import (
     publish_verified_audit_cycle,
     record_runtime_binding_digest,
 )
+from autoskillit.server._recipe_generation import RecipeGenerationError
+from autoskillit.server._recipe_initialization import stage_recipe_initialization
 from autoskillit.server.tools.tools_execution import run_skill
 from tests.conftest import _make_result
 
@@ -131,6 +141,44 @@ def _projection() -> RecipeBindingProjection:
     return RecipeBindingProjection({"dry": invocation})
 
 
+def _finalized_projection() -> FinalizedRecipeProjection:
+    return FinalizedRecipeProjection(
+        binding_projection=_projection(),
+        ordered_step_names=("dry",),
+        entrypoint="dry",
+        ordered_flow_edges=(),
+    )
+
+
+def _finalize_recipe_delivery(
+    payload: dict[str, Any],
+    *,
+    surface: str,
+    recipe_name: str,
+    tool_ctx: Any,
+    finalized_projection: FinalizedRecipeProjection,
+):
+    if not tool_ctx.kitchen_id:
+        tool_ctx.kitchen_id = "audit-cycle-delivery-test"
+    prepared = prepare_recipe_delivery_generation(
+        payload,
+        recipe_name=recipe_name,
+        tool_ctx=tool_ctx,
+        finalized_projection=finalized_projection,
+    )
+    return finalize_recipe_delivery(
+        payload,
+        surface=surface,
+        recipe_name=recipe_name,
+        tool_ctx=tool_ctx,
+        finalized_projection=finalized_projection,
+        flow_generation=prepared.flow_generation,
+        canonical_artifact_payload=prepared.canonical_artifact_payload,
+        execution_snapshot=prepared.execution_snapshot,
+        normalized_compile_key=prepared.normalized_compile_key,
+    )
+
+
 def _preflight_projection() -> RecipeBindingProjection:
     invocation = _projection().invocations["dry"]
     return RecipeBindingProjection(
@@ -164,6 +212,61 @@ def _wire_recipe_execution_factory(tool_ctx) -> None:
         )
 
     tool_ctx.recipe_execution_factory = _factory
+
+
+def _install_test_recipe_execution(
+    tool_ctx: Any,
+    *,
+    snapshot: RecipeExecutionSnapshot,
+):
+    """Stage the immutable test generation before installing READY authority."""
+    if not tool_ctx.kitchen_id:
+        tool_ctx.kitchen_id = "audit-cycle-execution-test"
+    flow_generation = RecipeFlowGeneration(
+        schema_version=RECIPE_FLOW_SCHEMA_VERSION,
+        records=(
+            json.dumps(
+                {"kind": "entrypoint", "name": snapshot.recipe_name},
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+        ),
+    )
+    artifact_generation = RecipeArtifactGeneration(
+        producer_tool="open_kitchen",
+        recipe_name=snapshot.recipe_name,
+        descriptor_version=RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+        schema_version=RECIPE_ARTIFACT_SCHEMA_VERSION,
+        payload_sha256=_HASH_A,
+        artifact_blob_sha256=_HASH_B,
+        artifact_blob_size_bytes=1,
+        body_sha256=_HASH_A,
+        body_size_bytes=1,
+        flow_schema_version=flow_generation.schema_version,
+        flow_sha256=flow_generation.flow_sha256,
+        flow_size_bytes=flow_generation.flow_size_bytes,
+        flow_record_count=flow_generation.record_count,
+    )
+    stage_recipe_initialization(
+        tool_ctx,
+        recipe_name=snapshot.recipe_name,
+        artifact_generation=artifact_generation,
+        flow_generation=flow_generation,
+        initialization_id=f"init-{snapshot.execution_id}",
+        staged_snapshot=snapshot,
+        requirements=(),
+        generation_store_key=f"test:{snapshot.execution_id}",
+    )
+    return install_recipe_execution(
+        tool_ctx,
+        snapshot=snapshot,
+        completion_receipt="sha256:" + ("c" * 64),
+    )
+
+
+def _replace_test_recipe_execution(tool_ctx: Any, installed: Any):
+    """Replace only READY runtime metadata while retaining generation identity."""
+    return install_recipe_execution(tool_ctx, prepared_execution=installed)
 
 
 def _artifact(path: Path, digest: str, *, byte_size: int = 1) -> ArtifactRef:
@@ -279,17 +382,17 @@ def test_delivery_persists_and_installs_matching_execution(
     minimal_ctx,
 ) -> None:
     _wire_recipe_execution_factory(minimal_ctx)
-    finalized = finalize_recipe_delivery(
+    finalized = _finalize_recipe_delivery(
         {
             "content": "name: demo\n",
             "content_hash": _HASH_A,
             "composite_hash": _HASH_B,
             "valid": True,
         },
-        surface="load_recipe",
+        surface="open_kitchen",
         recipe_name="demo",
         tool_ctx=minimal_ctx,
-        compiled_bindings=_projection(),
+        finalized_projection=_finalized_projection(),
     )
     assert finalized.artifact_generation is not None
     assert finalized.execution_snapshot is not None
@@ -326,17 +429,17 @@ def test_failed_execution_preparation_aborts_receipt_before_commit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _wire_recipe_execution_factory(minimal_ctx)
-    finalized = finalize_recipe_delivery(
+    finalized = _finalize_recipe_delivery(
         {
             "content": "name: demo\n",
             "content_hash": _HASH_A,
             "composite_hash": _HASH_B,
             "valid": True,
         },
-        surface="load_recipe",
+        surface="open_kitchen",
         recipe_name="demo",
         tool_ctx=minimal_ctx,
-        compiled_bindings=_projection(),
+        finalized_projection=_finalized_projection(),
     )
     handle = MagicMock()
     ledger = MagicMock()
@@ -348,7 +451,7 @@ def test_failed_execution_preparation_aborts_receipt_before_commit(
         receipt_ledger=ledger,
     )
     monkeypatch.setattr(
-        recipe_execution_module,
+        recipe_delivery_module,
         "prepare_recipe_execution",
         MagicMock(side_effect=RuntimeError("install failed")),
     )
@@ -374,11 +477,11 @@ def test_receipt_commit_failure_preserves_previous_execution(
         projection=_projection(),
         execution_id="previous-execution",
     )
-    previous = install_recipe_execution(
+    previous = _install_test_recipe_execution(
         tool_ctx_kitchen_open,
         snapshot=previous_snapshot,
     )
-    finalized = finalize_recipe_delivery(
+    finalized = _finalize_recipe_delivery(
         {
             "content": "name: replacement\n",
             "content_hash": _HASH_A,
@@ -388,7 +491,7 @@ def test_receipt_commit_failure_preserves_previous_execution(
         surface="load_recipe",
         recipe_name="replacement",
         tool_ctx=tool_ctx_kitchen_open,
-        compiled_bindings=_projection(),
+        finalized_projection=_finalized_projection(),
     )
     handle = MagicMock()
     ledger = MagicMock()
@@ -420,11 +523,11 @@ def test_transformed_delivery_preserves_previous_execution(
         projection=_projection(),
         execution_id="previous-execution",
     )
-    previous = install_recipe_execution(
+    previous = _install_test_recipe_execution(
         tool_ctx_kitchen_open,
         snapshot=previous_snapshot,
     )
-    finalized = finalize_recipe_delivery(
+    finalized = _finalize_recipe_delivery(
         {
             "content": "name: demo\n",
             "content_hash": _HASH_A,
@@ -434,7 +537,7 @@ def test_transformed_delivery_preserves_previous_execution(
         surface="load_recipe",
         recipe_name="demo",
         tool_ctx=tool_ctx_kitchen_open,
-        compiled_bindings=_projection(),
+        finalized_projection=_finalized_projection(),
     )
     assert complete_finalized_recipe_response(finalized, "bounded replacement") == (
         "bounded replacement"
@@ -446,8 +549,17 @@ def test_recipe_execution_compilation_failure_logs_exception_context(
     minimal_ctx,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    previous = MagicMock()
-    minimal_ctx.active_recipe_execution = previous
+    _wire_recipe_execution_factory(minimal_ctx)
+    previous = _install_test_recipe_execution(
+        minimal_ctx,
+        snapshot=build_recipe_execution_snapshot(
+            recipe_name="previous",
+            content_hash=_HASH_A,
+            composite_hash=_HASH_B,
+            projection=_projection(),
+            execution_id="previous-execution",
+        ),
+    )
     mock_logger = MagicMock()
     monkeypatch.setattr(recipe_delivery_module, "get_logger", lambda _name: mock_logger)
     monkeypatch.setattr(
@@ -456,27 +568,26 @@ def test_recipe_execution_compilation_failure_logs_exception_context(
         MagicMock(side_effect=ValueError("invalid template")),
     )
 
-    finalized = finalize_recipe_delivery(
-        {
-            "content": "name: demo\n",
-            "content_hash": _HASH_A,
-            "composite_hash": _HASH_B,
-            "valid": True,
-        },
-        surface="load_recipe",
-        recipe_name="demo",
-        tool_ctx=minimal_ctx,
-        compiled_bindings=_projection(),
-    )
+    with pytest.raises(
+        RecipeGenerationError,
+        match="recipe execution snapshot compilation failed",
+    ):
+        _finalize_recipe_delivery(
+            {
+                "content": "name: demo\n",
+                "content_hash": _HASH_A,
+                "composite_hash": _HASH_B,
+                "valid": True,
+            },
+            surface="load_recipe",
+            recipe_name="demo",
+            tool_ctx=minimal_ctx,
+            finalized_projection=_finalized_projection(),
+        )
 
-    assert json.loads(finalized.rendered) == {
-        "success": False,
-        "error": "recipe_execution_unavailable",
-    }
     mock_logger.warning.assert_called_once_with(
         "recipe_execution_compilation_failed",
         recipe_name="demo",
-        surface="load_recipe",
         error_type="ValueError",
         exc_info=True,
     )
@@ -702,7 +813,7 @@ def test_published_audit_head_binds_preflight_template_identity(
         projection=_projection(),
         execution_id="execution-1",
     )
-    install_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
+    _install_test_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
     authority = _authority(
         Path(tool_ctx_kitchen_open.temp_dir),
         generation="execution-1",
@@ -742,7 +853,7 @@ def test_audit_publication_does_not_mutate_replaced_execution(
         projection=_projection(),
         execution_id="execution-1",
     )
-    installed = install_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
+    installed = _install_test_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
     replacement = replace(
         installed,
         runtime_binding_digests={"replacement": _HASH_B},
@@ -767,7 +878,7 @@ def test_audit_publication_does_not_mutate_replaced_execution(
     ) -> bytes:
         nonlocal replaced
         if not replaced:
-            tool_ctx_kitchen_open.active_recipe_execution = replacement
+            _replace_test_recipe_execution(tool_ctx_kitchen_open, replacement)
             replaced = True
         return original_verify(verifier, artifact_ref)
 
@@ -785,7 +896,7 @@ def test_audit_publication_does_not_mutate_replaced_execution(
             expected_round=0,
         )
 
-    assert tool_ctx_kitchen_open.active_recipe_execution is replacement
+    assert get_recipe_execution(tool_ctx_kitchen_open) is replacement
     assert dict(replacement.runtime_binding_digests) == {"replacement": _HASH_B}
     assert (
         replacement.audit_cycle_heads.get(
@@ -808,7 +919,7 @@ def test_audit_publication_rejects_tampered_referenced_artifact(
         projection=_projection(),
         execution_id="execution-1",
     )
-    installed = install_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
+    installed = _install_test_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
     root = Path(tool_ctx_kitchen_open.temp_dir)
     authority = _authority(
         root,
@@ -852,7 +963,7 @@ def test_successful_audit_result_publishes_protected_successor_identity(
         projection=_projection(),
         execution_id="execution-1",
     )
-    installed = install_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
+    installed = _install_test_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
     authority = _authority(
         Path(tool_ctx_kitchen_open.temp_dir),
         generation="execution-1",
@@ -931,7 +1042,7 @@ def test_reported_audit_cycle_cannot_replace_attested_prior_lineage(
         projection=_projection(),
         execution_id="execution-1",
     )
-    installed = install_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
+    installed = _install_test_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
     root = Path(tool_ctx_kitchen_open.temp_dir)
     prior = _authority(
         root,
@@ -1765,7 +1876,7 @@ def test_runtime_binding_digest_rejects_replaced_execution(
         projection=_projection(),
         execution_id="execution-1",
     )
-    install_recipe_execution(tool_ctx_kitchen_open, snapshot=first)
+    _install_test_recipe_execution(tool_ctx_kitchen_open, snapshot=first)
     replacement = build_recipe_execution_snapshot(
         recipe_name="demo",
         content_hash=_HASH_A,
@@ -1773,7 +1884,7 @@ def test_runtime_binding_digest_rejects_replaced_execution(
         projection=_projection(),
         execution_id="execution-2",
     )
-    active = install_recipe_execution(tool_ctx_kitchen_open, snapshot=replacement)
+    active = _install_test_recipe_execution(tool_ctx_kitchen_open, snapshot=replacement)
 
     with pytest.raises(RecipeExecutionAdmissionError) as exc_info:
         record_runtime_binding_digest(
@@ -1800,7 +1911,7 @@ async def test_runtime_attestation_rejects_before_executor(
         projection=_projection(),
         execution_id="execution-1",
     )
-    install_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
+    _install_test_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
     calls_before = len(tool_ctx_kitchen_open.runner.call_args_list)
     result = json.loads(
         await run_skill(
@@ -1858,7 +1969,7 @@ async def test_dynamic_recipe_skill_step_executes_without_template_attestation(
         projection=projection,
         execution_id="execution-1",
     )
-    install_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
+    _install_test_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
     assert snapshot.templates == {}
     assert snapshot.dynamic_skill_step_names == frozenset({"fanout"})
     tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))
@@ -1914,7 +2025,7 @@ async def test_runtime_attestation_executes_bound_prompt_and_records_digest(
         projection=_preflight_projection(),
         execution_id="execution-1",
     )
-    installed = install_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
+    installed = _install_test_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
 
     class RecordingResolver:
         def __init__(self, wrapped: InputPreflightResolver) -> None:
@@ -1933,7 +2044,7 @@ async def test_runtime_attestation_executes_bound_prompt_and_records_digest(
         installed,
         input_preflight_resolver=recording_resolver,
     )
-    tool_ctx_kitchen_open.active_recipe_execution = installed
+    _replace_test_recipe_execution(tool_ctx_kitchen_open, installed)
     tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))
     tool_ctx_kitchen_open.runner.push(
         _make_result(
@@ -2027,10 +2138,9 @@ async def test_preflight_rejects_before_executor(
         projection=_preflight_projection(),
         execution_id="execution-1",
     )
-    installed = install_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
-    monkeypatch.setattr(
+    installed = _install_test_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
+    _replace_test_recipe_execution(
         tool_ctx_kitchen_open,
-        "active_recipe_execution",
         replace(
             installed,
             input_preflight_resolver=RejectingResolver(),

--- a/tests/server/test_cancellation_shield.py
+++ b/tests/server/test_cancellation_shield.py
@@ -88,6 +88,35 @@ def _typed_decorator(
     )
 
 
+@pytest.mark.anyio
+async def test_initialization_admission_precedes_typed_state_and_handler_side_effects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import autoskillit.server.tools._cancellation_shield as shield_module
+
+    events: list[str] = []
+    denial = json.dumps({"success": False, "error": "recipe_initialization_incomplete"})
+    monkeypatch.setattr(
+        shield_module,
+        "admit_registered_tool_during_initialization",
+        lambda tool_name: events.append(f"admit:{tool_name}") or denial,
+    )
+
+    state_var: ContextVar[_State] = ContextVar("admission-order")
+
+    @_typed_decorator(
+        lambda: events.append("state_factory") or _State("request", True, 512),
+        state_var,
+        lambda state, exc: "{}",
+    )
+    async def run_skill() -> str:
+        events.append("handler")
+        return "{}"
+
+    assert await run_skill() == denial
+    assert events == ["admit:run_skill"]
+
+
 @pytest.mark.parametrize(
     "typed_kwargs",
     [

--- a/tests/server/test_capability_admission_e2e.py
+++ b/tests/server/test_capability_admission_e2e.py
@@ -16,6 +16,7 @@ import pytest
 
 from autoskillit.core import BACKEND_CAPABILITY_INGREDIENTS, CAPABILITY_GATE_CALLABLES
 from autoskillit.recipe._api import load_and_validate
+from tests.server._helpers import _with_finalized_projection
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.medium]
 
@@ -195,19 +196,21 @@ def _make_feasible_load_result(
     post_prune_step_names: list[str] | None = None,
 ) -> dict[str, Any]:
     """Return a load_and_validate result dict for a feasible dispatch."""
-    return {
-        "content": "name: implementation\nsteps:\n  implement:\n    tool: run_skill\n",
-        "valid": True,
-        "errors": [],
-        "requires_packs": [],
-        "requires_features": [],
-        "content_hash": "abc123",
-        "composite_hash": "def456",
-        "recipe_version": "1.0",
-        "suggestions": [],
-        "post_prune_step_names": post_prune_step_names or ["implement", "retry_worktree"],
-        "dispatch_feasible": True,
-    }
+    return _with_finalized_projection(
+        {
+            "content": "name: implementation\nsteps:\n  implement:\n    tool: run_skill\n",
+            "valid": True,
+            "errors": [],
+            "requires_packs": [],
+            "requires_features": [],
+            "content_hash": "abc123",
+            "composite_hash": "def456",
+            "recipe_version": "1.0",
+            "suggestions": [],
+            "post_prune_step_names": post_prune_step_names or ["implement", "retry_worktree"],
+            "dispatch_feasible": True,
+        }
+    )
 
 
 def _setup_provider_override_ctx(tool_ctx: MagicMock) -> MagicMock:

--- a/tests/server/test_helpers_gate.py
+++ b/tests/server/test_helpers_gate.py
@@ -11,7 +11,12 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 def _valid_recipe_section_pages(format_family: str) -> list[dict[str, object]]:
-    from autoskillit.server._recipe_delivery import RecipeArtifactGeneration
+    from autoskillit.core import (
+        RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+        RECIPE_ARTIFACT_SCHEMA_VERSION,
+        RECIPE_FLOW_SCHEMA_VERSION,
+        RecipeArtifactGeneration,
+    )
     from autoskillit.server._recipe_section_pagination import (
         build_recipe_section_page_plan,
         render_recipe_section_page,
@@ -34,19 +39,23 @@ def _valid_recipe_section_pages(format_family: str) -> list[dict[str, object]]:
     generation = RecipeArtifactGeneration(
         producer_tool="open_kitchen",
         recipe_name="remediation",
-        descriptor_version=1,
-        schema_version=1,
+        descriptor_version=RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+        schema_version=RECIPE_ARTIFACT_SCHEMA_VERSION,
         payload_sha256="sha256:" + ("1" * 64),
         artifact_blob_sha256="sha256:" + ("2" * 64),
         artifact_blob_size_bytes=10_000,
         body_sha256="sha256:" + ("3" * 64),
         body_size_bytes=9_000,
+        flow_schema_version=RECIPE_FLOW_SCHEMA_VERSION,
+        flow_sha256="sha256:" + ("4" * 64),
+        flow_size_bytes=512,
+        flow_record_count=2,
     )
     plan = build_recipe_section_page_plan(
         kitchen_id="consumer-sequence",
         generation=generation,
         selected=select_recipe_section(payload, section),
-        recipe_section_bound_bytes=1_000,
+        recipe_section_bound_bytes=2_000,
     )
     pages = [
         json.loads(render_recipe_section_page(plan, part)) for part in range(plan.total_parts)

--- a/tests/server/test_lock_ingredients.py
+++ b/tests/server/test_lock_ingredients.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.server._helpers import _with_finalized_projection
 from tests.server.conftest import _make_mock_ctx
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
@@ -376,13 +377,19 @@ class TestAuthorityFeedbackConsistency:
         mock_ctx = _make_mock_ctx()
         mock_ctx.enable_components = AsyncMock()
         mock_ctx.recipes = MagicMock()
-        mock_ctx.recipes.load_and_validate.return_value = {
-            "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
-            "valid": True,
-            "suggestions": [],
-            "diagram": None,
-            "ingredients_table": "--- TABLE ---",
-        }
+        recipe_result = _with_finalized_projection(
+            {
+                "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+                "valid": True,
+                "suggestions": [],
+                "diagram": None,
+                "ingredients_table": "--- TABLE ---",
+                "post_prune_step_names": ["do"],
+            }
+        )
+        mock_ctx.recipes.load_and_validate.side_effect = lambda *_args, **_kwargs: dict(
+            recipe_result
+        )
         mock_recipe_info = MagicMock()
         mock_recipe_info.path = Path("/fake/recipe.yaml")
         mock_ctx.recipes.find.return_value = mock_recipe_info
@@ -421,7 +428,8 @@ class TestAuthorityFeedbackConsistency:
                                     matching = [w for w in warnings if key in w]
                                     assert matching, (
                                         f"open_kitchen must emit a warning mentioning {key!r} "
-                                        f"when overridden; got warnings={warnings}"
+                                        f"when overridden; got warnings={warnings}; "
+                                        f"response={parsed}"
                                     )
 
         # --- lock_ingredients: structured rejection must mention each key ---

--- a/tests/server/test_mcp_overrides.py
+++ b/tests/server/test_mcp_overrides.py
@@ -8,12 +8,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.server._helpers import _with_finalized_projection
+
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 def _make_mock_recipes(load_result: dict) -> MagicMock:
     """Create a mock recipe repository that returns the given load result."""
     mock = MagicMock()
+    if load_result.get("valid") is True:
+        load_result = _with_finalized_projection(load_result)
     mock.load_and_validate.return_value = load_result
     mock.find.return_value = None
     mock.list_all.return_value = {"recipes": [], "count": 0}
@@ -21,12 +25,22 @@ def _make_mock_recipes(load_result: dict) -> MagicMock:
 
 
 def _make_mock_ctx(recipes: MagicMock, temp_dir: Path) -> MagicMock:
+    from threading import RLock
+
+    from autoskillit.config import OutputBudgetConfig
+    from autoskillit.pipeline import NoActiveRecipe
+    from autoskillit.server._factory import make_recipe_execution
+
     mock_ctx = MagicMock()
     mock_ctx.recipes = recipes
     mock_ctx.temp_dir = temp_dir
     mock_ctx.kitchen_id = "test-mcp-overrides"
     mock_ctx.config.migration.suppressed = []
+    mock_ctx.config.output_budget = OutputBudgetConfig()
     mock_ctx.gate.is_enabled.return_value = True
+    mock_ctx.recipe_execution_lock = RLock()
+    mock_ctx.recipe_initialization_state = NoActiveRecipe()
+    mock_ctx.recipe_execution_factory = make_recipe_execution
     return mock_ctx
 
 

--- a/tests/server/test_open_kitchen_deferred_recall.py
+++ b/tests/server/test_open_kitchen_deferred_recall.py
@@ -11,6 +11,7 @@ import pytest
 from autoskillit.recipe._binding import bind_recipe
 from autoskillit.recipe.schema import Recipe, RecipeStep
 from autoskillit.server._recipe_execution import get_recipe_execution
+from tests.server._helpers import _with_finalized_projection
 from tests.server.conftest import _make_mock_ctx
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
@@ -42,7 +43,7 @@ def _compiled_recipe_payload() -> dict:
             )
         },
     )
-    return {
+    result = {
         "content": "name: test-recipe\n",
         "valid": True,
         "errors": [],
@@ -54,8 +55,8 @@ def _compiled_recipe_payload() -> dict:
         "suggestions": [],
         "post_prune_step_names": ["verify"],
         "dispatch_feasible": True,
-        "_compiled_bindings": bind_recipe(recipe),
     }
+    return _with_finalized_projection(result, binding_projection=bind_recipe(recipe))
 
 
 @pytest.mark.anyio
@@ -68,6 +69,7 @@ async def test_recipe_open_atomically_installs_compiled_execution(
 
     tool_ctx.gate.enable()
     tool_ctx.gate_infrastructure_ready = True
+    tool_ctx.kitchen_id = f"test-open-{deferred_recall}"
     tool_ctx.recipe_name = "test-recipe" if deferred_recall else ""
     recipes = MagicMock()
     recipes.find.return_value = None
@@ -136,6 +138,9 @@ async def test_deferred_recall_sets_active_recipe_steps_from_recipe():
         "suggestions": [],
         "post_prune_step_names": ["build", "test"],
     }
+    mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
+        mock_ctx.recipes.load_and_validate.return_value
+    )
     mock_recipe_info = MagicMock()
     mock_recipe_info.path = Path("/fake/.autoskillit/recipes/test-recipe.yaml")
     mock_ctx.recipes.find.return_value = mock_recipe_info
@@ -172,6 +177,9 @@ async def test_deferred_recall_sets_active_recipe_steps_none_when_find_raises():
         "recipe_version": "1.0",
         "suggestions": [],
     }
+    mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
+        mock_ctx.recipes.load_and_validate.return_value
+    )
     mock_ctx.recipes.find.side_effect = RuntimeError("disk error")
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
@@ -199,6 +207,9 @@ async def test_deferred_recall_sets_active_recipe_steps_none_when_find_returns_n
         "recipe_version": "1.0",
         "suggestions": [],
     }
+    mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
+        mock_ctx.recipes.load_and_validate.return_value
+    )
     mock_ctx.recipes.find.return_value = None
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
@@ -313,6 +324,9 @@ def _make_pre_revealed_ctx(name: str) -> MagicMock:
         "suggestions": [],
         "post_prune_step_names": ["build", "test"],
     }
+    ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
+        ctx.recipes.load_and_validate.return_value
+    )
     return ctx
 
 
@@ -518,6 +532,9 @@ async def test_deferred_recall_preserves_active_locks(tmp_path):
         "recipe_version": "1.0",
         "post_prune_step_names": ["investigate"],
     }
+    ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
+        ctx.recipes.load_and_validate.return_value
+    )
 
     mock_recipe_info = MagicMock()
     mock_recipe_info.path = Path("/fake/.autoskillit/recipes/test-recipe.yaml")

--- a/tests/server/test_pipeline_tracker.py
+++ b/tests/server/test_pipeline_tracker.py
@@ -7,6 +7,7 @@ import json
 import pytest
 
 from autoskillit.server.tools.tools_pipeline_tracker import record_pipeline_step
+from tests.server._helpers import _with_finalized_projection
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
@@ -172,18 +173,20 @@ def _configure_open_kitchen_mock(ctx, steps, tmp_path):
     from unittest.mock import MagicMock
 
     ctx.project_dir = tmp_path
-    ctx.recipes.load_and_validate.return_value = {
-        "content": "name: remediation\nsteps: {}\n",
-        "valid": True,
-        "errors": [],
-        "requires_packs": [],
-        "requires_features": [],
-        "content_hash": "abc",
-        "composite_hash": "def",
-        "recipe_version": "1.0",
-        "suggestions": [],
-        "post_prune_step_names": list(steps.keys()),
-    }
+    ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
+        {
+            "content": "name: remediation\nsteps: {}\n",
+            "valid": True,
+            "errors": [],
+            "requires_packs": [],
+            "requires_features": [],
+            "content_hash": "abc",
+            "composite_hash": "def",
+            "recipe_version": "1.0",
+            "suggestions": [],
+            "post_prune_step_names": list(steps.keys()),
+        }
+    )
     mock_recipe_info = MagicMock()
     mock_recipe_info.path = tmp_path / "remediation.yaml"
     ctx.recipes.find.return_value = mock_recipe_info

--- a/tests/server/test_recipe_generation.py
+++ b/tests/server/test_recipe_generation.py
@@ -1,0 +1,334 @@
+"""Focused contracts for the kitchen-scoped recipe generation store."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from threading import Barrier
+from typing import cast
+
+import pytest
+
+import autoskillit.server._recipe_generation as generation_module
+from autoskillit.core import (
+    RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+    RECIPE_ARTIFACT_SCHEMA_VERSION,
+    RECIPE_FLOW_SCHEMA_VERSION,
+    BindingMode,
+    BoundStepInvocation,
+    FinalizedRecipeProjection,
+    RecipeArtifactGeneration,
+    RecipeBindingProjection,
+    RecipeExecutionSnapshot,
+    RecipeFlowGeneration,
+    compute_recipe_execution_snapshot_digest,
+)
+from autoskillit.server._recipe_generation import (
+    RecipeGenerationCapacityError,
+    RecipeGenerationConflictError,
+    RecipeGenerationRecord,
+    RecipeGenerationRetiredError,
+    RecipeGenerationStore,
+    recipe_generation_weight_bytes,
+)
+from autoskillit.server.recipe_section._lifecycle import notify_kitchen_retired
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+def _hash(seed: str) -> str:
+    return f"sha256:{hashlib.sha256(seed.encode()).hexdigest()}"
+
+
+def _projection() -> FinalizedRecipeProjection:
+    invocation = BoundStepInvocation(
+        step_name="step",
+        tool_name="run_skill",
+        mode=BindingMode.RECIPE,
+        skill_name="example",
+        mcp_kwargs=(),
+        skill_inputs=(),
+    )
+    return FinalizedRecipeProjection(
+        binding_projection=RecipeBindingProjection({"step": invocation}),
+        ordered_step_names=("step",),
+        entrypoint="step",
+        ordered_flow_edges=(),
+    )
+
+
+def _snapshot(recipe_name: str, execution_id: str) -> RecipeExecutionSnapshot:
+    content_hash = _hash(f"{execution_id}:content")
+    composite_hash = _hash(f"{execution_id}:composite")
+    dynamic_skill_step_names = frozenset({"step"})
+    snapshot_digest = compute_recipe_execution_snapshot_digest(
+        execution_id=execution_id,
+        recipe_name=recipe_name,
+        content_hash=content_hash,
+        composite_hash=composite_hash,
+        templates={},
+        dynamic_skill_step_names=dynamic_skill_step_names,
+    )
+    return RecipeExecutionSnapshot(
+        execution_id=execution_id,
+        recipe_name=recipe_name,
+        content_hash=content_hash,
+        composite_hash=composite_hash,
+        templates={},
+        snapshot_digest=snapshot_digest,
+        dynamic_skill_step_names=dynamic_skill_step_names,
+    )
+
+
+def _record(
+    *,
+    kitchen_id: str = "kitchen-a",
+    compile_key: str = "compile-a",
+    recipe_name: str = "recipe",
+    payload_marker: str = "a",
+) -> RecipeGenerationRecord:
+    execution_id = f"execution-{compile_key}"
+    record = json.dumps(
+        {"kind": "entrypoint", "name": "step"},
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return RecipeGenerationRecord(
+        kitchen_id=kitchen_id,
+        normalized_compile_key=compile_key,
+        recipe_name=recipe_name,
+        finalized_projection=_projection(),
+        flow_generation=RecipeFlowGeneration(
+            schema_version=RECIPE_FLOW_SCHEMA_VERSION,
+            records=(record,),
+        ),
+        artifact_payload={
+            "marker": payload_marker,
+            "nested": {"items": [1, True, None]},
+        },
+        execution_snapshot=_snapshot(recipe_name, execution_id),
+        execution_id=execution_id,
+        compile_inputs={"ingredient_overrides": {"names": ["one", "two"]}},
+    )
+
+
+def _generation(
+    marker: str,
+    *,
+    recipe_name: str = "recipe",
+) -> RecipeArtifactGeneration:
+    return RecipeArtifactGeneration(
+        producer_tool=f"producer-{marker}",
+        recipe_name=recipe_name,
+        descriptor_version=RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+        schema_version=RECIPE_ARTIFACT_SCHEMA_VERSION,
+        payload_sha256=_hash(f"{marker}:payload"),
+        artifact_blob_sha256=_hash(f"{marker}:blob"),
+        artifact_blob_size_bytes=100,
+        body_sha256=_hash(f"{marker}:body"),
+        body_size_bytes=40,
+        flow_schema_version=RECIPE_FLOW_SCHEMA_VERSION,
+        flow_sha256=_hash(f"{marker}:flow"),
+        flow_size_bytes=20,
+        flow_record_count=1,
+    )
+
+
+def test_record_owns_canonical_immutable_primitive_copies() -> None:
+    payload = {"nested": {"items": [1, 2]}}
+    compile_inputs = {"names": ["first"]}
+    base = _record()
+    record = replace(
+        base,
+        artifact_payload=payload,
+        compile_inputs=compile_inputs,
+    )
+    payload["nested"]["items"].append(3)
+    compile_inputs["names"].append("second")
+
+    store = RecipeGenerationStore()
+    stored = store.put(record)
+    fetched = store.lookup_compile("kitchen-a", "compile-a")
+
+    assert fetched is not None
+    assert fetched is not stored
+    nested = cast(Mapping[str, object], fetched.artifact_payload["nested"])
+    assert nested["items"] == (1, 2)
+    assert fetched.compile_inputs["names"] == ("first",)
+    with pytest.raises(TypeError):
+        fetched.artifact_payload["new"] = "value"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        nested["new"] = "value"  # type: ignore[index]
+
+
+def test_put_accepts_exact_compile_replay_and_rejects_conflict() -> None:
+    store = RecipeGenerationStore()
+    record = _record()
+
+    first = store.put(record)
+    replay = store.put(record)
+
+    assert replay == first
+    assert store.entry_count == 1
+    with pytest.raises(RecipeGenerationConflictError):
+        store.put(replace(record, artifact_payload={"marker": "different"}))
+
+
+def test_surface_binding_is_exact_idempotent_and_dually_indexed() -> None:
+    store = RecipeGenerationStore()
+    record = store.put(_record())
+    artifact = _generation("one")
+
+    bound = store.bind_surface(
+        record.kitchen_id,
+        record.normalized_compile_key,
+        "open_kitchen",
+        artifact,
+    )
+    replay = store.bind_surface(
+        record.kitchen_id,
+        record.normalized_compile_key,
+        "open_kitchen",
+        artifact,
+    )
+
+    assert replay == bound
+    assert bound.surface_bindings == {"open_kitchen": artifact}
+    assert store.lookup_artifact(record.kitchen_id, artifact) == bound
+    with pytest.raises(RecipeGenerationConflictError):
+        store.bind_surface(
+            record.kitchen_id,
+            record.normalized_compile_key,
+            "open_kitchen",
+            _generation("different"),
+        )
+
+
+def test_artifact_generation_cannot_alias_another_compile_generation() -> None:
+    store = RecipeGenerationStore()
+    first = store.put(_record(compile_key="first"))
+    second = store.put(_record(compile_key="second"))
+    artifact = _generation("shared")
+    store.bind_surface(
+        first.kitchen_id,
+        first.normalized_compile_key,
+        "open_kitchen",
+        artifact,
+    )
+
+    with pytest.raises(RecipeGenerationConflictError):
+        store.bind_surface(
+            second.kitchen_id,
+            second.normalized_compile_key,
+            "load_recipe",
+            artifact,
+        )
+
+
+def test_entry_lru_eviction_removes_every_artifact_alias() -> None:
+    store = RecipeGenerationStore(max_entries=2)
+    first = store.put(_record(compile_key="first"))
+    second = store.put(_record(compile_key="second"))
+    first_artifact = _generation("first")
+    second_artifact = _generation("second")
+    store.bind_surface(
+        first.kitchen_id,
+        first.normalized_compile_key,
+        "open_kitchen",
+        first_artifact,
+    )
+    store.bind_surface(
+        second.kitchen_id,
+        second.normalized_compile_key,
+        "open_kitchen",
+        second_artifact,
+    )
+    assert store.lookup_artifact(first.kitchen_id, first_artifact) is not None
+
+    store.put(_record(compile_key="third"))
+
+    assert store.lookup_compile(second.kitchen_id, second.normalized_compile_key) is None
+    assert store.lookup_artifact(second.kitchen_id, second_artifact) is None
+    assert store.lookup_compile(first.kitchen_id, first.normalized_compile_key) is not None
+
+
+def test_canonical_weight_drives_byte_admission_and_lru_eviction() -> None:
+    first = _record(compile_key="first")
+    second = _record(compile_key="second", payload_marker="larger-payload")
+    first_weight = recipe_generation_weight_bytes(first)
+    second_weight = recipe_generation_weight_bytes(second)
+    store = RecipeGenerationStore(
+        max_entries=3,
+        max_bytes=first_weight + second_weight - 1,
+    )
+
+    store.put(first)
+    store.put(second)
+
+    assert store.lookup_compile(first.kitchen_id, first.normalized_compile_key) is None
+    assert store.lookup_compile(second.kitchen_id, second.normalized_compile_key) is not None
+    assert store.weight_bytes == second_weight
+
+    too_small = RecipeGenerationStore(
+        max_entries=1,
+        max_bytes=first_weight - 1,
+    )
+    with pytest.raises(RecipeGenerationCapacityError):
+        too_small.put(first)
+    assert too_small.entry_count == 0
+
+
+def test_retirement_callback_removes_kitchen_and_permanently_rejects_writes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = RecipeGenerationStore()
+    monkeypatch.setattr(generation_module, "_RECIPE_GENERATION_STORE", store)
+    record = store.put(_record())
+    artifact = _generation("retired")
+    store.bind_surface(
+        record.kitchen_id,
+        record.normalized_compile_key,
+        "open_kitchen",
+        artifact,
+    )
+
+    notify_kitchen_retired(record.kitchen_id)
+
+    assert store.lookup_compile(record.kitchen_id, record.normalized_compile_key) is None
+    assert store.lookup_artifact(record.kitchen_id, artifact) is None
+    assert store.entry_count == 0
+    assert store.weight_bytes == 0
+    with pytest.raises(RecipeGenerationRetiredError):
+        store.put(record)
+
+
+def test_concurrent_conflicting_surface_bind_has_one_winner() -> None:
+    store = RecipeGenerationStore()
+    record = store.put(_record())
+    generations = (_generation("left"), _generation("right"))
+    barrier = Barrier(2)
+
+    def bind(artifact: RecipeArtifactGeneration) -> str:
+        barrier.wait()
+        try:
+            store.bind_surface(
+                record.kitchen_id,
+                record.normalized_compile_key,
+                "open_kitchen",
+                artifact,
+            )
+        except RecipeGenerationConflictError:
+            return "conflict"
+        return "bound"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(bind, generations))
+
+    assert sorted(outcomes) == ["bound", "conflict"]
+    stored = store.lookup_compile(record.kitchen_id, record.normalized_compile_key)
+    assert stored is not None
+    winner = stored.surface_bindings["open_kitchen"]
+    assert store.lookup_artifact(record.kitchen_id, winner) == stored

--- a/tests/server/test_recipe_generation.py
+++ b/tests/server/test_recipe_generation.py
@@ -137,6 +137,11 @@ def _generation(
     )
 
 
+def test_record_rejects_empty_kitchen_id() -> None:
+    with pytest.raises(ValueError, match="kitchen_id must be a non-empty string"):
+        _record(kitchen_id="")
+
+
 def test_record_owns_canonical_immutable_primitive_copies() -> None:
     payload = {"nested": {"items": [1, 2]}}
     compile_inputs = {"names": ["first"]}

--- a/tests/server/test_recipe_generation.py
+++ b/tests/server/test_recipe_generation.py
@@ -305,6 +305,26 @@ def test_retirement_callback_removes_kitchen_and_permanently_rejects_writes(
         store.put(record)
 
 
+def test_lifecycle_authority_bounds_retirement_history_without_stale_reactivation() -> None:
+    store = RecipeGenerationStore(max_retired_kitchens=1)
+    first = _record(kitchen_id="first-kitchen", compile_key="first")
+    second = _record(kitchen_id="second-kitchen", compile_key="second")
+
+    store.activate_kitchen(first.kitchen_id)
+    store.put(first)
+    store.retire_kitchen(first.kitchen_id)
+    store.activate_kitchen(second.kitchen_id)
+    store.put(second)
+    store.retire_kitchen(second.kitchen_id)
+
+    assert store.retired_kitchen_count == 1
+    with pytest.raises(RecipeGenerationRetiredError):
+        store.put(first)
+
+    store.activate_kitchen(first.kitchen_id)
+    assert store.put(first).kitchen_id == first.kitchen_id
+
+
 def test_concurrent_conflicting_surface_bind_has_one_winner() -> None:
     store = RecipeGenerationStore()
     record = store.put(_record())

--- a/tests/server/test_recipe_generation.py
+++ b/tests/server/test_recipe_generation.py
@@ -232,27 +232,42 @@ def test_entry_lru_eviction_removes_every_artifact_alias() -> None:
     store = RecipeGenerationStore(max_entries=2)
     first = store.put(_record(compile_key="first"))
     second = store.put(_record(compile_key="second"))
-    first_artifact = _generation("first")
-    second_artifact = _generation("second")
-    store.bind_surface(
-        first.kitchen_id,
-        first.normalized_compile_key,
-        "open_kitchen",
-        first_artifact,
-    )
-    store.bind_surface(
-        second.kitchen_id,
-        second.normalized_compile_key,
-        "open_kitchen",
-        second_artifact,
-    )
-    assert store.lookup_artifact(first.kitchen_id, first_artifact) is not None
+    first_artifacts = (_generation("first-open"), _generation("first-load"))
+    second_artifacts = (_generation("second-open"), _generation("second-load"))
+    for surface, artifact in zip(
+        ("open_kitchen", "load_recipe"),
+        first_artifacts,
+        strict=True,
+    ):
+        store.bind_surface(
+            first.kitchen_id,
+            first.normalized_compile_key,
+            surface,
+            artifact,
+        )
+    for surface, artifact in zip(
+        ("open_kitchen", "load_recipe"),
+        second_artifacts,
+        strict=True,
+    ):
+        store.bind_surface(
+            second.kitchen_id,
+            second.normalized_compile_key,
+            surface,
+            artifact,
+        )
+    for artifact in first_artifacts:
+        assert store.lookup_artifact(first.kitchen_id, artifact) is not None
 
     store.put(_record(compile_key="third"))
 
     assert store.lookup_compile(second.kitchen_id, second.normalized_compile_key) is None
-    assert store.lookup_artifact(second.kitchen_id, second_artifact) is None
-    assert store.lookup_compile(first.kitchen_id, first.normalized_compile_key) is not None
+    for artifact in second_artifacts:
+        assert store.lookup_artifact(second.kitchen_id, artifact) is None
+    retained = store.lookup_compile(first.kitchen_id, first.normalized_compile_key)
+    assert retained is not None
+    for artifact in first_artifacts:
+        assert store.lookup_artifact(first.kitchen_id, artifact) == retained
 
 
 def test_canonical_weight_drives_byte_admission_and_lru_eviction() -> None:

--- a/tests/server/test_recipe_generation.py
+++ b/tests/server/test_recipe_generation.py
@@ -83,6 +83,18 @@ def _snapshot(recipe_name: str, execution_id: str) -> RecipeExecutionSnapshot:
     )
 
 
+def _flow_generation(*, entrypoint: str = "step") -> RecipeFlowGeneration:
+    record = json.dumps(
+        {"kind": "entrypoint", "name": entrypoint},
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return RecipeFlowGeneration(
+        schema_version=RECIPE_FLOW_SCHEMA_VERSION,
+        records=(record,),
+    )
+
+
 def _record(
     *,
     kitchen_id: str = "kitchen-a",
@@ -91,20 +103,12 @@ def _record(
     payload_marker: str = "a",
 ) -> RecipeGenerationRecord:
     execution_id = f"execution-{compile_key}"
-    record = json.dumps(
-        {"kind": "entrypoint", "name": "step"},
-        separators=(",", ":"),
-        sort_keys=True,
-    )
     return RecipeGenerationRecord(
         kitchen_id=kitchen_id,
         normalized_compile_key=compile_key,
         recipe_name=recipe_name,
         finalized_projection=_projection(),
-        flow_generation=RecipeFlowGeneration(
-            schema_version=RECIPE_FLOW_SCHEMA_VERSION,
-            records=(record,),
-        ),
+        flow_generation=_flow_generation(),
         artifact_payload={
             "marker": payload_marker,
             "nested": {"items": [1, True, None]},
@@ -119,7 +123,9 @@ def _generation(
     marker: str,
     *,
     recipe_name: str = "recipe",
+    flow_generation: RecipeFlowGeneration | None = None,
 ) -> RecipeArtifactGeneration:
+    flow = flow_generation or _flow_generation()
     return RecipeArtifactGeneration(
         producer_tool=f"producer-{marker}",
         recipe_name=recipe_name,
@@ -130,16 +136,33 @@ def _generation(
         artifact_blob_size_bytes=100,
         body_sha256=_hash(f"{marker}:body"),
         body_size_bytes=40,
-        flow_schema_version=RECIPE_FLOW_SCHEMA_VERSION,
-        flow_sha256=_hash(f"{marker}:flow"),
-        flow_size_bytes=20,
-        flow_record_count=1,
+        flow_schema_version=flow.schema_version,
+        flow_sha256=flow.flow_sha256,
+        flow_size_bytes=flow.flow_size_bytes,
+        flow_record_count=flow.record_count,
     )
 
 
 def test_record_rejects_empty_kitchen_id() -> None:
     with pytest.raises(ValueError, match="kitchen_id must be a non-empty string"):
         _record(kitchen_id="")
+
+
+def test_surface_binding_rejects_a_different_flow_generation() -> None:
+    record = _record()
+    store = RecipeGenerationStore()
+    store.put(record)
+
+    with pytest.raises(ValueError, match="must match the record flow generation"):
+        store.bind_surface(
+            record.kitchen_id,
+            record.normalized_compile_key,
+            "open_kitchen",
+            _generation(
+                "different-flow",
+                flow_generation=_flow_generation(entrypoint="other-step"),
+            ),
+        )
 
 
 def test_record_owns_canonical_immutable_primitive_copies() -> None:

--- a/tests/server/test_recipe_initialization.py
+++ b/tests/server/test_recipe_initialization.py
@@ -149,7 +149,15 @@ def test_completion_rejects_stale_or_altered_initialization_id(
     minimal_ctx,
     tmp_path,
 ) -> None:
-    _stage(minimal_ctx, tmp_path)
+    state = _stage(minimal_ctx, tmp_path)
+    with minimal_ctx.recipe_execution_lock:
+        minimal_ctx.recipe_initialization_state = record_initialization_page(
+            state,
+            initialization_id="initialization",
+            section="flow_records",
+            page_plan_sha256=_hash("flow-plan"),
+            part=0,
+        )
 
     assert json.loads(build_completion_response(minimal_ctx, "altered")) == {
         "success": False,

--- a/tests/server/test_recipe_initialization.py
+++ b/tests/server/test_recipe_initialization.py
@@ -1,0 +1,188 @@
+"""Server-owned recipe initialization completion transactions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+import autoskillit.server._state as server_state
+from autoskillit.core import (
+    RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+    RECIPE_ARTIFACT_SCHEMA_VERSION,
+    RECIPE_FLOW_SCHEMA_VERSION,
+    InstalledRecipeExecution,
+    RecipeArtifactGeneration,
+    RecipeBindingProjection,
+    RecipeFlowGeneration,
+)
+from autoskillit.pipeline import (
+    InitializingRecipe,
+    ReadyRecipe,
+    RecipeInitializationRequirement,
+    record_initialization_page,
+)
+from autoskillit.server._recipe_execution import (
+    DefaultAuditCycleHeadStore,
+    DefaultInputPreflightResolver,
+    build_recipe_execution_snapshot,
+)
+from autoskillit.server._recipe_initialization import (
+    FinalizedRecipeInitializationResponse,
+    admit_registered_tool_during_initialization,
+    build_completion_response,
+    complete_initialization_response,
+    stage_recipe_initialization,
+)
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+def _hash(seed: str) -> str:
+    return f"sha256:{hashlib.sha256(seed.encode()).hexdigest()}"
+
+
+def _stage(tool_ctx, tmp_path) -> InitializingRecipe:
+    tool_ctx.kitchen_id = "kitchen"
+    snapshot = build_recipe_execution_snapshot(
+        recipe_name="recipe",
+        content_hash=_hash("content"),
+        composite_hash=_hash("composite"),
+        projection=RecipeBindingProjection({}),
+        execution_id="execution",
+    )
+    flow = RecipeFlowGeneration(
+        schema_version=RECIPE_FLOW_SCHEMA_VERSION,
+        records=(
+            json.dumps(
+                {"kind": "entrypoint", "name": "step"},
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+        ),
+    )
+    artifact = RecipeArtifactGeneration(
+        producer_tool="open_kitchen",
+        recipe_name="recipe",
+        descriptor_version=RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+        schema_version=RECIPE_ARTIFACT_SCHEMA_VERSION,
+        payload_sha256=_hash("payload"),
+        artifact_blob_sha256=_hash("blob"),
+        artifact_blob_size_bytes=10,
+        body_sha256=_hash("body"),
+        body_size_bytes=5,
+        flow_schema_version=flow.schema_version,
+        flow_sha256=flow.flow_sha256,
+        flow_size_bytes=flow.flow_size_bytes,
+        flow_record_count=flow.record_count,
+    )
+    store = DefaultAuditCycleHeadStore()
+
+    def factory(*, snapshot, allowed_root):
+        return InstalledRecipeExecution(
+            snapshot=snapshot,
+            runtime_binding_digests={},
+            audit_cycle_heads=store,
+            input_preflight_resolver=DefaultInputPreflightResolver(
+                allowed_root=allowed_root,
+                head_store=store,
+            ),
+        )
+
+    tool_ctx.project_dir = tmp_path
+    tool_ctx.recipe_execution_factory = factory
+    return stage_recipe_initialization(
+        tool_ctx,
+        recipe_name="recipe",
+        artifact_generation=artifact,
+        flow_generation=flow,
+        initialization_id="initialization",
+        staged_snapshot=snapshot,
+        requirements=(
+            RecipeInitializationRequirement(
+                section="flow_records",
+                page_plan_sha256=_hash("flow-plan"),
+                total_parts=1,
+            ),
+        ),
+        generation_store_key="compile-key",
+    )
+
+
+def test_completion_is_server_owned_and_commits_ready_only_after_enforcement(
+    minimal_ctx,
+    tmp_path,
+) -> None:
+    state = _stage(minimal_ctx, tmp_path)
+
+    incomplete = json.loads(build_completion_response(minimal_ctx, "initialization"))
+    assert incomplete == {
+        "success": False,
+        "error": "recipe_initialization_incomplete",
+    }
+
+    with minimal_ctx.recipe_execution_lock:
+        minimal_ctx.recipe_initialization_state = record_initialization_page(
+            state,
+            initialization_id="initialization",
+            section="flow_records",
+            page_plan_sha256=_hash("flow-plan"),
+            part=0,
+        )
+
+    finalized = build_completion_response(minimal_ctx, "initialization")
+    assert isinstance(finalized, FinalizedRecipeInitializationResponse)
+    assert isinstance(minimal_ctx.recipe_initialization_state, InitializingRecipe)
+
+    assert complete_initialization_response(finalized, "substituted") == "substituted"
+    assert isinstance(minimal_ctx.recipe_initialization_state, InitializingRecipe)
+
+    assert complete_initialization_response(finalized, finalized.rendered) == finalized.rendered
+    assert isinstance(minimal_ctx.recipe_initialization_state, ReadyRecipe)
+
+    replay = build_completion_response(minimal_ctx, "initialization")
+    assert replay == finalized.rendered
+
+
+def test_completion_rejects_stale_or_altered_initialization_id(
+    minimal_ctx,
+    tmp_path,
+) -> None:
+    _stage(minimal_ctx, tmp_path)
+
+    assert json.loads(build_completion_response(minimal_ctx, "altered")) == {
+        "success": False,
+        "error": "recipe_initialization_incomplete",
+    }
+
+
+def test_common_admission_allows_only_recovery_inspection_and_lifecycle_control(
+    minimal_ctx,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stage(minimal_ctx, tmp_path)
+    monkeypatch.setattr(server_state, "_ctx", minimal_ctx)
+
+    for tool_name in (
+        "complete_recipe_initialization",
+        "get_recipe_section",
+        "kitchen_status",
+        "open_kitchen",
+        "close_kitchen",
+    ):
+        assert admit_registered_tool_during_initialization(tool_name) is None
+
+    for tool_name in (
+        "run_skill",
+        "run_cmd",
+        "test_check",
+        "merge_worktree",
+        "clone_repo",
+        "push_to_remote",
+        "reset_workspace",
+    ):
+        denial = json.loads(admit_registered_tool_during_initialization(tool_name) or "{}")
+        assert denial["error"] == "recipe_initialization_incomplete"
+        assert denial["initialization_id"] == "initialization"

--- a/tests/server/test_recipe_initialization.py
+++ b/tests/server/test_recipe_initialization.py
@@ -157,6 +157,40 @@ def test_completion_rejects_stale_or_altered_initialization_id(
     }
 
 
+def test_completion_normalizes_unexpected_execution_preparation_failures(
+    minimal_ctx,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = _stage(minimal_ctx, tmp_path)
+    with minimal_ctx.recipe_execution_lock:
+        minimal_ctx.recipe_initialization_state = record_initialization_page(
+            state,
+            initialization_id="initialization",
+            section="flow_records",
+            page_plan_sha256=_hash("flow-plan"),
+            part=0,
+        )
+    finalized = build_completion_response(minimal_ctx, "initialization")
+    assert isinstance(finalized, FinalizedRecipeInitializationResponse)
+
+    def _raise_prepare(*_args, **_kwargs):
+        raise RuntimeError("resolver unavailable")
+
+    monkeypatch.setattr(
+        "autoskillit.server._recipe_initialization.prepare_recipe_execution",
+        _raise_prepare,
+    )
+
+    response = complete_initialization_response(finalized, finalized.rendered)
+
+    assert json.loads(response) == {
+        "success": False,
+        "error": "recipe_execution_install_failed",
+    }
+    assert isinstance(minimal_ctx.recipe_initialization_state, InitializingRecipe)
+
+
 def test_common_admission_allows_only_recovery_inspection_and_lifecycle_control(
     minimal_ctx,
     tmp_path,

--- a/tests/server/test_recipe_section_pagination.py
+++ b/tests/server/test_recipe_section_pagination.py
@@ -16,17 +16,18 @@ from typing import Any
 import pytest
 
 from autoskillit.core import (
+    RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+    RECIPE_ARTIFACT_MAX_BLOB_BYTES,
+    RECIPE_ARTIFACT_SCHEMA_VERSION,
+    RECIPE_FLOW_SCHEMA_VERSION,
     RECIPE_SECTION_MANDATORY_FAILURE_CODES,
     RECIPE_SECTION_RESPONSE_FLOOR_BYTES,
+    RecipeArtifactGeneration,
     recipe_section_digest,
     recipe_section_element_digest,
     recipe_section_plan_digest,
 )
 from autoskillit.server import _recipe_section_pagination as pagination
-from autoskillit.server._recipe_delivery import (
-    RECIPE_ARTIFACT_MAX_BLOB_BYTES,
-    RecipeArtifactGeneration,
-)
 from autoskillit.server._recipe_section_pagination import (
     PagePlanCache,
     RecipeSectionPageDescriptor,
@@ -77,6 +78,7 @@ _RANGE_FIELDS_BY_FORMAT = {
         "fragment_byte_total",
     },
 }
+_PAGE_TEST_BOUND = 2_000
 
 
 @pytest.fixture(autouse=True)
@@ -88,13 +90,17 @@ def _generation(**changes: object) -> RecipeArtifactGeneration:
     base: dict[str, object] = {
         "producer_tool": "open_kitchen",
         "recipe_name": "remediation",
-        "descriptor_version": 1,
-        "schema_version": 1,
+        "descriptor_version": RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+        "schema_version": RECIPE_ARTIFACT_SCHEMA_VERSION,
         "payload_sha256": f"sha256:{'1' * 64}",
         "artifact_blob_sha256": f"sha256:{'2' * 64}",
         "artifact_blob_size_bytes": 4096,
         "body_sha256": f"sha256:{'3' * 64}",
         "body_size_bytes": 2048,
+        "flow_schema_version": RECIPE_FLOW_SCHEMA_VERSION,
+        "flow_sha256": f"sha256:{'4' * 64}",
+        "flow_size_bytes": 512,
+        "flow_record_count": 2,
     }
     base.update(changes)
     return RecipeArtifactGeneration(**base)  # type: ignore[arg-type]
@@ -219,7 +225,7 @@ def test_scalar_planning_never_serializes_the_whole_oversized_remainder(
         return original(value)
 
     monkeypatch.setattr(pagination, "canonical_recipe_section_json", _record_bounded_string)
-    bound = 1_000
+    bound = _PAGE_TEST_BOUND
     plan = _build(
         _payload(ingredients_table="x" * 10_000),
         "ingredients_table",
@@ -475,7 +481,7 @@ def _reconstruct(pages: list[dict[str, Any]]) -> object:
     ],
 )
 def test_raw_pages_preserve_text_and_exact_utf8_bounds(value: str) -> None:
-    bound = 1_000
+    bound = _PAGE_TEST_BOUND
     plan = _build(_payload(content=value), "content", bound=bound)
     pages = _decoded_pages(plan, bound=bound)
 
@@ -494,7 +500,7 @@ def test_raw_pages_preserve_text_and_exact_utf8_bounds(value: str) -> None:
 def test_json_scalar_pages_are_independently_valid_and_reconstruct_markdown(
     value: str,
 ) -> None:
-    bound = 1_000
+    bound = _PAGE_TEST_BOUND
     plan = _build(_payload(ingredients_table=value), "ingredients_table", bound=bound)
     pages = _decoded_pages(plan, bound=bound)
 
@@ -505,7 +511,7 @@ def test_json_scalar_pages_are_independently_valid_and_reconstruct_markdown(
 
 def test_ordered_array_pages_are_complete_json_documents() -> None:
     values = [f"warning-{index:03d}-☃" * 4 for index in range(80)]
-    bound = 1_000
+    bound = _PAGE_TEST_BOUND
     plan = _build(_payload(warnings=values), "warnings", bound=bound)
     pages = _decoded_pages(plan, bound=bound)
 
@@ -520,7 +526,7 @@ def test_oversized_array_elements_fragment_in_first_middle_and_final_positions(
 ) -> None:
     values = ["before", "middle", "after"]
     values[oversized_index] = 'oversized-"quoted"-\\\\-☃-' * 600
-    bound = 1_000
+    bound = _PAGE_TEST_BOUND
     plan = _build(_payload(warnings=values), "warnings", bound=bound)
     pages = _decoded_pages(plan, bound=bound)
 
@@ -541,7 +547,7 @@ def test_array_plan_can_interleave_ordinary_and_fragment_pages() -> None:
         "y" * 12_000,
         "ordinary-final",
     ]
-    bound = 1_000
+    bound = _PAGE_TEST_BOUND
     plan = _build(_payload(errors=values), "errors", bound=bound)
     pages = _decoded_pages(plan, bound=bound)
 
@@ -554,7 +560,7 @@ def test_array_plan_can_interleave_ordinary_and_fragment_pages() -> None:
 def test_raw_recipe_and_named_step_yaml_use_unchanged_raw_reconstruction() -> None:
     recipe = "name: demo\nsteps:\n  first:\n    run: echo unchanged\n"
     named_step = "first:\n  run: echo unchanged\n"
-    bound = 1_000
+    bound = _PAGE_TEST_BOUND
 
     recipe_plan = _build(_payload(content=recipe), "content", bound=bound)
     step_plan = _build(
@@ -628,7 +634,7 @@ def test_candidate_sizing_uses_binary_search_scale_oracle_calls(
 
     monkeypatch.setattr(pagination, "_fits", _counted_fits)
 
-    plan = _build(payload, section, bound=1_000)
+    plan = _build(payload, section, bound=_PAGE_TEST_BOUND)
 
     binary_search_scale = math.ceil(math.log2(search_space + 1))
     assert oracle_calls <= 6 * plan.total_parts * (binary_search_scale + 2)
@@ -674,7 +680,7 @@ def test_final_digest_injection_revalidates_descriptor_boundaries(
         RecipeSectionPaginationError,
         match="changed plan identity or boundaries",
     ):
-        _build(_payload(content="boundary-check-" * 500), "content", bound=1_000)
+        _build(_payload(content="boundary-check-" * 500), "content", bound=_PAGE_TEST_BOUND)
 
 
 @pytest.mark.parametrize(
@@ -734,13 +740,13 @@ def test_final_verifier_rejects_fragment_descriptor_and_content_corruption(
     )
 
     with pytest.raises(RecipeSectionPaginationError, match=message):
-        _build(_payload(warnings=["\\" * 5_000]), "warnings", bound=1_000)
+        _build(_payload(warnings=["\\" * 5_000]), "warnings", bound=_PAGE_TEST_BOUND)
 
 
 def test_page_and_fragment_indices_cross_two_digit_boundaries() -> None:
-    raw_plan = _build(_payload(content="r" * 120_000), "content", bound=1_000)
+    raw_plan = _build(_payload(content="r" * 120_000), "content", bound=_PAGE_TEST_BOUND)
     assert raw_plan.total_parts > 100
-    raw_pages = _decoded_pages(raw_plan, bound=1_000)
+    raw_pages = _decoded_pages(raw_plan, bound=_PAGE_TEST_BOUND)
     assert [raw_pages[index]["part"] for index in (8, 9, 10, 98, 99, 100)] == [
         8,
         9,
@@ -753,9 +759,9 @@ def test_page_and_fragment_indices_cross_two_digit_boundaries() -> None:
     fragment_plan = _build(
         _payload(warnings=["\\" * 120_000]),
         "warnings",
-        bound=1_000,
+        bound=_PAGE_TEST_BOUND,
     )
-    fragment_pages = _decoded_pages(fragment_plan, bound=1_000)
+    fragment_pages = _decoded_pages(fragment_plan, bound=_PAGE_TEST_BOUND)
     assert len(fragment_pages) > 100
     assert [fragment_pages[index]["fragment_index"] for index in (8, 9, 10, 98, 99, 100)] == [
         8,
@@ -769,7 +775,7 @@ def test_page_and_fragment_indices_cross_two_digit_boundaries() -> None:
 
 
 def test_plan_manifest_is_complete_and_plan_digest_is_non_self_referential() -> None:
-    bound = 1_000
+    bound = _PAGE_TEST_BOUND
     generation = _generation()
     plan = _build(
         _payload(warnings=["a", "b", "c"] * 20),
@@ -781,6 +787,7 @@ def test_plan_manifest_is_complete_and_plan_digest_is_non_self_referential() -> 
     manifest = dataclasses.asdict(plan.manifest)
 
     assert set(manifest) == {
+        "initialization_id",
         "pagination_version",
         "section_registry_sha256",
         "pagination_policy_sha256",
@@ -808,21 +815,21 @@ def test_string_scalar_strategy_rejects_non_string_values() -> None:
             kitchen_id="kitchen-test",
             generation=_generation(),
             selected=selected,
-            recipe_section_bound_bytes=1_000,
+            recipe_section_bound_bytes=_PAGE_TEST_BOUND,
         )
 
 
 def test_repeat_builds_and_fresh_cache_are_deterministic() -> None:
     payload = _payload(warnings=[f"value-{index}" for index in range(50)])
-    first = _build(payload, "warnings", bound=1_000)
-    second = _build(payload, "warnings", bound=1_000)
+    first = _build(payload, "warnings", bound=_PAGE_TEST_BOUND)
+    second = _build(payload, "warnings", bound=_PAGE_TEST_BOUND)
 
     assert first == second
     assert _rendered_pages(first) == _rendered_pages(second)
     assert first.page_plan_sha256 == second.page_plan_sha256
 
     _clear_page_plan_cache()
-    third = _build(payload, "warnings", bound=1_000)
+    third = _build(payload, "warnings", bound=_PAGE_TEST_BOUND)
     assert third == first
 
 
@@ -834,7 +841,7 @@ def test_cached_plans_are_reused_and_cache_clear_forces_a_rebuild(
         "kitchen_id": "kitchen-test",
         "generation": _generation(),
         "selected": selected,
-        "recipe_section_bound_bytes": 1_000,
+        "recipe_section_bound_bytes": _PAGE_TEST_BOUND,
     }
     calls = 0
     real_builder = pagination.build_recipe_section_page_plan
@@ -866,7 +873,7 @@ def test_concurrent_same_key_requests_share_one_page_plan_build(
         "kitchen_id": "kitchen-single-flight",
         "generation": _generation(),
         "selected": selected,
-        "recipe_section_bound_bytes": 1_000,
+        "recipe_section_bound_bytes": _PAGE_TEST_BOUND,
     }
     start = Barrier(3)
     build_started = Event()
@@ -905,7 +912,7 @@ def test_retirement_during_build_prevents_stale_cache_admission(
         "kitchen_id": "kitchen-retirement-race",
         "generation": generation,
         "selected": selected,
-        "recipe_section_bound_bytes": 1_000,
+        "recipe_section_bound_bytes": _PAGE_TEST_BOUND,
     }
     key = pagination._cache_key(**kwargs)
     cache = pagination._page_plan_cache()
@@ -960,7 +967,7 @@ def test_every_cache_key_dimension_prevents_aliasing(
         "kitchen_id": "kitchen-a",
         "generation": _generation(),
         "selected": baseline_selected,
-        "recipe_section_bound_bytes": 1_000,
+        "recipe_section_bound_bytes": _PAGE_TEST_BOUND,
     }
     baseline = get_or_build_recipe_section_page_plan(**kwargs)
 
@@ -976,7 +983,7 @@ def test_every_cache_key_dimension_prevents_aliasing(
     elif dimension == "section_digest":
         kwargs["selected"] = select_recipe_section(_payload(content="changed"), "content")
     elif dimension == "bound":
-        kwargs["recipe_section_bound_bytes"] = 1_001
+        kwargs["recipe_section_bound_bytes"] = _PAGE_TEST_BOUND + 1
     elif dimension == "registry_digest":
         monkeypatch.setattr(
             pagination,
@@ -1008,21 +1015,21 @@ def test_cache_entry_limit_evicts_oldest_plan() -> None:
         kitchen_id="kitchen-0",
         generation=generation,
         selected=selected,
-        recipe_section_bound_bytes=1_000,
+        recipe_section_bound_bytes=_PAGE_TEST_BOUND,
     )
     for index in range(1, pagination.PAGE_PLAN_CACHE_MAX_ENTRIES + 1):
         get_or_build_recipe_section_page_plan(
             kitchen_id=f"kitchen-{index}",
             generation=generation,
             selected=selected,
-            recipe_section_bound_bytes=1_000,
+            recipe_section_bound_bytes=_PAGE_TEST_BOUND,
         )
 
     rebuilt = get_or_build_recipe_section_page_plan(
         kitchen_id="kitchen-0",
         generation=generation,
         selected=selected,
-        recipe_section_bound_bytes=1_000,
+        recipe_section_bound_bytes=_PAGE_TEST_BOUND,
     )
     assert rebuilt == first
     assert rebuilt is not first
@@ -1031,12 +1038,12 @@ def test_cache_entry_limit_evicts_oldest_plan() -> None:
 def test_cache_rejects_a_single_plan_over_its_byte_limit() -> None:
     selected = select_recipe_section(_payload(content="overweight"), "content")
     generation = _generation()
-    plan = _build(_payload(content="overweight"), "content", bound=1_000)
+    plan = _build(_payload(content="overweight"), "content", bound=_PAGE_TEST_BOUND)
     key = pagination._cache_key(
         kitchen_id="kitchen-overweight",
         generation=generation,
         selected=selected,
-        recipe_section_bound_bytes=1_000,
+        recipe_section_bound_bytes=_PAGE_TEST_BOUND,
     )
     cache = PagePlanCache(max_bytes=plan.cache_weight_bytes - 1)
 
@@ -1050,7 +1057,7 @@ def test_cache_byte_limit_evicts_oldest_plan() -> None:
     selected = select_recipe_section(_payload(content="byte eviction"), "content")
     generation = _generation()
     plan = dataclasses.replace(
-        _build(_payload(content="byte eviction"), "content", bound=1_000),
+        _build(_payload(content="byte eviction"), "content", bound=_PAGE_TEST_BOUND),
         cache_weight_bytes=10,
     )
     keys = [
@@ -1058,7 +1065,7 @@ def test_cache_byte_limit_evicts_oldest_plan() -> None:
             kitchen_id=f"kitchen-{index}",
             generation=generation,
             selected=selected,
-            recipe_section_bound_bytes=1_000,
+            recipe_section_bound_bytes=_PAGE_TEST_BOUND,
         )
         for index in range(3)
     ]
@@ -1076,7 +1083,7 @@ def test_cache_byte_limit_evicts_oldest_plan() -> None:
 def test_cache_replacement_subtracts_the_previous_plan_weight() -> None:
     selected = select_recipe_section(_payload(content="replacement"), "content")
     generation = _generation()
-    base_plan = _build(_payload(content="replacement"), "content", bound=1_000)
+    base_plan = _build(_payload(content="replacement"), "content", bound=_PAGE_TEST_BOUND)
     first = dataclasses.replace(base_plan, cache_weight_bytes=7)
     replacement = dataclasses.replace(base_plan, cache_weight_bytes=3)
     other = dataclasses.replace(base_plan, cache_weight_bytes=7)
@@ -1084,13 +1091,13 @@ def test_cache_replacement_subtracts_the_previous_plan_weight() -> None:
         kitchen_id="kitchen-replacement",
         generation=generation,
         selected=selected,
-        recipe_section_bound_bytes=1_000,
+        recipe_section_bound_bytes=_PAGE_TEST_BOUND,
     )
     other_key = pagination._cache_key(
         kitchen_id="kitchen-other",
         generation=generation,
         selected=selected,
-        recipe_section_bound_bytes=1_000,
+        recipe_section_bound_bytes=_PAGE_TEST_BOUND,
     )
     cache = PagePlanCache(max_entries=10, max_bytes=10)
 
@@ -1107,7 +1114,7 @@ def test_cache_kitchen_eviction_subtracts_every_matching_plan_weight() -> None:
     selected = select_recipe_section(_payload(content="kitchen eviction"), "content")
     generation = _generation()
     plan = dataclasses.replace(
-        _build(_payload(content="kitchen eviction"), "content", bound=1_000),
+        _build(_payload(content="kitchen eviction"), "content", bound=_PAGE_TEST_BOUND),
         cache_weight_bytes=5,
     )
     retired_keys = [
@@ -1117,13 +1124,13 @@ def test_cache_kitchen_eviction_subtracts_every_matching_plan_weight() -> None:
             selected=selected,
             recipe_section_bound_bytes=bound,
         )
-        for bound in (1_000, 1_001)
+        for bound in (_PAGE_TEST_BOUND, _PAGE_TEST_BOUND + 1)
     ]
     retained_key = pagination._cache_key(
         kitchen_id="retained-kitchen",
         generation=generation,
         selected=selected,
-        recipe_section_bound_bytes=1_000,
+        recipe_section_bound_bytes=_PAGE_TEST_BOUND,
     )
     cache = PagePlanCache(max_entries=10, max_bytes=20)
     for key in (*retired_keys, retained_key):
@@ -1138,13 +1145,18 @@ def test_cache_kitchen_eviction_subtracts_every_matching_plan_weight() -> None:
 
 def test_cross_process_plan_and_rendering_are_deterministic() -> None:
     payload = _payload(warnings=["alpha", "snowman-☃", 'quote-"', "slash-\\"] * 20)
-    local = _build(payload, "warnings", bound=1_000)
+    local = _build(payload, "warnings", bound=_PAGE_TEST_BOUND)
     local_render_sha = hashlib.sha256(
         "\0".join(_rendered_pages(local)).encode("utf-8")
     ).hexdigest()
     script = f"""
 import hashlib
-from autoskillit.server._recipe_delivery import RecipeArtifactGeneration
+from autoskillit.core import (
+    RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+    RECIPE_ARTIFACT_SCHEMA_VERSION,
+    RECIPE_FLOW_SCHEMA_VERSION,
+    RecipeArtifactGeneration,
+)
 from autoskillit.server._recipe_section_pagination import (
     build_recipe_section_page_plan,
     render_recipe_section_page,
@@ -1154,19 +1166,23 @@ payload = {payload!r}
 generation = RecipeArtifactGeneration(
     producer_tool="open_kitchen",
     recipe_name="remediation",
-    descriptor_version=1,
-    schema_version=1,
+    descriptor_version=RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+    schema_version=RECIPE_ARTIFACT_SCHEMA_VERSION,
     payload_sha256="sha256:" + "1" * 64,
     artifact_blob_sha256="sha256:" + "2" * 64,
     artifact_blob_size_bytes=4096,
     body_sha256="sha256:" + "3" * 64,
     body_size_bytes=2048,
+    flow_schema_version=RECIPE_FLOW_SCHEMA_VERSION,
+    flow_sha256="sha256:" + "4" * 64,
+    flow_size_bytes=512,
+    flow_record_count=2,
 )
 plan = build_recipe_section_page_plan(
     kitchen_id="kitchen-test",
     generation=generation,
     selected=select_recipe_section(payload, "warnings"),
-    recipe_section_bound_bytes=1000,
+    recipe_section_bound_bytes=2000,
 )
 rendered = [render_recipe_section_page(plan, part) for part in range(plan.total_parts)]
 print(plan.page_plan_sha256)

--- a/tests/server/test_serve_idempotence.py
+++ b/tests/server/test_serve_idempotence.py
@@ -13,7 +13,10 @@ import pytest
 from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 
-from autoskillit.core import RECIPE_DELIVERY_SURFACE_REGISTRY
+from autoskillit.core import (
+    RECIPE_DELIVERY_SURFACE_REGISTRY,
+    RecipeArtifactGeneration,
+)
 from autoskillit.pipeline.context import ToolContext
 from tests.server._helpers import _resolve_recipe_section
 
@@ -354,6 +357,102 @@ async def test_serve_surfaces_parametric_content_identity(
         f"Routing divergence on surface={surface!r}: "
         "re-serve content differs from open_kitchen content"
     )
+
+
+async def test_all_surfaces_share_canonical_flow_artifact_and_execution_identity(
+    tool_ctx_kitchen_open: ToolContext,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: object,
+) -> None:
+    """Surface presentation may differ, but canonical compile outputs may not."""
+    monkeypatch.chdir(tmp_path)  # type: ignore[arg-type]
+    from autoskillit.recipe import _api_cache
+    from autoskillit.recipe._api_cache import LoadCache
+    from autoskillit.server._recipe_generation import (
+        get_recipe_generation_store,
+        thaw_recipe_generation_mapping,
+    )
+    from autoskillit.server.tools.tools_kitchen import get_recipe
+    from autoskillit.server.tools.tools_recipe import load_recipe
+
+    monkeypatch.setattr(_api_cache, "_LOAD_CACHE", LoadCache())
+    overrides = {"issue_url": _ISSUE_URL, "task_description": _TASK_DESC}
+    responses = [
+        await _open_kitchen_patched(_RECIPE, overrides, monkeypatch),
+        json.loads(await load_recipe(name=_RECIPE)),
+        json.loads(get_recipe(_RECIPE)),
+        await _open_kitchen_patched(_RECIPE, None, monkeypatch),
+    ]
+    assert all(response.get("success") is not False for response in responses)
+
+    canonical_fields = (
+        "payload_sha256",
+        "artifact_blob_sha256",
+        "artifact_blob_size_bytes",
+        "body_sha256",
+        "body_size_bytes",
+        "flow_schema_version",
+        "flow_sha256",
+        "flow_size_bytes",
+        "flow_record_count",
+    )
+    canonical_identities = [
+        tuple(response["recipe_pull"][field] for field in canonical_fields)
+        for response in responses
+    ]
+    records = []
+    for response in responses:
+        pull_identity = dict(response["recipe_pull"])
+        pull_identity.pop("pull_tool")
+        record = get_recipe_generation_store().lookup_artifact(
+            tool_ctx_kitchen_open.kitchen_id,
+            RecipeArtifactGeneration(**pull_identity),
+        )
+        assert record is not None
+        records.append(record)
+    for index, identity in enumerate(canonical_identities[1:], start=1):
+        first_payload = thaw_recipe_generation_mapping(records[0].artifact_payload)
+        current_payload = thaw_recipe_generation_mapping(records[index].artifact_payload)
+        assert identity == canonical_identities[0], (
+            index,
+            responses[index]["recipe_pull"]["producer_tool"],
+            responses[index]["recipe_pull"]["payload_sha256"],
+            responses[index]["recipe_pull"]["artifact_blob_size_bytes"],
+            records[index].execution_id,
+            [
+                key
+                for key in sorted(first_payload.keys() | current_payload.keys())
+                if first_payload.get(key) != current_payload.get(key)
+            ],
+        )
+    assert len({record.flow_generation.records for record in records}) == 1
+    assert (
+        len(
+            {
+                json.dumps(
+                    {
+                        "entrypoint": record.finalized_projection.entrypoint,
+                        "steps": record.finalized_projection.ordered_step_names,
+                        "edges": [
+                            (
+                                edge.source,
+                                edge.edge_type,
+                                edge.target,
+                                edge.condition,
+                                edge.result_field,
+                            )
+                            for edge in record.finalized_projection.ordered_flow_edges
+                        ],
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+                for record in records
+            }
+        )
+        == 1
+    )
+    assert len({record.execution_id for record in records}) == 1
 
 
 async def test_get_recipe_snapshot_lifecycle(

--- a/tests/server/test_server_tool_registration.py
+++ b/tests/server/test_server_tool_registration.py
@@ -109,6 +109,7 @@ class TestToolRegistration:
             "lock_ingredients",
             "reset_dispatch",
             "get_recipe_section",
+            "complete_recipe_initialization",
         }
         assert expected == tool_names
 

--- a/tests/server/test_tool_registry_parity.py
+++ b/tests/server/test_tool_registry_parity.py
@@ -145,26 +145,89 @@ def test_tool_contract_identity_tracks_registry_parameter_shape() -> None:
 
 
 def test_every_tool_has_an_explicit_initialization_operation() -> None:
-    assert all(
-        isinstance(definition.initialization_operation, ToolInitializationOperation)
-        for definition in TOOL_REGISTRY.values()
-    )
-    assert (
-        TOOL_REGISTRY["complete_recipe_initialization"].initialization_operation
-        is ToolInitializationOperation.RECOVERY
-    )
-    assert (
-        TOOL_REGISTRY["get_recipe_section"].initialization_operation
-        is ToolInitializationOperation.RECOVERY
-    )
-    assert (
-        TOOL_REGISTRY["open_kitchen"].initialization_operation
-        is ToolInitializationOperation.LIFECYCLE_CONTROL
-    )
-    assert (
-        TOOL_REGISTRY["run_skill"].initialization_operation
-        is ToolInitializationOperation.EXECUTION
-    )
+    expected = {
+        ToolInitializationOperation.RECOVERY: {
+            "complete_recipe_initialization",
+            "get_recipe_section",
+        },
+        ToolInitializationOperation.INSPECTION: {
+            "analyze_tool_sequences",
+            "check_pr_mergeable",
+            "check_repo_merge_state",
+            "fetch_github_issue",
+            "get_ci_status",
+            "get_issue_title",
+            "get_pipeline_report",
+            "get_pr_reviews",
+            "get_quota_events",
+            "get_timing_summary",
+            "get_token_summary",
+            "kitchen_status",
+            "list_recipes",
+            "load_recipe",
+            "read_db",
+            "validate_recipe",
+        },
+        ToolInitializationOperation.LIFECYCLE_CONTROL: {
+            "close_kitchen",
+            "open_kitchen",
+        },
+        ToolInitializationOperation.EXECUTION: {
+            "run_cmd",
+            "run_python",
+            "run_skill",
+            "test_check",
+        },
+        ToolInitializationOperation.MUTATION: {
+            "batch_cleanup_clones",
+            "bootstrap_clone",
+            "bulk_close_issues",
+            "claim_and_resolve_issue",
+            "claim_issue",
+            "classify_fix",
+            "clone_repo",
+            "commit_files",
+            "configure_fleet",
+            "configure_order",
+            "create_and_publish_branch",
+            "create_unique_branch",
+            "disable_quota_guard",
+            "dispatch_food_truck",
+            "enqueue_pr",
+            "enrich_issues",
+            "lock_ingredients",
+            "merge_worktree",
+            "migrate_recipe",
+            "prepare_issue",
+            "push_to_remote",
+            "record_gate_dispatch",
+            "record_pipeline_step",
+            "register_clone_status",
+            "release_issue",
+            "reload_session",
+            "remove_clone",
+            "report_bug",
+            "reset_dispatch",
+            "reset_test_dir",
+            "reset_workspace",
+            "set_commit_status",
+            "toggle_auto_merge",
+            "unlock_agent_pack",
+            "wait_for_ci",
+            "wait_for_merge_queue",
+            "write_telemetry_files",
+        },
+    }
+    actual = {
+        operation: {
+            name
+            for name, definition in TOOL_REGISTRY.items()
+            if definition.initialization_operation is operation
+        }
+        for operation in ToolInitializationOperation
+    }
+
+    assert actual == expected
 
 
 def test_tool_contract_identity_tracks_initialization_operation() -> None:

--- a/tests/server/test_tool_registry_parity.py
+++ b/tests/server/test_tool_registry_parity.py
@@ -10,6 +10,7 @@ import pytest
 
 from autoskillit.core import (
     TOOL_REGISTRY,
+    ToolInitializationOperation,
     ToolParamDef,
     ToolWireType,
     compute_tool_contract_identity,
@@ -138,6 +139,39 @@ def test_tool_contract_identity_tracks_registry_parameter_shape() -> None:
     changed = replace(
         run_skill,
         params=(*run_skill.params, ToolParamDef("future_parameter")),
+    )
+
+    assert compute_tool_contract_identity(changed) != compute_tool_contract_identity(run_skill)
+
+
+def test_every_tool_has_an_explicit_initialization_operation() -> None:
+    assert all(
+        isinstance(definition.initialization_operation, ToolInitializationOperation)
+        for definition in TOOL_REGISTRY.values()
+    )
+    assert (
+        TOOL_REGISTRY["complete_recipe_initialization"].initialization_operation
+        is ToolInitializationOperation.RECOVERY
+    )
+    assert (
+        TOOL_REGISTRY["get_recipe_section"].initialization_operation
+        is ToolInitializationOperation.RECOVERY
+    )
+    assert (
+        TOOL_REGISTRY["open_kitchen"].initialization_operation
+        is ToolInitializationOperation.LIFECYCLE_CONTROL
+    )
+    assert (
+        TOOL_REGISTRY["run_skill"].initialization_operation
+        is ToolInitializationOperation.EXECUTION
+    )
+
+
+def test_tool_contract_identity_tracks_initialization_operation() -> None:
+    run_skill = TOOL_REGISTRY["run_skill"]
+    changed = replace(
+        run_skill,
+        initialization_operation=ToolInitializationOperation.RECOVERY,
     )
 
     assert compute_tool_contract_identity(changed) != compute_tool_contract_identity(run_skill)

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -8,7 +8,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from tests.server._helpers import _PATCHED_DEFAULTS, _SERVER_ONLY_KEYS
+from tests.server._helpers import (
+    _PATCHED_DEFAULTS,
+    _SERVER_ONLY_KEYS,
+    _with_finalized_projection,
+)
 from tests.server.conftest import _make_mock_ctx
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
@@ -41,6 +45,9 @@ async def test_named_delivery_preserves_finalized_bytes_across_anonymous_guidanc
         "diagram": None,
         "ingredients_table": "",
     }
+    mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
+        mock_ctx.recipes.load_and_validate.return_value
+    )
     mock_ctx.recipes.find.return_value = None
     mock_ctx.config.migration.suppressed = []
     finalized = FinalizedRecipeResponse(
@@ -189,13 +196,9 @@ async def test_build_hook_diagnostic_warning_skips_missing_when_plugin_active(
         lambda scope: settings_dir / "settings.json",
     )
     monkeypatch.setattr("autoskillit.server._misc.validate_plugin_cache_hooks", lambda **_: [])
-    monkeypatch.setattr(
-        "autoskillit.server._misc.detect_autoskillit_mcp_prefix", lambda: MARKETPLACE_PREFIX
-    )
-
     from autoskillit.server._misc import _build_hook_diagnostic_warning
 
-    result = _build_hook_diagnostic_warning()
+    result = _build_hook_diagnostic_warning(MARKETPLACE_PREFIX)
     assert result is None
 
 
@@ -222,13 +225,9 @@ async def test_build_hook_diagnostic_warning_orphaned_still_fires_when_plugin_ac
     )
     monkeypatch.setattr("autoskillit.server._misc.find_broken_hook_scripts", lambda _: [])
     monkeypatch.setattr("autoskillit.server._misc.validate_plugin_cache_hooks", lambda **_: [])
-    monkeypatch.setattr(
-        "autoskillit.server._misc.detect_autoskillit_mcp_prefix", lambda: MARKETPLACE_PREFIX
-    )
-
     from autoskillit.server._misc import _build_hook_diagnostic_warning
 
-    result = _build_hook_diagnostic_warning()
+    result = _build_hook_diagnostic_warning(MARKETPLACE_PREFIX)
     assert result is not None
     assert "orphan" in result.lower()
     assert "1" in result
@@ -278,7 +277,7 @@ async def test_open_kitchen_no_name_returns_json_envelope_with_success_true(tmp_
                     result = await open_kitchen(ctx=mock_ctx)
 
     parsed = json.loads(result)
-    assert parsed["success"] is True
+    assert parsed["success"] is True, parsed
     assert parsed["kitchen"] == "open"
     assert "Kitchen is open" in parsed["content"]
     assert parsed["ingredients_table"] is None
@@ -300,6 +299,9 @@ async def test_open_kitchen_recipe_found_returns_envelope_with_content_and_ingre
         "diagram": None,
         "ingredients_table": "--- INGREDIENTS TABLE ---\n  task  required\n--- END TABLE ---",
     }
+    mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
+        mock_ctx.recipes.load_and_validate.return_value
+    )
     mock_ctx.recipes.find.return_value = None
     mock_ctx.config.migration.suppressed = []
 
@@ -313,8 +315,11 @@ async def test_open_kitchen_recipe_found_returns_envelope_with_content_and_ingre
 
                     result_str = await open_kitchen(name="demo", ctx=mock_ctx)
 
+    assert isinstance(result_str, str), (
+        f"open_kitchen returned {type(result_str).__name__}: {result_str!r}"
+    )
     parsed = json.loads(result_str)
-    assert parsed["success"] is True
+    assert parsed["success"] is True, parsed
     assert parsed["kitchen"] == "open"
     assert "version" in parsed
     assert "--- INGREDIENTS TABLE ---" in result_str
@@ -465,7 +470,7 @@ async def test_open_kitchen_smoke_test_renders_resolved_base_branch(monkeypatch)
                         result_str = await open_kitchen(name="smoke-test", ctx=mock_ctx)
 
     parsed = json.loads(result_str)
-    assert parsed["success"] is True
+    assert parsed["success"] is True, parsed
     ing_table = parsed.get("ingredients_table") or ""
     assert ing_table, "ingredients_table must be present and non-empty"
     assert "develop" in ing_table
@@ -546,6 +551,9 @@ async def test_open_kitchen_emits_authority_clobber_warning(tmp_path, monkeypatc
         "diagram": None,
         "ingredients_table": "--- TABLE ---",
     }
+    mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
+        mock_ctx.recipes.load_and_validate.return_value
+    )
     mock_recipe_info = MagicMock()
     mock_recipe_info.path = Path("/fake/recipe.yaml")
     mock_ctx.recipes.find.return_value = mock_recipe_info
@@ -637,7 +645,7 @@ async def test_open_kitchen_with_config_authority_ingredient(monkeypatch):
                         )
 
     parsed = json.loads(result_str)
-    assert parsed["success"] is True
+    assert parsed["success"] is True, parsed
     ing_table = parsed.get("ingredients_table") or ""
     assert ing_table, "ingredients_table must be present and non-empty"
     base_branch_rows = [line for line in ing_table.splitlines() if "base_branch" in line]

--- a/tests/server/test_tools_kitchen_gate_features.py
+++ b/tests/server/test_tools_kitchen_gate_features.py
@@ -141,6 +141,7 @@ async def test_open_kitchen_ingredients_only_strips_content(tmp_path, monkeypatc
     mock_ctx.config.migration.suppressed = []
     prior_initialization_state = mock_ctx.recipe_initialization_state
     mock_ctx.recipe_name = "already-active"
+    mock_ctx.gate.enabled = True
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
         with patch("autoskillit.server.logger"):
@@ -187,6 +188,11 @@ async def test_open_kitchen_ingredients_only_preserves_metadata(tmp_path, monkey
     }
     mock_ctx.recipes.find.return_value = MagicMock()
     mock_ctx.config.migration.suppressed = []
+    mock_ctx.gate.enabled = False
+    mock_ctx.active_recipe_packs = None
+    mock_ctx.active_recipe_features = None
+    mock_ctx.active_recipe_steps = None
+    mock_ctx.active_recipe_ingredients = None
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
         with patch("autoskillit.server.logger"):
@@ -210,6 +216,10 @@ async def test_open_kitchen_ingredients_only_preserves_metadata(tmp_path, monkey
     assert "version" in result
     assert result["valid"] is True
     assert result["suggestions"] == []
+    assert mock_ctx.active_recipe_packs == frozenset()
+    assert mock_ctx.active_recipe_features == frozenset()
+    assert mock_ctx.active_recipe_steps == {}
+    assert mock_ctx.active_recipe_ingredients == frozenset()
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_kitchen_gate_features.py
+++ b/tests/server/test_tools_kitchen_gate_features.py
@@ -9,6 +9,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.server._helpers import _with_finalized_projection
 from tests.server.conftest import _make_mock_ctx
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
@@ -138,6 +139,8 @@ async def test_open_kitchen_ingredients_only_strips_content(tmp_path, monkeypatc
     }
     mock_ctx.recipes.find.return_value = MagicMock()
     mock_ctx.config.migration.suppressed = []
+    prior_initialization_state = mock_ctx.recipe_initialization_state
+    mock_ctx.recipe_name = "already-active"
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
         with patch("autoskillit.server.logger"):
@@ -162,6 +165,8 @@ async def test_open_kitchen_ingredients_only_strips_content(tmp_path, monkeypatc
     assert "orchestration_rules" not in result
     assert "sous_chef_discipline" not in result
     assert "stop_step_semantics" not in result
+    assert mock_ctx.recipe_initialization_state is prior_initialization_state
+    assert mock_ctx.recipe_name == "already-active"
 
 
 @pytest.mark.anyio
@@ -405,6 +410,9 @@ def test_recipe_resource_returns_composed_content():
         "content": "name: test-recipe\nsteps:\n  stop:\n    action: stop\n    message: done\n",
         "valid": True,
     }
+    mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
+        mock_ctx.recipes.load_and_validate.return_value
+    )
     mock_ctx.backend = None
     mock_ctx.session_serve_overrides = None
 
@@ -432,7 +440,7 @@ def test_recipe_resource_returns_composed_content():
     mock_ctx.recipes.load_and_validate.assert_called_once_with(
         "test-recipe",
         mock_ctx.project_dir,
-        include_compiled_bindings=True,
+        include_finalized_projection=True,
         ingredient_overrides={
             "kitchen_id": ANY,
             "diagnostics_log_dir": ANY,

--- a/tests/server/test_tools_kitchen_visibility.py
+++ b/tests/server/test_tools_kitchen_visibility.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from autoskillit.core.types._type_constants import SOUS_CHEF_MANDATORY_SECTIONS
+from tests.server._helpers import _with_finalized_projection
 from tests.server.conftest import _make_mock_ctx
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
@@ -275,6 +276,9 @@ async def test_open_kitchen_with_recipe_returns_combined_response(tmp_path, monk
         "suggestions": [],
         "diagram": None,
     }
+    mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
+        mock_ctx.recipes.load_and_validate.return_value
+    )
     mock_ctx.recipes.find.return_value = None
     mock_ctx.config.migration.suppressed = []
 
@@ -490,6 +494,9 @@ async def test_sous_chef_discipline_not_in_open_kitchen_result(tmp_path, monkeyp
         "suggestions": [],
         "diagram": None,
     }
+    mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
+        mock_ctx.recipes.load_and_validate.return_value
+    )
     mock_ctx.recipes.find.return_value = None
     mock_ctx.config.migration.suppressed = []
 
@@ -527,6 +534,9 @@ async def test_open_kitchen_result_keys_match_typed_dict(tmp_path, monkeypatch):
         "suggestions": [],
         "diagram": None,
     }
+    mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
+        mock_ctx.recipes.load_and_validate.return_value
+    )
     mock_ctx.recipes.find.return_value = None
     mock_ctx.config.migration.suppressed = []
 

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -712,6 +712,30 @@ class TestLoadRecipeFailClosed:
         assert "content" in parsed["error"]
 
     @pytest.mark.anyio
+    async def test_load_recipe_fail_closed_missing_finalized_projection(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        monkeypatch.chdir(tmp_path)
+        test_result = {
+            "valid": True,
+            "content": "name: test-recipe\n",
+            "dispatch_feasible": True,
+        }
+        monkeypatch.setattr(self.ctx.recipes, "load_and_validate", lambda *a, **kw: test_result)
+        monkeypatch.setattr(self.ctx.recipes, "find", lambda *a, **kw: None)
+        with patch(
+            "autoskillit.server.tools.tools_recipe._apply_triage_gate",
+            new=AsyncMock(return_value=test_result),
+        ):
+            raw = await load_recipe(name="test-recipe")
+
+        parsed = json.loads(raw)
+        assert parsed["success"] is False
+        assert "finalized projection" in parsed["error"]
+
+    @pytest.mark.anyio
     async def test_load_recipe_blocks_on_dispatch_infeasible(self, monkeypatch, tmp_path):
         """load_recipe must hard-block when dispatch_feasible=False — no recipe
         content is delivered to the caller when the pipeline is infeasible."""

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -13,7 +13,11 @@ from autoskillit.core import SkillResult
 from autoskillit.core.types import RetryReason
 from autoskillit.pipeline.gate import DefaultGateState
 from autoskillit.server.tools.tools_recipe import load_recipe
-from tests.server._helpers import _MINIMAL_SCRIPT_YAML, _resolve_recipe_section
+from tests.server._helpers import (
+    _MINIMAL_SCRIPT_YAML,
+    _resolve_recipe_section,
+    _with_finalized_projection,
+)
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
@@ -577,13 +581,15 @@ class TestLoadRecipeAuthorityClobber:
         mock_recipe_obj.steps = {"do": MagicMock()}
         mock_recipe_obj.ingredients = {"base_branch": MagicMock()}
         mock_ctx.recipes.load.return_value = mock_recipe_obj
-        mock_ctx.recipes.load_and_validate.return_value = {
-            "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
-            "valid": True,
-            "suggestions": [],
-            "diagram": None,
-            "ingredients_table": "--- TABLE ---",
-        }
+        mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
+            {
+                "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+                "valid": True,
+                "suggestions": [],
+                "diagram": None,
+                "ingredients_table": "--- TABLE ---",
+            }
+        )
         mock_ctx.recipes.find.return_value = None
         mock_ctx.config.migration.suppressed = []
         mock_ctx.kitchen_id = "test-kitchen"

--- a/tests/server/test_tools_recipe.py
+++ b/tests/server/test_tools_recipe.py
@@ -9,7 +9,7 @@ import pytest
 
 from autoskillit.server.tools.tools_recipe import list_recipes as list_recipes_tool
 from autoskillit.server.tools.tools_recipe import validate_recipe
-from tests.server._helpers import _PATCHED_DEFAULTS
+from tests.server._helpers import _PATCHED_DEFAULTS, _with_finalized_projection
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
@@ -615,16 +615,18 @@ async def test_load_recipe_with_config_authority_ingredient(tool_ctx_kitchen_ope
 
     from autoskillit.server.tools.tools_recipe import load_recipe
 
-    _load_result = {
-        "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
-        "valid": True,
-        "suggestions": [],
-        "diagram": None,
-        "ingredients_table": (
-            "--- INGREDIENTS TABLE ---\n  base_branch  develop\n--- END TABLE ---"
-        ),
-        "success": True,
-    }
+    _load_result = _with_finalized_projection(
+        {
+            "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+            "valid": True,
+            "suggestions": [],
+            "diagram": None,
+            "ingredients_table": (
+                "--- INGREDIENTS TABLE ---\n  base_branch  develop\n--- END TABLE ---"
+            ),
+            "success": True,
+        }
+    )
     tool_ctx_kitchen_open.recipes = MagicMock()
     tool_ctx_kitchen_open.recipes.load_and_validate.return_value = _load_result
     tool_ctx_kitchen_open.recipes.find.return_value = None

--- a/tests/server/test_tools_recipe_pull.py
+++ b/tests/server/test_tools_recipe_pull.py
@@ -41,6 +41,7 @@ from autoskillit.execution import (
     RecipeDeliveryReceiptLedger,
 )
 from autoskillit.execution.backends import ClaudeCodeBackend, CodexBackend
+from autoskillit.pipeline import RecipeInitializationRequirement
 from autoskillit.recipe import load_and_validate
 from autoskillit.server import _recipe_delivery as recipe_delivery
 from autoskillit.server import _recipe_section_pagination as pagination
@@ -452,6 +453,42 @@ def _build_envelope(
         bound_bytes=bound_bytes,
     )
     return envelope, generation
+
+
+def test_recovery_order_is_derived_from_initialization_requirements(
+    tmp_path: Path,
+) -> None:
+    payload = _payload()
+    generation = _persist(tmp_path, payload)
+    flow_generation = _test_flow_generation(payload)
+    requirements = (
+        RecipeInitializationRequirement(
+            section="first",
+            page_plan_sha256="sha256:first-plan",
+            total_parts=2,
+        ),
+        RecipeInitializationRequirement(
+            section="flow_records",
+            page_plan_sha256="sha256:flow-plan",
+            total_parts=1,
+        ),
+    )
+
+    envelope = build_recipe_envelope(
+        payload,
+        recipe_name="remediation",
+        generation=generation,
+        flow_generation=flow_generation,
+        entrypoint="first",
+        bound_bytes=90_000,
+        initialization_requirements=requirements,
+    )
+
+    assert [item["section"] for item in envelope["required_sections"]] == [
+        "first",
+        "flow_records",
+    ]
+    assert envelope["recovery"]["ordered_sections"] == ["first", "flow_records"]
 
 
 def test_same_payload_is_idempotent_and_changed_payload_is_immutable(tmp_path: Path) -> None:

--- a/tests/server/test_tools_recipe_pull.py
+++ b/tests/server/test_tools_recipe_pull.py
@@ -849,6 +849,45 @@ def test_token_dense_payload_does_not_use_four_byte_ordinary_estimate(tool_ctx) 
     )
 
 
+def test_initialization_requirements_use_the_pull_response_bound(
+    tool_ctx,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response_max_bytes = RECIPE_SECTION_RESPONSE_FLOOR_BYTES + 500
+    tool_ctx.backend = CodexBackend()
+    tool_ctx.kitchen_id = "initialization-page-bound"
+    tool_ctx.config.output_budget = OutputBudgetConfig(response_max_bytes=response_max_bytes)
+    captured_bounds: list[int] = []
+
+    def _capture_requirements(
+        **kwargs: Any,
+    ) -> tuple[RecipeInitializationRequirement, ...]:
+        captured_bounds.append(kwargs["bound_bytes"])
+        return ()
+
+    monkeypatch.setattr(
+        recipe_delivery,
+        "_initialization_requirements",
+        _capture_requirements,
+    )
+
+    finalized = _finalize_recipe_delivery(
+        _payload("!" * 20_000),
+        surface="open_kitchen",
+        recipe_name="remediation",
+        tool_ctx=tool_ctx,
+        finalized_projection=_test_projection(),
+    )
+
+    assert finalized.decision.mode is RecipeDeliveryMode.ENVELOPE
+    assert captured_bounds == [
+        resolve_recipe_section_bound_bytes(
+            response_max_bytes,
+            CODEX_RECIPE_DELIVERY_BUDGET.ordinary_omitted_result_token_limit,
+        )
+    ]
+
+
 def test_envelope_manifest_ignores_ambient_multibyte_fields(tmp_path: Path) -> None:
     payload = _payload()
     payload["orchestration_rules"] = "雪" * 1_000

--- a/tests/server/test_tools_recipe_pull.py
+++ b/tests/server/test_tools_recipe_pull.py
@@ -192,6 +192,7 @@ def test_prepare_generation_rejects_non_finite_compile_values(tool_ctx) -> None:
 
 
 def test_compile_identity_and_artifact_share_one_source_projection(tool_ctx) -> None:
+    tool_ctx.kitchen_id = "compile-identity"
     payload = _payload()
     payload["custom_generation_input"] = {"value": 3}
     payload["initialization_id"] = "caller-owned-stale-id"
@@ -571,7 +572,7 @@ def test_persistence_collision_checks_use_bounded_descriptor_reads(
         ("producer_tool", "invalid"),
         ("payload_sha256", "sha256:" + ("0" * 64)),
         ("artifact_blob_sha256", "sha256:" + ("1" * 64)),
-        ("artifact_blob_size_bytes", 1),
+        ("artifact_blob_size_bytes", 999_999),
         ("body_sha256", "sha256:" + ("2" * 64)),
         ("body_size_bytes", 1),
     ],

--- a/tests/server/test_tools_recipe_pull.py
+++ b/tests/server/test_tools_recipe_pull.py
@@ -41,7 +41,7 @@ from autoskillit.execution import (
     RecipeDeliveryReceiptLedger,
 )
 from autoskillit.execution.backends import ClaudeCodeBackend, CodexBackend
-from autoskillit.pipeline import RecipeInitializationRequirement
+from autoskillit.pipeline import InitializingRecipe, RecipeInitializationRequirement
 from autoskillit.recipe import load_and_validate
 from autoskillit.server import _recipe_delivery as recipe_delivery
 from autoskillit.server import _recipe_section_pagination as pagination
@@ -886,6 +886,75 @@ def test_initialization_requirements_use_the_pull_response_bound(
             CODEX_RECIPE_DELIVERY_BUDGET.ordinary_omitted_result_token_limit,
         )
     ]
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_error"),
+    [
+        ("stale_initialization_id", "invalid_recipe_initialization_identity"),
+        ("altered_page_plan", "invalid_recipe_page_plan_identity"),
+        ("missing_continuation", "invalid_recipe_section_continuation"),
+        ("wrong_continuation", "invalid_recipe_section_continuation"),
+    ],
+)
+async def test_initialization_pull_rejections_preserve_progress(
+    tool_ctx_kitchen_open,
+    case: str,
+    expected_error: str,
+) -> None:
+    tool_ctx_kitchen_open.backend = CodexBackend()
+    tool_ctx_kitchen_open.kitchen_id = f"initialization-rejection-{case}"
+    tool_ctx_kitchen_open.config.output_budget = OutputBudgetConfig(
+        response_max_bytes=RECIPE_SECTION_RESPONSE_FLOOR_BYTES + 500
+    )
+    payload = _payload(
+        "name: remediation\nsteps:\n  first:\n    action: stop\n    message: "
+        + ("x" * 20_000)
+        + "\n"
+    )
+    finalized = _finalize_recipe_delivery(
+        payload,
+        surface="open_kitchen",
+        recipe_name="remediation",
+        tool_ctx=tool_ctx_kitchen_open,
+        finalized_projection=_test_projection(),
+    )
+    assert finalized.decision.mode is RecipeDeliveryMode.ENVELOPE
+    assert complete_finalized_recipe_response(finalized, finalized.rendered) == (
+        finalized.rendered
+    )
+    envelope = json.loads(finalized.rendered)
+    requirement = next(item for item in envelope["required_sections"] if item["total_parts"] > 1)
+    identity = dict(envelope["recipe_pull"])
+    identity.pop("pull_tool")
+    initialization_id = envelope["initialization_id"]
+    page_plan_sha256 = requirement["page_plan_sha256"]
+    part = 0
+    continuation = None
+    if case == "stale_initialization_id":
+        initialization_id = "stale-initialization"
+    elif case == "altered_page_plan":
+        page_plan_sha256 = "sha256:" + ("0" * 64)
+    else:
+        part = 1
+        if case == "wrong_continuation":
+            continuation = "wrong-continuation"
+
+    before = tool_ctx_kitchen_open.recipe_initialization_state
+    assert isinstance(before, InitializingRecipe)
+    response = json.loads(
+        await get_recipe_section(
+            section=requirement["section"],
+            part=part,
+            initialization_id=initialization_id,
+            page_plan_sha256=page_plan_sha256,
+            continuation=continuation,
+            **identity,
+        )
+    )
+
+    assert response["error"] == expected_error
+    assert tool_ctx_kitchen_open.recipe_initialization_state == before
 
 
 def test_envelope_manifest_ignores_ambient_multibyte_fields(tmp_path: Path) -> None:

--- a/tests/server/test_tools_recipe_pull.py
+++ b/tests/server/test_tools_recipe_pull.py
@@ -931,6 +931,7 @@ async def test_initialization_pull_rejections_preserve_progress(
     continuation = None
     if case == "stale_initialization_id":
         initialization_id = "stale-initialization"
+        page_plan_sha256 = None
     elif case == "altered_page_plan":
         page_plan_sha256 = "sha256:" + ("0" * 64)
     else:

--- a/tests/server/test_tools_recipe_pull.py
+++ b/tests/server/test_tools_recipe_pull.py
@@ -904,9 +904,7 @@ async def test_initialization_pull_rejections_preserve_progress(
 ) -> None:
     tool_ctx_kitchen_open.backend = CodexBackend()
     tool_ctx_kitchen_open.kitchen_id = f"initialization-rejection-{case}"
-    tool_ctx_kitchen_open.config.output_budget = OutputBudgetConfig(
-        response_max_bytes=RECIPE_SECTION_RESPONSE_FLOOR_BYTES + 500
-    )
+    tool_ctx_kitchen_open.config.output_budget = OutputBudgetConfig(response_max_bytes=8_000)
     payload = _payload(
         "name: remediation\nsteps:\n  first:\n    action: stop\n    message: "
         + ("x" * 20_000)

--- a/tests/server/test_tools_recipe_pull.py
+++ b/tests/server/test_tools_recipe_pull.py
@@ -1044,11 +1044,12 @@ def test_exemption_overrides_envelope_for_exempt_surface_within_ceiling(tool_ctx
     assert len(oversized_content.encode("utf-8")) > ordinary_limit * 4
     assert len(oversized_content.encode("utf-8")) < ceiling
 
-    finalized = finalize_recipe_delivery(
+    finalized = _finalize_recipe_delivery(
         _payload(oversized_content),
         surface="open_kitchen",
         recipe_name="remediation",
         tool_ctx=tool_ctx,
+        finalized_projection=_test_projection(),
     )
 
     assert finalized.decision.mode is RecipeDeliveryMode.ORDINARY_INLINE
@@ -1070,11 +1071,12 @@ def test_exemption_override_retains_envelope_for_payload_above_ceiling(tool_ctx)
         RESPONSE_BACKSTOP_EXEMPTION_REGISTRY["open_kitchen"].max_utf8_bytes + 1_000
     )
 
-    finalized = finalize_recipe_delivery(
+    finalized = _finalize_recipe_delivery(
         _payload(oversized_content),
         surface="open_kitchen",
         recipe_name="remediation",
         tool_ctx=tool_ctx,
+        finalized_projection=_test_projection(),
     )
 
     assert finalized.decision.mode is RecipeDeliveryMode.ENVELOPE
@@ -1091,11 +1093,12 @@ def test_exemption_override_does_not_apply_to_non_exempt_surface(tool_ctx) -> No
     ordinary_limit = ClaudeCodeBackend().capabilities.unnegotiated_tool_result_token_limit
     oversized_content = "z" * (ordinary_limit * 4 + 5_000)
 
-    finalized = finalize_recipe_delivery(
+    finalized = _finalize_recipe_delivery(
         _payload(oversized_content),
         surface="get_recipe",
         recipe_name="remediation",
         tool_ctx=tool_ctx,
+        finalized_projection=_test_projection(),
     )
 
     assert finalized.decision.mode is RecipeDeliveryMode.ENVELOPE

--- a/tests/server/test_tools_recipe_pull.py
+++ b/tests/server/test_tools_recipe_pull.py
@@ -9,19 +9,29 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import replace
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
+import autoskillit.core.types._type_recipe_delivery as recipe_delivery_types
 from autoskillit.config import OutputBudgetConfig
 from autoskillit.core import (
+    RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+    RECIPE_ARTIFACT_MAX_BLOB_BYTES,
+    RECIPE_ARTIFACT_SCHEMA_VERSION,
     RECIPE_DELIVERY_SURFACE_REGISTRY,
+    RECIPE_FLOW_SCHEMA_VERSION,
     RECIPE_SECTION_RESPONSE_FLOOR_BYTES,
     RESPONSE_BACKSTOP_EXEMPTION_REGISTRY,
+    FinalizedRecipeProjection,
+    RecipeArtifactGeneration,
+    RecipeBindingProjection,
     RecipeDeliveryAttestation,
     RecipeDeliveryEvidenceDef,
     RecipeDeliveryMode,
     RecipeDeliveryRequest,
+    RecipeFlowGeneration,
     load_yaml,
     recipe_delivery_request_digest,
 )
@@ -35,12 +45,10 @@ from autoskillit.recipe import load_and_validate
 from autoskillit.server import _recipe_delivery as recipe_delivery
 from autoskillit.server import _recipe_section_pagination as pagination
 from autoskillit.server._recipe_delivery import (
-    RECIPE_ARTIFACT_MAX_BLOB_BYTES,
     RECIPE_BODY_END,
     RECIPE_BODY_START,
     RECIPE_COMPLETION_SENTINEL,
     RecipeArtifactError,
-    RecipeArtifactGeneration,
     RecipeArtifactSchemaError,
     _canonical_payload,
     _generation_dir,
@@ -50,6 +58,7 @@ from autoskillit.server._recipe_delivery import (
     finalize_recipe_delivery,
     load_recipe_artifact,
     persist_recipe_artifact,
+    prepare_recipe_delivery_generation,
     recipe_pull_producers,
     recipe_recreation_producers,
     retire_recipe_artifacts,
@@ -71,13 +80,64 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.medium]
 _NOW = 1_800_000_000
 
 
+def _test_flow_generation(payload: dict[str, object]) -> RecipeFlowGeneration:
+    existing = payload.get("flow_records")
+    records = (
+        tuple(record for record in existing if isinstance(record, str))
+        if isinstance(existing, list)
+        else ()
+    )
+    if not records:
+        names = [
+            name for name in payload.get("post_prune_step_names") or [] if isinstance(name, str)
+        ]
+        name = names[0] if names else "first"
+        records = (
+            json.dumps(
+                {"kind": "entrypoint", "name": name},
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+            json.dumps(
+                {"index": 0, "kind": "step", "name": name},
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+        )
+    return RecipeFlowGeneration(
+        schema_version=RECIPE_FLOW_SCHEMA_VERSION,
+        records=records,
+    )
+
+
+def _test_projection() -> FinalizedRecipeProjection:
+    return FinalizedRecipeProjection(
+        binding_projection=RecipeBindingProjection({}),
+        ordered_step_names=("first",),
+        entrypoint="first",
+        ordered_flow_edges=(),
+    )
+
+
+def _with_flow(payload: dict[str, object]) -> tuple[dict[str, object], RecipeFlowGeneration]:
+    result = dict(payload)
+    flow_generation = _test_flow_generation(result)
+    result.setdefault("flow_records", list(flow_generation.records))
+    result.setdefault("recipe_flow", flow_generation.identity())
+    return result, flow_generation
+
+
 def _payload(
     content: str = "name: remediation\nsteps:\n  first:\n    action: stop\n",
 ) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "success": True,
         "valid": True,
         "content": content,
+        "content_hash": "sha256:" + ("a" * 64),
+        "composite_hash": "sha256:" + ("b" * 64),
         "post_prune_step_names": ["first"],
         "orchestration_rules": "follow the graph",
         "stop_step_semantics": "stop means stop",
@@ -85,6 +145,53 @@ def _payload(
         "errors": [],
         "warnings": [],
     }
+    return _with_flow(payload)[0]
+
+
+def _finalize_recipe_delivery(
+    payload: dict[str, object],
+    *,
+    surface: str,
+    recipe_name: str,
+    tool_ctx: Any,
+    finalized_projection: FinalizedRecipeProjection,
+    **kwargs: Any,
+):
+    prepared = prepare_recipe_delivery_generation(
+        payload,
+        recipe_name=recipe_name,
+        tool_ctx=tool_ctx,
+        finalized_projection=finalized_projection,
+    )
+    return finalize_recipe_delivery(
+        payload,
+        surface=surface,
+        recipe_name=recipe_name,
+        tool_ctx=tool_ctx,
+        finalized_projection=finalized_projection,
+        flow_generation=prepared.flow_generation,
+        canonical_artifact_payload=prepared.canonical_artifact_payload,
+        execution_snapshot=prepared.execution_snapshot,
+        normalized_compile_key=prepared.normalized_compile_key,
+        **kwargs,
+    )
+
+
+def _persist_finalized_generation(
+    tool_ctx: Any,
+    payload: dict[str, object] | None = None,
+):
+    source = dict(payload or _payload())
+    finalized = _finalize_recipe_delivery(
+        source,
+        surface="open_kitchen",
+        recipe_name="remediation",
+        tool_ctx=tool_ctx,
+        finalized_projection=_test_projection(),
+    )
+    assert finalized.artifact_generation is not None
+    assert finalized.execution_snapshot is not None
+    return finalized.artifact_generation, finalized
 
 
 def _persist(
@@ -94,12 +201,14 @@ def _persist(
     producer: str = "open_kitchen",
     kitchen_id: str = "kitchen-test",
 ) -> RecipeArtifactGeneration:
+    persisted_payload, flow_generation = _with_flow(dict(payload or _payload()))
     return persist_recipe_artifact(
         tmp_path,
         kitchen_id=kitchen_id,
         producer_tool=producer,
         recipe_name="remediation",
-        payload=dict(payload or _payload()),
+        payload=persisted_payload,
+        flow_generation=flow_generation,
     )
 
 
@@ -112,11 +221,13 @@ def _write_malformed_generation(
 ) -> RecipeArtifactGeneration:
     """Write a digest-consistent artifact while bypassing producer validation."""
     blob = _canonical_payload(payload)
+    flow_generation = _test_flow_generation(payload)
     generation = _generation_from_payload(
         producer_tool=producer,
         recipe_name="remediation",
         blob=blob,
         payload=payload,
+        flow_generation=flow_generation,
     )
     directory = _generation_dir(
         tmp_path,
@@ -298,14 +409,13 @@ def _build_envelope(
     tmp_path: Path, payload: dict[str, object], *, bound_bytes: int
 ) -> tuple[dict[str, object], RecipeArtifactGeneration]:
     generation = _persist(tmp_path, payload)
-    skeleton_source = MagicMock()
-    skeleton_source.recipe_name = "remediation"
-    skeleton_source.active_recipe_steps = {}
+    flow_generation = _test_flow_generation(payload)
     envelope = build_recipe_envelope(
         payload,
         recipe_name="remediation",
         generation=generation,
-        skeleton_source=skeleton_source,
+        flow_generation=flow_generation,
+        entrypoint="first",
         bound_bytes=bound_bytes,
     )
     return envelope, generation
@@ -332,13 +442,19 @@ def test_generation_path_includes_version_domain(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, version_name: str
 ) -> None:
     first = _persist(tmp_path)
-    monkeypatch.setattr(f"autoskillit.server._recipe_delivery.{version_name}", 2)
+    current_version = getattr(recipe_delivery, version_name)
+    monkeypatch.setattr(
+        f"autoskillit.server._recipe_delivery.{version_name}",
+        current_version + 1,
+    )
+    monkeypatch.setattr(recipe_delivery_types, version_name, current_version + 1)
 
     second = _persist(tmp_path)
 
     assert second.payload_sha256 == first.payload_sha256
     assert second.pull_identity() != first.pull_identity()
-    assert load_recipe_artifact(tmp_path, kitchen_id="kitchen-test", identity=first) == _payload()
+    with pytest.raises(RecipeArtifactError, match="invalid recipe artifact identity bounds"):
+        load_recipe_artifact(tmp_path, kitchen_id="kitchen-test", identity=first)
     assert load_recipe_artifact(tmp_path, kitchen_id="kitchen-test", identity=second) == _payload()
 
 
@@ -416,16 +532,21 @@ def test_non_utf8_payload_is_normalized_to_recipe_artifact_error(tmp_path: Path)
     qualified_blob_sha = f"sha256:{hashlib.sha256(blob).hexdigest()}"
     payload_sha = "sha256:" + hashlib.sha256(b"autoskillit.recipe-payload.v1\0" + blob).hexdigest()
     empty_body_sha = f"sha256:{hashlib.sha256(b'').hexdigest()}"
+    flow_generation = _test_flow_generation(_payload())
     generation = RecipeArtifactGeneration(
         producer_tool="open_kitchen",
         recipe_name="remediation",
-        descriptor_version=1,
-        schema_version=1,
+        descriptor_version=RECIPE_ARTIFACT_DESCRIPTOR_VERSION,
+        schema_version=RECIPE_ARTIFACT_SCHEMA_VERSION,
         payload_sha256=payload_sha,
         artifact_blob_sha256=qualified_blob_sha,
         artifact_blob_size_bytes=len(blob),
         body_sha256=empty_body_sha,
         body_size_bytes=0,
+        flow_schema_version=flow_generation.schema_version,
+        flow_sha256=flow_generation.flow_sha256,
+        flow_size_bytes=flow_generation.flow_size_bytes,
+        flow_record_count=flow_generation.record_count,
     )
     directory = _generation_dir(
         tmp_path,
@@ -459,6 +580,10 @@ def test_generation_descriptor_has_no_caller_selected_path(tmp_path: Path) -> No
         "artifact_blob_size_bytes",
         "body_sha256",
         "body_size_bytes",
+        "flow_schema_version",
+        "flow_sha256",
+        "flow_size_bytes",
+        "flow_record_count",
         "pull_tool",
     }
     assert not {"artifact_path", "path", "sha256"} & set(pull)
@@ -524,7 +649,7 @@ def test_kitchen_retirement_evicts_only_matching_page_plans(
     common = {
         "generation": generation,
         "selected": selected,
-        "recipe_section_bound_bytes": 1_000,
+        "recipe_section_bound_bytes": 10_000,
     }
     retired = get_or_build_recipe_section_page_plan(
         kitchen_id="kitchen-test",
@@ -615,13 +740,18 @@ def test_kitchen_retirement_rejects_dot_path_components(tmp_path: Path, kitchen_
 def test_codex_without_supported_host_evidence_uses_bounded_envelope(tool_ctx) -> None:
     tool_ctx.backend = CodexBackend()
     tool_ctx.kitchen_id = "codex-envelope"
-    payload = _payload("x" * 50_000)
+    payload = _payload(
+        "name: remediation\nsteps:\n  first:\n    action: stop\n    message: "
+        + ("x" * 50_000)
+        + "\n"
+    )
 
-    finalized = finalize_recipe_delivery(
+    finalized = _finalize_recipe_delivery(
         payload,
         surface="open_kitchen",
         recipe_name="remediation",
         tool_ctx=tool_ctx,
+        finalized_projection=_test_projection(),
     )
 
     assert finalized.decision.mode is RecipeDeliveryMode.ENVELOPE
@@ -635,11 +765,12 @@ def test_token_dense_payload_does_not_use_four_byte_ordinary_estimate(tool_ctx) 
     tool_ctx.backend = CodexBackend()
     tool_ctx.kitchen_id = "codex-token-dense"
 
-    finalized = finalize_recipe_delivery(
+    finalized = _finalize_recipe_delivery(
         _payload("!" * 20_000),
         surface="open_kitchen",
         recipe_name="remediation",
         tool_ctx=tool_ctx,
+        finalized_projection=_test_projection(),
     )
 
     assert finalized.decision.mode is RecipeDeliveryMode.ENVELOPE
@@ -648,7 +779,7 @@ def test_token_dense_payload_does_not_use_four_byte_ordinary_estimate(tool_ctx) 
     )
 
 
-def test_envelope_priority_fields_share_multibyte_budget_safely(tmp_path: Path) -> None:
+def test_envelope_manifest_ignores_ambient_multibyte_fields(tmp_path: Path) -> None:
     payload = _payload()
     payload["orchestration_rules"] = "雪" * 1_000
     payload["stop_step_semantics"] = "界" * 1_000
@@ -658,12 +789,10 @@ def test_envelope_priority_fields_share_multibyte_budget_safely(tmp_path: Path) 
     rendered = json.dumps(envelope, ensure_ascii=False, separators=(",", ":"))
 
     assert len(rendered.encode("utf-8")) <= bound_bytes
-    for key in ("orchestration_rules", "stop_step_semantics"):
-        projected = envelope[key]
-        assert isinstance(projected, str)
-        assert projected
-        assert len(projected.encode("utf-8")) < len(str(payload[key]).encode("utf-8"))
-        assert projected.encode("utf-8").decode("utf-8") == projected
+    assert envelope["success"] is True
+    assert envelope["recipe_flow"] == _test_flow_generation(payload).identity()
+    assert "orchestration_rules" not in envelope
+    assert "stop_step_semantics" not in envelope
 
 
 def test_envelope_fallbacks_follow_tight_and_extreme_bounds(tmp_path: Path) -> None:
@@ -704,11 +833,12 @@ def test_finalizer_uses_backend_selected_recipe_budget(tool_ctx) -> None:
     tool_ctx.backend = backend
     tool_ctx.kitchen_id = "selected-budget"
 
-    finalized = finalize_recipe_delivery(
+    finalized = _finalize_recipe_delivery(
         _payload(),
         surface="open_kitchen",
         recipe_name="remediation",
         tool_ctx=tool_ctx,
+        finalized_projection=_test_projection(),
     )
 
     assert finalized.decision.mode is RecipeDeliveryMode.ORDINARY_INLINE
@@ -872,11 +1002,12 @@ def test_attested_finalization_commits_only_after_exact_enforcement(
     tool_ctx.backend = _protected_codex_backend()
     tool_ctx.kitchen_id = "codex-attested"
     ledger = _ledger(tmp_path)
-    finalized = finalize_recipe_delivery(
+    finalized = _finalize_recipe_delivery(
         _payload("x" * 50_000),
         surface="open_kitchen",
         recipe_name="remediation",
         tool_ctx=tool_ctx,
+        finalized_projection=_test_projection(),
         delivery_request=_request(),
         attestation=_attestation(),
         supported_evidence=_evidence(),
@@ -909,11 +1040,12 @@ def test_transformed_attested_response_aborts_pending_receipt(tmp_path: Path, to
     tool_ctx.backend = _protected_codex_backend()
     tool_ctx.kitchen_id = "codex-abort"
     ledger = _ledger(tmp_path)
-    finalized = finalize_recipe_delivery(
+    finalized = _finalize_recipe_delivery(
         _payload("x" * 50_000),
         surface="load_recipe",
         recipe_name="remediation",
         tool_ctx=tool_ctx,
+        finalized_projection=_test_projection(),
         delivery_request=_request(),
         attestation=_attestation("thread-abort"),
         supported_evidence=_evidence(),
@@ -932,11 +1064,12 @@ def test_failed_receipt_abort_is_reported(
     tool_ctx.backend = _protected_codex_backend()
     tool_ctx.kitchen_id = "codex-abort-failure"
     ledger = _ledger(tmp_path)
-    finalized = finalize_recipe_delivery(
+    finalized = _finalize_recipe_delivery(
         _payload("x" * 50_000),
         surface="load_recipe",
         recipe_name="remediation",
         tool_ctx=tool_ctx,
+        finalized_projection=_test_projection(),
         delivery_request=_request(),
         attestation=_attestation("thread-abort-failure"),
         supported_evidence=_evidence(),
@@ -973,8 +1106,16 @@ async def test_pull_tool_reads_exact_generation_and_reports_byte_offsets(
     chunks: list[str] = []
     expected_byte_start = 0
     part = 0
+    page_plan_sha256: str | None = None
+    continuation: str | None = None
     while True:
-        rendered = await get_recipe_section(section="content", part=part, **kwargs)
+        rendered = await get_recipe_section(
+            section="content",
+            part=part,
+            page_plan_sha256=page_plan_sha256,
+            continuation=continuation,
+            **kwargs,
+        )
         assert len(rendered.encode("utf-8")) <= (
             CODEX_RECIPE_DELIVERY_BUDGET.ordinary_omitted_result_token_limit
         )
@@ -993,6 +1134,8 @@ async def test_pull_tool_reads_exact_generation_and_reports_byte_offsets(
             assert "next_part" not in response
             break
         assert response["next_part"] == part + 1
+        page_plan_sha256 = response["page_plan_sha256"]
+        continuation = response["continuation"]
         part = response["next_part"]
 
     assert part > 0
@@ -1149,21 +1292,10 @@ async def test_recreation_persistence_schema_failure_precedes_artifact_error(
 
     tool_ctx_kitchen_open.backend = CodexBackend()
     tool_ctx_kitchen_open.kitchen_id = "pull-recreate-schema-write"
-    generation = _persist(
-        tool_ctx_kitchen_open.temp_dir,
-        kitchen_id=tool_ctx_kitchen_open.kitchen_id,
-    )
+    generation, _finalized = _persist_finalized_generation(tool_ctx_kitchen_open)
     _remove_persisted_namespace(
         tool_ctx_kitchen_open.temp_dir,
         kitchen_id=tool_ctx_kitchen_open.kitchen_id,
-    )
-    malformed = _payload()
-    malformed["warnings"] = ["valid", 1]
-    monkeypatch.setattr(tools_recipe, "serve_recipe", lambda *_args, **_kwargs: malformed)
-    monkeypatch.setattr(
-        tools_recipe,
-        "build_open_kitchen_recipe_payload",
-        lambda data, *, version: data,
     )
     monkeypatch.setattr(
         tools_recipe,
@@ -1193,13 +1325,7 @@ async def test_post_recreation_reload_schema_failure_precedes_reload_error(
 
     tool_ctx_kitchen_open.backend = CodexBackend()
     tool_ctx_kitchen_open.kitchen_id = "pull-recreate-schema-reload"
-    generation = _persist(tool_ctx_kitchen_open.temp_dir)
-    monkeypatch.setattr(tools_recipe, "serve_recipe", lambda *_args, **_kwargs: _payload())
-    monkeypatch.setattr(
-        tools_recipe,
-        "build_open_kitchen_recipe_payload",
-        lambda data, *, version: data,
-    )
+    generation, _finalized = _persist_finalized_generation(tool_ctx_kitchen_open)
     monkeypatch.setattr(
         tools_recipe,
         "persist_recipe_artifact",
@@ -1238,13 +1364,7 @@ async def test_post_recreation_reload_artifact_failure_logs_exception_context(
 
     tool_ctx_kitchen_open.backend = CodexBackend()
     tool_ctx_kitchen_open.kitchen_id = "pull-recreate-artifact-reload"
-    generation = _persist(tool_ctx_kitchen_open.temp_dir)
-    monkeypatch.setattr(tools_recipe, "serve_recipe", lambda *_args, **_kwargs: _payload())
-    monkeypatch.setattr(
-        tools_recipe,
-        "build_open_kitchen_recipe_payload",
-        lambda data, *, version: data,
-    )
+    generation, _finalized = _persist_finalized_generation(tool_ctx_kitchen_open)
     monkeypatch.setattr(
         tools_recipe,
         "persist_recipe_artifact",
@@ -1424,9 +1544,17 @@ async def test_oversized_named_step_round_trips_through_continuation(
     kwargs.pop("pull_tool")
     chunks: list[str] = []
     part = 0
+    page_plan_sha256: str | None = None
+    continuation: str | None = None
 
     while True:
-        rendered = await get_recipe_section(section="giant_step", part=part, **kwargs)
+        rendered = await get_recipe_section(
+            section="giant_step",
+            part=part,
+            page_plan_sha256=page_plan_sha256,
+            continuation=continuation,
+            **kwargs,
+        )
         assert len(rendered.encode("utf-8")) <= (
             CODEX_RECIPE_DELIVERY_BUDGET.ordinary_omitted_result_token_limit
         )
@@ -1435,6 +1563,8 @@ async def test_oversized_named_step_round_trips_through_continuation(
         chunks.append(response["content"])
         if response["has_more"] is False:
             break
+        page_plan_sha256 = response["page_plan_sha256"]
+        continuation = response["continuation"]
         part = response["next_part"]
 
     assert part > 0
@@ -1486,21 +1616,15 @@ async def test_pull_tool_recreates_missing_exact_generation(
     import autoskillit.server.tools.tools_recipe as tools_recipe
 
     tool_ctx_kitchen_open.kitchen_id = "pull-recreate"
-    generation = persist_recipe_artifact(
-        tool_ctx_kitchen_open.temp_dir,
-        kitchen_id=tool_ctx_kitchen_open.kitchen_id,
-        producer_tool="open_kitchen",
-        recipe_name="remediation",
-        payload=_payload(),
-    )
+    generation, finalized = _persist_finalized_generation(tool_ctx_kitchen_open)
     _remove_persisted_namespace(
         tool_ctx_kitchen_open.temp_dir, kitchen_id=tool_ctx_kitchen_open.kitchen_id
     )
-    monkeypatch.setattr(tools_recipe, "serve_recipe", lambda *_args, **_kwargs: _payload())
+    recompile = MagicMock(side_effect=AssertionError("recreation must not recompile"))
     monkeypatch.setattr(
         tools_recipe,
-        "build_open_kitchen_recipe_payload",
-        lambda data, *, version: data,
+        "serve_recipe",
+        recompile,
     )
 
     kwargs = generation.pull_identity()
@@ -1509,50 +1633,41 @@ async def test_pull_tool_recreates_missing_exact_generation(
 
     assert response["success"] is True
     assert response["content"] == _payload()["content"]
-    assert (
-        load_recipe_artifact(
-            tool_ctx_kitchen_open.temp_dir,
-            kitchen_id=tool_ctx_kitchen_open.kitchen_id,
-            identity=generation,
-        )
-        == _payload()
+    recreated = load_recipe_artifact(
+        tool_ctx_kitchen_open.temp_dir,
+        kitchen_id=tool_ctx_kitchen_open.kitchen_id,
+        identity=generation,
     )
+    assert recreated["content"] == _payload()["content"]
+    assert recreated["recipe_execution"]["execution_id"] == (
+        finalized.execution_snapshot.execution_id
+    )
+    recompile.assert_not_called()
 
 
-async def test_recreation_does_not_attach_snapshot_for_different_recipe_hashes(
+async def test_recreation_reuses_original_snapshot_without_snapshot_factory(
     tool_ctx_kitchen_open, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    import autoskillit.server.tools.tools_recipe as tools_recipe
+    import autoskillit.server._recipe_execution as recipe_execution
 
     tool_ctx_kitchen_open.kitchen_id = "pull-recreate-stale-snapshot"
     payload = _payload()
     payload["content_hash"] = "sha256:" + ("a" * 64)
     payload["composite_hash"] = "sha256:" + ("b" * 64)
-    generation = persist_recipe_artifact(
-        tool_ctx_kitchen_open.temp_dir,
-        kitchen_id=tool_ctx_kitchen_open.kitchen_id,
-        producer_tool="open_kitchen",
-        recipe_name="remediation",
-        payload=payload,
+    generation, finalized = _persist_finalized_generation(
+        tool_ctx_kitchen_open,
+        payload,
     )
     _remove_persisted_namespace(
         tool_ctx_kitchen_open.temp_dir, kitchen_id=tool_ctx_kitchen_open.kitchen_id
     )
-    snapshot = MagicMock(
-        recipe_name="remediation",
-        content_hash="sha256:" + ("c" * 64),
-        composite_hash="sha256:" + ("d" * 64),
-    )
-    monkeypatch.setattr(tools_recipe, "serve_recipe", lambda *_args, **_kwargs: dict(payload))
-    monkeypatch.setattr(
-        tools_recipe,
-        "build_open_kitchen_recipe_payload",
-        lambda data, *, version: data,
+    snapshot_factory = MagicMock(
+        side_effect=AssertionError("recreation must reuse the original snapshot")
     )
     monkeypatch.setattr(
-        tools_recipe,
-        "get_recipe_execution",
-        lambda _tool_ctx: MagicMock(snapshot=snapshot),
+        recipe_execution,
+        "build_recipe_execution_snapshot",
+        snapshot_factory,
     )
 
     kwargs = generation.pull_identity()
@@ -1565,14 +1680,15 @@ async def test_recreation_does_not_attach_snapshot_for_different_recipe_hashes(
         kitchen_id=tool_ctx_kitchen_open.kitchen_id,
         identity=generation,
     )
-    assert "recipe_execution" not in recreated
+    assert recreated["recipe_execution"]["execution_id"] == (
+        finalized.execution_snapshot.execution_id
+    )
+    snapshot_factory.assert_not_called()
 
 
 async def test_pull_tool_reports_invalid_missing_generation_recreation(
-    tool_ctx_kitchen_open, monkeypatch: pytest.MonkeyPatch
+    tool_ctx_kitchen_open,
 ) -> None:
-    import autoskillit.server.tools.tools_recipe as tools_recipe
-
     tool_ctx_kitchen_open.kitchen_id = "pull-recreate-invalid"
     generation = persist_recipe_artifact(
         tool_ctx_kitchen_open.temp_dir,
@@ -1584,52 +1700,26 @@ async def test_pull_tool_reports_invalid_missing_generation_recreation(
     _remove_persisted_namespace(
         tool_ctx_kitchen_open.temp_dir, kitchen_id=tool_ctx_kitchen_open.kitchen_id
     )
-    monkeypatch.setattr(
-        tools_recipe,
-        "serve_recipe",
-        lambda *_args, **_kwargs: {"valid": False, "content": "invalid"},
-    )
 
     kwargs = generation.pull_identity()
     kwargs.pop("pull_tool")
     response = json.loads(await get_recipe_section(section="content", **kwargs))
 
-    assert response == {
-        "success": False,
-        "error": "recipe_artifact_unavailable",
-        "detail": "recreation returned invalid recipe",
-    }
+    assert response == {"success": False, "error": "invalid_recipe_artifact_identity"}
 
 
 async def test_pull_tool_rejects_changed_recreated_generation(
-    tool_ctx_kitchen_open, monkeypatch: pytest.MonkeyPatch
+    tool_ctx_kitchen_open,
 ) -> None:
-    import autoskillit.server.tools.tools_recipe as tools_recipe
-
     tool_ctx_kitchen_open.kitchen_id = "pull-recreate-changed"
-    generation = persist_recipe_artifact(
-        tool_ctx_kitchen_open.temp_dir,
-        kitchen_id=tool_ctx_kitchen_open.kitchen_id,
-        producer_tool="open_kitchen",
-        recipe_name="remediation",
-        payload=_payload(),
-    )
+    generation, _finalized = _persist_finalized_generation(tool_ctx_kitchen_open)
     _remove_persisted_namespace(
         tool_ctx_kitchen_open.temp_dir, kitchen_id=tool_ctx_kitchen_open.kitchen_id
-    )
-    monkeypatch.setattr(
-        tools_recipe,
-        "serve_recipe",
-        lambda *_args, **_kwargs: _payload("name: remediation\nsteps: {}\n"),
-    )
-    monkeypatch.setattr(
-        tools_recipe,
-        "build_open_kitchen_recipe_payload",
-        lambda data, *, version: data,
     )
 
     kwargs = generation.pull_identity()
     kwargs.pop("pull_tool")
+    kwargs["flow_sha256"] = "sha256:" + ("0" * 64)
     response = json.loads(await get_recipe_section(section="content", **kwargs))
 
     assert response == {"success": False, "error": "invalid_recipe_artifact_identity"}

--- a/tests/server/test_tools_recipe_pull.py
+++ b/tests/server/test_tools_recipe_pull.py
@@ -177,6 +177,19 @@ def _finalize_recipe_delivery(
     )
 
 
+def test_prepare_generation_rejects_non_finite_compile_values(tool_ctx) -> None:
+    payload = _payload()
+    payload["runtime_metadata"] = {"limit": float("nan")}
+
+    with pytest.raises(ValueError, match="non-finite float"):
+        prepare_recipe_delivery_generation(
+            payload,
+            recipe_name="remediation",
+            tool_ctx=tool_ctx,
+            finalized_projection=_test_projection(),
+        )
+
+
 def _persist_finalized_generation(
     tool_ctx: Any,
     payload: dict[str, object] | None = None,

--- a/tests/server/test_tools_recipe_pull.py
+++ b/tests/server/test_tools_recipe_pull.py
@@ -190,6 +190,26 @@ def test_prepare_generation_rejects_non_finite_compile_values(tool_ctx) -> None:
         )
 
 
+def test_compile_identity_and_artifact_share_one_source_projection(tool_ctx) -> None:
+    payload = _payload()
+    payload["custom_generation_input"] = {"value": 3}
+    payload["initialization_id"] = "caller-owned-stale-id"
+
+    prepared = prepare_recipe_delivery_generation(
+        payload,
+        recipe_name="remediation",
+        tool_ctx=tool_ctx,
+        finalized_projection=_test_projection(),
+    )
+    source_payload = prepared.compile_inputs["source_payload"]
+
+    assert isinstance(source_payload, dict)
+    assert source_payload["custom_generation_input"] == {"value": 3}
+    assert prepared.canonical_artifact_payload["custom_generation_input"] == {"value": 3}
+    assert "initialization_id" not in source_payload
+    assert "initialization_id" not in prepared.canonical_artifact_payload
+
+
 def _persist_finalized_generation(
     tool_ctx: Any,
     payload: dict[str, object] | None = None,

--- a/tests/server/test_track_response_size.py
+++ b/tests/server/test_track_response_size.py
@@ -385,3 +385,72 @@ class TestTrackResponseSize:
         assert result == bounded
         ledger.commit.assert_not_called()
         ledger.abort.assert_called_once_with(finalized.receipt_handle)
+
+    @pytest.mark.parametrize(
+        ("carrier_kind", "completion_target"),
+        [
+            (
+                "section",
+                "autoskillit.server._notify.complete_section_response",
+            ),
+            (
+                "initialization",
+                "autoskillit.server._notify.complete_initialization_response",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("enforced", ["exact response", "transformed response"])
+    @pytest.mark.anyio
+    async def test_initialization_carriers_complete_through_decorated_boundary(
+        self,
+        carrier_kind: str,
+        completion_target: str,
+        enforced: str,
+    ):
+        from autoskillit.server._notify import track_response_size
+        from autoskillit.server._recipe_initialization import (
+            FinalizedRecipeInitializationResponse,
+            FinalizedRecipeSectionResponse,
+        )
+
+        tool_ctx = MagicMock()
+        artifact_generation = MagicMock()
+        if carrier_kind == "section":
+            finalized = FinalizedRecipeSectionResponse(
+                rendered="exact response",
+                tool_ctx=tool_ctx,
+                initialization_id="initialization",
+                artifact_generation=artifact_generation,
+                section="flow_records",
+                page_plan_sha256="sha256:plan",
+                part=0,
+            )
+        else:
+            finalized = FinalizedRecipeInitializationResponse(
+                rendered="exact response",
+                tool_ctx=tool_ctx,
+                initialization_id="initialization",
+                artifact_generation=artifact_generation,
+                staged_snapshot=MagicMock(),
+                completion_receipt="sha256:receipt",
+            )
+
+        @track_response_size("initialization_boundary")
+        async def fake_handler():
+            return finalized
+
+        with (
+            patch(
+                "autoskillit.server._notify._get_ctx_or_none",
+                return_value=_tracking_ctx(),
+            ),
+            patch(
+                "autoskillit.server._notify.enforce_response_budget",
+                return_value=enforced,
+            ),
+            patch(completion_target, return_value=enforced) as complete,
+        ):
+            result = await fake_handler()
+
+        assert result == enforced
+        complete.assert_called_once_with(finalized, enforced)

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -209,7 +209,7 @@ class TestModuleCascadeCore:
 
     def test_type_recipe_delivery_cascade(self) -> None:
         assert MODULE_CASCADE_CORE["_type_recipe_delivery"] == frozenset(
-            {"core", "execution", "server"}
+            {"core", "execution", "pipeline", "server"}
         )
 
     def test_context_admission_persistence_cascade(self) -> None:


### PR DESCRIPTION
## Summary

The first phase creates the bounded, canonical producer side of recipe initialization. It keeps the intentional conservative Codex ordinary-result bound and replaces the current ambient-state skeleton with one immutable flow generation derived from the final post-prune recipe. The same flow is bound to the existing artifact, delivered through every registered surface, and reconstructable through fully generation-bound pages.

Closes #4362

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/rectify/rectify_generation_bound_recipe_initialization_2026-07-27_071654.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
