### PR TITLE
[FIX] Rectify: Fix #4399 — Envelope Truncation and Tool Registry Loss

### DIFF
--- a/src/autoskillit/server/_recipe_delivery.py
+++ b/src/autoskillit/server/_recipe_delivery.py
@@ -766,6 +766,14 @@ def finalize_recipe_delivery(
     """Persist, decide, shape, and transactionally reserve one recipe response."""
     execution_snapshot = None
     candidate_payload = dict(payload)
+    # ORDINARY_INLINE rendered output is the authoritative recipe payload serialized
+    # to JSON. Some callers (e.g. load_recipe) pass a payload without a `success`
+    # field; tests and downstream consumers require success=True on the wire shape.
+    # Open_kitchen callers already inject success=True via build_open_kitchen_recipe_payload
+    # so this is a no-op for that surface. Inject once here so ORDINARY_INLINE always
+    # carries the success indicator.
+    if "success" not in candidate_payload:
+        candidate_payload["success"] = True
     if compiled_bindings is not None:
         from autoskillit.server._recipe_execution import (  # circular-break
             build_recipe_execution_snapshot,
@@ -954,9 +962,15 @@ def finalize_recipe_delivery(
     # open_kitchen on Claude Code (protected_recipe_delivery_capable=False) get
     # ENVELOPE for any payload exceeding the 46.5K ordinary_limit, producing a
     # degenerate formatter output with no recipe body.
+    #
+    # Scoped to non-protected backends (those without a recipe_delivery_budget,
+    # i.e. Claude Code). Codex has its own recipe_delivery_budget and bounded
+    # envelope semantics — applying the override to Codex would regress
+    # `test_codex_without_supported_host_evidence_uses_bounded_envelope`.
     if (
         decision.mode is RecipeDeliveryMode.ENVELOPE
         and surface_definition.response_exemption_tool is not None
+        and capabilities.recipe_delivery_budget is None
     ):
         _exemption = RESPONSE_BACKSTOP_EXEMPTION_REGISTRY.get(
             surface_definition.response_exemption_tool

--- a/src/autoskillit/server/_recipe_delivery.py
+++ b/src/autoskillit/server/_recipe_delivery.py
@@ -22,6 +22,7 @@ from autoskillit.config import OutputBudgetConfig
 from autoskillit.core import (
     CLAUDE_CODE_CAPABILITIES,
     RECIPE_DELIVERY_SURFACE_REGISTRY,
+    RESPONSE_BACKSTOP_EXEMPTION_REGISTRY,
     BackendCapabilities,
     RecipeDeliveryAttestation,
     RecipeDeliveryDecision,
@@ -943,6 +944,34 @@ def finalize_recipe_delivery(
             else:
                 receipt_handle = reservation.handle
                 decision = replace(decision, receipt_status="pending")
+
+    # Issue #4399 exemption override: when an exempt surface's ordinary-rendered
+    # payload fits within the registered exemption ceiling, upgrade ENVELOPE back
+    # to ORDINARY_INLINE so the full recipe body survives. Placed after ALL
+    # ENVELOPE-producing branches (initial resolve, response-budget downgrade,
+    # receipt-store-missing downgrade, reservation-failure downgrade) so the
+    # override catches every path. Without this, exempt surfaces like
+    # open_kitchen on Claude Code (protected_recipe_delivery_capable=False) get
+    # ENVELOPE for any payload exceeding the 46.5K ordinary_limit, producing a
+    # degenerate formatter output with no recipe body.
+    if (
+        decision.mode is RecipeDeliveryMode.ENVELOPE
+        and surface_definition.response_exemption_tool is not None
+    ):
+        _exemption = RESPONSE_BACKSTOP_EXEMPTION_REGISTRY.get(
+            surface_definition.response_exemption_tool
+        )
+        if (
+            _exemption is not None
+            and len(ordinary_rendered.encode("utf-8")) <= _exemption.max_utf8_bytes
+        ):
+            decision = replace(
+                decision,
+                mode=RecipeDeliveryMode.ORDINARY_INLINE,
+                selected_result_token_limit=_exemption.max_utf8_bytes // 4,
+                reason="exemption_overrides_envelope",
+                receipt_status="not_required",
+            )
 
     if decision.mode is RecipeDeliveryMode.ORDINARY_INLINE:
         rendered = ordinary_rendered

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -880,7 +880,14 @@ async def open_kitchen(
                 and not _kctx_pre.backend.capabilities.supports_tool_list_changed
             )
             if _skip_notify:
-                logger.debug("open_kitchen_skip_enable", reason="pre-revealed at startup")
+                # Issue #4399: when the backend can't process tool/list_changed
+                # notifications, ctx.enable_components() is skipped. close_kitchen()
+                # appends global mcp.disable() for these tags, so without a
+                # refresh here, the tags would never re-enable. Append global
+                # enables to override the prior disables via FastMCP's last-match-wins.
+                mcp.enable(tags={"kitchen"})
+                mcp.enable(tags={"plan-review"})
+                logger.debug("open_kitchen_skip_enable", reason="global_enables_refreshed")
             else:
                 try:
                     await ctx.enable_components(tags={"kitchen"})

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1048,11 +1048,14 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "closure-scoped _spawn_error, and _write_pid fail-closed contract add ~33 lines",
     ),
     "server/_recipe_delivery.py": (
-        1100,
+        1150,
         "REQ-CNST-010-E12: immutable recipe generation persistence, host-attested delivery "
         "selection, receipt reservation, and compiled-execution publication form one "
         "transactional authority boundary; the snapshot carrier keeps installation before "
-        "durable delivery commit without introducing a second finalization path",
+        "durable delivery commit without introducing a second finalization path. "
+        "Bumped to 1150 for #4399: exemption-aware ENVELOPE→ORDINARY_INLINE override "
+        "(scope-check + byte budget + decision.replace; +18 net lines) and success=True "
+        "injection on candidate_payload before serialization (+8 net lines).",
     ),
     "tools_kitchen.py": (
         1700,

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1055,7 +1055,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "durable delivery commit without introducing a second finalization path",
     ),
     "tools_kitchen.py": (
-        1670,
+        1700,
         "REQ-CNST-010-E7: kitchen tool handlers — open_kitchen and lock_ingredients require "
         "inline validation helpers (_check_override_keys, _build_ingredient_key_suggestions) "
         "for ingredient key validation; splitting would cross import-layer boundaries; "
@@ -1099,7 +1099,9 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "resolve_general_output_token_limit + BackendCapabilities isinstance guard + "
         "maybe_envelope_recipe_response call (#4304 Part B, +24 net lines)"
         "; compiled recipe binding publication and execution-lifecycle cleanup across "
-        "recipe load, kitchen open, and kitchen close (+13 net lines)",
+        "recipe load, kitchen open, and kitchen close (+13 net lines)"
+        "; #4399 close→open visibility restore: mcp.enable() refresh in open_kitchen's "
+        "_skip_notify branch to override prior global mcp.disable() from close_kitchen (+2 lines)",
     ),
     "tools_execution.py": (
         1800,

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -1116,10 +1116,37 @@ def test_rendered_open_kitchen_payload_under_budget(tmp_path, monkeypatch):
     ``remediation.yaml`` legitimately grew the rendered payload)."""
     from autoskillit.core import resolve_general_output_token_limit
     from autoskillit.execution.backends import BACKEND_REGISTRY
+    from autoskillit.hooks.formatters import _fmt_recipe_compact
     from autoskillit.hooks.formatters.pretty_output_hook import _fmt_open_kitchen
     from autoskillit.recipe import _api_cache, all_validated_recipe_names, load_and_validate
     from autoskillit.recipe._api_cache import LoadCache
     from autoskillit.server._recipe_delivery import build_recipe_envelope, persist_recipe_artifact
+
+    def _strip_yaml_ingredients_block(yaml_text: str) -> str:
+        """Mirror hooks/formatters/_fmt_recipe.py::_strip_yaml_ingredients_block.
+
+        Drops the top-level ``ingredients:`` mapping plus all indented children.
+        Used by the formatter when ``ingredients_table`` is present so the
+        INGREDIENTS TABLE block does not duplicate the RECIPE body's ingredients
+        section. Mirror lives here in tests because the production helper is
+        stdlib-only and uses bare relative imports incompatible with this test's
+        Python-imported test harness.
+        """
+        lines = yaml_text.splitlines(keepends=True)
+        result: list[str] = []
+        in_ingredients = False
+        for line in lines:
+            if line.startswith("ingredients:"):
+                in_ingredients = True
+                continue
+            if in_ingredients:
+                if line and not line[0].isspace():
+                    in_ingredients = False
+                    result.append(line)
+                # else: still inside ingredients block — drop
+            else:
+                result.append(line)
+        return "".join(result)
 
     project_root = Path(__file__).resolve().parent.parent.parent
     ceiling = RESPONSE_BACKSTOP_EXEMPTION_REGISTRY["open_kitchen"].max_utf8_bytes
@@ -1187,14 +1214,25 @@ def test_rendered_open_kitchen_payload_under_budget(tmp_path, monkeypatch):
                 ordinary_rendered = _fmt_open_kitchen(
                     cast("OpenKitchenResult", dict(result)), pipeline=False
                 )
-                # Recipe YAML content must survive rendering for the exempt ORDINARY path
-                recipe_content = result.get("content") or ""
-                assert recipe_content, (
+                # Recipe YAML content must survive rendering for the exempt ORDINARY path.
+                # _fmt_recipe_body applies compact_recipe_display (strips top-level
+                # name/description/summary/recipe_version, step descriptions, then halves
+                # structural indentation) — and additionally strips the YAML
+                # ``ingredients:`` block when ``ingredients_table`` is present so the
+                # INGREDIENTS TABLE block doesn't duplicate it. Mirror that projection
+                # before substring-checking rather than comparing against raw bytes.
+                raw_recipe_content = result.get("content") or ""
+                assert raw_recipe_content, (
                     f"{recipe_name} ({mode_name}): recipe payload missing 'content' field"
                 )
-                assert recipe_content in ordinary_rendered, (
+                display_content = raw_recipe_content
+                if result.get("ingredients_table"):
+                    display_content = _strip_yaml_ingredients_block(display_content)
+                compacted_content = _fmt_recipe_compact.compact_recipe_display(display_content)
+                assert compacted_content in ordinary_rendered, (
                     f"{recipe_name} ({mode_name}): rendered ORDINARY_INLINE output "
-                    f"missing recipe content (only {len(ordinary_rendered)} bytes rendered)"
+                    f"missing compacted recipe content "
+                    f"(only {len(ordinary_rendered)} bytes rendered)"
                 )
 
     max_bytes, max_recipe, max_mode = maximum

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -1117,36 +1117,13 @@ def test_rendered_open_kitchen_payload_under_budget(tmp_path, monkeypatch):
     from autoskillit.core import resolve_general_output_token_limit
     from autoskillit.execution.backends import BACKEND_REGISTRY
     from autoskillit.hooks.formatters import _fmt_recipe_compact
-    from autoskillit.hooks.formatters.pretty_output_hook import _fmt_open_kitchen
+    from autoskillit.hooks.formatters.pretty_output_hook import (
+        _fmt_open_kitchen,
+        _strip_yaml_ingredients_block,
+    )
     from autoskillit.recipe import _api_cache, all_validated_recipe_names, load_and_validate
     from autoskillit.recipe._api_cache import LoadCache
     from autoskillit.server._recipe_delivery import build_recipe_envelope, persist_recipe_artifact
-
-    def _strip_yaml_ingredients_block(yaml_text: str) -> str:
-        """Mirror hooks/formatters/_fmt_recipe.py::_strip_yaml_ingredients_block.
-
-        Drops the top-level ``ingredients:`` mapping plus all indented children.
-        Used by the formatter when ``ingredients_table`` is present so the
-        INGREDIENTS TABLE block does not duplicate the RECIPE body's ingredients
-        section. Mirror lives here in tests because the production helper is
-        stdlib-only and uses bare relative imports incompatible with this test's
-        Python-imported test harness.
-        """
-        lines = yaml_text.splitlines(keepends=True)
-        result: list[str] = []
-        in_ingredients = False
-        for line in lines:
-            if line.startswith("ingredients:"):
-                in_ingredients = True
-                continue
-            if in_ingredients:
-                if line and not line[0].isspace():
-                    in_ingredients = False
-                    result.append(line)
-                # else: still inside ingredients block — drop
-            else:
-                result.append(line)
-        return "".join(result)
 
     project_root = Path(__file__).resolve().parent.parent.parent
     ceiling = RESPONSE_BACKSTOP_EXEMPTION_REGISTRY["open_kitchen"].max_utf8_bytes

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -11,6 +11,7 @@ import pytest
 
 if TYPE_CHECKING:
     from autoskillit.pipeline import ToolContext
+    from autoskillit.recipe._recipe_ingredients import OpenKitchenResult
 
 from autoskillit.core import (
     RESPONSE_BACKSTOP_EXEMPTION_REGISTRY,
@@ -1170,6 +1171,31 @@ def test_rendered_open_kitchen_payload_under_budget(tmp_path, monkeypatch):
             maximum = max(maximum, (byte_len, recipe_name, mode_name))
             if byte_len > ceiling:
                 over_budget.append(f"{recipe_name} ({mode_name}): {byte_len} bytes > {ceiling}")
+
+            # Issue #4399 content gate: when the ordinary-rendered payload fits within
+            # the exemption ceiling, the formatter must receive the raw ORDINARY_INLINE
+            # payload (containing `content`, `summary`, `diagram`) — not the stripped
+            # envelope — so the rendered output retains the recipe body. The envelope
+            # path strips `content`/`summary`/`diagram`, producing a degenerate
+            # `## open_kitchen ✓ v{version}` with no recipe body. This assertion
+            # fails before the fix because the test currently feeds the envelope
+            # to `_fmt_open_kitchen` regardless of size.
+            ordinary_payload_bytes = len(
+                json.dumps(dict(result), ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+            )
+            if ordinary_payload_bytes <= ceiling:
+                ordinary_rendered = _fmt_open_kitchen(
+                    cast("OpenKitchenResult", dict(result)), pipeline=False
+                )
+                # Recipe YAML content must survive rendering for the exempt ORDINARY path
+                recipe_content = result.get("content") or ""
+                assert recipe_content, (
+                    f"{recipe_name} ({mode_name}): recipe payload missing 'content' field"
+                )
+                assert recipe_content in ordinary_rendered, (
+                    f"{recipe_name} ({mode_name}): rendered ORDINARY_INLINE output "
+                    f"missing recipe content (only {len(ordinary_rendered)} bytes rendered)"
+                )
 
     max_bytes, max_recipe, max_mode = maximum
     assert not over_budget, (

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -122,7 +122,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools/tools_kitchen.py", 285),
     ("src/autoskillit/server/tools/tools_kitchen.py", 304),
     ("src/autoskillit/server/tools/tools_kitchen.py", 338),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 1453),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1460),
     # tools_pipeline_tracker.py — tracker_data dict (init) and mark_step_complete write
     # (same tracker file schema as init — not a new format, grandfathered alongside it)
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 256),

--- a/tests/server/test_tools_kitchen_visibility.py
+++ b/tests/server/test_tools_kitchen_visibility.py
@@ -144,8 +144,10 @@ async def test_open_kitchen_after_close_restores_pre_revealed_tools(tmp_path, mo
     mock_ctx.reset_visibility = AsyncMock()
 
     # close_kitchen uses real _close_kitchen_handler so gate_infrastructure_ready
-    # transition (True → False) is authentic.
-    await close_kitchen(ctx=mock_ctx)
+    # transition (True → False) is authentic. Patch _get_ctx so _close_kitchen_handler
+    # operates on mock_ctx (the function reads from _get_ctx, not the ctx parameter).
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        await close_kitchen(ctx=mock_ctx)
     assert mock_ctx.gate_infrastructure_ready is False
 
     tools_after_close = {t.name for t in await mcp.list_tools()}

--- a/tests/server/test_tools_kitchen_visibility.py
+++ b/tests/server/test_tools_kitchen_visibility.py
@@ -113,6 +113,76 @@ async def test_close_kitchen_hides_pre_revealed_tools(tmp_path, monkeypatch):
     )
 
 
+# T-VISIBILITY-3: close_kitchen→open_kitchen roundtrip — pre-revealed kitchen tools restored
+@pytest.mark.anyio
+async def test_open_kitchen_after_close_restores_pre_revealed_tools(tmp_path, monkeypatch):
+    """Issue #4399: after close_kitchen() hides pre-revealed kitchen tools, a subsequent
+    open_kitchen() with `_skip_notify=True` (Claude Code backend, no tool/list_changed
+    notification) must re-enable the kitchen and plan-review tags so the tools return
+    to list_tools(). Without the fix, the `_skip_notify` branch only logs a debug
+    message and never calls `mcp.enable()`, leaving tools invisible.
+    """
+    monkeypatch.chdir(tmp_path)
+    from autoskillit.core import FLEET_DISPATCH_TOOLS, FLEET_TOOLS, GATED_TOOLS
+    from autoskillit.server import mcp
+    from autoskillit.server.tools.tools_kitchen import close_kitchen
+
+    # Simulate _pre_reveal_kitchen() at startup: enable both tags globally.
+    mcp.enable(tags={"kitchen"})
+    mcp.enable(tags={"plan-review"})
+    tools_before = {t.name for t in await mcp.list_tools()}
+    kitchen_gated = GATED_TOOLS - FLEET_TOOLS - FLEET_DISPATCH_TOOLS
+    assert kitchen_gated.issubset(tools_before), (
+        "kitchen tools should be visible after pre-reveal enable"
+    )
+
+    # First lifecycle: gate_infrastructure_ready=True (prior successful open_kitchen).
+    # close_kitchen sets it back to False (line 603), so the next open_kitchen
+    # correctly enters the `if not _skip_handler:` block at line 876.
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.gate_infrastructure_ready = True
+    mock_ctx.reset_visibility = AsyncMock()
+
+    # close_kitchen uses real _close_kitchen_handler so gate_infrastructure_ready
+    # transition (True → False) is authentic.
+    await close_kitchen(ctx=mock_ctx)
+    assert mock_ctx.gate_infrastructure_ready is False
+
+    tools_after_close = {t.name for t in await mcp.list_tools()}
+    assert not kitchen_gated.intersection(tools_after_close), (
+        "kitchen tools should be hidden after close_kitchen"
+    )
+
+    # Second lifecycle: open_kitchen with Claude Code backend (no tool_list_changed).
+    # _skip_handler = False (gate_infrastructure_ready was reset by close_kitchen),
+    # so we enter the `if not _skip_handler:` block at line 876. Inside it,
+    # _skip_notify = (backend is not None and not supports_tool_list_changed) = True,
+    # so the buggy branch at line 882 is executed. Without the fix, the tools
+    # remain hidden. With the fix, global mcp.enable() restores visibility.
+    mock_ctx.backend.capabilities.supports_tool_list_changed = False
+    mock_ctx.enable_components = AsyncMock()
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()
+            ):
+                with patch(
+                    "autoskillit.server.tools.tools_kitchen._open_kitchen_handler",
+                    new=AsyncMock(return_value=None),
+                ):
+                    with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+                        from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+                        await open_kitchen(ctx=mock_ctx)
+
+    # Pre-revealed tools must be visible again — this is the assertion that fails before the fix.
+    tools_after_reopen = {t.name for t in await mcp.list_tools()}
+    assert kitchen_gated.issubset(tools_after_reopen), (
+        "kitchen tools should be visible after open_kitchen restores pre-revealed tags"
+    )
+
+
 @pytest.mark.anyio
 async def test_open_kitchen_does_not_write_gate_file(tmp_path, monkeypatch):
     """_open_kitchen_handler must never write a gate file."""

--- a/tests/server/test_tools_recipe_pull.py
+++ b/tests/server/test_tools_recipe_pull.py
@@ -17,6 +17,7 @@ from autoskillit.config import OutputBudgetConfig
 from autoskillit.core import (
     RECIPE_DELIVERY_SURFACE_REGISTRY,
     RECIPE_SECTION_RESPONSE_FLOOR_BYTES,
+    RESPONSE_BACKSTOP_EXEMPTION_REGISTRY,
     RecipeDeliveryAttestation,
     RecipeDeliveryEvidenceDef,
     RecipeDeliveryMode,
@@ -29,7 +30,7 @@ from autoskillit.execution import (
     ProtectedStoreAuthority,
     RecipeDeliveryReceiptLedger,
 )
-from autoskillit.execution.backends import CodexBackend
+from autoskillit.execution.backends import ClaudeCodeBackend, CodexBackend
 from autoskillit.recipe import load_and_validate
 from autoskillit.server import _recipe_delivery as recipe_delivery
 from autoskillit.server import _recipe_section_pagination as pagination
@@ -712,6 +713,86 @@ def test_finalizer_uses_backend_selected_recipe_budget(tool_ctx) -> None:
 
     assert finalized.decision.mode is RecipeDeliveryMode.ORDINARY_INLINE
     assert finalized.decision.contract_digest == selected_budget.contract_digest
+
+
+def test_exemption_overrides_envelope_for_exempt_surface_within_ceiling(tool_ctx) -> None:
+    """Issue #4399: when an exempt surface's ordinary-rendered payload exceeds the
+    backend's ordinary token limit but fits within the registered exemption ceiling,
+    finalize_recipe_delivery() must upgrade ENVELOPE back to ORDINARY_INLINE so the
+    full recipe body survives.
+
+    Claude Code backend: protected_recipe_delivery_capable=False → decision resolver
+    returns ENVELOPE based on ordinary_limit alone. The exemption override added in
+    Issue #4399 must catch this case and re-route to ORDINARY_INLINE.
+    """
+    tool_ctx.backend = ClaudeCodeBackend()
+    tool_ctx.kitchen_id = "claude-code-exemption"
+
+    ordinary_limit = ClaudeCodeBackend().capabilities.unnegotiated_tool_result_token_limit
+    # Payload whose ordinary JSON exceeds the ordinary_limit (in bytes) but stays
+    # under the 195,000-byte exemption ceiling.
+    oversized_content = "x" * (ordinary_limit * 4 + 10_000)
+    assert len(oversized_content.encode("utf-8")) > ordinary_limit * 4
+    assert len(oversized_content.encode("utf-8")) < (
+        RESPONSE_BACKSTOP_EXEMPTION_REGISTRY["open_kitchen"].max_utf8_bytes
+    )
+
+    finalized = finalize_recipe_delivery(
+        _payload(oversized_content),
+        surface="open_kitchen",
+        recipe_name="remediation",
+        tool_ctx=tool_ctx,
+    )
+
+    assert finalized.decision.mode is RecipeDeliveryMode.ORDINARY_INLINE
+    assert finalized.decision.reason == "exemption_overrides_envelope"
+    # Recipe content must be present in the rendered string (not stripped by ENVELOPE).
+    assert oversized_content in finalized.rendered
+
+
+def test_exemption_override_retains_envelope_for_payload_above_ceiling(tool_ctx) -> None:
+    """Issue #4399 boundary: payloads exceeding the 195KB exemption ceiling must
+    remain ENVELOPE — the override only applies when the ordinary-rendered payload
+    fits within the registered exemption.
+    """
+    tool_ctx.backend = ClaudeCodeBackend()
+    tool_ctx.kitchen_id = "claude-code-over-ceiling"
+
+    # Payload whose ordinary JSON exceeds the 195,000-byte exemption ceiling.
+    oversized_content = "y" * (
+        RESPONSE_BACKSTOP_EXEMPTION_REGISTRY["open_kitchen"].max_utf8_bytes + 1_000
+    )
+
+    finalized = finalize_recipe_delivery(
+        _payload(oversized_content),
+        surface="open_kitchen",
+        recipe_name="remediation",
+        tool_ctx=tool_ctx,
+    )
+
+    assert finalized.decision.mode is RecipeDeliveryMode.ENVELOPE
+    assert finalized.decision.reason != "exemption_overrides_envelope"
+
+
+def test_exemption_override_does_not_apply_to_non_exempt_surface(tool_ctx) -> None:
+    """Issue #4399 boundary: get_recipe has no response_exemption_tool registration,
+    so the override must not apply — ENVELOPE remains the result.
+    """
+    tool_ctx.backend = ClaudeCodeBackend()
+    tool_ctx.kitchen_id = "claude-code-get-recipe"
+
+    ordinary_limit = ClaudeCodeBackend().capabilities.unnegotiated_tool_result_token_limit
+    oversized_content = "z" * (ordinary_limit * 4 + 5_000)
+
+    finalized = finalize_recipe_delivery(
+        _payload(oversized_content),
+        surface="get_recipe",
+        recipe_name="remediation",
+        tool_ctx=tool_ctx,
+    )
+
+    assert finalized.decision.mode is RecipeDeliveryMode.ENVELOPE
+    assert finalized.decision.reason != "exemption_overrides_envelope"
 
 
 def _request() -> RecipeDeliveryRequest:

--- a/tests/server/test_tools_recipe_pull.py
+++ b/tests/server/test_tools_recipe_pull.py
@@ -731,11 +731,10 @@ def test_exemption_overrides_envelope_for_exempt_surface_within_ceiling(tool_ctx
     ordinary_limit = ClaudeCodeBackend().capabilities.unnegotiated_tool_result_token_limit
     # Payload whose ordinary JSON exceeds the ordinary_limit (in bytes) but stays
     # under the 195,000-byte exemption ceiling.
-    oversized_content = "x" * (ordinary_limit * 4 + 10_000)
+    ceiling = RESPONSE_BACKSTOP_EXEMPTION_REGISTRY["open_kitchen"].max_utf8_bytes
+    oversized_content = "x" * (min(ceiling - 1_000, ordinary_limit * 4 + 5_000))
     assert len(oversized_content.encode("utf-8")) > ordinary_limit * 4
-    assert len(oversized_content.encode("utf-8")) < (
-        RESPONSE_BACKSTOP_EXEMPTION_REGISTRY["open_kitchen"].max_utf8_bytes
-    )
+    assert len(oversized_content.encode("utf-8")) < ceiling
 
     finalized = finalize_recipe_delivery(
         _payload(oversized_content),


### PR DESCRIPTION
## Summary

Issue #4399 has two independent root causes:

1. **Envelope truncation:** `finalize_recipe_delivery()` delegates to `resolve_recipe_delivery_decision()`, which returns ENVELOPE mode for recipes exceeding ~46.5K tokens on Claude Code backends (`protected_recipe_delivery_capable=False`). The 195KB response exemption registered for `open_kitchen` is only consulted AFTER the delivery decision, at a different layer (`enforce_response_budget`), and only prevents a *different* downgrade (ORDINARY_INLINE→ENVELOPE for non-exempt oversized responses). The PostToolUse formatter `_fmt_open_kitchen` only reads ORDINARY_INLINE-shape keys (`content`, `summary`, `diagram`) and has zero knowledge of ENVELOPE-shape keys (`step_flow_skeleton`, `recipe_pull`), producing a degenerate `## open_kitchen ✓ v{version}` with no recipe body.

2. **Tool registry loss:** `close_kitchen()` appends permanent global `mcp.disable(tags={"kitchen"})` and `mcp.disable(tags={"plan-review"})` to FastMCP's append-only `Provider._transforms` list. The next `open_kitchen()` has `_skip_notify=True` for Claude Code backends (`supports_tool_list_changed=False`), so it skips `ctx.enable_components()` — the session-scoped enable that would override the global disable. The 41 kitchen-tagged tools permanently vanish.

Both defects share a pattern — lifecycle assumptions that hold on first use but are violated by subsequent state changes. The fix restores alignment between exemption scope and delivery decision, and tightens the visibility lifecycle so close/reopen cycles preserve the kitchen-tagged tool registry.

## Requirements

- [ ] A full `open_kitchen(name="remediation")` on Claude Code returns the recipe body — step flow, ingredients table and orchestration rules — not `## open_kitchen ✓ v`.
- [ ] `close_kitchen()` followed by `open_kitchen()` leaves all 41 kitchen-tagged tools callable; `run_skill` in particular resolves and executes.
- [ ] A regression test asserts tool-registry survival across a `close_kitchen` → `open_kitchen` lifecycle. The existing suite passes while the registry is empty, which is why this shipped.
- [ ] A regression test asserts the formatter renders real content for an exempt surface, rather than asserting only that it does not crash.
- [ ] Catalog breadth is **not** reduced to achieve any of the above (see #4363, which states breadth is intentional). Bound the delivery, never the catalog.

Closes #4399

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/fix-4362-20260727-154546-650120/.autoskillit/temp/rectify/rectify_fix_4362_envelope_truncation_and_registry_loss_2026-07-27_170000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
