### PR TITLE
Rectify: audit_impl preflight rejects the plan path the recipe supplies (#4387)

### DIFF
--- a/src/autoskillit/core/types/_type_recipe_execution.py
+++ b/src/autoskillit/core/types/_type_recipe_execution.py
@@ -254,6 +254,8 @@ class InputPreflightResolver(Protocol):
     def resolve(
         self,
         request: VerifiedInputPreflightRequest,
+        *,
+        allowed_root: Path | None = None,
     ) -> VerifiedInputPreflightResult: ...
 
 

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:5349af1fd7829045737aec256489a47917d7a45554c1ebb3ea6ab606aa13518b -->
+<!-- autoskillit-recipe-hash: sha256:8143b08d1f73f5fa0c8fca2e292fb53c4223f4ff51563db2dd8e1a794c81df8f -->
 <!-- autoskillit-diagram-format: v7 -->
 ## implementation
 

--- a/src/autoskillit/recipes/implementation.json
+++ b/src/autoskillit/recipes/implementation.json
@@ -1093,8 +1093,13 @@
           "route": "check_has_commits"
         },
         {
+          "when": "${{ result.stage }} starts with preflight",
+          "route": "register_clone_failure",
+          "note": "Preflight/infrastructure failure — the gate could not run. Distinct from a genuine NO GO verdict. register_clone_failure preserves the clone for diagnosis.\n"
+        },
+        {
           "when": "result.error",
-          "route": "register_clone_failure"
+          "route": "check_audit_remediation_loop"
         },
         {
           "when": "${{ result.verdict }} == NO GO",

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -961,8 +961,14 @@ steps:
     on_result:
     - when: ${{ result.verdict }} == GO
       route: check_has_commits
-    - when: result.error
+    - when: ${{ result.stage }} starts with preflight
       route: register_clone_failure
+      note: >
+        Preflight/infrastructure failure — the gate could not run.
+        Distinct from a genuine NO GO verdict. register_clone_failure
+        preserves the clone for diagnosis.
+    - when: result.error
+      route: check_audit_remediation_loop
     - when: ${{ result.verdict }} == NO GO
       route: check_audit_remediation_loop
     - route: check_audit_remediation_loop

--- a/src/autoskillit/server/_recipe_execution.py
+++ b/src/autoskillit/server/_recipe_execution.py
@@ -279,7 +279,7 @@ class DefaultInputPreflightResolver:
                     "a terminal GO cannot carry a plan disposition report",
                 )
             )
-        decision = self._verifier.evaluate_paths(
+        decision = verifier.evaluate_paths(
             authority_path=authority_path,
             report_path=report_path,
             trusted_head=head,

--- a/src/autoskillit/server/_recipe_execution.py
+++ b/src/autoskillit/server/_recipe_execution.py
@@ -222,6 +222,8 @@ class DefaultInputPreflightResolver:
     def resolve(
         self,
         request: VerifiedInputPreflightRequest,
+        *,
+        allowed_root: Path | None = None,
     ) -> VerifiedInputPreflightResult:
         authority_path = request.audit_cycle_path or None
         report_path = request.plan_disposition_path or None
@@ -234,8 +236,9 @@ class DefaultInputPreflightResolver:
                     "a disposition report cannot activate without authority",
                 )
             )
+        verifier = AuditCycleVerifier(allowed_root) if allowed_root is not None else self._verifier
         try:
-            authority = self._verifier.load_authority(authority_path)
+            authority = verifier.load_authority(authority_path)
         except Exception as exc:
             get_logger(__name__).error(
                 "audit-cycle authority verification failed",
@@ -511,6 +514,7 @@ def resolve_attested_input_preflight(
     step_name: str,
     template: InvocationTemplate,
     bound_inputs: tuple[tuple[str, BoundScalar], ...],
+    allowed_root: Path | None = None,
 ) -> VerifiedInputPreflightResult | None:
     """Resolve a compiled invocation's optional input preflight or fail closed."""
     contract = (
@@ -563,7 +567,8 @@ def resolve_attested_input_preflight(
             expected_plan_set_id=expected_identity[0],
             expected_scope_id=expected_identity[1],
             expected_part_id=expected_identity[2],
-        )
+        ),
+        allowed_root=allowed_root,
     )
     if result.decision.status is AdmissionStatus.REJECT:
         raise RecipeExecutionAdmissionError(
@@ -647,10 +652,11 @@ def _publish_loaded_audit_cycle(
     expected_parent_digest: str | None,
     expected_round: int,
     authorized_successor_part_id: str | None = None,
+    allowed_root: Path,
 ) -> AuditCycleHead:
     if authority.execution_generation != installed.snapshot.execution_id:
         raise AuditCycleHeadConflict("authority crosses recipe execution generations")
-    verifier = AuditCycleVerifier(tool_ctx.temp_dir)
+    verifier = AuditCycleVerifier(allowed_root)
     for audited_plan_ref in authority.audited_plan_refs:
         verifier.verify_artifact_ref(audited_plan_ref)
     verifier.verify_artifact_ref(authority.inventory_ref)
@@ -699,12 +705,13 @@ def publish_verified_audit_cycle(
     expected_parent_digest: str | None,
     expected_round: int,
     authorized_successor_part_id: str | None = None,
+    allowed_root: Path,
 ) -> AuditCycleHead:
     """Verify an explicit child output, then CAS-publish it as trusted."""
     installed = get_recipe_execution(tool_ctx)
     if installed is None:
         raise AuditCycleHeadConflict("no active recipe execution")
-    authority = AuditCycleVerifier(tool_ctx.temp_dir).load_authority(authority_path)
+    authority = AuditCycleVerifier(allowed_root).load_authority(authority_path)
     return _publish_loaded_audit_cycle(
         tool_ctx,
         installed=installed,
@@ -712,6 +719,7 @@ def publish_verified_audit_cycle(
         expected_parent_digest=expected_parent_digest,
         expected_round=expected_round,
         authorized_successor_part_id=authorized_successor_part_id,
+        allowed_root=allowed_root,
     )
 
 
@@ -720,12 +728,13 @@ def publish_reported_audit_cycle(
     *,
     authority_path: str,
     prior_authority_path: str | None,
+    allowed_root: Path,
 ) -> AuditCycleHead:
     """Verify and publish the authority path reported by a successful audit child."""
     installed = get_recipe_execution(tool_ctx)
     if installed is None:
         raise AuditCycleHeadConflict("no active recipe execution")
-    verifier = AuditCycleVerifier(tool_ctx.temp_dir)
+    verifier = AuditCycleVerifier(allowed_root)
     authority = verifier.load_authority(authority_path)
     if prior_authority_path:
         prior = verifier.load_authority(prior_authority_path)
@@ -768,6 +777,7 @@ def publish_reported_audit_cycle(
         authority=authority,
         expected_parent_digest=(current.current_authority_digest if current is not None else None),
         expected_round=current.audit_round if current is not None else 0,
+        allowed_root=allowed_root,
     )
 
 
@@ -777,6 +787,7 @@ def publish_audit_cycle_result(
     skill_result: SkillResult,
     installed: InstalledRecipeExecution | None,
     bound_inputs: tuple[tuple[str, BoundScalar], ...],
+    allowed_root: Path,
 ) -> None:
     """Publish a successful attested audit child's declared authority."""
     if not skill_result.success or target_name is None or installed is None:
@@ -801,4 +812,5 @@ def publish_audit_cycle_result(
             if isinstance(prior_authority_path, str) and prior_authority_path
             else None
         ),
+        allowed_root=allowed_root,
     )

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -852,7 +852,19 @@ async def run_skill(
         # is disjoint from the clone's temp tree in clone-based pipelines).
         # See #4387 — this must be defined BEFORE the if/elif chain so the
         # publish call site (later in the function) can reach it regardless
-        # of which branch was taken above.
+        # of which branch was taken above. An empty cwd is only rejected here
+        # (rather than by the earlier boundary guards) because it is only
+        # security-relevant once a recipe execution is active and this anchor
+        # is actually consumed as a containment root — ad-hoc skill calls with
+        # no active recipe execution never read _clone_allowed_root.
+        if _installed_execution is not None and not cwd:
+            return json.dumps(
+                deny_envelope(
+                    "run_skill: cwd must not be empty when a recipe execution is active.",
+                    stage="preflight:cwd",
+                    retriable=False,
+                )
+            )
         _clone_allowed_root = resolve_temp_dir(Path(cwd), tool_ctx.config.workspace.temp_dir)
         if _dynamic_recipe_call:
             if _claims_recipe_execution:

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -45,6 +45,7 @@ from autoskillit.core import (
     is_feature_enabled,
     parse_plan_paths,
     render_target_skill_command,
+    resolve_temp_dir,
 )
 from autoskillit.core import current_order_id as _current_order_id
 from autoskillit.core import current_step_name as _current_step_name
@@ -846,6 +847,13 @@ async def run_skill(
             and step_name
             and step_name in _installed_execution.snapshot.dynamic_skill_step_names
         )
+        # Resolved from cwd so the audit-cycle containment anchor matches the
+        # clone's actual artifact directory (orchestrator's tool_ctx.temp_dir
+        # is disjoint from the clone's temp tree in clone-based pipelines).
+        # See #4387 — this must be defined BEFORE the if/elif chain so the
+        # publish call site (later in the function) can reach it regardless
+        # of which branch was taken above.
+        _clone_allowed_root = resolve_temp_dir(Path(cwd), tool_ctx.config.workspace.temp_dir)
         if _dynamic_recipe_call:
             if _claims_recipe_execution:
                 return _recipe_execution_deny(
@@ -918,6 +926,7 @@ async def run_skill(
                     step_name=step_name,
                     template=_invocation_template,
                     bound_inputs=_bound_recipe_inputs,
+                    allowed_root=_clone_allowed_root,
                 )
             except RecipeExecutionAdmissionError as exc:
                 return _recipe_execution_deny(exc.code, str(exc))
@@ -1607,6 +1616,7 @@ async def run_skill(
                         skill_result,
                         (_installed_execution if _invocation_template is not None else None),
                         _bound_recipe_inputs,
+                        allowed_root=_clone_allowed_root,
                     )
                     tool_ctx.audit.record_success(skill_command)
                     clear_run_skill_state(tool_ctx.project_dir)

--- a/tests/recipe/test_rules_integration_predicate.py
+++ b/tests/recipe/test_rules_integration_predicate.py
@@ -239,7 +239,8 @@ class TestLoopBudgetSeparation:
         fallthrough = [
             c.route
             for c in audit_step.on_result.conditions
-            if c.when is None or ("GO" not in c.when and "error" not in c.when)
+            if c.when is None
+            or ("GO" not in c.when and "error" not in c.when and "preflight" not in c.when)
         ]
         assert fallthrough == ["check_audit_remediation_loop"]
 

--- a/tests/server/test_audit_cycle_delivery_integration.py
+++ b/tests/server/test_audit_cycle_delivery_integration.py
@@ -85,7 +85,7 @@ from autoskillit.server._recipe_execution import (
 )
 from autoskillit.server._recipe_generation import RecipeGenerationError
 from autoskillit.server._recipe_initialization import stage_recipe_initialization
-from autoskillit.server.tools.tools_execution import run_skill
+from autoskillit.server.tools.tools_execution import _recipe_execution_deny, run_skill
 from tests.conftest import _make_result
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
@@ -874,6 +874,7 @@ def test_published_audit_head_binds_preflight_template_identity(
         authority_path=str(authority_path),
         expected_parent_digest=None,
         expected_round=0,
+        allowed_root=Path(tool_ctx_kitchen_open.temp_dir),
     )
 
     installed = get_recipe_execution(tool_ctx_kitchen_open)
@@ -937,6 +938,7 @@ def test_audit_publication_does_not_mutate_replaced_execution(
             authority_path=str(authority_path),
             expected_parent_digest=None,
             expected_round=0,
+            allowed_root=Path(tool_ctx_kitchen_open.temp_dir),
         )
 
     assert get_recipe_execution(tool_ctx_kitchen_open) is replacement
@@ -982,6 +984,7 @@ def test_audit_publication_rejects_tampered_referenced_artifact(
             authority_path=str(authority_path),
             expected_parent_digest=None,
             expected_round=0,
+            allowed_root=Path(tool_ctx_kitchen_open.temp_dir),
         )
 
     assert (
@@ -1064,6 +1067,7 @@ def test_successful_audit_result_publishes_protected_successor_identity(
         result,
         installed,
         (),
+        allowed_root=Path(tool_ctx_kitchen_open.temp_dir),
     )
 
     installed = get_recipe_execution(tool_ctx_kitchen_open)
@@ -1102,6 +1106,7 @@ def test_reported_audit_cycle_cannot_replace_attested_prior_lineage(
         authority_path=str(prior_path),
         expected_parent_digest=None,
         expected_round=0,
+        allowed_root=Path(tool_ctx_kitchen_open.temp_dir),
     )
     unrelated = _authority(
         root,
@@ -1120,6 +1125,7 @@ def test_reported_audit_cycle_cannot_replace_attested_prior_lineage(
             tool_ctx_kitchen_open,
             authority_path=str(unrelated_path),
             prior_authority_path=str(prior_path),
+            allowed_root=Path(tool_ctx_kitchen_open.temp_dir),
         )
 
     current = installed.audit_cycle_heads.get(
@@ -2078,8 +2084,10 @@ async def test_runtime_attestation_executes_bound_prompt_and_records_digest(
         def resolve(
             self,
             request: VerifiedInputPreflightRequest,
+            *,
+            allowed_root: Path | None = None,
         ) -> VerifiedInputPreflightResult:
-            self.result = self._wrapped.resolve(request)
+            self.result = self._wrapped.resolve(request, allowed_root=allowed_root)
             return self.result
 
     recording_resolver = RecordingResolver(installed.input_preflight_resolver)
@@ -2163,7 +2171,7 @@ async def test_preflight_rejects_before_executor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class RejectingResolver:
-        def resolve(self, request):
+        def resolve(self, request, *, allowed_root: Path | None = None):
             assert request.expected_plan_set_id == "plans-1"
             assert request.expected_scope_id == "scope-1"
             assert request.expected_part_id == "part-a"
@@ -2212,3 +2220,154 @@ async def test_preflight_rejects_before_executor(
     assert result["success"] is False
     assert "input_preflight_plan_mismatch" in result["error"]
     assert len(tool_ctx_kitchen_open.runner.call_args_list) == calls_before
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #4387: audit_impl preflight rejects the plan path the
+# recipe supplies. These tests construct genuinely disjoint directory trees
+# to lock down the architectural invariant: containment root must match the
+# directory tree where artifacts were written.
+# ---------------------------------------------------------------------------
+
+
+def test_clone_layout_containment_root_required(tmp_path: Path) -> None:
+    """Containment root must match where artifacts live.
+
+    Disjoint directory tree (orchestrator_root vs clone_temp). Without the
+    fix, passing orchestrator_root as allowed_root rejects the request even
+    though the request is legitimate (artifacts are valid under clone_temp).
+    With the fix (allowed_root override), passing clone_temp accepts the
+    request and publishes the head.
+    """
+    orchestrator_root = tmp_path / "orchestrator" / ".autoskillit" / "temp"
+    orchestrator_root.mkdir(parents=True)
+    clone_root = tmp_path / "clone"
+    clone_root.mkdir()
+    clone_temp = clone_root / ".autoskillit" / "temp"
+    clone_temp.mkdir(parents=True)
+
+    store = DefaultAuditCycleHeadStore()
+    authority = _authority(
+        clone_root,
+        generation="execution-1",
+        round_=1,
+        parent=None,
+        verdict=AuditVerdict.GO,
+        materialize=True,
+    )
+    clone_temp.joinpath("authority.json").write_bytes(authority.canonical_bytes)
+
+    request = VerifiedInputPreflightRequest(
+        execution_generation="execution-1",
+        step_name="dry",
+        skill_name="dry-walkthrough",
+        plan_path=str(clone_root / "plan.md"),
+        audit_cycle_path=str(clone_temp / "authority.json"),
+        plan_disposition_path=None,
+        expected_plan_set_id="plans-1",
+        expected_scope_id="scope-1",
+        expected_part_id="part-a",
+    )
+
+    # Sanity check: orchestrator_root is disjoint from clone_temp.
+    assert not orchestrator_root.is_relative_to(clone_temp)  # type: ignore[attr-defined]
+    assert not clone_temp.is_relative_to(orchestrator_root)  # type: ignore[attr-defined]
+
+    # Without override (factory-time bound root = orchestrator_root), the
+    # audit-cycle authority path is rejected — it lies outside the
+    # orchestrator's trust boundary. This reproduces the bug from #4387.
+    broken_resolver = DefaultInputPreflightResolver(
+        allowed_root=orchestrator_root,
+        head_store=store,
+    )
+    broken_result = broken_resolver.resolve(request)
+    assert broken_result.decision.status.value == "REJECT"
+
+    # With the fix (allowed_root=clone_temp), the same request is accepted
+    # because containment anchors to the clone's temp directory.
+    fixed_resolver = DefaultInputPreflightResolver(
+        allowed_root=clone_temp,
+        head_store=store,
+    )
+    fixed_result = fixed_resolver.resolve(request)
+    assert fixed_result.decision.status.value == "ACCEPT"
+
+
+def test_recipe_execution_deny_envelope_carries_preflight_stage() -> None:
+    """Lock down the deny envelope shape so the recipe's preflight routing
+    condition can rely on ``stage`` starting with ``preflight:``.
+
+    Regression guard for #4387 acceptance criterion #2: distinguish
+    preflight/infrastructure failure from a genuine NO GO verdict.
+    """
+    envelope_text = _recipe_execution_deny(
+        "recipe_execution_attestation_missing",
+        "an active recipe requires recipe_execution_id and invocation_template_digest",
+    )
+    envelope = json.loads(envelope_text)
+    assert envelope["success"] is False
+    assert envelope["is_error"] is True
+    assert "stage" in envelope
+    assert envelope["stage"].startswith("preflight:")
+    assert envelope["retriable"] is False
+
+
+def test_preflight_resolver_protocol_accepts_allowed_root_override(
+    tmp_path: Path,
+) -> None:
+    """``DefaultInputPreflightResolver.resolve()`` accepts an optional
+    ``allowed_root`` keyword that overrides the constructor-bound root.
+
+    Backward-compatible: callers that omit ``allowed_root`` get the
+    constructor-bound root. Callers that pass ``allowed_root=<Path>`` get a
+    fresh verifier anchored to that path — necessary because the
+    orchestrator's temp directory is disjoint from the clone's temp
+    directory in clone-based pipelines.
+    """
+    orchestrator_root = tmp_path / "orchestrator" / ".autoskillit" / "temp"
+    orchestrator_root.mkdir(parents=True)
+    clone_root = tmp_path / "clone"
+    clone_root.mkdir()
+    clone_temp = clone_root / ".autoskillit" / "temp"
+    clone_temp.mkdir(parents=True)
+
+    store = DefaultAuditCycleHeadStore()
+    authority = _authority(
+        clone_root,
+        generation="execution-1",
+        round_=1,
+        parent=None,
+        verdict=AuditVerdict.GO,
+        materialize=True,
+    )
+    clone_temp.joinpath("authority.json").write_bytes(authority.canonical_bytes)
+
+    request = VerifiedInputPreflightRequest(
+        execution_generation="execution-1",
+        step_name="dry",
+        skill_name="dry-walkthrough",
+        plan_path=str(clone_root / "plan.md"),
+        audit_cycle_path=str(clone_temp / "authority.json"),
+        plan_disposition_path=None,
+        expected_plan_set_id="plans-1",
+        expected_scope_id="scope-1",
+        expected_part_id="part-a",
+    )
+
+    # Constructor-bound root is orchestrator_root (the broken case).
+    resolver = DefaultInputPreflightResolver(
+        allowed_root=orchestrator_root,
+        head_store=store,
+    )
+
+    # Default (no override) ⇒ rejects because the request lives under clone_temp.
+    default_result = resolver.resolve(request)
+    assert default_result.decision.status.value == "REJECT"
+
+    # Override with clone_temp ⇒ accepts because containment anchors to the clone.
+    override_result = resolver.resolve(request, allowed_root=clone_temp)
+    assert override_result.decision.status.value == "ACCEPT"
+
+    # ``allowed_root=None`` falls back to the constructor-bound root (rejects).
+    none_result = resolver.resolve(request, allowed_root=None)
+    assert none_result.decision.status.value == "REJECT"

--- a/tests/server/test_audit_cycle_delivery_integration.py
+++ b/tests/server/test_audit_cycle_delivery_integration.py
@@ -2376,3 +2376,141 @@ def test_preflight_resolver_protocol_accepts_allowed_root_override(
     # ``allowed_root=None`` falls back to the constructor-bound root (rejects).
     none_result = resolver.resolve(request, allowed_root=None)
     assert none_result.decision.status.value == "REJECT"
+
+
+@pytest.mark.anyio
+async def test_run_skill_containment_root_anchors_to_cwd_not_orchestrator_temp_dir(
+    tool_ctx_kitchen_open,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reproduce #4387 through the actual ``run_skill()`` entry point.
+
+    Disjoint directory tree: ``tool_ctx.temp_dir`` (orchestrator_root) is set at
+    recipe-install time, exactly like production's
+    ``prepare_recipe_execution(tool_ctx, ...)`` -> ``factory(..., allowed_root=
+    tool_ctx.temp_dir)``. The audit-cycle authority is materialized under a
+    genuinely disjoint ``clone_temp`` tree instead, and ``run_skill()`` is
+    called with ``cwd=str(clone_root)``.
+
+    Without the fix, ``run_skill`` never threads a cwd-derived containment
+    root through to ``resolve_attested_input_preflight``, so the resolver
+    falls back to its constructor-bound root (orchestrator_root) and rejects
+    the legitimate request. With the fix (``_clone_allowed_root`` computed
+    from ``cwd`` and passed as ``allowed_root``), the request is admitted.
+    This closes the gap left by ``test_clone_layout_containment_root_required``
+    and ``test_preflight_resolver_protocol_accepts_allowed_root_override``,
+    which only exercise ``DefaultInputPreflightResolver.resolve()`` directly.
+    """
+    orchestrator_root = tmp_path / "orchestrator" / ".autoskillit" / "temp"
+    orchestrator_root.mkdir(parents=True)
+    clone_root = tmp_path / "clone"
+    clone_root.mkdir()
+    clone_temp = clone_root / ".autoskillit" / "temp"
+    clone_temp.mkdir(parents=True)
+    assert not orchestrator_root.is_relative_to(clone_temp)  # type: ignore[attr-defined]
+    assert not clone_temp.is_relative_to(orchestrator_root)  # type: ignore[attr-defined]
+
+    projection = RecipeBindingProjection(
+        {
+            "dry": BoundStepInvocation(
+                step_name="dry",
+                tool_name="run_skill",
+                mode=BindingMode.RECIPE,
+                skill_name="dry-walkthrough",
+                mcp_kwargs=(
+                    _present("skill_command", "/dry-walkthrough"),
+                    _present(
+                        "cwd",
+                        "${{ context.worktree_path }}",
+                        origin=BoundValueOrigin.CONTEXT,
+                        dependencies=("worktree_path",),
+                    ),
+                ),
+                skill_inputs=(
+                    _present(
+                        "plan_path",
+                        "${{ context.plan_path }}",
+                        origin=BoundValueOrigin.CONTEXT,
+                        dependencies=("plan_path",),
+                    ),
+                    _present("issue_url", ""),
+                    _present(
+                        "audit_cycle_path",
+                        "${{ context.audit_cycle_path }}",
+                        origin=BoundValueOrigin.CONTEXT,
+                        dependencies=("audit_cycle_path",),
+                    ),
+                    BoundValue.absent("plan_disposition_path"),
+                ),
+            )
+        }
+    )
+    snapshot = build_recipe_execution_snapshot(
+        recipe_name="demo",
+        content_hash=_HASH_A,
+        composite_hash=_HASH_B,
+        projection=projection,
+        execution_id="execution-1",
+    )
+
+    # Recipe install happens with the orchestrator's temp_dir bound, exactly
+    # as production's prepare_recipe_execution() does.
+    monkeypatch.setattr(tool_ctx_kitchen_open, "temp_dir", orchestrator_root)
+    _wire_recipe_execution_factory(tool_ctx_kitchen_open)
+    installed = install_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
+
+    authority = _authority(
+        clone_root,
+        generation="execution-1",
+        round_=1,
+        parent=None,
+        verdict=AuditVerdict.GO,
+        materialize=True,
+    )
+    clone_temp.joinpath("authority.json").write_bytes(authority.canonical_bytes)
+    installed.audit_cycle_heads.publish(authority, expected_parent_digest=None, expected_round=0)
+    tool_ctx_kitchen_open.active_recipe_execution = replace(
+        installed,
+        preflight_identities={"dry": ("plans-1", "scope-1", "part-a")},
+    )
+
+    marker = "%%ORDER_UP::12345678%%"
+    monkeypatch.setattr(
+        "uuid.uuid4",
+        lambda: SimpleNamespace(hex="12345678000000000000000000000000"),
+    )
+    tool_ctx_kitchen_open.write_expected_resolver = None
+    tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))
+    tool_ctx_kitchen_open.runner.push(
+        _make_result(
+            0,
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "result": f"done\n{marker}",
+                    "session_id": "session-1",
+                }
+            ),
+            "",
+        )
+    )
+
+    result = json.loads(
+        await run_skill(
+            "/dry-walkthrough",
+            str(clone_root),
+            step_name="dry",
+            recipe_execution_id="execution-1",
+            invocation_template_digest=snapshot.templates["dry"].template_digest,
+            skill_inputs={
+                "plan_path": str(clone_root / "plan.md"),
+                "issue_url": "",
+                "audit_cycle_path": str(clone_temp / "authority.json"),
+            },
+        )
+    )
+
+    assert result["success"] is True, result

--- a/tests/server/test_audit_cycle_delivery_integration.py
+++ b/tests/server/test_audit_cycle_delivery_integration.py
@@ -2256,6 +2256,7 @@ def test_clone_layout_containment_root_required(tmp_path: Path) -> None:
         materialize=True,
     )
     clone_temp.joinpath("authority.json").write_bytes(authority.canonical_bytes)
+    store.publish(authority, expected_parent_digest=None, expected_round=0)
 
     request = VerifiedInputPreflightRequest(
         execution_generation="execution-1",
@@ -2283,14 +2284,16 @@ def test_clone_layout_containment_root_required(tmp_path: Path) -> None:
     broken_result = broken_resolver.resolve(request)
     assert broken_result.decision.status.value == "REJECT"
 
-    # With the fix (allowed_root=clone_temp), the same request is accepted
-    # because containment anchors to the clone's temp directory.
+    # With the fix (allowed_root=clone_temp), the same request is admitted
+    # because containment anchors to the clone's temp directory. A trusted GO
+    # authority at the same part_id admits as OMIT/TRUSTED_GO — the cycle is
+    # already terminal and no further audit gating is needed.
     fixed_resolver = DefaultInputPreflightResolver(
         allowed_root=clone_temp,
         head_store=store,
     )
     fixed_result = fixed_resolver.resolve(request)
-    assert fixed_result.decision.status.value == "ACCEPT"
+    assert fixed_result.decision.status.value == "OMIT"
 
 
 def test_recipe_execution_deny_envelope_carries_preflight_stage() -> None:
@@ -2341,6 +2344,7 @@ def test_preflight_resolver_protocol_accepts_allowed_root_override(
         materialize=True,
     )
     clone_temp.joinpath("authority.json").write_bytes(authority.canonical_bytes)
+    store.publish(authority, expected_parent_digest=None, expected_round=0)
 
     request = VerifiedInputPreflightRequest(
         execution_generation="execution-1",
@@ -2364,9 +2368,10 @@ def test_preflight_resolver_protocol_accepts_allowed_root_override(
     default_result = resolver.resolve(request)
     assert default_result.decision.status.value == "REJECT"
 
-    # Override with clone_temp ⇒ accepts because containment anchors to the clone.
+    # Override with clone_temp ⇒ admits (OMIT/TRUSTED_GO) because containment
+    # now anchors to the clone's temp directory where the authority lives.
     override_result = resolver.resolve(request, allowed_root=clone_temp)
-    assert override_result.decision.status.value == "ACCEPT"
+    assert override_result.decision.status.value == "OMIT"
 
     # ``allowed_root=None`` falls back to the constructor-bound root (rejects).
     none_result = resolver.resolve(request, allowed_root=None)

--- a/tests/server/test_audit_cycle_delivery_integration.py
+++ b/tests/server/test_audit_cycle_delivery_integration.py
@@ -2455,10 +2455,12 @@ async def test_run_skill_containment_root_anchors_to_cwd_not_orchestrator_temp_d
     )
 
     # Recipe install happens with the orchestrator's temp_dir bound, exactly
-    # as production's prepare_recipe_execution() does.
+    # as production's prepare_recipe_execution() does. The helper stages
+    # initialization before installing, mirroring the open_kitchen -> run_skill
+    # production lifecycle.
     monkeypatch.setattr(tool_ctx_kitchen_open, "temp_dir", orchestrator_root)
     _wire_recipe_execution_factory(tool_ctx_kitchen_open)
-    installed = install_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
+    installed = _install_test_recipe_execution(tool_ctx_kitchen_open, snapshot=snapshot)
 
     authority = _authority(
         clone_root,
@@ -2469,11 +2471,14 @@ async def test_run_skill_containment_root_anchors_to_cwd_not_orchestrator_temp_d
         materialize=True,
     )
     clone_temp.joinpath("authority.json").write_bytes(authority.canonical_bytes)
-    installed.audit_cycle_heads.publish(authority, expected_parent_digest=None, expected_round=0)
-    tool_ctx_kitchen_open.active_recipe_execution = replace(
-        installed,
-        preflight_identities={"dry": ("plans-1", "scope-1", "part-a")},
+    installed = _replace_test_recipe_execution(
+        tool_ctx_kitchen_open,
+        replace(
+            installed,
+            preflight_identities={"dry": ("plans-1", "scope-1", "part-a")},
+        ),
     )
+    installed.audit_cycle_heads.publish(authority, expected_parent_digest=None, expected_round=0)
 
     marker = "%%ORDER_UP::12345678%%"
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

The audit-cycle containment chain — preflight resolver, loaded-publish, verified-publish, reported-publish — hardcodes `tool_ctx.temp_dir` (the orchestrator's `.autoskillit/temp/`) as `allowed_root`. In clone-based pipelines, artifacts live under the clone's `.autoskillit/temp/`, a structurally disjoint path. The containment check always fails, producing a `ContainmentError` that routes to `register_clone_failure` → `escalate_stop`, indistinguishably from a genuine NO GO verdict. This plan addresses all three acceptance criteria from #4387:

1. Fix the containment root mismatch so `audit_impl` can reach a verdict in clone-based pipelines.
2. Distinguish preflight/infrastructure failure from a genuine NO GO in routing and result envelope.
3. Regression tests that structurally prevent the test-gap pattern (co-located roots) from masking this class of bug.

## Requirements

- `audit_impl` completes and returns a verdict on a standard clone-based remediation run
  with `open_pr=true`.
- A preflight failure is distinguishable from a NO GO in routing and in the result envelope.
- A test constructs the clone-based layout (`work_dir` outside the orchestrator temp) and
  asserts the preflight admits the recipe-supplied plan path.

Closes #4387

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/fix-4387-20260727-213059-759256/.autoskillit/temp/rectify/rectify_audit_impl_preflight_containment_root_2026-07-27_214500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
