### PR TITLE
Rectify: open_kitchen Registry Loss — Client-Cache Coherence

### DIFF
--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
+from mcp.types import ToolListChangedNotification
 
 from autoskillit import __version__
 from autoskillit.config import (
@@ -923,20 +924,46 @@ async def open_kitchen(
                     )
 
         if not _skip_handler:
+            # Scope-placement invariant (REQ-#4399): this branch is gated on
+            # `gate_infrastructure_ready == False` — i.e., tags can only be
+            # disabled by close_kitchen(), which always calls
+            # _close_kitchen_handler() (line 1468), and that handler
+            # unconditionally sets `gate_infrastructure_ready = False` (line
+            # 612). When _skip_handler=True (gate_infrastructure_ready was
+            # already True), tags are already correctly enabled — either from
+            # _pre_reveal_kitchen() at boot or from a prior open_kitchen() that
+            # ran the enable block. Therefore _skip_handler=True is
+            # structurally unreachable after a close_kitchen call; any future
+            # change to close_kitchen's gate_infrastructure_ready transition
+            # must preserve this invariant or it will silently break the
+            # notification asymmetry fixed in #4399.
             _kctx_pre = _get_ctx()
-            _skip_notify = (
+            _use_global_enable = (
                 _kctx_pre.backend is not None
                 and not _kctx_pre.backend.capabilities.supports_tool_list_changed
             )
-            if _skip_notify:
+            if _use_global_enable:
                 # Issue #4399: when the backend can't process tool/list_changed
-                # notifications, ctx.enable_components() is skipped. close_kitchen()
-                # appends global mcp.disable() for these tags, so without a
-                # refresh here, the tags would never re-enable. Append global
-                # enables to override the prior disables via FastMCP's last-match-wins.
+                # notifications, ctx.enable_components() is skipped.
+                # close_kitchen() appends global mcp.disable() for these tags,
+                # so without a refresh here, the tags would never re-enable.
+                # Append global enables to override the prior disables via
+                # FastMCP's last-match-wins, then send an explicit
+                # ToolListChangedNotification so any connected Client refreshes
+                # its stale tool cache. (close_kitchen's notification only
+                # refreshes after disable; without an explicit re-enable
+                # notification, the client keeps serving the post-close list.)
                 mcp.enable(tags={"kitchen"})
                 mcp.enable(tags={"plan-review"})
-                logger.debug("open_kitchen_skip_enable", reason="global_enables_refreshed")
+                logger.debug("open_kitchen_global_enables", reason="use_global_enable")
+                try:
+                    await ctx.send_notification(ToolListChangedNotification())
+                except Exception:
+                    logger.warning(
+                        "open_kitchen_notify_failed",
+                        stage="send_notification",
+                        exc_info=True,
+                    )
             else:
                 try:
                     await ctx.enable_components(tags={"kitchen"})

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -927,16 +927,16 @@ async def open_kitchen(
             # Scope-placement invariant (REQ-#4399): this branch is gated on
             # `gate_infrastructure_ready == False` — i.e., tags can only be
             # disabled by close_kitchen(), which always calls
-            # _close_kitchen_handler() (line 1468), and that handler
-            # unconditionally sets `gate_infrastructure_ready = False` (line
-            # 612). When _skip_handler=True (gate_infrastructure_ready was
-            # already True), tags are already correctly enabled — either from
-            # _pre_reveal_kitchen() at boot or from a prior open_kitchen() that
-            # ran the enable block. Therefore _skip_handler=True is
-            # structurally unreachable after a close_kitchen call; any future
-            # change to close_kitchen's gate_infrastructure_ready transition
-            # must preserve this invariant or it will silently break the
-            # notification asymmetry fixed in #4399.
+            # _close_kitchen_handler(), and that handler unconditionally sets
+            # `gate_infrastructure_ready = False`. When _skip_handler=True
+            # (gate_infrastructure_ready was already True), tags are already
+            # correctly enabled — either from _pre_reveal_kitchen() at boot or
+            # from a prior open_kitchen() that ran the enable block. Therefore
+            # _skip_handler=True is structurally unreachable after a
+            # close_kitchen call; any future change to close_kitchen's
+            # gate_infrastructure_ready transition must preserve this
+            # invariant or it will silently break the notification asymmetry
+            # fixed in #4399.
             _kctx_pre = _get_ctx()
             _use_global_enable = (
                 _kctx_pre.backend is not None

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -951,6 +951,9 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "server/test_kitchen_lifecycle.py",
             "server/test_tools_kitchen_gate.py",
             "server/test_tools_kitchen_gate_hook_config.py",
+            # file-level: formatter-renders-real-content test imports pretty_output_hook
+            # directly to exercise the _fmt_open_kitchen contract — see #4399 criterion 4
+            "server/test_tools_kitchen_envelope.py",
             "execution/test_quota_sleep.py",
             "execution/test_session_log_fields.py",
             # file-level: Codex output-budget config and generated agent contracts

--- a/tests/arch/test_notification_fallback_coverage.py
+++ b/tests/arch/test_notification_fallback_coverage.py
@@ -16,8 +16,11 @@ pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 
 _EXEMPT_FUNCTIONS: frozenset[str] = frozenset({"unlock_agent_pack"})
 
-# The guard variable name that signals a non-notification fallback.
-_SKIP_GUARD_NAMES: frozenset[str] = frozenset({"_skip_notify"})
+# The guard variable names that signal a non-notification fallback.
+# `_use_global_enable` is the post-#4399 name (replaces `_skip_notify`); the old
+# name is kept so any in-flight rename passes both old and new symbols until the
+# rename lands everywhere.
+_SKIP_GUARD_NAMES: frozenset[str] = frozenset({"_skip_notify", "_use_global_enable"})
 
 
 class _EnableComponentsCallFinder(ast.NodeVisitor):
@@ -38,7 +41,7 @@ class _EnableComponentsCallFinder(ast.NodeVisitor):
 
 
 class _SkipGuardPresenceChecker(ast.NodeVisitor):
-    """Check if a function body contains a _skip_notify (or similar) guard."""
+    """Check if a function body contains a guard name in `_SKIP_GUARD_NAMES`."""
 
     def __init__(self) -> None:
         self.has_skip_guard = False
@@ -46,6 +49,42 @@ class _SkipGuardPresenceChecker(ast.NodeVisitor):
     def visit_Name(self, node: ast.Name) -> None:
         if node.id in _SKIP_GUARD_NAMES:
             self.has_skip_guard = True
+        self.generic_visit(node)
+
+
+class _GuardBranchNotificationFinder(ast.NodeVisitor):
+    """Verify a guarded `if`-branch's body contains a `send_notification` call.
+
+    Scoped to the `ast.If.body` (not the whole function) so an unrelated
+    `send_notification` elsewhere in the function does not vacuously satisfy
+    the check. Only branches whose test references a guard name in
+    `_SKIP_GUARD_NAMES` are inspected.
+    """
+
+    def __init__(self) -> None:
+        self.guard_branch_without_notification: list[int] = []
+
+    def _test_references_guard(self, node: ast.expr) -> bool:
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Name) and sub.id in _SKIP_GUARD_NAMES:
+                return True
+        return False
+
+    def _body_calls_send_notification(self, body: list[ast.stmt]) -> bool:
+        for sub in ast.walk(ast.Module(body=body, type_ignores=[])):
+            if (
+                isinstance(sub, ast.Call)
+                and isinstance(sub.func, ast.Attribute)
+                and sub.func.attr == "send_notification"
+            ):
+                return True
+        return False
+
+    def visit_If(self, node: ast.If) -> None:
+        if self._test_references_guard(node.test) and not self._body_calls_send_notification(
+            node.body
+        ):
+            self.guard_branch_without_notification.append(node.lineno)
         self.generic_visit(node)
 
 
@@ -91,10 +130,47 @@ def test_enable_components_calls_have_notification_fallback():
                     violations.append(
                         f"{relpath}:{lineno} — {fn.name}() calls ctx.enable_components "
                         f"without a non-notification fallback guard "
-                        f"(add a _skip_notify check or add {fn.name!r} to _EXEMPT_FUNCTIONS)"
+                        f"(add a guard name in _SKIP_GUARD_NAMES or add {fn.name!r} to "
+                        f"_EXEMPT_FUNCTIONS)"
                     )
 
     assert not violations, (
         "ctx.enable_components calls without notification fallback:\n"
         + "\n".join(f"  {v}" for v in violations)
+    )
+
+
+def test_guard_branches_send_notification():
+    """Every guarded `if`-branch (test references a name in `_SKIP_GUARD_NAMES`)
+    must contain a `send_notification` call in its body. Prevents silent
+    notification suppression while a guard variable still exists.
+
+    Scoped to the `if`-branch body so an unrelated `send_notification` elsewhere
+    in the function does not vacuously satisfy the check.
+    """
+    from autoskillit.core import paths
+
+    tools_dir = paths.pkg_root() / "server" / "tools"
+    assert tools_dir.is_dir(), f"server/tools/ directory not found at {tools_dir}"
+
+    violations: list[str] = []
+    for py_file in sorted(tools_dir.glob("*.py")):
+        try:
+            tree = ast.parse(py_file.read_text())
+        except SyntaxError:
+            continue
+
+        for fn in _get_function_defs(tree):
+            finder = _GuardBranchNotificationFinder()
+            finder.visit(fn)
+            relpath = str(py_file.relative_to(paths.pkg_root()))
+            for lineno in finder.guard_branch_without_notification:
+                violations.append(
+                    f"{relpath}:{lineno} — {fn.name}() guard branch lacks a "
+                    f"send_notification() call in its `if`-branch body "
+                    f"(guard names: {sorted(_SKIP_GUARD_NAMES)})"
+                )
+
+    assert not violations, "Guard branches without send_notification:\n" + "\n".join(
+        f"  {v}" for v in violations
     )

--- a/tests/arch/test_notification_fallback_coverage.py
+++ b/tests/arch/test_notification_fallback_coverage.py
@@ -17,10 +17,7 @@ pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 _EXEMPT_FUNCTIONS: frozenset[str] = frozenset({"unlock_agent_pack"})
 
 # The guard variable names that signal a non-notification fallback.
-# `_use_global_enable` is the post-#4399 name (replaces `_skip_notify`); the old
-# name is kept so any in-flight rename passes both old and new symbols until the
-# rename lands everywhere.
-_SKIP_GUARD_NAMES: frozenset[str] = frozenset({"_skip_notify", "_use_global_enable"})
+_SKIP_GUARD_NAMES: frozenset[str] = frozenset({"_use_global_enable"})
 
 
 class _EnableComponentsCallFinder(ast.NodeVisitor):

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1063,7 +1063,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "for registered non-protected surfaces.",
     ),
     "tools_kitchen.py": (
-        1800,
+        1830,
         "REQ-CNST-010-E7: kitchen tool handlers — open_kitchen and lock_ingredients require "
         "inline validation helpers (_check_override_keys, _build_ingredient_key_suggestions) "
         "for ingredient key validation; splitting would cross import-layer boundaries; "
@@ -1109,7 +1109,12 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "; compiled recipe binding publication and execution-lifecycle cleanup across "
         "recipe load, kitchen open, and kitchen close (+13 net lines)"
         "; #4399 close→open visibility restore: mcp.enable() refresh in open_kitchen's "
-        "_skip_notify branch to override prior global mcp.disable() from close_kitchen (+2 lines)"
+        "_use_global_enable branch to override prior global mcp.disable() from close_kitchen "
+        "(+2 lines), plus ToolListChangedNotification send through ctx.send_notification so "
+        "connected Clients refresh their stale tool cache; rename of _skip_notify → "
+        "_use_global_enable clarifies the branch is about the enable mechanism, not "
+        "notification suppression; scope-placement invariant comment at the "
+        "`if not _skip_handler:` guard (+10 net lines)"
         "; finalized projection/flow generation and explicit activating-surface delivery "
         "are threaded through normal, deferred, and resource paths while named-open "
         "replacement clears stale readiness before every early return",

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -119,10 +119,10 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 90),
     # tools_kitchen.py — hook config, quota guard, git_ops_policy, ingredient locks overlay
-    ("src/autoskillit/server/tools/tools_kitchen.py", 290),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 309),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 343),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 1575),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 291),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 310),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 344),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1602),
     # tools_pipeline_tracker.py — tracker_data dict (init) and mark_step_complete write
     # (same tracker file schema as init — not a new format, grandfathered alongside it)
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 256),

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -7,7 +7,7 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
@@ -143,6 +143,11 @@ def _make_mock_ctx() -> MagicMock:
     ctx.recipe_execution_lock = RLock()
     ctx.recipe_initialization_state = NoActiveRecipe()
     ctx.recipe_execution_factory = make_recipe_execution
+    # Issue #4399: open_kitchen's `_use_global_enable` branch (formerly
+    # `_skip_notify`) now sends `await ctx.send_notification(...)` after global
+    # re-enables. A bare MagicMock is not awaitable, so provide a default
+    # AsyncMock for any caller that exercises that branch.
+    ctx.send_notification = AsyncMock()
     return ctx
 
 

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -284,6 +284,54 @@ async def test_open_kitchen_no_name_returns_json_envelope_with_success_true(tmp_
 
 
 @pytest.mark.anyio
+async def test_open_kitchen_exempt_surface_renders_real_content():
+    """Issue #4399 criterion 4: the open_kitchen formatter must render real recipe content
+    for an exempt surface, not just `## open_kitchen ✓ v`.
+
+    When a payload contains substantive fields (`content`, `summary`, `diagram`,
+    `ingredients_table`, `orchestration_rules`), `_fmt_open_kitchen` must emit
+    sections for each. The `--- STEP FLOW ---` marker is the regression assertion:
+    it is only emitted when the payload's `summary` is non-empty. Without the fix,
+    `summary` arrives empty and the formatter degrades to a degenerate
+    `## open_kitchen ✓ v` stub.
+
+    This is a formatter-level regression test: it verifies `_fmt_open_kitchen`'s
+    own contract — given a well-formed payload with real content fields, it renders
+    that content rather than a degenerate stub. A payload dict handed directly to
+    `_format_response` bypasses the upstream delivery-decision routing in
+    `_recipe_delivery.py` (`finalize_recipe_delivery`/`exemption_overrides_envelope`),
+    which is a separate layer with its own existing test coverage.
+    """
+    from autoskillit.hooks.formatters.pretty_output_hook import _format_response
+
+    payload = {
+        "valid": True,
+        "suggestions": [],
+        "content": "name: my-recipe\nsteps:\n  do:\n    tool: run_cmd\n",
+        "summary": "Run a quick smoke check on the project.",
+        "diagram": "step do --> done\n",
+        "ingredients_table": "--- INGREDIENTS TABLE ---\n  task  required\n--- END TABLE ---",
+        "orchestration_rules": "Run as orchestrator.",
+        "kitchen": "open",
+        "version": "1.2.3",
+    }
+
+    formatted = _format_response("open_kitchen", json.dumps(payload), pipeline=False)
+    assert formatted is not None
+    assert "## open_kitchen" in formatted
+    assert "v1.2.3" in formatted
+    # Real content must be present, not just the header.
+    assert "--- STEP FLOW ---" in formatted, (
+        "Formatter must emit --- STEP FLOW --- marker when payload summary is "
+        "non-empty. If missing, the formatter degrades to a degenerate "
+        "`## open_kitchen ✓ v` stub — see #4399 criterion 4."
+    )
+    assert "Run a quick smoke check" in formatted
+    assert "--- RECIPE ---" in formatted
+    assert "--- INGREDIENTS TABLE ---" in formatted
+
+
+@pytest.mark.anyio
 async def test_open_kitchen_recipe_found_returns_envelope_with_content_and_ingredients_table(
     tmp_path, monkeypatch
 ):

--- a/tests/server/test_tools_kitchen_visibility.py
+++ b/tests/server/test_tools_kitchen_visibility.py
@@ -114,13 +114,89 @@ async def test_close_kitchen_hides_pre_revealed_tools(tmp_path, monkeypatch):
     )
 
 
+# T-VISIBILITY-3a: client-cache coherence — close→open roundtrip restores tools via session
+@pytest.mark.anyio
+async def test_close_open_roundtrip_restores_tools_via_session(tool_ctx):
+    """Issue #4399 criterion 2: after close_kitchen() hides pre-revealed kitchen tools from a
+    connected Client session, a subsequent open_kitchen() must restore them — even when the
+    backend declares `supports_tool_list_changed=False` (Claude Code / Codex).
+
+    This test fails before the fix because open_kitchen's `_use_global_enable` branch
+    (formerly `_skip_notify`) silently re-enables the global tags without sending a
+    ToolListChangedNotification. The connected Client keeps serving the stale post-close
+    cache, so `client.list_tools()` returns an empty kitchen-tools set even though the
+    server-side state is correct.
+
+    The fix adds an explicit `ctx.send_notification(ToolListChangedNotification())` call
+    inside the `_use_global_enable` branch, which causes the Client to invalidate its
+    cache and re-query tools/list — restoring the kitchen tools to the next
+    `client.list_tools()` response.
+    """
+    from unittest.mock import MagicMock
+
+    from fastmcp.client import Client
+
+    from autoskillit.core import FLEET_DISPATCH_TOOLS, FLEET_TOOLS, GATED_TOOLS
+    from autoskillit.server import mcp
+
+    # Mirror production Claude Code / Codex: backend present and
+    # supports_tool_list_changed=False so open_kitchen enters the _use_global_enable
+    # branch. The Client is in-process (no subprocess); the FastMCP Context it creates
+    # has a real `.session` so `ctx.reset_visibility()` and `ctx.send_notification()`
+    # actually send notifications through the wire.
+    mock_backend = MagicMock()
+    mock_backend.capabilities.supports_tool_list_changed = False
+    tool_ctx.backend = mock_backend
+
+    # Simulate _pre_reveal_kitchen()'s effect on the global mcp singleton (boot-time
+    # global enable; per the established convention used by kitchen_enabled and
+    # test_server_init_gate::test_tool_list_changes_after_enable_within_session).
+    mcp.enable(tags={"kitchen"})
+    mcp.enable(tags={"plan-review"})
+
+    # tool_ctx.gate_infrastructure_ready=True mirrors the post-_pre_reveal_kitchen()
+    # boot state so the first open_kitchen would take the _skip_handler branch; close
+    # unconditionally flips it back to False (line 612), so the subsequent open_kitchen
+    # correctly enters `if not _skip_handler:` and exercises the _use_global_enable path.
+    tool_ctx.gate_infrastructure_ready = True
+    kitchen_gated = GATED_TOOLS - FLEET_TOOLS - FLEET_DISPATCH_TOOLS
+
+    async with Client(mcp) as client:
+        # Step 3: tools visible after global pre-reveal.
+        tools_before = {t.name for t in await client.list_tools()}
+        assert kitchen_gated.issubset(tools_before), (
+            "kitchen tools should be visible after pre-reveal enable"
+        )
+
+        # Step 4: real close_kitchen through the connected Client session.
+        await client.call_tool("close_kitchen", {})
+
+        # Step 5: tools hidden after close_kitchen's notification propagates.
+        tools_after_close = {t.name for t in await client.list_tools()}
+        assert not kitchen_gated.intersection(tools_after_close), (
+            "kitchen tools should be hidden after close_kitchen"
+        )
+
+        # Step 6: real open_kitchen (Claude Code backend, no tool_list_changed).
+        await client.call_tool("open_kitchen", {})
+
+        # Step 7: tools restored after open_kitchen's notification propagates.
+        # BEFORE the fix, this fails — the global mcp.enable() calls succeed
+        # server-side but no notification reaches the Client, so the Client keeps
+        # serving the stale post-close cache.
+        tools_after_reopen = {t.name for t in await client.list_tools()}
+        assert kitchen_gated.issubset(tools_after_reopen), (
+            "kitchen tools should be visible after open_kitchen restores pre-revealed tags"
+        )
+
+
 # T-VISIBILITY-3: close_kitchen→open_kitchen roundtrip — pre-revealed kitchen tools restored
 @pytest.mark.anyio
 async def test_open_kitchen_after_close_restores_pre_revealed_tools(tmp_path, monkeypatch):
     """Issue #4399: after close_kitchen() hides pre-revealed kitchen tools, a subsequent
-    open_kitchen() with `_skip_notify=True` (Claude Code backend, no tool/list_changed
+    open_kitchen() with `_use_global_enable=True` (Claude Code backend, no tool/list_changed
     notification) must re-enable the kitchen and plan-review tags so the tools return
-    to list_tools(). Without the fix, the `_skip_notify` branch only logs a debug
+    to list_tools(). Without the fix, the `_use_global_enable` branch only logs a debug
     message and never calls `mcp.enable()`, leaving tools invisible.
     """
     monkeypatch.chdir(tmp_path)
@@ -159,7 +235,7 @@ async def test_open_kitchen_after_close_restores_pre_revealed_tools(tmp_path, mo
     # Second lifecycle: open_kitchen with Claude Code backend (no tool_list_changed).
     # _skip_handler = False (gate_infrastructure_ready was reset by close_kitchen),
     # so we enter the `if not _skip_handler:` block at line 876. Inside it,
-    # _skip_notify = (backend is not None and not supports_tool_list_changed) = True,
+    # _use_global_enable = (backend is not None and not supports_tool_list_changed) = True,
     # so the buggy branch at line 882 is executed. Without the fix, the tools
     # remain hidden. With the fix, global mcp.enable() restores visibility.
     mock_ctx.backend.capabilities.supports_tool_list_changed = False

--- a/tests/server/test_tools_kitchen_visibility.py
+++ b/tests/server/test_tools_kitchen_visibility.py
@@ -48,7 +48,15 @@ async def test_open_kitchen_calls_enable_components_for_notification_backend(
 async def test_open_kitchen_skips_enable_components_for_pre_revealed_backend(
     tmp_path, monkeypatch
 ):
-    """open_kitchen must NOT call ctx.enable_components when backend was pre-revealed."""
+    """open_kitchen must NOT call ctx.enable_components when backend was pre-revealed.
+
+    This is the ``_use_global_enable`` branch (formerly named ``_skip_notify``): when
+    the backend was pre-revealed at boot, open_kitchen re-enables via the global
+    ``mcp.enable(tags=...)`` provider rather than the session-scoped
+    ``ctx.enable_components``. Emitting the tools/list_changed notification on that
+    branch is a separate concern, covered by T-VISIBILITY-3 and the close->open
+    roundtrip test.
+    """
     monkeypatch.chdir(tmp_path)
     mock_ctx = _make_mock_ctx()
     mock_ctx.enable_components = AsyncMock()


### PR DESCRIPTION
## Summary

After `close_kitchen()` → `open_kitchen()`, all 41 kitchen-tagged MCP tools vanish from the client's tool list. The server-side state is correct — the global `mcp.enable()` calls added in PR #4401 work and the server reports tools as enabled — but the client is never notified to re-query `tools/list`, so it keeps serving a stale cache from the close transition.

The architectural weakness is a **notification asymmetry**: `close_kitchen` unconditionally sends `ToolListChangedNotification` (via `ctx.reset_visibility()`), but `open_kitchen` deliberately suppresses notification when `_skip_notify=True` (all production backends). The `_skip_notify` flag correctly prevents notification at boot (no client connected yet) but is incorrectly reused mid-session (client IS connected and synced to the disabled state).

The fix is to send an explicit `ToolListChangedNotification` after the global re-enables in `open_kitchen`, and to structurally prevent this class of bug from recurring via an architectural guard and a session-level round-trip regression test.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260728-095428-498581/.autoskillit/temp/rectify/rectify_open_kitchen_registry_loss_residual_2026-07-28_101500.md`

Closes #4399

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
