### PR TITLE
Rectify: Marker Substring Match False Positives — Centralized Code-Region-Aware Detection

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -775,6 +775,7 @@ from .types import (
 )
 from .types import derive_backend_requirements as derive_backend_requirements
 from .types import describe_capability_mismatches as describe_capability_mismatches
+from .types import detect_body_marker as detect_body_marker
 from .types import (
     encode_stored_context_admission_envelope as encode_stored_context_admission_envelope,
 )
@@ -809,6 +810,7 @@ from .types import resume_spec_from_cli as resume_spec_from_cli
 from .types import session_type as session_type
 from .types import session_type_for_skill_execution_role as session_type_for_skill_execution_role
 from .types import strip_context_window_suffix as strip_context_window_suffix
+from .types import strip_markdown_code_regions as strip_markdown_code_regions
 from .types import truncate_text as truncate_text
 from .types import unsatisfied_backend_capabilities as unsatisfied_backend_capabilities
 from .types import (

--- a/src/autoskillit/core/types/_type_helpers.py
+++ b/src/autoskillit/core/types/_type_helpers.py
@@ -30,11 +30,13 @@ __all__ = [
     "extract_path_arg",
     "extract_positional_args",
     "extract_skill_name",
+    "detect_body_marker",
     "fleet_error",
     "render_target_skill_command",
     "resolve_skill_name",
     "resolve_target_skill",
     "session_type",
+    "strip_markdown_code_regions",
     "truncate_text",
 ]
 
@@ -426,6 +428,22 @@ def truncate_text(text: str, max_len: int = 5000) -> str:
     if len(text) <= max_len:
         return text
     return f"...[truncated {len(text) - max_len} chars]...\n" + text[-max_len:]
+
+
+_CODE_BLOCK_RE = re.compile(r"(```|~~~).*?\1", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+
+
+def strip_markdown_code_regions(text: str) -> str:
+    """Remove fenced code blocks and inline code spans from markdown text."""
+    text = _CODE_BLOCK_RE.sub("", text)
+    text = _INLINE_CODE_RE.sub("", text)
+    return text
+
+
+def detect_body_marker(body: str, marker: str) -> bool:
+    """Check whether *marker* appears in *body* outside markdown code regions."""
+    return marker in strip_markdown_code_regions(body)
 
 
 def fleet_error(

--- a/src/autoskillit/core/types/_type_helpers.py
+++ b/src/autoskillit/core/types/_type_helpers.py
@@ -436,9 +436,12 @@ _INLINE_CODE_RE = re.compile(r"`[^`]*`")
 
 def strip_markdown_code_regions(text: str) -> str:
     """Remove fenced code blocks and inline code spans from markdown text."""
-    text = _CODE_BLOCK_RE.sub("", text)
-    text = _INLINE_CODE_RE.sub("", text)
-    return text
+    while True:
+        stripped = _CODE_BLOCK_RE.sub("", text)
+        stripped = _INLINE_CODE_RE.sub("", stripped)
+        if stripped == text:
+            return stripped
+        text = stripped
 
 
 def detect_body_marker(body: str, marker: str) -> bool:

--- a/src/autoskillit/core/types/_type_helpers.py
+++ b/src/autoskillit/core/types/_type_helpers.py
@@ -431,7 +431,7 @@ def truncate_text(text: str, max_len: int = 5000) -> str:
 
 
 _CODE_BLOCK_RE = re.compile(r"(```|~~~).*?\1", re.DOTALL)
-_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+_INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
 
 
 def strip_markdown_code_regions(text: str) -> str:

--- a/src/autoskillit/server/tools/tools_issue_composite.py
+++ b/src/autoskillit/server/tools/tools_issue_composite.py
@@ -12,6 +12,7 @@ from autoskillit.core import (
     INVESTIGATION_COMPLETE_MARKER,
     REVIEW_APPROACH_MARKER,
     _parse_issue_ref,
+    detect_body_marker,
     get_logger,
 )
 from autoskillit.server import mcp
@@ -113,8 +114,8 @@ async def claim_and_resolve_issue(
                 )
 
             issue_body = fetch_result.get("body") or ""
-            review_approach_recommended = REVIEW_APPROACH_MARKER in issue_body
-            investigation_complete = INVESTIGATION_COMPLETE_MARKER in issue_body
+            review_approach_recommended = detect_body_marker(issue_body, REVIEW_APPROACH_MARKER)
+            investigation_complete = detect_body_marker(issue_body, INVESTIGATION_COMPLETE_MARKER)
 
             issue_state = fetch_result.get("state", "open").lower()
             if issue_state == "closed":

--- a/src/autoskillit/server/tools/tools_issue_labels.py
+++ b/src/autoskillit/server/tools/tools_issue_labels.py
@@ -11,6 +11,7 @@ from autoskillit.core import (
     INVESTIGATION_COMPLETE_MARKER,
     REVIEW_APPROACH_MARKER,
     _parse_issue_ref,
+    detect_body_marker,
     get_logger,
 )
 from autoskillit.server import mcp
@@ -89,8 +90,9 @@ async def claim_issue(
             if not result.get("success"):
                 return json.dumps({"success": False, "error": result.get("error", "fetch failed")})
 
-            review_approach_recommended = REVIEW_APPROACH_MARKER in (result.get("body") or "")
-            investigation_complete = INVESTIGATION_COMPLETE_MARKER in (result.get("body") or "")
+            _body = result.get("body") or ""
+            review_approach_recommended = detect_body_marker(_body, REVIEW_APPROACH_MARKER)
+            investigation_complete = detect_body_marker(_body, INVESTIGATION_COMPLETE_MARKER)
             issue_state = result.get("state", "open").lower()
             if issue_state == "closed":
                 return json.dumps(

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -183,8 +183,9 @@ When the in-progress context is empty, omit Step 2b entirely — `cross_assessme
 #### Investigation-Complete Detection (unconditional)
 
 For each issue, check whether the issue body contains the `<!-- investigation_complete: true -->`
-HTML comment marker. Set `investigation_complete: true` or `false` per issue. This is a simple
-substring check — no LLM assessment required.
+HTML comment marker **outside of markdown code regions** (fenced code blocks and inline code spans).
+Markers that appear only inside code examples are documentation references, not real markers.
+Set `investigation_complete: true` or `false` per issue.
 
 Emit a terminal token when at least one issue has the marker:
 ```

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -192,7 +192,7 @@ tests/
 ├── test_backend_gating_root.py
 ├── test_conftest.py                     # Tests for conftest fixtures
 ├── test_fakes_conformance.py
-├── test_helpers_strip.py                # Unit tests for strip_markdown_code_regions shared utility
+├── test_helpers_strip.py                # Unit tests for strip_markdown_code_regions (production IL-0, re-exported via tests/_helpers.py)
 ├── test_llm_triage.py
 ├── test_no_orchestration_tier_language.py
 ├── test_smoke_utils.py

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -5,19 +5,9 @@ from __future__ import annotations
 import re
 import sys
 
-_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
-_INLINE_CODE_RE = re.compile(r"`[^`]*`")
-
-
-def strip_markdown_code_regions(text: str) -> str:
-    """Remove fenced code blocks and inline code spans from markdown text.
-
-    Use before applying content-scanning rules that should only match
-    prose, not code examples.
-    """
-    text = _CODE_BLOCK_RE.sub("", text)
-    text = _INLINE_CODE_RE.sub("", text)
-    return text
+from autoskillit.core import (
+    strip_markdown_code_regions as strip_markdown_code_regions,
+)
 
 
 def _collect_structlog_proxies() -> list[object]:

--- a/tests/arch/AGENTS.md
+++ b/tests/arch/AGENTS.md
@@ -111,7 +111,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_skill_family_parity.py` | Parametrized parity tests: every GITHUB_API_SKILL_FAMILIES member must satisfy its family's required API pattern contracts |
 | `test_model_identity_contract.py` | AST guard: detect_model_drift must use normalize_model_id and _models_match, and must have a profile_name suppression guard with normalize_model_id — prevents raw-string false positives and profile-routed false MODEL_DRIFT |
 | `test_recipe_delivery_provenance.py` | AST guard: caller-requested, host-observed, selected-result, history-retention, and measured-byte authorities remain independent |
-| `test_helpers_exports.py` | Asserts shared test helpers export required symbols (strip_markdown_code_regions) |
+| `test_helpers_exports.py` | Asserts tests/_helpers.py re-exports required production symbols (strip_markdown_code_regions) |
 | `test_hook_efficacy_contract.py` | Arch contracts: HookDef mechanism presence, enforcement_strength backend coverage, codex hard-claim consistency, codex_status/strength coherence |
 | `test_hook_env_var_authority.py` | AST guard: every hook script that reads `AUTOSKILLIT_PROVIDER_PROFILE` must also read `AUTOSKILLIT_AGENT_BACKEND` so backend identity is checked independently of provider routing |
 | `test_serve_surface_registry.py` | Structural tests for the typed recipe-delivery surface registry and the `load_and_validate` call boundary |

--- a/tests/core/AGENTS.md
+++ b/tests/core/AGENTS.md
@@ -18,6 +18,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_cmd_runner.py` | Tests for core/_cmd_runner.py — CmdRunner protocol, default_cmd_runner, run_git, run_gh |
 | `test_core.py` | Tests for the core/ sub-package foundation layer |
 | `test_core_terminal_table.py` | Tests for core/_terminal_table.py — the L0 shared table primitive |
+| `test_detect_body_marker.py` | Tests for detect_body_marker and strip_markdown_code_regions in core.types._type_helpers |
 | `test_context_admission_coverage.py` | Exact producer/control-point coverage registry and evidence metadata contract |
 | `test_context_admission_reducer.py` | Pure context-admission reducer transition and replay tests |
 | `test_context_admission_state_machine.py` | Property-based context-admission accounting and lifecycle invariants |

--- a/tests/core/test_detect_body_marker.py
+++ b/tests/core/test_detect_body_marker.py
@@ -64,6 +64,13 @@ def test_detect_body_marker_marker_in_tilde_fence() -> None:
     assert detect_body_marker(body, INVESTIGATION_COMPLETE_MARKER) is False
 
 
+def test_detect_body_marker_survives_stray_backtick_on_other_line() -> None:
+    body = (
+        f"Use the `--foo flag (typo).\n\n{INVESTIGATION_COMPLETE_MARKER}\n\nAlso see `--bar` here."
+    )
+    assert detect_body_marker(body, INVESTIGATION_COMPLETE_MARKER) is True
+
+
 @given(st.text())
 def test_strip_markdown_code_regions_is_idempotent(text: str) -> None:
     stripped = strip_markdown_code_regions(text)

--- a/tests/core/test_detect_body_marker.py
+++ b/tests/core/test_detect_body_marker.py
@@ -1,0 +1,78 @@
+"""Tests for centralized issue-body marker detection."""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from autoskillit.core import (
+    INVESTIGATION_COMPLETE_MARKER,
+    REVIEW_APPROACH_MARKER,
+    detect_body_marker,
+    strip_markdown_code_regions,
+)
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+def test_detect_body_marker_genuine_marker() -> None:
+    body = f"## Investigation\n\n{INVESTIGATION_COMPLETE_MARKER}"
+    assert detect_body_marker(body, INVESTIGATION_COMPLETE_MARKER) is True
+
+
+def test_detect_body_marker_marker_in_fence() -> None:
+    body = f"```\n{INVESTIGATION_COMPLETE_MARKER}\n```"
+    assert detect_body_marker(body, INVESTIGATION_COMPLETE_MARKER) is False
+
+
+def test_detect_body_marker_marker_in_inline_span() -> None:
+    body = f"`{INVESTIGATION_COMPLETE_MARKER}`"
+    assert detect_body_marker(body, INVESTIGATION_COMPLETE_MARKER) is False
+
+
+def test_detect_body_marker_mixed_genuine_and_quoted() -> None:
+    body = (
+        f"## Investigation\n\n{INVESTIGATION_COMPLETE_MARKER}\n\n"
+        f"```\n{INVESTIGATION_COMPLETE_MARKER}\n```"
+    )
+    assert detect_body_marker(body, INVESTIGATION_COMPLETE_MARKER) is True
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        (f"## Review Approach\n\n{REVIEW_APPROACH_MARKER}", True),
+        (f"~~~\n{REVIEW_APPROACH_MARKER}\n~~~", False),
+        (f"`{REVIEW_APPROACH_MARKER}`", False),
+    ],
+)
+def test_detect_body_marker_review_approach(body: str, expected: bool) -> None:
+    assert detect_body_marker(body, REVIEW_APPROACH_MARKER) is expected
+
+
+def test_detect_body_marker_empty_body() -> None:
+    assert detect_body_marker("", INVESTIGATION_COMPLETE_MARKER) is False
+
+
+def test_detect_body_marker_no_marker() -> None:
+    assert detect_body_marker("Just a regular issue body.", INVESTIGATION_COMPLETE_MARKER) is False
+
+
+def test_detect_body_marker_marker_in_tilde_fence() -> None:
+    body = f"~~~\n{INVESTIGATION_COMPLETE_MARKER}\n~~~"
+    assert detect_body_marker(body, INVESTIGATION_COMPLETE_MARKER) is False
+
+
+@given(st.text())
+def test_strip_markdown_code_regions_is_idempotent(text: str) -> None:
+    stripped = strip_markdown_code_regions(text)
+    assert strip_markdown_code_regions(stripped) == stripped
+
+
+@given(st.text(), st.text(min_size=1))
+def test_detect_body_marker_stripped_occurrences_never_exceed_raw(
+    body: str,
+    marker: str,
+) -> None:
+    assert strip_markdown_code_regions(body).count(marker) <= body.count(marker)

--- a/tests/server/test_tools_bootstrap.py
+++ b/tests/server/test_tools_bootstrap.py
@@ -394,6 +394,48 @@ class TestClaimAndResolveIssue:
         result = json.loads(await claim_and_resolve_issue("owner/repo#42"))
         assert result["investigation_complete"] is False
 
+    @pytest.mark.anyio
+    async def test_claim_and_resolve_investigation_complete_false_when_marker_in_code_fence(
+        self, tool_ctx_kitchen_open
+    ):
+        """A fenced investigation marker does not set investigation_complete."""
+        tool_ctx_kitchen_open.github_client = AsyncMock()
+        tool_ctx_kitchen_open.github_client.fetch_title = AsyncMock(
+            return_value={"success": True, "number": 42, "title": "Fix bug", "slug": "fix-bug"}
+        )
+        tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
+            return_value={
+                "success": True,
+                "state": "closed",
+                "labels": [],
+                "body": "```\n<!-- investigation_complete: true -->\n```\nSome prose.",
+            }
+        )
+
+        result = json.loads(await claim_and_resolve_issue("owner/repo#42"))
+        assert result["investigation_complete"] is False
+
+    @pytest.mark.anyio
+    async def test_claim_and_resolve_review_approach_false_when_marker_in_code_fence(
+        self, tool_ctx_kitchen_open
+    ):
+        """A fenced review marker does not set review_approach_recommended."""
+        tool_ctx_kitchen_open.github_client = AsyncMock()
+        tool_ctx_kitchen_open.github_client.fetch_title = AsyncMock(
+            return_value={"success": True, "number": 42, "title": "Fix bug", "slug": "fix-bug"}
+        )
+        tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
+            return_value={
+                "success": True,
+                "state": "closed",
+                "labels": [],
+                "body": "```\n<!-- review_approach: true -->\n```\nSome prose.",
+            }
+        )
+
+        result = json.loads(await claim_and_resolve_issue("owner/repo#42"))
+        assert result["review_approach_recommended"] is False
+
 
 class TestCreateAndPublishBranch:
     @pytest.mark.anyio

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -1152,3 +1152,102 @@ async def test_claim_issue_returns_investigation_complete_success(
     )
     assert "investigation_complete" in result
     assert result["investigation_complete"] is True
+
+
+@pytest.mark.anyio
+async def test_claim_issue_investigation_complete_false_when_marker_in_code_fence(
+    tool_ctx_kitchen_open,
+) -> None:
+    """A marker quoted in a fenced code block is not an investigation signal."""
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
+        return_value={
+            "success": True,
+            "state": "closed",
+            "labels": [],
+            "body": "```\n<!-- investigation_complete: true -->\n```\nSome prose.",
+        }
+    )
+
+    result = json.loads(await claim_issue("https://github.com/owner/repo/issues/42"))
+    assert result["investigation_complete"] is False
+
+
+@pytest.mark.anyio
+async def test_claim_issue_investigation_complete_false_when_marker_in_inline_span(
+    tool_ctx_kitchen_open,
+) -> None:
+    """A marker quoted in an inline code span is not an investigation signal."""
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
+        return_value={
+            "success": True,
+            "state": "closed",
+            "labels": [],
+            "body": "Check `<!-- investigation_complete: true -->` for details.",
+        }
+    )
+
+    result = json.loads(await claim_issue("https://github.com/owner/repo/issues/42"))
+    assert result["investigation_complete"] is False
+
+
+@pytest.mark.anyio
+async def test_claim_issue_investigation_complete_true_with_genuine_and_quoted_marker(
+    tool_ctx_kitchen_open,
+) -> None:
+    """A genuine marker remains effective when another copy is fenced."""
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
+        return_value={
+            "success": True,
+            "state": "closed",
+            "labels": [],
+            "body": (
+                "## Investigation\n\n"
+                "<!-- investigation_complete: true -->\n\n"
+                "```\n<!-- investigation_complete: true -->\n```"
+            ),
+        }
+    )
+
+    result = json.loads(await claim_issue("https://github.com/owner/repo/issues/42"))
+    assert result["investigation_complete"] is True
+
+
+@pytest.mark.anyio
+async def test_claim_issue_review_approach_false_when_marker_in_code_fence(
+    tool_ctx_kitchen_open,
+) -> None:
+    """A review marker quoted in a fenced code block is ignored."""
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
+        return_value={
+            "success": True,
+            "state": "closed",
+            "labels": [],
+            "body": "```\n<!-- review_approach: true -->\n```\nSome prose.",
+        }
+    )
+
+    result = json.loads(await claim_issue("https://github.com/owner/repo/issues/42"))
+    assert result["review_approach_recommended"] is False
+
+
+@pytest.mark.anyio
+async def test_claim_issue_review_approach_false_when_marker_in_inline_span(
+    tool_ctx_kitchen_open,
+) -> None:
+    """A review marker quoted in an inline code span is ignored."""
+    tool_ctx_kitchen_open.github_client = AsyncMock()
+    tool_ctx_kitchen_open.github_client.fetch_issue = AsyncMock(
+        return_value={
+            "success": True,
+            "state": "closed",
+            "labels": [],
+            "body": "Check `<!-- review_approach: true -->` for details.",
+        }
+    )
+
+    result = json.loads(await claim_issue("https://github.com/owner/repo/issues/42"))
+    assert result["review_approach_recommended"] is False


### PR DESCRIPTION
## Summary

`INVESTIGATION_COMPLETE_MARKER` and `REVIEW_APPROACH_MARKER` are detected via naive `str.__contains__` against raw, unsanitized GitHub issue bodies at two duplicated call sites. This produces false positives when the marker text appears inside markdown fenced code blocks or inline code spans. A production-grade `strip_markdown_code_regions` utility does not exist in `src/` — only a test-only version in `tests/_helpers.py`. Additionally, the `build-execution-map` SKILL.md propagates the same vulnerability in prose by instructing the LLM to perform a "simple substring check."

The architectural weakness is twofold: (1) no centralized marker-detection predicate exists — each call site reimplements raw `in` checks independently, and (2) there is no shared code-region-stripping utility in production code. The fix promotes the stripping utility into IL-0 `core/`, creates a centralized `detect_body_marker()` predicate that strips before matching, replaces both duplicated call sites, fixes the SKILL.md prose, and adds false-positive rejection tests for both markers.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260728-142843-376918/.autoskillit/temp/rectify/rectify_marker_substring_match_2026-07-28_223749.md`

Closes #4386

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

---

## Audit gate bypassed — #4406

`audit_impl` did **not** gate this PR. It crashed with
`AuditCycleVerificationError: authority is not strict canonical versioned JSON` — that is
#4406: `audit-impl` writes `authority.json` pretty-printed, while its own verifier requires
the strict canonical profile (`sort_keys=True`, `separators=(",", ":")`). The crash is in the
cycle-artifact machinery *after* the audit itself completed, so it is not a quality finding
against this change.

The bypass was explicitly authorized by the repository owner. Evidence standing in for the gate:

- `task test-check` — 31848 passed, 557 skipped, 26 xfailed
- `pre-commit run --all-files` — all hooks passed
- `dry-walkthrough` — plan verified and stamped after three auditor passes
- no recorded deviations from the plan
