### PR TITLE
[FIX] Restore branch-targeted CI policy for #4405

### DIFF
--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -113,6 +113,9 @@ src/autoskillit/agents/**:
 .github/workflows/*.yml:
   - infra/
 
+.github/AGENTS.md:
+  - infra/
+
 CLAUDE.md:
   - infra/
   - contracts/
@@ -130,6 +133,10 @@ Taskfile.yml:
   - infra/
 
 .gitleaks.toml:
+  - infra/
+
+docs/developer/contributing.md:
+  - docs/
   - infra/
 
 docs/**/*.md:
@@ -255,6 +262,8 @@ scripts/regen_contracts.py:
 scripts/check_pyi_stub_format.py:
   - infra/
 scripts/check_pyi_stub_symbols.py:
+  - infra/
+scripts/ci_target_policy.py:
   - infra/
 scripts/measure_codex_read_repetition.py:
   - infra/

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -40,6 +40,14 @@ wheel cache consumed by downstream jobs:
 Jobs that run `uv sync --locked` may omit `enable-cache` (defaults to `auto`, enabled on
 GitHub-hosted runners).
 
+## Branch-targeted test policy
+
+`scripts/ci_target_policy.py` is the executable CI policy authority, and
+`docs/developer/contributing.md` is its durable contributor-facing record. Feature and
+fix work must not incidentally broaden or narrow CI runners or filtering. Any change
+requires an explicit CI-policy task and matching behavior-table tests in
+`tests/infra/test_ci_workflow.py`.
+
 ## Rust toolchain scope
 
 `dtolnay/rust-toolchain` is only needed in jobs that compile native Python extensions

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,19 +15,15 @@ jobs:
     name: Preflight checks
     runs-on: ubuntu-latest
     outputs:
-      os-matrix: ${{ steps.set-matrix.outputs.matrix }}
+      os-matrix: ${{ steps.ci-policy.outputs.os-matrix }}
+      test-filter-mode: ${{ steps.ci-policy.outputs.test-filter-mode }}
+      test-base-revision: ${{ steps.ci-policy.outputs.test-base-revision }}
     steps:
-      - name: Compute OS matrix
-        id: set-matrix
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "stable" ]] || \
-             [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/stable" ]]; then
-            echo 'matrix=["ubuntu-latest","macos-15"]' >> $GITHUB_OUTPUT
-          else
-            echo 'matrix=["ubuntu-latest"]' >> $GITHUB_OUTPUT
-          fi
-
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Resolve CI target policy
+        id: ci-policy
+        run: python3 scripts/ci_target_policy.py >> "$GITHUB_OUTPUT"
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -120,11 +116,10 @@ jobs:
         env:
           AUTOSKILLIT_FILTER_STATS_FILE: ${{ github.workspace }}/.autoskillit/temp/filter-stats.json
           AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED: "true"
+          AUTOSKILLIT_TEST_FILTER: ${{ needs.preflight.outputs.test-filter-mode }}
+          AUTOSKILLIT_TEST_BASE_REF: ${{ needs.preflight.outputs.test-base-revision }}
         run: |
           mkdir -p .autoskillit/temp
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "develop" ]]; then
-            export AUTOSKILLIT_TEST_FILTER=conservative
-          fi
           task test-check
 
       - name: Upload filter stats

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -2,6 +2,6 @@
 
 For people working on AutoSkillit itself.
 
-- [contributing.md](contributing.md) — pre-commit, version bumps, code-index setup
+- [contributing.md](contributing.md) — branch-targeted CI runner/filter policy, pre-commit, version bumps, code-index setup
 - [diagnostics.md](diagnostics.md) — session diagnostic logs and `sessions.jsonl`
 - [end-turn-hazards.md](end-turn-hazards.md) — recipe authoring hazards at session end

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -19,6 +19,28 @@ Tests run in parallel via pytest-xdist (`-n 4`). All tests must be safe for
 parallel execution. Never use `pytest` directly — always use `task test-all`
 (or `task test-check` for CI/automation).
 
+## Branch-Targeted CI Policy
+
+The target branch selects both the test runners and the test-filter mode:
+
+| Event target | Runners | Test filter |
+|---|---|---|
+| `develop` | `ubuntu-latest` | `conservative` |
+| `main` | `ubuntu-latest` | `none` |
+| `stable` | `ubuntu-latest`, `macos-15` | `none` |
+
+`pull_request` and `merge_group` each allow `develop|main|stable`.
+`push` allows only `main|stable`; push-to-develop is rejected. Pull requests and
+merge groups targeting the same branch must resolve to the same policy, including
+the immutable event base SHA used for conservative filtering. macOS is release-path
+coverage for `stable`; it is not a develop-branch requirement.
+
+PR #4396 introduced an unconditional Linux/macOS runner policy. PR #4405 exposed the
+regression in merge-queue integration and carries the correction. Feature and fix work
+must not incidentally broaden or narrow CI runners or filtering. An intentional policy
+change requires an explicit CI-policy task and matching behavioral tests in
+`tests/infra/test_ci_workflow.py`.
+
 ## Pre-commit Hooks
 
 Hooks run automatically on commit: ruff format, ruff check, mypy, uv lock check,

--- a/scripts/ci_target_policy.py
+++ b/scripts/ci_target_policy.py
@@ -107,7 +107,11 @@ def resolve_ci_profile(
 
     if target not in allowed_targets:
         raise ValueError(f"target {target!r} is not allowed for event {event_name!r}")
-    policy = CI_TARGET_POLICIES[target]
+    policy = CI_TARGET_POLICIES.get(target)
+    if policy is None:
+        raise ValueError(
+            f"target {target!r} is allowed for event {event_name!r} but has no registered policy"
+        )
 
     base_revision = ""
     if policy.filter_mode == "conservative":

--- a/scripts/ci_target_policy.py
+++ b/scripts/ci_target_policy.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Resolve the runner and test-filter policy for a GitHub Actions event."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+
+_HEAD_REF_PREFIX = "refs/heads/"
+_COMMIT_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+
+
+@dataclass(frozen=True, slots=True)
+class CiTargetPolicyDef:
+    """Static CI behavior registered for one target branch."""
+
+    os_runners: tuple[str, ...]
+    filter_mode: str
+
+
+CI_TARGET_POLICIES: Mapping[str, CiTargetPolicyDef] = MappingProxyType(
+    {
+        "develop": CiTargetPolicyDef(("ubuntu-latest",), "conservative"),
+        "main": CiTargetPolicyDef(("ubuntu-latest",), "none"),
+        "stable": CiTargetPolicyDef(("ubuntu-latest", "macos-15"), "none"),
+    }
+)
+
+ALLOWED_TARGETS_BY_EVENT: Mapping[str, frozenset[str]] = MappingProxyType(
+    {
+        "pull_request": frozenset({"develop", "main", "stable"}),
+        "merge_group": frozenset({"develop", "main", "stable"}),
+        "push": frozenset({"main", "stable"}),
+    }
+)
+
+
+def _require_mapping(value: object, field: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be an object")
+    return value
+
+
+def _require_string(mapping: Mapping[str, object], field: str) -> str:
+    value = mapping.get(field)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _target_from_head_ref(ref: str, field: str) -> str:
+    if not ref.startswith(_HEAD_REF_PREFIX):
+        raise ValueError(f"{field} must start with {_HEAD_REF_PREFIX!r}")
+    target = ref.removeprefix(_HEAD_REF_PREFIX)
+    if not target:
+        raise ValueError(f"{field} must name a branch")
+    return target
+
+
+def _require_commit_sha(value: object, field: str) -> str:
+    if not isinstance(value, str) or _COMMIT_SHA_PATTERN.fullmatch(value) is None:
+        raise ValueError(f"{field} must be a 40-character lowercase commit SHA")
+    return value
+
+
+def resolve_ci_profile(
+    event_name: str,
+    payload: Mapping[str, object],
+) -> tuple[CiTargetPolicyDef, str]:
+    """Resolve the immutable target policy and conservative-filter base revision."""
+
+    allowed_targets = ALLOWED_TARGETS_BY_EVENT.get(event_name)
+    if allowed_targets is None:
+        raise ValueError(f"unsupported event: {event_name!r}")
+
+    event_payload = _require_mapping(payload, "event payload")
+    base_sha: object | None = None
+    if event_name == "pull_request":
+        pull_request = _require_mapping(
+            event_payload.get("pull_request"),
+            "pull_request",
+        )
+        base = _require_mapping(pull_request.get("base"), "pull_request.base")
+        target = _require_string(base, "ref")
+        base_sha = base.get("sha")
+    elif event_name == "merge_group":
+        merge_group = _require_mapping(
+            event_payload.get("merge_group"),
+            "merge_group",
+        )
+        target = _target_from_head_ref(
+            _require_string(merge_group, "base_ref"),
+            "merge_group.base_ref",
+        )
+        base_sha = merge_group.get("base_sha")
+    else:
+        target = _target_from_head_ref(
+            _require_string(event_payload, "ref"),
+            "ref",
+        )
+
+    if target not in allowed_targets:
+        raise ValueError(f"target {target!r} is not allowed for event {event_name!r}")
+    policy = CI_TARGET_POLICIES[target]
+
+    base_revision = ""
+    if policy.filter_mode == "conservative":
+        base_revision = _require_commit_sha(base_sha, "base SHA")
+    return policy, base_revision
+
+
+def _load_event() -> tuple[str, Mapping[str, object]]:
+    event_name = os.environ.get("GITHUB_EVENT_NAME")
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_name:
+        raise ValueError("GITHUB_EVENT_NAME is required")
+    if not event_path:
+        raise ValueError("GITHUB_EVENT_PATH is required")
+
+    payload = json.loads(Path(event_path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("GitHub event payload must be an object")
+    return event_name, payload
+
+
+def main() -> int:
+    """Write a complete GitHub Actions output record, or fail without stdout."""
+
+    try:
+        event_name, payload = _load_event()
+        policy, base_revision = resolve_ci_profile(event_name, payload)
+        output_lines = (
+            "os-matrix=" + json.dumps(list(policy.os_runners), separators=(",", ":")),
+            f"test-filter-mode={policy.filter_mode}",
+            f"test-base-revision={base_revision}",
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        print(f"ci_target_policy: {exc}", file=sys.stderr)
+        return 2
+
+    sys.stdout.write("\n".join(output_lines) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/autoskillit/hooks/_capture/_authority.py
+++ b/src/autoskillit/hooks/_capture/_authority.py
@@ -22,17 +22,22 @@ if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
 if TYPE_CHECKING:
-    from autoskillit.hooks._capture_lifecycle import CaptureLifecycleStore
+    from autoskillit.hooks._capture_lifecycle import (
+        CaptureLifecycleError,
+        CaptureLifecycleStore,
+    )
 else:
     _capture_lifecycle = importlib.import_module(
         f"{__package__.rpartition('.')[0]}._capture_lifecycle"
         if __package__.startswith("autoskillit.")
         else "_capture_lifecycle"
     )
+    CaptureLifecycleError = _capture_lifecycle.CaptureLifecycleError
     CaptureLifecycleStore = _capture_lifecycle.CaptureLifecycleStore
 
 __all__ = [
     "CAPTURE_PATH_COMPONENTS",
+    "CaptureLifecycleError",
     "CaptureRoot",
     "CaptureSetupError",
     "CaptureStoreAbsentError",

--- a/src/autoskillit/hooks/capture_lifecycle_hook.py
+++ b/src/autoskillit/hooks/capture_lifecycle_hook.py
@@ -13,12 +13,10 @@ if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
 from _capture._authority import (  # type: ignore[import-not-found]  # noqa: E402
+    CaptureLifecycleError,
     CaptureSetupError,
     CaptureStoreAbsentError,
     open_capture_lifecycle,
-)
-from _capture_lifecycle import (  # type: ignore[import-not-found]  # noqa: E402
-    CaptureLifecycleError,
 )
 
 _MAX_INPUT_BYTES = 64 * 1024

--- a/tests/hooks/test_capture_lifecycle_hook.py
+++ b/tests/hooks/test_capture_lifecycle_hook.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import io
 import json
 import os
@@ -36,16 +37,20 @@ _CAPTURE_ID = "0123456789abcdef"
 
 def test_cleanup_hook_imports_minimal_shared_authority() -> None:
     source = SCRIPT.read_text(encoding="utf-8")
-    assert "from _capture._authority import" in source
-    assert "from _capture_artifacts import" not in source
-    assert "from _capture_lifecycle import" not in source
-    for lifecycle_name in (
+    tree = ast.parse(source)
+    imports = [
+        node for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) and node.level == 0
+    ]
+    authority_imports = [node for node in imports if node.module == "_capture._authority"]
+
+    assert len(authority_imports) == 1
+    assert {alias.name for alias in authority_imports[0].names} == {
         "CaptureLifecycleError",
         "CaptureSetupError",
         "CaptureStoreAbsentError",
         "open_capture_lifecycle",
-    ):
-        assert lifecycle_name in source
+    }
+    assert all(node.module not in {"_capture_artifacts", "_capture_lifecycle"} for node in imports)
 
 
 def test_package_authority_uses_package_lifecycle_identity() -> None:

--- a/tests/hooks/test_capture_lifecycle_hook.py
+++ b/tests/hooks/test_capture_lifecycle_hook.py
@@ -22,7 +22,11 @@ from autoskillit.hooks._capture._authority import (
     open_project_anchor,
 )
 from autoskillit.hooks._capture_artifacts import create_capture_artifact
-from autoskillit.hooks._capture_lifecycle import LEDGER_NAME, CaptureLifecycleStore
+from autoskillit.hooks._capture_lifecycle import (
+    LEDGER_NAME,
+    CaptureLifecycleError,
+    CaptureLifecycleStore,
+)
 
 pytestmark = [pytest.mark.layer("hooks"), pytest.mark.medium]
 
@@ -34,10 +38,43 @@ def test_cleanup_hook_imports_minimal_shared_authority() -> None:
     source = SCRIPT.read_text(encoding="utf-8")
     assert "from _capture._authority import" in source
     assert "from _capture_artifacts import" not in source
+    assert "from _capture_lifecycle import" not in source
+    for lifecycle_name in (
+        "CaptureLifecycleError",
+        "CaptureSetupError",
+        "CaptureStoreAbsentError",
+        "open_capture_lifecycle",
+    ):
+        assert lifecycle_name in source
 
 
 def test_package_authority_uses_package_lifecycle_identity() -> None:
     assert _authority.CaptureLifecycleStore is CaptureLifecycleStore
+    assert _authority.CaptureLifecycleError is CaptureLifecycleError
+    assert "CaptureLifecycleError" in _authority.__all__
+
+
+def test_standalone_authority_uses_standalone_lifecycle_identity() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from _capture import _authority\n"
+                "import _capture_lifecycle\n"
+                "assert _authority.CaptureLifecycleError "
+                "is _capture_lifecycle.CaptureLifecycleError\n"
+                "assert 'CaptureLifecycleError' in _authority.__all__\n"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=SCRIPT.parent,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == ""
 
 
 def _run_hook(

--- a/tests/infra/test_ci_dev_config.py
+++ b/tests/infra/test_ci_dev_config.py
@@ -248,51 +248,6 @@ class TestCIWorkflow:
         pr_branches = triggers["pull_request"]["branches"]
         assert "develop" in pr_branches, "CI must trigger on PRs targeting develop branch"
 
-    def test_ci_preflight_outputs_os_matrix(self) -> None:
-        """preflight must export every value selected by the CI policy authority."""
-        workflow = load_yaml(CI_WORKFLOW)
-        outputs = workflow["jobs"]["preflight"].get("outputs", {})
-        assert set(outputs) == {
-            "os-matrix",
-            "test-filter-mode",
-            "test-base-revision",
-        }
-
-    def test_ci_test_matrix_uses_preflight_os_matrix(self) -> None:
-        """test job matrix must consume the os-matrix from preflight, not a hardcoded list."""
-        workflow = load_yaml(CI_WORKFLOW)
-        matrix = workflow["jobs"]["test"]["strategy"]["matrix"]
-        os_value = matrix["os"]
-        assert "fromJSON" in os_value or "needs.preflight" in str(os_value), (
-            "test job os matrix must be dynamic (fromJSON of preflight output), "
-            "not a hardcoded list — hardcoded list cannot vary by PR target"
-        )
-
-    def test_ci_preflight_delegates_to_target_policy_resolver(self) -> None:
-        """preflight must call the checked-in CI policy authority exactly once."""
-        workflow = load_yaml(CI_WORKFLOW)
-        steps = workflow["jobs"]["preflight"]["steps"]
-        policy_steps = [step for step in steps if step.get("id") == "ci-policy"]
-        assert len(policy_steps) == 1
-        assert policy_steps[0].get("run") == (
-            'python3 scripts/ci_target_policy.py >> "$GITHUB_OUTPUT"'
-        )
-
-    def test_ci_test_step_consumes_target_policy_filter_outputs(self) -> None:
-        """Run tests must consume filter mode and immutable base from preflight."""
-        workflow = load_yaml(CI_WORKFLOW)
-        run_step = next(
-            step for step in workflow["jobs"]["test"]["steps"] if step.get("name") == "Run tests"
-        )
-        assert run_step["env"]["AUTOSKILLIT_TEST_FILTER"] == (
-            "${{ needs.preflight.outputs.test-filter-mode }}"
-        )
-        assert run_step["env"]["AUTOSKILLIT_TEST_BASE_REF"] == (
-            "${{ needs.preflight.outputs.test-base-revision }}"
-        )
-        assert "github.event" not in run_step["run"]
-        assert "develop" not in run_step["run"]
-
     def test_ci_push_trigger_includes_stable(self) -> None:
         """CI must trigger on push to stable branch.
 

--- a/tests/infra/test_ci_dev_config.py
+++ b/tests/infra/test_ci_dev_config.py
@@ -249,13 +249,14 @@ class TestCIWorkflow:
         assert "develop" in pr_branches, "CI must trigger on PRs targeting develop branch"
 
     def test_ci_preflight_outputs_os_matrix(self) -> None:
-        """preflight job must export an os-matrix output computed from base_ref."""
+        """preflight must export every value selected by the CI policy authority."""
         workflow = load_yaml(CI_WORKFLOW)
         outputs = workflow["jobs"]["preflight"].get("outputs", {})
-        assert "os-matrix" in outputs, (
-            "preflight must export os-matrix so the test job can vary runners "
-            "based on PR target branch"
-        )
+        assert set(outputs) == {
+            "os-matrix",
+            "test-filter-mode",
+            "test-base-revision",
+        }
 
     def test_ci_test_matrix_uses_preflight_os_matrix(self) -> None:
         """test job matrix must consume the os-matrix from preflight, not a hardcoded list."""
@@ -267,36 +268,30 @@ class TestCIWorkflow:
             "not a hardcoded list — hardcoded list cannot vary by PR target"
         )
 
-    def test_ci_preflight_computes_matrix_from_branch_context(self) -> None:
-        """preflight must contain a step that computes os matrix based on branch context.
-
-        Uses github.base_ref for pull_request events and github.ref for push events,
-        since github.base_ref is empty on direct push events.
-        """
+    def test_ci_preflight_delegates_to_target_policy_resolver(self) -> None:
+        """preflight must call the checked-in CI policy authority exactly once."""
         workflow = load_yaml(CI_WORKFLOW)
         steps = workflow["jobs"]["preflight"]["steps"]
-        matrix_steps = [
-            s
-            for s in steps
-            if any(kw in str(s.get("run", "")) for kw in ("base_ref", "github.ref"))
-            and "stable" in str(s.get("run", ""))
-        ]
-        assert matrix_steps, (
-            "preflight must have a step that branches on github.base_ref (for PRs) "
-            "or github.ref (for pushes) to produce the os-matrix output"
+        policy_steps = [step for step in steps if step.get("id") == "ci-policy"]
+        assert len(policy_steps) == 1
+        assert policy_steps[0].get("run") == (
+            'python3 scripts/ci_target_policy.py >> "$GITHUB_OUTPUT"'
         )
 
-    def test_ci_stable_target_produces_dual_os_matrix(self) -> None:
-        """The stable branch must produce a dual-element ubuntu+macos matrix."""
+    def test_ci_test_step_consumes_target_policy_filter_outputs(self) -> None:
+        """Run tests must consume filter mode and immutable base from preflight."""
         workflow = load_yaml(CI_WORKFLOW)
-        steps = workflow["jobs"]["preflight"]["steps"]
-        for step in steps:
-            run = step.get("run", "")
-            if "stable" in run and ("base_ref" in run or "github.ref" in run):
-                assert "macos" in run, "When branch targets stable, matrix must include macOS"
-                break
-        else:
-            pytest.fail("No step computes stable-specific matrix in preflight")
+        run_step = next(
+            step for step in workflow["jobs"]["test"]["steps"] if step.get("name") == "Run tests"
+        )
+        assert run_step["env"]["AUTOSKILLIT_TEST_FILTER"] == (
+            "${{ needs.preflight.outputs.test-filter-mode }}"
+        )
+        assert run_step["env"]["AUTOSKILLIT_TEST_BASE_REF"] == (
+            "${{ needs.preflight.outputs.test-base-revision }}"
+        )
+        assert "github.event" not in run_step["run"]
+        assert "develop" not in run_step["run"]
 
     def test_ci_push_trigger_includes_stable(self) -> None:
         """CI must trigger on push to stable branch.

--- a/tests/infra/test_ci_workflow.py
+++ b/tests/infra/test_ci_workflow.py
@@ -83,6 +83,18 @@ def _run_cli(
     )
 
 
+def _assert_cli_rejection(
+    completed: subprocess.CompletedProcess[str],
+    expected_error: str,
+) -> None:
+    assert completed.returncode == 2
+    assert completed.stdout == ""
+    assert completed.stderr.startswith("ci_target_policy: ")
+    assert expected_error in completed.stderr
+    assert completed.stderr.count("\n") == 1
+    assert "Traceback" not in completed.stderr
+
+
 @pytest.mark.parametrize(
     ("event_name", "target", "expected_runners", "expected_filter", "expected_base"),
     [
@@ -302,25 +314,47 @@ def test_resolver_fails_closed_for_malformed_or_unregistered_context(
 
 
 @pytest.mark.parametrize(
-    ("event_name", "payload", "raw_payload"),
+    ("event_name", "payload", "raw_payload", "expected_error"),
     [
-        ("pull_request", ["not", "an", "object"], None),
-        ("pull_request", None, "{invalid-json"),
-        ("pull_request", {"merge_group": {}}, None),
-        ("workflow_dispatch", _event_payload("pull_request", "develop"), None),
+        (
+            "pull_request",
+            ["not", "an", "object"],
+            None,
+            "GitHub event payload must be an object",
+        ),
+        ("pull_request", None, "{invalid-json", "Expecting property name"),
+        (
+            "pull_request",
+            {"merge_group": {}},
+            None,
+            "pull_request must be an object",
+        ),
+        (
+            "workflow_dispatch",
+            _event_payload("pull_request", "develop"),
+            None,
+            "unsupported event: 'workflow_dispatch'",
+        ),
         (
             "pull_request",
             {"pull_request": {"base": {"ref": "develop", "sha": "bad"}}},
             None,
+            "base SHA must be a 40-character lowercase commit SHA",
         ),
-        ("push", {"ref": "refs/heads/develop"}, None),
+        (
+            "push",
+            {"ref": "refs/heads/develop"},
+            None,
+            "target 'develop' is not allowed for event 'push'",
+        ),
     ],
 )
-def test_cli_failures_are_nonzero_and_silent_on_stdout(
+def test_cli_failures_use_handled_rejection_contract(
     tmp_path: Path,
     event_name: str,
     payload: object | None,
     raw_payload: str | None,
+    expected_error: str,
 ) -> None:
     completed = _run_cli(
         tmp_path,
@@ -329,26 +363,29 @@ def test_cli_failures_are_nonzero_and_silent_on_stdout(
         raw_payload=raw_payload,
     )
 
-    assert completed.returncode != 0
-    assert completed.stdout == ""
+    _assert_cli_rejection(completed, expected_error)
 
 
 @pytest.mark.parametrize(
-    ("event_name", "payload"),
+    ("event_name", "payload", "expected_error"),
     [
-        (None, _event_payload("pull_request", "develop")),
-        ("pull_request", None),
+        (
+            None,
+            _event_payload("pull_request", "develop"),
+            "GITHUB_EVENT_NAME is required",
+        ),
+        ("pull_request", None, "GITHUB_EVENT_PATH is required"),
     ],
 )
 def test_cli_requires_inherited_event_environment(
     tmp_path: Path,
     event_name: str | None,
     payload: object | None,
+    expected_error: str,
 ) -> None:
     completed = _run_cli(tmp_path, event_name=event_name, payload=payload)
 
-    assert completed.returncode != 0
-    assert completed.stdout == ""
+    _assert_cli_rejection(completed, expected_error)
 
 
 def test_cli_delegates_to_resolver_exactly_once(

--- a/tests/infra/test_ci_workflow.py
+++ b/tests/infra/test_ci_workflow.py
@@ -313,6 +313,26 @@ def test_resolver_fails_closed_for_malformed_or_unregistered_context(
         ci_target_policy.resolve_ci_profile(event_name, payload)
 
 
+def test_resolver_rejects_allowed_target_without_registered_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    allowed_targets = {
+        **ci_target_policy.ALLOWED_TARGETS_BY_EVENT,
+        "push": ci_target_policy.ALLOWED_TARGETS_BY_EVENT["push"] | frozenset({"unregistered"}),
+    }
+    monkeypatch.setattr(
+        ci_target_policy,
+        "ALLOWED_TARGETS_BY_EVENT",
+        allowed_targets,
+    )
+
+    with pytest.raises(ValueError, match="has no registered policy"):
+        ci_target_policy.resolve_ci_profile(
+            "push",
+            _event_payload("push", "unregistered"),
+        )
+
+
 @pytest.mark.parametrize(
     ("event_name", "payload", "raw_payload", "expected_error"),
     [

--- a/tests/infra/test_ci_workflow.py
+++ b/tests/infra/test_ci_workflow.py
@@ -1,16 +1,456 @@
-"""CI workflow structural tests."""
+"""Behavioral and structural tests for branch-targeted CI policy."""
 
 from __future__ import annotations
 
+import dataclasses
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Iterator, Mapping
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
+from autoskillit.core.io import load_yaml
+
 pytestmark = [pytest.mark.layer("infra"), pytest.mark.medium]
+
+_BASE_SHA = "0123456789abcdef0123456789abcdef01234567"
+_POLICY_MODULE_NAME = "_autoskillit_ci_target_policy"
 
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
+
+
+def _load_policy_module() -> ModuleType:
+    script = _repo_root() / "scripts" / "ci_target_policy.py"
+    spec = importlib.util.spec_from_file_location(_POLICY_MODULE_NAME, script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_POLICY_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ci_target_policy = _load_policy_module()
+
+
+def _event_payload(event_name: str, target: str) -> dict[str, object]:
+    if event_name == "pull_request":
+        return {"pull_request": {"base": {"ref": target, "sha": _BASE_SHA}}}
+    if event_name == "merge_group":
+        return {
+            "merge_group": {
+                "base_ref": f"refs/heads/{target}",
+                "base_sha": _BASE_SHA,
+            }
+        }
+    if event_name == "push":
+        return {"ref": f"refs/heads/{target}"}
+    raise AssertionError(f"unsupported test event: {event_name}")
+
+
+def _run_cli(
+    tmp_path: Path,
+    *,
+    event_name: str | None,
+    payload: object | None = None,
+    raw_payload: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env.pop("GITHUB_EVENT_NAME", None)
+    env.pop("GITHUB_EVENT_PATH", None)
+    if event_name is not None:
+        env["GITHUB_EVENT_NAME"] = event_name
+    if payload is not None or raw_payload is not None:
+        event_path = tmp_path / "event.json"
+        event_path.write_text(
+            raw_payload if raw_payload is not None else json.dumps(payload),
+            encoding="utf-8",
+        )
+        env["GITHUB_EVENT_PATH"] = str(event_path)
+    return subprocess.run(
+        [sys.executable, str(_repo_root() / "scripts" / "ci_target_policy.py")],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("event_name", "target", "expected_runners", "expected_filter", "expected_base"),
+    [
+        ("pull_request", "develop", ("ubuntu-latest",), "conservative", _BASE_SHA),
+        ("merge_group", "develop", ("ubuntu-latest",), "conservative", _BASE_SHA),
+        ("pull_request", "main", ("ubuntu-latest",), "none", ""),
+        ("merge_group", "main", ("ubuntu-latest",), "none", ""),
+        (
+            "pull_request",
+            "stable",
+            ("ubuntu-latest", "macos-15"),
+            "none",
+            "",
+        ),
+        (
+            "merge_group",
+            "stable",
+            ("ubuntu-latest", "macos-15"),
+            "none",
+            "",
+        ),
+        ("push", "main", ("ubuntu-latest",), "none", ""),
+        ("push", "stable", ("ubuntu-latest", "macos-15"), "none", ""),
+    ],
+)
+def test_resolver_applies_exact_event_target_policy(
+    event_name: str,
+    target: str,
+    expected_runners: tuple[str, ...],
+    expected_filter: str,
+    expected_base: str,
+) -> None:
+    policy, base_revision = ci_target_policy.resolve_ci_profile(
+        event_name,
+        _event_payload(event_name, target),
+    )
+
+    assert policy.os_runners == expected_runners
+    assert policy.filter_mode == expected_filter
+    assert base_revision == expected_base
+
+
+@pytest.mark.parametrize(
+    ("event_name", "target", "expected_lines"),
+    [
+        (
+            "pull_request",
+            "develop",
+            (
+                'os-matrix=["ubuntu-latest"]',
+                "test-filter-mode=conservative",
+                f"test-base-revision={_BASE_SHA}",
+            ),
+        ),
+        (
+            "merge_group",
+            "develop",
+            (
+                'os-matrix=["ubuntu-latest"]',
+                "test-filter-mode=conservative",
+                f"test-base-revision={_BASE_SHA}",
+            ),
+        ),
+        (
+            "pull_request",
+            "main",
+            (
+                'os-matrix=["ubuntu-latest"]',
+                "test-filter-mode=none",
+                "test-base-revision=",
+            ),
+        ),
+        (
+            "merge_group",
+            "main",
+            (
+                'os-matrix=["ubuntu-latest"]',
+                "test-filter-mode=none",
+                "test-base-revision=",
+            ),
+        ),
+        (
+            "pull_request",
+            "stable",
+            (
+                'os-matrix=["ubuntu-latest","macos-15"]',
+                "test-filter-mode=none",
+                "test-base-revision=",
+            ),
+        ),
+        (
+            "merge_group",
+            "stable",
+            (
+                'os-matrix=["ubuntu-latest","macos-15"]',
+                "test-filter-mode=none",
+                "test-base-revision=",
+            ),
+        ),
+        (
+            "push",
+            "main",
+            (
+                'os-matrix=["ubuntu-latest"]',
+                "test-filter-mode=none",
+                "test-base-revision=",
+            ),
+        ),
+        (
+            "push",
+            "stable",
+            (
+                'os-matrix=["ubuntu-latest","macos-15"]',
+                "test-filter-mode=none",
+                "test-base-revision=",
+            ),
+        ),
+    ],
+)
+def test_cli_emits_exact_profile_outputs(
+    tmp_path: Path,
+    event_name: str,
+    target: str,
+    expected_lines: tuple[str, ...],
+) -> None:
+    completed = _run_cli(
+        tmp_path,
+        event_name=event_name,
+        payload=_event_payload(event_name, target),
+    )
+
+    assert completed.returncode == 0
+    assert completed.stdout.splitlines() == list(expected_lines)
+    assert completed.stderr == ""
+
+
+def test_policy_registry_is_exact_and_deeply_immutable() -> None:
+    policy_type = ci_target_policy.CiTargetPolicyDef
+    assert dataclasses.is_dataclass(policy_type)
+    assert policy_type.__dataclass_params__.frozen
+    assert policy_type.__slots__ == ("os_runners", "filter_mode")
+    assert dict(ci_target_policy.ALLOWED_TARGETS_BY_EVENT) == {
+        "pull_request": frozenset({"develop", "main", "stable"}),
+        "merge_group": frozenset({"develop", "main", "stable"}),
+        "push": frozenset({"main", "stable"}),
+    }
+    assert set(ci_target_policy.CI_TARGET_POLICIES) == {"develop", "main", "stable"}
+    assert all(
+        isinstance(policy.os_runners, tuple)
+        for policy in ci_target_policy.CI_TARGET_POLICIES.values()
+    )
+
+    with pytest.raises(TypeError):
+        ci_target_policy.CI_TARGET_POLICIES["develop"] = policy_type((), "none")
+    with pytest.raises(TypeError):
+        ci_target_policy.ALLOWED_TARGETS_BY_EVENT["push"] = frozenset()
+    with pytest.raises(AttributeError):
+        ci_target_policy.ALLOWED_TARGETS_BY_EVENT["push"].add("develop")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        ci_target_policy.CI_TARGET_POLICIES["main"].filter_mode = "conservative"
+
+
+class _AccessRaisingPayload(Mapping[str, object]):
+    def __getitem__(self, key: str) -> object:
+        raise AssertionError(f"payload was read for unsupported event via {key!r}")
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(())
+
+    def __len__(self) -> int:
+        return 0
+
+
+def test_resolver_rejects_unsupported_event_before_payload_access() -> None:
+    with pytest.raises(ValueError, match="unsupported event"):
+        ci_target_policy.resolve_ci_profile("workflow_dispatch", _AccessRaisingPayload())
+
+
+@pytest.mark.parametrize(
+    ("event_name", "payload"),
+    [
+        ("pull_request", {}),
+        ("pull_request", {"pull_request": []}),
+        ("pull_request", {"pull_request": {"base": {"ref": "develop"}}}),
+        (
+            "pull_request",
+            {"pull_request": {"base": {"ref": "develop", "sha": "not-a-sha"}}},
+        ),
+        (
+            "pull_request",
+            {"pull_request": {"base": {"ref": "refs/heads/develop", "sha": _BASE_SHA}}},
+        ),
+        (
+            "merge_group",
+            {"merge_group": {"base_ref": "develop", "base_sha": _BASE_SHA}},
+        ),
+        (
+            "merge_group",
+            {"merge_group": {"base_ref": "refs/tags/develop", "base_sha": _BASE_SHA}},
+        ),
+        (
+            "merge_group",
+            {"merge_group": {"base_ref": "refs/heads/develop"}},
+        ),
+        ("push", {"ref": "main"}),
+        ("push", {"ref": "refs/tags/main"}),
+        ("push", {"ref": "refs/heads/develop"}),
+        ("push", {"ref": "refs/heads/unknown"}),
+    ],
+)
+def test_resolver_fails_closed_for_malformed_or_unregistered_context(
+    event_name: str,
+    payload: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError):
+        ci_target_policy.resolve_ci_profile(event_name, payload)
+
+
+@pytest.mark.parametrize(
+    ("event_name", "payload", "raw_payload"),
+    [
+        ("pull_request", ["not", "an", "object"], None),
+        ("pull_request", None, "{invalid-json"),
+        ("pull_request", {"merge_group": {}}, None),
+        ("workflow_dispatch", _event_payload("pull_request", "develop"), None),
+        (
+            "pull_request",
+            {"pull_request": {"base": {"ref": "develop", "sha": "bad"}}},
+            None,
+        ),
+        ("push", {"ref": "refs/heads/develop"}, None),
+    ],
+)
+def test_cli_failures_are_nonzero_and_silent_on_stdout(
+    tmp_path: Path,
+    event_name: str,
+    payload: object | None,
+    raw_payload: str | None,
+) -> None:
+    completed = _run_cli(
+        tmp_path,
+        event_name=event_name,
+        payload=payload,
+        raw_payload=raw_payload,
+    )
+
+    assert completed.returncode != 0
+    assert completed.stdout == ""
+
+
+@pytest.mark.parametrize(
+    ("event_name", "payload"),
+    [
+        (None, _event_payload("pull_request", "develop")),
+        ("pull_request", None),
+    ],
+)
+def test_cli_requires_inherited_event_environment(
+    tmp_path: Path,
+    event_name: str | None,
+    payload: object | None,
+) -> None:
+    completed = _run_cli(tmp_path, event_name=event_name, payload=payload)
+
+    assert completed.returncode != 0
+    assert completed.stdout == ""
+
+
+def test_cli_delegates_to_resolver_exactly_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    event_path = tmp_path / "event.json"
+    payload = _event_payload("push", "main")
+    event_path.write_text(json.dumps(payload), encoding="utf-8")
+    calls: list[tuple[str, object]] = []
+
+    def resolve_once(event_name: str, received_payload: object):
+        calls.append((event_name, received_payload))
+        return ci_target_policy.CI_TARGET_POLICIES["main"], ""
+
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setattr(ci_target_policy, "resolve_ci_profile", resolve_once)
+
+    assert ci_target_policy.main() == 0
+    assert calls == [("push", payload)]
+    assert capsys.readouterr().out.splitlines() == [
+        'os-matrix=["ubuntu-latest"]',
+        "test-filter-mode=none",
+        "test-base-revision=",
+    ]
+
+
+def test_workflow_consumes_one_target_policy_authority() -> None:
+    workflow_path = _repo_root() / ".github" / "workflows" / "tests.yml"
+    workflow = load_yaml(workflow_path)
+    triggers = workflow.get("on", workflow.get(True))
+    assert triggers["pull_request"]["branches"] == ["main", "develop", "stable"]
+    assert triggers["push"]["branches"] == ["main", "stable"]
+
+    preflight = workflow["jobs"]["preflight"]
+    assert preflight["name"] == "Preflight checks"
+    assert preflight["outputs"] == {
+        "os-matrix": "${{ steps.ci-policy.outputs.os-matrix }}",
+        "test-filter-mode": "${{ steps.ci-policy.outputs.test-filter-mode }}",
+        "test-base-revision": "${{ steps.ci-policy.outputs.test-base-revision }}",
+    }
+    steps = preflight["steps"]
+    checkout_steps = [
+        (index, step)
+        for index, step in enumerate(steps)
+        if str(step.get("uses", "")).startswith("actions/checkout@")
+    ]
+    policy_steps = [
+        (index, step) for index, step in enumerate(steps) if step.get("id") == "ci-policy"
+    ]
+    assert len(checkout_steps) == 1
+    assert len(policy_steps) == 1
+    assert checkout_steps[0][0] == 0
+    assert checkout_steps[0][0] < policy_steps[0][0]
+    assert policy_steps[0][1]["run"] == ('python3 scripts/ci_target_policy.py >> "$GITHUB_OUTPUT"')
+
+    test_job = workflow["jobs"]["test"]
+    assert test_job["name"] == "Test (${{ matrix.shard }}) on ${{ matrix.os }}"
+    assert test_job["strategy"]["matrix"] == {
+        "os": "${{ fromJSON(needs.preflight.outputs.os-matrix) }}",
+        "shard": ["execution", "general"],
+    }
+    test_checkout = next(
+        step
+        for step in test_job["steps"]
+        if str(step.get("uses", "")).startswith("actions/checkout@")
+    )
+    assert test_checkout["with"]["fetch-depth"] == 0
+    run_tests = next(step for step in test_job["steps"] if step.get("name") == "Run tests")
+    assert run_tests["env"]["AUTOSKILLIT_TEST_FILTER"] == (
+        "${{ needs.preflight.outputs.test-filter-mode }}"
+    )
+    assert run_tests["env"]["AUTOSKILLIT_TEST_BASE_REF"] == (
+        "${{ needs.preflight.outputs.test-base-revision }}"
+    )
+    assert "github.event" not in run_tests["run"]
+    assert "develop" not in run_tests["run"]
+
+    workflow_source = workflow_path.read_text(encoding="utf-8")
+    assert "GITHUB_EVENT_NAME:" not in workflow_source
+    assert "GITHUB_EVENT_PATH:" not in workflow_source
+
+
+def test_ci_policy_is_recorded_in_durable_contributor_instructions() -> None:
+    contributing = (_repo_root() / "docs" / "developer" / "contributing.md").read_text(
+        encoding="utf-8"
+    )
+    assert "| `develop` | `ubuntu-latest` | `conservative` |" in contributing
+    assert "| `main` | `ubuntu-latest` | `none` |" in contributing
+    assert "| `stable` | `ubuntu-latest`, `macos-15` | `none` |" in contributing
+    assert "`pull_request` and `merge_group` each allow `develop|main|stable`" in contributing
+    assert "`push` allows only `main|stable`; push-to-develop is rejected" in contributing
+    assert "must not incidentally broaden or narrow CI runners or filtering" in contributing
+    assert "explicit CI-policy task" in contributing
+
+    agent_rules = (_repo_root() / ".github" / "AGENTS.md").read_text(encoding="utf-8")
+    assert "scripts/ci_target_policy.py" in agent_rules
+    assert "docs/developer/contributing.md" in agent_rules
+    assert "tests/infra/test_ci_workflow.py" in agent_rules
+    assert "explicit CI-policy task" in agent_rules
 
 
 def test_ci_workflow_does_not_pre_regenerate_hooks_json() -> None:
@@ -20,8 +460,6 @@ def test_ci_workflow_does_not_pre_regenerate_hooks_json() -> None:
     then the test compared on-disk vs generate_hooks_json() — always passing.
     The new test uses registry.sha256 (committed) which cannot be silenced by pre-regen.
     """
-    from autoskillit.core.io import load_yaml
-
     workflow = load_yaml(_repo_root() / ".github" / "workflows" / "tests.yml")
     step_names = [s.get("name") for job in workflow["jobs"].values() for s in job.get("steps", [])]
     assert not any("Generate hooks.json" in (n or "") for n in step_names), (

--- a/tests/infra/test_manifest_completeness.py
+++ b/tests/infra/test_manifest_completeness.py
@@ -42,7 +42,6 @@ _IGNORE_FILES: frozenset[str] = frozenset(
         "tests/CLAUDE.md",
         "tests/AGENTS.md",
         ".github/CLAUDE.md",
-        ".github/AGENTS.md",
         # Generated/state files in .autoskillit/ that carry no test-routing signal.
         ".autoskillit/.gitignore",
         ".autoskillit/.onboarded",

--- a/tests/infra/test_manifest_directory_completeness.py
+++ b/tests/infra/test_manifest_directory_completeness.py
@@ -26,6 +26,13 @@ _MANIFEST_PATH = _REPO_ROOT / ".autoskillit" / "test-filter-manifest.yaml"
 # Registry: test directory name -> frozenset of manifest patterns that directory's
 # tests consume. Each entry declares a dependency that the manifest must satisfy.
 _SOURCE_DEPENDENCIES: dict[str, frozenset[str]] = {
+    "infra": frozenset(
+        {
+            ".github/AGENTS.md",
+            "docs/developer/contributing.md",
+            "scripts/ci_target_policy.py",
+        }
+    ),
     "workspace": frozenset(
         {
             "src/autoskillit/skills/*/SKILL.md",


### PR DESCRIPTION
## Summary

- Restore branch-targeted CI runner and test-filter policy through one fail-closed event resolver.
- Give develop-targeted pull requests and merge groups the immutable event base SHA for conservative filtering.
- Remove PR #4405's redundant lifecycle-exception import suppression and add behavioral, manifest, and documentation ratchets.

## Target policy

| Target | Runners | Filter |
|---|---|---|
| `develop` | `ubuntu-latest` | `conservative` |
| `main` | `ubuntu-latest` | `none` |
| `stable` | `ubuntu-latest`, `macos-15` | `none` |

## Stacked PR

This correction is based on and targets PR #4405's head branch: `impl-rectify_codex_shell_capture_cleanup_lifecycle_2026-07-27_233858-20260728-080540`.

## Verification

- Focused CI, manifest, hook, and Pyright suppression gate passed.
- `task test-check`: 33,799 passed.
- `pre-commit run --all-files` passed.
- Hook registry hash and `.autoskillit/test-source-map.json` remained unchanged.