### PR TITLE
Implementation Plan: Remove No-Op Guidance Pairs After Catalog Removal (#4441)

### DIFF
--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -116,12 +116,12 @@ src/autoskillit/agents/**:
 .github/AGENTS.md:
   - infra/
 
-CLAUDE.md:
+/CLAUDE.md:
   - infra/
   - contracts/
   - docs/
 
-AGENTS.md:
+/AGENTS.md:
   - infra/
   - contracts/
   - docs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ generic_automation_mcp/
 └── pyproject.toml
 ```
 
-`src/autoskillit/` packages — the table below is an index, not required reading: consult a package's own `AGENTS.md` (package-specific guidance) only for packages you are modifying. Each package has its own `AGENTS.md` plus a thin `CLAUDE.md` shim that imports it (except `recipes/`, `skills/`, and `skills_extended/` — `AGENTS.md` files for these are pending):
+`src/autoskillit/` packages — the table below is an index, not required reading. Packages without a local `AGENTS.md` inherit the nearest ancestor guide; consult package-local guides when present and applicable. Retained non-root guides use thin sibling `CLAUDE.md` shims except the intentionally unpaired `hooks/_capture/AGENTS.md`; root `CLAUDE.md` remains an overlay:
 
 | Package | IL | Purpose |
 |---|---|---|

--- a/src/autoskillit/cli/AGENTS.md
+++ b/src/autoskillit/cli/AGENTS.md
@@ -1,7 +1,7 @@
 # cli/
 
 IL-3 CLI layer — entry points for all user-facing commands.
-Sub-packages: doctor/ (see doctor/AGENTS.md), fleet/ (see fleet/AGENTS.md),
+Sub-packages: doctor/ (see doctor/AGENTS.md), fleet/,
 session/ (see session/AGENTS.md), ui/ (see ui/AGENTS.md), update/ (see update/AGENTS.md).
 
 ## Architecture Notes

--- a/src/autoskillit/cli/fleet/AGENTS.md
+++ b/src/autoskillit/cli/fleet/AGENTS.md
@@ -1,3 +1,0 @@
-# fleet/
-
-Fleet campaign CLI subcommands for multi-issue dispatch orchestration.

--- a/src/autoskillit/cli/fleet/CLAUDE.md
+++ b/src/autoskillit/cli/fleet/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/src/autoskillit/report/AGENTS.md
+++ b/src/autoskillit/report/AGENTS.md
@@ -1,3 +1,0 @@
-# report/
-
-IL-1 subpackage — HTML report renderer for bundle-local-report.

--- a/src/autoskillit/report/CLAUDE.md
+++ b/src/autoskillit/report/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/src/autoskillit/server/recipe_section/AGENTS.md
+++ b/src/autoskillit/server/recipe_section/AGENTS.md
@@ -1,3 +1,0 @@
-# recipe_section/
-
-Supporting internals for deterministic, schema-driven recipe-section delivery.

--- a/src/autoskillit/server/recipe_section/CLAUDE.md
+++ b/src/autoskillit/server/recipe_section/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/src/autoskillit/smoke_utils/AGENTS.md
+++ b/src/autoskillit/smoke_utils/AGENTS.md
@@ -1,3 +1,0 @@
-# smoke_utils/
-
-Utility callables for smoke-test pipeline `run_python` steps (decomposed from monolithic `smoke_utils.py`).

--- a/src/autoskillit/smoke_utils/CLAUDE.md
+++ b/src/autoskillit/smoke_utils/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -182,12 +182,12 @@ to directory-level cascade — no error is raised. Refresh cadence:
 ```
 tests/
 ├── arch/                                # AST enforcement + sub-package layer contracts (see arch/AGENTS.md)
-├── assets/                              # Vendored asset integrity tests (see assets/AGENTS.md)
+├── assets/                              # Vendored asset integrity tests
 ├── cli/                                 # CLI command tests (see cli/AGENTS.md)
-├── config/                              # Config loading tests (see config/AGENTS.md)
+├── config/                              # Config loading tests
 ├── contracts/                           # Protocol satisfaction + package gateway contracts (see contracts/AGENTS.md)
 ├── core/                                # Core layer tests (see core/AGENTS.md)
-├── docs/                                # Documentation integrity tests (see docs/AGENTS.md)
+├── docs/                                # Documentation integrity tests
 ├── execution/                           # Subprocess integration + session tests (see execution/AGENTS.md)
 ├── fleet/                               # Fleet campaign + dispatch tests (see fleet/AGENTS.md)
 ├── hooks/                               # Hook script tests (see hooks/AGENTS.md)
@@ -195,14 +195,14 @@ tests/
 ├── integration/                         # Cross-layer integration tests
 ├── fixtures/
 │   └── context_admission_journals/      # Versioned content-free golden journal vectors
-├── migration/                           # Migration engine and store tests (see migration/AGENTS.md)
-├── pipeline/                            # Audit log, gate, fidelity, and PR-gate tests (see pipeline/AGENTS.md)
+├── migration/                           # Migration engine and store tests
+├── pipeline/                            # Audit log, gate, fidelity, and PR-gate tests
 ├── planner/                             # Planner manifest, validation, and compilation tests (see planner/AGENTS.md)
 ├── recipe/                              # Recipe I/O, validation, schema tests (see recipe/AGENTS.md)
 │   └── fixtures/                        # YAML test data: sample recipes, expected diagram output
 ├── server/                              # Server unit tests — tool handlers (see server/AGENTS.md)
 ├── skills/                              # Skill contract and compliance tests (see skills/AGENTS.md)
-├── skills_extended/                     # Extended skill tests (see skills_extended/AGENTS.md)
+├── skills_extended/                     # Extended skill tests
 └── workspace/                           # Workspace and clone tests (see workspace/AGENTS.md)
 
 temp/                        # Temporary/working files (gitignored)

--- a/tests/arch/test_intake_rule_registry.py
+++ b/tests/arch/test_intake_rule_registry.py
@@ -42,8 +42,8 @@ _PATH_CLASS_PROBE_PATHS: dict[str, tuple[str, ...]] = {
     # agents-md is GENERATED from the live tree, not hand-listed — see below.
 }
 
-# The one per-package AGENTS.md the harness denies, with the reason it is denied.
-# Generated sweep found exactly 1 of 39 AGENTS.md files under src/autoskillit/ blocked.
+# The generated sweep discovers the live root-and-source guide set.
+# Only the listed source guide is blocked, for the reason recorded below.
 KNOWN_BLOCKED_AGENTS_MD: dict[str, str] = {
     "src/autoskillit/agents/AGENTS.md": (
         "Matches recipe_read_guard.py:31 (src/autoskillit/agents/.*\\.md), which exists to "

--- a/tests/assets/AGENTS.md
+++ b/tests/assets/AGENTS.md
@@ -1,3 +1,0 @@
-# assets/
-
-Vendored asset integrity tests.

--- a/tests/assets/CLAUDE.md
+++ b/tests/assets/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/tests/config/AGENTS.md
+++ b/tests/config/AGENTS.md
@@ -1,3 +1,0 @@
-# config/
-
-Configuration loading, defaults, and schema tests.

--- a/tests/config/CLAUDE.md
+++ b/tests/config/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/tests/docs/AGENTS.md
+++ b/tests/docs/AGENTS.md
@@ -1,3 +1,0 @@
-# docs/
-
-Documentation integrity, link validity, and naming convention tests.

--- a/tests/docs/CLAUDE.md
+++ b/tests/docs/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/tests/docs/test_sub_claude_md_completeness.py
+++ b/tests/docs/test_sub_claude_md_completeness.py
@@ -16,7 +16,7 @@ _CAPTURE_GUIDE = "src/autoskillit/hooks/_capture/AGENTS.md"
 _CAPTURE_ADAPTER = "src/autoskillit/hooks/_capture/CLAUDE.md"
 
 
-def _load_tracked_guidance_paths() -> frozenset[str]:
+def _load_tracked_guidance_paths(repo_root: Path = REPO_ROOT) -> frozenset[str]:
     result = subprocess.run(
         [
             "git",
@@ -26,13 +26,15 @@ def _load_tracked_guidance_paths() -> frozenset[str]:
             ":(glob)**/AGENTS.md",
             ":(glob)**/CLAUDE.md",
         ],
-        cwd=REPO_ROOT,
+        cwd=repo_root,
         check=True,
         capture_output=True,
         text=True,
         timeout=10,
     )
-    return frozenset(line for line in result.stdout.splitlines() if line)
+    return frozenset(
+        path for path in result.stdout.splitlines() if path and (repo_root / path).is_file()
+    )
 
 
 TRACKED_GUIDANCE_PATHS = _load_tracked_guidance_paths()
@@ -138,7 +140,33 @@ def _catalog_violations(markdown: str) -> list[str]:
     return violations
 
 
-def test_tracked_guidance_families_and_counts() -> None:
+def test_load_tracked_guidance_paths_excludes_missing_worktree_files(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    subprocess.run(
+        ["git", "init"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    (repo_root / "AGENTS.md").write_text("# Guide\n", encoding="utf-8")
+    (repo_root / "CLAUDE.md").write_text("@AGENTS.md\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "AGENTS.md", "CLAUDE.md"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    (repo_root / "CLAUDE.md").unlink()
+
+    assert _load_tracked_guidance_paths(repo_root) == frozenset({"AGENTS.md"})
+
+
+def test_tracked_guidance_families_partition_all_paths() -> None:
     families = (
         ROOT_GUIDANCE_PATHS,
         GITHUB_GUIDANCE_PATHS,
@@ -147,20 +175,6 @@ def test_tracked_guidance_families_and_counts() -> None:
     )
     assert frozenset().union(*families) == TRACKED_GUIDANCE_PATHS
     assert sum(len(family) for family in families) == len(TRACKED_GUIDANCE_PATHS)
-    # Intentional ratchets: guidance additions and removals require an explicit inventory update.
-    assert tuple(len(family) for family in families) == (2, 2, 81, 40)
-    assert len(ALL_GUIDES) == 63
-    assert len(ALL_ADAPTERS) == 62
-
-
-def test_source_python_packages_have_guides() -> None:
-    package_dirs = sorted(init_file.parent for init_file in SRC_ROOT.rglob("__init__.py"))
-    missing = [
-        str(package_dir.relative_to(REPO_ROOT))
-        for package_dir in package_dirs
-        if not (package_dir / "AGENTS.md").is_file()
-    ]
-    assert not missing, f"Python packages missing AGENTS.md guidance: {missing}"
 
 
 def test_guide_adapter_sibling_contract() -> None:

--- a/tests/docs/test_tests_sub_claude_md_completeness.py
+++ b/tests/docs/test_tests_sub_claude_md_completeness.py
@@ -1,4 +1,4 @@
-"""Structural tests for per-subfolder CLAUDE.md documentation files under tests/."""
+"""Structural tests for AGENTS.md documentation files under tests/."""
 
 import re
 from pathlib import Path
@@ -9,53 +9,28 @@ pytestmark = pytest.mark.small
 
 TESTS_ROOT = Path(__file__).resolve().parents[1]
 
-EXPECTED_SUB_CLAUDE_MDS = [
-    "arch/AGENTS.md",
-    "assets/AGENTS.md",
-    "cli/AGENTS.md",
-    "config/AGENTS.md",
-    "contracts/AGENTS.md",
-    "core/AGENTS.md",
-    "docs/AGENTS.md",
-    "execution/AGENTS.md",
-    "fleet/AGENTS.md",
-    "hooks/AGENTS.md",
-    "infra/AGENTS.md",
-    "migration/AGENTS.md",
-    "pipeline/AGENTS.md",
-    "planner/AGENTS.md",
-    "recipe/AGENTS.md",
-    "server/AGENTS.md",
-    "skills/AGENTS.md",
-    "skills_extended/AGENTS.md",
-    "workspace/AGENTS.md",
-]
+_DIRECT_CHILD_GUIDE_REFERENCE_RE = re.compile(
+    r"\bsee (?P<reference>[A-Za-z0-9_-]+/AGENTS\.md)(?![\w./-])"
+)
 
 
-def test_expected_sub_guidance_paths_match_tree():
-    actual = {path.relative_to(TESTS_ROOT).as_posix() for path in TESTS_ROOT.glob("*/AGENTS.md")}
-    assert set(EXPECTED_SUB_CLAUDE_MDS) == actual
-
-
-def test_all_tests_sub_claude_md_files_exist():
-    """Every test subdirectory has a CLAUDE.md file."""
-    missing = [p for p in EXPECTED_SUB_CLAUDE_MDS if not (TESTS_ROOT / p).is_file()]
-    assert not missing, f"Missing tests/ sub-CLAUDE.md files: {missing}"
-
-
-def test_top_level_tests_claude_md_references_all_subdirs():
-    """The top-level tests/AGENTS.md references each subdirectory's AGENTS.md."""
+def test_top_level_tests_agents_md_references_existing_guidance_files():
+    """Every direct-child guidance reference in tests/AGENTS.md resolves."""
     top_agents_md = TESTS_ROOT / "AGENTS.md"
     if not top_agents_md.is_file():
         pytest.fail("tests/AGENTS.md does not exist")
-    content = top_agents_md.read_text()
-    failures = []
-    for rel_path in EXPECTED_SUB_CLAUDE_MDS:
-        subdir = rel_path.split("/")[0]
-        marker = f"see {subdir}/AGENTS.md"
-        if marker not in content:
-            failures.append(f"tests/AGENTS.md missing reference: '{marker}'")
-    assert not failures, "Top-level tree missing sub-AGENTS.md references:\n" + "\n".join(failures)
+    content = top_agents_md.read_text(encoding="utf-8")
+    references = sorted(
+        {match.group("reference") for match in _DIRECT_CHILD_GUIDE_REFERENCE_RE.finditer(content)}
+    )
+    assert references, "tests/AGENTS.md contains no direct-child guidance references"
+
+    missing = sorted(
+        (TESTS_ROOT / reference).relative_to(TESTS_ROOT.parent).as_posix()
+        for reference in references
+        if not (TESTS_ROOT / reference).is_file()
+    )
+    assert not missing, f"tests/AGENTS.md references missing guidance files: {missing}"
 
 
 def test_top_level_tests_claude_md_no_per_file_subdir_listings():

--- a/tests/migration/AGENTS.md
+++ b/tests/migration/AGENTS.md
@@ -1,3 +1,0 @@
-# migration/
-
-Migration engine, store, and loader tests.

--- a/tests/migration/CLAUDE.md
+++ b/tests/migration/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/tests/pipeline/AGENTS.md
+++ b/tests/pipeline/AGENTS.md
@@ -1,3 +1,0 @@
-# pipeline/
-
-Audit log, gate state, token tracking, and PR-gate tests.

--- a/tests/pipeline/CLAUDE.md
+++ b/tests/pipeline/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/tests/skills_extended/AGENTS.md
+++ b/tests/skills_extended/AGENTS.md
@@ -1,3 +1,0 @@
-# skills_extended/
-
-Extended (Tier 2/3) skill tests.

--- a/tests/skills_extended/CLAUDE.md
+++ b/tests/skills_extended/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -864,15 +864,22 @@ class TestApplyManifest:
         result = apply_manifest({"docs/developer/SETUP.md"}, manifest)
         assert result == {"docs"}
 
-    def test_apply_manifest_tests_claude_md_empty_cascade(self) -> None:
-        manifest = {"tests/**/CLAUDE.md": []}
-        result = apply_manifest({"tests/core/CLAUDE.md"}, manifest)
-        assert result == set()
-
-    def test_apply_manifest_tests_nested_claude_md(self) -> None:
-        manifest = {"tests/**/CLAUDE.md": []}
-        result = apply_manifest({"tests/execution/CLAUDE.md"}, manifest)
-        assert result == set()
+    def test_production_manifest_guidance_routes_are_root_scoped(self) -> None:
+        manifest = manifest_load_manifest(MANIFEST_PATH)
+        nested_paths = tuple(
+            f"{root}/{name}"
+            for root in ("src/autoskillit/core", "tests/core")
+            for name in ("AGENTS.md", "CLAUDE.md")
+        )
+        cases = {
+            ("AGENTS.md", "CLAUDE.md"): {"infra/", "contracts/", "docs/"},
+            (".github/AGENTS.md",): {"infra/"},
+            nested_paths: set(),
+        }
+        for paths, expected in cases.items():
+            for path in paths:
+                assert apply_manifest({path}, manifest) == expected
+                assert manifest_apply_manifest([path], manifest) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -881,12 +888,7 @@ class TestApplyManifest:
 
 
 class TestApplyManifestEquivalence:
-    """Cross-validates conftest apply_manifest against production manifest_apply_manifest.
-
-    Both modules must agree on matched outputs. When a file matches patterns in one,
-    it must match the same patterns in the other. The two implementations are allowed
-    to differ only in how they handle the unmatched case (both must return None there too).
-    """
+    """Cross-validates the test and production manifest implementations."""
 
     MANIFEST = {
         "src/autoskillit/recipes/*.yaml": ["recipe", "contracts"],


### PR DESCRIPTION
## Summary

Delete exactly the ten named no-op `AGENTS.md`/`CLAUDE.md` pairs after first replacing
the repository's fixed guidance counts and blanket directory-coverage requirements with
dynamic validation of guidance that is both tracked and present. Source packages and test
directories may inherit parent guidance when they have no non-inferable local rule, while
every retained guide must still participate in the existing sibling/thin-shim contract
except for the explicit `_capture` exception.

Closes #4441

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/make-plan/remove_noop_guidance_pairs_plan_2026-07-30_214905.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
