### PR TITLE
[FIX] Pin Claude Sonnet Alias to Sonnet 5

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,7 @@ test_check:
   command: ["task", "test-check"]
 
 model:
-  default: "claude-sonnet-4-6"
+  default: "claude-sonnet-5"
 
 worktree_setup:
   command: ["task", "install-worktree"]
@@ -70,7 +70,7 @@ AutoSkillit uses [dynaconf](https://www.dynaconf.com/) for configuration. Enviro
 
 ```bash
 AUTOSKILLIT_TEST_CHECK__TIMEOUT=300           # sets test_check.timeout to 300
-AUTOSKILLIT_MODEL__DEFAULT=claude-sonnet-4-6  # sets model.default
+AUTOSKILLIT_MODEL__DEFAULT=claude-sonnet-5    # sets model.default
 AUTOSKILLIT_QUOTA_GUARD__ENABLED=false        # disables quota guard
 ```
 
@@ -375,7 +375,7 @@ test_check:
   command: ["pytest", "-v", "--tb=short"]
 
 model:
-  default: "claude-sonnet-4-6"
+  default: "claude-sonnet-5"
 
 worktree_setup:
   command: ["task", "install-worktree"]

--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -227,7 +227,7 @@ ALL_PROJECT_LOCAL_SKILL_SEARCH_DIRS: tuple[str, ...] = (
 _CONTEXT_WINDOW_SUFFIX_RE: _re.Pattern[str] = _re.compile(r"\[\d+[mk]?\]$", _re.IGNORECASE)
 
 CLAUDE_MODEL_ALIASES: dict[str, str] = {
-    "sonnet": "sonnet",
+    "sonnet": "claude-sonnet-5",
     "opus": "opus",
     "haiku": "haiku",
 }

--- a/tests/arch/test_no_hardcoded_model_ids_in_translation_tests.py
+++ b/tests/arch/test_no_hardcoded_model_ids_in_translation_tests.py
@@ -1,7 +1,7 @@
 """Architectural guard: translation tests must not hardcode alias-resolved model IDs.
 
-Tests must assert against CODEX_MODEL_ALIASES[key] rather than literal alias output
-strings. This prevents co-authoring of wrong values: if the alias dict is wrong,
+Tests must assert against the backend alias registries rather than literal alias output
+strings. This prevents co-authoring of wrong values: if an alias dict is wrong,
 tests that hardcode the same wrong value pass silently.
 
 Passthrough tests (e.g., translate_model("o3") == "o3") are NOT flagged because
@@ -23,9 +23,12 @@ def _get_test_model_translation_path() -> Path:
 
 
 def _get_alias_values() -> frozenset[str]:
-    from autoskillit.core.types._type_backend import CODEX_MODEL_ALIASES
+    from autoskillit.core.types._type_backend import CLAUDE_MODEL_ALIASES, CODEX_MODEL_ALIASES
 
-    return frozenset(CODEX_MODEL_ALIASES.values())
+    registries = (CLAUDE_MODEL_ALIASES, CODEX_MODEL_ALIASES)
+    return frozenset(
+        value for aliases in registries for key, value in aliases.items() if value != key
+    )
 
 
 def _collect_rhs_string_literals_in_assert_eq(tree: ast.AST) -> list[str]:
@@ -68,6 +71,6 @@ def test_no_hardcoded_model_ids_in_translation_tests() -> None:
     assert not violations, (
         f"test_model_translation.py hardcodes alias-resolved model ID(s) in assert "
         f"comparisons: {violations!r}. "
-        "Use CODEX_MODEL_ALIASES[key] instead of literal strings so tests track the "
-        "source dict rather than cementing stale values."
+        "Use the backend alias registry instead of literal strings so tests track the "
+        "source mapping rather than cementing stale values."
     )

--- a/tests/execution/backends/test_model_translation.py
+++ b/tests/execution/backends/test_model_translation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.core import SkillSessionConfig
-from autoskillit.core.types._type_backend import CODEX_MODEL_ALIASES
+from autoskillit.core.types._type_backend import CLAUDE_MODEL_ALIASES, CODEX_MODEL_ALIASES
 from autoskillit.execution.backends.claude import ClaudeCodeBackend
 from autoskillit.execution.backends.codex import CodexBackend
 from tests.execution.backends._plugin_binding import plugin_binding
@@ -36,8 +36,8 @@ class TestCodexTranslateModel:
 
 
 class TestClaudeTranslateModel:
-    def test_identity(self) -> None:
-        assert ClaudeCodeBackend().translate_model("sonnet") == "sonnet"
+    def test_sonnet_alias(self) -> None:
+        assert ClaudeCodeBackend().translate_model("sonnet") == CLAUDE_MODEL_ALIASES["sonnet"]
 
     def test_preserves_context_suffix(self) -> None:
         assert ClaudeCodeBackend().translate_model("opus[1m]") == "opus[1m]"
@@ -90,13 +90,13 @@ class TestClaudeBuildCmdTranslatesModel:
     def test_build_interactive_cmd_preserves_suffix(self) -> None:
         spec = ClaudeCodeBackend().build_interactive_cmd(model="sonnet[1m]")
         model_idx = list(spec.cmd).index("--model")
-        assert spec.cmd[model_idx + 1] == "sonnet[1m]"
+        assert spec.cmd[model_idx + 1] == f"{CLAUDE_MODEL_ALIASES['sonnet']}[1m]"
 
     def test_build_skill_session_cmd_preserves_suffix(self) -> None:
         config = SkillSessionConfig(model="sonnet[1m]", completion_marker="%%DONE%%")
         spec = ClaudeCodeBackend().build_skill_session_cmd("/test", "/repo", config)
         model_idx = list(spec.cmd).index("--model")
-        assert spec.cmd[model_idx + 1] == "sonnet[1m]"
+        assert spec.cmd[model_idx + 1] == f"{CLAUDE_MODEL_ALIASES['sonnet']}[1m]"
 
     def test_build_food_truck_cmd_preserves_suffix(self) -> None:
         from pathlib import Path

--- a/tests/execution/test_model_alias_registry.py
+++ b/tests/execution/test_model_alias_registry.py
@@ -6,7 +6,7 @@ import pytest
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
-VALID_CLAUDE_MODEL_IDS: frozenset[str] = frozenset({"sonnet", "opus", "haiku"})
+VALID_CLAUDE_MODEL_IDS: frozenset[str] = frozenset({"claude-sonnet-5", "opus", "haiku"})
 
 
 def test_anomaly_detection_aliases_keys_match_shared() -> None:
@@ -58,6 +58,12 @@ def test_claude_alias_values_in_allowlist() -> None:
             f"CLAUDE_MODEL_ALIASES[{key!r}] = {value!r} is not in VALID_CLAUDE_MODEL_IDS. "
             "Update VALID_CLAUDE_MODEL_IDS if the intended target model changed."
         )
+
+
+def test_claude_sonnet_alias_uses_sonnet_5() -> None:
+    from autoskillit.core.types._type_backend import CLAUDE_MODEL_ALIASES
+
+    assert CLAUDE_MODEL_ALIASES["sonnet"] == "claude-sonnet-5"
 
 
 def test_codex_alias_values_differ_from_keys() -> None:

--- a/tests/server/test_tools_execution_command.py
+++ b/tests/server/test_tools_execution_command.py
@@ -13,6 +13,7 @@ from autoskillit.config import (
     RunSkillConfig,
 )
 from autoskillit.core.claude_conventions import ClaudeDirectoryConventions
+from autoskillit.core.types._type_backend import CLAUDE_MODEL_ALIASES
 from autoskillit.execution.commands import _inject_completion_directive
 from autoskillit.server.tools.tools_execution import run_skill
 from tests.conftest import _make_result
@@ -239,7 +240,7 @@ class TestRunSkillModel:
         await run_skill("/investigate error", "/tmp", model="sonnet")
         cmd = tool_ctx_kitchen_open.runner.call_args_list[-1][0]
         assert "--model" in cmd
-        assert cmd[cmd.index("--model") + 1] == "sonnet"
+        assert cmd[cmd.index("--model") + 1] == CLAUDE_MODEL_ALIASES["sonnet"]
 
     # MOD_S3
     @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Pin AutoSkillit's Claude `sonnet` alias to the canonical `claude-sonnet-5` model ID while leaving Opus, `opus[1m]`, runtime defaults, and Codex mappings unchanged. Update the direct regression tests, command-path assertion, architectural stale-ID guard, and configuration examples.

## Testing

- `pre-commit run --all-files` — passed
- Directly affected `task test-check` selection — 63 passed
- Full `task test-check` — 35,633 passed; 48 unrelated `tests/hooks/` shell-capture tests failed because the host session rejected the capture path for unsafe ownership/mode

## Implementation Plan

Plan file: `/home/talon/projects/worktrees/hotfix-sonnet-5/.autoskillit/temp/prepare-pr/sonnet5-hotfix-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
