### PR TITLE
Implementation Plan: Fix Codex persistent_root scope mismatch (#4391)

### DIFF
--- a/src/autoskillit/cli/doctor/_doctor_config.py
+++ b/src/autoskillit/cli/doctor/_doctor_config.py
@@ -201,14 +201,21 @@ def _check_standing_backend_pins_feasibility(
     Re-reads each config.yaml layer individually (mirrors
     ``_check_config_layers_for_secrets``) and resolves every ``recipe_overrides``
     and ``step_overrides`` pin against the step's versioned semantic plan.
+
+    Also checks the persistent-session-root axis (#4391): a pin to a backend
+    whose `capabilities.session_dir_persistent` is True but whose generated-home
+    root convention cannot be derived is reported as an ERROR naming the dotted
+    config key — this runs for both recipe and global `step_overrides` pins,
+    before the recipe-specific semantic-adaptation check below.
     """
     from autoskillit.core import (
         YAMLError,
         load_yaml,
+        resolve_temp_dir,
     )
     from autoskillit.execution import get_backend
     from autoskillit.recipe import find_recipe_by_name, load_recipe
-    from autoskillit.workspace import DefaultSkillResolver
+    from autoskillit.workspace import DefaultSkillResolver, resolve_persistent_session_root
 
     root = project_dir or Path.cwd()
     config_paths = [
@@ -255,6 +262,29 @@ def _check_standing_backend_pins_feasibility(
                     )
                 )
                 continue
+
+            if backend.capabilities.session_dir_persistent:
+                workspace_cfg = data.get("workspace")
+                temp_override = (
+                    workspace_cfg.get("temp_dir") if isinstance(workspace_cfg, dict) else None
+                )
+                base_root = resolve_temp_dir(
+                    root, temp_override if isinstance(temp_override, str) else None
+                )
+                try:
+                    resolve_persistent_session_root(base_root, backend)
+                except RuntimeError as exc:
+                    results.append(
+                        DoctorResult(
+                            Severity.ERROR,
+                            "standing_backend_pins_feasibility",
+                            f"{config_path}: {dotted_key} pins persistent backend "
+                            f"{backend_name!r}, but no persistent session root can be "
+                            f"derived: {exc}. Remove or change this pin, or fix the "
+                            "backend's generated-home convention.",
+                        )
+                    )
+                    continue
 
             if not is_recipe_pin:
                 # Global step_overrides pins are not tied to a single recipe's step

--- a/src/autoskillit/cli/fleet/__init__.py
+++ b/src/autoskillit/cli/fleet/__init__.py
@@ -308,11 +308,7 @@ def fleet_status(
             sys.exit(_watch_loop(state_path))
         _render_status_display(state)
         if cleanup:
-            from autoskillit.core import (
-                resolve_temp_dir,
-                run_git,
-                sweep_stale_markers,
-            )
+            from autoskillit.core import resolve_temp_dir, run_git, sweep_stale_markers
             from autoskillit.execution import all_backends, delete_skill_session_contracts
             from autoskillit.workspace import (
                 DefaultSessionSkillManager,

--- a/src/autoskillit/cli/fleet/__init__.py
+++ b/src/autoskillit/cli/fleet/__init__.py
@@ -309,17 +309,17 @@ def fleet_status(
         _render_status_display(state)
         if cleanup:
             from autoskillit.core import (
-                CODEX_SESSIONS_SUBDIR,
                 resolve_temp_dir,
                 run_git,
                 sweep_stale_markers,
             )
-            from autoskillit.execution import delete_skill_session_contracts
+            from autoskillit.execution import all_backends, delete_skill_session_contracts
             from autoskillit.workspace import (
                 DefaultSessionSkillManager,
                 SkillsDirectoryProvider,
                 batch_delete,
                 resolve_ephemeral_root,
+                resolve_persistent_session_roots,
             )
 
             batch_delete("", _remove_clone_fn, owner=campaign_id)
@@ -333,7 +333,9 @@ def fleet_status(
                 skill_mgr = DefaultSessionSkillManager(
                     provider=SkillsDirectoryProvider(),
                     ephemeral_root=resolve_ephemeral_root(),
-                    persistent_root=resolve_temp_dir(_project_root) / CODEX_SESSIONS_SUBDIR,
+                    persistent_roots=resolve_persistent_session_roots(
+                        resolve_temp_dir(_project_root), all_backends()
+                    ),
                 )
                 for d in state.dispatches:
                     if d.dispatched_session_id:

--- a/src/autoskillit/cli/session/_session_cook.py
+++ b/src/autoskillit/cli/session/_session_cook.py
@@ -53,13 +53,14 @@ def cook(
 ) -> None:
     """Launch Claude with all bundled AutoSkillit skills as slash commands."""
     from autoskillit.config import iter_display_categories, load_config
+    from autoskillit.execution import all_backends
     from autoskillit.workspace import (
         DefaultSessionSkillManager,
         DefaultSkillResolver,
         SkillsDirectoryProvider,
         compile_session_skill_catalog,
         resolve_ephemeral_root,
-        resolve_persistent_session_root,
+        resolve_persistent_session_roots,
         validate_skill_tier_roles,
         write_skill_unavailability_metadata,
     )
@@ -160,9 +161,10 @@ def cook(
         raise ValueError(f"{CODEX_STARTUP_TRACE_ENV_VAR} must be absent or exactly '1'")
     trace_enabled = trace_setting == "1" and backend.capabilities.cook_startup_observer_capable
 
-    persistent_root = resolve_persistent_session_root(
+    persistent_roots = resolve_persistent_session_roots(
         resolve_temp_dir(project_dir, config.workspace.temp_dir),
-        backend,
+        all_backends(),
+        required_backend_names={backend.name},
     )
     initial_prompt: str | None = None
     first_run = is_first_run(project_dir)
@@ -190,7 +192,7 @@ def cook(
     session_mgr = DefaultSessionSkillManager(
         skills_provider,
         ephemeral_root,
-        persistent_root=persistent_root,
+        persistent_roots=persistent_roots,
     )
     session_mgr.cleanup_stale()
 

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -46,6 +46,7 @@ from autoskillit.execution.backends import (
     _read_codex_config,
     _serialize_toml,
     _write_codex_config,
+    all_backends,
     codex_recipe_delivery_calling_contract,
     ensure_codex_mcp_registered,
     enumerate_fresh_codex_marker_ids,
@@ -328,5 +329,6 @@ __all__ = [
     "is_valid_fidelity_finding",
     "partition_files_by_domain",
     # backends
+    "all_backends",
     "get_backend",
 ]

--- a/src/autoskillit/execution/backends/__init__.py
+++ b/src/autoskillit/execution/backends/__init__.py
@@ -80,8 +80,14 @@ def get_backend(name: str) -> CodingAgentBackend:
     return cls()
 
 
+def all_backends() -> list[CodingAgentBackend]:
+    """Instantiate every registered backend, in registry-name order."""
+    return [get_backend(name) for name in sorted(BACKEND_REGISTRY)]
+
+
 __all__ = [
     "BACKEND_REGISTRY",
+    "all_backends",
     "CODEX_EXEC_FLAGS",
     "CODEX_TOP_LEVEL_ONLY_FLAGS",
     "CompositeSessionLocator",

--- a/src/autoskillit/recipe/_analysis_bfs.py
+++ b/src/autoskillit/recipe/_analysis_bfs.py
@@ -130,6 +130,19 @@ def bfs_reachable_without_barrier(
     return _bfs_capped(graph, {start}, barriers)
 
 
+def bfs_reachable_without_barrier_in_graph(
+    graph: dict[str, set[str]],
+    start: str,
+    barrier: frozenset[str],
+) -> set[str]:
+    """BFS over a caller-supplied adjacency, visiting but not expanding barriers.
+
+    Unlike bfs_reachable_without_barrier, the caller chooses the edge model —
+    pass ctx.step_graph to traverse failure/context-limit/rate-limit edges too.
+    """
+    return _bfs_capped(graph, {start}, set(barrier))
+
+
 def _bfs_capped(
     graph: dict[str, set[str]],
     start_nodes: set[str],

--- a/src/autoskillit/recipe/rules/graph/rules_graph_review.py
+++ b/src/autoskillit/recipe/rules/graph/rules_graph_review.py
@@ -6,7 +6,10 @@ import regex as re
 
 from autoskillit.core import SKILL_TOOLS, Severity, get_logger, resolve_skill_name
 from autoskillit.recipe._analysis import ValidationContext
-from autoskillit.recipe._analysis_bfs import bfs_reachable_without_barrier
+from autoskillit.recipe._analysis_bfs import (
+    bfs_reachable_without_barrier,
+    bfs_reachable_without_barrier_in_graph,
+)
 from autoskillit.recipe.contracts import load_bundled_manifest
 from autoskillit.recipe.registry import RuleFinding, make_finding, semantic_rule
 
@@ -328,3 +331,73 @@ def _check_review_mode_reentry_waypoint(ctx: ValidationContext) -> list[RuleFind
             "review_loop_count on every iteration.",
         )
     ]
+
+
+_REVIEW_FAMILY_SKILLS = frozenset({"review-pr", "resolve-review"})
+_REVIEW_FAILURE_EDGE_FIELDS = (
+    "on_failure",
+    "on_context_limit",
+    "on_rate_limit",
+    "on_exhausted",
+)
+_REVIEW_FAILURE_ADVANCE_GATES = frozenset(
+    {"check_review_loop", "check_repo_ci_event", "derive_batch_ci_event"}
+)
+
+
+def _get_review_family_steps(ctx: ValidationContext) -> list[str]:
+    """Step IDs dispatching review-pr or resolve-review (any step id).
+
+    Module-level so silence tests can assert the rule is triggered on the
+    recipe under test before asserting zero findings.
+    """
+    return [
+        step_id
+        for step_id, step in ctx.recipe.steps.items()
+        if step.tool == "run_skill" and step.skill_name in _REVIEW_FAMILY_SKILLS
+    ]
+
+
+@semantic_rule(
+    name="review-failure-fallthrough-guard",
+    severity=Severity.ERROR,
+    description=(
+        "From a review-family step's failure-shaped edges (on_failure, "
+        "on_context_limit, on_rate_limit, on_exhausted), no CI-advance gate "
+        "(check_review_loop, check_repo_ci_event, derive_batch_ci_event) may be "
+        "reachable without first crossing check_review_posted or re-entering a "
+        "review-family step. A review that never ran must not fall through to "
+        "CI as though it had (#1684 shipped exactly that edge for three months; "
+        "#4448 reversed it with nothing preventing a re-flip)."
+    ),
+)
+def _check_review_failure_fallthrough(ctx: ValidationContext) -> list[RuleFinding]:
+    review_steps = _get_review_family_steps(ctx)
+    if not review_steps:
+        return []
+    barrier = frozenset({"check_review_posted"} | set(review_steps))
+    findings: list[RuleFinding] = []
+    for step_id in review_steps:
+        step = ctx.recipe.steps[step_id]
+        for field in _REVIEW_FAILURE_EDGE_FIELDS:
+            target = getattr(step, field)
+            if not target or target not in ctx.recipe.steps:
+                continue
+            reachable = bfs_reachable_without_barrier_in_graph(ctx.step_graph, target, barrier)
+            for gate in sorted(_REVIEW_FAILURE_ADVANCE_GATES & reachable):
+                findings.append(
+                    make_finding(
+                        rule_name="review-failure-fallthrough-guard",
+                        step_name=step_id,
+                        message=(
+                            f"Step '{step_id}' routes {field} to '{target}', "
+                            f"from which advance gate '{gate}' is reachable "
+                            f"without crossing check_review_posted — a review "
+                            f"that never ran could fall through to CI as an "
+                            f"unreviewed pass. Route failure-shaped edges to a "
+                            f"failure-family terminal "
+                            f"(e.g. release_issue_failure)."
+                        ),
+                    )
+                )
+    return findings

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -59,6 +59,7 @@ from autoskillit.execution import (
     GitHubReviewLedger,
     GitHubReviewMutationCoordinator,
     RecordingSubprocessRunner,
+    all_backends,
     build_replay_runner,
     get_backend,
 )
@@ -96,7 +97,7 @@ from autoskillit.workspace import (
     project_default_plugin_authority,
     project_direct_install_authority,
     resolve_ephemeral_root,
-    resolve_persistent_session_root,
+    resolve_persistent_session_roots,
     validate_skill_tier_roles,
 )
 
@@ -338,11 +339,15 @@ def make_context(
             catalog=session_catalog,
         )
     ephemeral_root = resolve_ephemeral_root()
-    persistent_root = resolve_persistent_session_root(temp_dir, backend)
+    persistent_roots = resolve_persistent_session_roots(
+        temp_dir,
+        all_backends(),
+        required_backend_names={backend.name},
+    )
     session_mgr = DefaultSessionSkillManager(
         provider,
         ephemeral_root,
-        persistent_root=persistent_root,
+        persistent_roots=persistent_roots,
     )
 
     audit = DefaultAuditLog()

--- a/src/autoskillit/server/tools/_preflight.py
+++ b/src/autoskillit/server/tools/_preflight.py
@@ -14,6 +14,7 @@ from autoskillit.core import (
 )
 from autoskillit.hook_registry import HOOK_REGISTRY
 from autoskillit.server._misc import get_backend
+from autoskillit.workspace import resolve_persistent_session_root
 
 if TYPE_CHECKING:
     from autoskillit.config._config_dataclasses import AgentBackendConfig
@@ -64,6 +65,7 @@ def _check_dispatch_feasibility(
     config_backend: AgentBackendConfig | None = None,
     skill_resolver: SkillResolver | None,
     project_root: Path | None = None,
+    temp_dir: Path | None = None,
 ) -> str | None:
     """Fail-closed dispatch-feasibility preflight.
 
@@ -75,6 +77,12 @@ def _check_dispatch_feasibility(
     `skill_resolver` is REQUIRED for explicit-pin hard-capability feasibility
     checks. When omitted, the function fails closed for any pinned step: the
     dispatch is refused as infeasible rather than silently bypassing the gate.
+
+    `temp_dir` is required to verify the persistent session root for an
+    explicitly-pinned step whose backend has
+    `capabilities.session_dir_persistent=True` (#4391). When a persistent pin
+    is found and `temp_dir` is absent, or its root convention cannot be
+    derived, the dispatch fails closed.
     """
     if backend is None:
         return None
@@ -107,6 +115,50 @@ def _check_dispatch_feasibility(
                     _pinned_backend = get_backend(_explicit)
                 except (ValueError, KeyError):
                     continue
+                if _pinned_backend.capabilities.session_dir_persistent:
+                    if temp_dir is None:
+                        return json.dumps(
+                            {
+                                "success": False,
+                                "kitchen": "preflight_failed",
+                                "user_visible_message": (
+                                    f"Cannot verify persistent session root for "
+                                    f"explicitly-pinned step '{step_name}' (backend "
+                                    f"'{_explicit}'): temp_dir is not available."
+                                ),
+                                "error": "persistent_root_unverifiable_for_pinned_step",
+                                "stage": "dispatch_feasibility_preflight",
+                                "step": step_name,
+                                "backend": _explicit,
+                            }
+                        )
+                    try:
+                        resolve_persistent_session_root(temp_dir, _pinned_backend)
+                    except RuntimeError as exc:
+                        return json.dumps(
+                            {
+                                "success": False,
+                                "kitchen": "preflight_failed",
+                                "user_visible_message": (
+                                    f"Cannot dispatch step '{step_name}': explicitly "
+                                    f"pinned to backend '{_explicit}', which requires "
+                                    f"a persistent session root that cannot be "
+                                    f"derived ({exc})."
+                                ),
+                                "error": "persistent_root_unresolvable_for_pinned_step",
+                                "stage": "dispatch_feasibility_preflight",
+                                "backend": _explicit,
+                                "step": step_name,
+                                "origin": _resolution.key_path,
+                                "remedy": (
+                                    f"Remove or change '{_resolution.key_path}' in "
+                                    "~/.autoskillit/config.yaml or "
+                                    "<project>/.autoskillit/config.yaml, or pin a "
+                                    "backend whose persistent generated-home "
+                                    "convention is valid."
+                                ),
+                            }
+                        )
                 if skill_resolver is None:
                     return json.dumps(
                         {

--- a/src/autoskillit/server/tools/tools_fleet_dispatch.py
+++ b/src/autoskillit/server/tools/tools_fleet_dispatch.py
@@ -649,6 +649,7 @@ async def dispatch_food_truck(
                 config_backend=tool_ctx.config.agent_backend,
                 skill_resolver=tool_ctx.skill_resolver,
                 project_root=tool_ctx.project_dir,
+                temp_dir=tool_ctx.temp_dir,
             )
             if _preflight_err is not None:
                 return _preflight_err

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -1463,6 +1463,7 @@ async def open_kitchen(
                         config_backend=tool_ctx.config.agent_backend,
                         skill_resolver=tool_ctx.skill_resolver,
                         project_root=tool_ctx.project_dir,
+                        temp_dir=tool_ctx.temp_dir,
                     )
                     if _preflight_err is not None:
                         transition_abort(tool_ctx, KITCHEN_EFFECT_RECIPE_SERVING)
@@ -1634,6 +1635,7 @@ async def open_kitchen(
                     config_backend=tool_ctx.config.agent_backend,
                     skill_resolver=tool_ctx.skill_resolver,
                     project_root=tool_ctx.project_dir,
+                    temp_dir=tool_ctx.temp_dir,
                 )
                 if _preflight_err is not None:
                     transition_abort(tool_ctx, KITCHEN_EFFECT_RECIPE_SERVING)

--- a/src/autoskillit/workspace/__init__.py
+++ b/src/autoskillit/workspace/__init__.py
@@ -71,6 +71,7 @@ from autoskillit.workspace.session_skills import (
     resolve_closure_write_dirs,
     resolve_ephemeral_root,
     resolve_persistent_session_root,
+    resolve_persistent_session_roots,
     write_skill_unavailability_metadata,
 )
 from autoskillit.workspace.skill_capabilities import (
@@ -200,6 +201,7 @@ __all__ = [
     "remove_clone",
     "resolve_ephemeral_root",
     "resolve_persistent_session_root",
+    "resolve_persistent_session_roots",
     "WORKTREES_DIR",
     "parse_frontmatter_content",
     "prepare_catalog_skill_projection",

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -134,6 +134,7 @@ def resolve_persistent_session_roots(
             logger.warning(
                 "persistent_root_unresolvable_for_backend",
                 backend=backend.name,
+                exc_info=True,
             )
             continue
         if root is not None:

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -968,6 +968,9 @@ class DefaultSessionSkillManager:
                 failures.append(exc)
         return failures
 
+    def _candidate_roots(self) -> tuple[Path, ...]:
+        return (self._root, *self._persistent_roots.values())
+
     def cleanup_session(self, session_id: str) -> bool:
         """Remove the session skill directory for a completed session.
 
@@ -991,7 +994,7 @@ class DefaultSessionSkillManager:
             _raise_failures("Owned session cleanup failed", failures)
             return existed
 
-        for root in (self._root, *self._persistent_roots.values()):
+        for root in self._candidate_roots():
             resolved_root = root.resolve()
             candidate = resolved_root / session_id
             if not os.path.lexists(candidate):
@@ -1025,7 +1028,7 @@ class DefaultSessionSkillManager:
 
     def validate_session_exists(self, session_id: str) -> bool:
         """Return True if session directory exists and is non-empty."""
-        for root in (self._root, *self._persistent_roots.values()):
+        for root in self._candidate_roots():
             candidate = root / session_id
             if candidate.is_dir():
                 try:
@@ -1041,7 +1044,7 @@ class DefaultSessionSkillManager:
         """
         now = time.time()
         removed = 0
-        for root in (self._root, *self._persistent_roots.values()):
+        for root in self._candidate_roots():
             if not root.exists():
                 continue
             resolved_root = root.resolve()

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -12,7 +12,8 @@ import os
 import shutil
 import tempfile
 import time
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Set as AbstractSet
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -108,6 +109,36 @@ def resolve_persistent_session_root(
     if subdir.is_absolute() or ".." in subdir.parts:
         raise RuntimeError(f"Unsafe persistent generated-home root convention: {subdir}")
     return base_root / subdir
+
+
+def resolve_persistent_session_roots(
+    base_root: Path,
+    backends: Iterable[CodingAgentBackend],
+    *,
+    required_backend_names: AbstractSet[str] = frozenset(),
+) -> dict[str, Path]:
+    """Resolve persistent generated-home roots for every persistent backend.
+
+    A backend whose root convention is malformed is skipped unless its name is
+    in required_backend_names, in which case the RuntimeError propagates —
+    construction sites require their own load-bearing backend to be resolvable
+    while deferring pinned-backend enforcement to preflight/doctor validation.
+    """
+    roots: dict[str, Path] = {}
+    for backend in backends:
+        try:
+            root = resolve_persistent_session_root(base_root, backend)
+        except RuntimeError:
+            if backend.name in required_backend_names:
+                raise
+            logger.warning(
+                "persistent_root_unresolvable_for_backend",
+                backend=backend.name,
+            )
+            continue
+        if root is not None:
+            roots[backend.name] = root
+    return roots
 
 
 @dataclass(slots=True)
@@ -538,11 +569,11 @@ class DefaultSessionSkillManager:
         provider: SkillsDirectoryProvider,
         ephemeral_root: Path,
         *,
-        persistent_root: Path | None = None,
+        persistent_roots: Mapping[str, Path] | None = None,
     ) -> None:
         self._provider = provider
         self._root = ephemeral_root
-        self._persistent_root = persistent_root
+        self._persistent_roots: dict[str, Path] = dict(persistent_roots or {})
         self._session_roots: dict[str, Path] = {}
         self._session_leases: dict[str, _SessionLease] = {}
         self._session_skills_subdirs: dict[str, Path] = {}
@@ -735,7 +766,10 @@ class DefaultSessionSkillManager:
         )
         backend = projection_context.backend
         persistent = backend is not None and backend.capabilities.session_dir_persistent
-        configured_root = self._persistent_root if persistent else self._root
+        if backend is not None and persistent:
+            configured_root = self._persistent_roots.get(backend.name)
+        else:
+            configured_root = self._root
         if configured_root is None:
             raise RuntimeError(
                 "A persistent_root is required for persistent generated-home sessions"
@@ -953,9 +987,7 @@ class DefaultSessionSkillManager:
             _raise_failures("Owned session cleanup failed", failures)
             return existed
 
-        for root in (self._root, self._persistent_root):
-            if root is None:
-                continue
+        for root in (self._root, *self._persistent_roots.values()):
             resolved_root = root.resolve()
             candidate = resolved_root / session_id
             if not os.path.lexists(candidate):
@@ -989,9 +1021,7 @@ class DefaultSessionSkillManager:
 
     def validate_session_exists(self, session_id: str) -> bool:
         """Return True if session directory exists and is non-empty."""
-        for root in (self._root, self._persistent_root):
-            if root is None:
-                continue
+        for root in (self._root, *self._persistent_roots.values()):
             candidate = root / session_id
             if candidate.is_dir():
                 try:
@@ -1007,8 +1037,8 @@ class DefaultSessionSkillManager:
         """
         now = time.time()
         removed = 0
-        for root in (self._root, self._persistent_root):
-            if root is None or not root.exists():
+        for root in (self._root, *self._persistent_roots.values()):
+            if not root.exists():
                 continue
             resolved_root = root.resolve()
             for entry in resolved_root.iterdir():

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -772,8 +772,11 @@ class DefaultSessionSkillManager:
         else:
             configured_root = self._root
         if configured_root is None:
+            selected_backend = backend.name if backend is not None else None
             raise RuntimeError(
-                "A persistent_root is required for persistent generated-home sessions"
+                "A persistent_root is required for persistent generated-home sessions; "
+                f"selected_backend={selected_backend!r}; "
+                f"configured_backend_keys={sorted(self._persistent_roots)!r}"
             )
         try:
             effective_root = configured_root.resolve()

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -819,6 +819,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "server/test_tools_kitchen_envelope.py",
             "server/test_tools_kitchen_visibility.py",
             "server/test_tools_clone.py",
+            "server/test_tools_execution_persistent_root.py",
             "server/test_tools_execution_provider.py",
             "server/test_tools_execution_routing.py",
             "server/test_run_skill_add_dirs.py",

--- a/tests/cli/test_doctor_standing_pins.py
+++ b/tests/cli/test_doctor_standing_pins.py
@@ -22,6 +22,7 @@ class TestStandingBackendPinsFeasibility:
             _check_standing_backend_pins_feasibility,
         )
         from autoskillit.core import (
+            BackendCapabilities,
             Severity,
             SkillSemanticAdaptationResult,
             SkillSemanticOperation,
@@ -36,7 +37,8 @@ class TestStandingBackendPinsFeasibility:
                         backend="codex",
                         operation=SkillSemanticOperation.GIT_METADATA_WRITE,
                     )
-                )
+                ),
+                "capabilities": BackendCapabilities(),
             },
         )()
         monkeypatch.setattr("autoskillit.execution.get_backend", lambda _name: backend)
@@ -129,3 +131,104 @@ class TestStandingBackendPinsFeasibility:
 
         warnings = [r for r in results if r.severity == Severity.WARNING]
         assert warnings, f"Expected WARNING for unknown backend, got: {results}"
+
+    def _malformed_persistent_backend(self):
+        """Stub whose capabilities declare session_dir_persistent but whose
+        conventions have no persistent_session_root_subdir (#4391)."""
+        from autoskillit.core import BackendCapabilities, BackendConventions
+
+        return type(
+            "MalformedPersistentBackend",
+            (),
+            {
+                "capabilities": BackendCapabilities(session_dir_persistent=True),
+                "conventions": BackendConventions(),
+            },
+        )()
+
+    def test_persistent_root_axis_reports_error_for_malformed_convention(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """T7 — a recipe pin to a persistent backend with no derivable root
+        reports an ERROR naming the dotted config key and the backend name."""
+        from autoskillit.cli.doctor._doctor_config import (
+            _check_standing_backend_pins_feasibility,
+        )
+        from autoskillit.core import Severity
+
+        backend = self._malformed_persistent_backend()
+        monkeypatch.setattr("autoskillit.execution.get_backend", lambda _name: backend)
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+        config_dir = tmp_path / "home" / ".autoskillit"
+        _write_config(
+            config_dir / "config.yaml",
+            "agent_backend:\n  recipe_overrides:\n    remediation:\n      assess: codex\n",
+        )
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        results = _check_standing_backend_pins_feasibility(project_dir=project_dir)
+
+        errors = [r for r in results if r.severity == Severity.ERROR]
+        assert errors, f"Expected at least one ERROR result, got: {results}"
+        msg = errors[0].message
+        assert "agent_backend.recipe_overrides.remediation.assess" in msg
+        assert "codex" in msg
+
+    def test_persistent_root_axis_passes_for_real_codex_backend(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """T7 — a well-formed persistent pin (real codex) reports no
+        persistent-root ERROR; existing feasible-pin expectations unchanged."""
+        from autoskillit.cli.doctor._doctor_config import (
+            _check_standing_backend_pins_feasibility,
+        )
+        from autoskillit.core import Severity
+
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+        config_dir = tmp_path / "home" / ".autoskillit"
+        _write_config(
+            config_dir / "config.yaml",
+            "agent_backend:\n  recipe_overrides:\n    remediation:\n      assess: codex\n",
+        )
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        results = _check_standing_backend_pins_feasibility(project_dir=project_dir)
+
+        persistent_root_errors = [
+            r
+            for r in results
+            if r.severity == Severity.ERROR and "persistent session root" in r.message
+        ]
+        assert not persistent_root_errors, results
+
+    def test_persistent_root_axis_covers_global_step_overrides_pin(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """T7 — a global step_overrides pin to a malformed persistent backend
+        also reports the ERROR, proving the new branch runs before the
+        is_recipe_pin early-continue."""
+        from autoskillit.cli.doctor._doctor_config import (
+            _check_standing_backend_pins_feasibility,
+        )
+        from autoskillit.core import Severity
+
+        backend = self._malformed_persistent_backend()
+        monkeypatch.setattr("autoskillit.execution.get_backend", lambda _name: backend)
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+        config_dir = tmp_path / "home" / ".autoskillit"
+        _write_config(
+            config_dir / "config.yaml",
+            "agent_backend:\n  step_overrides:\n    resolve_review: codex\n",
+        )
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        results = _check_standing_backend_pins_feasibility(project_dir=project_dir)
+
+        errors = [r for r in results if r.severity == Severity.ERROR]
+        assert errors, f"Expected at least one ERROR result, got: {results}"
+        msg = errors[0].message
+        assert "agent_backend.step_overrides.resolve_review" in msg
+        assert "codex" in msg

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -430,62 +430,87 @@ def minimal_ctx(tmp_path):
 
 
 @pytest.fixture
-def tool_ctx(monkeypatch, tmp_path):
-    """Provide a fully isolated ToolContext for server integration tests.
+def make_tool_ctx(monkeypatch, tmp_path):
+    """Factory fixture building a fully isolated ToolContext for server tests.
 
-    Full-stack fixture: calls make_context() from server/_factory.py, which
-    imports ALL production layers (L0–L3). Use minimal_ctx instead when the
-    test only needs gate, audit, token_log, timing_log, or config fields.
+    Full-stack factory: each call runs make_context() from server/_factory.py,
+    which imports ALL production layers (L0–L3). Use minimal_ctx instead when
+    the test only needs gate, audit, token_log, timing_log, or config fields.
 
-    Monkeypatches server._ctx so all server tool calls use this context.
-    Gate starts closed (matching production) — use tool_ctx_kitchen_open
-    when a test needs the gate open.
+    Monkeypatches server._ctx so all server tool calls use the most recently
+    built context. Gate starts closed (matching production) — use
+    tool_ctx_kitchen_open when a test needs the gate open.
 
     All service fields (executor, tester, db_reader, workspace_mgr, recipes,
     migrations) are wired via make_context() so routing tests work correctly.
+
+    Pass config to build a context from a specific AutomationConfig (e.g. to
+    pin agent_backend.recipe_overrides before context creation); omit it for
+    the default AutomationConfig(features={"fleet": True}).
     """
     from autoskillit.config import AutomationConfig
     from autoskillit.server import _state
     from autoskillit.server._factory import make_context
     from tests.fakes import FakePluginArtifactAuthority, MockSubprocessRunner
 
-    mock_runner = MockSubprocessRunner()
-    plugin_authority = FakePluginArtifactAuthority(tmp_path)
-    ctx = make_context(
-        AutomationConfig(features={"fleet": True}),
-        runner=mock_runner,
-        plugin_authority=plugin_authority,
-        project_dir=tmp_path,
-    )
-    ctx.audit_admission_ledger.recover_all()
-    ctx.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
-    ctx.config.linux_tracing.tmpfs_path = str(tmp_path / "shm")
-    ctx.temp_dir = tmp_path / ".autoskillit" / "temp"
-    test_skills_root = tmp_path / ".claude" / "skills"
-    for skill_name in (
-        "do-a",
-        "do-b",
-        "eval-agent",
-        "idle-scope",
-        "implement",
-        "probe",
-        "some-skill",
-        "target-skill",
-        "test",
-        "test-skill",
-    ):
-        skill_dir = test_skills_root / skill_name
-        skill_dir.mkdir(parents=True, exist_ok=True)
-        (skill_dir / "SKILL.md").write_text(
-            f"---\nname: {skill_name}\ndescription: Test fixture skill\n---\n"
-            "# Test fixture skill\n"
+    created_authorities: list[FakePluginArtifactAuthority] = []
+
+    def _factory(config: AutomationConfig | None = None):
+        mock_runner = MockSubprocessRunner()
+        plugin_authority = FakePluginArtifactAuthority(tmp_path)
+        created_authorities.append(plugin_authority)
+        ctx = make_context(
+            config if config is not None else AutomationConfig(features={"fleet": True}),
+            runner=mock_runner,
+            plugin_authority=plugin_authority,
+            project_dir=tmp_path,
         )
-    monkeypatch.setattr(_state, "_ctx", ctx)
-    monkeypatch.setattr(_state, "_startup_ready", None)
+        ctx.audit_admission_ledger.recover_all()
+        ctx.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
+        ctx.config.linux_tracing.tmpfs_path = str(tmp_path / "shm")
+        # Independent of the basis already baked into ctx.session_skill_manager
+        # at make_context() time — tests asserting manager roots must derive
+        # expectations from resolve_temp_dir(project_dir, config.workspace.temp_dir),
+        # not ctx.temp_dir.
+        ctx.temp_dir = tmp_path / ".autoskillit" / "temp"
+        test_skills_root = tmp_path / ".claude" / "skills"
+        for skill_name in (
+            "do-a",
+            "do-b",
+            "eval-agent",
+            "idle-scope",
+            "implement",
+            "probe",
+            "some-skill",
+            "target-skill",
+            "test",
+            "test-skill",
+        ):
+            skill_dir = test_skills_root / skill_name
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            (skill_dir / "SKILL.md").write_text(
+                f"---\nname: {skill_name}\ndescription: Test fixture skill\n---\n"
+                "# Test fixture skill\n"
+            )
+        monkeypatch.setattr(_state, "_ctx", ctx)
+        monkeypatch.setattr(_state, "_startup_ready", None)
+        return ctx
+
     try:
-        yield ctx
+        yield _factory
     finally:
-        plugin_authority.close()
+        for plugin_authority in created_authorities:
+            plugin_authority.close()
+
+
+@pytest.fixture
+def tool_ctx(make_tool_ctx):
+    """Provide a fully isolated ToolContext for server integration tests.
+
+    Thin wrapper around make_tool_ctx() using the default AutomationConfig.
+    See make_tool_ctx for the full contract.
+    """
+    return make_tool_ctx()
 
 
 @pytest.fixture

--- a/tests/execution/backends/test_backend_registry.py
+++ b/tests/execution/backends/test_backend_registry.py
@@ -90,6 +90,7 @@ class TestBackendRegistry:
             "_read_codex_config",
             "_serialize_toml",
             "_write_codex_config",
+            "all_backends",
             "codex_recipe_delivery_calling_contract",
             "ensure_codex_mcp_registered",
             "enumerate_fresh_codex_marker_ids",

--- a/tests/execution/backends/test_session_skills_provider_integration.py
+++ b/tests/execution/backends/test_session_skills_provider_integration.py
@@ -82,7 +82,7 @@ def test_materialize_invocation_uses_structured_refusal_and_preserves_diagnostic
     manager = DefaultSessionSkillManager(
         SkillsDirectoryProvider(),
         ephemeral_root=tmp_path / "ephemeral",
-        persistent_root=persistent_root,
+        persistent_roots={"codex": persistent_root},
     )
 
     with pytest.raises(SkillContractError) as exc_info:

--- a/tests/hooks/conftest.py
+++ b/tests/hooks/conftest.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+from collections.abc import Iterator
+
 import pytest
 
 
@@ -7,6 +10,11 @@ import pytest
 def _isolate_hook_cwd(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
-) -> None:
-    """Run every hook test from its per-test temporary project root."""
-    monkeypatch.chdir(tmp_path)
+) -> Iterator[None]:
+    """Run every hook test from an isolated root with secure directory modes."""
+    previous_umask = os.umask(0o022)
+    try:
+        monkeypatch.chdir(tmp_path)
+        yield
+    finally:
+        os.umask(previous_umask)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -122,7 +122,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools/tools_kitchen.py", 536),
     ("src/autoskillit/server/tools/tools_kitchen.py", 555),
     ("src/autoskillit/server/tools/tools_kitchen.py", 589),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 1905),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1907),
     # tools_pipeline_tracker.py — tracker_data dict (init) and mark_step_complete write
     # (same tracker file schema as init — not a new format, grandfathered alongside it)
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 256),

--- a/tests/recipe/test_rules_review_failure_fallthrough.py
+++ b/tests/recipe/test_rules_review_failure_fallthrough.py
@@ -1,0 +1,183 @@
+"""
+Tests for the review-failure-fallthrough-guard semantic rule (#4391 criterion 2).
+
+The rule fires when a CI-advance gate (check_review_loop, check_repo_ci_event,
+derive_batch_ci_event) is BFS-reachable from a review-family step's
+failure-shaped edges (on_failure, on_context_limit, on_rate_limit,
+on_exhausted) without first crossing check_review_posted or re-entering a
+review-family step. #1684 shipped exactly that fall-through for three
+months; #4448 reversed it with nothing preventing a re-flip.
+"""
+
+import pytest
+
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+from autoskillit.recipe.registry import _RULE_REGISTRY, run_semantic_rules
+from autoskillit.recipe.rules.graph.rules_graph_review import _get_review_family_steps
+from autoskillit.recipe.schema import Recipe, RecipeStep
+from tests.recipe.conftest import BUNDLED_RECIPE_NAMES, assert_no_rule_errors
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+RULE_ID = "review-failure-fallthrough-guard"
+REVIEW_FAMILY_RECIPE_NAMES = [
+    "implementation",
+    "remediation",
+    "implementation-groups",
+    "merge-prs",
+]
+
+
+def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:
+    return Recipe(name="test", description="test", steps=steps, kitchen_rules=["test"])
+
+
+def _review_pr_step(**kwargs) -> RecipeStep:
+    return RecipeStep(
+        tool="run_skill",
+        with_args={"skill_command": "/autoskillit:review-pr"},
+        **kwargs,
+    )
+
+
+def _resolve_review_step(**kwargs) -> RecipeStep:
+    return RecipeStep(
+        tool="run_skill",
+        with_args={"skill_command": "/autoskillit:resolve-review"},
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# T8.1 — registration
+# ---------------------------------------------------------------------------
+
+
+def test_rule_is_registered():
+    """The rule must be registered in the semantic rule registry."""
+    rule_ids = {r.name for r in _RULE_REGISTRY}
+    assert RULE_ID in rule_ids, (
+        f"{RULE_ID} not found in rule registry. Registered rules: {sorted(rule_ids)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T8.2 — silence on all bundled recipes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("recipe_name", BUNDLED_RECIPE_NAMES)
+def test_rule_silent_on_bundled_recipes(recipe_name):
+    """The rule must not fire on any bundled recipe — the routing shape #4448
+    established (and this rule guards) is already the shipped shape."""
+    recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+    findings = run_semantic_rules(recipe)
+    assert_no_rule_errors(findings, context=recipe_name)
+
+
+@pytest.mark.parametrize("recipe_name", REVIEW_FAMILY_RECIPE_NAMES)
+def test_rule_is_exercised_not_vacuously_silent(recipe_name):
+    """Proves the silence in test_rule_silent_on_bundled_recipes is earned —
+    each of these recipes actually has review-family steps for the rule to
+    check, not an empty early-return."""
+    from autoskillit.recipe._analysis import make_validation_context
+
+    recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+    ctx = make_validation_context(recipe)
+    review_steps = _get_review_family_steps(ctx)
+    assert review_steps, f"[{recipe_name}] expected review-family steps, found none"
+
+
+# ---------------------------------------------------------------------------
+# T8.3 — positive, #1684 shape
+# ---------------------------------------------------------------------------
+
+
+def test_rule_fires_on_direct_fallthrough_1684_shape():
+    """A review-pr step's on_failure routing straight to check_repo_ci_event
+    (the exact #1684 shape) must fire exactly one finding naming the step
+    and the gate."""
+    recipe = _make_recipe(
+        {
+            "review_pr": _review_pr_step(on_failure="check_repo_ci_event"),
+            "check_review_posted": RecipeStep(tool="run_python"),
+            "check_review_loop": RecipeStep(tool="run_python"),
+            "check_repo_ci_event": RecipeStep(tool="check_repo_merge_state"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == RULE_ID]
+    assert len(findings) == 1
+    assert findings[0].step_name == "review_pr"
+    assert "check_repo_ci_event" in findings[0].message
+
+
+# ---------------------------------------------------------------------------
+# T8.4 — positive, multi-hop
+# ---------------------------------------------------------------------------
+
+
+def test_rule_fires_across_intermediate_step():
+    """The advance gate need not be the direct on_failure target — an
+    intermediate step routing onward to it without crossing the barrier
+    also fires."""
+    recipe = _make_recipe(
+        {
+            "review_pr": _review_pr_step(on_failure="intermediate_step"),
+            "intermediate_step": RecipeStep(tool="run_python", on_success="check_review_loop"),
+            "check_review_posted": RecipeStep(tool="run_python"),
+            "check_review_loop": RecipeStep(tool="run_python"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == RULE_ID]
+    assert len(findings) == 1
+    assert findings[0].step_name == "review_pr"
+    assert "check_review_loop" in findings[0].message
+
+
+# ---------------------------------------------------------------------------
+# T8.5 — negative, failure-family routing
+# ---------------------------------------------------------------------------
+
+
+def test_rule_silent_when_failure_edges_terminate_in_failure_family():
+    """Failure edges routing to a failure-family terminal chain
+    (release_issue_failure -> register_clone_failure) never reach an
+    advance gate — zero findings."""
+    recipe = _make_recipe(
+        {
+            "review_pr": _review_pr_step(on_failure="release_issue_failure"),
+            "release_issue_failure": RecipeStep(
+                tool="release_issue", on_success="register_clone_failure"
+            ),
+            "register_clone_failure": RecipeStep(tool="remove_clone"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == RULE_ID]
+    assert not findings
+
+
+# ---------------------------------------------------------------------------
+# T8.6 — negative, merge-prs shape (barrier absorbs the advance path)
+# ---------------------------------------------------------------------------
+
+
+def test_rule_silent_when_rebase_retry_crosses_barrier_before_advance_gate():
+    """merge-prs' rebase-retry loop: resolve-review's on_context_limit
+    re-enters through a rebase/push chain whose on_success crosses
+    check_review_posted before any advance gate — legitimate, zero
+    findings (the barrier absorbs the advance path)."""
+    recipe = _make_recipe(
+        {
+            "resolve_review_integration": _resolve_review_step(
+                on_context_limit="rebase_step",
+            ),
+            "rebase_step": RecipeStep(tool="run_git", on_success="push_step"),
+            "push_step": RecipeStep(tool="push_to_remote", on_success="check_review_posted"),
+            "check_review_posted": RecipeStep(
+                tool="run_python", on_success="derive_batch_ci_event"
+            ),
+            "derive_batch_ci_event": RecipeStep(tool="run_python"),
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == RULE_ID]
+    assert not findings

--- a/tests/server/test_explicit_backend_override.py
+++ b/tests/server/test_explicit_backend_override.py
@@ -114,7 +114,7 @@ class TestExplicitOverrideProviderPrecedence:
         tool_ctx_kitchen_open.session_skill_manager = DefaultSessionSkillManager(
             SkillsDirectoryProvider(),
             ephemeral_root=tmp_path / "ephemeral-sessions",
-            persistent_root=tmp_path / "persistent-sessions",
+            persistent_roots={"codex": tmp_path / "persistent-sessions"},
         )
         monkeypatch.setattr(
             tool_ctx_kitchen_open.launch_resolver,

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -731,3 +731,15 @@ def test_make_context_codex_backend_not_none_plain_config(tmp_path) -> None:
     ctx = make_context(cfg, runner=_runner(), project_dir=tmp_path)
     assert ctx.backend is not None
     assert isinstance(ctx.backend, CodexBackend)
+
+
+def test_make_context_builds_persistent_roots_over_all_registered_backends(tmp_path) -> None:
+    """T4 (#4391): make_context() derives persistent_roots for every backend, not
+    just the configured global one — proving the fix's core wiring."""
+    from autoskillit.core import CODEX_SESSIONS_SUBDIR, resolve_temp_dir
+
+    config = AutomationConfig()
+    ctx = make_context(config, runner=_runner(), project_dir=tmp_path)
+
+    expected_root = resolve_temp_dir(tmp_path, config.workspace.temp_dir) / CODEX_SESSIONS_SUBDIR
+    assert ctx.session_skill_manager._persistent_roots == {"codex": expected_root}

--- a/tests/server/test_preflight_explicit_backend.py
+++ b/tests/server/test_preflight_explicit_backend.py
@@ -50,10 +50,15 @@ def _make_skill_resolver_with_no_caps() -> MagicMock:
 
 
 class TestPreflightExplicitBackend:
-    def test_explicit_override_to_missing_binary_excluded(self) -> None:
+    def test_explicit_override_to_missing_binary_excluded(self, tmp_path) -> None:
         """An explicit override pointing to a backend excludes that step from
         feasibility — with a synthetic fix-required hook, preflight passes
-        because the excluded step is not feasible."""
+        because the excluded step is not feasible.
+
+        Pins to the real (unpatched) CodexBackend, which is persistent — pass
+        temp_dir so the #4391 persistent-root axis derives cleanly and this
+        test keeps exercising its original fix-required-hook path (T6b).
+        """
         from autoskillit.config.settings import ProvidersConfig
         from autoskillit.server.tools._preflight import _check_dispatch_feasibility
 
@@ -77,6 +82,7 @@ class TestPreflightExplicitBackend:
                 recipe_name="remediation",
                 config_backend=cfg,
                 skill_resolver=_make_skill_resolver_with_no_caps(),
+                temp_dir=tmp_path,
             )
         assert err is None
 

--- a/tests/server/test_tools_execution_backend_mixing.py
+++ b/tests/server/test_tools_execution_backend_mixing.py
@@ -58,7 +58,7 @@ def _install_codex_launch_backend(tool_ctx: Any, tmp_path: Path, monkeypatch) ->
     tool_ctx.session_skill_manager = DefaultSessionSkillManager(
         SkillsDirectoryProvider(),
         ephemeral_root=tmp_path / "ephemeral-sessions",
-        persistent_root=tmp_path / "persistent-sessions",
+        persistent_roots={"codex": tmp_path / "persistent-sessions"},
     )
     monkeypatch.setattr(
         tool_ctx.launch_resolver,

--- a/tests/server/test_tools_execution_persistent_root.py
+++ b/tests/server/test_tools_execution_persistent_root.py
@@ -1,0 +1,140 @@
+"""Contract test for the #4391 Codex persistent_root scope-mismatch fix.
+
+A recipe-level backend override pins a step to a persistent backend (codex)
+while the *global* backend is non-persistent (claude-code). Before the fix,
+DefaultSessionSkillManager resolved persistent_root once against the global
+backend at make_context() time, so any step-level pin to a persistent
+backend crashed with "A persistent_root is required for persistent
+generated-home sessions". This test drives the real, unpatched manager
+built by make_context() through run_skill() to prove the fix end to end.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.mark.anyio
+async def test_recipe_pin_to_persistent_backend_resolves_root_when_global_backend_is_ephemeral(
+    make_tool_ctx, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """T5 — the #4391 contract test.
+
+    Do not touch ctx.backend and do not replace ctx.session_skill_manager —
+    the unpatched manager built by make_context() is the object under test.
+    On develop before the #4391 fix, this test crashes with the persistent
+    root RuntimeError; it is the bug reproduction.
+    """
+    from autoskillit.config import AgentBackendConfig, AutomationConfig
+    from autoskillit.core import (
+        CODEX_SESSIONS_SUBDIR,
+        SkillExecutionRole,
+        SkillSource,
+        resolve_temp_dir,
+    )
+    from autoskillit.execution.backends.codex import CodexBackend
+    from autoskillit.pipeline.gate import DefaultGateState
+    from autoskillit.server.tools.tools_execution import run_skill
+    from autoskillit.workspace import EffectiveSkillInvocation, SkillInfo
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    config = AutomationConfig(features={"fleet": True})
+    config.agent_backend = AgentBackendConfig(
+        backend="claude-code",
+        recipe_overrides={"remediation": {"investigate": "codex"}},
+    )
+    ctx = make_tool_ctx(config)
+    ctx.gate = DefaultGateState(enabled=True)
+    ctx.kitchen_id = "test-kitchen"
+    ctx.recipe_name = "remediation"
+
+    executor = InMemoryHeadlessExecutor()
+    ctx.executor = executor
+
+    root = SkillInfo(
+        name="investigate",
+        source=SkillSource.BUNDLED_EXTENDED,
+        path=tmp_path / "investigate" / "SKILL.md",
+        canonical_content=(
+            "---\nname: investigate\ndescription: Test skill.\n"
+            "execution_role: session\n---\n# Investigate\n"
+        ),
+    )
+    invocation = EffectiveSkillInvocation(
+        root=root,
+        closure=(root,),
+        capability_union=frozenset(),
+        project_root=tmp_path,
+        execution_role=SkillExecutionRole.SESSION,
+    )
+    resolver = MagicMock()
+    resolver.resolve_invocation.return_value = invocation
+    ctx.skill_resolver = resolver
+
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution.shutil.which",
+        lambda binary: f"/test-bin/{binary}",
+    )
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_execution.is_feature_enabled",
+        lambda *a, **kw: True,
+    )
+
+    # DefaultLaunchResolver.backend_for_authority proves environment-dependent
+    # under the mock runner (it does real binary/path lookups); monkeypatch it
+    # to return the real codex backend instance for this pinned step. Rooted
+    # under tmp_path so it never touches the developer's real ~/.codex.
+    real_codex = CodexBackend(source_codex_home=tmp_path / "codex-home")
+    monkeypatch.setattr(
+        ctx.launch_resolver,
+        "backend_for_authority",
+        lambda _authority: real_codex,
+    )
+
+    # session_skill_manager stays the real, unpatched object make_context()
+    # built — the map it derives persistent_roots from is exactly what #4391
+    # fixes. run_skill()'s finally block unconditionally calls
+    # cleanup_session(), which removes the session's _session_roots entry and
+    # generated home before control returns here. Wrap (not replace)
+    # cleanup_session to capture that transient state at the moment cleanup
+    # would destroy it, without altering any of the manager's real behavior —
+    # the wrapped call still performs the real cleanup.
+    manager = ctx.session_skill_manager
+    assert manager is not None
+    captured: dict[str, object] = {}
+    original_cleanup_session = manager.cleanup_session
+
+    def _spy_cleanup_session(session_id: str) -> bool:
+        captured["session_roots"] = dict(manager._session_roots)
+        session_root = manager._session_roots.get(session_id)
+        if session_root is not None:
+            captured["generated_home_existed"] = (session_root / session_id).exists()
+        return original_cleanup_session(session_id)
+
+    monkeypatch.setattr(manager, "cleanup_session", _spy_cleanup_session)
+
+    response = json.loads(
+        await run_skill(
+            "/autoskillit:investigate backend-routing-test",
+            str(tmp_path),
+            step_name="investigate",
+        )
+    )
+
+    # No RuntimeError escaped run_skill() — the #4391 crash reproduction.
+    session_roots = cast("dict[str, Path]", captured.get("session_roots"))
+    assert session_roots, f"expected materialization to populate _session_roots: {response}"
+    assert len(session_roots) == 1, session_roots
+    (actual_root,) = session_roots.values()
+    expected_root = (
+        resolve_temp_dir(tmp_path, config.workspace.temp_dir) / CODEX_SESSIONS_SUBDIR
+    ).resolve()
+    assert actual_root == expected_root
+    assert captured.get("generated_home_existed") is True

--- a/tests/server/test_tools_execution_provider.py
+++ b/tests/server/test_tools_execution_provider.py
@@ -465,7 +465,7 @@ async def test_anthropic_base_url_cannot_override_codex_backend_authority(
     tool_ctx_kitchen_open.session_skill_manager = DefaultSessionSkillManager(
         SkillsDirectoryProvider(),
         ephemeral_root=tmp_path / "ephemeral-sessions",
-        persistent_root=tmp_path / "persistent-sessions",
+        persistent_roots={"codex": tmp_path / "persistent-sessions"},
     )
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
     _feat = "autoskillit.server.tools.tools_execution.is_feature_enabled"

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -738,7 +738,7 @@ async def test_process_issues_l2_parent_executes_session_child_on_each_backend(
         wraps=DefaultSessionSkillManager(
             SkillsDirectoryProvider(),
             ephemeral_root=tmp_path / "ephemeral-sessions",
-            persistent_root=tmp_path / "persistent-sessions",
+            persistent_roots={"codex": tmp_path / "persistent-sessions"},
         )
     )
     executor = InMemoryHeadlessExecutor()

--- a/tests/server/test_tools_kitchen_preflight.py
+++ b/tests/server/test_tools_kitchen_preflight.py
@@ -96,7 +96,7 @@ def _make_persistent_backend(*, well_formed: bool) -> MagicMock:
     None, matching the malformed-convention shape resolve_persistent_session_root
     raises RuntimeError for.
     """
-    from autoskillit.core import BackendCapabilities
+    from autoskillit.core import BackendCapabilities, BackendConventions
 
     caps = BackendCapabilities(
         session_dir_persistent=True,
@@ -106,8 +106,8 @@ def _make_persistent_backend(*, well_formed: bool) -> MagicMock:
     backend = MagicMock()
     backend.name = "codex"
     backend.capabilities = caps
-    backend.conventions.persistent_session_root_subdir = (
-        Path("codex-sessions") if well_formed else None
+    backend.conventions = BackendConventions(
+        persistent_session_root_subdir=(Path("codex-sessions") if well_formed else None)
     )
     return backend
 

--- a/tests/server/test_tools_kitchen_preflight.py
+++ b/tests/server/test_tools_kitchen_preflight.py
@@ -13,6 +13,7 @@ itself and its integration into open_kitchen and dispatch_food_truck.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -85,6 +86,29 @@ def _make_claude_backend() -> MagicMock:
     backend = MagicMock()
     backend.name = AGENT_BACKEND_CLAUDE_CODE
     backend.capabilities = caps
+    return backend
+
+
+def _make_persistent_backend(*, well_formed: bool) -> MagicMock:
+    """Mock backend with capabilities.session_dir_persistent=True (#4391).
+
+    `well_formed=False` leaves conventions.persistent_session_root_subdir as
+    None, matching the malformed-convention shape resolve_persistent_session_root
+    raises RuntimeError for.
+    """
+    from autoskillit.core import BackendCapabilities
+
+    caps = BackendCapabilities(
+        session_dir_persistent=True,
+        applicable_guards=frozenset(),
+        anthropic_provider_capable=False,
+    )
+    backend = MagicMock()
+    backend.name = "codex"
+    backend.capabilities = caps
+    backend.conventions.persistent_session_root_subdir = (
+        Path("codex-sessions") if well_formed else None
+    )
     return backend
 
 
@@ -220,6 +244,109 @@ class TestCheckDispatchFeasibilityUnit:
         assert parsed.get("error") == "invalid_skill_invocation_for_pinned_step"
         assert parsed.get("skill") == "missing-skill"
         assert parsed.get("step") == "unknown_step"
+
+    def test_persistent_root_unresolvable_for_pinned_step_fails_closed(
+        self, tmp_path: Path
+    ) -> None:
+        """T6 (#4391) — a pin to a persistent backend with no derivable root
+        fails closed with an envelope naming the config key."""
+        from autoskillit.config._config_dataclasses import AgentBackendConfig
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
+
+        backend = _make_persistent_backend(well_formed=False)
+        active_steps: dict[str, Any] = {
+            "resolve_review": _make_recipe_step(
+                "resolve_review", tool="run_skill", skill_name="resolve-review"
+            ),
+        }
+        config_backend = AgentBackendConfig(
+            recipe_overrides={"test-recipe": {"resolve_review": "codex"}},
+        )
+        with patch("autoskillit.server.tools._preflight.get_backend", return_value=backend):
+            result = _check_dispatch_feasibility(
+                post_prune_step_names=["resolve_review"],
+                active_recipe_steps=active_steps,
+                backend=backend,
+                config_providers=_DEFAULT_PROVIDERS,
+                recipe_name="test-recipe",
+                config_backend=config_backend,
+                skill_resolver=None,
+                temp_dir=tmp_path,
+            )
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed.get("error") == "persistent_root_unresolvable_for_pinned_step"
+        assert parsed.get("stage") == "dispatch_feasibility_preflight"
+        assert parsed.get("origin") == "agent_backend.recipe_overrides.test-recipe.resolve_review"
+        assert "resolve_review" in parsed.get("user_visible_message", "")
+        assert "agent_backend.recipe_overrides.test-recipe.resolve_review" in parsed.get(
+            "remedy", ""
+        )
+
+    def test_persistent_root_axis_passes_for_real_codex_pin(self, tmp_path: Path) -> None:
+        """T6 (#4391) — a pin to real codex (well-formed root) proceeds past
+        the persistent-root axis to the pre-existing semantic checks (the
+        "runs" branch of acceptance criterion 1)."""
+        from autoskillit.config._config_dataclasses import AgentBackendConfig
+        from autoskillit.execution.backends.codex import CodexBackend
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
+
+        backend = CodexBackend()
+        active_steps: dict[str, Any] = {
+            "resolve_review": _make_recipe_step(
+                "resolve_review", tool="run_skill", skill_name="resolve-review"
+            ),
+        }
+        config_backend = AgentBackendConfig(
+            recipe_overrides={"test-recipe": {"resolve_review": "codex"}},
+        )
+        with patch("autoskillit.server.tools._preflight.get_backend", return_value=backend):
+            result = _check_dispatch_feasibility(
+                post_prune_step_names=["resolve_review"],
+                active_recipe_steps=active_steps,
+                backend=backend,
+                config_providers=_DEFAULT_PROVIDERS,
+                recipe_name="test-recipe",
+                config_backend=config_backend,
+                skill_resolver=None,
+                temp_dir=tmp_path,
+            )
+        # No persistent-root envelope — falls through to the next pre-existing
+        # check (missing skill_resolver), proving the persistent-root axis
+        # passed cleanly for a well-formed pin.
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed.get("error") == "skill_resolver_unavailable_for_pinned_step"
+
+    def test_persistent_root_unverifiable_when_temp_dir_absent(self) -> None:
+        """T6 (#4391) — a pin to a persistent backend fails closed when
+        temp_dir is absent, before any root derivation is attempted."""
+        from autoskillit.config._config_dataclasses import AgentBackendConfig
+        from autoskillit.server.tools._preflight import _check_dispatch_feasibility
+
+        backend = _make_persistent_backend(well_formed=True)
+        active_steps: dict[str, Any] = {
+            "resolve_review": _make_recipe_step(
+                "resolve_review", tool="run_skill", skill_name="resolve-review"
+            ),
+        }
+        config_backend = AgentBackendConfig(
+            recipe_overrides={"test-recipe": {"resolve_review": "codex"}},
+        )
+        with patch("autoskillit.server.tools._preflight.get_backend", return_value=backend):
+            result = _check_dispatch_feasibility(
+                post_prune_step_names=["resolve_review"],
+                active_recipe_steps=active_steps,
+                backend=backend,
+                config_providers=_DEFAULT_PROVIDERS,
+                recipe_name="test-recipe",
+                config_backend=config_backend,
+                skill_resolver=None,
+            )
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed.get("error") == "persistent_root_unverifiable_for_pinned_step"
+        assert parsed.get("stage") == "dispatch_feasibility_preflight"
 
     def test_incompatible_backend_fails(self) -> None:
         """Backend with empty applicable_guards returns error (1b)."""

--- a/tests/workspace/conftest.py
+++ b/tests/workspace/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -11,6 +12,8 @@ from autoskillit.workspace.session_skills import (
     DefaultSessionSkillManager,
     SkillsDirectoryProvider,
 )
+
+_UNSET = object()
 
 
 @pytest.fixture
@@ -107,13 +110,19 @@ def make_session_skill_manager(tmp_path: Path):
     def _factory(
         *,
         ephemeral_root: Path | None = None,
-        codex_root: Path | None = None,
+        codex_root: Path | None | object = _UNSET,
     ) -> DefaultSessionSkillManager:
         provider = SkillsDirectoryProvider()
+        if codex_root is None:
+            persistent_roots: dict[str, Path] = {}
+        elif codex_root is _UNSET:
+            persistent_roots = {"codex": tmp_path / "codex-root"}
+        else:
+            persistent_roots = {"codex": cast(Path, codex_root)}
         return DefaultSessionSkillManager(
             provider,
             ephemeral_root=ephemeral_root or tmp_path,
-            persistent_root=codex_root or tmp_path / "codex-root",
+            persistent_roots=persistent_roots,
         )
 
     return _factory

--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -696,3 +696,81 @@ def test_session_projection_is_agent_safe_for_each_backend(
         "execution_role",
     }.isdisjoint(frontmatter)
     assert frontmatter["name"] == "make-arch-diag"
+
+
+def _stub_backend(
+    name: str,
+    *,
+    session_dir_persistent: bool = True,
+    persistent_session_root_subdir: Path | None,
+) -> MagicMock:
+    """Minimal stub with .name/.capabilities/.conventions built from real dataclasses."""
+    from autoskillit.core import BackendCapabilities, BackendConventions
+
+    backend = MagicMock()
+    backend.name = name
+    backend.capabilities = BackendCapabilities(session_dir_persistent=session_dir_persistent)
+    backend.conventions = BackendConventions(
+        persistent_session_root_subdir=persistent_session_root_subdir
+    )
+    return backend
+
+
+class TestResolvePersistentSessionRoot:
+    """T1 — direct unit tests for resolve_persistent_session_root (#4391)."""
+
+    def test_non_persistent_backend_returns_none(self, tmp_path: Path) -> None:
+        from autoskillit.execution.backends import get_backend
+
+        backend = get_backend("claude-code")
+        assert session_skills.resolve_persistent_session_root(tmp_path, backend) is None
+
+    def test_codex_backend_returns_subdir_of_base_root(self, tmp_path: Path) -> None:
+        from autoskillit.core import CODEX_SESSIONS_SUBDIR
+        from autoskillit.execution.backends import get_backend
+
+        backend = get_backend("codex")
+        assert session_skills.resolve_persistent_session_root(tmp_path, backend) == (
+            tmp_path / CODEX_SESSIONS_SUBDIR
+        )
+
+    def test_missing_root_convention_raises(self, tmp_path: Path) -> None:
+        backend = _stub_backend("synthetic", persistent_session_root_subdir=None)
+        with pytest.raises(RuntimeError, match="no generated-home root convention"):
+            session_skills.resolve_persistent_session_root(tmp_path, backend)
+
+    def test_absolute_subdir_raises_unsafe(self, tmp_path: Path) -> None:
+        backend = _stub_backend("synthetic", persistent_session_root_subdir=Path("/abs"))
+        with pytest.raises(RuntimeError, match="Unsafe persistent generated-home root"):
+            session_skills.resolve_persistent_session_root(tmp_path, backend)
+
+    def test_parent_traversal_subdir_raises_unsafe(self, tmp_path: Path) -> None:
+        backend = _stub_backend("synthetic", persistent_session_root_subdir=Path("../x"))
+        with pytest.raises(RuntimeError, match="Unsafe persistent generated-home root"):
+            session_skills.resolve_persistent_session_root(tmp_path, backend)
+
+
+class TestResolvePersistentSessionRoots:
+    """T2 — unit tests for resolve_persistent_session_roots (#4391)."""
+
+    def test_only_persistent_backends_are_included(self, tmp_path: Path) -> None:
+        from autoskillit.core import CODEX_SESSIONS_SUBDIR
+        from autoskillit.execution.backends import get_backend
+
+        backends = [get_backend("claude-code"), get_backend("codex")]
+        roots = session_skills.resolve_persistent_session_roots(tmp_path, backends)
+        assert roots == {"codex": tmp_path / CODEX_SESSIONS_SUBDIR}
+
+    def test_malformed_backend_not_in_required_names_is_skipped(self, tmp_path: Path) -> None:
+        backend = _stub_backend("synthetic", persistent_session_root_subdir=None)
+        roots = session_skills.resolve_persistent_session_roots(tmp_path, [backend])
+        assert roots == {}
+
+    def test_malformed_backend_in_required_names_raises(self, tmp_path: Path) -> None:
+        backend = _stub_backend("synthetic", persistent_session_root_subdir=None)
+        with pytest.raises(RuntimeError, match="no generated-home root convention"):
+            session_skills.resolve_persistent_session_roots(
+                tmp_path,
+                [backend],
+                required_backend_names=frozenset({"synthetic"}),
+            )

--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -319,8 +319,12 @@ def test_persistent_backend_declares_its_own_inert_paths(
     make_session_skill_manager,
     tmp_path: Path,
 ) -> None:
+    # backend.name stays "codex" (from _make_codex_backend()) because persistent
+    # roots are now resolved per backend name (#4391) — the fixture's codex_root
+    # kwarg only populates a "codex" entry in the manager's persistent_roots map.
+    # The point under test is that inert-path declaration follows
+    # capabilities.session_dir_symlinks generically, not a hardcoded convention.
     backend = _make_codex_backend()
-    backend.name = "persistent-test"
     backend.capabilities = replace(
         _CODEX_CAPABILITIES,
         session_dir_symlinks=frozenset({"records"}),
@@ -409,7 +413,7 @@ def test_codex_session_requires_persistent_root_before_any_home_mutation(
     mgr = DefaultSessionSkillManager(
         SkillsDirectoryProvider(),
         ephemeral_root=ephemeral_root,
-        persistent_root=None,
+        persistent_roots={},
     )
 
     with pytest.raises(RuntimeError, match="persistent_root"):

--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -416,9 +416,13 @@ def test_codex_session_requires_persistent_root_before_any_home_mutation(
         persistent_roots={},
     )
 
-    with pytest.raises(RuntimeError, match="persistent_root"):
+    with pytest.raises(RuntimeError) as exc_info:
         _materialize(mgr, "0123456789abcdef", backend=codex_env.backend)
 
+    assert str(exc_info.value) == (
+        "A persistent_root is required for persistent generated-home sessions; "
+        "selected_backend='codex'; configured_backend_keys=[]"
+    )
     assert not ephemeral_root.exists()
     assert mgr._session_roots == {}
     assert mgr._session_leases == {}

--- a/tests/workspace/test_session_skills_provider.py
+++ b/tests/workspace/test_session_skills_provider.py
@@ -277,7 +277,7 @@ def test_skill_write_failure_rolls_back_unpublished_codex_home(
     manager = DefaultSessionSkillManager(
         provider,
         ephemeral_root=tmp_path / "ephemeral",
-        persistent_root=codex_root,
+        persistent_roots={"codex": codex_root},
     )
     backend = _codex_backend()
     catalog, context = _catalog_context(provider, tmp_path, backend=backend)
@@ -302,7 +302,7 @@ def test_skills_subdirectory_is_owned_per_session_not_manager_wide(tmp_path: Pat
     manager = DefaultSessionSkillManager(
         provider,
         ephemeral_root=tmp_path / "ephemeral",
-        persistent_root=tmp_path / "persistent" / "codex-sessions",
+        persistent_roots={"codex": tmp_path / "persistent" / "codex-sessions"},
     )
     codex_backend = _codex_backend()
     claude_catalog, claude_context = _catalog_context(provider, tmp_path)


### PR DESCRIPTION
## Summary

Issue #4391: any recipe step routed to a persistent-session backend (Codex) via
`agent_backend.recipe_overrides`/`step_overrides` crashes before launch with
`RuntimeError: A persistent_root is required for persistent generated-home sessions`
whenever the *global* backend (`config.agent_backend.backend`, default
`claude-code`) is non-persistent. Root cause is a scope mismatch: `make_context()`
resolves `persistent_root` exactly once against the global backend
(`server/_factory.py:341`) and bakes it into the kitchen-lifetime
`DefaultSessionSkillManager`, while `_initialize_bound_records`
(`workspace/session_skills.py:736-742`) computes `persistent` from the *step*
backend (`projection_context.backend`). The persistent root is a pure function of
`(temp_dir, backend)` — `resolve_persistent_session_root` derives
`temp_dir / backend.conventions.persistent_session_root_subdir` — so a single
baked `Path | None` is the wrong shape for a manager that serves per-step backends.

Closes #4391

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/make-plan/issue_4391_codex_persistent_root_scope_fix_plan_2026-08-04_172051.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
