### PR TITLE
Implementation Plan: Codex Cook Pre-Reveal Guidance

### DIFF
--- a/src/autoskillit/cli/session/_session_cook.py
+++ b/src/autoskillit/cli/session/_session_cook.py
@@ -34,6 +34,15 @@ if TYPE_CHECKING:
     )
 
 
+_COOK_PRE_REVEALED_KITCHEN_PROMPT = (
+    "This interactive cook session's AutoSkillit kitchen tools are already active and "
+    "pre-revealed. Do not call open_kitchen() with no arguments solely to gain tool "
+    "access. open_kitchen remains valid when the user explicitly requests activation "
+    "or promotion, to load a named recipe with open_kitchen(name=...), or to reopen "
+    "the kitchen after close_kitchen()."
+)
+
+
 def _build_cook_projection_context(
     skills_provider: SkillsDirectoryProvider,
     session_catalog: EffectiveSkillCatalog,
@@ -116,6 +125,11 @@ def cook(
         from autoskillit.cli.session._session_backend import resolve_global_backend
 
         backend = resolve_global_backend(config.agent_backend.backend)
+    cook_system_prompt = (
+        _COOK_PRE_REVEALED_KITCHEN_PROMPT
+        if not backend.capabilities.supports_tool_list_changed
+        else None
+    )
 
     if shutil.which(backend.binary_name()) is None:
         print(
@@ -352,6 +366,7 @@ def cook(
                     generated_home=managed_home.generated_home,
                     initial_prompt=current_initial_prompt,
                     resume_spec=current_resume_spec,
+                    system_prompt=cook_system_prompt,
                     env_extras=cook_env_extras,
                 )
                 final_cmd = built_spec.cmd

--- a/src/autoskillit/server/AGENTS.md
+++ b/src/autoskillit/server/AGENTS.md
@@ -35,7 +35,9 @@ Controls whether the tool appears in `tools/list` (whether the agent can see it)
   - **FLEET** sessions: `fleet`-tagged tools revealed; `fleet-dispatch` revealed only in dispatch mode
   - **ORCHESTRATOR + HEADLESS**: `kitchen` (or `kitchen-core` + pack tags) revealed
   - **SKILL + HEADLESS**: `headless`-tagged tools revealed (`test_check`); with `HEADLESS_AUTO_GATE=1`, `kitchen-core` also revealed
-  - **Interactive** (no HEADLESS): nothing pre-revealed; `open_kitchen` reveals `kitchen` tag
+  - **ORCHESTRATOR/SKILL + interactive + non-notification backend**: lifespan boot runs `_pre_reveal_kitchen()`
+  - **ORCHESTRATOR/SKILL + interactive + notification-capable backend**: nothing pre-revealed; `open_kitchen` reveals the `kitchen` tag
+  - **Direct sessions without a registered ORCHESTRATOR/SKILL interactive handler**: not implicitly pre-revealed
 - All tags in `ALL_VISIBILITY_TAGS` are disabled at startup via `for tag in sorted(ALL_VISIBILITY_TAGS): mcp.disable(tags={tag})`. Session-type dispatch and `open_kitchen` selectively re-enable per session. `ALL_VISIBILITY_TAGS` is defined in `core/types/_type_constants_registries.py`.
 
 ### Application-Gate (Python layer)

--- a/src/autoskillit/server/__init__.py
+++ b/src/autoskillit/server/__init__.py
@@ -5,8 +5,8 @@ Architecture" section for the full matrix.
 
 Tag-Visibility (FastMCP): kitchen-tagged tools are hidden at startup via
 mcp.disable(tags={'kitchen'}). Session-type dispatch (_apply_session_type_visibility)
-selectively reveals tags per session type. open_kitchen reveals all kitchen-tagged
-tools for interactive sessions.
+selectively reveals tags per session type and backend capability. open_kitchen reveals
+all kitchen-tagged tools when explicit activation or reopening is required.
 
 Application-Gate (Python): most tools call _require_enabled() internally, which
 checks ctx.gate.enabled and returns a gate_error envelope if the kitchen is closed.
@@ -17,7 +17,11 @@ Startup tag visibility is determined by AUTOSKILLIT_SESSION_TYPE (3-branch dispa
   ORCHESTRATOR + HEADLESS=1 — all kitchen-tagged tools pre-revealed
   SKILL + HEADLESS=1 — headless-tagged tools (test_check) pre-revealed;
   with AUTO_GATE=1, kitchen-core also revealed
-  ORCHESTRATOR/SKILL (interactive) — no pre-reveal; open_kitchen unlocks
+  ORCHESTRATOR/SKILL (interactive, non-notification backend) — lifespan boot
+  runs _pre_reveal_kitchen()
+  ORCHESTRATOR/SKILL (interactive, notification-capable backend) — no pre-reveal;
+  open_kitchen unlocks
+  Direct sessions without either registered interactive handler — no implicit pre-reveal
 
 Transport: stdio (default for FastMCP).
 """

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -1150,10 +1150,11 @@ async def open_kitchen(
 ) -> str:
     """Open the AutoSkillit kitchen for service.
 
-    A no-argument call solely to gain access is unnecessary when authoritative
+    A no-argument call made solely to gain access is unnecessary when authoritative
     session guidance says the kitchen was pre-revealed. Valid uses remain
-    human-requested activation or promotion when access is not active, named recipe
-    loading with ``name=...``, and restoration after close_kitchen.
+    human-requested activation when access is not active, human-requested promotion
+    including from a pre-revealed session, named recipe loading with ``name=...``, and
+    restoration after close_kitchen.
 
     When ``name`` is provided, the kitchen is opened AND the named recipe is
     loaded in a single call, reducing terminal noise from two tool calls to one.

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -1150,6 +1150,11 @@ async def open_kitchen(
 ) -> str:
     """Open the AutoSkillit kitchen for service.
 
+    A no-argument call solely to gain access is unnecessary when authoritative
+    session guidance says the kitchen was pre-revealed. Valid uses remain
+    human-requested activation or promotion when access is not active, named recipe
+    loading with ``name=...``, and restoration after close_kitchen.
+
     When ``name`` is provided, the kitchen is opened AND the named recipe is
     loaded in a single call, reducing terminal noise from two tool calls to one.
 

--- a/src/autoskillit/skills/open-kitchen/SKILL.md
+++ b/src/autoskillit/skills/open-kitchen/SKILL.md
@@ -18,15 +18,18 @@ Activate the AutoSkillit kitchen when the host has not already made its tools av
 
 **ALWAYS:**
 - Treat authoritative host/session guidance about pre-revealed tools as the source of truth
-- Preserve human-requested activation, named recipe loading, and reopening after `close_kitchen`
+- Preserve explicit human-requested activation or promotion, named recipe loading, and
+  reopening after `close_kitchen`
 
 ## Steps
 
-1. Check the host/session guidance for the current tool state.
-2. If the host says the kitchen tools are pre-revealed, confirm that they are already
-   active and do not make a redundant no-argument `open_kitchen` call.
-3. Otherwise, honor the human-requested activation by calling `open_kitchen` with no
-   arguments, then confirm that the kitchen tools are available.
+1. Check the host/session guidance and the user's requested outcome.
+2. If the host says the kitchen tools are pre-revealed and the user did not explicitly
+   request promotion, confirm that they are already active and do not make a redundant
+   no-argument `open_kitchen` call solely to gain access.
+3. If the user explicitly requests activation or promotion, call `open_kitchen` with no
+   arguments; promotion remains valid even when the tools are pre-revealed.
+4. Confirm that the requested kitchen state is active.
 
 The kitchen state is session-scoped. `open_kitchen(name=...)` remains valid for named
 recipe loading, and a no-argument call remains valid to reopen the kitchen after

--- a/src/autoskillit/skills/open-kitchen/SKILL.md
+++ b/src/autoskillit/skills/open-kitchen/SKILL.md
@@ -7,24 +7,27 @@ disable-model-invocation: true
 
 # Open Kitchen
 
-Call the `open_kitchen` MCP tool to reveal all 24 kitchen tools for this session.
+Activate the AutoSkillit kitchen when the host has not already made its tools available.
 
 ## Critical Constraints
 
 **NEVER:**
 - Fabricate, invent, or embellish information not supported by the available evidence or code.
 
-- Skip calling `open_kitchen` and assume the kitchen is already open
 - Call this skill from a headless or automated session (it is human-only)
 
 **ALWAYS:**
-- Call `open_kitchen` with no arguments
-- Confirm to the user that kitchen tools are now available
+- Treat authoritative host/session guidance about pre-revealed tools as the source of truth
+- Preserve human-requested activation, named recipe loading, and reopening after `close_kitchen`
 
 ## Steps
 
-1. Call `open_kitchen` with no arguments.
-2. Confirm the kitchen is open by displaying the list of newly available tools.
-3. Inform the user that all kitchen tools are now available for this session.
+1. Check the host/session guidance for the current tool state.
+2. If the host says the kitchen tools are pre-revealed, confirm that they are already
+   active and do not make a redundant no-argument `open_kitchen` call.
+3. Otherwise, honor the human-requested activation by calling `open_kitchen` with no
+   arguments, then confirm that the kitchen tools are available.
 
-The kitchen state is session-scoped. Each new coding-agent session starts with kitchen tools hidden. Use `/autoskillit:open-kitchen` to reveal them at the start of each session.
+The kitchen state is session-scoped. `open_kitchen(name=...)` remains valid for named
+recipe loading, and a no-argument call remains valid to reopen the kitchen after
+`close_kitchen`.

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+import tomllib
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -67,8 +68,11 @@ def _stub_plugin_artifact_authority(
 
     def choose(**kwargs: object):
         backend = kwargs["backend"]
-        if getattr(backend, "name", None) == "codex" and kwargs["generated_home"] is not None:
-            return None, PluginLoadMode.GENERATED_HOME
+        if (
+            getattr(backend, "name", None) == "codex"
+            and kwargs["generated_home_available"] is True
+        ):
+            return authority, PluginLoadMode.GENERATED_HOME
         return authority, PluginLoadMode.EXPLICIT_PLUGIN_DIR
 
     monkeypatch.setattr(
@@ -84,6 +88,7 @@ class _Backend:
         hook_trust_policy=HookTrustPolicy.AUTOMATED,
         session_dir_persistent=False,
         skill_injection_capable=True,
+        supports_tool_list_changed=True,
     )
     adapt_skill_semantics = staticmethod(adapt_test_skill_semantics)
 
@@ -235,6 +240,64 @@ def _install_harness(
     captured["generated_home"] = generated_home
     captured["skills_dir"] = skills_dir
     return captured
+
+
+def test_codex_cook_adds_pre_reveal_developer_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from autoskillit.execution.backends.codex import CodexBackend, CodexFlags
+
+    class _DelegatingCodexBackend(_Backend):
+        name = "codex"
+        capabilities = CodexBackend.capabilities
+
+        def __init__(self) -> None:
+            super().__init__()
+            self._command_backend = CodexBackend()
+
+        def binary_name(self) -> str:
+            return "codex"
+
+        def build_interactive_cmd(self, **kwargs: object) -> CmdSpec:
+            self.build_calls.append(kwargs)
+            return self._command_backend.build_interactive_cmd(**kwargs)  # type: ignore[arg-type]
+
+    backend = _DelegatingCodexBackend()
+    captured = _install_harness(monkeypatch, tmp_path)
+
+    cli.cook(backend=backend)
+
+    spec = captured["spec"]
+    assert isinstance(spec, CmdSpec)
+    overrides = (
+        spec.cmd[index + 1]
+        for index, value in enumerate(spec.cmd[:-1])
+        if value == CodexFlags.CONFIG_OVERRIDE
+    )
+    rendered = next(
+        value.removeprefix("developer_instructions=")
+        for value in overrides
+        if value.startswith("developer_instructions=")
+    )
+    guidance = tomllib.loads(f"developer_instructions = {rendered}")["developer_instructions"]
+    assert "kitchen tools are already active" in guidance
+    assert "no arguments solely to gain tool access" in guidance
+    assert "explicitly requests activation or promotion" in guidance
+    assert "open_kitchen(name=...)" in guidance
+    assert "after close_kitchen()" in guidance
+
+
+def test_notification_capable_cook_has_no_pre_reveal_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    backend = _Backend()
+    _install_harness(monkeypatch, tmp_path)
+
+    cli.cook(backend=backend)
+
+    assert backend.build_calls[0]["system_prompt"] is None
 
 
 def test_cook_uses_managed_home_for_final_child_context(
@@ -485,6 +548,7 @@ def test_cook_final_confirmation_precedes_registry_and_attempt(
             hook_trust_policy=HookTrustPolicy.AUTOMATED,
             session_dir_persistent=False,
             skill_injection_capable=True,
+            supports_tool_list_changed=True,
         )
         adapt_skill_semantics = staticmethod(adapt_test_skill_semantics)
 
@@ -577,6 +641,7 @@ def test_cook_does_not_treat_persistent_sessions_as_codex(
         session_dir_persistent=True,
         cook_startup_observer_capable=False,
         skill_injection_capable=True,
+        supports_tool_list_changed=True,
     )
     captured = _install_harness(monkeypatch, tmp_path)
 

--- a/tests/cli/test_cook_profile.py
+++ b/tests/cli/test_cook_profile.py
@@ -47,6 +47,7 @@ def _make_mock_backend_class():
         capabilities = SimpleNamespace(
             hook_trust_policy=HookTrustPolicy.AUTOMATED,
             session_dir_persistent=False,
+            supports_tool_list_changed=True,
             skill_injection_capable=False,
             plugin_install_capable=True,
         )
@@ -296,6 +297,7 @@ def test_finalized_profile_spec_is_shared_by_validator_context_and_child(
         capabilities = SimpleNamespace(
             hook_trust_policy=HookTrustPolicy.REVIEW_EACH_SESSION,
             session_dir_persistent=True,
+            supports_tool_list_changed=False,
             cook_startup_observer_capable=False,
             skill_injection_capable=True,
             plugin_install_capable=False,

--- a/tests/cli/test_reload_loop.py
+++ b/tests/cli/test_reload_loop.py
@@ -129,6 +129,7 @@ def test_cook_keeps_managed_home_across_reload_and_transfers_resume_after_attemp
         capabilities = SimpleNamespace(
             hook_trust_policy=HookTrustPolicy.AUTOMATED,
             session_dir_persistent=False,
+            supports_tool_list_changed=True,
             skill_injection_capable=True,
         )
         adapt_skill_semantics = staticmethod(adapt_test_skill_semantics)
@@ -351,6 +352,7 @@ def test_cook_rejects_repeated_and_excessive_reload_requests(
         capabilities = SimpleNamespace(
             hook_trust_policy=HookTrustPolicy.AUTOMATED,
             session_dir_persistent=False,
+            supports_tool_list_changed=True,
             skill_injection_capable=True,
         )
         adapt_skill_semantics = staticmethod(adapt_test_skill_semantics)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -126,7 +126,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools/tools_kitchen.py", 540),
     ("src/autoskillit/server/tools/tools_kitchen.py", 559),
     ("src/autoskillit/server/tools/tools_kitchen.py", 593),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 1923),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 1929),
     # tools_pipeline_tracker.py — tracker_data dict (init) and mark_step_complete write
     # (same tracker file schema as init — not a new format, grandfathered alongside it)
     ("src/autoskillit/server/tools/tools_pipeline_tracker.py", 256),

--- a/tests/server/test_tools_kitchen_gate.py
+++ b/tests/server/test_tools_kitchen_gate.py
@@ -255,8 +255,10 @@ async def test_open_kitchen_description_distinguishes_valid_calls() -> None:
     tool = await mcp.get_tool("open_kitchen")
     assert tool is not None
     description = tool.description.lower()
-    assert "pre-revealed" in description and "no-argument" in description
-    assert "human-requested activation or promotion" in description
+    assert "pre-revealed" in description and "solely to gain access" in description
+    assert "human-requested promotion" in description
+    assert "including from a pre-revealed session" in description
+    assert "activation or promotion when access is not active" not in description
     assert "name=" in description
     assert "after close_kitchen" in description
 

--- a/tests/server/test_tools_kitchen_gate.py
+++ b/tests/server/test_tools_kitchen_gate.py
@@ -248,6 +248,19 @@ async def test_open_kitchen_has_always_load_meta() -> None:
     )
 
 
+@pytest.mark.anyio
+async def test_open_kitchen_description_distinguishes_valid_calls() -> None:
+    from autoskillit.server import mcp
+
+    tool = await mcp.get_tool("open_kitchen")
+    assert tool is not None
+    description = tool.description.lower()
+    assert "pre-revealed" in description and "no-argument" in description
+    assert "human-requested activation or promotion" in description
+    assert "name=" in description
+    assert "after close_kitchen" in description
+
+
 # ---------------------------------------------------------------------------
 # Triple-ID unification: kitchen_id inherits AUTOSKILLIT_CAMPAIGN_ID
 # ---------------------------------------------------------------------------

--- a/tests/skills/test_phase2_skills.py
+++ b/tests/skills/test_phase2_skills.py
@@ -24,6 +24,19 @@ def test_open_kitchen_skill_has_disable_model_invocation() -> None:
     assert fm.get("name") == "open-kitchen"
 
 
+def test_open_kitchen_skill_respects_host_declared_visibility() -> None:
+    content = (pkg_root() / "skills" / "open-kitchen" / "SKILL.md").read_text()
+
+    assert "Each new coding-agent session starts with kitchen tools hidden" not in content
+    assert "Skip calling `open_kitchen` and assume the kitchen is already open" not in content
+    assert "**ALWAYS:**\n- Call `open_kitchen` with no arguments" not in content
+    assert "host" in content and "pre-revealed" in content
+    assert "no-argument" in content and "redundant" in content
+    assert "human" in content and "activation" in content
+    assert "name=" in content
+    assert "close_kitchen" in content and "reopen" in content
+
+
 def test_close_kitchen_skill_has_disable_model_invocation() -> None:
     skill_md = pkg_root() / "skills" / "close-kitchen" / "SKILL.md"
     assert skill_md.exists()

--- a/tests/skills/test_phase2_skills.py
+++ b/tests/skills/test_phase2_skills.py
@@ -31,8 +31,9 @@ def test_open_kitchen_skill_respects_host_declared_visibility() -> None:
     assert "Skip calling `open_kitchen` and assume the kitchen is already open" not in content
     assert "**ALWAYS:**\n- Call `open_kitchen` with no arguments" not in content
     assert "host" in content and "pre-revealed" in content
-    assert "no-argument" in content and "redundant" in content
-    assert "human" in content and "activation" in content
+    assert "no-argument" in content and "solely to gain access" in content
+    assert "explicitly requests activation or promotion" in content
+    assert "promotion remains valid even when the tools are pre-revealed" in content
     assert "name=" in content
     assert "close_kitchen" in content and "reopen" in content
 


### PR DESCRIPTION
## Summary

Interactive Codex cook sessions already pre-reveal and enable kitchen tools because Codex does not support `tools/list_changed`, but the model is not told that runtime fact. Add cook-specific developer guidance through the existing `system_prompt` argument passed to `CodingAgentBackend.build_interactive_cmd()`, conditional on `supports_tool_list_changed=False`. The guidance must say that tool access is already active, prohibit inferring a redundant no-argument `open_kitchen()` call merely to gain access, and preserve legitimate uses: explicit user-requested activation/promotion, `open_kitchen(name=...)` recipe loading, and reopening after `close_kitchen()`.

## Requirements

**REQ-STATE-001:** An interactive cook session whose kitchen tools were pre-revealed must provide the model an authoritative statement that tool access is already active.

**REQ-STATE-002:** Model-facing guidance must distinguish a redundant no-argument activation call from valid `open_kitchen` uses such as explicit L1→L2 promotion, named recipe loading, and reopening after `close_kitchen`.

**REQ-STATE-003:** Bundled skill guidance presented in a pre-revealed cook session must not claim that kitchen tools are necessarily hidden or that no-argument activation is always mandatory.

**REQ-COMP-001:** Direct interactive/plugin sessions that genuinely require human-driven activation must retain a working `open_kitchen` entry point.

**REQ-COMP-002:** Named recipe loading and same-session `close_kitchen`→`open_kitchen` restoration must continue to work for notification and non-notification clients.

**REQ-COMP-003:** Existing selected-headless denial and Codex host-side auto-gating behavior must remain unchanged; the reported incident is interactive and does not justify broadening the fix into headless visibility policy.

**REQ-TEST-001:** Regression coverage must verify the authoritative pre-reveal guidance delivered to interactive Codex cook sessions.

**REQ-TEST-002:** Regression coverage must prove that valid interactive activation, named recipe loading, and close→reopen behavior remain available.

**REQ-TEST-003:** Regression coverage must retain the existing negative contract denying `open_kitchen` from non-orchestrator headless sessions.

Closes #4490

Issue: https://github.com/TalonT-Org/AutoSkillit/issues/4490

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/make-plan/codex_cook_pre_reveal_guidance_plan_2026-08-08_103112.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
