### PR TITLE
Rectify: Parameter-Role Authority for Attested `run_skill` Invocations (#4402)

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -268,6 +268,7 @@ from .tool_registry import TOOL_REGISTRY as TOOL_REGISTRY
 from .tool_registry import all_tool_names as all_tool_names
 from .tool_registry import compute_tool_contract_identity as compute_tool_contract_identity
 from .tool_registry import get_tool_def as get_tool_def
+from .tool_registry import runtime_exempt_param_names as runtime_exempt_param_names
 from .tool_registry import unsupported_tool_params as unsupported_tool_params
 from .tool_sequence_analysis import DFG as DFG
 from .tool_sequence_analysis import AnalysisResult as AnalysisResult
@@ -1010,6 +1011,7 @@ from .types import ToolCallId as ToolCallId
 from .types import ToolDef as ToolDef
 from .types import ToolInitializationOperation as ToolInitializationOperation
 from .types import ToolParamDef as ToolParamDef
+from .types import ToolParamRole as ToolParamRole
 from .types import ToolWireType as ToolWireType
 from .types import TraditionManifest as TraditionManifest
 from .types import TurnId as TurnId

--- a/src/autoskillit/core/tool_registry.py
+++ b/src/autoskillit/core/tool_registry.py
@@ -129,6 +129,11 @@ def _tool(
     required_set = frozenset(required)
     declared_wire_types = wire_types or {}
     declared_roles = roles or {}
+    unknown_role_params = set(declared_roles) - set(params)
+    if unknown_role_params:
+        raise ValueError(
+            f"Tool {name!r} declares roles for unknown parameter(s): {sorted(unknown_role_params)}"
+        )
     return ToolDef(
         name=name,
         params=tuple(

--- a/src/autoskillit/core/tool_registry.py
+++ b/src/autoskillit/core/tool_registry.py
@@ -16,6 +16,7 @@ from .types._type_recipe_binding import (
     ToolDef,
     ToolInitializationOperation,
     ToolParamDef,
+    ToolParamRole,
     ToolWireType,
 )
 
@@ -24,6 +25,7 @@ __all__ = [
     "all_tool_names",
     "compute_tool_contract_identity",
     "get_tool_def",
+    "runtime_exempt_param_names",
     "unsupported_tool_params",
 ]
 
@@ -122,9 +124,11 @@ def _tool(
     *,
     required: tuple[str, ...] = (),
     wire_types: Mapping[str, ToolWireType] | None = None,
+    roles: Mapping[str, ToolParamRole] | None = None,
 ) -> ToolDef:
     required_set = frozenset(required)
     declared_wire_types = wire_types or {}
+    declared_roles = roles or {}
     return ToolDef(
         name=name,
         params=tuple(
@@ -132,11 +136,45 @@ def _tool(
                 param,
                 wire_type=declared_wire_types.get(param, ToolWireType.SCALAR),
                 required=param in required_set,
+                role=declared_roles.get(param, ToolParamRole.CHILD_INPUT),
             )
             for param in params
         ),
         initialization_operation=_initialization_operation(name),
     )
+
+
+# The single classification authority for what each run_skill parameter is
+# for. Every attestation-relevant surface (the runtime gate's always-admit
+# set, the actual-kwargs assembly, the execution-tuning fallback table, and
+# the frozen ledger in tests/contracts/test_run_skill_kwarg_ledger.py) is
+# derived from this mapping — see ToolParamRole for what each role means.
+_RUN_SKILL_PARAM_ROLES: Mapping[str, ToolParamRole] = MappingProxyType(
+    {
+        "skill_command": ToolParamRole.CHILD_INPUT,
+        "cwd": ToolParamRole.CHILD_INPUT,
+        "model": ToolParamRole.EXECUTION_TUNING,
+        "step_name": ToolParamRole.PROTOCOL,
+        "recipe_execution_id": ToolParamRole.PROTOCOL,
+        "invocation_template_digest": ToolParamRole.PROTOCOL,
+        "step_provider": ToolParamRole.EXECUTION_TUNING,
+        "order_id": ToolParamRole.ORCHESTRATOR_SCOPING,
+        "stale_threshold": ToolParamRole.EXECUTION_TUNING,
+        "idle_output_timeout": ToolParamRole.EXECUTION_TUNING,
+        "output_dir": ToolParamRole.CHILD_INPUT,
+        "resume_session_id": ToolParamRole.SESSION_FLOW,
+        "retry_after_audit_attempt_id": ToolParamRole.SESSION_FLOW,
+        "native_shell_capture_mode": ToolParamRole.SESSION_FLOW,
+        "closure_authority_path": ToolParamRole.SESSION_FLOW,
+        "closure_authority_hash": ToolParamRole.SESSION_FLOW,
+        "closure_plan_paths": ToolParamRole.SESSION_FLOW,
+        "closure_base_sha": ToolParamRole.SESSION_FLOW,
+        "closure_diff_sha": ToolParamRole.SESSION_FLOW,
+        "closure_target_sha": ToolParamRole.SESSION_FLOW,
+        "dispatch_items": ToolParamRole.SESSION_FLOW,
+        "skill_inputs": ToolParamRole.CHILD_INPUT,
+    }
+)
 
 
 def _run_skill() -> ToolDef:
@@ -165,18 +203,28 @@ def _run_skill() -> ToolDef:
             name,
             wire_type=ToolWireType.STRING,
             required=name in {"skill_command", "cwd"},
+            role=_RUN_SKILL_PARAM_ROLES[name],
         )
         for name in string_params
     ]
     params[8:8] = [
-        ToolParamDef("stale_threshold", ToolWireType.INTEGER),
-        ToolParamDef("idle_output_timeout", ToolWireType.INTEGER),
+        ToolParamDef(
+            "stale_threshold",
+            ToolWireType.INTEGER,
+            role=_RUN_SKILL_PARAM_ROLES["stale_threshold"],
+        ),
+        ToolParamDef(
+            "idle_output_timeout",
+            ToolWireType.INTEGER,
+            role=_RUN_SKILL_PARAM_ROLES["idle_output_timeout"],
+        ),
     ]
     params.append(
         ToolParamDef(
             "dispatch_items",
             ToolWireType.STRING,
             handler_parameter=False,
+            role=_RUN_SKILL_PARAM_ROLES["dispatch_items"],
         )
     )
     params.append(
@@ -185,6 +233,7 @@ def _run_skill() -> ToolDef:
             ToolWireType.OBJECT,
             structured_skill_inputs=True,
             handler_parameter=True,
+            role=_RUN_SKILL_PARAM_ROLES["skill_inputs"],
         )
     )
     return ToolDef(
@@ -379,6 +428,10 @@ _TOOL_DEFS = (
             "resume_checkpoint": ToolWireType.OBJECT,
             "native_shell_capture_mode": ToolWireType.STRING,
         },
+        # Must match run_skill's native_shell_capture_mode role exactly:
+        # test_tool_registry_parity.py::test_managed_launch_tools_share_native_shell_capture_schema
+        # asserts full dataclass equality between the two ToolParamDef instances.
+        roles={"native_shell_capture_mode": ToolParamRole.SESSION_FLOW},
     ),
     _tool(
         "record_gate_dispatch",
@@ -659,6 +712,20 @@ if not HEADLESS_TOOLS <= TOOL_REGISTRY.keys():
 
 def get_tool_def(tool_name: str) -> ToolDef | None:
     return TOOL_REGISTRY.get(tool_name)
+
+
+def runtime_exempt_param_names(tool_def: ToolDef) -> frozenset[str]:
+    """Names always admitted by the runtime attestation gate, regardless of with:.
+
+    PROTOCOL params are the attestation identity triple; ORCHESTRATOR_SCOPING
+    params are runtime scoping that is never recipe-authorable. Every other
+    role must be compiled into the template's with: block to be admitted.
+    """
+    return frozenset(
+        param.name
+        for param in tool_def.params
+        if param.role in (ToolParamRole.PROTOCOL, ToolParamRole.ORCHESTRATOR_SCOPING)
+    )
 
 
 def compute_tool_contract_identity(tool_def: ToolDef) -> str:

--- a/src/autoskillit/core/tool_registry.py
+++ b/src/autoskillit/core/tool_registry.py
@@ -739,6 +739,7 @@ def compute_tool_contract_identity(tool_def: ToolDef) -> str:
         {
             "name": tool_def.name,
             "initialization_operation": tool_def.initialization_operation.value,
+            # Parameter roles are server-side gate policy, not client-visible wire shape.
             "params": [
                 {
                     "handler_parameter": param.handler_parameter,

--- a/src/autoskillit/core/types/_type_recipe_binding.py
+++ b/src/autoskillit/core/types/_type_recipe_binding.py
@@ -7,7 +7,7 @@ and server dispatch share these values without importing one another.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from types import MappingProxyType
 from typing import TypeAlias
@@ -29,6 +29,7 @@ __all__ = [
     "ToolDef",
     "ToolInitializationOperation",
     "ToolParamDef",
+    "ToolParamRole",
     "ToolWireType",
 ]
 
@@ -58,6 +59,33 @@ class ToolInitializationOperation(StrEnum):
     MUTATION = "mutation"
 
 
+class ToolParamRole(StrEnum):
+    """The single classification authority for what a tool parameter is for.
+
+    The runtime attestation gate's always-admit set, the actual-kwargs
+    assembly, and the server-side ``RecipeStep`` fallback obligation for
+    execution-tuning parameters are all derived from this field — see
+    ``runtime_exempt_param_names`` (core/tool_registry.py) and
+    ``bind_runtime_skill_invocation`` (recipe/_binding.py).
+    """
+
+    PROTOCOL = "protocol"
+    """Attestation identity (step_name, recipe_execution_id, invocation_template_digest);
+    always admitted."""
+
+    CHILD_INPUT = "child_input"
+    """Child-skill inputs; admitted iff with:-compiled."""
+
+    EXECUTION_TUNING = "execution_tuning"
+    """Server-resolved from RecipeStep; forward only via with:."""
+
+    ORCHESTRATOR_SCOPING = "orchestrator_scoping"
+    """Runtime scoping; never recipe-authorable; always admitted."""
+
+    SESSION_FLOW = "session_flow"
+    """Resume/retry/capture plumbing; admitted iff with:-compiled."""
+
+
 @dataclass(frozen=True, slots=True)
 class ToolParamDef:
     """Static definition of one public MCP handler parameter."""
@@ -67,6 +95,7 @@ class ToolParamDef:
     required: bool = False
     structured_skill_inputs: bool = False
     handler_parameter: bool = True
+    role: ToolParamRole = field(kw_only=True)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/recipe/_binding.py
+++ b/src/autoskillit/recipe/_binding.py
@@ -18,10 +18,13 @@ from autoskillit.core import (
     BoundValueState,
     InvocationTemplate,
     RecipeBindingProjection,
+    ToolDef,
     ToolParamDef,
+    ToolParamRole,
     ToolWireType,
     get_tool_def,
     resolve_skill_name,
+    runtime_exempt_param_names,
 )
 from autoskillit.recipe._contracts_manifest import (
     compute_skill_contract_identity as _compute_skill_contract_identity,
@@ -843,6 +846,34 @@ def _is_dynamic_binding(value: BoundValue) -> bool:
     return bool(value.context_dependencies or value.input_dependencies)
 
 
+def _undeclared_runtime_param_message(tool_def: ToolDef, undeclared_names: list[str]) -> str:
+    """Denial text for undeclared non-empty runtime tool parameters.
+
+    Keeps the original generic shape naming every undeclared parameter, and
+    appends an actionable remedy for any EXECUTION_TUNING name: it is
+    server-resolved from the recipe step, must be omitted from the call,
+    and declaring it under the step's ``with:`` block is the only per-step
+    override channel. Every other role keeps the plain generic shape.
+    """
+    message = (
+        f"runtime tool parameters are absent from the compiled template: {undeclared_names!r}"
+    )
+    tuning_names = [
+        name
+        for name in undeclared_names
+        if (param := tool_def.param_def(name)) is not None
+        and param.role is ToolParamRole.EXECUTION_TUNING
+    ]
+    if tuning_names:
+        remedies = "; ".join(
+            f"{name!r} is server-resolved from the recipe step — omit it, or declare "
+            f"{name!r} under this step's with: block for a per-step override"
+            for name in tuning_names
+        )
+        message = f"{message}; {remedies}"
+    return message
+
+
 def bind_runtime_skill_invocation(
     template: InvocationTemplate,
     *,
@@ -860,6 +891,11 @@ def bind_runtime_skill_invocation(
             "runtime skill identity differs from the compiled template",
         )
     compiled_mcp_names = frozenset(value.name for value in invocation.mcp_kwargs)
+    # protocol_mcp_values is used solely for its value-binding duty below (the
+    # three protocol params are checked/bound against their expected values).
+    # It no longer doubles as the undeclared-name membership allow-list — that
+    # allow-list is the role-derived runtime_exempt_param_names() set, the
+    # single source of truth for "which params are always admitted."
     protocol_mcp_values = {
         "step_name": step_name,
         "recipe_execution_id": execution_id,
@@ -871,18 +907,22 @@ def bind_runtime_skill_invocation(
                 "recipe_execution_tool_shape",
                 f"attestation parameter {name!r} differs from the active invocation",
             )
+    bound_tool_def = get_tool_def(invocation.tool_name)
+    if bound_tool_def is None:
+        raise RuntimeBindingError(
+            "recipe_execution_tool_shape",
+            f"no canonical tool definition for {invocation.tool_name!r}",
+        )
+    runtime_admitted_names = compiled_mcp_names | runtime_exempt_param_names(bound_tool_def)
     undeclared_effective_names = sorted(
         name
         for name, value in actual_mcp_kwargs.items()
-        if name not in compiled_mcp_names and name not in protocol_mcp_values and value != ""
+        if name not in runtime_admitted_names and value != ""
     )
     if undeclared_effective_names:
         raise RuntimeBindingError(
             "recipe_execution_tool_shape",
-            (
-                "runtime tool parameters are absent from the compiled template: "
-                f"{undeclared_effective_names!r}"
-            ),
+            _undeclared_runtime_param_message(bound_tool_def, undeclared_effective_names),
         )
     manifest = load_bundled_manifest()
     contract = get_skill_contract(invocation.skill_name or "", manifest)

--- a/src/autoskillit/recipe/_binding.py
+++ b/src/autoskillit/recipe/_binding.py
@@ -891,11 +891,7 @@ def bind_runtime_skill_invocation(
             "runtime skill identity differs from the compiled template",
         )
     compiled_mcp_names = frozenset(value.name for value in invocation.mcp_kwargs)
-    # protocol_mcp_values is used solely for its value-binding duty below (the
-    # three protocol params are checked/bound against their expected values).
-    # It no longer doubles as the undeclared-name membership allow-list — that
-    # allow-list is the role-derived runtime_exempt_param_names() set, the
-    # single source of truth for "which params are always admitted."
+    # Bind the three protocol parameters against their expected attestation values.
     protocol_mcp_values = {
         "step_name": step_name,
         "recipe_execution_id": execution_id,

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -862,9 +862,15 @@ def _build_actual_mcp_kwargs(
 # when the caller left the run_skill param at its vacancy sentinel (empty
 # string for str params, None for int params — see the fallback block
 # below). Single source of truth for "which EXECUTION_TUNING params get a
-# RecipeStep fallback"; every loop-table entry is actually read, and this
-# set is verified disjoint from _EXECUTION_TUNING_EXTERNALLY_RESOLVED by
-# tests/contracts/test_tool_param_roles.py.
+# RecipeStep fallback", cross-checked two ways: test_tool_param_roles.py
+# verifies this set is disjoint from _EXECUTION_TUNING_EXTERNALLY_RESOLVED
+# and matches the EXECUTION_TUNING role assignments; test_run_skill_execution_tuning_fallbacks.py
+# verifies each entry has a real `_recipe_step.<field>` read site in the
+# fallback block below (a per-field explicit `if`, not a runtime loop over
+# this dict — each field needs a distinct vacancy-sentinel check and writes
+# a distinct local variable, which Python cannot dispatch generically by
+# name without unsafe locals() mutation; that per-field test is what keeps
+# a new table entry from becoming a silent no-op).
 _EXECUTION_TUNING_STEP_FIELDS: Mapping[str, str] = {
     "model": "model",
     "stale_threshold": "stale_threshold",
@@ -1783,7 +1789,17 @@ async def run_skill(
                     # params) — an explicit caller idle_output_timeout=0 (the
                     # documented "disabled for this step" value) must survive
                     # untouched. See _EXECUTION_TUNING_STEP_FIELDS.
-                    if effective_model == "" and _recipe_step.model:
+                    if (
+                        effective_model == ""
+                        and _recipe_step.model
+                        and "${{" not in _recipe_step.model
+                    ):
+                        # Skip values containing unresolved template references —
+                        # load() returns raw YAML without ingredient resolution,
+                        # so ${{ inputs.* }}/${{ context.* }} placeholders may
+                        # survive (see the output_dir fallback above for the
+                        # same guard). A raw template string is never a valid
+                        # --model value.
                         effective_model = _recipe_step.model
                         logger.warning(
                             "model_resolved_from_recipe",

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -7,6 +7,7 @@ import json
 import os
 import shutil
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -57,6 +58,7 @@ from autoskillit.core import (
     SkillExecutionRole,
     SkillResult,
     TerminationReason,
+    ToolDef,
     ValidatedAddDir,
     WriteBehaviorSpec,
     closure_authority_spec_from_args,
@@ -67,6 +69,7 @@ from autoskillit.core import (
     extract_skill_name,
     find_caller_session_id,
     get_logger,
+    get_tool_def,
     is_feature_enabled,
     parse_plan_paths,
     render_target_skill_command,
@@ -811,6 +814,72 @@ async def run_python(
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
+def _build_actual_mcp_kwargs(
+    tool_def: ToolDef, values: Mapping[str, BoundScalar | None]
+) -> dict[str, BoundScalar]:
+    """Assemble the actual runtime kwargs the attestation gate checks.
+
+    Iterates ``tool_def``'s handler params only — a param declared
+    ``handler_parameter=False`` (e.g. ``dispatch_items``) or
+    ``structured_skill_inputs=True`` (``skill_inputs``, which has its own
+    dedicated channel) is excluded — and pulls each remaining param's
+    runtime value from ``values``, keyed by param name, which the caller
+    builds from the handler's locals.
+
+    A param missing from ``values``, or a ``values`` key absent from the
+    filtered param set, is a loud construction-time bug: adding a
+    ``ToolParamDef`` without wiring its runtime value (or vice versa) fails
+    the first attested call instead of silently drifting. ``None`` values
+    are omitted — the vacancy sentinel for optional params such as
+    ``stale_threshold``/``idle_output_timeout`` (subsumes the prior
+    hand-typed ``if ... is not None`` special case).
+    """
+    handler_param_names = frozenset(
+        param.name
+        for param in tool_def.params
+        if param.handler_parameter and not param.structured_skill_inputs
+    )
+    missing = handler_param_names - values.keys()
+    if missing:
+        raise ValueError(
+            f"{tool_def.name}: no runtime value supplied for handler params: {sorted(missing)!r}"
+        )
+    unknown = values.keys() - handler_param_names
+    if unknown:
+        raise ValueError(
+            f"{tool_def.name}: runtime values supplied for unknown handler params: "
+            f"{sorted(unknown)!r}"
+        )
+    result: dict[str, BoundScalar] = {}
+    for name in handler_param_names:
+        value = values[name]
+        if value is not None:
+            result[name] = value
+    return result
+
+
+# EXECUTION_TUNING params server-resolved from the matching RecipeStep field
+# when the caller left the run_skill param at its vacancy sentinel (empty
+# string for str params, None for int params — see the fallback block
+# below). Single source of truth for "which EXECUTION_TUNING params get a
+# RecipeStep fallback"; every loop-table entry is actually read, and this
+# set is verified disjoint from _EXECUTION_TUNING_EXTERNALLY_RESOLVED by
+# tests/contracts/test_tool_param_roles.py.
+_EXECUTION_TUNING_STEP_FIELDS: Mapping[str, str] = {
+    "model": "model",
+    "stale_threshold": "stale_threshold",
+    "idle_output_timeout": "idle_output_timeout",
+}
+# EXECUTION_TUNING params resolved elsewhere (site named per entry) rather
+# than by the fallback block below. Contract-coverage documentation only —
+# not consumed at runtime.
+_EXECUTION_TUNING_EXTERNALLY_RESOLVED: Mapping[str, str] = {
+    # Pre-gate profile resolution — see the step_provider_resolved_from_recipe
+    # block earlier in run_skill().
+    "step_provider": "provider",
+}
+
+
 @mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
 @_cancellation_shield()
 @track_response_size("run_skill")
@@ -1147,30 +1216,33 @@ async def run_skill(
                     "recipe_execution_step_missing",
                     "an attested recipe invocation requires its exact step_name",
                 )
-            _actual_mcp_kwargs: dict[str, BoundScalar] = {
-                "skill_command": skill_command,
-                "cwd": cwd,
-                "model": model,
-                "step_name": step_name,
-                "recipe_execution_id": recipe_execution_id,
-                "invocation_template_digest": invocation_template_digest,
-                "step_provider": step_provider,
-                "order_id": order_id,
-                "output_dir": output_dir,
-                "resume_session_id": resume_session_id,
-                "closure_authority_path": closure_authority_path,
-                "closure_authority_hash": closure_authority_hash,
-                "closure_plan_paths": closure_plan_paths,
-                "closure_base_sha": closure_base_sha,
-                "closure_diff_sha": closure_diff_sha,
-                "closure_target_sha": closure_target_sha,
-                "retry_after_audit_attempt_id": retry_after_audit_attempt_id,
-                "native_shell_capture_mode": native_shell_capture_mode,
-            }
-            if stale_threshold is not None:
-                _actual_mcp_kwargs["stale_threshold"] = stale_threshold
-            if idle_output_timeout is not None:
-                _actual_mcp_kwargs["idle_output_timeout"] = idle_output_timeout
+            _run_skill_tool_def = get_tool_def("run_skill")
+            assert _run_skill_tool_def is not None, "run_skill must be a registered ToolDef"
+            _actual_mcp_kwargs = _build_actual_mcp_kwargs(
+                _run_skill_tool_def,
+                {
+                    "skill_command": skill_command,
+                    "cwd": cwd,
+                    "model": model,
+                    "step_name": step_name,
+                    "recipe_execution_id": recipe_execution_id,
+                    "invocation_template_digest": invocation_template_digest,
+                    "step_provider": step_provider,
+                    "order_id": order_id,
+                    "stale_threshold": stale_threshold,
+                    "idle_output_timeout": idle_output_timeout,
+                    "output_dir": output_dir,
+                    "resume_session_id": resume_session_id,
+                    "closure_authority_path": closure_authority_path,
+                    "closure_authority_hash": closure_authority_hash,
+                    "closure_plan_paths": closure_plan_paths,
+                    "closure_base_sha": closure_base_sha,
+                    "closure_diff_sha": closure_diff_sha,
+                    "closure_target_sha": closure_target_sha,
+                    "retry_after_audit_attempt_id": retry_after_audit_attempt_id,
+                    "native_shell_capture_mode": native_shell_capture_mode,
+                },
+            )
             try:
                 _bound_recipe_inputs, _invocation_template = bind_attested_runtime_invocation(
                     _installed_execution,
@@ -1447,6 +1519,9 @@ async def run_skill(
             _in_fleet_dispatch = bool(os.environ.get(DISPATCH_ID_ENV_VAR))
             _inspector_model = _cfg.fleet.inspector_model if _in_fleet_dispatch else ""
 
+            # step_provider's execution-tuning fallback lives here (pre-gate,
+            # profile-interplay semantics) rather than in the post-gate
+            # fallback loop — see _EXECUTION_TUNING_EXTERNALLY_RESOLVED.
             if not step_provider and step_name and tool_ctx.active_recipe_steps is not None:
                 _recipe_step_pre = tool_ctx.active_recipe_steps.get(step_name)
                 if _recipe_step_pre is not None and _recipe_step_pre.provider:
@@ -1701,6 +1776,20 @@ async def run_skill(
                                 step=step_name,
                                 output_dir=output_dir,
                             )
+
+                    # Vacancy sentinels are per-type identity checks, never a
+                    # blanket falsy check: model is "==  ''" (a str param),
+                    # stale_threshold/idle_output_timeout are "is None" (int
+                    # params) — an explicit caller idle_output_timeout=0 (the
+                    # documented "disabled for this step" value) must survive
+                    # untouched. See _EXECUTION_TUNING_STEP_FIELDS.
+                    if effective_model == "" and _recipe_step.model:
+                        effective_model = _recipe_step.model
+                        logger.warning(
+                            "model_resolved_from_recipe",
+                            step=step_name,
+                            value=effective_model,
+                        )
 
                     if stale_threshold is None and _recipe_step.stale_threshold is not None:
                         stale_threshold = _recipe_step.stale_threshold

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -1223,7 +1223,8 @@ async def run_skill(
                     "an attested recipe invocation requires its exact step_name",
                 )
             _run_skill_tool_def = get_tool_def("run_skill")
-            assert _run_skill_tool_def is not None, "run_skill must be a registered ToolDef"
+            if _run_skill_tool_def is None:
+                raise RuntimeError("run_skill must be a registered ToolDef")
             _actual_mcp_kwargs = _build_actual_mcp_kwargs(
                 _run_skill_tool_def,
                 {

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -521,7 +521,7 @@ parallel run of the same step reports under the same canonical step name.
 
 ---
 
-## PARAMETER FORWARDING — step_name, output_dir, stale_threshold, idle_output_timeout, step_provider
+## PARAMETER FORWARDING — step_name, output_dir
 
 When a recipe step's `with:` block contains `step_name`, you MUST pass it as the
 `step_name` parameter of `run_skill`. This enables ingredient lock enforcement,
@@ -532,14 +532,13 @@ When a recipe step's `with:` block contains `output_dir`, you MUST pass it as th
 `output_dir` parameter of `run_skill`. This controls the write guard — omitting it
 causes the session to write to the wrong directory.
 
-When a recipe step has a top-level `stale_threshold` or `idle_output_timeout` field,
-pass it as the corresponding `run_skill` parameter. These control session kill thresholds.
-
-When a recipe step has a top-level `provider` field, pass the value as the
-`step_provider` parameter of `run_skill`. This controls which LLM provider
-(e.g., Minimax, Bedrock) the session uses. Omitting it causes the session to
-fall back to the default Anthropic provider, silently ignoring the recipe's
-declared provider.
+`model`, `stale_threshold`, `idle_output_timeout`, and `step_provider` are a
+different case: each is resolved server-side from the step's matching
+top-level field (`model:`, `stale_threshold:`, `idle_output_timeout:`,
+`provider:`). Do not include any of them in an attested `run_skill` call — the
+runtime attestation gate denies all four outright unless the step's `with:`
+block itself declares the name (a genuine per-step call-time override,
+distinct from the top-level field).
 
 **Example:**
 ```yaml
@@ -554,9 +553,10 @@ implement:
     output_dir: "${{ context.work_dir }}/${{ context.autoskillit_temp }}"
 ```
 
-Call: `run_skill(skill_command=..., cwd=..., step_name="implement", output_dir="...", stale_threshold=2400, step_provider="minimax")`
+Call: `run_skill(skill_command=..., cwd=..., step_name="implement", output_dir="...")`
 
-This provides defense-in-depth: the server resolves parameters server-side, AND the LLM is instructed to forward them.
+The server resolves `stale_threshold` and `step_provider` from the step
+definition above without either name appearing in the call.
 
 ---
 
@@ -609,9 +609,15 @@ the call with: `"arg 'output_dir' is a relative path but work_dir was not provid
 
 ---
 
-## MODEL PROPAGATION — MANDATORY
+## MODEL RESOLUTION
 
-**MODEL PROPAGATION** — When the user specifies a model (e.g. "use opus"), apply it to the `model` parameter of ALL `run_skill` calls for steps that declare a `model:` field — including follow-on steps (retry_worktree, fix, resolve_review, resolve_ci, conflict resolution). All `run_skill` steps in orchestrated recipes must declare a `model:` field; steps that omit it are ineligible for propagation and silently bypass user model selection.
+The server resolves `model` from the step's top-level `model:` field — this is
+how user model selection (e.g. "use opus") reaches child sessions, including
+follow-on steps (retry_worktree, fix, resolve_review, resolve_ci, conflict
+resolution). All `run_skill` steps in orchestrated recipes should still
+declare a `model:` field; steps that omit it are ineligible for selection. Do
+not include `model` in an attested `run_skill` call; declare it under the
+step's `with:` block only for a genuine per-step call-time override.
 
 ---
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -251,3 +251,43 @@ registered entity must update its retirement registry in the SAME commit:
   repos with no way to see a tightened contract coming; the registry forces every new
   validation to declare a `DETERMINISTIC` migration or `ADVISORY` hint before it can
   ship. `tests/contracts/test_skill_contract_remediations.py` fails otherwise.
+
+## run_skill Parameter-Role Ledgers (#4402)
+
+Two frozen ledgers guard the junctions where the run_skill parameter-role
+authority mechanism can silently drift. Same discipline as the config-key
+ledger (#4303, `test_config_key_ledger.py`), applied to `ToolParamRole` and
+`RecipeStep` field classification — inline Python dict literals rather than
+external `.txt` files, since these are name→classification mappings whose
+values carry structure (`inert-tracked:#NNNN` is itself validated), not flat
+name lists:
+
+- **`tests/contracts/test_run_skill_kwarg_ledger.py`** — a frozen
+  `(param_name, role)` table diffed bidirectionally against the live
+  `get_tool_def("run_skill").params` registry. A parameter added, removed, or
+  re-roled without a matching ledger edit fails CI, naming the drifted entry.
+  Ledger edits ship in the SAME commit as the registry change they witness —
+  a role change alters gate admission behavior, so the diff must be visible
+  at review time, not discovered later.
+- **`tests/contracts/test_recipe_step_field_ledger.py`** — a frozen
+  `RecipeStep` field-name → classification table
+  (`execution` / `composition` / `validation-only` / `inert-tracked:#NNNN`),
+  diffed bidirectionally against `dataclasses.fields(RecipeStep)`. A new field
+  without a conscious classification fails; an `inert-tracked` entry without a
+  live issue reference fails. Same same-commit rule: classify a new field
+  when you add it, and file a tracking issue immediately if it has no runtime
+  consumer yet rather than leaving a silently-inert field for someone else to
+  rediscover.
+
+**`tool_ctx_ready_recipe`** (`tests/server/conftest.py`) is the required
+fixture entry point for attested-path server tests. `tool_ctx_kitchen_open`
+alone leaves `recipe_initialization_state = NoActiveRecipe()` and cannot
+reach the attested `run_skill` branch — the fixture drives the real
+production `open_kitchen` → credit sections → pull step →
+`complete_recipe_initialization` flow so tests exercise a genuinely attested
+context (proven by `test_tool_ctx_ready_recipe_fixture_yields_genuine_attestation`
+round-tripping the installed snapshot's template digest), never the
+low-level `bind_recipe`/`build_recipe_execution_snapshot`/
+`install_recipe_execution` chain directly — those functions precondition on
+`InitializingRecipe` → `ReadyRecipe` staging that only the production flow
+performs, so bypassing it would test a context no real session ever has.

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -858,6 +858,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "hooks/test_recipe_contract_freshness.py",
             "migration",
             # Server file-level entries importing autoskillit.recipe:
+            "server/test_run_skill_execution_tuning_fallbacks.py",
             "server/test_serve_idempotence.py",
             "server/test_attestation_delivery_reachability.py",
             "server/test_open_kitchen_deferred_recall.py",

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1071,6 +1071,11 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "REQ-CNST-010-E1: canonical type registry — wide surface required to prevent "
         "circular imports; all enums/protocols/constants consolidated here",
     ),
+    "recipe/_binding.py": (
+        1050,
+        "REQ-CNST-010-E24: #4402 keeps runtime attestation admission and its "
+        "parameter-role denial remedies beside the compile-time binding pipeline",
+    ),
     "hooks/_capture_artifacts.py": (
         1200,
         "REQ-CNST-010-E22: descriptor-anchored capture authority and isolated runner — "

--- a/tests/contracts/test_recipe_step_field_ledger.py
+++ b/tests/contracts/test_recipe_step_field_ledger.py
@@ -38,7 +38,7 @@ from autoskillit.recipe.schema import RecipeStep
 
 pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
 
-_INERT_TRACKED_RE = re.compile(r"^inert-tracked:#\d+$")
+_INERT_TRACKED_RE = re.compile(r"^inert-tracked:#[1-9]\d*$")
 _KNOWN_CLASSIFICATIONS = frozenset({"execution", "composition", "validation-only"})
 
 # Keys MUST stay sorted — enforced by test_ledger_is_sorted() below.
@@ -157,8 +157,8 @@ def test_no_silent_field_removals() -> None:
     )
 
 
-def test_inert_tracked_entries_cite_a_live_issue() -> None:
-    """An inert-tracked entry without a live issue reference is invisible at review time."""
+def test_inert_tracked_entries_have_a_valid_issue_reference() -> None:
+    """An inert-tracked entry without a valid issue reference is invisible at review time."""
     malformed = sorted(
         f"{name}={value!r}"
         for name, value in RECIPE_STEP_FIELD_CLASSIFICATION.items()

--- a/tests/contracts/test_recipe_step_field_ledger.py
+++ b/tests/contracts/test_recipe_step_field_ledger.py
@@ -1,0 +1,178 @@
+"""RecipeStep field-classification ledger — the forcing function for silent
+declared-but-inert fields (#4402).
+
+A frozen field-name -> classification mapping, diffed bidirectionally
+against ``dataclasses.fields(RecipeStep)``. A new field without a conscious
+classification fails; a removed field leaves a stale entry that fails.
+Mirrors the config-key-ledger pattern (#4303, ``test_config_key_ledger.py``)
+— an inline Python dict rather than an external ``.txt`` file, since these
+values carry structure (``inert-tracked:#NNNN`` is itself validated), unlike
+that ledger's flat name list.
+
+Classifications:
+  ``execution``          — read on a runtime code path (server fallback,
+                            composition dispatch, executor argument).
+  ``composition``         — consumed while composing/pruning the pipeline
+                            graph before dispatch.
+  ``validation-only``     — consumed exclusively by ``recipe/rules/`` lint
+                            rules or schema validation, never by
+                            execution/composition.
+  ``inert-tracked:#NNNN`` — zero consumer outside schema/parse code; the
+                            open tracking issue is part of the value, so an
+                            inert entry without a live ticket is visible at
+                            review time.
+
+Populated by reading actual consumer sites (not copied blindly from any
+plan) — where a description and the code disagree, the code wins and the
+ledger records reality.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import fields as dataclass_fields
+
+import pytest
+
+from autoskillit.recipe.schema import RecipeStep
+
+pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
+
+_INERT_TRACKED_RE = re.compile(r"^inert-tracked:#\d+$")
+_KNOWN_CLASSIFICATIONS = frozenset({"execution", "composition", "validation-only"})
+
+# Keys MUST stay sorted — enforced by test_ledger_is_sorted() below.
+RECIPE_STEP_FIELD_CLASSIFICATION: dict[str, str] = {
+    # tool/action select and shape what a step dispatches to; action's
+    # per-step stop semantics reach the orchestrating agent verbatim via
+    # _api.py's orchestration_rules payload.
+    "action": "execution",
+    # Lint-rule-only YAML routing hint (rules_bypass.py et al.); no runtime
+    # composition/dispatch consumer.
+    "block": "validation-only",
+    # capture/capture_list are read by validator.py and the dataflow
+    # analysis detectors (lint rules) — no execution-time consumer found.
+    "capture": "validation-only",
+    "capture_list": "validation-only",
+    # Discriminates a constant-value step at compile time; excluded from
+    # bind_step_invocation's compiler (only tool-having steps compile), so
+    # its only consumers are schema/lint validation.
+    "constant": "validation-only",
+    # The compile-time binding input record — bind_step_invocation reads it
+    # directly; the real dispatch call site (server/_recipe_execution.py)
+    # sets it explicitly on synthetic bound steps.
+    "declared_with_args": "execution",
+    # #4498 — zero consumer outside schema/parse code.
+    "description": "inert-tracked:#4498",
+    # Decides sub-recipe merge vs. drop in _recipe_composition.py.
+    "gate": "composition",
+    # Server-side RecipeStep fallback (tools_execution.py) — the #2969/#3377
+    # pattern.
+    "idle_output_timeout": "execution",
+    # Embedded verbatim into the runtime orchestration_rules/
+    # stop_step_semantics payload served to the orchestrating agent
+    # (_api.py:_build_stop_step_semantics).
+    "message": "execution",
+    # Server-side RecipeStep fallback — the one EXECUTION_TUNING param this
+    # plan newly wires (previously parsed and lint-validated but read by
+    # zero runtime code).
+    "model": "execution",
+    # Read by rules_reachability.py/rules_blocks.py (lint rules) and the
+    # analysis-block extraction chain, which is itself lint-only.
+    "name": "validation-only",
+    # Lint-rule-only (rules_bypass.py, rules_note_shape_contradiction.py, …).
+    "note": "validation-only",
+    # Routing field — the pipeline composer reads it to build the flow
+    # graph and derive pipeline dependencies before dispatch.
+    "on_context_limit": "composition",
+    "on_exhausted": "composition",
+    "on_failure": "composition",
+    "on_rate_limit": "composition",
+    "on_result": "composition",
+    "on_success": "composition",
+    # Schema/lint-only guard field.
+    "optional": "validation-only",
+    "optional_context_refs": "validation-only",
+    "pass_through": "validation-only",
+    "phoropter_family": "validation-only",
+    # step_provider's server-side RecipeStep fallback (pre-gate, profile
+    # resolution) — tools_execution.py.
+    "provider": "execution",
+    # Discriminates a python-callable step; same "excluded from the
+    # compiler, lint/schema-only consumers" shape as constant.
+    "python": "validation-only",
+    # Validated by schema/validator only — the retry loop itself is
+    # agent-prompt-driven (cli/_prompts_orchestrator.py generic text), not a
+    # per-step Python read site.
+    "retries": "validation-only",
+    # Full execution chain: pipeline composition pruning
+    # (_recipe_composition.py) and lock enforcement (tools_kitchen.py).
+    "skip_when_false": "composition",
+    # #4497 — zero runtime skip effect (unlike its sibling skip_when_false).
+    "skip_when_true": "inert-tracked:#4497",
+    # Server-side RecipeStep fallback — the #2969/#3377 pattern this plan
+    # extends to model.
+    "stale_threshold": "execution",
+    # _recipe_composition.py's _build_active_recipe loads/merges the
+    # sub-recipe or drops the placeholder before dispatch.
+    "sub_recipe": "composition",
+    # Selects the ToolDef that compiles the actual dispatch
+    # (bind_step_invocation); read at the real dispatch call site too.
+    "tool": "execution",
+    # Server-side RecipeStep fallback reads with_args directly
+    # (tools_execution.py's output_dir resolution) in addition to compiling
+    # through bind_step_invocation.
+    "with_args": "execution",
+}
+
+
+def _live_recipe_step_field_names() -> set[str]:
+    return {field.name for field in dataclass_fields(RecipeStep)}
+
+
+def test_ledger_is_sorted() -> None:
+    keys = list(RECIPE_STEP_FIELD_CLASSIFICATION)
+    assert keys == sorted(keys), (
+        "RECIPE_STEP_FIELD_CLASSIFICATION keys must stay sorted so a diff always "
+        "isolates exactly the entry that changed."
+    )
+
+
+def test_no_silent_field_additions() -> None:
+    """Every live RecipeStep field must have a conscious ledger classification."""
+    missing = sorted(_live_recipe_step_field_names() - set(RECIPE_STEP_FIELD_CLASSIFICATION))
+    assert not missing, (
+        f"RecipeStep has field(s) not present in RECIPE_STEP_FIELD_CLASSIFICATION: "
+        f"{missing}. Classify each as execution / composition / validation-only / "
+        "inert-tracked:#NNNN — file a tracking issue first if it has no consumer yet."
+    )
+
+
+def test_no_silent_field_removals() -> None:
+    """Every ledger entry must name a live RecipeStep field."""
+    stale = sorted(set(RECIPE_STEP_FIELD_CLASSIFICATION) - _live_recipe_step_field_names())
+    assert not stale, (
+        f"RECIPE_STEP_FIELD_CLASSIFICATION has entries for field(s) RecipeStep no "
+        f"longer declares: {stale}. Remove these entries."
+    )
+
+
+def test_inert_tracked_entries_cite_a_live_issue() -> None:
+    """An inert-tracked entry without a live issue reference is invisible at review time."""
+    malformed = sorted(
+        f"{name}={value!r}"
+        for name, value in RECIPE_STEP_FIELD_CLASSIFICATION.items()
+        if value.startswith("inert-tracked") and not _INERT_TRACKED_RE.match(value)
+    )
+    assert not malformed, (
+        f"inert-tracked entries must match 'inert-tracked:#NNNN' exactly: {malformed}"
+    )
+
+
+def test_classifications_are_known_values() -> None:
+    unknown = sorted(
+        f"{name}={value!r}"
+        for name, value in RECIPE_STEP_FIELD_CLASSIFICATION.items()
+        if value not in _KNOWN_CLASSIFICATIONS and not _INERT_TRACKED_RE.match(value)
+    )
+    assert not unknown, f"unrecognized classification value(s): {unknown}"

--- a/tests/contracts/test_run_skill_kwarg_ledger.py
+++ b/tests/contracts/test_run_skill_kwarg_ledger.py
@@ -1,0 +1,104 @@
+"""run_skill param/role ledger — change-visibility forcing function (#4402).
+
+A frozen ``(param_name, role)`` table, diffed bidirectionally against the
+live ``get_tool_def("run_skill").params`` registry. A parameter added,
+removed, or re-roled without a matching edit here fails CI, naming the
+drifted entry.
+
+This intentionally overlaps ``test_tool_param_roles.py`` (T2): that module
+proves internal consistency (the gate's admission set derives correctly from
+role); this ledger proves *change visibility* — the same
+frozen-review-artifact discipline ``test_config_key_ledger.py`` established
+for ``_CONFIG_SCHEMA`` (issue #4303), applied to ``ToolParamRole``. Unlike
+that ledger, this one is a name -> classification mapping whose values carry
+structure, so an inline Python dict is the honest representation rather than
+an external sorted ``.txt`` file — the sortedness/dedup discipline is
+preserved by asserting the dict's key order directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import ToolParamRole, get_tool_def
+
+pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
+
+# Frozen (param_name -> role) ledger. Keys MUST stay sorted — enforced by
+# test_ledger_is_sorted() below — so a diff always shows exactly the entry
+# that changed.
+RUN_SKILL_PARAM_ROLE_LEDGER: dict[str, ToolParamRole] = {
+    "closure_authority_hash": ToolParamRole.SESSION_FLOW,
+    "closure_authority_path": ToolParamRole.SESSION_FLOW,
+    "closure_base_sha": ToolParamRole.SESSION_FLOW,
+    "closure_diff_sha": ToolParamRole.SESSION_FLOW,
+    "closure_plan_paths": ToolParamRole.SESSION_FLOW,
+    "closure_target_sha": ToolParamRole.SESSION_FLOW,
+    "cwd": ToolParamRole.CHILD_INPUT,
+    "dispatch_items": ToolParamRole.SESSION_FLOW,
+    "idle_output_timeout": ToolParamRole.EXECUTION_TUNING,
+    "invocation_template_digest": ToolParamRole.PROTOCOL,
+    "model": ToolParamRole.EXECUTION_TUNING,
+    "native_shell_capture_mode": ToolParamRole.SESSION_FLOW,
+    "order_id": ToolParamRole.ORCHESTRATOR_SCOPING,
+    "output_dir": ToolParamRole.CHILD_INPUT,
+    "recipe_execution_id": ToolParamRole.PROTOCOL,
+    "resume_session_id": ToolParamRole.SESSION_FLOW,
+    "retry_after_audit_attempt_id": ToolParamRole.SESSION_FLOW,
+    "skill_command": ToolParamRole.CHILD_INPUT,
+    "skill_inputs": ToolParamRole.CHILD_INPUT,
+    "stale_threshold": ToolParamRole.EXECUTION_TUNING,
+    "step_name": ToolParamRole.PROTOCOL,
+    "step_provider": ToolParamRole.EXECUTION_TUNING,
+}
+
+
+def _live_run_skill_roles() -> dict[str, ToolParamRole]:
+    tool_def = get_tool_def("run_skill")
+    assert tool_def is not None, "run_skill must be a registered ToolDef"
+    return {param.name: param.role for param in tool_def.params}
+
+
+def test_ledger_is_sorted() -> None:
+    keys = list(RUN_SKILL_PARAM_ROLE_LEDGER)
+    assert keys == sorted(keys), (
+        "RUN_SKILL_PARAM_ROLE_LEDGER keys must stay sorted so a diff always "
+        "isolates exactly the entry that changed."
+    )
+
+
+def test_no_silent_param_additions() -> None:
+    """Every live run_skill param must have a ledger entry."""
+    live = _live_run_skill_roles()
+    missing = sorted(set(live) - set(RUN_SKILL_PARAM_ROLE_LEDGER))
+    assert not missing, (
+        f"run_skill has params not present in RUN_SKILL_PARAM_ROLE_LEDGER: {missing}. "
+        "Add a (name -> role) entry for each — see ToolParamRole in "
+        "core/types/_type_recipe_binding.py for what each role means."
+    )
+
+
+def test_no_silent_param_removals() -> None:
+    """Every ledger entry must name a live run_skill param."""
+    live = _live_run_skill_roles()
+    stale = sorted(set(RUN_SKILL_PARAM_ROLE_LEDGER) - set(live))
+    assert not stale, (
+        f"RUN_SKILL_PARAM_ROLE_LEDGER has entries for params run_skill no longer "
+        f"declares: {stale}. Remove these entries."
+    )
+
+
+def test_no_silent_reroles() -> None:
+    """A param's role in the ledger must match its live role exactly."""
+    live = _live_run_skill_roles()
+    drifted = sorted(
+        name
+        for name, ledger_role in RUN_SKILL_PARAM_ROLE_LEDGER.items()
+        if name in live and live[name] is not ledger_role
+    )
+    assert not drifted, (
+        f"run_skill param(s) re-roled without a matching ledger edit: {drifted}. "
+        f"Live roles: {[(n, live[n].value) for n in drifted]!r}. "
+        "Update RUN_SKILL_PARAM_ROLE_LEDGER to match, and confirm the re-role "
+        "was intentional — a role change alters gate admission behavior."
+    )

--- a/tests/contracts/test_skill_prose_forwarding.py
+++ b/tests/contracts/test_skill_prose_forwarding.py
@@ -76,7 +76,8 @@ def _find_violations(text: str, names: tuple[str, ...]) -> list[str]:
             local_start = max(0, match.start() - _PROSE_TRIGGER_WINDOW)
             local_end = min(len(text), match.end() + _PROSE_TRIGGER_WINDOW)
             local_window = text[local_start:local_end]
-            if not any(word in local_window for word in _PROSE_TRIGGER_WORDS):
+            normalized_local_window = local_window.lower()
+            if not any(word in normalized_local_window for word in _PROSE_TRIGGER_WORDS):
                 continue
             wide_start = max(0, match.start() - _RUN_SKILL_WINDOW)
             wide_end = min(len(text), match.end() + _RUN_SKILL_WINDOW)
@@ -132,6 +133,10 @@ def test_no_bundled_skill_instructs_forwarding_execution_tuning_params() -> None
             '(e.g. "use opus"), apply it to the `model` parameter of ALL '
             "`run_skill` calls for steps that declare a `model:` field",
             id="model_prose_mandate",
+        ),
+        pytest.param(
+            "Forward the `model` Parameter to `run_skill` when selected.",
+            id="mixed_case_trigger_words",
         ),
         pytest.param(
             "Call: `run_skill(skill_command=..., cwd=..., "

--- a/tests/contracts/test_skill_prose_forwarding.py
+++ b/tests/contracts/test_skill_prose_forwarding.py
@@ -1,0 +1,149 @@
+"""Prose-contract sweep: no bundled skill instructs forwarding an
+EXECUTION_TUNING run_skill parameter (#4402).
+
+Before #4402, sous-chef's PARAMETER FORWARDING and MODEL PROPAGATION
+sections mandated forwarding ``stale_threshold``/``idle_output_timeout``/
+``step_provider``/``model`` to ``run_skill`` — a channel the runtime
+attestation gate guaranteed would deny (an int or non-empty str is never
+``""``, the gate's undeclared-name exemption). This sweeps every bundled
+skill for the same instruction pattern recurring.
+
+**Literal ``param=`` regex alone is insufficient** — verified during
+authoring: the only pre-#4402 literal-form hit in the whole tree was
+sous-chef's worked example (``stale_threshold=2400``); the actual mandates
+were prose-form with no ``=`` at all ("pass it as the corresponding
+``run_skill`` parameter", "apply it to the ``model`` parameter of ALL
+``run_skill`` calls"). Two pattern families, both scoped to passages
+mentioning ``run_skill`` nearby, so an unrelated doc using these words in a
+different context isn't flagged:
+
+  (a) literal kwarg forms: ``(model|stale_threshold|idle_output_timeout|step_provider)=``
+  (b) prose forms: an EXECUTION_TUNING param name within ~60 characters of
+      "parameter"/"pass"/"forward"
+
+The forbidden name list is derived from the live role registry
+(``role is EXECUTION_TUNING``), never a hardcoded copy — a future re-role
+changes what this test enforces automatically.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core import ToolParamRole, get_tool_def
+
+pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SKILLS_ROOT = _REPO_ROOT / "src" / "autoskillit" / "skills"
+
+# Generous scope-in window: does this passage concern run_skill at all?
+_RUN_SKILL_WINDOW = 400
+# Tight window for the actual forwarding-mandate trigger words.
+_PROSE_TRIGGER_WINDOW = 60
+_PROSE_TRIGGER_WORDS = ("parameter", "pass", "forward")
+
+
+def _execution_tuning_param_names() -> tuple[str, ...]:
+    tool_def = get_tool_def("run_skill")
+    assert tool_def is not None, "run_skill must be a registered ToolDef"
+    return tuple(
+        sorted(
+            param.name for param in tool_def.params if param.role is ToolParamRole.EXECUTION_TUNING
+        )
+    )
+
+
+def _literal_kwarg_pattern(names: tuple[str, ...]) -> re.Pattern[str]:
+    return re.compile(r"(?:" + "|".join(re.escape(name) for name in names) + r")=")
+
+
+def _find_violations(text: str, names: tuple[str, ...]) -> list[str]:
+    violations: list[str] = []
+
+    for match in _literal_kwarg_pattern(names).finditer(text):
+        window_start = max(0, match.start() - _RUN_SKILL_WINDOW)
+        window_end = min(len(text), match.end() + _RUN_SKILL_WINDOW)
+        if "run_skill" not in text[window_start:window_end]:
+            continue
+        violations.append(f"literal kwarg form {match.group(0)!r}")
+
+    for name in names:
+        for match in re.finditer(re.escape(name), text):
+            local_start = max(0, match.start() - _PROSE_TRIGGER_WINDOW)
+            local_end = min(len(text), match.end() + _PROSE_TRIGGER_WINDOW)
+            local_window = text[local_start:local_end]
+            if not any(word in local_window for word in _PROSE_TRIGGER_WORDS):
+                continue
+            wide_start = max(0, match.start() - _RUN_SKILL_WINDOW)
+            wide_end = min(len(text), match.end() + _RUN_SKILL_WINDOW)
+            if "run_skill" not in text[wide_start:wide_end]:
+                continue
+            violations.append(f"prose form near {name!r}: {local_window!r}")
+
+    return violations
+
+
+def test_no_bundled_skill_instructs_forwarding_execution_tuning_params() -> None:
+    names = _execution_tuning_param_names()
+    assert names, (
+        "no EXECUTION_TUNING-role run_skill params found — has the role registry drifted?"
+    )
+
+    offenders: dict[str, list[str]] = {}
+    for skill_md in sorted(_SKILLS_ROOT.glob("*/SKILL.md")):
+        text = skill_md.read_text(encoding="utf-8")
+        violations = _find_violations(text, names)
+        if violations:
+            offenders[str(skill_md.relative_to(_REPO_ROOT))] = violations
+
+    assert not offenders, (
+        "bundled skill(s) instruct forwarding an EXECUTION_TUNING-role run_skill "
+        "parameter — these are server-resolved from the recipe step and the runtime "
+        f"attestation gate denies them if forwarded: {offenders!r}"
+    )
+
+
+# Calibration pins: the detection heuristic must actually catch the four
+# passages that motivated this test (they existed verbatim in sous-chef
+# SKILL.md before #4402's rewrite). If these regress to non-detection, the
+# sweep above has gone blind, not merely "found nothing to report."
+@pytest.mark.parametrize(
+    "passage",
+    [
+        pytest.param(
+            "When a recipe step has a top-level `stale_threshold` or "
+            "`idle_output_timeout` field, pass it as the corresponding "
+            "`run_skill` parameter. These control session kill thresholds.",
+            id="stale_threshold_idle_output_timeout_prose_mandate",
+        ),
+        pytest.param(
+            "When a recipe step has a top-level `provider` field, pass the "
+            "value as the `step_provider` parameter of `run_skill`. This "
+            "controls which LLM provider (e.g., Minimax, Bedrock) the "
+            "session uses.",
+            id="step_provider_prose_mandate",
+        ),
+        pytest.param(
+            "**MODEL PROPAGATION** — When the user specifies a model "
+            '(e.g. "use opus"), apply it to the `model` parameter of ALL '
+            "`run_skill` calls for steps that declare a `model:` field",
+            id="model_prose_mandate",
+        ),
+        pytest.param(
+            "Call: `run_skill(skill_command=..., cwd=..., "
+            'step_name="implement", output_dir="...", stale_threshold=2400, '
+            'step_provider="minimax")`',
+            id="worked_example_literal_kwargs",
+        ),
+    ],
+)
+def test_detection_heuristic_catches_the_original_defect(passage: str) -> None:
+    names = _execution_tuning_param_names()
+    assert _find_violations(passage, names), (
+        "the detection heuristic no longer flags a known pre-#4402 forwarding "
+        "mandate passage — it has gone blind, not merely found a clean codebase"
+    )

--- a/tests/contracts/test_sous_chef_parameter_forwarding.py
+++ b/tests/contracts/test_sous_chef_parameter_forwarding.py
@@ -1,4 +1,11 @@
-"""Architectural contract: sous-chef SKILL.md must instruct LLM to forward recipe parameters."""
+"""Architectural contract: sous-chef SKILL.md forwarding/resolution guidance.
+
+``step_name`` and ``output_dir`` remain LLM-forwarded — the gate always needs
+these from the caller. ``model``, ``stale_threshold``, ``idle_output_timeout``,
+and ``step_provider`` are the opposite case: they are server-resolved from the
+recipe step and must NOT be forwarded on attested ``run_skill`` calls — the
+runtime attestation gate denies them (see #4402's rectify plan).
+"""
 
 from __future__ import annotations
 
@@ -19,15 +26,21 @@ def test_sous_chef_skill_md_mentions_output_dir():
     )
 
 
-def test_sous_chef_skill_md_mentions_step_provider():
-    """Sous-chef SKILL.md must instruct the LLM to forward step_provider."""
+def test_sous_chef_skill_md_states_step_provider_is_server_resolved():
+    """Sous-chef SKILL.md must state step_provider is server-resolved, not forwarded."""
     skill_md = (
         Path(__file__).parents[2] / "src/autoskillit/skills/sous-chef/SKILL.md"
     ).read_text()
-    assert "step_provider" in skill_md, (
-        "sous-chef SKILL.md does not mention step_provider. "
-        "The LLM must be instructed to forward step_provider from recipe "
-        "step provider: fields to run_skill."
+    assert "step_provider" in skill_md, "sous-chef SKILL.md does not mention step_provider."
+    assert "server-side" in skill_md, (
+        "sous-chef SKILL.md must state that step_provider (along with model, "
+        "stale_threshold, and idle_output_timeout) is resolved server-side from "
+        "the recipe step, not forwarded by the LLM — forwarding these is denied "
+        "by the runtime attestation gate, not merely redundant."
+    )
+    assert "Do not include any of them in an attested" in skill_md, (
+        "sous-chef SKILL.md must instruct the LLM to omit step_provider (and "
+        "model/stale_threshold/idle_output_timeout) from attested run_skill calls."
     )
 
 

--- a/tests/contracts/test_tool_param_roles.py
+++ b/tests/contracts/test_tool_param_roles.py
@@ -1,0 +1,160 @@
+"""Role-derivation contract: ToolParamRole is the single classification authority (#4402).
+
+Every attestation-relevant surface must derive from ``ToolParamDef.role``
+rather than maintaining its own hand-copied param list: the runtime gate's
+always-admit set (``runtime_exempt_param_names``), the execution-tuning
+fallback tables in ``tools_execution.py``, the pre-existing
+``RUN_SKILL_ATTESTATION_PARAMS`` frozenset, and ``compute_tool_contract_identity``
+(which must explicitly exclude ``role`` — it is server-side policy, not wire
+shape). This module pins each derivation so a future edit to any one surface
+that silently diverges from the registry fails here first.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields as dataclass_fields
+from dataclasses import replace
+
+import pytest
+
+from autoskillit.core import (
+    RUN_SKILL_ATTESTATION_PARAMS,
+    ToolParamRole,
+    compute_tool_contract_identity,
+    get_tool_def,
+    runtime_exempt_param_names,
+)
+from autoskillit.recipe.schema import RecipeStep
+from autoskillit.server.tools.tools_execution import (
+    _EXECUTION_TUNING_EXTERNALLY_RESOLVED,
+    _EXECUTION_TUNING_STEP_FIELDS,
+    _build_actual_mcp_kwargs,
+)
+
+pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
+
+
+def _run_skill_tool_def():
+    tool_def = get_tool_def("run_skill")
+    assert tool_def is not None, "run_skill must be a registered ToolDef"
+    return tool_def
+
+
+def test_every_run_skill_param_has_a_role() -> None:
+    """role is a required kw-only field — this should be structurally impossible to fail."""
+    for param in _run_skill_tool_def().params:
+        assert isinstance(param.role, ToolParamRole), (
+            f"{param.name} has no ToolParamRole; ToolParamDef's role default may have changed"
+        )
+
+
+def test_gate_admit_set_matches_role_derivation() -> None:
+    """runtime_exempt_param_names (the symbol _binding.py's gate consumes) must equal
+    exactly the PROTOCOL | ORCHESTRATOR_SCOPING name set derived locally from role."""
+    tool_def = _run_skill_tool_def()
+    expected = frozenset(
+        param.name
+        for param in tool_def.params
+        if param.role in (ToolParamRole.PROTOCOL, ToolParamRole.ORCHESTRATOR_SCOPING)
+    )
+    assert runtime_exempt_param_names(tool_def) == expected
+
+
+def test_execution_tuning_fallback_tables_cover_role_exactly() -> None:
+    """The EXECUTION_TUNING param set equals the *disjoint* union of the two
+    tools_execution.py fallback tables' keys, and every mapped RecipeStep field
+    name is real. Disjointness matters: a param in both tables, or in neither,
+    is a coverage bug."""
+    tool_def = _run_skill_tool_def()
+    execution_tuning_names = frozenset(
+        param.name for param in tool_def.params if param.role is ToolParamRole.EXECUTION_TUNING
+    )
+    loop_keys = frozenset(_EXECUTION_TUNING_STEP_FIELDS)
+    external_keys = frozenset(_EXECUTION_TUNING_EXTERNALLY_RESOLVED)
+
+    overlap = loop_keys & external_keys
+    assert not overlap, (
+        f"param(s) declared in BOTH execution-tuning fallback tables: {sorted(overlap)}"
+    )
+
+    combined = loop_keys | external_keys
+    assert combined == execution_tuning_names, (
+        "EXECUTION_TUNING params and the fallback-table keys have drifted. "
+        f"EXECUTION_TUNING but in neither table: {sorted(execution_tuning_names - combined)}. "
+        f"In a table but not EXECUTION_TUNING-roled: {sorted(combined - execution_tuning_names)}."
+    )
+
+    recipe_step_field_names = frozenset(field.name for field in dataclass_fields(RecipeStep))
+    mapped_fields = frozenset(_EXECUTION_TUNING_STEP_FIELDS.values()) | frozenset(
+        _EXECUTION_TUNING_EXTERNALLY_RESOLVED.values()
+    )
+    unmapped = mapped_fields - recipe_step_field_names
+    assert not unmapped, (
+        f"execution-tuning table value(s) name fields RecipeStep does not declare: "
+        f"{sorted(unmapped)}"
+    )
+
+
+def test_build_actual_mcp_kwargs_fails_fast_on_drift() -> None:
+    """The kwargs-assembly helper must raise on a missing handler param and on an
+    unknown values key, and must NOT demand values for dispatch_items
+    (handler_parameter=False) or skill_inputs (structured_skill_inputs=True) —
+    pinning the filter that keeps assembly aligned with the real handler surface."""
+    tool_def = _run_skill_tool_def()
+    handler_param_names = frozenset(
+        param.name
+        for param in tool_def.params
+        if param.handler_parameter and not param.structured_skill_inputs
+    )
+    assert "dispatch_items" not in handler_param_names
+    assert "skill_inputs" not in handler_param_names
+
+    complete_values: dict[str, object] = dict.fromkeys(handler_param_names, "")
+
+    incomplete = dict(complete_values)
+    del incomplete["order_id"]
+    with pytest.raises(ValueError, match="order_id"):
+        _build_actual_mcp_kwargs(tool_def, incomplete)
+
+    excess = dict(complete_values)
+    excess["not_a_real_param"] = ""
+    with pytest.raises(ValueError, match="not_a_real_param"):
+        _build_actual_mcp_kwargs(tool_def, excess)
+
+    result = _build_actual_mcp_kwargs(tool_def, complete_values)
+    assert set(result) <= handler_param_names
+
+
+def test_run_skill_attestation_params_is_subset_of_protocol_role() -> None:
+    """RUN_SKILL_ATTESTATION_PARAMS (a pre-existing hand-maintained frozenset of 2 of
+    the 3 protocol names) must remain a subset of the role-derived PROTOCOL set, so a
+    protocol-param rename cannot desync this fifth surface silently."""
+    tool_def = _run_skill_tool_def()
+    protocol_names = frozenset(
+        param.name for param in tool_def.params if param.role is ToolParamRole.PROTOCOL
+    )
+    assert RUN_SKILL_ATTESTATION_PARAMS <= protocol_names, (
+        f"RUN_SKILL_ATTESTATION_PARAMS {sorted(RUN_SKILL_ATTESTATION_PARAMS)} is not a "
+        f"subset of the PROTOCOL-role param names {sorted(protocol_names)}"
+    )
+
+
+def test_contract_identity_excludes_role() -> None:
+    """role must not participate in compute_tool_contract_identity's hash input.
+
+    Structural check, not a hardcoded digest: build a variant ToolDef whose
+    ONLY difference from the real one is a single param's role, and assert
+    the identities are equal — proving role cannot affect the hash.
+    """
+    tool_def = _run_skill_tool_def()
+    original_param = tool_def.param_def("order_id")
+    assert original_param is not None
+    reroled_param = replace(original_param, role=ToolParamRole.SESSION_FLOW)
+    reroled_params = tuple(
+        reroled_param if param.name == "order_id" else param for param in tool_def.params
+    )
+    reroled_tool_def = replace(tool_def, params=reroled_params)
+
+    assert compute_tool_contract_identity(reroled_tool_def) == compute_tool_contract_identity(
+        tool_def
+    ), "role changed compute_tool_contract_identity's output — it must be excluded by construction"

--- a/tests/contracts/test_tool_param_roles.py
+++ b/tests/contracts/test_tool_param_roles.py
@@ -122,7 +122,7 @@ def test_build_actual_mcp_kwargs_fails_fast_on_drift() -> None:
         _build_actual_mcp_kwargs(tool_def, excess)
 
     result = _build_actual_mcp_kwargs(tool_def, complete_values)
-    assert set(result) <= handler_param_names
+    assert set(result) == handler_param_names
 
 
 def test_run_skill_attestation_params_is_subset_of_protocol_role() -> None:

--- a/tests/recipe/test_runtime_skill_invocation_binding.py
+++ b/tests/recipe/test_runtime_skill_invocation_binding.py
@@ -1,0 +1,171 @@
+"""Runtime skill invocation binding — the attestation gate's admission behavior (#4402).
+
+``bind_runtime_skill_invocation`` is the runtime half of the compile-time
+``bind_step_invocation`` covered in ``test_skill_invocation_binding.py``.
+Before #4402 this had zero direct coverage anywhere under ``tests/`` — the
+one e2e attestation test structurally could not reach the denial path (it
+never passed a non-empty undeclared param), so compile-time coverage stood
+in as an untested proxy for a runtime contract nobody actually exercised.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import (
+    BoundScalar,
+    InvocationTemplate,
+    compute_invocation_template_digest,
+    compute_tool_contract_identity,
+    get_tool_def,
+)
+from autoskillit.recipe._binding import (
+    RuntimeBindingError,
+    bind_runtime_skill_invocation,
+    bind_step_invocation,
+)
+from autoskillit.recipe._contracts_manifest import compute_skill_contract_identity
+from autoskillit.recipe.schema import RecipeStep
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+_MANIFEST = {
+    "skills": {
+        "dry-walkthrough": {
+            "inputs": [
+                {"name": "plan_path", "type": "file_path", "required": True},
+            ]
+        }
+    }
+}
+_EXECUTION_ID = "exec-1"
+_STEP_NAME = "verify"
+
+
+def _template(**extra_with_args: object) -> InvocationTemplate:
+    """Build a compiled InvocationTemplate the way the production initialization
+    envelope does (see server/_recipe_execution.py:build_recipe_execution_snapshot),
+    without driving the full server stack."""
+    step = RecipeStep(
+        name=_STEP_NAME,
+        tool="run_skill",
+        with_args={
+            "skill_command": "/autoskillit:dry-walkthrough",
+            "cwd": "/repo",
+            "skill_inputs": {"plan_path": "/tmp/plan.md"},
+            "step_name": _STEP_NAME,
+            **extra_with_args,
+        },
+    )
+    invocation = bind_step_invocation(_STEP_NAME, step, manifest=_MANIFEST)
+    assert invocation.is_valid, invocation.failures
+    assert invocation.skill_name is not None
+    tool_def = get_tool_def("run_skill")
+    assert tool_def is not None
+    tool_identity = compute_tool_contract_identity(tool_def)
+    skill_identity = compute_skill_contract_identity(invocation.skill_name)
+    digest = compute_invocation_template_digest(
+        execution_id=_EXECUTION_ID,
+        recipe_name="test-recipe",
+        content_hash="c" * 64,
+        composite_hash="d" * 64,
+        invocation=invocation,
+        tool_contract_identity=tool_identity,
+        skill_contract_identity=skill_identity,
+    )
+    return InvocationTemplate(
+        invocation=invocation,
+        tool_contract_identity=tool_identity,
+        skill_contract_identity=skill_identity,
+        template_digest=digest,
+    )
+
+
+def _bind(template: InvocationTemplate, **overrides: BoundScalar):
+    """Bind against ``template``, matching production's shape: the caller
+    always supplies actual values for every compiled (with:-declared)
+    param — see ``_build_actual_mcp_kwargs`` in tools_execution.py, which
+    never produces a sparse dict. ``skill_command``/``cwd``/``step_name``
+    are always compiled (every ``_template()`` step declares them); pass
+    extra kwargs to override or to supply values for anything else under
+    test."""
+    actual_mcp_kwargs: dict[str, BoundScalar] = {
+        "skill_command": "/autoskillit:dry-walkthrough",
+        "cwd": "/repo",
+        "step_name": _STEP_NAME,
+    }
+    actual_mcp_kwargs.update(overrides)
+    return bind_runtime_skill_invocation(
+        template,
+        execution_id=_EXECUTION_ID,
+        step_name=_STEP_NAME,
+        skill_command="/autoskillit:dry-walkthrough",
+        skill_inputs={"plan_path": "/tmp/plan.md"},
+        actual_mcp_kwargs=actual_mcp_kwargs,
+    )
+
+
+def test_undeclared_non_empty_value_is_denied() -> None:
+    """(a) characterization — passes today; unaffected by #4402."""
+    template = _template()
+    with pytest.raises(RuntimeBindingError) as excinfo:
+        _bind(template, resume_session_id="sess-123")
+    assert excinfo.value.code == "recipe_execution_tool_shape"
+
+
+def test_order_id_is_admitted_with_any_value() -> None:
+    """(b) FAILED before #4402 — order_id is ORCHESTRATOR_SCOPING, always
+    admitted regardless of with:-declaration. Restores the #4296 escape hatch."""
+    template = _template()
+    result = _bind(template, order_id="AB")
+    assert result == (("plan_path", "/tmp/plan.md"),)
+
+
+def test_protocol_values_with_correct_bindings_are_admitted() -> None:
+    """(c) characterization — the three protocol values are always admitted
+    when they match the active invocation."""
+    template = _template()
+    result = _bind(
+        template,
+        step_name=_STEP_NAME,
+        recipe_execution_id=_EXECUTION_ID,
+        invocation_template_digest=template.template_digest,
+    )
+    assert result == (("plan_path", "/tmp/plan.md"),)
+
+
+def test_with_declared_model_override_is_admitted() -> None:
+    """(d) characterization — a with:-declared model is a genuine per-step
+    call-time override channel, distinct from (and independent of) the
+    top-level model: field's server-side resolution."""
+    template = _template(model="sonnet")
+    result = _bind(template, model="sonnet")
+    assert result == (("plan_path", "/tmp/plan.md"),)
+
+
+def test_undeclared_empty_string_values_are_admitted() -> None:
+    """(e) characterization — "" is the omitted-param vacancy sentinel. This
+    exemption is intentional and load-bearing: closing it would deny every
+    ordinary call that simply omits an optional parameter it isn't using."""
+    template = _template()
+    result = _bind(template, resume_session_id="", step_provider="", model="")
+    assert result == (("plan_path", "/tmp/plan.md"),)
+
+
+@pytest.mark.parametrize(
+    "param_name,value", [("stale_threshold", 2400), ("model", "claude-opus-5")]
+)
+def test_undeclared_execution_tuning_denial_carries_actionable_remedy(
+    param_name: str, value: BoundScalar
+) -> None:
+    """(f) FAILED before #4402 — denial for an undeclared EXECUTION_TUNING param
+    must name the parameter, state it is server-resolved, and name the with:
+    override option (see _binding.py:_undeclared_runtime_param_message)."""
+    template = _template()
+    with pytest.raises(RuntimeBindingError) as excinfo:
+        _bind(template, **{param_name: value})
+    message = str(excinfo.value)
+    assert excinfo.value.code == "recipe_execution_tool_shape"
+    assert param_name in message
+    assert "server-resolved" in message
+    assert "with:" in message

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import os
 from collections.abc import Generator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -15,6 +17,7 @@ import structlog.contextvars
 import structlog.testing
 
 if TYPE_CHECKING:
+    from autoskillit.pipeline import ToolContext
     from autoskillit.pipeline.timings import DefaultTimingLog
 
 
@@ -340,6 +343,107 @@ def build_ctx_open(build_ctx):
         return ctx
 
     return _factory
+
+
+@pytest.fixture()
+def forbid_artifact_reads(monkeypatch: pytest.MonkeyPatch):
+    """Return an arming callable that fails any persisted-artifact read.
+
+    Shared by attested-path tests that must prove a value came from a tool
+    response, never from re-reading the recipe artifact off disk.
+    """
+    import autoskillit.server.tools.tools_recipe as tools_recipe
+
+    def _forbidden(*_args, **_kwargs):
+        raise AssertionError("credential must come from responses, not payload.json")
+
+    return lambda: monkeypatch.setattr(tools_recipe, "load_recipe_artifact", _forbidden)
+
+
+_READY_RECIPE_ENVELOPE = "remediation"
+_READY_RECIPE_ATTESTED_STEP = "investigate"
+_READY_RECIPE_OVERRIDES = {
+    "issue_url": "https://github.com/TalonT-Org/AutoSkillit/issues/4411",
+    "task_description": "test task",
+}
+
+
+@dataclass(frozen=True)
+class ReadyRecipeContext:
+    """A real attested ToolContext plus the delivered credential and step body.
+
+    ``tool_ctx.recipe_initialization_state`` is a genuine ``ReadyRecipe`` —
+    built via the production ``open_kitchen`` -> ``complete_recipe_initialization``
+    flow, not the low-level ``bind_recipe`` -> ``build_recipe_execution_snapshot``
+    -> ``install_recipe_execution`` chain (those functions precondition on
+    ``InitializingRecipe`` -> ``ReadyRecipe`` staging that only the production
+    flow performs).
+    """
+
+    tool_ctx: ToolContext
+    receipt: dict[str, Any]
+    step_body: dict[str, Any]
+    step_name: str = _READY_RECIPE_ATTESTED_STEP
+
+    @property
+    def credential(self) -> dict[str, Any]:
+        from autoskillit.core import RECIPE_EXECUTION_CREDENTIAL_WIRE_KEY
+
+        return self.receipt[RECIPE_EXECUTION_CREDENTIAL_WIRE_KEY]
+
+    @property
+    def template_digest(self) -> str:
+        return self.credential["invocation_template_digests"][self.step_name]
+
+    @property
+    def with_args(self) -> dict[str, Any]:
+        return self.step_body["with"]
+
+
+@pytest.fixture
+async def tool_ctx_ready_recipe(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    tool_ctx_kitchen_open,
+    forbid_artifact_reads,
+) -> ReadyRecipeContext:
+    """A ToolContext driven through real production initialization into ReadyRecipe.
+
+    Required entry point for attested-path server tests: ``tool_ctx_kitchen_open``
+    alone leaves ``recipe_initialization_state = NoActiveRecipe()`` and cannot
+    reach the attested ``run_skill`` branch. This fixture drives the same
+    ``open_kitchen`` -> credit sections -> pull step -> ``complete_recipe_initialization``
+    flow test_attestation_delivery_reachability.py exercises, promoted to a
+    shared fixture, so tests use a genuinely attested context rather than a
+    mock of one. The credential-artifact-read poison is armed after the step
+    pull completes (get_recipe_section legitimately reads the artifact to
+    serve pages) and stays armed for the returned context's remaining calls.
+    """
+    from autoskillit.recipe import _api_cache
+    from autoskillit.recipe._api_cache import LoadCache
+    from autoskillit.server.tools.tools_recipe import complete_recipe_initialization
+    from tests.server._helpers import (
+        _credit_initialization_sections,
+        _open_kitchen_patched,
+        _pull_step_section,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_api_cache, "_LOAD_CACHE", LoadCache())
+
+    envelope = await _open_kitchen_patched(
+        _READY_RECIPE_ENVELOPE, _READY_RECIPE_OVERRIDES, monkeypatch
+    )
+    assert envelope["success"] is True
+    assert envelope["delivery_bound_spill"] is True
+
+    await _credit_initialization_sections(envelope)
+    step_body = await _pull_step_section(envelope, _READY_RECIPE_ATTESTED_STEP)
+    forbid_artifact_reads()
+    receipt = json.loads(await complete_recipe_initialization(envelope["initialization_id"]))
+    assert receipt["success"] is True
+
+    return ReadyRecipeContext(tool_ctx=tool_ctx_kitchen_open, receipt=receipt, step_body=step_body)
 
 
 @contextmanager

--- a/tests/server/test_attestation_delivery_reachability.py
+++ b/tests/server/test_attestation_delivery_reachability.py
@@ -206,8 +206,8 @@ async def test_attested_run_skill_never_forwards_an_unresolved_model_template(
 
     assert result.get("stage") != "preflight:recipe_execution", result
     assert len(executor.calls) == 1
-    assert "${{" not in executor.calls[0].model, (
-        f"unresolved recipe template leaked into the executor's model kwarg: "
+    assert executor.calls[0].model == "", (
+        "unresolved recipe model must preserve the executor's vacancy sentinel, got "
         f"{executor.calls[0].model!r}"
     )
 

--- a/tests/server/test_attestation_delivery_reachability.py
+++ b/tests/server/test_attestation_delivery_reachability.py
@@ -189,6 +189,7 @@ async def test_attested_run_skill_never_forwards_an_unresolved_model_template(
     executor = InMemoryHeadlessExecutor()
     ready.tool_ctx.executor = executor
     with_args = ready.with_args
+    assert "${{" in ready.step_body["model"]
     work_dir = tmp_path / "work"
     work_dir.mkdir()
 

--- a/tests/server/test_attestation_delivery_reachability.py
+++ b/tests/server/test_attestation_delivery_reachability.py
@@ -189,7 +189,6 @@ async def test_attested_run_skill_never_forwards_an_unresolved_model_template(
     executor = InMemoryHeadlessExecutor()
     ready.tool_ctx.executor = executor
     with_args = ready.with_args
-    assert "${{" in ready.step_body["model"]
     work_dir = tmp_path / "work"
     work_dir.mkdir()
 

--- a/tests/server/test_attestation_delivery_reachability.py
+++ b/tests/server/test_attestation_delivery_reachability.py
@@ -212,6 +212,37 @@ async def test_attested_run_skill_never_forwards_an_unresolved_model_template(
     )
 
 
+async def test_attested_run_skill_reports_missing_canonical_tool_def(
+    tmp_path,
+    tool_ctx_ready_recipe,
+    monkeypatch,
+) -> None:
+    """A missing canonical run_skill definition remains a loud runtime invariant."""
+    from autoskillit.server.tools import tools_execution
+
+    ready = tool_ctx_ready_recipe
+    with_args = ready.with_args
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    monkeypatch.setattr(tools_execution, "get_tool_def", lambda _name: None)
+
+    result = json.loads(
+        await tools_execution.run_skill(
+            with_args["skill_command"],
+            str(work_dir),
+            step_name=with_args["step_name"],
+            output_dir=with_args["output_dir"],
+            recipe_execution_id=ready.credential["execution_id"],
+            invocation_template_digest=ready.template_digest,
+            skill_inputs={name: "probe value" for name in with_args["skill_inputs"]},
+        )
+    )
+
+    assert result["success"] is False
+    assert result["subtype"] == "crashed"
+    assert "RuntimeError: run_skill must be a registered ToolDef" in result["result"]
+
+
 async def test_tool_ctx_ready_recipe_fixture_yields_genuine_attestation(
     tmp_path,
     tool_ctx_ready_recipe,

--- a/tests/server/test_attestation_delivery_reachability.py
+++ b/tests/server/test_attestation_delivery_reachability.py
@@ -165,6 +165,53 @@ async def test_attested_run_skill_admits_explicit_order_id(
     assert executor.calls[0].order_id == "AB"
 
 
+async def test_attested_run_skill_never_forwards_an_unresolved_model_template(
+    tmp_path,
+    tool_ctx_ready_recipe,
+) -> None:
+    """#4402 remediation — restores T3.b's original intent against the real
+    recipe, catching the defect the synthetic-literal-model unit tests in
+    test_run_skill_execution_tuning_fallbacks.py structurally could not see.
+
+    The real remediation.yaml investigate step declares
+    ``model: ${{ 'opus[1m]' if inputs.depth == 'deep' else 'sonnet' }}`` — a
+    template load_recipe() never interpolates (it's a thin YAML parse; see
+    the output_dir fallback's identical "${{" guard). Since sous-chef now
+    mandates omitting model from attested calls, every real invocation of
+    this step reaches the RecipeStep.model fallback. Before the fix, the
+    fallback had no template guard (unlike its output_dir sibling) and would
+    forward the raw, broken template string straight to --model.
+    """
+    from autoskillit.server.tools.tools_execution import run_skill
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    ready = tool_ctx_ready_recipe
+    executor = InMemoryHeadlessExecutor()
+    ready.tool_ctx.executor = executor
+    with_args = ready.with_args
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+
+    result = json.loads(
+        await run_skill(
+            with_args["skill_command"],
+            str(work_dir),
+            step_name=with_args["step_name"],
+            output_dir=with_args["output_dir"],
+            recipe_execution_id=ready.credential["execution_id"],
+            invocation_template_digest=ready.template_digest,
+            skill_inputs={name: "probe value" for name in with_args["skill_inputs"]},
+        )
+    )
+
+    assert result.get("stage") != "preflight:recipe_execution", result
+    assert len(executor.calls) == 1
+    assert "${{" not in executor.calls[0].model, (
+        f"unresolved recipe template leaked into the executor's model kwarg: "
+        f"{executor.calls[0].model!r}"
+    )
+
+
 async def test_tool_ctx_ready_recipe_fixture_yields_genuine_attestation(
     tmp_path,
     tool_ctx_ready_recipe,

--- a/tests/server/test_attestation_delivery_reachability.py
+++ b/tests/server/test_attestation_delivery_reachability.py
@@ -10,7 +10,6 @@ No test here reads ``payload.json`` or any file under ``recipe-delivery/``.
 from __future__ import annotations
 
 import json
-from typing import Any
 
 import pytest
 
@@ -22,11 +21,6 @@ from autoskillit.core import (
 )
 from autoskillit.pipeline import ReadyRecipe
 from tests.conftest import _make_result
-from tests.server._helpers import (
-    _credit_initialization_sections,
-    _open_kitchen_patched,
-    _pull_step_section,
-)
 from tests.server.test_tools_recipe_pull import (
     _NOW,
     _attestation,
@@ -50,60 +44,14 @@ _OVERRIDES = {
 }
 
 
-@pytest.fixture()
-def forbid_artifact_reads(monkeypatch: pytest.MonkeyPatch):
-    """Return an arming callable that fails any persisted-artifact read."""
-    import autoskillit.server.tools.tools_recipe as tools_recipe
-
-    def _forbidden(*_args, **_kwargs):
-        raise AssertionError("credential must come from responses, not payload.json")
-
-    return lambda: monkeypatch.setattr(tools_recipe, "load_recipe_artifact", _forbidden)
-
-
-async def _drive_bounded_initialization(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path,
-    arm,
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Drive the bounded envelope flow through real tools, returning (receipt, step_body).
-
-    The poison is armed AFTER the pull is complete so that ``get_recipe_section`` (which
-    legitimately reads the artifact to serve pages) continues to work; only
-    ``complete_recipe_initialization`` and ``run_skill`` are poisoned thereafter.
-    """
-    monkeypatch.chdir(tmp_path)
-    from autoskillit.recipe import _api_cache
-    from autoskillit.recipe._api_cache import LoadCache
-    from autoskillit.server.tools.tools_recipe import complete_recipe_initialization
-
-    monkeypatch.setattr(_api_cache, "_LOAD_CACHE", LoadCache())
-    envelope = await _open_kitchen_patched(_RECIPE_ENVELOPE, _OVERRIDES, monkeypatch)
-    assert envelope["success"] is True
-    assert envelope["delivery_bound_spill"] is True
-    assert envelope["recipe_pull"]["pull_tool"] == "get_recipe_section"
-    assert RECIPE_EXECUTION_CREDENTIAL_WIRE_KEY not in envelope
-    assert isinstance(envelope["initialization_id"], str) and envelope["initialization_id"]
-
-    await _credit_initialization_sections(envelope)
-    step_body = await _pull_step_section(envelope, _ATTESTED_STEP)
-    arm()
-    receipt = json.loads(await complete_recipe_initialization(envelope["initialization_id"]))
-    return receipt, step_body
-
-
 async def test_bounded_initialization_delivers_attestation_credential(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path,
-    forbid_artifact_reads,
-    tool_ctx_kitchen_open,
+    tool_ctx_ready_recipe,
 ) -> None:
     """REQ-031: the bounded envelope path puts the credential on the completion receipt."""
-    arm = forbid_artifact_reads
-    receipt, _step_body = await _drive_bounded_initialization(monkeypatch, tmp_path, arm)
+    ready = tool_ctx_ready_recipe
 
-    assert receipt["success"] is True
-    credential = receipt[RECIPE_EXECUTION_CREDENTIAL_WIRE_KEY]
+    assert ready.receipt["success"] is True
+    credential = ready.credential
     assert set(credential) == RECIPE_EXECUTION_CREDENTIAL_WIRE_FIELDS
     digests = credential["invocation_template_digests"]
     assert digests, "invocation_template_digests is empty"
@@ -114,27 +62,22 @@ async def test_bounded_initialization_delivers_attestation_credential(
         assert value.removeprefix("sha256:").islower()
     assert _ATTESTED_STEP in digests
     assert credential["execution_id"]
-    assert isinstance(tool_ctx_kitchen_open.recipe_initialization_state, ReadyRecipe)
+    assert isinstance(ready.tool_ctx.recipe_initialization_state, ReadyRecipe)
 
 
 async def test_attested_run_skill_succeeds_using_only_delivered_values(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path,
-    forbid_artifact_reads,
-    tool_ctx_kitchen_open,
+    tool_ctx_ready_recipe,
 ) -> None:
     """REQ-032: the attested ``run_skill`` must be drivable from received values alone."""
     from autoskillit.server.tools.tools_execution import run_skill
 
-    arm = forbid_artifact_reads
-    receipt, step_body = await _drive_bounded_initialization(monkeypatch, tmp_path, arm)
-
-    credential = receipt[RECIPE_EXECUTION_CREDENTIAL_WIRE_KEY]
-    with_args = step_body["with"]
+    ready = tool_ctx_ready_recipe
+    with_args = ready.with_args
     work_dir = tmp_path / "work"
     work_dir.mkdir()
-    tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))
-    tool_ctx_kitchen_open.runner.push(
+    ready.tool_ctx.runner.push(_make_result(returncode=1))
+    ready.tool_ctx.runner.push(
         _make_result(
             0,
             json.dumps(
@@ -149,7 +92,7 @@ async def test_attested_run_skill_succeeds_using_only_delivered_values(
             "",
         )
     )
-    calls_before = len(tool_ctx_kitchen_open.runner.call_args_list)
+    calls_before = len(ready.tool_ctx.runner.call_args_list)
 
     result = json.loads(
         await run_skill(
@@ -157,8 +100,8 @@ async def test_attested_run_skill_succeeds_using_only_delivered_values(
             str(work_dir),
             step_name=with_args["step_name"],
             output_dir=with_args["output_dir"],
-            recipe_execution_id=credential["execution_id"],
-            invocation_template_digest=credential["invocation_template_digests"][_ATTESTED_STEP],
+            recipe_execution_id=ready.credential["execution_id"],
+            invocation_template_digest=ready.template_digest,
             skill_inputs={name: "probe value" for name in with_args["skill_inputs"]},
         )
     )
@@ -167,7 +110,7 @@ async def test_attested_run_skill_succeeds_using_only_delivered_values(
     assert "recipe_execution_attestation_missing" not in serialized
     assert "RECIPE EXECUTION REJECTED" not in serialized
     assert result.get("stage") != "preflight:recipe_execution"
-    assert len(tool_ctx_kitchen_open.runner.call_args_list) > calls_before
+    assert len(ready.tool_ctx.runner.call_args_list) > calls_before
 
 
 @pytest.mark.parametrize("mode", list(RecipeDeliveryMode), ids=lambda m: m.value)

--- a/tests/server/test_attestation_delivery_reachability.py
+++ b/tests/server/test_attestation_delivery_reachability.py
@@ -113,6 +113,119 @@ async def test_attested_run_skill_succeeds_using_only_delivered_values(
     assert len(ready.tool_ctx.runner.call_args_list) > calls_before
 
 
+async def test_attested_run_skill_admits_explicit_order_id(
+    tmp_path,
+    tool_ctx_ready_recipe,
+) -> None:
+    """#4402/T3.a — order_id is ORCHESTRATOR_SCOPING: an attested call may pass
+    it explicitly alongside the delivered protocol values without denial (the
+    #4296 escape hatch), and the passed value reaches the executor ahead of
+    the AUTOSKILLIT_DISPATCH_ID env fallback (effective_order_id = order_id or
+    env, tools_execution.py). Unreachable for attested calls before #4402 —
+    order_id had no with:-declared template entry, so any non-empty value was
+    an "undeclared effective name" and the gate denied it outright.
+
+    model/stale_threshold RecipeStep-fallback e2e coverage (T3.b/T3.c) lives
+    in test_run_skill_execution_tuning_fallbacks.py instead of here: that
+    fallback block runs whenever step_name and tool_ctx.active_recipe_steps
+    are set, independent of attestation status, and the real "remediation"
+    recipe's investigate step declares only a templated model: field (bare
+    aliases, #4412 — out of scope here) and no stale_threshold: field at all,
+    so it cannot pin a literal fallback value without a bespoke fixture
+    recipe this plan does not add.
+    """
+    from autoskillit.server.tools.tools_execution import run_skill
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    ready = tool_ctx_ready_recipe
+    executor = InMemoryHeadlessExecutor()
+    ready.tool_ctx.executor = executor
+    with_args = ready.with_args
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+
+    result = json.loads(
+        await run_skill(
+            with_args["skill_command"],
+            str(work_dir),
+            step_name=with_args["step_name"],
+            output_dir=with_args["output_dir"],
+            recipe_execution_id=ready.credential["execution_id"],
+            invocation_template_digest=ready.template_digest,
+            skill_inputs={name: "probe value" for name in with_args["skill_inputs"]},
+            order_id="AB",
+        )
+    )
+
+    serialized = json.dumps(result)
+    assert "recipe_execution_attestation_missing" not in serialized
+    assert "RECIPE EXECUTION REJECTED" not in serialized
+    assert result.get("stage") != "preflight:recipe_execution"
+    assert len(executor.calls) == 1
+    assert executor.calls[0].order_id == "AB"
+
+
+async def test_tool_ctx_ready_recipe_fixture_yields_genuine_attestation(
+    tmp_path,
+    tool_ctx_ready_recipe,
+) -> None:
+    """#4402/T8 — tool_ctx_ready_recipe must yield a genuinely attested context,
+    not a mock of one: its installed snapshot's template digest round-trips
+    through a real ``run_skill`` admission — the genuine digest succeeds, a
+    fabricated one is denied at ``preflight:recipe_execution``. A mock that
+    accepted any digest would pass the first half and fail to distinguish
+    the second.
+    """
+    from autoskillit.server.tools.tools_execution import run_skill
+
+    ready = tool_ctx_ready_recipe
+    with_args = ready.with_args
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    ready.tool_ctx.runner.push(_make_result(returncode=1))
+    ready.tool_ctx.runner.push(
+        _make_result(
+            0,
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "result": "done",
+                    "session_id": "session-1",
+                }
+            ),
+            "",
+        )
+    )
+
+    genuine = json.loads(
+        await run_skill(
+            with_args["skill_command"],
+            str(work_dir),
+            step_name=with_args["step_name"],
+            output_dir=with_args["output_dir"],
+            recipe_execution_id=ready.credential["execution_id"],
+            invocation_template_digest=ready.template_digest,
+            skill_inputs={name: "probe value" for name in with_args["skill_inputs"]},
+        )
+    )
+    assert genuine.get("stage") != "preflight:recipe_execution", genuine
+
+    fabricated = json.loads(
+        await run_skill(
+            with_args["skill_command"],
+            str(work_dir),
+            step_name=with_args["step_name"],
+            output_dir=with_args["output_dir"],
+            recipe_execution_id=ready.credential["execution_id"],
+            invocation_template_digest="sha256:" + "0" * 64,
+            skill_inputs={name: "probe value" for name in with_args["skill_inputs"]},
+        )
+    )
+    assert fabricated.get("stage") == "preflight:recipe_execution", fabricated
+
+
 @pytest.mark.parametrize("mode", list(RecipeDeliveryMode), ids=lambda m: m.value)
 async def test_no_delivery_mode_omits_the_attestation_credential(
     mode: RecipeDeliveryMode,

--- a/tests/server/test_run_skill_execution_tuning_fallbacks.py
+++ b/tests/server/test_run_skill_execution_tuning_fallbacks.py
@@ -1,0 +1,107 @@
+"""RecipeStep.model fallback and vacancy-sentinel guards for run_skill (#4402).
+
+Extends the proven #2969/#3377 server-side RecipeStep fallback pattern (see
+``tests/server/test_tools_execution_step_resolution.py`` for the
+``stale_threshold``/``output_dir`` precedents) to ``model`` — the one
+EXECUTION_TUNING param that previously had no fallback and zero runtime
+consumer, despite ``RecipeStep.model`` being parsed and lint-validated.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.recipe.schema import RecipeStep
+from autoskillit.server.tools.tools_execution import run_skill
+from tests.fakes import InMemoryHeadlessExecutor
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.mark.anyio
+async def test_empty_caller_model_falls_back_to_recipe_step_model(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+) -> None:
+    """caller model="" + RecipeStep.model set -> the recipe's model reaches the executor."""
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    step = RecipeStep(name="implement", model="claude-sonnet-5")
+    tool_ctx_kitchen_open.active_recipe_steps = {"implement": step}
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    await run_skill("/implement ...", str(tmp_path), step_name="implement")
+
+    assert executor.calls[0].model == "claude-sonnet-5"
+
+
+@pytest.mark.anyio
+async def test_explicit_caller_model_beats_recipe_step_model(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+) -> None:
+    """An explicit non-empty caller model must win — the fallback only fills a vacancy."""
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    step = RecipeStep(name="implement", model="claude-sonnet-5")
+    tool_ctx_kitchen_open.active_recipe_steps = {"implement": step}
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    await run_skill("/implement ...", str(tmp_path), step_name="implement", model="claude-opus-5")
+
+    assert executor.calls[0].model == "claude-opus-5"
+
+
+@pytest.mark.anyio
+async def test_both_model_sources_empty_does_not_crash(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+) -> None:
+    """Neither caller nor recipe step declares model -> "" reaches the executor
+    (downstream _resolve_model's tier-5 default_model applies from there; this
+    only pins that the vacancy is left alone, not what the eventual default is)."""
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    step = RecipeStep(name="implement")
+    tool_ctx_kitchen_open.active_recipe_steps = {"implement": step}
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    await run_skill("/implement ...", str(tmp_path), step_name="implement")
+
+    assert executor.calls[0].model == ""
+
+
+@pytest.mark.anyio
+async def test_config_model_override_beats_recipe_step_fallback(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+) -> None:
+    """config.model.model_override is a pre-executor config tier that already
+    outranks the param channel (tools_execution.py's own effective_model
+    resolution, ahead of the RecipeStep fallback this plan adds) — the
+    RecipeStep.model fallback must not un-do it."""
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    tool_ctx_kitchen_open.config.model.model_override = "config-forced-model"
+    step = RecipeStep(name="implement", model="claude-sonnet-5")
+    tool_ctx_kitchen_open.active_recipe_steps = {"implement": step}
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    await run_skill("/implement ...", str(tmp_path), step_name="implement")
+
+    assert executor.calls[0].model == "config-forced-model"
+
+
+@pytest.mark.anyio
+async def test_explicit_zero_idle_output_timeout_is_not_overwritten(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+) -> None:
+    """idle_output_timeout=0 is documented as "disabled for this step" (handler
+    docstring) — the vacancy sentinel for this int param is `is None`, never a
+    falsy check, so an explicit 0 must survive untouched even when the recipe
+    step declares a truthy fallback value."""
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    step = RecipeStep(name="implement", idle_output_timeout=900)
+    tool_ctx_kitchen_open.active_recipe_steps = {"implement": step}
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    await run_skill("/implement ...", str(tmp_path), step_name="implement", idle_output_timeout=0)
+
+    assert executor.calls[0].idle_output_timeout == 0.0

--- a/tests/server/test_run_skill_execution_tuning_fallbacks.py
+++ b/tests/server/test_run_skill_execution_tuning_fallbacks.py
@@ -146,15 +146,24 @@ def test_execution_tuning_step_fields_have_matching_runtime_read_sites() -> None
     inside run_skill(), so a table entry added without a matching if-block
     — the exact silent-no-op drift this table exists to prevent — fails CI
     instead of silently doing nothing at runtime."""
+    import ast
     import inspect
 
     from autoskillit.server.tools import tools_execution
 
-    source = inspect.getsource(tools_execution.run_skill)
+    tree = ast.parse(inspect.getsource(tools_execution.run_skill))
+    read_fields = {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "_recipe_step"
+        and isinstance(node.ctx, ast.Load)
+    }
     missing = [
         field_name
         for field_name in tools_execution._EXECUTION_TUNING_STEP_FIELDS.values()
-        if f"_recipe_step.{field_name}" not in source
+        if field_name not in read_fields
     ]
     assert not missing, (
         f"EXECUTION_TUNING RecipeStep field(s) in _EXECUTION_TUNING_STEP_FIELDS have "

--- a/tests/server/test_run_skill_execution_tuning_fallbacks.py
+++ b/tests/server/test_run_skill_execution_tuning_fallbacks.py
@@ -105,3 +105,61 @@ async def test_explicit_zero_idle_output_timeout_is_not_overwritten(
     await run_skill("/implement ...", str(tmp_path), step_name="implement", idle_output_timeout=0)
 
     assert executor.calls[0].idle_output_timeout == 0.0
+
+
+@pytest.mark.anyio
+async def test_unresolved_model_template_is_not_forwarded(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+) -> None:
+    """#4402 remediation — RecipeStep.model is a plain str field, unlike the int
+    stale_threshold/idle_output_timeout fields, so it can (and in the real
+    bundled remediation.yaml investigate step, does) carry an unresolved
+    ``${{ ... }}`` ingredient template: load_recipe() is a thin YAML parse
+    with no interpolation. The fallback must skip it — mirroring the
+    identical "${{" guard the output_dir fallback already has — rather than
+    forward a broken template string as --model. See
+    test_attestation_delivery_reachability.py::
+    test_attested_run_skill_never_forwards_an_unresolved_model_template for
+    the same guard proven against the real recipe step."""
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx_kitchen_open.executor = executor
+    step = RecipeStep(
+        name="implement",
+        model="${{ 'opus[1m]' if inputs.depth == 'deep' else 'sonnet' }}",
+    )
+    tool_ctx_kitchen_open.active_recipe_steps = {"implement": step}
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx_kitchen_open)
+
+    await run_skill("/implement ...", str(tmp_path), step_name="implement")
+
+    assert "${{" not in executor.calls[0].model
+    assert executor.calls[0].model == ""
+
+
+def test_execution_tuning_step_fields_have_matching_runtime_read_sites() -> None:
+    """_EXECUTION_TUNING_STEP_FIELDS documents which RecipeStep fields the
+    post-gate fallback reads — it is NOT itself iterated at runtime (each
+    field needs a distinct vacancy-sentinel check and writes a distinct
+    local variable, which Python cannot dispatch generically by name
+    without unsafe locals() mutation). This is the alternative safety net:
+    every table entry must have a real ``_recipe_step.<field>`` read site
+    inside run_skill(), so a table entry added without a matching if-block
+    — the exact silent-no-op drift this table exists to prevent — fails CI
+    instead of silently doing nothing at runtime."""
+    import inspect
+
+    from autoskillit.server.tools import tools_execution
+
+    source = inspect.getsource(tools_execution.run_skill)
+    missing = [
+        field_name
+        for field_name in tools_execution._EXECUTION_TUNING_STEP_FIELDS.values()
+        if f"_recipe_step.{field_name}" not in source
+    ]
+    assert not missing, (
+        f"EXECUTION_TUNING RecipeStep field(s) in _EXECUTION_TUNING_STEP_FIELDS have "
+        f"no matching '_recipe_step.<field>' read site inside run_skill(): {missing}. "
+        "A table entry with no runtime consumer silently does nothing — add the "
+        "matching fallback if-block (see model/stale_threshold/idle_output_timeout "
+        "for the pattern)."
+    )

--- a/tests/server/test_tool_registry_parity.py
+++ b/tests/server/test_tool_registry_parity.py
@@ -13,6 +13,7 @@ from autoskillit.core import (
     TOOL_REGISTRY,
     ToolInitializationOperation,
     ToolParamDef,
+    ToolParamRole,
     ToolWireType,
     compute_tool_contract_identity,
 )
@@ -149,12 +150,12 @@ def test_run_skill_has_one_compiler_owned_structured_input_channel() -> None:
 
 
 def test_tool_def_freezes_caller_owned_parameter_sequences() -> None:
-    params = [ToolParamDef("first")]
+    params = [ToolParamDef("first", role=ToolParamRole.CHILD_INPUT)]
 
     tool = replace(TOOL_REGISTRY["close_kitchen"], params=params)
-    params.append(ToolParamDef("later"))
+    params.append(ToolParamDef("later", role=ToolParamRole.CHILD_INPUT))
 
-    assert tool.params == (ToolParamDef("first"),)
+    assert tool.params == (ToolParamDef("first", role=ToolParamRole.CHILD_INPUT),)
 
 
 def test_tool_def_rejects_non_parameter_definitions() -> None:
@@ -166,7 +167,10 @@ def test_tool_contract_identity_tracks_registry_parameter_shape() -> None:
     run_skill = TOOL_REGISTRY["run_skill"]
     changed = replace(
         run_skill,
-        params=(*run_skill.params, ToolParamDef("future_parameter")),
+        params=(
+            *run_skill.params,
+            ToolParamDef("future_parameter", role=ToolParamRole.CHILD_INPUT),
+        ),
     )
 
     assert compute_tool_contract_identity(changed) != compute_tool_contract_identity(run_skill)

--- a/tests/server/test_tool_registry_parity.py
+++ b/tests/server/test_tool_registry_parity.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+import autoskillit.core.tool_registry as tool_registry
 from autoskillit.core import (
     EXPLORATION_TOOLS,
     TOOL_REGISTRY,
@@ -68,6 +69,15 @@ def test_handler_collection_rejects_duplicate_registrations(tmp_path: Path) -> N
 
 def test_registry_matches_handler_names_bidirectionally() -> None:
     assert set(TOOL_REGISTRY) == set(_handler_signatures())
+
+
+def test_tool_builder_rejects_roles_for_unknown_parameters() -> None:
+    with pytest.raises(ValueError, match="unknown parameter.*typo"):
+        tool_registry._tool(
+            "run_cmd",
+            ("cmd",),
+            roles={"typo": ToolParamRole.PROTOCOL},
+        )
 
 
 def test_registry_matches_handler_order_and_requiredness() -> None:


### PR DESCRIPTION
## Summary

No single artifact in AutoSkillit declares what role each `run_skill` parameter plays: the attestation allow-list, the actual-kwargs assembly, and the server-side `RecipeStep` fallback each derive their own emergent taxonomy, which lets attested calls carrying `model`, `order_id`, `stale_threshold`, or `idle_output_timeout` get wrongly denied while `RecipeStep.model` sits parsed and validated but never read by any runtime code. This PR introduces a required `role` classification on `ToolParamDef` that becomes the single source of truth driving the attestation gate's always-admit set, kwargs assembly, and the `RecipeStep` fallback for execution-tuning parameters — the same frozenset-registry pattern already used for `CONFIG_AUTHORITY_KEYS`/`SERVER_AUTHORITATIVE_INGREDIENTS` — so a contradiction across injection, admission, and fallback now requires editing one registry instead of four independently maintained surfaces. It also adds drift-alarm tests (a frozen RecipeStep field-classification ledger and a frozen run_skill param/role ledger) so the next instance of a declared-but-inert field or misclassified parameter is caught immediately rather than shipping silently.

Closes #4402

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/rectify/rectify_run-skill-param-role-authority-4402_2026-08-08_103736.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
