### PR TITLE
Profile recipe/general CI shard split (#4355)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJSON(needs.preflight.outputs.os-matrix) }}
-        shard: [execution, recipe, server, general]
+        shard: [execution, recipe, general]
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -113,8 +113,7 @@ jobs:
         id: test-paths
         run: |
           SHARD_A_DIRS="tests/execution tests/contracts tests/core tests/exploration tests/planner tests/pipeline tests/migration tests/integration"
-          SHARD_B_DIRS="tests/recipe tests/docs"
-          SHARD_C_DIRS="tests/server"
+          SHARD_B_DIRS="tests/recipe tests/docs tests/server"
           if find tests/ -maxdepth 1 -name 'test_*.py' -print0 | grep -qz ' '; then
             echo "::error::Test filenames with spaces are not supported by the shard path splitter"
             exit 1
@@ -127,12 +126,9 @@ jobs:
             recipe)
               echo "PYTEST_TEST_PATHS=${SHARD_B_DIRS}" >> "$GITHUB_ENV"
               ;;
-            server)
-              echo "PYTEST_TEST_PATHS=${SHARD_C_DIRS}" >> "$GITHUB_ENV"
-              ;;
             general)
               IGNORES=""
-              for d in $SHARD_A_DIRS $SHARD_B_DIRS $SHARD_C_DIRS; do
+              for d in $SHARD_A_DIRS $SHARD_B_DIRS; do
                 IGNORES="$IGNORES --ignore=$d"
               done
               ROOT_IGNORES=$(find tests/ -maxdepth 1 -name 'test_*.py' | sort | sed 's|^|--ignore=|' | tr '\n' ' ')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJSON(needs.preflight.outputs.os-matrix) }}
-        shard: [execution, recipe, general]
+        shard: [execution, recipe, server, general]
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -112,8 +112,9 @@ jobs:
       - name: Compute test paths
         id: test-paths
         run: |
-          SHARD_A_DIRS="tests/execution tests/contracts tests/core tests/exploration tests/planner tests/pipeline tests/migration tests/integration tests/server"
+          SHARD_A_DIRS="tests/execution tests/contracts tests/core tests/exploration tests/planner tests/pipeline tests/migration tests/integration"
           SHARD_B_DIRS="tests/recipe tests/docs"
+          SHARD_C_DIRS="tests/server"
           if find tests/ -maxdepth 1 -name 'test_*.py' -print0 | grep -qz ' '; then
             echo "::error::Test filenames with spaces are not supported by the shard path splitter"
             exit 1
@@ -126,9 +127,12 @@ jobs:
             recipe)
               echo "PYTEST_TEST_PATHS=${SHARD_B_DIRS}" >> "$GITHUB_ENV"
               ;;
+            server)
+              echo "PYTEST_TEST_PATHS=${SHARD_C_DIRS}" >> "$GITHUB_ENV"
+              ;;
             general)
               IGNORES=""
-              for d in $SHARD_A_DIRS $SHARD_B_DIRS; do
+              for d in $SHARD_A_DIRS $SHARD_B_DIRS $SHARD_C_DIRS; do
                 IGNORES="$IGNORES --ignore=$d"
               done
               ROOT_IGNORES=$(find tests/ -maxdepth 1 -name 'test_*.py' | sort | sed 's|^|--ignore=|' | tr '\n' ' ')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJSON(needs.preflight.outputs.os-matrix) }}
-        shard: [execution, general]
+        shard: [execution, recipe, general]
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -113,22 +113,33 @@ jobs:
         id: test-paths
         run: |
           SHARD_A_DIRS="tests/execution tests/contracts tests/core tests/exploration tests/planner tests/pipeline tests/migration tests/integration"
+          SHARD_B_DIRS="tests/recipe tests/docs"
           if find tests/ -maxdepth 1 -name 'test_*.py' -print0 | grep -qz ' '; then
             echo "::error::Test filenames with spaces are not supported by the shard path splitter"
             exit 1
           fi
-          if [[ "${{ matrix.shard }}" == "execution" ]]; then
-            ROOT_FILES=$(find tests/ -maxdepth 1 -name 'test_*.py' | sort | tr '\n' ' ')
-            echo "PYTEST_TEST_PATHS=${SHARD_A_DIRS} ${ROOT_FILES}" >> "$GITHUB_ENV"
-          else
-            IGNORES=""
-            for d in $SHARD_A_DIRS; do
-              IGNORES="$IGNORES --ignore=$d"
-            done
-            ROOT_IGNORES=$(find tests/ -maxdepth 1 -name 'test_*.py' | sort | sed 's|^|--ignore=|' | tr '\n' ' ')
-            echo "PYTEST_TEST_PATHS=tests/" >> "$GITHUB_ENV"
-            echo "PYTEST_IGNORE_PATHS=${IGNORES} ${ROOT_IGNORES}" >> "$GITHUB_ENV"
-          fi
+          case "${{ matrix.shard }}" in
+            execution)
+              ROOT_FILES=$(find tests/ -maxdepth 1 -name 'test_*.py' | sort | tr '\n' ' ')
+              echo "PYTEST_TEST_PATHS=${SHARD_A_DIRS} ${ROOT_FILES}" >> "$GITHUB_ENV"
+              ;;
+            recipe)
+              echo "PYTEST_TEST_PATHS=${SHARD_B_DIRS}" >> "$GITHUB_ENV"
+              ;;
+            general)
+              IGNORES=""
+              for d in $SHARD_A_DIRS $SHARD_B_DIRS; do
+                IGNORES="$IGNORES --ignore=$d"
+              done
+              ROOT_IGNORES=$(find tests/ -maxdepth 1 -name 'test_*.py' | sort | sed 's|^|--ignore=|' | tr '\n' ' ')
+              echo "PYTEST_TEST_PATHS=tests/" >> "$GITHUB_ENV"
+              echo "PYTEST_IGNORE_PATHS=${IGNORES} ${ROOT_IGNORES}" >> "$GITHUB_ENV"
+              ;;
+            *)
+              echo "::error::Unknown test shard: ${{ matrix.shard }}"
+              exit 1
+              ;;
+          esac
 
       - name: Lint imports
         if: matrix.shard == 'execution'
@@ -138,7 +149,7 @@ jobs:
         env:
           AUTOSKILLIT_FILTER_STATS_FILE: ${{ github.workspace }}/.autoskillit/temp/filter-stats.json
           AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED: "true"
-          AUTOSKILLIT_TEST_FILTER: ${{ needs.preflight.outputs.test-filter-mode }}
+          AUTOSKILLIT_TEST_FILTER: ${{ github.event_name == 'pull_request' && github.base_ref == 'develop' && github.head_ref == 'experiment/4355-ci-shard-profile' && github.event.pull_request.head.repo.full_name == github.repository && 'none' || needs.preflight.outputs.test-filter-mode }}
           AUTOSKILLIT_TEST_BASE_REF: ${{ needs.preflight.outputs.test-base-revision }}
         run: |
           mkdir -p .autoskillit/temp

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Compute test paths
         id: test-paths
         run: |
-          SHARD_A_DIRS="tests/execution tests/contracts tests/core tests/exploration tests/planner tests/pipeline tests/migration tests/integration"
+          SHARD_A_DIRS="tests/execution tests/contracts tests/core tests/exploration tests/planner tests/pipeline tests/migration tests/integration tests/server"
           SHARD_B_DIRS="tests/recipe tests/docs"
           if find tests/ -maxdepth 1 -name 'test_*.py' -print0 | grep -qz ' '; then
             echo "::error::Test filenames with spaces are not supported by the shard path splitter"

--- a/tests/infra/test_ci_shard_config.py
+++ b/tests/infra/test_ci_shard_config.py
@@ -17,12 +17,10 @@ KNOWN_GENERAL_SHARD_DIRS = {
     "backend",
     "cli",
     "config",
-    "docs",
     "fixtures",
     "fleet",
     "hooks",
     "infra",
-    "recipe",
     "report",
     "skills",
     "skills_extended",
@@ -30,34 +28,40 @@ KNOWN_GENERAL_SHARD_DIRS = {
 }
 
 
-def _parse_shard_a_dirs_from_workflow() -> list[str]:
+def _parse_explicit_shard_dirs_from_workflow() -> dict[str, list[str]]:
     if not WORKFLOW_PATH.exists():
         pytest.skip(
             f"Workflow file not found: {WORKFLOW_PATH}",
             allow_module_level=True,
         )
     text = WORKFLOW_PATH.read_text()
-    match = re.search(r'SHARD_A_DIRS="([^"]+)"', text)
-    if not match:
+    matches = re.findall(r'(SHARD_[A-Z]_DIRS)="([^"]+)"', text)
+    if not matches:
         pytest.skip(
-            "SHARD_A_DIRS not found in tests.yml — skipping shard config tests",
+            "Explicit shard directory sets not found in tests.yml — skipping shard config tests",
             allow_module_level=True,
         )
-    return match.group(1).split()
+    return {name: paths.split() for name, paths in matches}
 
 
-SHARD_A_DIRS = _parse_shard_a_dirs_from_workflow()
+EXPLICIT_SHARD_DIRS = _parse_explicit_shard_dirs_from_workflow()
 
 
 class TestCIShardConfig:
-    def test_shard_a_directories_exist(self) -> None:
-        for d in SHARD_A_DIRS:
-            assert (REPO_ROOT / d).is_dir(), f"Shard A directory {d} does not exist"
+    def test_explicit_shard_directories_exist(self) -> None:
+        for paths in EXPLICIT_SHARD_DIRS.values():
+            for path in paths:
+                assert (REPO_ROOT / path).is_dir(), f"Shard directory {path} does not exist"
 
-    def test_shard_a_directories_contain_tests(self) -> None:
-        for d in SHARD_A_DIRS:
-            test_files = list((REPO_ROOT / d).rglob("test_*.py"))
-            assert test_files, f"Shard A directory {d} contains no test files"
+    def test_explicit_shard_directories_contain_tests(self) -> None:
+        for paths in EXPLICIT_SHARD_DIRS.values():
+            for path in paths:
+                test_files = list((REPO_ROOT / path).rglob("test_*.py"))
+                assert test_files, f"Shard directory {path} contains no test files"
+
+    def test_explicit_shard_directories_are_disjoint(self) -> None:
+        all_paths = [path for paths in EXPLICIT_SHARD_DIRS.values() for path in paths]
+        assert len(all_paths) == len(set(all_paths))
 
     def test_known_general_dirs_exist(self) -> None:
         all_test_dirs = {
@@ -77,10 +81,13 @@ class TestCIShardConfig:
             for p in (REPO_ROOT / "tests").iterdir()
             if p.is_dir() and not p.name.startswith("_") and not p.name.startswith(".")
         }
-        shard_a_names = {d.removeprefix("tests/") for d in SHARD_A_DIRS}
-        assigned = shard_a_names | KNOWN_GENERAL_SHARD_DIRS
+        explicit_names = {
+            path.removeprefix("tests/") for paths in EXPLICIT_SHARD_DIRS.values() for path in paths
+        }
+        assigned = explicit_names | KNOWN_GENERAL_SHARD_DIRS
         unassigned = all_test_dirs - assigned
         assert not unassigned, (
             f"Test directories not assigned to any shard: {unassigned}. "
-            "Add to SHARD_A_DIRS in tests.yml or KNOWN_GENERAL_SHARD_DIRS in this file."
+            "Add to an explicit shard directory set in tests.yml or "
+            "KNOWN_GENERAL_SHARD_DIRS in this file."
         )

--- a/tests/infra/test_ci_shard_config.py
+++ b/tests/infra/test_ci_shard_config.py
@@ -24,7 +24,6 @@ KNOWN_GENERAL_SHARD_DIRS = {
     "infra",
     "recipe",
     "report",
-    "server",
     "skills",
     "skills_extended",
     "workspace",

--- a/tests/infra/test_ci_workflow.py
+++ b/tests/infra/test_ci_workflow.py
@@ -468,7 +468,7 @@ def test_workflow_consumes_one_target_policy_authority() -> None:
     assert test_job["name"] == "Test (${{ matrix.shard }}) on ${{ matrix.os }}"
     assert test_job["strategy"]["matrix"] == {
         "os": "${{ fromJSON(needs.preflight.outputs.os-matrix) }}",
-        "shard": ["execution", "general"],
+        "shard": ["execution", "recipe", "general"],
     }
     test_checkout = next(
         step
@@ -485,7 +485,10 @@ def test_workflow_consumes_one_target_policy_authority() -> None:
     assert "brew install ripgrep" in install_rg["run"]
     assert 'case "$RUNNER_OS" in' in install_rg["run"]
     assert run_tests["env"]["AUTOSKILLIT_TEST_FILTER"] == (
-        "${{ needs.preflight.outputs.test-filter-mode }}"
+        "${{ github.event_name == 'pull_request' && github.base_ref == 'develop' && "
+        "github.head_ref == 'experiment/4355-ci-shard-profile' && "
+        "github.event.pull_request.head.repo.full_name == github.repository && 'none' || "
+        "needs.preflight.outputs.test-filter-mode }}"
     )
     assert run_tests["env"]["AUTOSKILLIT_TEST_BASE_REF"] == (
         "${{ needs.preflight.outputs.test-base-revision }}"

--- a/tests/infra/test_ci_workflow.py
+++ b/tests/infra/test_ci_workflow.py
@@ -468,7 +468,7 @@ def test_workflow_consumes_one_target_policy_authority() -> None:
     assert test_job["name"] == "Test (${{ matrix.shard }}) on ${{ matrix.os }}"
     assert test_job["strategy"]["matrix"] == {
         "os": "${{ fromJSON(needs.preflight.outputs.os-matrix) }}",
-        "shard": ["execution", "recipe", "server", "general"],
+        "shard": ["execution", "recipe", "general"],
     }
     test_checkout = next(
         step

--- a/tests/infra/test_ci_workflow.py
+++ b/tests/infra/test_ci_workflow.py
@@ -468,7 +468,7 @@ def test_workflow_consumes_one_target_policy_authority() -> None:
     assert test_job["name"] == "Test (${{ matrix.shard }}) on ${{ matrix.os }}"
     assert test_job["strategy"]["matrix"] == {
         "os": "${{ fromJSON(needs.preflight.outputs.os-matrix) }}",
-        "shard": ["execution", "recipe", "general"],
+        "shard": ["execution", "recipe", "server", "general"],
     }
     test_checkout = next(
         step


### PR DESCRIPTION
## Summary

This draft PR profiles a candidate three-shard CI layout on isolated GitHub-hosted runners. It assigns `tests/recipe` and `tests/docs` to a new `recipe` shard, preserves the existing `execution` shard, and leaves `general` as the catch-all complement.

The shards run fully and without path filtering so their timings can inform the implementation decision for #4355. This PR is an evidence-gathering experiment only and must not be merged.

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/issue-4355-review/profiling-pr-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
