### PR TITLE
Rectify: Retained Session Index Consistency

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -82,10 +82,11 @@ Run health checks on your setup.
 **Flags:**
 - `--output-json` — Output results as JSON
 
-Runs 41 ungated checks (up to 47 with fleet enabled) enumerated by `run_doctor`
-in `cli/doctor/__init__.py`: 22 numbered base checks (1–23, excluding 5),
-7 lettered sub-checks (`2b`, `2c`, `2d`, `2e`, `4b`, `7b`, `7c`), and
-12 backend/runtime checks (30–40, including `31b`). The checks cover stale MCP
+Runs 45 ungated checks (up to 51 with fleet enabled) enumerated by `run_doctor`
+in `cli/doctor/__init__.py`: 36 numbered checks (1–23, excluding 5, and 30–43)
+and 9 lettered sub-checks (`2b`, `2c`, `2d`, `2e`, `4b`, `7b`, `7c`, `17b`,
+`31b`). With fleet enabled the structural total is 42 numbered plus 9 lettered
+checks. The checks cover stale MCP
 servers, plugin registration, plugin cache existence and integrity, PATH,
 project config, secrets placement, shared exact-artifact/install-state consistency,
 hook health, hook registration, hook registry drift, recipe version health, gitignore
@@ -94,8 +95,10 @@ points, source drift, quota cache schema, process state, install classification,
 update dismissal state, ambient env leaks, feature gate consistency, codex version,
 script binary, claude binary, codex MCP timeouts, codex graduation, CLI conformance,
 codex NDJSON drift, codex model-alias staleness, standing backend pin feasibility,
-local recipe validity, codex limits pin freshness, and bundled skill capability
-authenticity (including the 6 fleet checks 24–29). See
+local recipe validity, codex limits pin freshness, bundled skill capability
+authenticity, capture-store statistics, project-local skill contracts, and
+retained session-index projection consistency (including the 6 fleet checks
+24–29). See
 [installation.md](installation.md#post-install-verification) for the full table.
 
 ---

--- a/docs/developer/diagnostics.md
+++ b/docs/developer/diagnostics.md
@@ -24,7 +24,7 @@ Logs are stored in a **global** directory (not per-project), so they persist acr
 
 ```
 ~/.local/share/autoskillit/logs/
-├── sessions.jsonl                    # Append-only index (one JSON line per session)
+├── sessions.jsonl                    # Retained derived index (one row per committed session)
 └── sessions/
     └── {session_id}/                 # or pid_{pid}_{timestamp} if session_id unavailable
         ├── proc_trace.jsonl          # Full ProcSnapshot series
@@ -70,10 +70,18 @@ Logs are stored in a **global** directory (not per-project), so they persist acr
 ## How It Works
 
 1. **Accumulate**: During a headless session, `LinuxTracingHandle` collects `ProcSnapshot` objects in memory at the configured interval (default 5s)
-2. **Flush**: After the session completes, `flush_session_log()` writes all data to disk
-3. **Detect**: Anomaly detection runs over the complete snapshot series at flush time
-4. **Index**: Each session appends one line to `sessions.jsonl` for quick scanning
-5. **Retain**: Automatic cleanup keeps at most 500 session directories
+2. **Flush**: After the session completes, `flush_session_log()` writes all per-session artifacts
+3. **Commit**: `summary.json` is published last and commits an eligible diagnostic session
+4. **Index**: One exclusive transaction upserts the committed session into the retained `sessions.jsonl` projection
+5. **Retain**: Automatic cleanup targets at most 2,000 committed directories; active-campaign protection may keep more
+
+`sessions.jsonl` is a bounded derived index, not an append-only ledger. Its
+`timestamp` field remains the session `start_ts`, not completion or index-write
+time. Starting from an exact summary/index projection, a successful transaction
+preserves that projection, while deterministic crash-recovery replay heals its
+current key. Historical inconsistencies for other keys remain doctor-visible.
+Publication is atomic for concurrent writers and process crashes, but does not
+promise strict power-loss durability or snapshot isolation for unlocked readers.
 
 ## Configuration
 

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -278,6 +278,12 @@ See **[Hooks](../safety/hooks.md)** for the complete safety system: protected br
 
 Pipeline sessions are logged to `~/.local/share/autoskillit/logs/` (Linux) or `~/Library/Application Support/autoskillit/logs/` (macOS). Each session records token usage, timing, and process traces.
 
+`summary.json` is the committed completion witness and is published last among
+per-session artifacts. A shared exclusive-lease transaction upserts the session
+row, applies committed-directory retention, and atomically replaces the bounded
+`sessions.jsonl` derived index. Doctor compares retained summary parents with
+physical index-row multiplicity under the corresponding shared lease.
+
 Query the index: `jq 'select(.success == false)' ~/.local/share/autoskillit/logs/sessions.jsonl`
 
 See **[Session Diagnostics](../developer/diagnostics.md)** for details.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -67,10 +67,10 @@ projects need.
 
     autoskillit doctor
 
-Doctor runs 41 ungated checks: 22 numbered base checks (1–23, excluding 5),
-7 lettered sub-checks (`2b`, `2c`, `2d`, `2e`, `4b`, `7b`, `7c`), and
-12 backend/runtime checks (30–40, including `31b`). Enabling the fleet feature
-adds checks 24–29, for 47 total.
+Doctor runs 45 ungated checks: 36 numbered checks (1–23, excluding 5,
+and 30–43) plus 9 lettered sub-checks (`2b`, `2c`, `2d`, `2e`, `4b`,
+`7b`, `7c`, `17b`, `31b`). Enabling the fleet feature adds checks 24–29,
+for 51 total: 42 numbered and 9 lettered checks.
 Enumerated by `run_doctor` in `src/autoskillit/cli/doctor/__init__.py`:
 
 | # | Check | What it verifies |
@@ -98,6 +98,7 @@ Enumerated by `run_doctor` in `src/autoskillit/cli/doctor/__init__.py`:
 | 15 | Claude process state | Reports D-state and CPU breakdown of running `claude` processes via `ps` |
 | 16 | Install classification | `direct_url.json` classifies the install type and requested revision |
 | 17 | Update dismissal state | Active update-prompt dismissal window and conditions, if any |
+| 17b | Publication obligation | Pending local publication obligations are reported without mutation |
 | 18 | Ambient SESSION_TYPE=leaf | No stray `SESSION_TYPE=leaf` env var in interactive shell |
 | 19 | Ambient SESSION_TYPE=orchestrator | No stray `SESSION_TYPE=orchestrator` env var |
 | 20 | Ambient SESSION_TYPE=fleet | No stray `SESSION_TYPE=fleet` env var |
@@ -118,6 +119,9 @@ Enumerated by `run_doctor` in `src/autoskillit/cli/doctor/__init__.py`:
 | 38 | Local recipe validity | Local recipes satisfy the current recipe contract |
 | 39 | Codex limits pin | Codex limits version pin is current |
 | 40 | Skill capability authenticity | Bundled skill capabilities match authentic source evidence |
+| 41 | Capture-store statistics | Capture ledger and retained-directory statistics are readable |
+| 42 | Project-local skill contracts | Excluded or shadowed project-local skill copies are reported |
+| 43 | Session index projection | Retained committed summary parents match index-row multiplicity |
 
 See **[Hooks](safety/hooks.md)** for what each PreToolUse / PostToolUse /
 SessionStart hook actually enforces.

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -78,7 +78,7 @@ sessions/
     proc_trace.jsonl    # ProcSnapshot stream
     anomalies.jsonl     # detected anomalies
     raw_stdout.jsonl    # captured headless stdout
-sessions.jsonl          # one summary line per session
+sessions.jsonl          # retained row per committed summary
 ```
 
 Session directory names are **hyphen-separated**, never underscored — see the
@@ -231,11 +231,15 @@ find "$TRACE_ROOT" -name '*.jsonl' -type f -print0 |
 On macOS, substitute `~/Library/Application Support/autoskillit/logs` for the
 Linux default log directory.
 
-## 500-directory retention
+## Retained session projection
 
-`execution/session_log.py` keeps the most recent 500 session directories and
-prunes older ones at every new session start. `sessions.jsonl` is also rewritten
-on each prune to remove entries for deleted session directories.
+`execution/session_log.py` targets the most recent 2,000 committed session
+directories. Active-campaign protection can keep the survivor count above that
+target. Under one exclusive lease, retention ranks only directories containing
+`summary.json`, deletes expired unprotected sessions, and rewrites
+`sessions.jsonl` to exactly the retained committed projection. `summary.json` is
+the final per-session artifact and completion witness; the index `timestamp` is
+still the session start time.
 
 ## Recording and replay
 

--- a/src/autoskillit/cli/doctor/AGENTS.md
+++ b/src/autoskillit/cli/doctor/AGENTS.md
@@ -1,6 +1,6 @@
 # doctor/
 
-Diagnostic health checks for the autoskillit installation (49 checks).
+Diagnostic health checks for the autoskillit installation (51 checks).
 
 ## Architecture Notes
 

--- a/src/autoskillit/cli/doctor/__init__.py
+++ b/src/autoskillit/cli/doctor/__init__.py
@@ -72,6 +72,7 @@ from ._doctor_runtime import (
     _check_codex_ndjson_drift,
     _check_quota_cache_schema,
     _check_script_binary,
+    _check_session_index_projection,
 )
 from ._doctor_skills import (
     _check_project_local_skill_contracts,
@@ -239,6 +240,8 @@ def run_doctor(*, output_json: bool = False) -> None:
     results.append(_check_capture_store_stats())
     # Check 42: Project-local skill contracts (excluded/shadowed stale copies)
     results.extend(_check_project_local_skill_contracts())
+    # Check 43: Retained committed summaries exactly match physical index rows
+    results.append(_check_session_index_projection(log_dir=cfg.linux_tracing.log_dir))
     # Output
     for line in _format_results(results, output_json=output_json):
         print(line)

--- a/src/autoskillit/cli/doctor/_doctor_runtime.py
+++ b/src/autoskillit/cli/doctor/_doctor_runtime.py
@@ -29,8 +29,9 @@ from autoskillit.execution import (
     CODEX_LIMITS_LAST_VERIFIED_VERSION,
     QUOTA_CACHE_SCHEMA_VERSION,
     CodexBackend,
+    resolve_log_dir,
+    session_index_lock_path,
 )
-from autoskillit.execution.session_log import _session_index_lock_path, resolve_log_dir
 
 from ._doctor_types import DoctorResult
 
@@ -483,7 +484,7 @@ def _read_session_index_projection(
 def _check_session_index_projection(*, log_dir: str = "") -> DoctorResult:
     check_name = "session_index_projection"
     log_root = resolve_log_dir(log_dir)
-    lock_path = _session_index_lock_path(log_root)
+    lock_path = session_index_lock_path(log_root)
 
     if lock_path.is_file():
         with ArtifactLease.acquire_existing_shared(lock_path):

--- a/src/autoskillit/cli/doctor/_doctor_runtime.py
+++ b/src/autoskillit/cli/doctor/_doctor_runtime.py
@@ -7,6 +7,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+from collections import Counter
 from datetime import date
 from pathlib import Path
 from typing import NamedTuple
@@ -16,6 +17,7 @@ import regex as re
 from autoskillit.core import (
     CODEX_MODEL_ALIASES,
     CODEX_MODEL_ALIASES_LAST_VERIFIED,
+    ArtifactLease,
     CodingAgentBackend,
     Severity,
     atomic_write,
@@ -28,6 +30,7 @@ from autoskillit.execution import (
     QUOTA_CACHE_SCHEMA_VERSION,
     CodexBackend,
 )
+from autoskillit.execution.session_log import _session_index_lock_path, resolve_log_dir
 
 from ._doctor_types import DoctorResult
 
@@ -445,6 +448,73 @@ def _check_codex_ndjson_drift(
             " — parser vocabulary may be stale",
         )
     return DoctorResult(Severity.OK, check_name, "No NDJSON vocabulary drift detected")
+
+
+def _read_session_index_projection(
+    log_root: Path,
+) -> tuple[Counter[str], Counter[str], int]:
+    summaries = Counter(
+        summary.parent.name for summary in (log_root / "sessions").glob("*/summary.json")
+    )
+    rows: Counter[str] = Counter()
+    malformed = 0
+    try:
+        lines = (log_root / "sessions.jsonl").read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        lines = []
+    except OSError:
+        return summaries, rows, 1
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            malformed += 1
+            continue
+        dir_name = row.get("dir_name") if isinstance(row, dict) else None
+        if isinstance(dir_name, str) and dir_name:
+            rows[dir_name] += 1
+        else:
+            malformed += 1
+    return summaries, rows, malformed
+
+
+def _check_session_index_projection(*, log_dir: str = "") -> DoctorResult:
+    check_name = "session_index_projection"
+    log_root = resolve_log_dir(log_dir)
+    lock_path = _session_index_lock_path(log_root)
+
+    if lock_path.is_file():
+        with ArtifactLease.acquire_existing_shared(lock_path):
+            summaries, rows, malformed = _read_session_index_projection(log_root)
+    else:
+        summaries, rows, malformed = _read_session_index_projection(log_root)
+        if lock_path.is_file():
+            with ArtifactLease.acquire_existing_shared(lock_path):
+                summaries, rows, malformed = _read_session_index_projection(log_root)
+
+    if summaries == rows and malformed == 0:
+        return DoctorResult(
+            Severity.OK,
+            check_name,
+            f"{sum(summaries.values())} committed session(s) exactly match the retained index",
+        )
+
+    missing = summaries - rows
+    duplicate_names = {name for name, count in rows.items() if count > 1}
+    dangling = set(rows) - set(summaries)
+    details = [
+        f"missing={sum(missing.values())}",
+        f"duplicate={len(duplicate_names)}",
+        f"dangling={len(dangling)}",
+        f"malformed={malformed}",
+    ]
+    return DoctorResult(
+        Severity.WARNING,
+        check_name,
+        "Committed summary/index projection mismatch (" + ", ".join(details) + ")",
+    )
 
 
 def _check_codex_model_alias_staleness() -> DoctorResult:

--- a/src/autoskillit/cli/doctor/_doctor_runtime.py
+++ b/src/autoskillit/cli/doctor/_doctor_runtime.py
@@ -463,8 +463,6 @@ def _read_session_index_projection(
         lines = (log_root / "sessions.jsonl").read_text(encoding="utf-8").splitlines()
     except FileNotFoundError:
         lines = []
-    except OSError:
-        return summaries, rows, 1
     for line in lines:
         if not line.strip():
             continue
@@ -486,14 +484,21 @@ def _check_session_index_projection(*, log_dir: str = "") -> DoctorResult:
     log_root = resolve_log_dir(log_dir)
     lock_path = session_index_lock_path(log_root)
 
-    if lock_path.is_file():
-        with ArtifactLease.acquire_existing_shared(lock_path):
-            summaries, rows, malformed = _read_session_index_projection(log_root)
-    else:
-        summaries, rows, malformed = _read_session_index_projection(log_root)
+    try:
         if lock_path.is_file():
             with ArtifactLease.acquire_existing_shared(lock_path):
                 summaries, rows, malformed = _read_session_index_projection(log_root)
+        else:
+            summaries, rows, malformed = _read_session_index_projection(log_root)
+            if lock_path.is_file():
+                with ArtifactLease.acquire_existing_shared(lock_path):
+                    summaries, rows, malformed = _read_session_index_projection(log_root)
+    except OSError as exc:
+        return DoctorResult(
+            Severity.WARNING,
+            check_name,
+            f"Could not inspect retained session index: {exc}",
+        )
 
     if summaries == rows and malformed == 0:
         return DoctorResult(

--- a/src/autoskillit/cli/doctor/_doctor_runtime.py
+++ b/src/autoskillit/cli/doctor/_doctor_runtime.py
@@ -486,13 +486,19 @@ def _check_session_index_projection(*, log_dir: str = "") -> DoctorResult:
 
     try:
         if lock_path.is_file():
-            with ArtifactLease.acquire_existing_shared(lock_path):
+            try:
+                with ArtifactLease.acquire_existing_shared(lock_path):
+                    summaries, rows, malformed = _read_session_index_projection(log_root)
+            except FileNotFoundError:
                 summaries, rows, malformed = _read_session_index_projection(log_root)
         else:
             summaries, rows, malformed = _read_session_index_projection(log_root)
             if lock_path.is_file():
-                with ArtifactLease.acquire_existing_shared(lock_path):
-                    summaries, rows, malformed = _read_session_index_projection(log_root)
+                try:
+                    with ArtifactLease.acquire_existing_shared(lock_path):
+                        summaries, rows, malformed = _read_session_index_projection(log_root)
+                except FileNotFoundError:
+                    pass
     except OSError as exc:
         return DoctorResult(
             Severity.WARNING,

--- a/src/autoskillit/cli/doctor/_doctor_runtime.py
+++ b/src/autoskillit/cli/doctor/_doctor_runtime.py
@@ -468,7 +468,7 @@ def _read_session_index_projection(
             continue
         try:
             row = json.loads(line)
-        except (json.JSONDecodeError, ValueError):
+        except ValueError:
             malformed += 1
             continue
         dir_name = row.get("dir_name") if isinstance(row, dict) else None

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -167,6 +167,7 @@ from autoskillit.execution.session_log import (
     flush_session_log,
     read_telemetry_clear_marker,
     resolve_log_dir,
+    session_index_lock_path,
     write_telemetry_clear_marker,
 )
 from autoskillit.execution.testing import (
@@ -322,6 +323,7 @@ __all__ = [
     "read_telemetry_clear_marker",
     "recover_crashed_sessions",
     "resolve_log_dir",
+    "session_index_lock_path",
     "write_telemetry_clear_marker",
     # pr_analysis
     "DOMAIN_PATHS",

--- a/src/autoskillit/execution/_session_log_recovery.py
+++ b/src/autoskillit/execution/_session_log_recovery.py
@@ -9,14 +9,20 @@ from pathlib import Path
 
 import psutil
 
-from autoskillit.core import get_logger
+from autoskillit.core import CampaignProtector, get_logger
 from autoskillit.execution.linux_tracing import read_boot_id, read_enrollment, read_starttime_ticks
 from autoskillit.execution.session_log import flush_session_log
 
 logger = get_logger(__name__)
 
 
-def recover_crashed_sessions(tmpfs_path: str = "/dev/shm", log_dir: str = "") -> int:
+def recover_crashed_sessions(
+    tmpfs_path: str = "/dev/shm",
+    log_dir: str = "",
+    project_dir: str = "",
+    max_sessions: int | None = None,
+    build_protected_campaign_ids: CampaignProtector | None = None,
+) -> int:
     """Scan tmpfs for orphaned trace files from SIGKILL'd sessions and finalize them.
 
     Returns the number of sessions recovered.
@@ -121,6 +127,10 @@ def recover_crashed_sessions(tmpfs_path: str = "/dev/shm", log_dir: str = "") ->
                 provider_outcome=ProviderOutcome.none_used(),
                 recipe_identity=RecipeIdentity.empty(),
                 telemetry=SessionTelemetry.empty(),
+                project_dir=project_dir,
+                max_sessions=max_sessions,
+                build_protected_campaign_ids=build_protected_campaign_ids,
+                is_crash_recovery=True,
             )
         except Exception:
             logger.debug(

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -705,7 +705,15 @@ def flush_session_log(
             if protected_ids:
                 try:
                     meta = json.loads((candidate / "meta.json").read_text(encoding="utf-8"))
-                except (json.JSONDecodeError, OSError):
+                except FileNotFoundError:
+                    meta = {}
+                except (json.JSONDecodeError, OSError) as exc:
+                    logger.warning(
+                        "session_retention_meta_read_failed",
+                        path=candidate,
+                        error=str(exc),
+                        exc_info=True,
+                    )
                     meta = {}
                 if meta.get("campaign_id") in protected_ids:
                     surviving_names.add(candidate.name)

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -707,7 +707,11 @@ def flush_session_log(
                 if meta.get("campaign_id") in protected_ids:
                     surviving_names.add(candidate.name)
                     continue
-            shutil.rmtree(candidate, ignore_errors=True)
+            try:
+                shutil.rmtree(candidate)
+            except OSError:
+                logger.warning("session_retention_delete_failed", path=candidate, exc_info=True)
+                surviving_names.add(candidate.name)
 
         retained_rows = [row for row in index_rows if row.get("dir_name") in surviving_names]
         atomic_write(

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -699,6 +699,9 @@ def flush_session_log(
             else frozenset()
         )
         for candidate in expired:
+            if reuse_committed_recovery and candidate.name == dir_name:
+                surviving_names.add(candidate.name)
+                continue
             if protected_ids:
                 try:
                     meta = json.loads((candidate / "meta.json").read_text(encoding="utf-8"))

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -2,21 +2,22 @@
 
 Writes structured JSON logs to a global, XDG-aware directory. Each headless
 session gets its own directory keyed by session ID, containing process trace
-data, a session summary, and flagged anomalies. An append-only index file
-provides quick scanning across all sessions.
+data, a session summary, and flagged anomalies. A bounded derived index provides
+quick scanning across retained committed sessions.
 """
 
 from __future__ import annotations
 
 import json
 import shutil
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from autoskillit.core import (
+        CampaignProtector,
         NativeShellCaptureDiagnostic,
         ProviderOutcome,
         RecipeIdentity,
@@ -26,6 +27,7 @@ if TYPE_CHECKING:
 
 
 from autoskillit.core import (
+    ArtifactLease,
     ModelIdentity,
     atomic_write,
     default_log_dir,
@@ -67,6 +69,27 @@ def resolve_log_dir(log_dir: str) -> Path:
     if log_dir:
         return Path(log_dir).expanduser()
     return default_log_dir()
+
+
+def _session_index_lock_path(log_root: Path) -> Path:
+    """Return the stable lease path for session-index transactions."""
+    return Path(log_root) / ".locks" / "sessions-index.lock"
+
+
+def _read_index_rows(index_path: Path) -> list[dict[str, Any]]:
+    if not index_path.is_file():
+        return []
+    rows: list[dict[str, Any]] = []
+    for line in index_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict):
+            rows.append(row)
+    return rows
 
 
 def write_telemetry_clear_marker(log_root: Path) -> None:
@@ -118,7 +141,7 @@ def flush_session_log(
     campaign_id: str = "",
     dispatch_id: str = "",
     project_dir: str = "",
-    build_protected_campaign_ids: Callable[[Path], frozenset[str]] | None = None,
+    build_protected_campaign_ids: CampaignProtector | None = None,
     session_id: str,
     pid: int,
     skill_command: str,
@@ -169,11 +192,12 @@ def flush_session_log(
     outcome_invariant_violated: bool = False,
     outcome_qualifier: str | None = None,
     native_shell_capture: NativeShellCaptureDiagnostic | None = None,
+    is_crash_recovery: bool = False,
 ) -> None:
     """Flush session diagnostics to disk.
 
     Writes proc_trace.jsonl, summary.json, anomalies.jsonl (if any),
-    and appends to the global sessions.jsonl index. Applies retention
+    and transactionally projects the session into sessions.jsonl. Applies retention
     to keep at most ``_MAX_SESSIONS`` session directories (default 2000,
     configurable via ``linux_tracing.max_sessions``).
 
@@ -245,33 +269,44 @@ def flush_session_log(
         except OSError:
             logger.debug("channel_b_log_read_error", path=cc_log_str, exc_info=True)
 
-    session_dir = log_root / "sessions" / dir_name
-    session_dir.mkdir(parents=True, exist_ok=True)
+    with ArtifactLease.acquire_exclusive(_session_index_lock_path(log_root), blocking=True):
+        sessions_dir = log_root / "sessions"
+        session_dir = sessions_dir / dir_name
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        for abandoned in sessions_dir.iterdir():
+            if abandoned.is_dir() and not (abandoned / "summary.json").is_file():
+                shutil.rmtree(abandoned, ignore_errors=True)
+        summary_path = session_dir / "summary.json"
+        reuse_committed_recovery = is_crash_recovery and summary_path.is_file()
+        if not reuse_committed_recovery:
+            session_dir.mkdir(parents=True, exist_ok=True)
+        publish_artifacts = not reuse_committed_recovery
 
-    snapshot_count = 0
-    peak_rss_kb = 0
-    peak_oom_score = 0
-    peak_fd_ratio = 0.0
-    anomalies: list[dict[str, object]] = []
-    _effective_tracked_comm: str | None = tracked_comm
-    _tracked_comm_drift: bool = False
+        snapshot_count = 0
+        peak_rss_kb = 0
+        peak_oom_score = 0
+        peak_fd_ratio = 0.0
+        anomalies: list[dict[str, object]] = []
+        _effective_tracked_comm: str | None = tracked_comm
+        _tracked_comm_drift: bool = False
 
-    # Write proc_trace.jsonl
-    if proc_snapshots:
-        snapshot_count = len(proc_snapshots)
-        trace_path = session_dir / "proc_trace.jsonl"
-        with trace_path.open("w") as f:
-            for seq, snap in enumerate(proc_snapshots):
-                record = {
-                    "ts": snap.get("captured_at") or start_ts,
-                    "seq": seq,
-                    "pid": pid,
-                    **snap,
-                    "event": snap.get("event", "snapshot"),
-                }
-                f.write(_fast_dumps(record, sort_keys=True) + "\n")
+        # Write proc_trace.jsonl
+        if proc_snapshots:
+            snapshot_count = len(proc_snapshots)
+            if publish_artifacts:
+                trace_path = session_dir / "proc_trace.jsonl"
+                with trace_path.open("w") as f:
+                    for seq, snap in enumerate(proc_snapshots):
+                        record = {
+                            "ts": snap.get("captured_at") or start_ts,
+                            "seq": seq,
+                            "pid": pid,
+                            **snap,
+                            "event": snap.get("event", "snapshot"),
+                        }
+                        f.write(_fast_dumps(record, sort_keys=True) + "\n")
 
-                # Track peaks
+            for snap in proc_snapshots:
                 rss = snap.get("vm_rss_kb", 0)
                 if isinstance(rss, int) and rss > peak_rss_kb:
                     peak_rss_kb = rss
@@ -281,359 +316,406 @@ def flush_session_log(
                 fd_count = snap.get("fd_count", 0)
                 fd_limit = snap.get("fd_soft_limit", 0)
                 if isinstance(fd_count, int) and isinstance(fd_limit, int) and fd_limit > 0:
-                    ratio = fd_count / fd_limit
-                    if ratio > peak_fd_ratio:
-                        peak_fd_ratio = ratio
+                    peak_fd_ratio = max(peak_fd_ratio, fd_count / fd_limit)
 
-        # Compute effective tracked_comm from snapshots if not provided by caller
-        if _effective_tracked_comm is None:
-            # Use modal comm value across all snapshots
-            comm_counts: dict[str, int] = {}
-            for snap in proc_snapshots:
-                c = snap.get("comm", "")
-                if c and isinstance(c, str):
-                    comm_counts[c] = comm_counts.get(c, 0) + 1
-            if comm_counts:
-                _effective_tracked_comm = max(comm_counts, key=lambda k: comm_counts[k])
+            if _effective_tracked_comm is None:
+                comm_counts: dict[str, int] = {}
+                for snap in proc_snapshots:
+                    comm = snap.get("comm", "")
+                    if comm and isinstance(comm, str):
+                        comm_counts[comm] = comm_counts.get(comm, 0) + 1
+                if comm_counts:
+                    _effective_tracked_comm = max(comm_counts, key=lambda key: comm_counts[key])
 
-        # Detect identity drift: if snapshots have mixed comm values, flag it
-        if _effective_tracked_comm:
-            comms_seen = {snap.get("comm", "") for snap in proc_snapshots if snap.get("comm", "")}
-            if len(comms_seen) > 1:
-                _tracked_comm_drift = True
+            if _effective_tracked_comm:
+                comms_seen = {
+                    snap.get("comm", "") for snap in proc_snapshots if snap.get("comm", "")
+                }
+                if len(comms_seen) > 1:
+                    _tracked_comm_drift = True
 
-        # Anomaly detection (standard)
-        anomalies = detect_anomalies(proc_snapshots, pid)
-        # Identity drift anomaly (post-fix immunity check)
-        if _effective_tracked_comm:
-            drift_anomalies = detect_identity_drift(
-                proc_snapshots, _effective_tracked_comm, comm_aliases=comm_aliases
+            anomalies = detect_anomalies(proc_snapshots, pid)
+            if _effective_tracked_comm:
+                anomalies.extend(
+                    detect_identity_drift(
+                        proc_snapshots, _effective_tracked_comm, comm_aliases=comm_aliases
+                    )
+                )
+
+        # Outcome anomaly detection (correlates session result with token usage)
+        if token_usage:
+            outcome_anomalies = detect_outcome_anomalies(
+                token_usage, subtype, has_thinking_only_turn=has_thinking_only_turn
             )
-            anomalies.extend(drift_anomalies)
+            anomalies.extend(outcome_anomalies)
 
-    # Outcome anomaly detection (correlates session result with token usage)
-    if token_usage:
-        outcome_anomalies = detect_outcome_anomalies(
-            token_usage, subtype, has_thinking_only_turn=has_thinking_only_turn
-        )
-        anomalies.extend(outcome_anomalies)
+        # API retry exhaustion anomaly — fires regardless of token_usage presence
+        if api_retry_exhausted:
+            from autoskillit.execution.anomaly_detection import (
+                OUTCOME_ANOMALY_PID_SENTINEL,
+                OUTCOME_ANOMALY_SEQ_SENTINEL,
+                AnomalyKind,
+                AnomalySeverity,
+            )
 
-    # API retry exhaustion anomaly — fires regardless of token_usage presence
-    if api_retry_exhausted:
-        from autoskillit.execution.anomaly_detection import (
-            OUTCOME_ANOMALY_PID_SENTINEL,
-            OUTCOME_ANOMALY_SEQ_SENTINEL,
-            AnomalyKind,
-            AnomalySeverity,
-        )
+            anomalies.append(
+                {
+                    "ts": datetime.now(UTC).isoformat(),
+                    "seq": OUTCOME_ANOMALY_SEQ_SENTINEL,
+                    "event": "anomaly",
+                    "kind": str(AnomalyKind.API_RETRY_EXHAUSTION),
+                    "severity": str(AnomalySeverity.WARNING),
+                    "pid": OUTCOME_ANOMALY_PID_SENTINEL,
+                    "detail": {"subtype": subtype, "api_retry_count": api_retry_count},
+                    "snapshot": {},
+                }
+            )
 
-        anomalies.append(
-            {
-                "ts": datetime.now(UTC).isoformat(),
-                "seq": OUTCOME_ANOMALY_SEQ_SENTINEL,
-                "event": "anomaly",
-                "kind": str(AnomalyKind.API_RETRY_EXHAUSTION),
-                "severity": str(AnomalySeverity.WARNING),
-                "pid": OUTCOME_ANOMALY_PID_SENTINEL,
-                "detail": {"subtype": subtype, "api_retry_count": api_retry_count},
-                "snapshot": {},
-            }
-        )
+        if ndjson_unknown_event_count > 0 or ndjson_unknown_item_count > 0:
+            from autoskillit.execution.anomaly_detection import (
+                OUTCOME_ANOMALY_PID_SENTINEL,
+                OUTCOME_ANOMALY_SEQ_SENTINEL,
+                AnomalyKind,
+                AnomalySeverity,
+            )
 
-    if ndjson_unknown_event_count > 0 or ndjson_unknown_item_count > 0:
-        from autoskillit.execution.anomaly_detection import (
-            OUTCOME_ANOMALY_PID_SENTINEL,
-            OUTCOME_ANOMALY_SEQ_SENTINEL,
-            AnomalyKind,
-            AnomalySeverity,
-        )
+            anomalies.append(
+                {
+                    "ts": datetime.now(UTC).isoformat(),
+                    "seq": OUTCOME_ANOMALY_SEQ_SENTINEL,
+                    "event": "anomaly",
+                    "kind": str(AnomalyKind.NDJSON_DRIFT),
+                    "severity": str(AnomalySeverity.WARNING),
+                    "pid": OUTCOME_ANOMALY_PID_SENTINEL,
+                    "detail": {
+                        "ndjson_unknown_event_count": ndjson_unknown_event_count,
+                        "ndjson_unknown_item_count": ndjson_unknown_item_count,
+                    },
+                    "snapshot": {},
+                }
+            )
 
-        anomalies.append(
-            {
-                "ts": datetime.now(UTC).isoformat(),
-                "seq": OUTCOME_ANOMALY_SEQ_SENTINEL,
-                "event": "anomaly",
-                "kind": str(AnomalyKind.NDJSON_DRIFT),
-                "severity": str(AnomalySeverity.WARNING),
-                "pid": OUTCOME_ANOMALY_PID_SENTINEL,
-                "detail": {
-                    "ndjson_unknown_event_count": ndjson_unknown_event_count,
-                    "ndjson_unknown_item_count": ndjson_unknown_item_count,
-                },
-                "snapshot": {},
-            }
+        effective_model_id = model_identity.effective_model or _primary_model_identifier(
+            token_usage
         )
-
-    effective_model_id = model_identity.effective_model or _primary_model_identifier(token_usage)
-    _observed = _primary_model_identifier(token_usage) if token_usage else ""
-    anomalies.extend(
-        detect_model_drift(
-            model_identity.configured_model, _observed, profile_name=model_identity.profile_name
-        )
-    )
-    if model_identity.profile_name and model_identity.profile_name != "anthropic":
-        if effective_model_id.startswith("claude-") or effective_model_id in (
-            "sonnet",
-            "opus",
-            "haiku",
-        ):
-            logger.warning(
-                "model_identity_mismatch",
-                effective_model_id=effective_model_id,
+        _observed = _primary_model_identifier(token_usage) if token_usage else ""
+        anomalies.extend(
+            detect_model_drift(
+                model_identity.configured_model,
+                _observed,
                 profile_name=model_identity.profile_name,
-                configured_model=model_identity.configured_model,
+            )
+        )
+        if model_identity.profile_name and model_identity.profile_name != "anthropic":
+            if effective_model_id.startswith("claude-") or effective_model_id in (
+                "sonnet",
+                "opus",
+                "haiku",
+            ):
+                logger.warning(
+                    "model_identity_mismatch",
+                    effective_model_id=effective_model_id,
+                    profile_name=model_identity.profile_name,
+                    configured_model=model_identity.configured_model,
+                )
+
+        # Write anomalies.jsonl (only if anomalies exist)
+        if anomalies and publish_artifacts:
+            anomalies_path = session_dir / "anomalies.jsonl"
+            with anomalies_path.open("w") as f:
+                for a in anomalies:
+                    f.write(_fast_dumps(a, sort_keys=True) + "\n")
+
+        anomaly_count = len(anomalies)
+
+        duration_seconds: float | None = None
+        if elapsed_seconds is not None:
+            duration_seconds = elapsed_seconds
+        elif end_ts:
+            try:
+                duration_seconds = max(
+                    0.0,
+                    (
+                        datetime.fromisoformat(end_ts) - datetime.fromisoformat(start_ts)
+                    ).total_seconds(),
+                )
+            except ValueError:
+                pass
+
+        # Write github_api_usage.json from pre-computed telemetry bundle
+        github_api_requests = telemetry.github_api_requests
+        execution_identity = telemetry.execution_identity
+        if telemetry.github_api_usage is not None and publish_artifacts:
+            atomic_write(
+                session_dir / "github_api_usage.json",
+                _fast_dumps(telemetry.github_api_usage, sort_keys=True, indent=True) + "\n",
             )
 
-    # Write anomalies.jsonl (only if anomalies exist)
-    if anomalies:
-        anomalies_path = session_dir / "anomalies.jsonl"
-        with anomalies_path.open("w") as f:
-            for a in anomalies:
-                f.write(_fast_dumps(a, sort_keys=True) + "\n")
-
-    anomaly_count = len(anomalies)
-
-    duration_seconds: float | None = None
-    if elapsed_seconds is not None:
-        duration_seconds = elapsed_seconds
-    elif end_ts:
-        try:
-            duration_seconds = max(
-                0.0,
-                (
-                    datetime.fromisoformat(end_ts) - datetime.fromisoformat(start_ts)
-                ).total_seconds(),
-            )
-        except ValueError:
-            pass
-
-    # Write github_api_usage.json from pre-computed telemetry bundle
-    github_api_requests = telemetry.github_api_requests
-    execution_identity = telemetry.execution_identity
-    if telemetry.github_api_usage is not None:
-        atomic_write(
-            session_dir / "github_api_usage.json",
-            _fast_dumps(telemetry.github_api_usage, sort_keys=True, indent=True) + "\n",
+        native_shell_capture_projection = (
+            native_shell_capture.to_dict(stage="exit")
+            if native_shell_capture is not None
+            else None
         )
 
-    native_shell_capture_projection = (
-        native_shell_capture.to_dict(stage="exit") if native_shell_capture is not None else None
-    )
-
-    # Write summary.json
-    summary = {
-        "session_id": session_id,
-        "dir_name": dir_name,
-        "pid": pid,
-        "cwd": cwd,
-        "claude_code_log": cc_log_str,
-        "codex_log": _codex_log_str,
-        "skill_command": skill_command,
-        "success": success,
-        "subtype": subtype,
-        "cli_subtype": cli_subtype,
-        "exit_code": exit_code,
-        "start_ts": start_ts,
-        "end_ts": end_ts,
-        "duration_seconds": duration_seconds,
-        "silent_gap_seconds": silent_gap_seconds,
-        "snapshot_interval_seconds": snapshot_interval_seconds,
-        "snapshot_count": snapshot_count,
-        "anomaly_count": anomaly_count,
-        "peak_rss_kb": peak_rss_kb,
-        "peak_oom_score": peak_oom_score,
-        "peak_fd_ratio": round(peak_fd_ratio, 3),
-        "termination_reason": termination_reason,
-        "kill_reason": kill_reason,
-        "provider_used": provider_outcome.provider_used,
-        "provider_fallback": provider_outcome.fallback_activated,
-        "write_path_warnings": effective_write_path_warnings,
-        "write_call_count": write_call_count,
-        "fs_writes_detected": fs_writes_detected,
-        "git_writes_detected": git_writes_detected,
-        "file_changes_count": file_changes_count,
-        "clone_contamination_reverted": clone_contamination_reverted,
-        # Tracer target resolution fields (issue #806)
-        "tracked_comm": _effective_tracked_comm,
-        "tracked_comm_drift": _tracked_comm_drift,
-        "tracer_target_resolution_version": 2,
-        "backend": backend,
-        "backend_authority": dict(backend_authority) if backend_authority is not None else None,
-        "launch_contract_digest": launch_contract_digest,
-        "execution_identity": execution_identity.to_dict(),
-        "orphaned_tool_result": orphaned_tool_result,
-        "last_stop_reason": last_stop_reason,
-        "request_ids": _cb_request_ids,
-        "turn_timestamps": _cb_turn_timestamps,
-        "turn_tool_calls": _cb_turn_tool_calls,
-        "campaign_id": campaign_id,
-        "dispatch_id": dispatch_id,
-        "github_api_requests": github_api_requests,
-        "caller_session_id": caller_session_id,
-        "api_retry_count": api_retry_count,
-        "api_retry_last_error": api_retry_last_error,
-        "api_retry_last_status": api_retry_last_status,
-        "api_retry_exhausted": api_retry_exhausted,
-        "ndjson_unknown_event_count": ndjson_unknown_event_count,
-        "ndjson_unknown_item_count": ndjson_unknown_item_count,
-        "native_shell_capture": native_shell_capture_projection,
-    }
-    if versions is not None:
-        summary["versions"] = {
-            **versions,
-            "model_identifier": effective_model_id,
-        }
-    if recipe_identity.name or recipe_identity.content_hash:
-        summary["recipe_provenance"] = {
-            "schema_version": 1,
-            "name": recipe_identity.name,
-            "version": recipe_identity.version,
-            "content_hash": recipe_identity.content_hash,
-            "composite_hash": recipe_identity.composite_hash,
-        }
-    summary_path = session_dir / "summary.json"
-    atomic_write(summary_path, _fast_dumps(summary, sort_keys=True, indent=True) + "\n")
-
-    if campaign_id:
-        meta_path = session_dir / "meta.json"
-        atomic_write(
-            meta_path,
-            _fast_dumps({"campaign_id": campaign_id, "dispatch_id": dispatch_id}, sort_keys=True),
-        )
-
-    if not success and raw_stdout:
-        atomic_write(session_dir / "raw_stdout.jsonl", raw_stdout)
-
-    if exception_text:
-        atomic_write(session_dir / "crash_exception.txt", exception_text)
-
-    # Write per-session telemetry files; gate on data presence, not session identity
-    label = _resolve_session_label(step_name, dispatch_id)
-    if token_usage is not None:
-        _cw_raw = token_usage.get("cache_write_tokens")
-        _cache_write = (
-            _cw_raw
-            if _cw_raw is not None
-            else (token_usage.get("cache_creation_input_tokens") or 0)
-        )
-        _cr_raw = token_usage.get("cache_read_tokens")
-        _cache_read = (
-            _cr_raw if _cr_raw is not None else (token_usage.get("cache_read_input_tokens") or 0)
-        )
-        tu_data = {
-            "session_label": label,
-            "input_tokens": token_usage.get("input_tokens") or 0,
-            "output_tokens": token_usage.get("output_tokens") or 0,
-            "cache_write_tokens": _cache_write,
-            "cache_read_tokens": _cache_read,
-            "timing_seconds": timing_seconds if timing_seconds is not None else 0.0,
-            "order_id": order_id,
-            "loc_insertions": loc_insertions,
-            "loc_deletions": loc_deletions,
-            "peak_context": token_usage.get("peak_context", 0),
-            "turn_count": token_usage.get("turn_count", 0),
+        # Write summary.json
+        summary = {
+            "session_id": session_id,
+            "dir_name": dir_name,
+            "pid": pid,
+            "cwd": cwd,
+            "claude_code_log": cc_log_str,
+            "codex_log": _codex_log_str,
+            "skill_command": skill_command,
+            "success": success,
+            "subtype": subtype,
+            "cli_subtype": cli_subtype,
+            "exit_code": exit_code,
+            "start_ts": start_ts,
+            "end_ts": end_ts,
+            "duration_seconds": duration_seconds,
+            "silent_gap_seconds": silent_gap_seconds,
+            "snapshot_interval_seconds": snapshot_interval_seconds,
+            "snapshot_count": snapshot_count,
+            "anomaly_count": anomaly_count,
+            "peak_rss_kb": peak_rss_kb,
+            "peak_oom_score": peak_oom_score,
+            "peak_fd_ratio": round(peak_fd_ratio, 3),
+            "termination_reason": termination_reason,
+            "kill_reason": kill_reason,
             "provider_used": provider_outcome.provider_used,
+            "provider_fallback": provider_outcome.fallback_activated,
+            "write_path_warnings": effective_write_path_warnings,
+            "write_call_count": write_call_count,
+            "fs_writes_detected": fs_writes_detected,
+            "git_writes_detected": git_writes_detected,
+            "file_changes_count": file_changes_count,
+            "clone_contamination_reverted": clone_contamination_reverted,
+            # Tracer target resolution fields (issue #806)
+            "tracked_comm": _effective_tracked_comm,
+            "tracked_comm_drift": _tracked_comm_drift,
+            "tracer_target_resolution_version": 2,
+            "backend": backend,
+            "backend_authority": dict(backend_authority)
+            if backend_authority is not None
+            else None,
+            "launch_contract_digest": launch_contract_digest,
+            "execution_identity": execution_identity.to_dict(),
+            "orphaned_tool_result": orphaned_tool_result,
+            "last_stop_reason": last_stop_reason,
+            "request_ids": _cb_request_ids,
+            "turn_timestamps": _cb_turn_timestamps,
+            "turn_tool_calls": _cb_turn_tool_calls,
+            "campaign_id": campaign_id,
+            "dispatch_id": dispatch_id,
+            "github_api_requests": github_api_requests,
+            "caller_session_id": caller_session_id,
+            "api_retry_count": api_retry_count,
+            "api_retry_last_error": api_retry_last_error,
+            "api_retry_last_status": api_retry_last_status,
+            "api_retry_exhausted": api_retry_exhausted,
+            "ndjson_unknown_event_count": ndjson_unknown_event_count,
+            "ndjson_unknown_item_count": ndjson_unknown_item_count,
+            "native_shell_capture": native_shell_capture_projection,
+        }
+        if versions is not None:
+            summary["versions"] = {
+                **versions,
+                "model_identifier": effective_model_id,
+            }
+        if recipe_identity.name or recipe_identity.content_hash:
+            summary["recipe_provenance"] = {
+                "schema_version": 1,
+                "name": recipe_identity.name,
+                "version": recipe_identity.version,
+                "content_hash": recipe_identity.content_hash,
+                "composite_hash": recipe_identity.composite_hash,
+            }
+        if campaign_id and publish_artifacts:
+            meta_path = session_dir / "meta.json"
+            atomic_write(
+                meta_path,
+                _fast_dumps(
+                    {"campaign_id": campaign_id, "dispatch_id": dispatch_id}, sort_keys=True
+                ),
+            )
+
+        if not success and raw_stdout and publish_artifacts:
+            atomic_write(session_dir / "raw_stdout.jsonl", raw_stdout)
+
+        if exception_text and publish_artifacts:
+            atomic_write(session_dir / "crash_exception.txt", exception_text)
+
+        # Write per-session telemetry files; gate on data presence, not session identity
+        label = _resolve_session_label(step_name, dispatch_id)
+        if token_usage is not None and publish_artifacts:
+            _cw_raw = token_usage.get("cache_write_tokens")
+            _cache_write = (
+                _cw_raw
+                if _cw_raw is not None
+                else (token_usage.get("cache_creation_input_tokens") or 0)
+            )
+            _cr_raw = token_usage.get("cache_read_tokens")
+            _cache_read = (
+                _cr_raw
+                if _cr_raw is not None
+                else (token_usage.get("cache_read_input_tokens") or 0)
+            )
+            tu_data = {
+                "session_label": label,
+                "input_tokens": token_usage.get("input_tokens") or 0,
+                "output_tokens": token_usage.get("output_tokens") or 0,
+                "cache_write_tokens": _cache_write,
+                "cache_read_tokens": _cache_read,
+                "timing_seconds": timing_seconds if timing_seconds is not None else 0.0,
+                "order_id": order_id,
+                "loc_insertions": loc_insertions,
+                "loc_deletions": loc_deletions,
+                "peak_context": token_usage.get("peak_context", 0),
+                "turn_count": token_usage.get("turn_count", 0),
+                "provider_used": provider_outcome.provider_used,
+                "model_identifier": effective_model_id,
+                "configured_model": model_identity.configured_model,
+                "profile_name": model_identity.profile_name,
+                "dispatch_id": dispatch_id,
+                "campaign_id": campaign_id,
+            }
+            write_versioned_json(session_dir / "token_usage.json", tu_data, schema_version=2)
+
+        if timing_seconds is not None and publish_artifacts:
+            atomic_write(
+                session_dir / "step_timing.json",
+                _fast_dumps(
+                    {
+                        "step_name": label,
+                        "total_seconds": max(0.0, timing_seconds),
+                        "order_id": order_id,
+                    }
+                ),
+            )
+
+        if step_name and audit_record is not None and publish_artifacts:
+            atomic_write(session_dir / "audit_log.json", _fast_dumps([audit_record]))
+
+        if publish_artifacts:
+            atomic_write(summary_path, _fast_dumps(summary, sort_keys=True, indent=True) + "\n")
+
+        # Project the committed session into the retained index.
+        index_entry = {
+            "session_id": session_id,
+            "dir_name": dir_name,
+            "timestamp": start_ts,
+            "cwd": cwd,
+            "kitchen_id": kitchen_id,
+            "order_id": order_id,
+            "campaign_id": campaign_id,
+            "dispatch_id": dispatch_id,
+            "claude_code_log": cc_log_str,
+            "codex_log": _codex_log_str,
+            "skill_command": skill_command,
+            "success": success,
+            "subtype": subtype,
+            "cli_subtype": cli_subtype,
+            "exit_code": exit_code,
+            "snapshot_count": snapshot_count,
+            "anomaly_count": anomaly_count,
+            "peak_rss_kb": peak_rss_kb,
+            "peak_oom_score": peak_oom_score,
+            "step_name": step_name,
+            "input_tokens": (token_usage.get("input_tokens") or 0) if token_usage else 0,
+            "output_tokens": (token_usage.get("output_tokens") or 0) if token_usage else 0,
+            "cache_write_tokens": (token_usage.get("cache_write_tokens") or 0)
+            if token_usage
+            else 0,
+            "cache_read_tokens": (token_usage.get("cache_read_tokens") or 0) if token_usage else 0,
+            "write_call_count": write_call_count,
+            "fs_writes_detected": fs_writes_detected,
+            "git_writes_detected": git_writes_detected,
+            "file_changes_count": file_changes_count,
+            "tracked_comm": _effective_tracked_comm,
+            "tracked_comm_drift": _tracked_comm_drift,
+            "backend": backend,
+            "backend_authority": dict(backend_authority)
+            if backend_authority is not None
+            else None,
+            "launch_contract_digest": launch_contract_digest,
+            "requested_parent_backend": execution_identity.requested_parent_backend,
+            "effective_parent_backend": execution_identity.effective_parent_backend,
+            "requested_parent_model": execution_identity.requested_parent_model,
+            "effective_parent_model": execution_identity.effective_parent_model,
+            "requested_parent_effort": execution_identity.requested_parent_effort,
+            "effective_parent_effort": execution_identity.effective_parent_effort,
+            "execution_cli_version": execution_identity.cli_version,
+            "backend_override_tier": execution_identity.override_tier,
+            "backend_override_key_path": execution_identity.override_key_path,
+            "parent_session_id": execution_identity.parent_session_id,
+            "child_executions": [child.to_dict() for child in execution_identity.children],
+            "autoskillit_version": versions.get("autoskillit_version", "") if versions else "",
+            "claude_code_version": versions.get("claude_code_version", "") if versions else "",
+            "codex_version": versions.get("codex_version", "") if versions else "",
+            "recipe_name": recipe_identity.name,
+            "recipe_content_hash": recipe_identity.content_hash,
+            "recipe_composite_hash": recipe_identity.composite_hash,
+            "recipe_version": recipe_identity.version,
+            "duration_seconds": duration_seconds,
+            "github_api_requests": github_api_requests,
+            "provider_used": provider_outcome.provider_used,
+            "provider_fallback": provider_outcome.fallback_activated,
+            "caller_session_id": caller_session_id,
+            "api_retry_count": api_retry_count,
+            "api_retry_exhausted": api_retry_exhausted,
+            "api_retry_last_error": api_retry_last_error,
+            "api_retry_last_status": api_retry_last_status,
+            "ndjson_unknown_event_count": ndjson_unknown_event_count,
+            "ndjson_unknown_item_count": ndjson_unknown_item_count,
+            "outcome_fields": outcome_fields,
+            "outcome_invariant_violated": outcome_invariant_violated,
+            "outcome_qualifier": outcome_qualifier,
+            "native_shell_capture": native_shell_capture_projection,
             "model_identifier": effective_model_id,
             "configured_model": model_identity.configured_model,
             "profile_name": model_identity.profile_name,
-            "dispatch_id": dispatch_id,
-            "campaign_id": campaign_id,
+            "schema_version": 7,
         }
-        write_versioned_json(session_dir / "token_usage.json", tu_data, schema_version=2)
+        index_path = log_root / "sessions.jsonl"
+        index_rows = [
+            row for row in _read_index_rows(index_path) if row.get("dir_name") != dir_name
+        ]
+        index_rows.append(index_entry)
 
-    if timing_seconds is not None:
-        atomic_write(
-            session_dir / "step_timing.json",
-            _fast_dumps(
-                {
-                    "step_name": label,
-                    "total_seconds": max(0.0, timing_seconds),
-                    "order_id": order_id,
-                }
+        committed_dirs = sorted(
+            (
+                candidate
+                for candidate in sessions_dir.iterdir()
+                if candidate.is_dir() and (candidate / "summary.json").is_file()
             ),
+            key=lambda candidate: candidate.stat().st_mtime,
+        )
+        effective_max_sessions = max_sessions if max_sessions is not None else _MAX_SESSIONS
+        expired = committed_dirs[: max(0, len(committed_dirs) - effective_max_sessions)]
+        surviving_names = {candidate.name for candidate in committed_dirs[len(expired) :]}
+        protected_ids = (
+            build_protected_campaign_ids(Path(project_dir))
+            if project_dir and build_protected_campaign_ids is not None
+            else frozenset()
+        )
+        for candidate in expired:
+            if protected_ids:
+                try:
+                    meta = json.loads((candidate / "meta.json").read_text(encoding="utf-8"))
+                except (json.JSONDecodeError, OSError):
+                    meta = {}
+                if meta.get("campaign_id") in protected_ids:
+                    surviving_names.add(candidate.name)
+                    continue
+            shutil.rmtree(candidate, ignore_errors=True)
+
+        retained_rows = [row for row in index_rows if row.get("dir_name") in surviving_names]
+        atomic_write(
+            index_path,
+            "".join(_fast_dumps(row, sort_keys=True) + "\n" for row in retained_rows),
         )
 
-    if step_name and audit_record is not None:
-        atomic_write(session_dir / "audit_log.json", _fast_dumps([audit_record]))
-
-    # Append to sessions.jsonl index
-    index_entry = {
-        "session_id": session_id,
-        "dir_name": dir_name,
-        "timestamp": start_ts,
-        "cwd": cwd,
-        "kitchen_id": kitchen_id,
-        "order_id": order_id,
-        "campaign_id": campaign_id,
-        "dispatch_id": dispatch_id,
-        "claude_code_log": cc_log_str,
-        "codex_log": _codex_log_str,
-        "skill_command": skill_command,
-        "success": success,
-        "subtype": subtype,
-        "cli_subtype": cli_subtype,
-        "exit_code": exit_code,
-        "snapshot_count": snapshot_count,
-        "anomaly_count": anomaly_count,
-        "peak_rss_kb": peak_rss_kb,
-        "peak_oom_score": peak_oom_score,
-        "step_name": step_name,
-        "input_tokens": (token_usage.get("input_tokens") or 0) if token_usage else 0,
-        "output_tokens": (token_usage.get("output_tokens") or 0) if token_usage else 0,
-        "cache_write_tokens": (token_usage.get("cache_write_tokens") or 0) if token_usage else 0,
-        "cache_read_tokens": (token_usage.get("cache_read_tokens") or 0) if token_usage else 0,
-        "write_call_count": write_call_count,
-        "fs_writes_detected": fs_writes_detected,
-        "git_writes_detected": git_writes_detected,
-        "file_changes_count": file_changes_count,
-        "tracked_comm": _effective_tracked_comm,
-        "tracked_comm_drift": _tracked_comm_drift,
-        "backend": backend,
-        "backend_authority": dict(backend_authority) if backend_authority is not None else None,
-        "launch_contract_digest": launch_contract_digest,
-        "requested_parent_backend": execution_identity.requested_parent_backend,
-        "effective_parent_backend": execution_identity.effective_parent_backend,
-        "requested_parent_model": execution_identity.requested_parent_model,
-        "effective_parent_model": execution_identity.effective_parent_model,
-        "requested_parent_effort": execution_identity.requested_parent_effort,
-        "effective_parent_effort": execution_identity.effective_parent_effort,
-        "execution_cli_version": execution_identity.cli_version,
-        "backend_override_tier": execution_identity.override_tier,
-        "backend_override_key_path": execution_identity.override_key_path,
-        "parent_session_id": execution_identity.parent_session_id,
-        "child_executions": [child.to_dict() for child in execution_identity.children],
-        "autoskillit_version": versions.get("autoskillit_version", "") if versions else "",
-        "claude_code_version": versions.get("claude_code_version", "") if versions else "",
-        "codex_version": versions.get("codex_version", "") if versions else "",
-        "recipe_name": recipe_identity.name,
-        "recipe_content_hash": recipe_identity.content_hash,
-        "recipe_composite_hash": recipe_identity.composite_hash,
-        "recipe_version": recipe_identity.version,
-        "duration_seconds": duration_seconds,
-        "github_api_requests": github_api_requests,
-        "provider_used": provider_outcome.provider_used,
-        "provider_fallback": provider_outcome.fallback_activated,
-        "caller_session_id": caller_session_id,
-        "api_retry_count": api_retry_count,
-        "api_retry_exhausted": api_retry_exhausted,
-        "api_retry_last_error": api_retry_last_error,
-        "api_retry_last_status": api_retry_last_status,
-        "ndjson_unknown_event_count": ndjson_unknown_event_count,
-        "ndjson_unknown_item_count": ndjson_unknown_item_count,
-        "outcome_fields": outcome_fields,
-        "outcome_invariant_violated": outcome_invariant_violated,
-        "outcome_qualifier": outcome_qualifier,
-        "native_shell_capture": native_shell_capture_projection,
-        "model_identifier": effective_model_id,
-        "configured_model": model_identity.configured_model,
-        "profile_name": model_identity.profile_name,
-        "schema_version": 7,
-    }
-    index_path = log_root / "sessions.jsonl"
-    with index_path.open("a") as f:
-        f.write(_fast_dumps(index_entry, sort_keys=True) + "\n")
-
-    # Co-write session provenance record
+    # Co-write session provenance outside the session-index transaction.
     if cwd:
         from autoskillit.core import ProvenanceRecord, write_provenance_record
 
@@ -649,78 +731,3 @@ def flush_session_log(
             ),
             project_dir=Path(project_dir) if project_dir else None,
         )
-
-    # Retention: keep at most _MAX_SESSIONS session directories
-    _enforce_retention(
-        log_root,
-        project_dir=project_dir,
-        build_protected_campaign_ids=build_protected_campaign_ids,
-        max_sessions=max_sessions if max_sessions is not None else _MAX_SESSIONS,
-    )
-
-
-def _enforce_retention(
-    log_root: Path,
-    project_dir: str | None = None,
-    build_protected_campaign_ids: Callable[[Path], frozenset[str]] | None = None,
-    *,
-    max_sessions: int = _MAX_SESSIONS,
-) -> None:
-    """Delete oldest session directories if count exceeds *max_sessions*.
-
-    When ``project_dir`` is provided, reads fleet state files and ``meta.json``
-    sidecars to skip deletion of sessions belonging to active campaigns.
-    """
-    sessions_dir = log_root / "sessions"
-    if not sessions_dir.is_dir():
-        return
-
-    dirs = sorted(sessions_dir.iterdir(), key=lambda p: p.stat().st_mtime)
-    if len(dirs) <= max_sessions:
-        return
-
-    expired = dirs[: len(dirs) - max_sessions]
-    surviving_names = {d.name for d in dirs[len(dirs) - max_sessions :]}
-
-    protected_ids = (
-        build_protected_campaign_ids(Path(project_dir))
-        if project_dir and build_protected_campaign_ids is not None
-        else frozenset()
-    )
-
-    for d in expired:
-        if protected_ids:
-            meta_path = d / "meta.json"
-            if meta_path.is_file():
-                try:
-                    meta = json.loads(meta_path.read_text(encoding="utf-8"))
-                    if meta.get("campaign_id") in protected_ids:
-                        surviving_names.add(d.name)
-                        continue
-                except (json.JSONDecodeError, OSError):
-                    pass
-        shutil.rmtree(d, ignore_errors=True)
-
-    # Rewrite sessions.jsonl to remove expired entries
-    index_path = log_root / "sessions.jsonl"
-    if index_path.is_file():
-        # Accepted read-modify-write race: between read_text() below and atomic_write()
-        # at the end of this block, a concurrent flush_session_log() call may append a
-        # new entry to sessions.jsonl via open("a"). That entry will not be present in
-        # `lines`, so it will be silently lost when atomic_write() overwrites the file.
-        # Worst case: one diagnostic index entry dropped per concurrent session flush that
-        # races this retention sweep. Correctness of the running session is unaffected.
-        # File locking (fcntl.flock) is not warranted: the overhead exceeds the value of
-        # protecting a best-effort diagnostic artifact.
-        lines = index_path.read_text().splitlines()
-        kept: list[str] = []
-        for line in lines:
-            if not line.strip():
-                continue
-            try:
-                entry = json.loads(line)
-                if entry.get("dir_name") in surviving_names:
-                    kept.append(line)
-            except json.JSONDecodeError:
-                continue
-        atomic_write(index_path, "\n".join(kept) + "\n" if kept else "")

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -71,7 +71,7 @@ def resolve_log_dir(log_dir: str) -> Path:
     return default_log_dir()
 
 
-def _session_index_lock_path(log_root: Path) -> Path:
+def session_index_lock_path(log_root: Path) -> Path:
     """Return the stable lease path for session-index transactions."""
     return Path(log_root) / ".locks" / "sessions-index.lock"
 
@@ -269,7 +269,7 @@ def flush_session_log(
         except OSError:
             logger.debug("channel_b_log_read_error", path=cc_log_str, exc_info=True)
 
-    with ArtifactLease.acquire_exclusive(_session_index_lock_path(log_root), blocking=True):
+    with ArtifactLease.acquire_exclusive(session_index_lock_path(log_root), blocking=True):
         sessions_dir = log_root / "sessions"
         session_dir = sessions_dir / dir_name
         sessions_dir.mkdir(parents=True, exist_ok=True)

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -597,7 +597,6 @@ def flush_session_log(
         if publish_artifacts:
             atomic_write(summary_path, _fast_dumps(summary, sort_keys=True, indent=True) + "\n")
 
-        # Project the committed session into the retained index.
         index_entry = {
             "session_id": session_id,
             "dir_name": dir_name,

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -419,7 +419,6 @@ def flush_session_log(
                     configured_model=model_identity.configured_model,
                 )
 
-        # Write anomalies.jsonl (only if anomalies exist)
         if anomalies and publish_artifacts:
             anomalies_path = session_dir / "anomalies.jsonl"
             with anomalies_path.open("w") as f:

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -456,7 +456,6 @@ def flush_session_log(
             else None
         )
 
-        # Write summary.json
         summary = {
             "session_id": session_id,
             "dir_name": dir_name,

--- a/src/autoskillit/server/_state.py
+++ b/src/autoskillit/server/_state.py
@@ -149,6 +149,9 @@ async def deferred_initialize(ctx: ToolContext, *, ready_event: asyncio.Event) -
             n = recover_crashed_sessions(
                 tmpfs_path=cfg.tmpfs_path,
                 log_dir=cfg.log_dir,
+                project_dir=str(ctx.project_dir),
+                max_sessions=cfg.max_sessions,
+                build_protected_campaign_ids=ctx.build_protected_campaign_ids,
             )
             if n > 0:
                 logger.info("Recovered %d crashed session trace(s) from tmpfs", n)

--- a/tests/arch/test_import_paths.py
+++ b/tests/arch/test_import_paths.py
@@ -353,6 +353,7 @@ def test_req_imp_007_server_cli_no_unauthorized_cross_submodule_imports() -> Non
         Path("cli/session/_session_cook.py"),  # REQ-IMP-011
         Path("cli/_workspace.py"),  # REQ-IMP-012
         Path("cli/_hooks_codex.py"),  # Re-export shim for execution/backends/_codex_hooks
+        Path("cli/doctor/_doctor_runtime.py"),  # shared private session-index lease path
     }
     forbidden_pkgs = {"execution", "workspace", "recipe", "migration"}
     violations: list[str] = []

--- a/tests/arch/test_import_paths.py
+++ b/tests/arch/test_import_paths.py
@@ -353,7 +353,6 @@ def test_req_imp_007_server_cli_no_unauthorized_cross_submodule_imports() -> Non
         Path("cli/session/_session_cook.py"),  # REQ-IMP-011
         Path("cli/_workspace.py"),  # REQ-IMP-012
         Path("cli/_hooks_codex.py"),  # Re-export shim for execution/backends/_codex_hooks
-        Path("cli/doctor/_doctor_runtime.py"),  # shared private session-index lease path
     }
     forbidden_pkgs = {"execution", "workspace", "recipe", "migration"}
     violations: list[str] = []

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -997,14 +997,7 @@ def test_migration_no_forbidden_imports() -> None:
 # ── REQ-ARCH-001: No cross-package submodule imports ─────────────────────────
 
 
-_CROSS_PACKAGE_SUBMODULE_EXEMPTIONS: frozenset[tuple[str, str]] = frozenset(
-    {
-        (
-            "cli/doctor/_doctor_runtime.py",
-            "autoskillit.execution.session_log",
-        ),
-    }
-)
+_CROSS_PACKAGE_SUBMODULE_EXEMPTIONS: frozenset[tuple[str, str]] = frozenset()
 
 
 def test_no_cross_package_submodule_imports() -> None:

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -997,7 +997,14 @@ def test_migration_no_forbidden_imports() -> None:
 # ── REQ-ARCH-001: No cross-package submodule imports ─────────────────────────
 
 
-_CROSS_PACKAGE_SUBMODULE_EXEMPTIONS: frozenset[tuple[str, str]] = frozenset()
+_CROSS_PACKAGE_SUBMODULE_EXEMPTIONS: frozenset[tuple[str, str]] = frozenset(
+    {
+        (
+            "cli/doctor/_doctor_runtime.py",
+            "autoskillit.execution.session_log",
+        ),
+    }
+)
 
 
 def test_no_cross_package_submodule_imports() -> None:
@@ -1691,8 +1698,8 @@ _TEST_LAYER_ALLOWLIST: dict[str, frozenset[str]] = {
     "tests/fleet/test_fleet_e2e_codex.py": frozenset(
         {"autoskillit.execution", "autoskillit.workspace"}
     ),
-    # session_log retention tests verify callback injection into
-    # _enforce_retention — needs fleet.state
+    # session_log retention tests verify campaign protection in the writer
+    # transaction — needs fleet.state
     "tests/execution/test_session_log_retention.py": frozenset({"autoskillit.fleet"}),
     # provider forwarding test verifies budget guard preserves provider_used — needs DefaultAuditLog
     "tests/execution/test_headless_provider_forwarding.py": frozenset({"autoskillit.pipeline"}),

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -390,6 +390,7 @@ class TestCLIDoctor:
             "stale_fleet_state",
             "campaign_onboarding_hint",
             "campaign_manifest_clone_dests",
+            "session_index_projection",
         }
         assert expected <= check_names
 

--- a/tests/cli/test_doctor_runtime.py
+++ b/tests/cli/test_doctor_runtime.py
@@ -315,6 +315,7 @@ class TestCheckSessionIndexProjection:
 
         assert completed.is_set()
         assert result[0].severity is Severity.OK
+        assert result[0].message.startswith("1 committed session(s)")
 
     def test_absent_lock_race_retries_under_existing_shared_lease(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/cli/test_doctor_runtime.py
+++ b/tests/cli/test_doctor_runtime.py
@@ -231,13 +231,13 @@ class TestCheckSessionIndexProjection:
         )
 
     @pytest.mark.parametrize(
-        ("summaries", "rows", "severity"),
+        ("summaries", "rows", "severity", "expected_detail"),
         [
-            ((), (), Severity.OK),
-            (("complete",), ("complete",), Severity.OK),
-            (("missing",), (), Severity.WARNING),
-            (("duplicate",), ("duplicate", "duplicate"), Severity.WARNING),
-            ((), ("dangling",), Severity.WARNING),
+            ((), (), Severity.OK, None),
+            (("complete",), ("complete",), Severity.OK, None),
+            (("missing",), (), Severity.WARNING, "missing=1"),
+            (("duplicate",), ("duplicate", "duplicate"), Severity.WARNING, "duplicate=1"),
+            ((), ("dangling",), Severity.WARNING, "dangling=1"),
         ],
     )
     def test_projection_multiplicity(
@@ -246,6 +246,7 @@ class TestCheckSessionIndexProjection:
         summaries: tuple[str, ...],
         rows: tuple[str, ...],
         severity: Severity,
+        expected_detail: str | None,
     ) -> None:
         from autoskillit.cli.doctor._doctor_runtime import _check_session_index_projection
 
@@ -257,6 +258,8 @@ class TestCheckSessionIndexProjection:
         result = _check_session_index_projection(log_dir=str(tmp_path))
 
         assert result.severity is severity
+        if expected_detail is not None:
+            assert expected_detail in result.message
         assert not (tmp_path / ".locks" / "sessions-index.lock").exists()
 
     def test_reports_malformed_index_row(self, tmp_path: Path) -> None:

--- a/tests/cli/test_doctor_runtime.py
+++ b/tests/cli/test_doctor_runtime.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import json
+import threading
 from datetime import date, timedelta
+from pathlib import Path
 
 import pytest
+
+from autoskillit.core import Severity
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
@@ -207,3 +212,106 @@ class TestCheckCodexLimitsVerified:
         result = mod._check_codex_limits_verified(backend=CodexBackend())
         assert result.severity == Severity.OK
         assert "Skipped" in result.message
+
+
+class TestCheckSessionIndexProjection:
+    @staticmethod
+    def _write_summary(log_root: Path, dir_name: str) -> None:
+        session_dir = log_root / "sessions" / dir_name
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / "summary.json").write_text(json.dumps({"dir_name": dir_name}))
+
+    @staticmethod
+    def _write_index(log_root: Path, *dir_names: str) -> None:
+        (log_root / "sessions.jsonl").write_text(
+            "".join(
+                json.dumps({"dir_name": name, "timestamp": "2000-01-01"}) + "\n"
+                for name in dir_names
+            )
+        )
+
+    @pytest.mark.parametrize(
+        ("summaries", "rows", "severity"),
+        [
+            ((), (), Severity.OK),
+            (("complete",), ("complete",), Severity.OK),
+            (("missing",), (), Severity.WARNING),
+            (("duplicate",), ("duplicate", "duplicate"), Severity.WARNING),
+            ((), ("dangling",), Severity.WARNING),
+        ],
+    )
+    def test_projection_multiplicity(
+        self,
+        tmp_path: Path,
+        summaries: tuple[str, ...],
+        rows: tuple[str, ...],
+        severity: Severity,
+    ) -> None:
+        from autoskillit.cli.doctor._doctor_runtime import _check_session_index_projection
+
+        for dir_name in summaries:
+            self._write_summary(tmp_path, dir_name)
+        if rows:
+            self._write_index(tmp_path, *rows)
+
+        result = _check_session_index_projection(log_dir=str(tmp_path))
+
+        assert result.severity is severity
+        assert not (tmp_path / ".locks" / "sessions-index.lock").exists()
+
+    def test_waits_for_existing_writer_lease(self, tmp_path: Path) -> None:
+        from autoskillit.cli.doctor._doctor_runtime import _check_session_index_projection
+        from autoskillit.core import ArtifactLease
+        from autoskillit.execution.session_log import _session_index_lock_path
+
+        self._write_summary(tmp_path, "complete")
+        self._write_index(tmp_path, "complete")
+        lock_path = _session_index_lock_path(tmp_path)
+        writer = ArtifactLease.acquire_exclusive(lock_path, blocking=True)
+        completed = threading.Event()
+        result: list[object] = []
+
+        def check() -> None:
+            result.append(_check_session_index_projection(log_dir=str(tmp_path)))
+            completed.set()
+
+        thread = threading.Thread(target=check)
+        try:
+            thread.start()
+            assert not completed.wait(timeout=0.2)
+        finally:
+            writer.close()
+            thread.join(timeout=5)
+
+        assert completed.is_set()
+        assert result[0].severity is Severity.OK
+
+    def test_absent_lock_race_retries_under_existing_shared_lease(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import autoskillit.cli.doctor._doctor_runtime as doctor_runtime
+        from autoskillit.core import ArtifactLease
+        from autoskillit.execution.session_log import _session_index_lock_path
+
+        self._write_summary(tmp_path, "complete")
+        self._write_index(tmp_path, "complete")
+        original_read = doctor_runtime._read_session_index_projection
+        reads = 0
+
+        def racing_read(log_root: Path):
+            nonlocal reads
+            reads += 1
+            snapshot = original_read(log_root)
+            if reads == 1:
+                with ArtifactLease.acquire_exclusive(
+                    _session_index_lock_path(log_root), blocking=True
+                ):
+                    pass
+            return snapshot
+
+        monkeypatch.setattr(doctor_runtime, "_read_session_index_projection", racing_read)
+
+        result = doctor_runtime._check_session_index_projection(log_dir=str(tmp_path))
+
+        assert result.severity is Severity.OK
+        assert reads == 2

--- a/tests/cli/test_doctor_runtime.py
+++ b/tests/cli/test_doctor_runtime.py
@@ -271,6 +271,23 @@ class TestCheckSessionIndexProjection:
 
         assert result.severity is Severity.WARNING
 
+    def test_reports_index_read_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import autoskillit.cli.doctor._doctor_runtime as doctor_runtime
+
+        (tmp_path / "sessions.jsonl").write_text("{}\n")
+
+        def deny_read(_path: Path, *args: object, **kwargs: object) -> str:
+            raise PermissionError("denied")
+
+        monkeypatch.setattr(Path, "read_text", deny_read)
+
+        result = doctor_runtime._check_session_index_projection(log_dir=str(tmp_path))
+
+        assert result.severity is Severity.WARNING
+        assert result.message == "Could not inspect retained session index: denied"
+
     def test_waits_for_existing_writer_lease(self, tmp_path: Path) -> None:
         from autoskillit.cli.doctor._doctor_runtime import _check_session_index_projection
         from autoskillit.core import ArtifactLease

--- a/tests/cli/test_doctor_runtime.py
+++ b/tests/cli/test_doctor_runtime.py
@@ -345,3 +345,35 @@ class TestCheckSessionIndexProjection:
 
         assert result.severity is Severity.OK
         assert reads == 2
+
+    def test_absent_lock_race_keeps_snapshot_when_lock_disappears(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import autoskillit.cli.doctor._doctor_runtime as doctor_runtime
+        from autoskillit.core import ArtifactLease
+        from autoskillit.execution import session_index_lock_path
+
+        self._write_summary(tmp_path, "complete")
+        self._write_index(tmp_path, "complete")
+        lock_path = session_index_lock_path(tmp_path)
+        original_read = doctor_runtime._read_session_index_projection
+
+        def racing_read(log_root: Path):
+            snapshot = original_read(log_root)
+            with ArtifactLease.acquire_exclusive(lock_path, blocking=True):
+                pass
+            return snapshot
+
+        original_acquire = ArtifactLease.acquire_existing_shared
+
+        def disappearing_acquire(path: Path):
+            path.unlink()
+            return original_acquire(path)
+
+        monkeypatch.setattr(doctor_runtime, "_read_session_index_projection", racing_read)
+        monkeypatch.setattr(ArtifactLease, "acquire_existing_shared", disappearing_acquire)
+
+        result = doctor_runtime._check_session_index_projection(log_dir=str(tmp_path))
+
+        assert result.severity is Severity.OK
+        assert result.message.startswith("1 committed session(s)")

--- a/tests/cli/test_doctor_runtime.py
+++ b/tests/cli/test_doctor_runtime.py
@@ -262,11 +262,11 @@ class TestCheckSessionIndexProjection:
     def test_waits_for_existing_writer_lease(self, tmp_path: Path) -> None:
         from autoskillit.cli.doctor._doctor_runtime import _check_session_index_projection
         from autoskillit.core import ArtifactLease
-        from autoskillit.execution.session_log import _session_index_lock_path
+        from autoskillit.execution import session_index_lock_path
 
         self._write_summary(tmp_path, "complete")
         self._write_index(tmp_path, "complete")
-        lock_path = _session_index_lock_path(tmp_path)
+        lock_path = session_index_lock_path(tmp_path)
         writer = ArtifactLease.acquire_exclusive(lock_path, blocking=True)
         completed = threading.Event()
         result: list[object] = []
@@ -291,7 +291,7 @@ class TestCheckSessionIndexProjection:
     ) -> None:
         import autoskillit.cli.doctor._doctor_runtime as doctor_runtime
         from autoskillit.core import ArtifactLease
-        from autoskillit.execution.session_log import _session_index_lock_path
+        from autoskillit.execution import session_index_lock_path
 
         self._write_summary(tmp_path, "complete")
         self._write_index(tmp_path, "complete")
@@ -304,7 +304,7 @@ class TestCheckSessionIndexProjection:
             snapshot = original_read(log_root)
             if reads == 1:
                 with ArtifactLease.acquire_exclusive(
-                    _session_index_lock_path(log_root), blocking=True
+                    session_index_lock_path(log_root), blocking=True
                 ):
                     pass
             return snapshot

--- a/tests/cli/test_doctor_runtime.py
+++ b/tests/cli/test_doctor_runtime.py
@@ -260,7 +260,6 @@ class TestCheckSessionIndexProjection:
         assert result.severity is severity
         if expected_detail is not None:
             assert expected_detail in result.message
-        assert not (tmp_path / ".locks" / "sessions-index.lock").exists()
 
     def test_reports_malformed_index_row(self, tmp_path: Path) -> None:
         from autoskillit.cli.doctor._doctor_runtime import _check_session_index_projection

--- a/tests/cli/test_doctor_runtime.py
+++ b/tests/cli/test_doctor_runtime.py
@@ -270,6 +270,7 @@ class TestCheckSessionIndexProjection:
         result = _check_session_index_projection(log_dir=str(tmp_path))
 
         assert result.severity is Severity.WARNING
+        assert "malformed=1" in result.message
 
     def test_reports_index_read_failure(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/cli/test_doctor_runtime.py
+++ b/tests/cli/test_doctor_runtime.py
@@ -259,6 +259,15 @@ class TestCheckSessionIndexProjection:
         assert result.severity is severity
         assert not (tmp_path / ".locks" / "sessions-index.lock").exists()
 
+    def test_reports_malformed_index_row(self, tmp_path: Path) -> None:
+        from autoskillit.cli.doctor._doctor_runtime import _check_session_index_projection
+
+        (tmp_path / "sessions.jsonl").write_text("not-json\n")
+
+        result = _check_session_index_projection(log_dir=str(tmp_path))
+
+        assert result.severity is Severity.WARNING
+
     def test_waits_for_existing_writer_lease(self, tmp_path: Path) -> None:
         from autoskillit.cli.doctor._doctor_runtime import _check_session_index_projection
         from autoskillit.core import ArtifactLease

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -242,11 +242,11 @@ def test_quota_thresholds_defaults() -> None:
     assert long_ == pytest.approx(95.0)
 
 
-def test_doctor_check_count_is_50() -> None:
-    # Combined-tree canonical count: 41 numbered checks + 9 lettered sub-checks.
+def test_doctor_check_count_is_51() -> None:
+    # Combined-tree canonical count: 42 numbered checks + 9 lettered sub-checks.
     # Update both tests whenever a new doctor check is added.
     count = _count_doctor_checks()
-    assert count == 50, f"Expected 50 doctor checks; found {count}"
+    assert count == 51, f"Expected 51 doctor checks; found {count}"
 
 
 def test_bundled_recipe_count_is_15() -> None:

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -149,6 +149,29 @@ def test_next_writer_removes_abandoned_session_before_retention(
     assert _index_session_counter(tmp_path) == Counter({"committed-new": 1})
 
 
+def test_retention_delete_failure_preserves_index_projection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import autoskillit.execution.session_log as session_log
+
+    _flush(tmp_path, session_id="committed-old", max_sessions=2)
+    committed_old = tmp_path / "sessions" / "committed-old"
+    os.utime(committed_old, (1, 1))
+    original_rmtree = session_log.shutil.rmtree
+
+    def fail_old_delete(path: Path, *, ignore_errors: bool = False) -> None:
+        if path == committed_old:
+            raise PermissionError("denied")
+        original_rmtree(path, ignore_errors=ignore_errors)
+
+    monkeypatch.setattr(session_log.shutil, "rmtree", fail_old_delete)
+
+    _flush(tmp_path, session_id="committed-new", max_sessions=1)
+
+    assert committed_old.is_dir()
+    assert _index_session_counter(tmp_path) == _committed_session_counter(tmp_path)
+
+
 def test_concurrent_retention_preserves_committed_index_projection(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import json
 import os
+import threading
+from collections import Counter
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -104,6 +106,133 @@ def test_flush_session_log_appends_to_index(tmp_path):
     b = json.loads(lines[1])
     assert a["session_id"] == "session-a"
     assert b["session_id"] == "session-b"
+
+
+def _committed_session_counter(log_root: Path) -> Counter[str]:
+    return Counter(path.parent.name for path in (log_root / "sessions").glob("*/summary.json"))
+
+
+def _index_session_counter(log_root: Path) -> Counter[str]:
+    return Counter(
+        json.loads(line)["dir_name"]
+        for line in (log_root / "sessions.jsonl").read_text().splitlines()
+        if line.strip()
+    )
+
+
+def test_concurrent_retention_preserves_committed_index_projection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rollover transaction cannot overwrite a concurrently committed row."""
+    import autoskillit.execution.session_log as session_log
+
+    _flush(tmp_path, session_id="seed-0", max_sessions=2)
+    _flush(tmp_path, session_id="seed-1", max_sessions=2)
+
+    writer_a_at_index_replace = threading.Event()
+    release_writer_a = threading.Event()
+    original_atomic_write = session_log.atomic_write
+
+    def pausing_atomic_write(path: Path, content: str) -> None:
+        if path == tmp_path / "sessions.jsonl" and threading.current_thread().name == "writer-a":
+            writer_a_at_index_replace.set()
+            assert release_writer_a.wait(timeout=10), "writer A was not released"
+        original_atomic_write(path, content)
+
+    monkeypatch.setattr(session_log, "atomic_write", pausing_atomic_write)
+    errors: list[BaseException] = []
+
+    def flush(session_id: str) -> None:
+        try:
+            _flush(tmp_path, session_id=session_id, max_sessions=2)
+        except BaseException as exc:
+            errors.append(exc)
+
+    writer_a = threading.Thread(target=flush, args=("writer-a",), name="writer-a")
+    writer_b = threading.Thread(target=flush, args=("writer-b",), name="writer-b")
+    try:
+        writer_a.start()
+        assert writer_a_at_index_replace.wait(timeout=5), "writer A never reached index replace"
+        writer_b.start()
+        writer_b.join(timeout=0.2)
+    finally:
+        release_writer_a.set()
+        writer_a.join(timeout=5)
+        writer_b.join(timeout=5)
+
+    assert not writer_a.is_alive()
+    assert not writer_b.is_alive()
+    assert not errors
+    assert _index_session_counter(tmp_path) == _committed_session_counter(tmp_path)
+    assert _index_session_counter(tmp_path) == Counter({"writer-a": 1, "writer-b": 1})
+
+
+def test_retention_cannot_delete_an_in_progress_writer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Retention waits while another writer has not yet published its summary."""
+    import autoskillit.execution.session_log as session_log
+
+    _flush(tmp_path, session_id="seed", max_sessions=2)
+    os.utime(tmp_path / "sessions" / "seed", (2, 2))
+
+    writer_a_before_summary = threading.Event()
+    release_writer_a = threading.Event()
+    original_atomic_write = session_log.atomic_write
+
+    def pausing_atomic_write(path: Path, content: str) -> None:
+        if path == tmp_path / "sessions" / "writer-a" / "summary.json":
+            os.utime(path.parent, (1, 1))
+            writer_a_before_summary.set()
+            assert release_writer_a.wait(timeout=5), "writer A was not released"
+        original_atomic_write(path, content)
+
+    monkeypatch.setattr(session_log, "atomic_write", pausing_atomic_write)
+    errors: list[BaseException] = []
+
+    def flush(session_id: str) -> None:
+        try:
+            _flush(tmp_path, session_id=session_id, max_sessions=2)
+        except BaseException as exc:
+            errors.append(exc)
+
+    writer_a = threading.Thread(target=flush, args=("writer-a",), name="writer-a")
+    writer_b = threading.Thread(target=flush, args=("writer-b",), name="writer-b")
+    try:
+        writer_a.start()
+        assert writer_a_before_summary.wait(timeout=5), "writer A never reached summary publish"
+        writer_b.start()
+        writer_b.join(timeout=1)
+    finally:
+        release_writer_a.set()
+        writer_a.join(timeout=5)
+        writer_b.join(timeout=5)
+
+    assert not writer_a.is_alive()
+    assert not writer_b.is_alive()
+    assert not errors
+    assert (tmp_path / "sessions" / "writer-a" / "summary.json").is_file()
+    assert _index_session_counter(tmp_path) == _committed_session_counter(tmp_path)
+
+
+def test_summary_is_last_per_session_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import autoskillit.execution.session_log as session_log
+
+    writes: list[Path] = []
+    original_atomic_write = session_log.atomic_write
+
+    def recording_atomic_write(path: Path, content: str) -> None:
+        writes.append(path)
+        original_atomic_write(path, content)
+
+    monkeypatch.setattr(session_log, "atomic_write", recording_atomic_write)
+    _flush(tmp_path, session_id="summary-last", campaign_id="campaign", raw_stdout="raw")
+
+    session_dir = tmp_path / "sessions" / "summary-last"
+    session_writes = [path for path in writes if path.parent == session_dir]
+    assert session_writes[-1].name == "summary.json"
 
 
 def test_flush_session_log_fallback_dirname_when_no_session_id(tmp_path):

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -244,8 +244,9 @@ def test_retention_cannot_delete_an_in_progress_writer(
     assert _index_session_counter(tmp_path) == _committed_session_counter(tmp_path)
 
 
+@pytest.mark.parametrize("success", [True, False])
 def test_summary_is_last_per_session_artifact(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, success: bool
 ) -> None:
     import autoskillit.execution.session_log as session_log
 
@@ -257,10 +258,18 @@ def test_summary_is_last_per_session_artifact(
         original_atomic_write(path, content)
 
     monkeypatch.setattr(session_log, "atomic_write", recording_atomic_write)
-    _flush(tmp_path, session_id="summary-last", campaign_id="campaign", raw_stdout="raw")
+    _flush(
+        tmp_path,
+        session_id="summary-last",
+        campaign_id="campaign",
+        raw_stdout="raw",
+        success=success,
+    )
 
     session_dir = tmp_path / "sessions" / "summary-last"
     session_writes = [path for path in writes if path.parent == session_dir]
+    if not success:
+        assert [path.name for path in session_writes[-2:]] == ["raw_stdout.jsonl", "summary.json"]
     assert session_writes[-1].name == "summary.json"
 
 

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -120,6 +120,35 @@ def _index_session_counter(log_root: Path) -> Counter[str]:
     )
 
 
+def test_next_writer_removes_abandoned_session_before_retention(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Summary-less directories are removed before committed sessions are ranked."""
+    import autoskillit.execution.session_log as session_log
+
+    _flush(tmp_path, session_id="committed-old", max_sessions=2)
+    committed_old = tmp_path / "sessions" / "committed-old"
+    os.utime(committed_old, (1, 1))
+
+    abandoned = tmp_path / "sessions" / "abandoned"
+    abandoned.mkdir()
+    (abandoned / "proc_trace.jsonl").write_text("incomplete\n")
+
+    removed: list[Path] = []
+    original_rmtree = session_log.shutil.rmtree
+
+    def recording_rmtree(path: Path, *, ignore_errors: bool = False) -> None:
+        removed.append(path)
+        original_rmtree(path, ignore_errors=ignore_errors)
+
+    monkeypatch.setattr(session_log.shutil, "rmtree", recording_rmtree)
+    _flush(tmp_path, session_id="committed-new", max_sessions=1)
+
+    assert removed == [abandoned, committed_old]
+    assert not abandoned.exists()
+    assert _index_session_counter(tmp_path) == Counter({"committed-new": 1})
+
+
 def test_concurrent_retention_preserves_committed_index_projection(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/execution/test_session_log_retention.py
+++ b/tests/execution/test_session_log_retention.py
@@ -19,7 +19,7 @@ from autoskillit.core.types._type_results_execution import (
 from autoskillit.execution._session_log_recovery import recover_crashed_sessions
 from autoskillit.execution.linux_tracing import read_boot_id, read_starttime_ticks
 from autoskillit.execution.session_log import flush_session_log
-from autoskillit.fleet import build_protected_campaign_ids
+from autoskillit.fleet import FLEET_STATE_SCHEMA_VERSION, build_protected_campaign_ids
 from tests.execution.conftest import _flush, _snap
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
@@ -110,6 +110,96 @@ def test_recover_crashed_sessions_finalizes_orphaned_file(tmp_path):
     summary = json.loads((sessions[0] / "summary.json").read_text())
     assert summary["termination_reason"] == "CRASHED"
     assert summary["success"] is False
+
+
+def test_recovery_replay_upserts_without_rewriting_committed_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tmpfs = tmp_path / "shm"
+    tmpfs.mkdir()
+    trace = _write_old_trace(
+        tmpfs,
+        "autoskillit_trace_99998.jsonl",
+        json.dumps({"vm_rss_kb": 300, "captured_at": "2026-03-03T10:00:00+00:00"}) + "\n",
+    )
+    original_unlink = Path.unlink
+
+    def interrupt_trace_ack(path: Path, *args, **kwargs) -> None:
+        if path == trace:
+            raise OSError("simulated interruption before trace acknowledgement")
+        original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", interrupt_trace_ack)
+    with pytest.raises(OSError, match="simulated interruption"):
+        recover_crashed_sessions(tmpfs_path=str(tmpfs), log_dir=str(tmp_path / "logs"))
+    monkeypatch.setattr(Path, "unlink", original_unlink)
+
+    session_dir = next((tmp_path / "logs" / "sessions").iterdir())
+    committed_mtime = session_dir.stat().st_mtime_ns
+    assert recover_crashed_sessions(tmpfs_path=str(tmpfs), log_dir=str(tmp_path / "logs")) == 1
+
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "logs" / "sessions.jsonl").read_text().splitlines()
+    ]
+    assert [row["dir_name"] for row in rows].count(session_dir.name) == 1
+    assert session_dir.stat().st_mtime_ns == committed_mtime
+
+
+def test_recovery_uses_configured_retention_and_campaign_protection(tmp_path: Path) -> None:
+    log_root = tmp_path / "logs"
+    sessions_dir = log_root / "sessions"
+    sessions_dir.mkdir(parents=True)
+    index_path = log_root / "sessions.jsonl"
+    for index, (dir_name, campaign_id) in enumerate(
+        (("protected", "active-campaign"), ("unprotected", ""))
+    ):
+        session_dir = sessions_dir / dir_name
+        session_dir.mkdir()
+        if campaign_id:
+            (session_dir / "meta.json").write_text(
+                json.dumps({"campaign_id": campaign_id, "dispatch_id": "dispatch"})
+            )
+        (session_dir / "summary.json").write_text(json.dumps({"dir_name": dir_name}))
+        os.utime(session_dir, (1_000_000_000 + index, 1_000_000_000 + index))
+        with index_path.open("a") as index_file:
+            index_file.write(json.dumps({"dir_name": dir_name, "campaign_id": campaign_id}) + "\n")
+
+    tmpfs = tmp_path / "shm"
+    tmpfs.mkdir()
+    _write_old_trace(
+        tmpfs,
+        "autoskillit_trace_99997.jsonl",
+        json.dumps({"vm_rss_kb": 200, "captured_at": "2026-03-03T10:00:00+00:00"}) + "\n",
+    )
+    project_dir = tmp_path / "project"
+    observed: list[Path] = []
+
+    def protector(path: Path) -> frozenset[str]:
+        observed.append(path)
+        return frozenset({"active-campaign"})
+
+    assert (
+        recover_crashed_sessions(
+            tmpfs_path=str(tmpfs),
+            log_dir=str(log_root),
+            project_dir=str(project_dir),
+            max_sessions=1,
+            build_protected_campaign_ids=protector,
+        )
+        == 1
+    )
+
+    assert observed == [project_dir]
+    assert (sessions_dir / "protected").is_dir()
+    assert not (sessions_dir / "unprotected").exists()
+    committed = {summary.parent.name for summary in sessions_dir.glob("*/summary.json")}
+    indexed = {
+        json.loads(line)["dir_name"]
+        for line in index_path.read_text().splitlines()
+        if line.strip()
+    }
+    assert indexed == committed
 
 
 def test_recover_crashed_sessions_deletes_tmpfs_file(tmp_path):
@@ -372,12 +462,12 @@ def test_flush_defaults_campaign_dispatch_empty(tmp_path):
 # --- Group M: retention protection tests ---
 
 
-def _make_sessions(tmp_path, count, start_mtime=1_000_000_000, campaign_id=""):
-    """Create `count` session directories with staggered mtimes.
+def _commit_seeded_session(session_dir: Path, dir_name: str) -> None:
+    (session_dir / "summary.json").write_text(json.dumps({"dir_name": dir_name}))
 
-    Returns list of dir_names in mtime order (oldest first).
-    Seeds meta.json with campaign_id if provided.
-    """
+
+def _make_sessions(tmp_path, count, start_mtime=1_000_000_000, campaign_id=""):
+    """Create committed session directories with staggered mtimes."""
     sessions_dir = tmp_path / "sessions"
     sessions_dir.mkdir(parents=True, exist_ok=True)
     index_path = tmp_path / "sessions.jsonl"
@@ -386,12 +476,13 @@ def _make_sessions(tmp_path, count, start_mtime=1_000_000_000, campaign_id=""):
         dir_name = f"session-{i:04d}"
         d = sessions_dir / dir_name
         d.mkdir(exist_ok=True)
-        mtime = start_mtime + i
-        os.utime(d, (mtime, mtime))
         if campaign_id:
             (d / "meta.json").write_text(
                 json.dumps({"campaign_id": campaign_id, "dispatch_id": f"d-{i}"})
             )
+        _commit_seeded_session(d, dir_name)
+        mtime = start_mtime + i
+        os.utime(d, (mtime, mtime))
         with index_path.open("a") as f:
             f.write(
                 json.dumps(
@@ -411,6 +502,7 @@ def _make_state_file(project_dir, campaign_id, status):
     state_path.write_text(
         json.dumps(
             {
+                "schema_version": FLEET_STATE_SCHEMA_VERSION,
                 "campaign_id": campaign_id,
                 "dispatches": [{"name": "truck-1", "status": status}],
             }
@@ -442,6 +534,8 @@ def test_retention_protects_active_campaign_sessions(tmp_path, monkeypatch):
         (d / "meta.json").write_text(
             json.dumps({"campaign_id": "active-campaign", "dispatch_id": f"d{i}"})
         )
+        _commit_seeded_session(d, dir_name)
+        os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         with index_path.open("a") as f:
             f.write(
                 json.dumps(
@@ -454,11 +548,13 @@ def test_retention_protects_active_campaign_sessions(tmp_path, monkeypatch):
                 + "\n"
             )
 
-    # Next 4 dirs: non-campaign sessions
-    for i in range(2, 6):
+    # Next 6 dirs: enough non-campaign sessions to enter the expired slice
+    for i in range(2, 8):
         dir_name = f"session-{i:04d}"
         d = sessions_dir / dir_name
         d.mkdir()
+        os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
+        _commit_seeded_session(d, dir_name)
         os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         with index_path.open("a") as f:
             f.write(
@@ -468,13 +564,13 @@ def test_retention_protects_active_campaign_sessions(tmp_path, monkeypatch):
 
     _make_state_file(project_dir, "active-campaign", "running")
 
-    # Flush a 7th session to trigger retention (5 max, so 2 should expire)
+    # Flush a 9th session: four are expired, including two unprotected sessions
     flush_session_log(
         log_dir=str(tmp_path),
         cwd="/some/project",
         project_dir=str(project_dir),
         build_protected_campaign_ids=build_protected_campaign_ids,
-        session_id="session-0006",
+        session_id="session-0008",
         pid=12345,
         skill_command="/autoskillit:implement",
         success=True,
@@ -487,8 +583,7 @@ def test_retention_protects_active_campaign_sessions(tmp_path, monkeypatch):
         recipe_identity=RecipeIdentity.empty(),
     )
 
-    # Protected sessions survive — campaign meta.json writes update their mtime so they
-    # end up in the "surviving" window; even if they landed in expired, protection saves them.
+    # Protected sessions are in the expired slice and survive even above the target.
     assert (sessions_dir / "session-0000").exists(), "active campaign session must survive"
     assert (sessions_dir / "session-0001").exists(), "active campaign session must survive"
     # The 2 non-campaign sessions with oldest mtimes (0002, 0003) are deleted.
@@ -504,7 +599,7 @@ def test_retention_protects_active_campaign_sessions(tmp_path, monkeypatch):
     assert (sessions_dir / "session-0004").exists(), "session-0004 must survive"
     assert (sessions_dir / "session-0005").exists(), "session-0005 must survive"
     # Newly flushed session must be present
-    assert (sessions_dir / "session-0006").exists()
+    assert (sessions_dir / "session-0008").exists()
 
 
 def test_retention_deletes_released_campaign_sessions(tmp_path, monkeypatch):
@@ -528,6 +623,8 @@ def test_retention_deletes_released_campaign_sessions(tmp_path, monkeypatch):
             (d / "meta.json").write_text(
                 json.dumps({"campaign_id": "done-campaign", "dispatch_id": f"d{i}"})
             )
+        _commit_seeded_session(d, dir_name)
+        os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         with index_path.open("a") as f:
             cid = "done-campaign" if i < 2 else ""
             f.write(
@@ -588,6 +685,8 @@ def test_retention_preserves_index_for_protected(tmp_path, monkeypatch):
                 json.dumps({"campaign_id": "live-campaign", "dispatch_id": f"d{i}"})
             )
         cid = "live-campaign" if i < 2 else ""
+        _commit_seeded_session(d, dir_name)
+        os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         with index_path.open("a") as f:
             f.write(
                 json.dumps({"session_id": dir_name, "dir_name": dir_name, "campaign_id": cid})
@@ -640,6 +739,8 @@ def test_retention_handles_missing_meta_json(tmp_path, monkeypatch):
         d.mkdir()
         os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         # No meta.json written — sessions are not linked to any campaign
+        _commit_seeded_session(d, dir_name)
+        os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         with index_path.open("a") as f:
             f.write(json.dumps({"session_id": dir_name, "dir_name": dir_name}) + "\n")
 
@@ -686,6 +787,8 @@ def test_retention_handles_missing_franchise_state_dir(tmp_path, monkeypatch):
         (d / "meta.json").write_text(
             json.dumps({"campaign_id": "some-campaign", "dispatch_id": f"d{i}"})
         )
+        _commit_seeded_session(d, dir_name)
+        os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         with index_path.open("a") as f:
             f.write(json.dumps({"session_id": dir_name, "dir_name": dir_name}) + "\n")
         # Set mtime AFTER all writes inside the dir to get the intended ordering
@@ -735,6 +838,8 @@ def test_retention_handles_corrupt_meta_json(tmp_path, monkeypatch):
         if i < 2:
             # Write corrupt JSON so meta.json is unreadable
             (d / "meta.json").write_text("not valid json {{{{")
+        _commit_seeded_session(d, dir_name)
+        os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         with index_path.open("a") as f:
             f.write(json.dumps({"session_id": dir_name, "dir_name": dir_name}) + "\n")
         # Set mtime AFTER all writes inside the dir to get the intended ordering
@@ -802,6 +907,8 @@ def test_retention_no_protection_when_callback_is_none(tmp_path: Path, monkeypat
             )
             # Reset mtime after meta.json write (writing a file bumps directory mtime)
             os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
+        _commit_seeded_session(d, dir_name)
+        os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         with index_path.open("a") as f:
             f.write(json.dumps({"session_id": dir_name, "dir_name": dir_name}) + "\n")
 
@@ -828,43 +935,25 @@ def test_retention_no_protection_when_callback_is_none(tmp_path: Path, monkeypat
     assert not (sessions_dir / "session-0001").exists()
 
 
-def test_flush_session_log_passes_callback_to_enforce_retention(
-    tmp_path: Path, monkeypatch
-) -> None:
-    """SL_CB_7: flush_session_log forwards build_protected_campaign_ids to _enforce_retention."""
-    import autoskillit.execution.session_log as sl_module
+def test_flush_uses_campaign_protector_during_transaction(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _make_sessions(tmp_path, count=1)
+    observed: list[Path] = []
 
-    captured: list = []
+    def protector(path: Path) -> frozenset[str]:
+        observed.append(path)
+        return frozenset()
 
-    def fake_enforce_retention(
-        log_root, project_dir="", build_protected_campaign_ids=None, **kwargs
-    ) -> None:
-        captured.append(build_protected_campaign_ids)
-
-    monkeypatch.setattr(sl_module, "_enforce_retention", fake_enforce_retention)
-
-    sentinel = build_protected_campaign_ids
-    flush_session_log(
-        log_dir=str(tmp_path),
-        cwd="/some/project",
-        project_dir=str(tmp_path),
-        build_protected_campaign_ids=sentinel,
-        session_id="session-cb7",
-        pid=12345,
-        skill_command="/autoskillit:implement",
-        success=True,
-        subtype="completed",
-        exit_code=0,
-        start_ts="2026-04-20T10:00:00+00:00",
-        proc_snapshots=None,
-        telemetry=SessionTelemetry.empty(),
-        provider_outcome=ProviderOutcome.none_used(),
-        recipe_identity=RecipeIdentity.empty(),
+    _flush(
+        tmp_path,
+        session_id="new-session",
+        project_dir=str(project_dir),
+        build_protected_campaign_ids=protector,
+        max_sessions=1,
     )
 
-    assert (tmp_path / "sessions.jsonl").exists()
-    assert len(captured) == 1
-    assert captured[0] is sentinel
+    assert observed == [project_dir]
 
 
 # --- max_sessions configurability tests ---
@@ -877,31 +966,20 @@ def test_max_sessions_constant_is_2000():
     assert _MAX_SESSIONS == 2000
 
 
-def test_enforce_retention_respects_max_sessions_param(tmp_path):
-    """T3: Passing max_sessions overrides the module-level _MAX_SESSIONS."""
-    import autoskillit.execution.session_log as sl_module
-
+def test_flush_respects_max_sessions_param(tmp_path: Path) -> None:
     _make_sessions(tmp_path, count=10)
-    sl_module._enforce_retention(tmp_path, max_sessions=7)
+
+    _flush(tmp_path, session_id="new-session", max_sessions=7)
+
     remaining = list((tmp_path / "sessions").iterdir())
     assert len(remaining) == 7
+    assert (tmp_path / "sessions" / "new-session").is_dir()
 
 
-def test_flush_threads_max_sessions_to_enforce_retention(tmp_path, monkeypatch):
-    """T4: flush_session_log passes max_sessions through to _enforce_retention."""
-    import autoskillit.execution.session_log as sl_module
+def test_flush_applies_small_max_sessions_at_rollover(tmp_path: Path) -> None:
+    _make_sessions(tmp_path, count=3)
 
-    captured: dict = {}
+    _flush(tmp_path, session_id="new-session", max_sessions=2)
 
-    def fake_enforce(
-        log_root,
-        project_dir="",
-        build_protected_campaign_ids=None,
-        *,
-        max_sessions=sl_module._MAX_SESSIONS,
-    ) -> None:
-        captured["max_sessions"] = max_sessions
-
-    monkeypatch.setattr(sl_module, "_enforce_retention", fake_enforce)
-    _flush(tmp_path, max_sessions=999)
-    assert captured["max_sessions"] == 999
+    remaining = {path.name for path in (tmp_path / "sessions").iterdir()}
+    assert remaining == {"session-0002", "new-session"}

--- a/tests/execution/test_session_log_retention.py
+++ b/tests/execution/test_session_log_retention.py
@@ -530,7 +530,6 @@ def test_retention_protects_active_campaign_sessions(tmp_path, monkeypatch):
         dir_name = f"session-{i:04d}"
         d = sessions_dir / dir_name
         d.mkdir()
-        os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         (d / "meta.json").write_text(
             json.dumps({"campaign_id": "active-campaign", "dispatch_id": f"d{i}"})
         )
@@ -553,7 +552,6 @@ def test_retention_protects_active_campaign_sessions(tmp_path, monkeypatch):
         dir_name = f"session-{i:04d}"
         d = sessions_dir / dir_name
         d.mkdir()
-        os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         _commit_seeded_session(d, dir_name)
         os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         with index_path.open("a") as f:
@@ -679,7 +677,6 @@ def test_retention_preserves_index_for_protected(tmp_path, monkeypatch):
         dir_name = f"session-{i:04d}"
         d = sessions_dir / dir_name
         d.mkdir()
-        os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         if i < 2:
             (d / "meta.json").write_text(
                 json.dumps({"campaign_id": "live-campaign", "dispatch_id": f"d{i}"})
@@ -737,7 +734,6 @@ def test_retention_handles_missing_meta_json(tmp_path, monkeypatch):
         dir_name = f"session-{i:04d}"
         d = sessions_dir / dir_name
         d.mkdir()
-        os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         # No meta.json written — sessions are not linked to any campaign
         _commit_seeded_session(d, dir_name)
         os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
@@ -900,13 +896,10 @@ def test_retention_no_protection_when_callback_is_none(tmp_path: Path, monkeypat
         dir_name = f"session-{i:04d}"
         d = sessions_dir / dir_name
         d.mkdir()
-        os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         if i < 2:
             (d / "meta.json").write_text(
                 json.dumps({"campaign_id": "active-campaign", "dispatch_id": f"d{i}"})
             )
-            # Reset mtime after meta.json write (writing a file bumps directory mtime)
-            os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         _commit_seeded_session(d, dir_name)
         os.utime(d, (1_000_000_000 + i, 1_000_000_000 + i))
         with index_path.open("a") as f:

--- a/tests/execution/test_session_log_retention.py
+++ b/tests/execution/test_session_log_retention.py
@@ -832,6 +832,12 @@ def test_retention_handles_corrupt_meta_json(tmp_path, monkeypatch):
     import autoskillit.execution.session_log as sl_module
 
     monkeypatch.setattr(sl_module, "_MAX_SESSIONS", 5)
+    warning_events: list[str] = []
+    monkeypatch.setattr(
+        sl_module.logger,
+        "warning",
+        lambda event, **_kwargs: warning_events.append(event),
+    )
 
     project_dir = tmp_path / "project"
     project_dir.mkdir()
@@ -875,6 +881,7 @@ def test_retention_handles_corrupt_meta_json(tmp_path, monkeypatch):
     # Corrupt meta.json → not protected → deleted normally
     assert not (sessions_dir / "session-0000").exists()
     assert not (sessions_dir / "session-0001").exists()
+    assert warning_events.count("session_retention_meta_read_failed") == 2
 
 
 def test_session_log_removed_build_protected_function() -> None:

--- a/tests/execution/test_session_log_retention.py
+++ b/tests/execution/test_session_log_retention.py
@@ -135,14 +135,27 @@ def test_recovery_replay_upserts_without_rewriting_committed_directory(
     monkeypatch.setattr(Path, "unlink", original_unlink)
 
     session_dir = next((tmp_path / "logs" / "sessions").iterdir())
+    newer_dir = tmp_path / "logs" / "sessions" / "newer"
+    newer_dir.mkdir()
+    (newer_dir / "summary.json").write_text(json.dumps({"dir_name": "newer"}))
+    with (tmp_path / "logs" / "sessions.jsonl").open("a") as index_file:
+        index_file.write(json.dumps({"dir_name": "newer"}) + "\n")
+    os.utime(session_dir, (1_000_000_000, 1_000_000_000))
+    os.utime(newer_dir, (1_000_000_001, 1_000_000_001))
     committed_mtime = session_dir.stat().st_mtime_ns
-    assert recover_crashed_sessions(tmpfs_path=str(tmpfs), log_dir=str(tmp_path / "logs")) == 1
+    assert (
+        recover_crashed_sessions(
+            tmpfs_path=str(tmpfs), log_dir=str(tmp_path / "logs"), max_sessions=1
+        )
+        == 1
+    )
 
     rows = [
         json.loads(line)
         for line in (tmp_path / "logs" / "sessions.jsonl").read_text().splitlines()
     ]
     assert [row["dir_name"] for row in rows].count(session_dir.name) == 1
+    assert newer_dir.is_dir()
     assert session_dir.stat().st_mtime_ns == committed_mtime
 
 

--- a/tests/infra/test_plugin_source_ratchets.py
+++ b/tests/infra/test_plugin_source_ratchets.py
@@ -50,6 +50,11 @@ DESTINATION_RESOLVE_ALLOWLIST: dict[str, str] = {
 }
 
 PLUGIN_MUTATION_ALLOWLIST: dict[tuple[str, str, str], tuple[int, str]] = {
+    ("execution/session_log.py", "flush_session_log", "shutil.rmtree"): (
+        2,
+        "The exclusive session-index transaction removes only abandoned summary-less "
+        "session directories and expired committed directories selected by retention.",
+    ),
     ("cli/_install_snapshot/_snapshot.py", "_remove", "path.unlink"): (
         1,
         "Transaction restoration removes the failed replacement before restoring its staged copy.",

--- a/tests/server/test_state.py
+++ b/tests/server/test_state.py
@@ -31,7 +31,10 @@ def _make_mock_ctx(tmp_path: Path) -> MagicMock:
     tracing_cfg = MagicMock()
     tracing_cfg.tmpfs_path = str(tmp_path / "tmpfs")
     tracing_cfg.log_dir = str(tmp_path / "logs")
+    tracing_cfg.max_sessions = 17
     ctx.config.linux_tracing = tracing_cfg
+    ctx.project_dir = tmp_path / "project"
+    ctx.build_protected_campaign_ids = Mock(name="build_protected_campaign_ids")
     store_health = ContextAdmissionStoreHealth(ContextAdmissionStorageHealthStatus.HEALTHY)
     ctx.context_admission_ledger.recover_all.return_value = ContextAdmissionRecoveryResult(
         status=ContextAdmissionStorageHealthStatus.HEALTHY,
@@ -281,11 +284,20 @@ async def test_deferred_initialize_runs_recovery_operations(tmp_path):
     mock_ctx.audit.load_from_log_dir.return_value = 0
 
     event = asyncio.Event()
-    with patch("autoskillit.execution.recover_crashed_sessions", return_value=0):
+    with patch(
+        "autoskillit.server._state.recover_crashed_sessions", return_value=0
+    ) as recover_crashed_sessions:
         await deferred_initialize(mock_ctx, ready_event=event)
 
     assert event.is_set(), "deferred_initialize did not signal readiness"
     mock_ctx.context_admission_ledger.recover_all.assert_called_once_with()
+    recover_crashed_sessions.assert_called_once_with(
+        tmpfs_path=mock_ctx.config.linux_tracing.tmpfs_path,
+        log_dir=mock_ctx.config.linux_tracing.log_dir,
+        project_dir=str(mock_ctx.project_dir),
+        max_sessions=mock_ctx.config.linux_tracing.max_sessions,
+        build_protected_campaign_ids=mock_ctx.build_protected_campaign_ids,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The investigation disproves the issue's original claim that `sessions.jsonl` stopped accepting rows at 2,000. The observed count is consistent with the configured 2,000-directory retention target, and the cited session was checked before its qualifying terminal flush. This PR addresses the smaller retained-index consistency weakness without claiming it caused the alleged multi-day halt.

Closes #4458

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/rectify/rectify_session_index_consistency_2026-08-08_185634.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
