### PR TITLE
Rectify: Codex Explorer Web-Search Policy and External-Schema Drift

### DIFF
--- a/src/autoskillit/agents/repository-impact-profiler.md
+++ b/src/autoskillit/agents/repository-impact-profiler.md
@@ -8,8 +8,9 @@ codex:
   model: gpt-5.6-luna
   reasoning_effort: max
   sandbox_mode: read-only
-  disabled_features: [apps, apps_mcp_path_override, browser_use, browser_use_external, browser_use_full_cdp_access, code_mode, code_mode_buffered_exec, code_mode_host, code_mode_only, computer_use, enable_mcp_apps, goals, image_generation, in_app_browser, js_repl, js_repl_tools_only, multi_agent, multi_agent_v2, plugin_sharing, plugins, remote_plugin, request_permissions_tool, shell_tool, standalone_web_search, tool_search_always_defer_mcp_tools, tool_suggest, unified_exec, unified_exec_zsh_fork, web_search_cached, web_search_request]
+  disabled_features: [apps, browser_use, browser_use_external, browser_use_full_cdp_access, code_mode, code_mode_buffered_exec, code_mode_host, code_mode_only, computer_use, enable_mcp_apps, goals, image_generation, in_app_browser, multi_agent, multi_agent_v2, plugin_sharing, plugins, remote_plugin, request_permissions_tool, shell_tool, standalone_web_search, tool_suggest, unified_exec, unified_exec_zsh_fork]
   agents_enabled: false
+  web_search: disabled
 ---
 
 # repository-impact-profiler

--- a/src/autoskillit/agents/semantic-code-navigator.md
+++ b/src/autoskillit/agents/semantic-code-navigator.md
@@ -8,8 +8,9 @@ codex:
   model: gpt-5.6-luna
   reasoning_effort: max
   sandbox_mode: read-only
-  disabled_features: [apps, apps_mcp_path_override, browser_use, browser_use_external, browser_use_full_cdp_access, code_mode, code_mode_buffered_exec, code_mode_host, code_mode_only, computer_use, enable_mcp_apps, goals, image_generation, in_app_browser, js_repl, js_repl_tools_only, multi_agent, multi_agent_v2, plugin_sharing, plugins, remote_plugin, request_permissions_tool, shell_tool, standalone_web_search, tool_search_always_defer_mcp_tools, tool_suggest, unified_exec, unified_exec_zsh_fork, web_search_cached, web_search_request]
+  disabled_features: [apps, browser_use, browser_use_external, browser_use_full_cdp_access, code_mode, code_mode_buffered_exec, code_mode_host, code_mode_only, computer_use, enable_mcp_apps, goals, image_generation, in_app_browser, multi_agent, multi_agent_v2, plugin_sharing, plugins, remote_plugin, request_permissions_tool, shell_tool, standalone_web_search, tool_suggest, unified_exec, unified_exec_zsh_fork]
   agents_enabled: false
+  web_search: disabled
 ---
 
 # semantic-code-navigator

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -93,6 +93,9 @@ from ._terminal_table import _render_terminal_table as _render_terminal_table
 from ._version_snapshot import collect_version_snapshot as collect_version_snapshot
 from .agent_definition import AGENT_DEFINITION_DIGEST_DOMAIN as AGENT_DEFINITION_DIGEST_DOMAIN
 from .agent_definition import BUNDLED_EXPLORER_ROLES as BUNDLED_EXPLORER_ROLES
+from .agent_definition import (
+    CODEX_DISABLED_WEB_SEARCH_POLICY as CODEX_DISABLED_WEB_SEARCH_POLICY,
+)
 from .agent_definition import CODEX_EXPLORER_IDENTITY as CODEX_EXPLORER_IDENTITY
 from .agent_definition import (
     REPOSITORY_IMPACT_PROFILER_ROLE as REPOSITORY_IMPACT_PROFILER_ROLE,

--- a/src/autoskillit/core/agent_definition.py
+++ b/src/autoskillit/core/agent_definition.py
@@ -7,7 +7,7 @@ import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from .io import load_yaml
 from .paths import pkg_root
@@ -48,7 +48,6 @@ _CODEX_CLI_VERSION_RE = re.compile(r"(?:codex-cli )?(?P<version>[0-9]+\.[0-9]+\.
 _READ_ONLY_AGENT_TOOLS = frozenset({"Read", "Grep", "Glob", "LSP"})
 _CODEX_DISABLEABLE_FEATURES = (
     "apps",
-    "apps_mcp_path_override",
     "browser_use",
     "browser_use_external",
     "browser_use_full_cdp_access",
@@ -61,8 +60,6 @@ _CODEX_DISABLEABLE_FEATURES = (
     "goals",
     "image_generation",
     "in_app_browser",
-    "js_repl",
-    "js_repl_tools_only",
     "multi_agent",
     "multi_agent_v2",
     "plugin_sharing",
@@ -71,12 +68,9 @@ _CODEX_DISABLEABLE_FEATURES = (
     "request_permissions_tool",
     "shell_tool",
     "standalone_web_search",
-    "tool_search_always_defer_mcp_tools",
     "tool_suggest",
     "unified_exec",
     "unified_exec_zsh_fork",
-    "web_search_cached",
-    "web_search_request",
 )
 _CODEX_DISABLEABLE_FEATURE_SET = frozenset(_CODEX_DISABLEABLE_FEATURES)
 
@@ -106,6 +100,7 @@ class CodexAgentProjectionDef:
     sandbox_mode: str
     disabled_features: tuple[str, ...] = ()
     agents_enabled: bool = True
+    web_search: Literal["disabled"] | None = None
 
     def __post_init__(self) -> None:
         if self.model is not None and self.model not in CODEX_VALID_MODEL_IDS:
@@ -136,6 +131,8 @@ class CodexAgentProjectionDef:
             raise AgentDefinitionError("Codex disabled_features must use canonical order")
         if type(self.agents_enabled) is not bool:
             raise AgentDefinitionError("Codex agents_enabled must be a boolean")
+        if self.web_search is not None and self.web_search != "disabled":
+            raise AgentDefinitionError("Codex web_search must be 'disabled'")
 
 
 @dataclass(frozen=True, slots=True)
@@ -194,6 +191,7 @@ def _derived_codex_projection(
             "sandbox_mode",
             "disabled_features",
             "agents_enabled",
+            "web_search",
         }
         if unexpected:
             raise AgentDefinitionError(
@@ -204,6 +202,7 @@ def _derived_codex_projection(
         sandbox = raw.get("sandbox_mode")
         disabled_features = raw.get("disabled_features", [])
         agents_enabled = raw.get("agents_enabled", True)
+        web_search = raw.get("web_search")
         if (
             not isinstance(model, str)
             or not isinstance(effort, str)
@@ -224,6 +223,7 @@ def _derived_codex_projection(
             sandbox,
             tuple(disabled_features),
             agents_enabled,
+            web_search,
         )
 
     model_key = meta.get("model")
@@ -300,6 +300,7 @@ def agent_definition_digest(definition: AgentDef) -> str:
             "sandbox_mode": definition.codex.sandbox_mode,
             "disabled_features": list(definition.codex.disabled_features),
             "agents_enabled": definition.codex.agents_enabled,
+            "web_search": definition.codex.web_search,
         },
         "description": definition.description,
         "max_turns": definition.max_turns,

--- a/src/autoskillit/core/agent_definition.py
+++ b/src/autoskillit/core/agent_definition.py
@@ -22,6 +22,7 @@ from .types import (
 __all__ = [
     "AGENT_DEFINITION_DIGEST_DOMAIN",
     "BUNDLED_EXPLORER_ROLES",
+    "CODEX_DISABLED_WEB_SEARCH_POLICY",
     "CODEX_EXPLORER_IDENTITY",
     "REPOSITORY_IMPACT_PROFILER_ROLE",
     "SEMANTIC_CODE_NAVIGATOR_ROLE",
@@ -37,6 +38,7 @@ __all__ = [
 
 
 AGENT_DEFINITION_DIGEST_DOMAIN = "autoskillit.agent-definition.v1"
+CODEX_DISABLED_WEB_SEARCH_POLICY: Literal["disabled"] = "disabled"
 CODEX_EXPLORER_IDENTITY: tuple[str, str] = ("gpt-5.6-luna", "max")
 SEMANTIC_CODE_NAVIGATOR_ROLE: str = "semantic-code-navigator"
 REPOSITORY_IMPACT_PROFILER_ROLE: str = "repository-impact-profiler"
@@ -131,8 +133,10 @@ class CodexAgentProjectionDef:
             raise AgentDefinitionError("Codex disabled_features must use canonical order")
         if type(self.agents_enabled) is not bool:
             raise AgentDefinitionError("Codex agents_enabled must be a boolean")
-        if self.web_search is not None and self.web_search != "disabled":
-            raise AgentDefinitionError("Codex web_search must be 'disabled'")
+        if self.web_search is not None and self.web_search != CODEX_DISABLED_WEB_SEARCH_POLICY:
+            raise AgentDefinitionError(
+                f"Codex web_search must be {CODEX_DISABLED_WEB_SEARCH_POLICY!r}"
+            )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/execution/backends/_codex/explorer_projection.py
+++ b/src/autoskillit/execution/backends/_codex/explorer_projection.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from autoskillit.core import (
     BUNDLED_EXPLORER_ROLES,
+    CODEX_DISABLED_WEB_SEARCH_POLICY,
     CODEX_EXPLORER_IDENTITY,
     DIRECT_PREFIX,
     AgentDef,
@@ -132,8 +133,11 @@ def _validated_explorer_binding_envs(
             )
         if definition.codex.sandbox_mode != "read-only":
             raise ValueError(f"explorer role {role!r} must be read-only")
-        if definition.codex.web_search != "disabled":
-            raise ValueError(f"explorer role {role!r} must disable native web search")
+        if definition.codex.web_search != CODEX_DISABLED_WEB_SEARCH_POLICY:
+            raise ValueError(
+                f"explorer role {role!r} must disable native web search "
+                f"({CODEX_DISABLED_WEB_SEARCH_POLICY!r})"
+            )
 
         binding = _validated_explorer_binding_env(role, explorer_binding_env[role])
         if shared_binding is None:

--- a/src/autoskillit/execution/backends/_codex/explorer_projection.py
+++ b/src/autoskillit/execution/backends/_codex/explorer_projection.py
@@ -132,6 +132,8 @@ def _validated_explorer_binding_envs(
             )
         if definition.codex.sandbox_mode != "read-only":
             raise ValueError(f"explorer role {role!r} must be read-only")
+        if definition.codex.web_search != "disabled":
+            raise ValueError(f"explorer role {role!r} must disable native web search")
 
         binding = _validated_explorer_binding_env(role, explorer_binding_env[role])
         if shared_binding is None:

--- a/src/autoskillit/execution/backends/_explorer_conformance.py
+++ b/src/autoskillit/execution/backends/_explorer_conformance.py
@@ -39,7 +39,6 @@ _LUNA_BUNDLED_APPLY_PATCH_TOOL_TYPE = "freeform"
 _LUNA_EFFECTIVE_APPLY_PATCH_TOOL_TYPE = None
 EXPLORER_DISABLED_FEATURES = (
     "apps",
-    "apps_mcp_path_override",
     "browser_use",
     "browser_use_external",
     "browser_use_full_cdp_access",
@@ -52,8 +51,6 @@ EXPLORER_DISABLED_FEATURES = (
     "goals",
     "image_generation",
     "in_app_browser",
-    "js_repl",
-    "js_repl_tools_only",
     "multi_agent",
     "multi_agent_v2",
     "plugin_sharing",
@@ -62,17 +59,22 @@ EXPLORER_DISABLED_FEATURES = (
     "request_permissions_tool",
     "shell_tool",
     "standalone_web_search",
-    "tool_search_always_defer_mcp_tools",
     "tool_suggest",
     "unified_exec",
     "unified_exec_zsh_fork",
-    "web_search_cached",
-    "web_search_request",
 )
 EXPLORER_PARENT_DISABLED_FEATURES = tuple(
     feature
     for feature in EXPLORER_DISABLED_FEATURES
     if feature not in {"multi_agent", "multi_agent_v2"}
+)
+_EXPLORER_PROBE_PROJECTION = CodexAgentProjectionDef(
+    model=EXPLORER_MODEL,
+    reasoning_effort=EXPLORER_REASONING_EFFORT,
+    sandbox_mode=EXPLORER_SANDBOX_MODE,
+    disabled_features=EXPLORER_DISABLED_FEATURES,
+    agents_enabled=False,
+    web_search="disabled",
 )
 EXPLORER_MAX_SESSION_THREADS = 2
 EXPLORER_MCP_TOOLS = (
@@ -82,8 +84,8 @@ EXPLORER_MCP_TOOLS = (
     "deny_operations",
 )
 _EXPLORER_TOOL_SURFACE = {
-    "child_agents_enabled": False,
-    "child_disabled_features": EXPLORER_DISABLED_FEATURES,
+    "child_agents_enabled": _EXPLORER_PROBE_PROJECTION.agents_enabled,
+    "child_disabled_features": _EXPLORER_PROBE_PROJECTION.disabled_features,
     "mcp_servers": {
         "explorer_probe": {
             "default_tools_approval_mode": "approve",
@@ -105,7 +107,7 @@ _EXPLORER_TOOL_SURFACE = {
     "request_user_input_enabled": False,
     "repository_direct_mount": False,
     "session_thread_cap": EXPLORER_MAX_SESSION_THREADS,
-    "web_search": "disabled",
+    "web_search": _EXPLORER_PROBE_PROJECTION.web_search,
 }
 EXPLORER_TOOL_SURFACE_DIGEST = (
     "sha256:"
@@ -171,13 +173,7 @@ def explorer_probe_agent_definition() -> AgentDef:
             "listed in the parent message. Do not inspect repository policy or credential "
             "files except for the explicit denial checks. Never synthesize or modify source."
         ),
-        codex=CodexAgentProjectionDef(
-            model=EXPLORER_MODEL,
-            reasoning_effort=EXPLORER_REASONING_EFFORT,
-            sandbox_mode=EXPLORER_SANDBOX_MODE,
-            disabled_features=EXPLORER_DISABLED_FEATURES,
-            agents_enabled=False,
-        ),
+        codex=_EXPLORER_PROBE_PROJECTION,
     )
 
 

--- a/src/autoskillit/execution/backends/_explorer_conformance.py
+++ b/src/autoskillit/execution/backends/_explorer_conformance.py
@@ -7,9 +7,10 @@ import json
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 from autoskillit.core import (
+    CODEX_DISABLED_WEB_SEARCH_POLICY,
     CODEX_EXPLORER_IDENTITY,
     SEMANTIC_CODE_NAVIGATOR_ROLE,
     AgentDef,
@@ -31,7 +32,6 @@ EXPLORER_ATTESTATION_FUTURE_SKEW_SECONDS = 5 * 60
 EXPLORER_PARENT_MODEL = "gpt-5.6-sol"
 EXPLORER_MODEL, EXPLORER_REASONING_EFFORT = CODEX_EXPLORER_IDENTITY
 EXPLORER_SANDBOX_MODE = "read-only"
-_EXPLORER_WEB_SEARCH_POLICY: Literal["disabled"] = "disabled"
 EXPLORER_PROBE_ROLE = SEMANTIC_CODE_NAVIGATOR_ROLE
 EXPLORER_PROBE_TASK_NAME = "capability_probe"
 _LUNA_BUNDLED_TOOL_MODE = "code_mode_only"
@@ -100,7 +100,7 @@ _EXPLORER_TOOL_SURFACE = {
     "request_user_input_enabled": False,
     "repository_direct_mount": False,
     "session_thread_cap": EXPLORER_MAX_SESSION_THREADS,
-    "web_search": _EXPLORER_WEB_SEARCH_POLICY,
+    "web_search": CODEX_DISABLED_WEB_SEARCH_POLICY,
 }
 EXPLORER_TOOL_SURFACE_DIGEST = (
     "sha256:"
@@ -172,7 +172,7 @@ def explorer_probe_agent_definition() -> AgentDef:
             sandbox_mode=EXPLORER_SANDBOX_MODE,
             disabled_features=EXPLORER_DISABLED_FEATURES,
             agents_enabled=False,
-            web_search=_EXPLORER_WEB_SEARCH_POLICY,
+            web_search=CODEX_DISABLED_WEB_SEARCH_POLICY,
         ),
     )
 

--- a/src/autoskillit/execution/backends/_explorer_conformance.py
+++ b/src/autoskillit/execution/backends/_explorer_conformance.py
@@ -7,7 +7,7 @@ import json
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from autoskillit.core import (
     CODEX_EXPLORER_IDENTITY,
@@ -31,6 +31,7 @@ EXPLORER_ATTESTATION_FUTURE_SKEW_SECONDS = 5 * 60
 EXPLORER_PARENT_MODEL = "gpt-5.6-sol"
 EXPLORER_MODEL, EXPLORER_REASONING_EFFORT = CODEX_EXPLORER_IDENTITY
 EXPLORER_SANDBOX_MODE = "read-only"
+_EXPLORER_WEB_SEARCH_POLICY: Literal["disabled"] = "disabled"
 EXPLORER_PROBE_ROLE = SEMANTIC_CODE_NAVIGATOR_ROLE
 EXPLORER_PROBE_TASK_NAME = "capability_probe"
 _LUNA_BUNDLED_TOOL_MODE = "code_mode_only"
@@ -68,14 +69,6 @@ EXPLORER_PARENT_DISABLED_FEATURES = tuple(
     for feature in EXPLORER_DISABLED_FEATURES
     if feature not in {"multi_agent", "multi_agent_v2"}
 )
-_EXPLORER_PROBE_PROJECTION = CodexAgentProjectionDef(
-    model=EXPLORER_MODEL,
-    reasoning_effort=EXPLORER_REASONING_EFFORT,
-    sandbox_mode=EXPLORER_SANDBOX_MODE,
-    disabled_features=EXPLORER_DISABLED_FEATURES,
-    agents_enabled=False,
-    web_search="disabled",
-)
 EXPLORER_MAX_SESSION_THREADS = 2
 EXPLORER_MCP_TOOLS = (
     "bounded_literal_search",
@@ -84,8 +77,8 @@ EXPLORER_MCP_TOOLS = (
     "deny_operations",
 )
 _EXPLORER_TOOL_SURFACE = {
-    "child_agents_enabled": _EXPLORER_PROBE_PROJECTION.agents_enabled,
-    "child_disabled_features": _EXPLORER_PROBE_PROJECTION.disabled_features,
+    "child_agents_enabled": False,
+    "child_disabled_features": EXPLORER_DISABLED_FEATURES,
     "mcp_servers": {
         "explorer_probe": {
             "default_tools_approval_mode": "approve",
@@ -107,7 +100,7 @@ _EXPLORER_TOOL_SURFACE = {
     "request_user_input_enabled": False,
     "repository_direct_mount": False,
     "session_thread_cap": EXPLORER_MAX_SESSION_THREADS,
-    "web_search": _EXPLORER_PROBE_PROJECTION.web_search,
+    "web_search": _EXPLORER_WEB_SEARCH_POLICY,
 }
 EXPLORER_TOOL_SURFACE_DIGEST = (
     "sha256:"
@@ -173,7 +166,14 @@ def explorer_probe_agent_definition() -> AgentDef:
             "listed in the parent message. Do not inspect repository policy or credential "
             "files except for the explicit denial checks. Never synthesize or modify source."
         ),
-        codex=_EXPLORER_PROBE_PROJECTION,
+        codex=CodexAgentProjectionDef(
+            model=EXPLORER_MODEL,
+            reasoning_effort=EXPLORER_REASONING_EFFORT,
+            sandbox_mode=EXPLORER_SANDBOX_MODE,
+            disabled_features=EXPLORER_DISABLED_FEATURES,
+            agents_enabled=False,
+            web_search=_EXPLORER_WEB_SEARCH_POLICY,
+        ),
     )
 
 

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -1067,26 +1067,24 @@ def _validate_existing_explorer_role_toml(
     require_binding_env: bool,
     explorer_mcp_transport: Mapping[str, object],
 ) -> dict[str, str] | None:
-    """Ensure a resumed role artifact still has the canonical non-secret projection."""
+    """Validate persisted role identity and recover its binding environment."""
     try:
         current = tomllib.loads(toml_path.read_text(encoding="utf-8"))
     except (OSError, tomllib.TOMLDecodeError) as exc:
         raise ValueError(f"invalid materialized explorer role {toml_path}: {exc}") from exc
-    expected = tomllib.loads(
-        _render_agent_toml(
-            definition,
-            explorer_mcp_transport=explorer_mcp_transport,
-            project_explorer_mcp=True,
-        )
-    )
-    current_server = current.get("mcp_servers", {}).get("autoskillit")
-    expected_server = expected["mcp_servers"]["autoskillit"]
+    servers = current.get("mcp_servers")
+    if not isinstance(servers, dict) or set(servers) != {"autoskillit"}:
+        raise ValueError(f"materialized explorer role missing MCP projection: {toml_path}")
+    current_server = servers.get("autoskillit")
     if not isinstance(current_server, dict):
         raise ValueError(f"materialized explorer role missing MCP projection: {toml_path}")
+    current_server = dict(current_server)
     current_env = current_server.pop("env", None)
-    expected_server.pop("env", None)
-    if current != expected:
-        raise ValueError(f"materialized explorer role does not match its AgentDef: {toml_path}")
+    expected_server = _explorer_mcp_projection(explorer_mcp_transport, None)
+    if current_server != expected_server:
+        raise ValueError(f"materialized explorer role has a divergent MCP projection: {toml_path}")
+    if current.get("name") != definition.name:
+        raise ValueError(f"materialized explorer role identity mismatch: {toml_path}")
     if current_env is None and not require_binding_env:
         return None
     if not isinstance(current_env, dict):

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -929,6 +929,8 @@ def _render_agent_toml(
         lines.append(
             f"model_reasoning_effort = {_format_toml_value(definition.codex.reasoning_effort)}"
         )
+    if definition.codex.web_search is not None:
+        lines.append(f"web_search = {_format_toml_value(definition.codex.web_search)}")
     body = (
         f"{definition.body}\n\n"
         f"AutoSkillit agent definition digest: {digest}\n\n"

--- a/tests/_codex_feature_policy.py
+++ b/tests/_codex_feature_policy.py
@@ -1,0 +1,10 @@
+"""Codex CLI feature names retired from generated test fixtures."""
+
+RETIRED_CODEX_FEATURES = (
+    "apps_mcp_path_override",
+    "js_repl",
+    "js_repl_tools_only",
+    "tool_search_always_defer_mcp_tools",
+    "web_search_cached",
+    "web_search_request",
+)

--- a/tests/core/test_agent_definition.py
+++ b/tests/core/test_agent_definition.py
@@ -26,6 +26,14 @@ from autoskillit.core import (
 pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 _EXPLORATION_BROKER_TOOLS = frozenset(f"{DIRECT_PREFIX}{tool}" for tool in EXPLORATION_TOOLS)
+_RETIRED_CODEX_FEATURES = (
+    "apps_mcp_path_override",
+    "js_repl",
+    "js_repl_tools_only",
+    "tool_search_always_defer_mcp_tools",
+    "web_search_cached",
+    "web_search_request",
+)
 
 
 @pytest.mark.parametrize(
@@ -49,6 +57,8 @@ def test_specialized_explorers_are_terminal_luna_broker_roles(
         definition.codex.reasoning_effort,
     ) == CODEX_EXPLORER_IDENTITY
     assert definition.codex.sandbox_mode == "read-only"
+    assert definition.codex.web_search == "disabled"
+    assert not (set(_RETIRED_CODEX_FEATURES) & set(definition.codex.disabled_features))
     assert not definition.codex.agents_enabled
     assert role_boundary in definition.body
     assert "spawn peers" in definition.body
@@ -81,6 +91,7 @@ def test_explicit_luna_projection_is_independent_from_claude_model(tmp_path: Pat
         "  sandbox_mode: read-only\n"
         "  disabled_features: [apps, shell_tool]\n"
         "  agents_enabled: false\n"
+        "  web_search: disabled\n"
         "---\n\n"
         "Return bounded evidence only.\n",
         encoding="utf-8",
@@ -93,6 +104,7 @@ def test_explicit_luna_projection_is_independent_from_claude_model(tmp_path: Pat
         sandbox_mode="read-only",
         disabled_features=("apps", "shell_tool"),
         agents_enabled=False,
+        web_search="disabled",
     )
 
 
@@ -157,6 +169,41 @@ def test_invalid_native_projection_fails_closed(projection: tuple[str, str, str]
         CodexAgentProjectionDef(*projection)
 
 
+@pytest.mark.parametrize("web_search", ["enabled", False, 1])
+def test_invalid_web_search_policy_fails_closed(web_search: object) -> None:
+    with pytest.raises(AgentDefinitionError, match="web_search must be 'disabled'"):
+        CodexAgentProjectionDef(
+            "gpt-5.6-luna",
+            "max",
+            "read-only",
+            web_search=web_search,  # type: ignore[arg-type]
+        )
+
+
+def test_web_search_policy_is_optional_and_positional_arguments_remain_stable() -> None:
+    assert CodexAgentProjectionDef(None, None, "read-only").web_search is None
+    projection = CodexAgentProjectionDef(
+        "gpt-5.6-luna",
+        "max",
+        "read-only",
+        ("apps",),
+        False,
+    )
+    assert projection.agents_enabled is False
+    assert projection.web_search is None
+
+
+@pytest.mark.parametrize("disabled_feature", (*_RETIRED_CODEX_FEATURES, "web_search"))
+def test_retired_codex_features_fail_closed(disabled_feature: str) -> None:
+    with pytest.raises(AgentDefinitionError, match="unsupported Codex disabled features"):
+        CodexAgentProjectionDef(
+            "gpt-5.6-luna",
+            "max",
+            "read-only",
+            (disabled_feature,),
+        )
+
+
 @pytest.mark.parametrize(
     "disabled_features",
     [
@@ -186,7 +233,6 @@ def test_extension_surface_disabled_features_are_valid_and_canonical() -> None:
         "plugins",
         "remote_plugin",
         "standalone_web_search",
-        "tool_search_always_defer_mcp_tools",
         "tool_suggest",
     )
     projection = CodexAgentProjectionDef(
@@ -297,7 +343,22 @@ def test_definition_digest_is_domain_separated_and_content_bound() -> None:
             agents_enabled=False,
         ),
     )
+    changed_web_search = AgentDef(
+        name=definition.name,
+        description=definition.description,
+        tools=definition.tools,
+        model=definition.model,
+        max_turns=definition.max_turns,
+        body=definition.body,
+        codex=CodexAgentProjectionDef(
+            "gpt-5.6-luna",
+            "max",
+            "read-only",
+            web_search="disabled",
+        ),
+    )
     assert digest.startswith("sha256:")
     assert digest != agent_definition_digest(changed)
     assert digest != agent_definition_digest(changed_features)
     assert digest != agent_definition_digest(changed_agents_enabled)
+    assert digest != agent_definition_digest(changed_web_search)

--- a/tests/core/test_agent_definition.py
+++ b/tests/core/test_agent_definition.py
@@ -22,18 +22,11 @@ from autoskillit.core import (
     load_bundled_agent_definitions,
     pkg_root,
 )
+from tests._codex_feature_policy import RETIRED_CODEX_FEATURES
 
 pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 _EXPLORATION_BROKER_TOOLS = frozenset(f"{DIRECT_PREFIX}{tool}" for tool in EXPLORATION_TOOLS)
-_RETIRED_CODEX_FEATURES = (
-    "apps_mcp_path_override",
-    "js_repl",
-    "js_repl_tools_only",
-    "tool_search_always_defer_mcp_tools",
-    "web_search_cached",
-    "web_search_request",
-)
 
 
 @pytest.mark.parametrize(
@@ -58,7 +51,7 @@ def test_specialized_explorers_are_terminal_luna_broker_roles(
     ) == CODEX_EXPLORER_IDENTITY
     assert definition.codex.sandbox_mode == "read-only"
     assert definition.codex.web_search == "disabled"
-    assert not (set(_RETIRED_CODEX_FEATURES) & set(definition.codex.disabled_features))
+    assert not (set(RETIRED_CODEX_FEATURES) & set(definition.codex.disabled_features))
     assert not definition.codex.agents_enabled
     assert role_boundary in definition.body
     assert "spawn peers" in definition.body
@@ -193,7 +186,7 @@ def test_web_search_policy_is_optional_and_positional_arguments_remain_stable() 
     assert projection.web_search is None
 
 
-@pytest.mark.parametrize("disabled_feature", (*_RETIRED_CODEX_FEATURES, "web_search"))
+@pytest.mark.parametrize("disabled_feature", (*RETIRED_CODEX_FEATURES, "web_search"))
 def test_retired_codex_features_fail_closed(disabled_feature: str) -> None:
     with pytest.raises(AgentDefinitionError, match="unsupported Codex disabled features"):
         CodexAgentProjectionDef(

--- a/tests/execution/backends/test_cli_conformance_probes.py
+++ b/tests/execution/backends/test_cli_conformance_probes.py
@@ -36,9 +36,12 @@ from autoskillit._probe_canary import (
 )
 from autoskillit.config import OutputBudgetConfig
 from autoskillit.core import (
+    BUNDLED_EXPLORER_ROLES,
     CLAUDE_CODE_CAPABILITIES,
     OUTPUT_DISCIPLINE_DIGEST,
     RESPONSE_BACKSTOP_EXEMPTION_REGISTRY,
+    agent_definition_digest,
+    load_agent_definitions,
     normalize_codex_cli_version,
     pkg_root,
 )
@@ -110,6 +113,18 @@ from tests.execution.backends._live_codex_parent import (
 )
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.large, pytest.mark.smoke]
+
+# Intentionally independent of production; checked against codex-rs/features/src/lib.rs,
+# codex-rs/features/src/legacy.rs, and the root web_search configuration schema.
+_FORBIDDEN_CHILD_FEATURES = {
+    "apps_mcp_path_override",
+    "js_repl",
+    "js_repl_tools_only",
+    "tool_search_always_defer_mcp_tools",
+    "web_search",
+    "web_search_cached",
+    "web_search_request",
+}
 
 _SKIP_REASON = (
     "Set CODEX_SMOKE_TEST=1 and one of: CODEX_API_KEY, OPENAI_API_KEY,"
@@ -760,6 +775,8 @@ def _configure_generated_child_session(
     assert agent_definition["model"] == EXPLORER_MODEL
     assert agent_definition["model_reasoning_effort"] == EXPLORER_REASONING_EFFORT
     assert agent_definition["sandbox_mode"] == EXPLORER_SANDBOX_MODE
+    assert agent_definition["web_search"] == "disabled"
+    assert not (_FORBIDDEN_CHILD_FEATURES & set(agent_definition.get("features", {})))
     assert agent_definition["features"] == {
         feature: False for feature in EXPLORER_DISABLED_FEATURES
     }
@@ -1089,6 +1106,17 @@ def _run_generated_child_probe(
     agent_role = EXPLORER_PROBE_ROLE
     definition = explorer_probe_agent_definition()
     definition_digest = explorer_probe_definition_digest()
+    bundled_explorers = tuple(
+        definition
+        for definition in load_agent_definitions(pkg_root() / "agents")
+        if definition.name in BUNDLED_EXPLORER_ROLES
+    )
+    assert definition_digest == agent_definition_digest(definition)
+    assert (
+        {item.codex.web_search for item in bundled_explorers}
+        == {definition.codex.web_search}
+        == {"disabled"}
+    )
     prepared = prepare_live_codex_parent(
         tmp_path=tmp_path,
         monkeypatch=monkeypatch,

--- a/tests/execution/backends/test_cli_conformance_probes.py
+++ b/tests/execution/backends/test_cli_conformance_probes.py
@@ -88,6 +88,7 @@ from autoskillit.hooks._capture_contract import (
     decode_capture_request,
     encode_capture_request,
 )
+from tests._codex_feature_policy import RETIRED_CODEX_FEATURES
 from tests.execution.backends._conformance_assertions import (
     assert_boundary_spill_behavior,
     assert_config_schema,
@@ -117,13 +118,8 @@ pytestmark = [pytest.mark.layer("execution"), pytest.mark.large, pytest.mark.smo
 # Intentionally independent of production; checked against codex-rs/features/src/lib.rs,
 # codex-rs/features/src/legacy.rs, and the root web_search configuration schema.
 _FORBIDDEN_CHILD_FEATURES = {
-    "apps_mcp_path_override",
-    "js_repl",
-    "js_repl_tools_only",
-    "tool_search_always_defer_mcp_tools",
+    *RETIRED_CODEX_FEATURES,
     "web_search",
-    "web_search_cached",
-    "web_search_request",
 }
 
 _SKIP_REASON = (

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import tomllib
 from collections.abc import Mapping
+from dataclasses import replace
 from enum import StrEnum
 from pathlib import Path
 from typing import cast
@@ -1928,6 +1929,31 @@ class TestCodexBackendSetupSessionDir:
         original_config = (self.session_dir / "config.toml").read_text(encoding="utf-8")
 
         with pytest.raises(ValueError, match="cover exactly the generated explorer roles"):
+            CodexBackend().setup_session_dir(
+                self.session_dir,
+                parent_sandbox_mode="read-only",
+                agent_defs=definitions,
+                explorer_binding_env=binding_envs,
+            )
+
+        assert (self.session_dir / "config.toml").read_text(encoding="utf-8") == original_config
+        assert not (self.session_dir / "agents").exists()
+
+    @pytest.mark.parametrize("role", sorted(BUNDLED_EXPLORER_ROLES))
+    def test_explorer_projection_rejects_missing_web_search_policy_before_mutation(
+        self, role: str
+    ) -> None:
+        canonical_definitions = self._explorer_definitions()
+        definitions = tuple(
+            replace(definition, codex=replace(definition.codex, web_search=None))
+            if definition.name == role
+            else definition
+            for definition in canonical_definitions
+        )
+        binding_envs = self._explorer_binding_envs(definitions, generation="first")
+        original_config = (self.session_dir / "config.toml").read_text(encoding="utf-8")
+
+        with pytest.raises(ValueError, match="must disable native web search"):
             CodexBackend().setup_session_dir(
                 self.session_dir,
                 parent_sandbox_mode="read-only",

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -1680,6 +1680,34 @@ class TestCodexBackendSetupSessionDir:
         }
         return {definition.name: dict(shared_binding) for definition in definitions}
 
+    @staticmethod
+    def _materialize_pre_change_explorer_roles(
+        session_dir: Path, definitions: tuple[AgentDef, ...]
+    ) -> None:
+        stale_features = (
+            "apps_mcp_path_override",
+            "js_repl",
+            "js_repl_tools_only",
+            "tool_search_always_defer_mcp_tools",
+            "web_search_cached",
+            "web_search_request",
+        )
+        for definition in definitions:
+            path = session_dir / "agents" / f"{definition.name}.toml"
+            text = path.read_text(encoding="utf-8")
+            assert 'web_search = "disabled"\n' in text
+            assert "[features]\n" in text
+            text = text.replace('web_search = "disabled"\n', "", 1)
+            text = text.replace(
+                "[features]\n",
+                "[features]\n"
+                + "\n".join(f"{feature} = false" for feature in stale_features)
+                + "\n",
+                1,
+            )
+            text = text.replace(agent_definition_digest(definition), "sha256:" + ("0" * 64))
+            path.write_text(text, encoding="utf-8")
+
     def test_happy_path_all_files_provisioned(self) -> None:
         self._write_all_source_files()
         CodexBackend().setup_session_dir(self.session_dir)
@@ -2012,6 +2040,86 @@ class TestCodexBackendSetupSessionDir:
         assert projected_bindings == [next(iter(second.values()))] * 3
         assert (self.session_dir / "config.toml").read_text(encoding="utf-8") != before_config
 
+    def test_refresh_replaces_pre_change_policy_and_is_idempotent(self) -> None:
+        definitions = self._explorer_definitions()
+        first = self._explorer_binding_envs(definitions, generation="first")
+        second = self._explorer_binding_envs(definitions, generation="second")
+        CodexBackend().setup_session_dir(
+            self.session_dir,
+            parent_sandbox_mode="read-only",
+            agent_defs=definitions,
+            explorer_binding_env=first,
+        )
+        self._materialize_pre_change_explorer_roles(self.session_dir, definitions)
+
+        refresh_explorer_binding_env(self.session_dir, second)
+
+        paths = [
+            self.session_dir / "config.toml",
+            *(
+                self.session_dir / "agents" / f"{definition.name}.toml"
+                for definition in definitions
+            ),
+        ]
+        first_refresh = {path.relative_to(self.session_dir): path.read_bytes() for path in paths}
+        for definition in definitions:
+            role_text = (self.session_dir / "agents" / f"{definition.name}.toml").read_text(
+                encoding="utf-8"
+            )
+            parsed = tomllib.loads(role_text)
+            assert parsed["web_search"] == "disabled"
+            assert agent_definition_digest(definition) in role_text
+            assert not {
+                "apps_mcp_path_override",
+                "js_repl",
+                "js_repl_tools_only",
+                "tool_search_always_defer_mcp_tools",
+                "web_search_cached",
+                "web_search_request",
+            } & set(parsed["features"])
+            assert parsed["mcp_servers"]["autoskillit"]["env"] == next(iter(second.values()))
+
+        refresh_explorer_binding_env(self.session_dir, second)
+
+        assert {
+            path.relative_to(self.session_dir): path.read_bytes() for path in paths
+        } == first_refresh
+
+    def test_refresh_rejects_wrong_role_name_with_valid_mcp_projection(self) -> None:
+        definitions = self._explorer_definitions()
+        first = self._explorer_binding_envs(definitions, generation="first")
+        second = self._explorer_binding_envs(definitions, generation="second")
+        CodexBackend().setup_session_dir(
+            self.session_dir,
+            parent_sandbox_mode="read-only",
+            agent_defs=definitions,
+            explorer_binding_env=first,
+        )
+        role_path = self.session_dir / "agents" / "repository-impact-profiler.toml"
+        role_path.write_text(
+            role_path.read_text(encoding="utf-8").replace(
+                'name = "repository-impact-profiler"', 'name = "tampered-role"', 1
+            ),
+            encoding="utf-8",
+        )
+        before = {
+            path.relative_to(self.session_dir): path.read_bytes()
+            for path in (
+                self.session_dir / "config.toml",
+                *(
+                    self.session_dir / "agents" / f"{definition.name}.toml"
+                    for definition in definitions
+                ),
+            )
+        }
+
+        with pytest.raises(ValueError, match="identity mismatch"):
+            refresh_explorer_binding_env(self.session_dir, second)
+
+        assert {
+            relative: (self.session_dir / relative).read_bytes() for relative in before
+        } == before
+
     def test_refresh_explorer_binding_env_prevalidation_preserves_old_bindings(self) -> None:
         definitions = self._explorer_definitions()
         first = self._explorer_binding_envs(definitions, generation="first")
@@ -2218,6 +2326,36 @@ class TestCodexBackendSetupSessionDir:
         for key, value in next(iter(binding_envs.values())).items():
             assert key not in parent_text
             assert value not in parent_text
+
+    def test_clear_replaces_pre_change_policy_while_scrubbing_bindings(self) -> None:
+        definitions = self._explorer_definitions()
+        binding_envs = self._explorer_binding_envs(definitions, generation="first")
+        CodexBackend().setup_session_dir(
+            self.session_dir,
+            parent_sandbox_mode="read-only",
+            agent_defs=definitions,
+            explorer_binding_env=binding_envs,
+        )
+        self._materialize_pre_change_explorer_roles(self.session_dir, definitions)
+
+        clear_explorer_binding_env(self.session_dir, frozenset(binding_envs))
+
+        for definition in definitions:
+            role_text = (self.session_dir / "agents" / f"{definition.name}.toml").read_text(
+                encoding="utf-8"
+            )
+            parsed = tomllib.loads(role_text)
+            assert parsed["web_search"] == "disabled"
+            assert agent_definition_digest(definition) in role_text
+            assert "env" not in parsed["mcp_servers"]["autoskillit"]
+            assert not {
+                "apps_mcp_path_override",
+                "js_repl",
+                "js_repl_tools_only",
+                "tool_search_always_defer_mcp_tools",
+                "web_search_cached",
+                "web_search_request",
+            } & set(parsed["features"])
 
     def test_clear_explorer_binding_env_is_idempotent_after_scrubbing(self) -> None:
         definitions = self._explorer_definitions()

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -53,6 +53,7 @@ from autoskillit.execution.backends.codex import (
     clear_explorer_binding_env,
     refresh_explorer_binding_env,
 )
+from tests._codex_feature_policy import RETIRED_CODEX_FEATURES
 from tests.execution.backends._plugin_binding import plugin_binding
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
@@ -1684,14 +1685,6 @@ class TestCodexBackendSetupSessionDir:
     def _materialize_pre_change_explorer_roles(
         session_dir: Path, definitions: tuple[AgentDef, ...]
     ) -> None:
-        stale_features = (
-            "apps_mcp_path_override",
-            "js_repl",
-            "js_repl_tools_only",
-            "tool_search_always_defer_mcp_tools",
-            "web_search_cached",
-            "web_search_request",
-        )
         for definition in definitions:
             path = session_dir / "agents" / f"{definition.name}.toml"
             text = path.read_text(encoding="utf-8")
@@ -1701,7 +1694,7 @@ class TestCodexBackendSetupSessionDir:
             text = text.replace(
                 "[features]\n",
                 "[features]\n"
-                + "\n".join(f"{feature} = false" for feature in stale_features)
+                + "\n".join(f"{feature} = false" for feature in RETIRED_CODEX_FEATURES)
                 + "\n",
                 1,
             )
@@ -2069,14 +2062,7 @@ class TestCodexBackendSetupSessionDir:
             parsed = tomllib.loads(role_text)
             assert parsed["web_search"] == "disabled"
             assert agent_definition_digest(definition) in role_text
-            assert not {
-                "apps_mcp_path_override",
-                "js_repl",
-                "js_repl_tools_only",
-                "tool_search_always_defer_mcp_tools",
-                "web_search_cached",
-                "web_search_request",
-            } & set(parsed["features"])
+            assert not set(RETIRED_CODEX_FEATURES) & set(parsed["features"])
             assert parsed["mcp_servers"]["autoskillit"]["env"] == next(iter(second.values()))
 
         refresh_explorer_binding_env(self.session_dir, second)
@@ -2348,14 +2334,7 @@ class TestCodexBackendSetupSessionDir:
             assert parsed["web_search"] == "disabled"
             assert agent_definition_digest(definition) in role_text
             assert "env" not in parsed["mcp_servers"]["autoskillit"]
-            assert not {
-                "apps_mcp_path_override",
-                "js_repl",
-                "js_repl_tools_only",
-                "tool_search_always_defer_mcp_tools",
-                "web_search_cached",
-                "web_search_request",
-            } & set(parsed["features"])
+            assert not set(RETIRED_CODEX_FEATURES) & set(parsed["features"])
 
     def test_clear_explorer_binding_env_is_idempotent_after_scrubbing(self) -> None:
         definitions = self._explorer_definitions()

--- a/tests/execution/backends/test_codex_explorer_registration.py
+++ b/tests/execution/backends/test_codex_explorer_registration.py
@@ -9,11 +9,22 @@ import pytest
 
 from autoskillit.core import (
     BUNDLED_EXPLORER_ROLES,
+    EXPLORATION_TOOLS,
     load_bundled_agent_definitions,
 )
 from autoskillit.execution.backends.codex import _generate_agent_tomls
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+_FORBIDDEN_CODEX_FEATURES = (
+    "apps_mcp_path_override",
+    "js_repl",
+    "js_repl_tools_only",
+    "tool_search_always_defer_mcp_tools",
+    "web_search",
+    "web_search_cached",
+    "web_search_request",
+)
 
 
 class TestExplorerRegistrationDerivesFromBindings:
@@ -29,6 +40,8 @@ class TestExplorerRegistrationDerivesFromBindings:
         all_defs = load_bundled_agent_definitions()
         non_explorer_count = sum(1 for d in all_defs if d.name not in BUNDLED_EXPLORER_ROLES)
         assert count == non_explorer_count
+        for path in (tmp_path / "agents").glob("*.toml"):
+            assert "web_search" not in tomllib.loads(path.read_text(encoding="utf-8"))
 
     def test_bound_includes_explorer_roles(self, tmp_path: Path) -> None:
         from autoskillit.execution.backends._codex.explorer_projection import (
@@ -76,4 +89,9 @@ class TestExplorerRegistrationDerivesFromBindings:
             )
             assert data["sandbox_mode"] == "read-only", (
                 f"explorer role {role} must have sandbox_mode=read-only"
+            )
+            assert data["web_search"] == "disabled"
+            assert not (set(_FORBIDDEN_CODEX_FEATURES) & set(data.get("features", {})))
+            assert frozenset(data["mcp_servers"]["autoskillit"]["enabled_tools"]) == frozenset(
+                EXPLORATION_TOOLS
             )

--- a/tests/execution/backends/test_codex_explorer_registration.py
+++ b/tests/execution/backends/test_codex_explorer_registration.py
@@ -13,18 +13,11 @@ from autoskillit.core import (
     load_bundled_agent_definitions,
 )
 from autoskillit.execution.backends.codex import _generate_agent_tomls
+from tests._codex_feature_policy import RETIRED_CODEX_FEATURES
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
-_FORBIDDEN_CODEX_FEATURES = (
-    "apps_mcp_path_override",
-    "js_repl",
-    "js_repl_tools_only",
-    "tool_search_always_defer_mcp_tools",
-    "web_search",
-    "web_search_cached",
-    "web_search_request",
-)
+_FORBIDDEN_CODEX_FEATURES = (*RETIRED_CODEX_FEATURES, "web_search")
 
 
 class TestExplorerRegistrationDerivesFromBindings:


### PR DESCRIPTION
## Summary

This PR replaces six stale Codex explorer feature declarations with the native root `web_search = "disabled"` policy. It adds a validated, digest-covered projection field, requires the policy at the canonical explorer binding boundary, and gives conformance tests an independent external-schema oracle. Refresh and credential cleanup now regenerate renewable role policy while preserving exact role identity and MCP binding validation. Validation passed with `pre-commit run --all-files` and `task test-check` (37,257 passed, 667 skipped, 27 xfailed).

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/rectify/rectify_codex_web_search_policy_2026-08-08_212258.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

Closes: https://github.com/TalonT-Org/AutoSkillit/issues/4491
