### PR TITLE
fix: retry Codex model-capacity failures

### DIFF
--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -120,6 +120,8 @@ class BackendCapabilities:
     triage_capable: bool = field(default=False)
     # Forward-declared: planned for context exhaustion handling
     supports_context_exhaustion_detection: bool = field(default=False)
+    # True when provider error evidence can identify exact model-capacity failures
+    supports_model_capacity_error_detection: bool = field(default=False)
     # False triggers pre-reveal kitchen at startup instead of notification-driven reveal
     supports_tool_list_changed: bool = field(default=True)
     # SKILL.md front-matter fields required by this backend
@@ -338,6 +340,7 @@ CLAUDE_CODE_CAPABILITIES: BackendCapabilities = BackendCapabilities(
     session_record_types=frozenset({"assistant"}),
     triage_capable=True,
     supports_context_exhaustion_detection=True,
+    supports_model_capacity_error_detection=False,
     supports_tool_list_changed=False,
     required_skill_fields=frozenset({"name", "description"}),
     required_session_files=frozenset(),

--- a/src/autoskillit/execution/backends/_codex_parse.py
+++ b/src/autoskillit/execution/backends/_codex_parse.py
@@ -305,6 +305,12 @@ def _scan_codex_ndjson(stdout: str) -> _CodexParseAccumulator:
                 acc.last_usage = usage
             if not acc.saw_failure:
                 acc.success = True
+        elif event_type == CodexEventType.ERROR:
+            error_message = obj.get("message")
+            if isinstance(error_message, str):
+                acc.error_message = error_message
+                acc.saw_failure = True
+                acc.success = False
         elif event_type == CodexEventType.TURN_FAILED:
             error = obj.get("error", {})
             if isinstance(error, dict):

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -1417,12 +1417,12 @@ class CodexBackend(BackendCmdBuilderBase):
             session_record_types=frozenset({"item.completed"}),
             triage_capable=False,
             supports_context_exhaustion_detection=False,
+            supports_model_capacity_error_detection=True,
             supports_tool_list_changed=False,
             required_skill_fields=frozenset({"name", "description"}),
             required_session_files=frozenset({"config.toml"}),
             session_dir_symlinks=frozenset({"sessions", "archived_sessions"}),
             applicable_guards=frozenset({"write_guard"}),
-            # Codex uses run_cmd instead of Write/Edit — those tools don't exist in Codex
             write_guard_tool_names=frozenset({"apply_patch", "Bash", "run_cmd"}),
             env_denylist_prefixes=CODEX_ENV_PREFIX_DENYLIST,
             min_version="0.130.0",

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -1422,7 +1422,7 @@ class CodexBackend(BackendCmdBuilderBase):
             required_skill_fields=frozenset({"name", "description"}),
             required_session_files=frozenset({"config.toml"}),
             session_dir_symlinks=frozenset({"sessions", "archived_sessions"}),
-            applicable_guards=frozenset({"write_guard"}),
+            applicable_guards=frozenset({"write_guard"}),  # run_cmd, not Write/Edit
             write_guard_tool_names=frozenset({"apply_patch", "Bash", "run_cmd"}),
             env_denylist_prefixes=CODEX_ENV_PREFIX_DENYLIST,
             min_version="0.130.0",

--- a/src/autoskillit/execution/session/_exit_classification.py
+++ b/src/autoskillit/execution/session/_exit_classification.py
@@ -50,6 +50,21 @@ _RATE_LIMIT_PATTERNS: tuple[re.Pattern[str], ...] = (
 _CODEX_CONTEXT_EXHAUSTION_PATTERN: re.Pattern[str] = re.compile(
     CODEX_CONTEXT_EXHAUSTION_MARKER, re.IGNORECASE
 )
+_MODEL_CAPACITY_ERROR: str = "Selected model is at capacity. Please try a different model."
+
+
+def _has_model_capacity_error(
+    session: ClaudeSessionResult,
+    result: SubprocessResult,
+    capabilities: BackendCapabilities,
+) -> bool:
+    """Match exact provider capacity evidence from backend-owned error channels."""
+    if not capabilities.supports_model_capacity_error_detection:
+        return False
+    expected = _MODEL_CAPACITY_ERROR.casefold()
+    return any(error.strip().casefold() == expected for error in session.errors) or any(
+        line.strip().casefold() == expected for line in result.stderr.splitlines()
+    )
 
 
 def _all_text_sources(
@@ -122,6 +137,8 @@ def classify_infra_exit(
         p.search(msg) for p in _RATE_LIMIT_PATTERNS for msg in _all_text_sources(session, result)
     ):
         return InfraExitCategory.RATE_LIMITED
+    if _has_model_capacity_error(session, result, capabilities):
+        return InfraExitCategory.API_ERROR
     if session._has_api_error() or any(p.search(result.stderr) for p in _KNOWN_API_ERROR_PATTERNS):
         return InfraExitCategory.API_ERROR
     # Separate guard: _has_api_error() scans message text for known patterns, but

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -96,6 +96,7 @@ def test_backend_capabilities_field_count():
         "food_truck_capable",
         "triage_capable",
         "supports_context_exhaustion_detection",
+        "supports_model_capacity_error_detection",
         "supports_tool_list_changed",
         "replay_capable",
         "record_capable",
@@ -157,6 +158,7 @@ def test_backend_capabilities_field_names_locked():
         "session_record_types",
         "triage_capable",
         "supports_context_exhaustion_detection",
+        "supports_model_capacity_error_detection",
         "required_skill_fields",
         "required_session_files",
         "session_dir_symlinks",
@@ -213,6 +215,7 @@ def test_claude_code_capabilities_field_values():
     assert CLAUDE_CODE_CAPABILITIES.session_record_types == frozenset({"assistant"})
     assert CLAUDE_CODE_CAPABILITIES.triage_capable is True
     assert CLAUDE_CODE_CAPABILITIES.supports_context_exhaustion_detection is True
+    assert CLAUDE_CODE_CAPABILITIES.supports_model_capacity_error_detection is False
     assert CLAUDE_CODE_CAPABILITIES.required_skill_fields == frozenset({"name", "description"})
     assert CLAUDE_CODE_CAPABILITIES.required_session_files == frozenset()
     assert CLAUDE_CODE_CAPABILITIES.session_dir_symlinks == frozenset()

--- a/tests/execution/backends/fixtures/codex_ndjson/event_error.json
+++ b/tests/execution/backends/fixtures/codex_ndjson/event_error.json
@@ -2,12 +2,16 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
+    "message": {
+      "type": "string"
+    },
     "type": {
       "const": "error",
       "type": "string"
     }
   },
   "required": [
+    "message",
     "type"
   ],
   "type": "object"

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -171,6 +171,9 @@ class TestCodexBackend:
     def test_capabilities_supports_context_exhaustion_detection_false(self) -> None:
         assert CodexBackend().capabilities.supports_context_exhaustion_detection is False
 
+    def test_capabilities_supports_model_capacity_error_detection_true(self) -> None:
+        assert CodexBackend().capabilities.supports_model_capacity_error_detection is True
+
     def test_capabilities_required_skill_fields(self) -> None:
         assert CodexBackend().capabilities.required_skill_fields == frozenset(
             {"name", "description"}

--- a/tests/execution/backends/test_codex_fixtures.py
+++ b/tests/execution/backends/test_codex_fixtures.py
@@ -13,6 +13,7 @@ from autoskillit.execution.process import _marker_is_standalone
 from tests.fixtures.codex import (
     CODEX_FIXTURE_MIN_VERSION,
     CODEX_SCHEMA_VERSION,
+    FLAT_ERROR_MODEL_CAPACITY,
     HAPPY_PATH_SINGLE_TURN,
     HAPPY_PATH_V0136,
     LARGE_EMBEDDED_PAYLOAD_V1,
@@ -21,6 +22,7 @@ from tests.fixtures.codex import (
     SESSION_WITH_MCP_TOOL_CALL,
     SESSION_WITH_REASONING,
     TURN_FAILED_ERROR,
+    TURN_FAILED_MODEL_CAPACITY,
     fixture_path,
 )
 from tests.fixtures.codex import (
@@ -30,11 +32,13 @@ from tests.fixtures.codex import (
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 ALL_FIXTURE_NAMES = [
+    FLAT_ERROR_MODEL_CAPACITY,
     HAPPY_PATH_SINGLE_TURN,
     HAPPY_PATH_V0136,
     MARKER_DETECTION_V0136,
     MULTI_TURN_WITH_COMPACTION,
     TURN_FAILED_ERROR,
+    TURN_FAILED_MODEL_CAPACITY,
     SESSION_WITH_REASONING,
     SESSION_WITH_MCP_TOOL_CALL,
 ]
@@ -59,7 +63,7 @@ class TestCodexFixturePackage:
             assert fixture_path(name).is_file()
 
     def test_all_exports_count(self) -> None:
-        assert len(CODEX_ALL) == 11
+        assert len(CODEX_ALL) == 13
 
     def test_large_embedded_payload_is_realistic_jsonl_data(self) -> None:
         path = fixture_path(LARGE_EMBEDDED_PAYLOAD_V1)

--- a/tests/execution/backends/test_codex_result_parser.py
+++ b/tests/execution/backends/test_codex_result_parser.py
@@ -35,6 +35,10 @@ def _turn_failed_code_line(code: str, message: str) -> str:
     return json.dumps({"type": "turn.failed", "error": {"message": message, "code": code}})
 
 
+def _flat_error_line(message: object) -> str:
+    return json.dumps({"type": "error", "message": message})
+
+
 def _item_completed_message_line(text: str) -> str:
     return json.dumps(
         {
@@ -217,6 +221,19 @@ class TestCodexResultParserStdout:
         result = parser.parse_stdout(ndjson)
         assert result.raw["subtype"] == "error_during_execution"
         assert result.success is False
+
+    def test_parse_stdout_flat_error_preserves_message(self) -> None:
+        result = CodexResultParser().parse_stdout(_flat_error_line("something broke"))
+
+        assert result.success is False
+        assert result.raw["subtype"] == "error_during_execution"
+        assert result.error == "something broke"
+
+    def test_parse_stdout_flat_error_non_string_message_is_unparseable(self) -> None:
+        result = CodexResultParser().parse_stdout(_flat_error_line({"detail": "bad"}))
+
+        assert result.success is False
+        assert result.raw["subtype"] == "unparseable"
 
     def test_parse_stdout_unparseable_returns_unparseable(self) -> None:
         parser = CodexResultParser()

--- a/tests/execution/backends/test_coding_agent_backend_conformance.py
+++ b/tests/execution/backends/test_coding_agent_backend_conformance.py
@@ -83,6 +83,7 @@ CAPABILITY_CLASSIFICATION: dict[str, Literal["REQUIRED", "OPTIONAL"]] = {
     "supports_claude_format_stdout": "REQUIRED",
     "supports_context_exhaustion_detection": "OPTIONAL",
     "supports_context_window_suffix": "OPTIONAL",
+    "supports_model_capacity_error_detection": "OPTIONAL",
     "supports_model_invocation_gating": "OPTIONAL",
     "supports_thinking_blocks": "OPTIONAL",
     "supports_tool_list_changed": "OPTIONAL",
@@ -426,6 +427,13 @@ class TestCodingAgentBackendConformance(BackendContractBase):
     def test_supports_context_exhaustion_detection_is_bool(self) -> None:
         """BackendCapabilities.supports_context_exhaustion_detection — capability is bool-typed."""
         assert isinstance(self.backend.capabilities.supports_context_exhaustion_detection, bool)
+
+    def test_supports_model_capacity_error_detection_is_bool(self) -> None:
+        """BackendCapabilities.supports_model_capacity_error_detection is bool-typed."""
+        assert isinstance(
+            self.backend.capabilities.supports_model_capacity_error_detection,
+            bool,
+        )
 
     def test_protected_recipe_delivery_capable_is_bool(self) -> None:
         """BackendCapabilities.protected_recipe_delivery_capable — protected host gate is bool."""

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -20,12 +20,14 @@ from autoskillit.core import (
     BackendCapabilities,
     CmdSpec,
     ExecutionIdentity,
+    InfraExitCategory,
     LaunchPreparation,
     LaunchResolutionRequest,
     LaunchSurface,
     LaunchValueSource,
     LaunchValueSourceKind,
     ResolvedLaunchContract,
+    RetryReason,
     SemanticLaunchPlan,
 )
 from autoskillit.core.types import SubprocessResult, TerminationReason
@@ -33,10 +35,28 @@ from autoskillit.execution.launch_resolution import DefaultLaunchResolver
 from autoskillit.execution.session import ClaudeSessionResult
 from autoskillit.execution.session._exit_classification import _CODEX_API_ERROR_PATTERNS
 from tests._helpers import make_tracing_config
+from tests.fixtures.codex import FLAT_ERROR_MODEL_CAPACITY, TURN_FAILED_MODEL_CAPACITY
 
 # Strip regex metacharacters (e.g. \b word boundaries) to yield plain test signal strings.
 CODEX_API_ERROR_SIGNAL_STRINGS: tuple[str, ...] = tuple(
     p.pattern.replace(r"\b", "") for p in _CODEX_API_ERROR_PATTERNS
+)
+
+CODEX_OBSERVED_PROVIDER_FAILURE_CASES: tuple[
+    tuple[str, str, InfraExitCategory, RetryReason], ...
+] = (
+    (
+        "turn.failed",
+        TURN_FAILED_MODEL_CAPACITY,
+        InfraExitCategory.API_ERROR,
+        RetryReason.RESUME,
+    ),
+    (
+        "error",
+        FLAT_ERROR_MODEL_CAPACITY,
+        InfraExitCategory.API_ERROR,
+        RetryReason.RESUME,
+    ),
 )
 
 

--- a/tests/execution/test_api_error_signal_invariants.py
+++ b/tests/execution/test_api_error_signal_invariants.py
@@ -1,9 +1,8 @@
-"""API error signal invariants: API errors must be detected regardless of channel.
+"""Consistency checks for API error patterns already registered in production.
 
-Architectural immunity test: classify_infra_exit must return API_ERROR (or
-RATE_LIMITED for rate-limit signals) whether the signal arrives via stderr
-(non-PTY) or via stdout/NDJSON assistant messages (PTY). Adding a new detection
-path that only reads one channel will cause this test to fail immediately.
+Each registered generic pattern must classify consistently across stderr (non-PTY)
+and stdout/NDJSON assistant messages (PTY). Observed provider failures that are not
+part of the generic pattern union have independent fixture-based acceptance tests.
 """
 
 from __future__ import annotations
@@ -41,8 +40,8 @@ _RATE_LIMIT_SIGNAL_STRINGS: frozenset[str] = frozenset(
     }
 )
 
-# All patterns that _KNOWN_API_ERROR_PATTERNS covers
-API_ERROR_SIGNALS: list[str] = [
+# Plain strings corresponding to patterns already in _KNOWN_API_ERROR_PATTERNS.
+REGISTERED_API_ERROR_SIGNALS: list[str] = [
     "overloaded",
     "529",
     "503",
@@ -104,10 +103,10 @@ def _make_result(
 # ---------------------------------------------------------------------------
 
 
-class TestApiErrorChannelInvariant:
-    """API errors must be classified as API_ERROR (or RATE_LIMITED) regardless of channel."""
+class TestRegisteredApiErrorChannelConsistency:
+    """Registered generic patterns classify consistently across supported channels."""
 
-    @pytest.mark.parametrize("signal", API_ERROR_SIGNALS)
+    @pytest.mark.parametrize("signal", REGISTERED_API_ERROR_SIGNALS)
     def test_api_error_in_assistant_messages(self, signal: str) -> None:
         """PTY mode: signal in assistant_messages (via stdout NDJSON) → correct category."""
         session = _make_api_error_session(signal)
@@ -116,7 +115,7 @@ class TestApiErrorChannelInvariant:
             signal
         )
 
-    @pytest.mark.parametrize("signal", API_ERROR_SIGNALS)
+    @pytest.mark.parametrize("signal", REGISTERED_API_ERROR_SIGNALS)
     def test_api_error_in_result_field(self, signal: str) -> None:
         """Signal in session.result (via parsed stdout) → correct category."""
         session = ClaudeSessionResult(
@@ -130,7 +129,7 @@ class TestApiErrorChannelInvariant:
             signal
         )
 
-    @pytest.mark.parametrize("signal", API_ERROR_SIGNALS)
+    @pytest.mark.parametrize("signal", REGISTERED_API_ERROR_SIGNALS)
     def test_api_error_in_errors_field(self, signal: str) -> None:
         """Signal in session.errors (via parsed stdout) → correct category."""
         session = ClaudeSessionResult(
@@ -145,7 +144,7 @@ class TestApiErrorChannelInvariant:
             signal
         )
 
-    @pytest.mark.parametrize("signal", API_ERROR_SIGNALS)
+    @pytest.mark.parametrize("signal", REGISTERED_API_ERROR_SIGNALS)
     def test_api_error_in_stderr_fallback(self, signal: str) -> None:
         """Stderr fallback: signal in result.stderr → correct category via classify_infra_exit."""
         session = ClaudeSessionResult(
@@ -165,10 +164,10 @@ class TestApiErrorChannelInvariant:
 # ---------------------------------------------------------------------------
 
 
-class TestApiErrorPtyModeEndToEnd:
-    """PTY-mode subprocess result (empty stderr, API error in stdout) → RESUME or RATE_LIMITED."""
+class TestRegisteredApiErrorPtyModeEndToEnd:
+    """Registered generic patterns route consistently through the Claude PTY path."""
 
-    @pytest.mark.parametrize("signal", API_ERROR_SIGNALS)
+    @pytest.mark.parametrize("signal", REGISTERED_API_ERROR_SIGNALS)
     def test_api_error_pty_mode_routes_correctly(self, signal: str) -> None:
         """Empty stderr + API error in stdout NDJSON → needs_retry=True, correct reason."""
 

--- a/tests/execution/test_exit_classification.py
+++ b/tests/execution/test_exit_classification.py
@@ -13,23 +13,29 @@ from autoskillit.core.types import (
     ChannelConfirmation,
     CliSubtype,
     InfraExitCategory,
+    RetryReason,
     SubprocessResult,
     TerminationReason,
 )
 from autoskillit.execution.backends._codex_parse import CodexResultParser
+from autoskillit.execution.backends.codex import CodexBackend
 from autoskillit.execution.headless._headless_evidence import _adapt_agent_result
 from autoskillit.execution.session._exit_classification import (
-    _CODEX_API_ERROR_PATTERNS,
     _RATE_LIMIT_PATTERNS,
     classify_infra_exit,
     is_signal_death_code,
 )
 from autoskillit.execution.session._session_model import ClaudeSessionResult
-from tests.execution.conftest import CODEX_API_ERROR_SIGNAL_STRINGS
+from tests.execution.conftest import (
+    CODEX_API_ERROR_SIGNAL_STRINGS,
+    CODEX_OBSERVED_PROVIDER_FAILURE_CASES,
+)
+from tests.fixtures.codex import fixture_path
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 _CAPS = CLAUDE_CODE_CAPABILITIES
+_MODEL_CAPACITY_MESSAGE = "Selected model is at capacity. Please try a different model."
 
 # CODEX signals that do NOT match rate-limit patterns (must still classify as API_ERROR).
 _NON_RATE_LIMIT_CODEX_SIGNALS: tuple[str, ...] = tuple(
@@ -395,6 +401,140 @@ class TestContextExhaustionCapabilityGate:
             == InfraExitCategory.CONTEXT_EXHAUSTED
         )
 
+
+class TestModelCapacityClassification:
+    @pytest.mark.parametrize(
+        "message",
+        [_MODEL_CAPACITY_MESSAGE, _MODEL_CAPACITY_MESSAGE.swapcase()],
+        ids=["exact", "case-insensitive"],
+    )
+    def test_enabled_capability_matches_exact_error(self, message: str) -> None:
+        session = ClaudeSessionResult(
+            subtype=CliSubtype.EMPTY_OUTPUT,
+            is_error=True,
+            result="",
+            session_id="s1",
+            errors=[message],
+        )
+        caps = BackendCapabilities(supports_model_capacity_error_detection=True)
+
+        assert (
+            classify_infra_exit(session, _sr(returncode=1), capabilities=caps)
+            == InfraExitCategory.API_ERROR
+        )
+
+    def test_enabled_capability_matches_individual_stderr_line(self) -> None:
+        session = ClaudeSessionResult(
+            subtype=CliSubtype.EMPTY_OUTPUT,
+            is_error=True,
+            result="",
+            session_id="s1",
+        )
+        result = _sr(returncode=1, stderr=f"diagnostic\n  {_MODEL_CAPACITY_MESSAGE}  \nfooter")
+        caps = BackendCapabilities(supports_model_capacity_error_detection=True)
+
+        assert (
+            classify_infra_exit(session, result, capabilities=caps) == InfraExitCategory.API_ERROR
+        )
+
+    @pytest.mark.parametrize(
+        "assistant_messages,result_text",
+        [([_MODEL_CAPACITY_MESSAGE], ""), ([], _MODEL_CAPACITY_MESSAGE)],
+        ids=["assistant-messages", "result"],
+    )
+    def test_non_error_prose_does_not_supply_capacity_evidence(
+        self,
+        assistant_messages: list[str],
+        result_text: str,
+    ) -> None:
+        session = ClaudeSessionResult(
+            subtype=CliSubtype.EMPTY_OUTPUT,
+            is_error=True,
+            result=result_text,
+            session_id="s1",
+            assistant_messages=assistant_messages,
+        )
+        caps = BackendCapabilities(supports_model_capacity_error_detection=True)
+
+        assert (
+            classify_infra_exit(session, _sr(returncode=1), capabilities=caps)
+            == InfraExitCategory.COMPLETED
+        )
+
+    def test_disabled_capability_ignores_error_and_stderr_evidence(self) -> None:
+        session = ClaudeSessionResult(
+            subtype=CliSubtype.EMPTY_OUTPUT,
+            is_error=True,
+            result="",
+            session_id="s1",
+            errors=[_MODEL_CAPACITY_MESSAGE],
+        )
+        result = _sr(returncode=1, stderr=_MODEL_CAPACITY_MESSAGE)
+
+        assert (
+            classify_infra_exit(session, result, capabilities=BackendCapabilities())
+            == InfraExitCategory.COMPLETED
+        )
+
+    @pytest.mark.parametrize(
+        "message",
+        [f"prefix {_MODEL_CAPACITY_MESSAGE}", "worker pool is at capacity"],
+    )
+    def test_surrounding_or_benign_capacity_text_does_not_match(self, message: str) -> None:
+        session = ClaudeSessionResult(
+            subtype=CliSubtype.EMPTY_OUTPUT,
+            is_error=True,
+            result="",
+            session_id="s1",
+            errors=[message],
+        )
+        caps = BackendCapabilities(supports_model_capacity_error_detection=True)
+
+        assert (
+            classify_infra_exit(session, _sr(returncode=1), capabilities=caps)
+            == InfraExitCategory.COMPLETED
+        )
+
+    @pytest.mark.parametrize(
+        "event_type,fixture_name,expected_category,_expected_retry_reason",
+        CODEX_OBSERVED_PROVIDER_FAILURE_CASES,
+        ids=[case[0] for case in CODEX_OBSERVED_PROVIDER_FAILURE_CASES],
+    )
+    def test_observed_provider_fixture_classifies_from_parser_evidence(
+        self,
+        event_type: str,
+        fixture_name: str,
+        expected_category: InfraExitCategory,
+        _expected_retry_reason: RetryReason,
+    ) -> None:
+        payload = fixture_path(fixture_name).read_text()
+        assert json.loads(payload.splitlines()[-1])["type"] == event_type
+        session = _adapt_agent_result(CodexResultParser().parse_stdout(payload, exit_code=1))
+
+        assert (
+            classify_infra_exit(
+                session,
+                _sr(returncode=1),
+                capabilities=CodexBackend().capabilities,
+            )
+            == expected_category
+        )
+
+    def test_unrelated_flat_error_remains_terminal(self) -> None:
+        payload = json.dumps({"type": "error", "message": "permission denied"})
+        session = _adapt_agent_result(CodexResultParser().parse_stdout(payload, exit_code=1))
+
+        assert (
+            classify_infra_exit(
+                session,
+                _sr(returncode=1),
+                capabilities=CodexBackend().capabilities,
+            )
+            == InfraExitCategory.COMPLETED
+        )
+
+
+class TestContextExhaustionCapabilityStderrGate:
     def test_capability_false_suppresses_context_exhausted_via_stderr(self):
         """capability=False + Codex stderr pattern → NOT CONTEXT_EXHAUSTED."""
         caps = BackendCapabilities(supports_context_exhaustion_detection=False)
@@ -671,8 +811,3 @@ def test_positive_signal_death_codes_classified_as_process_killed(returncode: in
 def test_is_signal_death_code_boundary_cases(returncode: int, expected: bool) -> None:
     """is_signal_death_code boundary cases (Test 1B)."""
     assert is_signal_death_code(returncode) is expected
-
-
-def test_codex_api_error_patterns_count() -> None:
-    """Structural test: _CODEX_API_ERROR_PATTERNS has exactly 4 entries."""
-    assert len(_CODEX_API_ERROR_PATTERNS) == 4

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -18,6 +18,7 @@ from autoskillit.core.types import (
     TerminationReason,
 )
 from autoskillit.execution.backends.claude import ClaudeCodeBackend
+from autoskillit.execution.backends.codex import CodexBackend
 from autoskillit.execution.commands import _ensure_skill_prefix
 from autoskillit.execution.headless import (
     NormalizedMessages,
@@ -27,6 +28,7 @@ from autoskillit.execution.headless import (
 )
 from tests.conftest import _make_result, _make_timeout_result
 from tests.execution.conftest import _mock_backend, _sr, _success_session_json
+from tests.fixtures.codex import TURN_FAILED_MODEL_CAPACITY, fixture_path
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -2918,6 +2920,29 @@ class TestRetryBudgetEnforcement:
             max_consecutive_retries=3,
             backend=ClaudeCodeBackend(),
         )
+        assert sr.needs_retry is False
+        assert sr.retry_reason == RetryReason.BUDGET_EXHAUSTED
+
+    def test_budget_caps_codex_model_capacity_resume(self) -> None:
+        skill_command = "/autoskillit:implement-worktree-no-merge"
+        audit = self._make_audit_with_failures(skill_command, 3)
+        result = SubprocessResult(
+            returncode=1,
+            stdout=fixture_path(TURN_FAILED_MODEL_CAPACITY).read_text(),
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+        )
+
+        sr = _build_skill_result(
+            result,
+            skill_command=skill_command,
+            audit=audit,  # type: ignore[arg-type]
+            max_consecutive_retries=3,
+            supports_claude_format_stdout=False,
+            backend=CodexBackend(),
+        )
+
         assert sr.needs_retry is False
         assert sr.retry_reason == RetryReason.BUDGET_EXHAUSTED
 

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -14,6 +14,7 @@ from autoskillit.core import AGENT_BACKEND_CLAUDE_CODE, BackendCapabilities
 from autoskillit.core.types import (
     AgentSessionResult,
     CliSubtype,
+    InfraExitCategory,
     KillReason,
     RetryReason,
     SkillResult,
@@ -36,7 +37,12 @@ from autoskillit.execution.headless._headless_evidence import (
 )
 from autoskillit.execution.session import ClaudeSessionResult
 from autoskillit.execution.session._session_outcome import _compute_outcome
-from tests.execution.conftest import _make_tool_use_line, _sr, _success_session_json
+from tests.execution.conftest import (
+    CODEX_OBSERVED_PROVIDER_FAILURE_CASES,
+    _make_tool_use_line,
+    _sr,
+    _success_session_json,
+)
 from tests.fixtures.codex import (
     HAPPY_PATH_SINGLE_TURN,
     HAPPY_PATH_V0136,
@@ -1180,6 +1186,42 @@ class TestCodexPipelineTurnFailed:
     def test_failure_token_usage_none(self):
         sr = self._build()
         assert sr.token_usage is None
+
+
+class TestCodexModelCapacityFailures:
+    @pytest.mark.parametrize(
+        "event_type,fixture_name,expected_category,expected_retry_reason",
+        CODEX_OBSERVED_PROVIDER_FAILURE_CASES,
+        ids=[case[0] for case in CODEX_OBSERVED_PROVIDER_FAILURE_CASES],
+    )
+    def test_exit_code_one_routes_observed_capacity_failure_to_resume(
+        self,
+        event_type: str,
+        fixture_name: str,
+        expected_category: InfraExitCategory,
+        expected_retry_reason: RetryReason,
+    ) -> None:
+        content = fixture_path(fixture_name).read_text()
+        assert json.loads(content.splitlines()[-1])["type"] == event_type
+        result = _codex_subprocess_result(
+            content,
+            returncode=1,
+            termination=TerminationReason.NATURAL_EXIT,
+            kill_reason=KillReason.NATURAL_EXIT,
+        )
+
+        skill_result = _build_skill_result(
+            result,
+            supports_claude_format_stdout=False,
+            backend=CodexBackend(),
+        )
+
+        assert skill_result.success is False
+        assert skill_result.is_error is True
+        assert skill_result.needs_retry is True
+        assert skill_result.retry_reason == expected_retry_reason
+        assert skill_result.infra.exit_category == expected_category.value
+        assert skill_result.subtype == CliSubtype.ERROR_DURING_EXECUTION.value
 
 
 class TestCodexPipelineTerminationBranches:

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -1196,13 +1196,12 @@ class TestCodexModelCapacityFailures:
     )
     def test_exit_code_one_routes_observed_capacity_failure_to_resume(
         self,
-        event_type: str,
+        _event_type: str,
         fixture_name: str,
         expected_category: InfraExitCategory,
         expected_retry_reason: RetryReason,
     ) -> None:
         content = fixture_path(fixture_name).read_text()
-        assert json.loads(content.splitlines()[-1])["type"] == event_type
         result = _codex_subprocess_result(
             content,
             returncode=1,

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -1190,7 +1190,7 @@ class TestCodexPipelineTurnFailed:
 
 class TestCodexModelCapacityFailures:
     @pytest.mark.parametrize(
-        "event_type,fixture_name,expected_category,expected_retry_reason",
+        "_event_type,fixture_name,expected_category,expected_retry_reason",
         CODEX_OBSERVED_PROVIDER_FAILURE_CASES,
         ids=[case[0] for case in CODEX_OBSERVED_PROVIDER_FAILURE_CASES],
     )

--- a/tests/fixtures/codex/__init__.py
+++ b/tests/fixtures/codex/__init__.py
@@ -9,10 +9,12 @@ CODEX_FIXTURE_MIN_VERSION: str = "0.130.0"
 
 HAPPY_PATH_SINGLE_TURN: str = "happy_path_single_turn_v0133.ndjson"
 HAPPY_PATH_V0136: str = "happy_path_v0136.ndjson"
+FLAT_ERROR_MODEL_CAPACITY: str = "flat_error_model_capacity_v0133.ndjson"
 MARKER_DETECTION_V0136: str = "marker_detection_v0136.ndjson"
 LARGE_EMBEDDED_PAYLOAD_V1: str = "large_embedded_payload_v1.jsonl"
 MULTI_TURN_WITH_COMPACTION: str = "multi_turn_with_compaction_v0133.ndjson"
 TURN_FAILED_ERROR: str = "turn_failed_error_v0133.ndjson"
+TURN_FAILED_MODEL_CAPACITY: str = "turn_failed_model_capacity_v0133.ndjson"
 SESSION_WITH_REASONING: str = "session_with_reasoning_v0133.ndjson"
 SESSION_WITH_MCP_TOOL_CALL: str = "session_with_mcp_tool_call_v0133.ndjson"
 
@@ -25,6 +27,7 @@ def fixture_path(name: str) -> Path:
 __all__ = [
     "CODEX_FIXTURE_MIN_VERSION",
     "CODEX_SCHEMA_VERSION",
+    "FLAT_ERROR_MODEL_CAPACITY",
     "HAPPY_PATH_SINGLE_TURN",
     "HAPPY_PATH_V0136",
     "LARGE_EMBEDDED_PAYLOAD_V1",
@@ -33,5 +36,6 @@ __all__ = [
     "SESSION_WITH_MCP_TOOL_CALL",
     "SESSION_WITH_REASONING",
     "TURN_FAILED_ERROR",
+    "TURN_FAILED_MODEL_CAPACITY",
     "fixture_path",
 ]

--- a/tests/fixtures/codex/flat_error_model_capacity_v0133.ndjson
+++ b/tests/fixtures/codex/flat_error_model_capacity_v0133.ndjson
@@ -1,0 +1,3 @@
+{"type":"thread.started","thread_id":"thread_capacity_flat_error"}
+{"type":"turn.started"}
+{"type":"error","message":"Selected model is at capacity. Please try a different model."}

--- a/tests/fixtures/codex/turn_failed_model_capacity_v0133.ndjson
+++ b/tests/fixtures/codex/turn_failed_model_capacity_v0133.ndjson
@@ -1,0 +1,3 @@
+{"type":"thread.started","thread_id":"thread_capacity_turn_failed"}
+{"type":"turn.started"}
+{"type":"turn.failed","error":{"message":"Selected model is at capacity. Please try a different model."}}


### PR DESCRIPTION
## Summary

- normalize flat Codex `error` events into the existing parser failure path
- classify the exact model-capacity provider error only for capable backends and provider-owned error channels
- cover `turn.failed` and flat `error` exit-code-1 routing, capability gating, malformed events, and retry-budget enforcement

## Verification

- `pre-commit run --all-files` passed
- `task test-check`: 37,256 passed; the fixture-count and source-line-limit failures were corrected afterward; `test_sigterm_writes_scenario_json` timed out waiting for its subprocess readiness sentinel

Closes #4226

Issue: https://github.com/TalonT-Org/AutoSkillit/issues/4226
