### PR TITLE
Rectify: Shell Capture Execution Authority

### DIFF
--- a/src/autoskillit/hooks/_capture_artifacts.py
+++ b/src/autoskillit/hooks/_capture_artifacts.py
@@ -699,7 +699,7 @@ def run_capture(
                 raise CaptureSetupError.unknown("runner observation recording failed")
         if effective_direct:
             try:
-                spawned = _spawn_bash(anchor, bash_path, command, capture_output=False)
+                spawned = _spawn_bash(bash_path, command, capture_output=False)
                 process = _own_spawned_process(spawned, capture_output=False)
                 return _normalized_returncode(process.wait())
             except BaseException as exc:
@@ -739,7 +739,7 @@ def run_capture(
         finalized_capture: FinalizedCapture | None = None
         failure_stage = "capture process spawn"
         try:
-            spawned = _spawn_bash(anchor, bash_path, command, capture_output=True)
+            spawned = _spawn_bash(bash_path, command, capture_output=True)
             process = _own_spawned_process(spawned, capture_output=True)
             failure_stage = "capture readback"
             result = _drain_capture(process, artifact_writer_fd, policy.inline_bytes)

--- a/src/autoskillit/hooks/_capture_process.py
+++ b/src/autoskillit/hooks/_capture_process.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
         _READ_FLAGS,
         _UNTRUSTED_WRITE_BITS,
         CaptureSetupError,
-        ProjectAnchor,
     )
     from autoskillit.hooks._capture._snapshot import CaptureMeasurement
     from autoskillit.hooks._capture_contract import PROTECTED_CAPTURE_ENV_VARS
@@ -38,7 +37,6 @@ elif __package__:
         _READ_FLAGS,
         _UNTRUSTED_WRITE_BITS,
         CaptureSetupError,
-        ProjectAnchor,
     )
     from ._capture._snapshot import CaptureMeasurement
     from ._capture_contract import PROTECTED_CAPTURE_ENV_VARS
@@ -49,7 +47,6 @@ else:
         _READ_FLAGS,
         _UNTRUSTED_WRITE_BITS,
         CaptureSetupError,
-        ProjectAnchor,
     )
     from _capture._snapshot import CaptureMeasurement
     from _capture_contract import PROTECTED_CAPTURE_ENV_VARS
@@ -379,14 +376,13 @@ def _scrubbed_user_environment() -> dict[str, str]:
 
 
 def _spawn_bash(
-    anchor: ProjectAnchor,
     bash_path: str,
     command: str,
     *,
     capture_output: bool,
 ) -> subprocess.Popen[bytes]:
     try:
-        original_cwd_fd = os.open(
+        inherited_cwd_fd = os.open(
             ".",
             _DIRECTORY_FLAGS & ~getattr(os, "O_NOFOLLOW", 0),
         )
@@ -396,7 +392,7 @@ def _spawn_bash(
     process: subprocess.Popen[bytes] | None = None
     restore_error: OSError | None = None
     try:
-        os.fchdir(anchor.fd)
+        os.fchdir(inherited_cwd_fd)
         process = subprocess.Popen(
             [bash_path, "-c", _wrap_user_command(command)],
             stdout=subprocess.PIPE if capture_output else None,
@@ -415,10 +411,10 @@ def _spawn_bash(
         raise CaptureSetupError.from_os_error(exc, "cannot spawn capture shell") from exc
     finally:
         try:
-            os.fchdir(original_cwd_fd)
+            os.fchdir(inherited_cwd_fd)
         except OSError as exc:
             restore_error = exc
-        os.close(original_cwd_fd)
+        os.close(inherited_cwd_fd)
 
     if restore_error is not None:
         if process is not None:

--- a/tests/execution/backends/test_cli_conformance_probes.py
+++ b/tests/execution/backends/test_cli_conformance_probes.py
@@ -81,13 +81,18 @@ from autoskillit.execution.backends._probe_cache import (
 )
 from autoskillit.execution.backends.codex import CodexBackend
 from autoskillit.hook_registry import generate_hooks_json
-from autoskillit.hooks._capture_artifacts import run_capture
+from autoskillit.hooks._capture_artifacts import (
+    CAPTURE_PATH_COMPONENTS,
+    open_capture_lifecycle,
+    run_capture,
+)
 from autoskillit.hooks._capture_contract import (
     CAPTURE_REQUEST_PROTOCOL_VERSION,
     CaptureRequest,
     decode_capture_request,
     encode_capture_request,
 )
+from autoskillit.hooks._capture_lifecycle import CaptureState
 from tests._codex_feature_policy import RETIRED_CODEX_FEATURES
 from tests.execution.backends._conformance_assertions import (
     assert_boundary_spill_behavior,
@@ -1665,7 +1670,7 @@ def _run_shell_capture_probe(backend: str, tmp_path: Path) -> _DenyRoundTripOutp
     )
 
 
-def _parse_capture_runner(command: str) -> tuple[str, str] | None:
+def _parse_capture_runner(command: str) -> CaptureRequest | None:
     try:
         argv = shlex.split(command.splitlines()[-1])
         runner_index = next(
@@ -1676,7 +1681,7 @@ def _parse_capture_runner(command: str) -> tuple[str, str] | None:
         request = decode_capture_request(argv[runner_index + 1])
         if request.action != "run" or request.command is None:
             return None
-        return request.command, request.capture_id
+        return request
     except (
         StopIteration,
         IndexError,
@@ -1685,14 +1690,9 @@ def _parse_capture_runner(command: str) -> tuple[str, str] | None:
         return None
 
 
-def _assert_shell_capture_round_trip(output: _DenyRoundTripOutput) -> None:
-    denial_reason = _policy_denial_reason(output.transcript)
-    assert denial_reason is None, (
-        "Policy denial detected in shell-capture transcript. "
-        f"The generated harness was rejected by Codex's exec-policy engine: {denial_reason}"
-    )
+def _completed_command_execution_items(transcript: str) -> list[dict[str, object]]:
     completed_items: list[dict[str, object]] = []
-    for line in output.transcript.splitlines():
+    for line in transcript.splitlines():
         try:
             event = json.loads(line)
         except (json.JSONDecodeError, TypeError):
@@ -1704,7 +1704,16 @@ def _assert_shell_capture_round_trip(output: _DenyRoundTripOutput) -> None:
             continue
         if item.get("status") == "completed":
             completed_items.append(item)
+    return completed_items
 
+
+def _assert_shell_capture_round_trip(output: _DenyRoundTripOutput) -> None:
+    denial_reason = _policy_denial_reason(output.transcript)
+    assert denial_reason is None, (
+        "Policy denial detected in shell-capture transcript. "
+        f"The generated harness was rejected by Codex's exec-policy engine: {denial_reason}"
+    )
+    completed_items = _completed_command_execution_items(output.transcript)
     assert completed_items, (
         "No completed command_execution event found — the rewritten command did not execute"
     )
@@ -1717,9 +1726,9 @@ def _assert_shell_capture_round_trip(output: _DenyRoundTripOutput) -> None:
     ]
     assert parsed, "No completed rewritten command invoked the isolated shell-capture runner"
     matching = [
-        (capture_id, item)
-        for (command, capture_id), item in parsed
-        if command == _OUTPUT_BUDGET_CANARY_COMMAND
+        (request.capture_id, item)
+        for request, item in parsed
+        if request.command == _OUTPUT_BUDGET_CANARY_COMMAND
     ]
     assert len(matching) == 1, (
         "The completed runner invocation did not transport the canary command"
@@ -1940,6 +1949,97 @@ def _exercise_shell_capture_probe(backend: str, tmp_path: Path) -> None:
 class TestCodexShellCaptureRoundTrip:
     def test_hook_fires_and_command_is_rewritten(self, tmp_path: Path) -> None:
         _exercise_shell_capture_probe("codex", tmp_path)
+
+
+@_skip_unless_codex_output_budget_smoke
+@pytest.mark.timeout(1200)
+def test_codex_shell_capture_preserves_divergent_execution_workdir(
+    tmp_path: Path,
+) -> None:
+    probe_root = tmp_path / "divergent-workdir"
+    workspace = probe_root / "workspace"
+    execution_dir = workspace / "execution"
+    execution_dir.mkdir(parents=True)
+    env, codex_home, _claude_config = _isolated_cli_env(probe_root, workspace)
+    env["AUTOSKILLIT_AGENT_BACKEND"] = "codex"
+    sync_hooks_to_codex_config(config_path=codex_home / "config.toml")
+    init_result = subprocess.run(  # noqa: S603
+        ["git", "init", "-q"],
+        cwd=workspace,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if init_result.returncode != 0:
+        raise OSError(f"isolated git init failed: {init_result.stderr}")
+
+    probe_command = (
+        "printf 'pwd=%s\\n' \"$PWD\"; "
+        "printf execution > execution-sentinel; "
+        'python3 -c "import os; '
+        "os.write(1, b'execution_authority_probe ' * 1000)\""
+    )
+    prompt = (
+        "This is a hook conformance probe. Use the shell tool exactly once with "
+        f"workdir set to the absolute path {str(execution_dir)!r}. Run exactly "
+        f"`{probe_command}` without adding cd or changing the command. After the tool "
+        "completes, stop without running any other tool."
+    )
+    timeout = int(os.environ.get("OUTPUT_BUDGET_HOOK_SMOKE_TIMEOUT", "120"))
+    result = subprocess.run(  # noqa: S603
+        ["codex", "exec", "--json", "--sandbox", "workspace-write", prompt],
+        cwd=workspace,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    transcript = result.stdout + "\n" + result.stderr
+    if result.returncode != 0 and _policy_denial_reason(transcript) is None:
+        raise OSError(
+            "codex divergent-workdir shell-capture probe failed "
+            f"with rc={result.returncode}: {transcript}"
+        )
+
+    matching: list[tuple[CaptureRequest, dict[str, object]]] = []
+    for item in _completed_command_execution_items(transcript):
+        command = item.get("command")
+        if not isinstance(command, str) or "autoskillit-shell-capture" not in command:
+            continue
+        request = _parse_capture_runner(command)
+        if request is not None and request.command == probe_command:
+            matching.append((request, item))
+    assert len(matching) == 1
+    request, completed_item = matching[0]
+    assert completed_item.get("workdir") == str(execution_dir.resolve())
+    assert request.command == probe_command
+    assert request.cwd == str(workspace)
+
+    sentinel = execution_dir / "execution-sentinel"
+    assert sentinel.read_text() == "execution"
+    assert os.path.samefile(sentinel.parent, execution_dir)
+    assert not (workspace / "execution-sentinel").exists()
+
+    completed_output = completed_item.get("aggregated_output")
+    assert isinstance(completed_output, str)
+    authority = assert_shell_capture_marker_authority(
+        completed_output,
+        workspace,
+        request.capture_id,
+        sentinels=(b"execution_authority_probe",),
+    )
+    assert f"pwd={execution_dir.resolve()}\n".encode() in authority.capture_bytes
+    capture_root = workspace.joinpath(*CAPTURE_PATH_COMPONENTS)
+    assert (capture_root / f"shell_{request.capture_id}.log").is_file()
+    assert (capture_root / ".capture-lifecycle.ledger").is_file()
+    assert (capture_root / ".capture-lifecycle.lock").is_file()
+    assert not list(capture_root.glob(f".capture-staging-{request.capture_id}-*"))
+    with open_capture_lifecycle(str(workspace), create=False) as lifecycle:
+        record = lifecycle.get_record(request.capture_id)
+    assert record is not None
+    assert record.state is CaptureState.FINALIZED
+    assert not execution_dir.joinpath(*CAPTURE_PATH_COMPONENTS).exists()
 
 
 _SOURCE_SPILL_THRESHOLD = OutputBudgetConfig().inline_max_chars

--- a/tests/hooks/test_capture_artifacts.py
+++ b/tests/hooks/test_capture_artifacts.py
@@ -2895,10 +2895,14 @@ def test_artifact_write_failure_emits_failure_marker(
     captured = capfd.readouterr()
     assert sentinel.read_text() == "ran"
     raw_failure = next(
-        line
-        for line in captured.err.splitlines()
-        if line.startswith("[AutoSkillit shell capture failure v3:")
+        (
+            line
+            for line in captured.err.splitlines()
+            if line.startswith("[AutoSkillit shell capture failure v3:")
+        ),
+        None,
     )
+    assert raw_failure is not None
     payload = json.loads(
         raw_failure.removeprefix("[AutoSkillit shell capture failure v3:").removesuffix("]")
     )

--- a/tests/hooks/test_capture_artifacts.py
+++ b/tests/hooks/test_capture_artifacts.py
@@ -1391,7 +1391,6 @@ def test_spawn_scrubs_all_protected_controls_from_user_bash_environment(
         assert os.environ[name] == f"hostile-{name}"
 
 
-@pytest.mark.parametrize("capture_output", [False, True], ids=("direct", "capture"))
 @pytest.mark.parametrize(
     "spawn_errno",
     [None, errno.EPERM, errno.E2BIG],
@@ -1399,7 +1398,6 @@ def test_spawn_scrubs_all_protected_controls_from_user_bash_environment(
 )
 def test_spawn_bash_anchors_and_closes_inherited_cwd_fd(
     monkeypatch: pytest.MonkeyPatch,
-    capture_output: bool,
     spawn_errno: int | None,
 ) -> None:
     inherited_cwd_fds: list[int] = []
@@ -1443,7 +1441,7 @@ def test_spawn_bash_anchors_and_closes_inherited_cwd_fd(
             capture_artifacts._spawn_bash(
                 "/bin/bash",
                 "printf safe",
-                capture_output=capture_output,
+                capture_output=False,
             )
             is process
         )
@@ -1457,7 +1455,7 @@ def test_spawn_bash_anchors_and_closes_inherited_cwd_fd(
             capture_artifacts._spawn_bash(
                 "/bin/bash",
                 "printf safe",
-                capture_output=capture_output,
+                capture_output=False,
             )
 
     assert len(inherited_cwd_fds) == 1

--- a/tests/hooks/test_capture_artifacts.py
+++ b/tests/hooks/test_capture_artifacts.py
@@ -1365,12 +1365,8 @@ def test_dispatch_uses_only_request_mode_and_keeps_lineage_anchor_distinct_from_
 
 
 def test_spawn_scrubs_all_protected_controls_from_user_bash_environment(
-    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    project = tmp_path / "project"
-    project.mkdir()
-    anchor = open_project_anchor(str(project))
     observed: dict[str, object] = {}
 
     def record_popen(*_args, **kwargs):
@@ -1381,15 +1377,11 @@ def test_spawn_scrubs_all_protected_controls_from_user_bash_environment(
         monkeypatch.setenv(name, f"hostile-{name}")
     monkeypatch.setenv("PHASE4_UNRELATED_ENV", "preserved")
     monkeypatch.setattr(capture_artifacts.subprocess, "Popen", record_popen)
-    try:
-        capture_artifacts._spawn_bash(
-            anchor,
-            capture_artifacts._resolve_bash(),
-            "printf safe",
-            capture_output=False,
-        )
-    finally:
-        anchor.close()
+    capture_artifacts._spawn_bash(
+        capture_artifacts._resolve_bash(),
+        "printf safe",
+        capture_output=False,
+    )
 
     child_environment = observed["env"]
     assert isinstance(child_environment, dict)
@@ -1397,6 +1389,130 @@ def test_spawn_scrubs_all_protected_controls_from_user_bash_environment(
     assert child_environment["PHASE4_UNRELATED_ENV"] == "preserved"
     for name in PROTECTED_CAPTURE_ENV_VARS:
         assert os.environ[name] == f"hostile-{name}"
+
+
+@pytest.mark.parametrize("capture_output", [False, True], ids=("direct", "capture"))
+@pytest.mark.parametrize(
+    "spawn_errno",
+    [None, errno.EPERM, errno.E2BIG],
+    ids=("success", "spawn-failure", "e2big"),
+)
+def test_spawn_bash_anchors_and_closes_inherited_cwd_fd(
+    monkeypatch: pytest.MonkeyPatch,
+    capture_output: bool,
+    spawn_errno: int | None,
+) -> None:
+    inherited_cwd_fds: list[int] = []
+    closed_fds: list[int] = []
+    fchdir_fds: list[int] = []
+    popen_kwargs: list[dict[str, object]] = []
+    real_open = capture_artifacts.os.open
+    real_close = capture_artifacts.os.close
+    real_fchdir = capture_artifacts.os.fchdir
+
+    def record_open(path, flags, mode=0o777, *, dir_fd=None):
+        fd = real_open(path, flags, mode, dir_fd=dir_fd)
+        if path == "." and dir_fd is None:
+            inherited_cwd_fds.append(fd)
+        return fd
+
+    def record_close(fd):
+        if fd in inherited_cwd_fds:
+            closed_fds.append(fd)
+        real_close(fd)
+
+    def record_fchdir(fd):
+        fchdir_fds.append(fd)
+        real_fchdir(fd)
+
+    process = SimpleNamespace()
+
+    def record_popen(*_args, **kwargs):
+        popen_kwargs.append(kwargs)
+        if spawn_errno is not None:
+            raise OSError(spawn_errno, "fault injection")
+        return process
+
+    monkeypatch.setattr(capture_artifacts.os, "open", record_open)
+    monkeypatch.setattr(capture_artifacts.os, "close", record_close)
+    monkeypatch.setattr(capture_artifacts.os, "fchdir", record_fchdir)
+    monkeypatch.setattr(capture_artifacts.subprocess, "Popen", record_popen)
+
+    if spawn_errno is None:
+        assert (
+            capture_artifacts._spawn_bash(
+                "/bin/bash",
+                "printf safe",
+                capture_output=capture_output,
+            )
+            is process
+        )
+    else:
+        message = (
+            "argument/environment exceeds system limit"
+            if spawn_errno == errno.E2BIG
+            else "cannot spawn capture shell"
+        )
+        with pytest.raises(CaptureSetupError, match=message):
+            capture_artifacts._spawn_bash(
+                "/bin/bash",
+                "printf safe",
+                capture_output=capture_output,
+            )
+
+    assert len(inherited_cwd_fds) == 1
+    inherited_cwd_fd = inherited_cwd_fds[0]
+    assert fchdir_fds == [inherited_cwd_fd, inherited_cwd_fd]
+    assert closed_fds == [inherited_cwd_fd]
+    with pytest.raises(OSError):
+        os.fstat(inherited_cwd_fd)
+    assert len(popen_kwargs) == 1
+    assert popen_kwargs[0]["close_fds"] is True
+
+
+@pytest.mark.skipif(
+    not Path("/proc/self/fd").is_dir(),
+    reason="descriptor target probe requires procfs",
+)
+@pytest.mark.parametrize("capture_output", [False, True], ids=("direct", "capture"))
+def test_spawn_bash_does_not_leak_inherited_cwd_fd_to_child(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capture_output: bool,
+) -> None:
+    execution_dir = tmp_path / "execution"
+    execution_dir.mkdir()
+    monkeypatch.chdir(execution_dir)
+    result_path = execution_dir / "fd-result"
+    script = "\n".join(
+        [
+            "import os",
+            "target = os.stat('.')",
+            "leaked = []",
+            "for name in os.listdir('/proc/self/fd'):",
+            "    try:",
+            "        value = os.stat('/proc/self/fd/' + name)",
+            "    except FileNotFoundError:",
+            "        continue",
+            "    if (value.st_dev, value.st_ino) == (target.st_dev, target.st_ino):",
+            "        leaked.append(name)",
+            (
+                "print(','.join(leaked))"
+                if capture_output
+                else "open('fd-result', 'w').write(','.join(leaked))"
+            ),
+        ]
+    )
+    process = capture_artifacts._spawn_bash(
+        "/bin/bash",
+        shlex.join([sys.executable, "-c", script]),
+        capture_output=capture_output,
+    )
+    stdout, _stderr = process.communicate(timeout=10)
+
+    assert process.returncode == 0
+    result = stdout.decode().strip() if capture_output else result_path.read_text()
+    assert result == ""
 
 
 def test_e2big_spawn_failure_is_explicit_bounded_and_fail_closed(
@@ -1553,25 +1669,31 @@ def test_post_duplication_failure_closes_all_fds_and_prevents_command(
             os.fstat(fd)
 
 
-def test_restore_failure_closes_pipe_and_original_cwd_fd(
-    tmp_path: Path,
+@pytest.mark.parametrize("capture_output", [False, True], ids=("direct", "capture"))
+def test_restore_failure_closes_pipe_and_inherited_cwd_fd(
     monkeypatch: pytest.MonkeyPatch,
+    capture_output: bool,
 ) -> None:
-    project = tmp_path / "project"
-    project.mkdir()
-    anchor = open_project_anchor(str(project))
     process = _FakeCaptureProcess(b"")
     runner_cwd_fd = os.open(".", os.O_RDONLY | os.O_DIRECTORY)
-    original_cwd_fds: list[int] = []
+    inherited_cwd_fds: list[int] = []
+    closed_fds: list[int] = []
+    popen_kwargs: list[dict[str, object]] = []
     real_open = capture_artifacts.os.open
+    real_close = capture_artifacts.os.close
     real_fchdir = capture_artifacts.os.fchdir
     fchdir_calls = 0
 
     def record_open(path, flags, mode=0o777, *, dir_fd=None):
         fd = real_open(path, flags, mode, dir_fd=dir_fd)
         if path == "." and dir_fd is None:
-            original_cwd_fds.append(fd)
+            inherited_cwd_fds.append(fd)
         return fd
+
+    def record_close(fd):
+        if fd in inherited_cwd_fds:
+            closed_fds.append(fd)
+        real_close(fd)
 
     def fail_restore(fd):
         nonlocal fchdir_calls
@@ -1580,28 +1702,33 @@ def test_restore_failure_closes_pipe_and_original_cwd_fd(
             raise OSError("fault injection")
         real_fchdir(fd)
 
+    def record_popen(*_args, **kwargs):
+        popen_kwargs.append(kwargs)
+        return process
+
     monkeypatch.setattr(capture_artifacts.os, "open", record_open)
+    monkeypatch.setattr(capture_artifacts.os, "close", record_close)
     monkeypatch.setattr(capture_artifacts.os, "fchdir", fail_restore)
-    monkeypatch.setattr(capture_artifacts.subprocess, "Popen", lambda *_args, **_kwargs: process)
+    monkeypatch.setattr(capture_artifacts.subprocess, "Popen", record_popen)
 
     try:
         with pytest.raises(CaptureSetupError, match="cannot restore runner cwd"):
             capture_artifacts._spawn_bash(
-                anchor,
                 "/bin/bash",
                 "printf never",
-                capture_output=True,
+                capture_output=capture_output,
             )
         assert process.stdout.closed
         assert process.terminated
         assert process.wait_calls == 1
-        assert len(original_cwd_fds) == 1
+        assert len(inherited_cwd_fds) == 1
+        assert closed_fds == inherited_cwd_fds
+        assert popen_kwargs[0]["close_fds"] is True
         with pytest.raises(OSError):
-            os.fstat(original_cwd_fds[0])
+            os.fstat(inherited_cwd_fds[0])
     finally:
         real_fchdir(runner_cwd_fd)
         os.close(runner_cwd_fd)
-        anchor.close()
 
 
 def test_post_creation_identity_failure_closes_artifact_and_emits_failure(
@@ -2758,16 +2885,27 @@ def test_artifact_write_failure_emits_failure_marker(
 ) -> None:
     project = tmp_path / "project"
     project.mkdir()
+    sentinel = tmp_path / "command-ran"
 
     def fail_write(fd, data):
         raise OSError("fault injection")
 
     monkeypatch.setattr(capture_artifacts, "_write_all", fail_write)
 
-    assert run_capture("printf ran > command_ran; printf output", str(project), _CAPTURE_ID) == 1
+    command = f"printf ran > {shlex.quote(str(sentinel))}; printf output"
+    assert run_capture(command, str(project), _CAPTURE_ID) == 1
     captured = capfd.readouterr()
-    assert (project / "command_ran").read_text() == "ran"
-    assert '"status":"capture_failed"' in captured.err
+    assert sentinel.read_text() == "ran"
+    raw_failure = next(
+        line
+        for line in captured.err.splitlines()
+        if line.startswith("[AutoSkillit shell capture failure v3:")
+    )
+    payload = json.loads(
+        raw_failure.removeprefix("[AutoSkillit shell capture failure v3:").removesuffix("]")
+    )
+    assert payload["status"] == "capture_failed"
+    assert _single_failure_marker(captured.err).stage == "artifact_write"
     assert "shell capture v2:" not in captured.out + captured.err
 
 

--- a/tests/hooks/test_capture_observation.py
+++ b/tests/hooks/test_capture_observation.py
@@ -286,10 +286,14 @@ def test_invalid_observation_authority_does_not_change_command_output(
     assert not _observation_root(anchor).exists()
 
 
-def test_command_cwd_remains_separate_from_exact_lineage_anchor(tmp_path: Path) -> None:
+def test_command_cwd_remains_separate_from_exact_lineage_anchor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     lineage_anchor, store, lineage, reference = _lineage(tmp_path)
     command_cwd = tmp_path / "command-cwd"
     command_cwd.mkdir()
+    monkeypatch.chdir(command_cwd)
 
     assert (
         run_capture(

--- a/tests/hooks/test_shell_capture_conformance.py
+++ b/tests/hooks/test_shell_capture_conformance.py
@@ -301,7 +301,12 @@ def _run_runner(
     project: Path,
     *,
     mode: str,
+    execution_dir: Path | None = None,
 ) -> subprocess.CompletedProcess[bytes]:
+    if execution_dir is None:
+        execution_dir = project
+    else:
+        assert not execution_dir.samefile(project)
     lineage_ref = _direct_lineage_reference(project) if mode == "direct" else None
     request = CaptureRequest(
         protocol_version=CAPTURE_REQUEST_PROTOCOL_VERSION,
@@ -321,7 +326,7 @@ def _run_runner(
             encode_capture_request(request),
         ],
         capture_output=True,
-        cwd=project,
+        cwd=execution_dir,
         timeout=_TIMEOUT,
         check=False,
     )
@@ -358,6 +363,77 @@ def test_capture_direct_runner_matrix_preserves_shell_semantics(
     assert captured.stdout == raw.stdout + raw.stderr, label
     assert captured.stderr == b"", label
     assert len(_artifact_files(project)) == 1, label
+
+
+@pytest.mark.parametrize(
+    (
+        "requested_mode",
+        "project_policy_disabled",
+        "execution_policy_disabled",
+        "expect_capture",
+    ),
+    [
+        ("capture", False, True, True),
+        ("direct", False, True, False),
+        ("capture", True, False, False),
+    ],
+    ids=("capture", "lineage-direct", "project-policy-disabled"),
+)
+def test_runner_keeps_project_and_execution_authorities_distinct(
+    tmp_path: Path,
+    requested_mode: str,
+    project_policy_disabled: bool,
+    execution_policy_disabled: bool,
+    expect_capture: bool,
+) -> None:
+    project = tmp_path / "project"
+    execution_dir = tmp_path / "execution"
+    project.mkdir()
+    execution_dir.mkdir()
+    for authority, disabled in (
+        (project, project_policy_disabled),
+        (execution_dir, execution_policy_disabled),
+    ):
+        config = authority / ".autoskillit" / "temp" / ".hook_config.json"
+        config.parent.mkdir(parents=True)
+        config.write_text(json.dumps({"output_budget_policy": {"disabled": disabled}}))
+
+    completed = _run_runner(
+        "printf 'pwd=%s\\n' \"$PWD\"; printf ran > execution-sentinel",
+        project,
+        mode=requested_mode,
+        execution_dir=execution_dir,
+    )
+
+    assert completed.returncode == 0
+    assert f"pwd={execution_dir.resolve()}\n".encode() in completed.stdout
+    assert (execution_dir / "execution-sentinel").read_text() == "ran"
+    assert not (project / "execution-sentinel").exists()
+    assert not _artifact_files(execution_dir)
+
+    project_artifacts = _artifact_files(project)
+    assert bool(project_artifacts) is expect_capture
+    if expect_capture:
+        assert len(project_artifacts) == 1
+        capture_id = project_artifacts[0].stem.removeprefix("shell_")
+        with open_capture_lifecycle(str(project), create=False) as lifecycle:
+            record = lifecycle.get_record(capture_id)
+        assert record is not None
+        assert record.state is CaptureState.FINALIZED
+        assert (_capture_dir(project) / ".capture-lifecycle.ledger").is_file()
+        assert not _capture_dir(execution_dir).exists()
+    else:
+        assert not _capture_dir(project).exists()
+
+    if requested_mode == "direct":
+        store = DefaultManagedHeadlessSessionLineageStore()
+        lineage = store.load(lineage_anchor=project, launch_id=_DIRECT_LAUNCH_ID)
+        collected = store.collect_runner_observations(lineage.reference)
+        assert len(collected.observations) == 1
+        observation = collected.observations[0]
+        assert observation.effective_mode is NativeShellCaptureMode.DIRECT
+        assert observation.reason.value == "launch_authorized_direct"
+        assert not observation.project_policy_disabled
 
 
 @pytest.mark.parametrize("label,command", _CORPUS, ids=[row[0] for row in _CORPUS])


### PR DESCRIPTION
## Summary

This PR fixes shell-capture commands running from the project checkout instead of Codex's call-local `workdir`. `_spawn_bash()` no longer accepts `ProjectAnchor`; it launches Bash from its preserved inherited-cwd descriptor, while project policy, capture artifacts, lifecycle state, provenance, lineage observation, and cleanup remain project-relative.

Coverage separates project and execution directories across capture, lineage-authorized direct, and policy-disabled modes, and adds focused descriptor lifecycle/leak checks plus a gated real-Codex conformance probe. General write containment, Windows, and remote execution remain out of scope.

## Verification

- Standalone implementation audit: **GO / MERGE APPROVED** at `381e945f2` with no accepted deviations.
- Addressed after audit: the first full gate exposed one stale lineage test that still relied on `run_capture(cwd=...)` changing the child cwd. Commit `e3e6e765c` now establishes that execution cwd explicitly.
- `pre-commit run --all-files`: passed after the follow-up test fix.
- `task test-all`: passed — 37,271 passed, 667 skipped, 27 xfailed.
- `task test-smoke-codex`: 11 passed, 10 skipped, 3 failed. The new divergent-workdir probe skipped because neither `CODEX_API_KEY` nor `OPENAI_API_KEY` is available; the failures were separate live Codex selection/delivery probes and a pre-existing assertion-message mismatch.

Closes #4510

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/rectify/rectify_shell_capture_execution_authority_2026-08-09_010614.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
