### PR TITLE
Implementation Plan: Add a Luna Web-Evidence Agent for Review-Approach

### DIFF
--- a/.github/workflows/conformance-probes.yml
+++ b/.github/workflows/conformance-probes.yml
@@ -57,18 +57,40 @@ jobs:
           mkdir -p .autoskillit/temp
           uv sync --locked --extra dev
 
+      - name: Install pinned Codex CLI
+        run: npm install --global @openai/codex@0.147.0
+
       - name: Resolve Codex CLI version
         id: resolve-version
         run: |
           CLI_VERSION=$(codex --version 2>/dev/null || echo 'unknown')
-          if [ "$CLI_VERSION" = "unknown" ]; then
-            echo "::error::Codex CLI is not installed — cannot run conformance probes"
+          if [ "$CLI_VERSION" != "codex-cli 0.147.0" ]; then
+            echo "::error::Expected codex-cli 0.147.0, got $CLI_VERSION"
             exit 1
           fi
           echo "cli_version=${CLI_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Validate installed Codex config parsing
         run: task test-codex-config-parse
+
+      - name: Run authenticated live-web agent gate
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "::error::OPENAI_API_KEY secret is not configured — cannot run live-web agent gate"
+            exit 1
+          fi
+          task test-smoke-codex-web-agent-live-gate
+
+      - name: Upload live-web agent gate evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: codex-live-web-agent-gate-0.147.0
+          path: .autoskillit/temp/conformance/live-web-agent-gate/live-web-agent-gate.json
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Run non-cached Luna explorer capability gate
         env:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -299,7 +299,7 @@ tasks:
           echo "Explorer gate did not produce one non-skipped pass"
           PYTEST_EXIT=1
         fi
-        if [[ $PYTEST_EXIT -eq 0 ]] && { [[ ! -s "$ATTESTATION_DIR/codex-explorer-conformance-v6.json" ]] || [[ ! -s "$ATTESTATION_DIR/codex-explorer-conformance-v6.json.sha256" ]]; }; then
+        if [[ $PYTEST_EXIT -eq 0 ]] && { [[ ! -s "$ATTESTATION_DIR/codex-explorer-conformance-v7.json" ]] || [[ ! -s "$ATTESTATION_DIR/codex-explorer-conformance-v7.json.sha256" ]]; }; then
           echo "Explorer gate did not publish its attestation and digest sidecar"
           PYTEST_EXIT=1
         fi
@@ -323,7 +323,7 @@ tasks:
         ).stdout
         if attestation.model_catalog_digest != project_codex_luna_catalog(catalog).projected_sha256:
             raise ValueError("published explorer attestation catalog does not match Codex")
-        ' "$ATTESTATION_DIR/codex-explorer-conformance-v6.json" || PYTEST_EXIT=1
+        ' "$ATTESTATION_DIR/codex-explorer-conformance-v7.json" || PYTEST_EXIT=1
         fi
         echo "Codex explorer gate output saved to: $TEST_OUTPUT"
         exit $PYTEST_EXIT

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -375,6 +375,55 @@ tasks:
         fi
         $PYTHON_CMD -c 'import json, sys; data=json.load(open(sys.argv[1], encoding="utf-8")); expected={"contract":"live-production-shared-explorer-principal-v2","principal_role":"shared-explorer-session","authenticated_resume":"denied"}; bad=any(data.get(key) != value for key, value in expected.items()); sys.exit(f"invalid live explorer evidence: {data!r}" if bad else 0)' "$EVIDENCE"
 
+  test-smoke-codex-web-agent-live-gate:
+    desc: Run the pinned, uncached live-web Luna child conformance gate
+    deps: [_tmpdir-setup]
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+      OMP_NUM_THREADS: "1"
+      CODEX_SMOKE_TEST: "1"
+      AUTOSKILLIT_WEB_AGENT_LIVE_GATE: "1"
+      TMPDIR: "{{.PYTEST_TMPDIR}}"
+    preconditions:
+      - sh: command -v codex >/dev/null 2>&1
+        msg: "Codex CLI must be installed"
+      - sh: test "$(codex --version 2>/dev/null)" = "codex-cli 0.147.0"
+        msg: "Codex CLI must be exactly codex-cli 0.147.0"
+      - sh: test -n "$OPENAI_API_KEY" || test -n "$CODEX_API_KEY" || test -f "$HOME/.codex/auth.json"
+        msg: "Codex authentication required: set OPENAI_API_KEY or CODEX_API_KEY, or run 'codex login'"
+    cmds:
+      - |
+        if [[ -d ".venv" ]]; then
+          PYTHON_CMD=".venv/bin/python"
+        else
+          PYTHON_CMD="python"
+        fi
+        ARTIFACT_DIR=".autoskillit/temp/conformance/live-web-agent-gate"
+        EVIDENCE="$ARTIFACT_DIR/live-web-agent-gate.json"
+        TEST_OUTPUT="$ARTIFACT_DIR/pytest-output.txt"
+        JUNIT_REPORT="$ARTIFACT_DIR/pytest-report.xml"
+        mkdir -p "$ARTIFACT_DIR"
+        rm -f "$EVIDENCE" "$TEST_OUTPUT" "$JUNIT_REPORT"
+        export AUTOSKILLIT_WEB_AGENT_LIVE_GATE_ARTIFACT_DIR="$ARTIFACT_DIR"
+        set +e
+        $PYTHON_CMD -m pytest tests/execution/backends/test_web_agent_live_gate.py \
+          -q --tb=short -m smoke -p no:cacheprovider -o "addopts=" \
+          --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" \
+          --junitxml="$JUNIT_REPORT" >"$TEST_OUTPUT" 2>&1
+        PYTEST_EXIT=$?
+        set -e
+        tail -c 16000 "$TEST_OUTPUT"
+        if [[ $PYTEST_EXIT -ne 0 ]]; then
+          echo "Live web-agent gate failed; bounded output is saved to: $TEST_OUTPUT"
+          exit $PYTEST_EXIT
+        fi
+        $PYTHON_CMD -c 'import sys, xml.etree.ElementTree as E; cases=list(E.parse(sys.argv[1]).getroot().iter("testcase")); skipped=sum(bool(case.findall("skipped")) for case in cases); bad=len(cases) != 1 or skipped; sys.exit(f"live web-agent gate requires exactly one non-skipped test, got tests={len(cases)} skipped={skipped}" if bad else 0)' "$JUNIT_REPORT"
+        if [[ ! -s "$EVIDENCE" ]]; then
+          echo "Live web-agent gate did not publish fresh evidence: $EVIDENCE"
+          exit 1
+        fi
+        $PYTHON_CMD -c 'import json, sys; data=json.load(open(sys.argv[1], encoding="utf-8")); expected={"contract":"live-web-agent-codex-0.147.0","cli_version":"codex-cli 0.147.0","parent_web_search":"disabled","child_web_search":"live","child_model":"gpt-5.6-luna","child_reasoning_effort":"xhigh","child_sandbox_mode":"read-only","child_agents_enabled":False}; bad=any(data.get(key) != value for key, value in expected.items()); sys.exit(f"invalid live web-agent evidence: {data!r}" if bad else 0)' "$EVIDENCE"
+
   test-smoke-claude-explorer-live-gate:
     desc: Run the Claude session-scoped explorer conformance gate
     deps: [_tmpdir-setup]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,6 +110,12 @@ registered role definition and is not controlled by `model.default`, `model.over
 project configuration setting. An L1 parent owns routing and synthesis; callers must not add
 per-role model, permission, or delegation overrides. See [Explorer agents](execution/explorer-agents.md).
 
+`web-evidence-researcher` is likewise definition-owned on Codex: it always launches as a
+`gpt-5.6-luna`/xhigh, read-only terminal child with live web search and no descendant-agent
+capability. `model.default` and `model.override` select neither that Codex child identity nor
+its permissions. On Claude, the same packless role omits a model override and therefore
+inherits the configured/default child model.
+
 ## Worktree Setup
 
 Command to run after creating a git worktree (e.g. to install dependencies).

--- a/src/autoskillit/agents/AGENTS.md
+++ b/src/autoskillit/agents/AGENTS.md
@@ -7,7 +7,7 @@ Bundled agent definition markdown files that serve as both **plugin agents**
 ## Layout
 
 Each `.md` file defines one agent with YAML frontmatter (`name`, `description`,
-`tools`, `model`, `maxTurns`) and a markdown body containing the agent's system prompt.
+`tools`, optional `model`, `maxTurns`) and a markdown body containing the agent's system prompt.
 
 ## Invocation
 
@@ -43,6 +43,7 @@ agent definitions are readable via `ReadMcpResourceTool` at `agent://{pack}/{nam
 | _(none)_ | _(none)_ | `audit-impl-slice-auditor` | audit-impl Step 3 (subagent_type-only) |
 | _(none)_ | _(none)_ | `audit-impl-deviation-evaluator` | audit-impl Step 3.5 (subagent_type-only) |
 | _(none)_ | _(none)_ | `semantic-code-navigator`, `repository-impact-profiler` | L1 exploration parent (subagent_type-only) |
+| _(none)_ | _(none)_ | `web-evidence-researcher` | review-approach (subagent_type-only) |
 
 ## Adding Agents
 
@@ -59,7 +60,11 @@ agent definitions are readable via `ReadMcpResourceTool` at `agent://{pack}/{nam
 Current packless agents: `wp-elaborator`, `pipeline-health-scanner`, `audit-impl-slice-auditor`,
 `pr-review-auditor-baseline`, `pr-review-auditor-v1-precision`, `pr-review-auditor-v2-contrastive`,
 `pr-review-auditor-v3-simulation`, `pr-review-auditor-reachability`,
-`pr-review-auditor-abstraction-surface`, `audit-impl-deviation-evaluator`.
+`pr-review-auditor-abstraction-surface`, `audit-impl-deviation-evaluator`,
+`web-evidence-researcher`.
+The web-evidence role's Codex definition owns its Luna/xhigh/read-only/live-web/no-descendants
+policy; callers do not pass model or permission overrides. Claude inherits the configured/default
+child model because this definition omits the top-level `model` key.
 The specialized explorers `semantic-code-navigator` and `repository-impact-profiler` are also
 packless terminal leaves. Their fixed Luna/max/read-only policy is documented in
 `docs/execution/explorer-agents.md`; do not add model or permission overrides to callers.

--- a/src/autoskillit/agents/web-evidence-researcher.md
+++ b/src/autoskillit/agents/web-evidence-researcher.md
@@ -14,9 +14,11 @@ codex:
 
 # web-evidence-researcher
 
-## Tool-surface conformance
+## Tool use
 
-First verify that a web search or page-fetch capability exists. If the effective surface includes file access, shell or arbitrary local/code execution, browser or computer control, or an agent-spawning capability, record `CONTRACT VIOLATION` and `Verdict: blocked` through the common return envelope below, then stop. Missing web search and fetch capability is the same blocked contract violation.
+Use only web search, page fetch, and `view_image` when an image is relevant to the supplied topic.
+
+Never actually call a shell or terminal tool, mutate repository or other files, control a browser or computer, or spawn another agent. If the required web capability fails when called, return `Verdict: blocked` with the concrete failure through the common return envelope.
 
 ## Role boundary
 
@@ -36,7 +38,7 @@ Every exit path returns this bounded terminal structure:
 
 ```text
 Verdict: answered | partial | blocked
-Coverage: established facets, uncovered facets, or CONTRACT VIOLATION detail
+Coverage: established facets, uncovered facets, or blocking tool failure
 Queries: every query, including zero-result searches
 Findings: supported claim; exact URL; publication date/date not stated; freshness; fetched/read, snippet-only, or inference
 Conflicts: both supported sides, or none

--- a/src/autoskillit/agents/web-evidence-researcher.md
+++ b/src/autoskillit/agents/web-evidence-researcher.md
@@ -1,0 +1,47 @@
+---
+name: web-evidence-researcher
+description: "Terminal single-topic specialist for bounded external web evidence."
+tools: [WebSearch, WebFetch]
+maxTurns: 80
+codex:
+  model: gpt-5.6-luna
+  reasoning_effort: xhigh
+  sandbox_mode: read-only
+  disabled_features: [apps, browser_use, browser_use_external, browser_use_full_cdp_access, code_mode, code_mode_buffered_exec, code_mode_host, code_mode_only, computer_use, enable_mcp_apps, goals, image_generation, in_app_browser, multi_agent, multi_agent_v2, plugin_sharing, plugins, remote_plugin, request_permissions_tool, shell_tool, tool_suggest, unified_exec, unified_exec_zsh_fork]
+  agents_enabled: false
+  web_search: live
+---
+
+# web-evidence-researcher
+
+## Tool-surface conformance
+
+First verify that a web search or page-fetch capability exists. If the effective surface includes file access, shell or arbitrary local/code execution, browser or computer control, or an agent-spawning capability, record `CONTRACT VIOLATION` and `Verdict: blocked` through the common return envelope below, then stop. Missing web search and fetch capability is the same blocked contract violation.
+
+## Role boundary
+
+Research exactly the one supplied external topic. You are a terminal evidence collector. The parent alone selects topics, compares across topics, makes project-level recommendations, synthesizes results, and writes the report. Repository work is outside this role.
+
+## Procedure
+
+Start with two or three short broad queries, inspect their results, then narrow. Prefer primary and authoritative sources. Read the strongest three to six sources. Use at most eight searches and six fetches. After three relevant sources agree, or after two consecutive searches add nothing, stop only further search/fetch calls and continue to the common return envelope.
+
+## Evidence honesty
+
+Cite only URLs returned by search or successfully fetched. Never construct, complete, or guess a URL. For each source, attach its publication date or `date not stated`, freshness relevance, and whether the evidence was fetched/read, snippet-only, or inference. Mark unreachable sources `SOURCE_UNREACHABLE`. Report both sides of explicit source conflicts. Label predictions and speculation.
+
+## Common return envelope
+
+Every exit path returns this bounded terminal structure:
+
+```text
+Verdict: answered | partial | blocked
+Coverage: established facets, uncovered facets, or CONTRACT VIOLATION detail
+Queries: every query, including zero-result searches
+Findings: supported claim; exact URL; publication date/date not stated; freshness; fetched/read, snippet-only, or inference
+Conflicts: both supported sides, or none
+Unusable sources: URL or attempted source; SOURCE_UNREACHABLE/reason
+Unknowns: named unresolved questions
+```
+
+Repository work returns `Verdict: blocked`. Uncovered adjacent facets return `Verdict: partial` without researching them. Never make a project-level recommendation.

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -101,6 +101,7 @@ from .agent_definition import (
     REPOSITORY_IMPACT_PROFILER_ROLE as REPOSITORY_IMPACT_PROFILER_ROLE,
 )
 from .agent_definition import SEMANTIC_CODE_NAVIGATOR_ROLE as SEMANTIC_CODE_NAVIGATOR_ROLE
+from .agent_definition import WEB_EVIDENCE_RESEARCHER_ROLE as WEB_EVIDENCE_RESEARCHER_ROLE
 from .agent_definition import AgentDef as AgentDef
 from .agent_definition import AgentDefinitionError as AgentDefinitionError
 from .agent_definition import CodexAgentProjectionDef as CodexAgentProjectionDef

--- a/src/autoskillit/core/agent_definition.py
+++ b/src/autoskillit/core/agent_definition.py
@@ -7,7 +7,7 @@ import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypeAlias, get_args
 
 from .io import load_yaml
 from .paths import pkg_root
@@ -77,7 +77,8 @@ _CODEX_DISABLEABLE_FEATURES = (
     "unified_exec_zsh_fork",
 )
 _CODEX_DISABLEABLE_FEATURE_SET = frozenset(_CODEX_DISABLEABLE_FEATURES)
-_CODEX_WEB_SEARCH_MODES = frozenset({"disabled", "cached", "indexed", "live"})
+_CodexWebSearchMode: TypeAlias = Literal["disabled", "cached", "indexed", "live"]
+_CODEX_WEB_SEARCH_MODES: frozenset[str] = frozenset(get_args(_CodexWebSearchMode))
 
 
 class AgentDefinitionError(ValueError):
@@ -105,7 +106,7 @@ class CodexAgentProjectionDef:
     sandbox_mode: str
     disabled_features: tuple[str, ...] = ()
     agents_enabled: bool = True
-    web_search: Literal["disabled", "cached", "indexed", "live"] | None = None
+    web_search: _CodexWebSearchMode | None = None
 
     def __post_init__(self) -> None:
         if self.model is not None and self.model not in CODEX_VALID_MODEL_IDS:
@@ -137,9 +138,8 @@ class CodexAgentProjectionDef:
         if type(self.agents_enabled) is not bool:
             raise AgentDefinitionError("Codex agents_enabled must be a boolean")
         if self.web_search is not None and self.web_search not in _CODEX_WEB_SEARCH_MODES:
-            raise AgentDefinitionError(
-                "Codex web_search must be one of 'cached', 'disabled', 'indexed', or 'live'"
-            )
+            allowed = ", ".join(repr(mode) for mode in sorted(_CODEX_WEB_SEARCH_MODES))
+            raise AgentDefinitionError(f"Codex web_search must be one of {allowed}")
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/core/agent_definition.py
+++ b/src/autoskillit/core/agent_definition.py
@@ -26,6 +26,7 @@ __all__ = [
     "CODEX_EXPLORER_IDENTITY",
     "REPOSITORY_IMPACT_PROFILER_ROLE",
     "SEMANTIC_CODE_NAVIGATOR_ROLE",
+    "WEB_EVIDENCE_RESEARCHER_ROLE",
     "AgentDef",
     "AgentDefinitionError",
     "CodexAgentProjectionDef",
@@ -42,6 +43,7 @@ CODEX_DISABLED_WEB_SEARCH_POLICY: Literal["disabled"] = "disabled"
 CODEX_EXPLORER_IDENTITY: tuple[str, str] = ("gpt-5.6-luna", "max")
 SEMANTIC_CODE_NAVIGATOR_ROLE: str = "semantic-code-navigator"
 REPOSITORY_IMPACT_PROFILER_ROLE: str = "repository-impact-profiler"
+WEB_EVIDENCE_RESEARCHER_ROLE: str = "web-evidence-researcher"
 BUNDLED_EXPLORER_ROLES: frozenset[str] = frozenset(
     {SEMANTIC_CODE_NAVIGATOR_ROLE, REPOSITORY_IMPACT_PROFILER_ROLE}
 )
@@ -75,6 +77,7 @@ _CODEX_DISABLEABLE_FEATURES = (
     "unified_exec_zsh_fork",
 )
 _CODEX_DISABLEABLE_FEATURE_SET = frozenset(_CODEX_DISABLEABLE_FEATURES)
+_CODEX_WEB_SEARCH_MODES = frozenset({"disabled", "cached", "indexed", "live"})
 
 
 class AgentDefinitionError(ValueError):
@@ -102,7 +105,7 @@ class CodexAgentProjectionDef:
     sandbox_mode: str
     disabled_features: tuple[str, ...] = ()
     agents_enabled: bool = True
-    web_search: Literal["disabled"] | None = None
+    web_search: Literal["disabled", "cached", "indexed", "live"] | None = None
 
     def __post_init__(self) -> None:
         if self.model is not None and self.model not in CODEX_VALID_MODEL_IDS:
@@ -133,9 +136,9 @@ class CodexAgentProjectionDef:
             raise AgentDefinitionError("Codex disabled_features must use canonical order")
         if type(self.agents_enabled) is not bool:
             raise AgentDefinitionError("Codex agents_enabled must be a boolean")
-        if self.web_search is not None and self.web_search != CODEX_DISABLED_WEB_SEARCH_POLICY:
+        if self.web_search is not None and self.web_search not in _CODEX_WEB_SEARCH_MODES:
             raise AgentDefinitionError(
-                f"Codex web_search must be {CODEX_DISABLED_WEB_SEARCH_POLICY!r}"
+                "Codex web_search must be one of 'cached', 'disabled', 'indexed', or 'live'"
             )
 
 

--- a/src/autoskillit/core/types/_type_intake_policy.py
+++ b/src/autoskillit/core/types/_type_intake_policy.py
@@ -21,7 +21,7 @@ __all__ = [
 
 CODEX_INTAKE_DISCIPLINE_VERSION: Final[int] = 3
 
-# Always-on injection: every byte is replicated into 13 bundled agent TOMLs at session
+# Always-on injection: every byte is replicated into 14 bundled agent TOMLs at session
 # setup plus one copy per session prompt across 5 delivery surfaces. Raising either
 # ceiling is a decision, not a consequence — record measured before/after in the PR.
 CODEX_INTAKE_DISCIPLINE_BYTE_BUDGET: Final[int] = 1200

--- a/src/autoskillit/core/types/_type_skill_semantics.py
+++ b/src/autoskillit/core/types/_type_skill_semantics.py
@@ -80,11 +80,19 @@ class ChildSpawnSpec:
 
     role: str
     count: int = 1
+    for_each: str | None = None
 
     def __post_init__(self) -> None:
         _require_nonempty(self.role, "child spawn role")
         if self.count < 1:
             raise SkillContractError("child spawn count must be positive")
+        if self.for_each is not None:
+            if not isinstance(self.for_each, str) or not self.for_each.strip():
+                raise SkillContractError("child spawn for_each must be non-empty")
+            if self.count != 1:
+                raise SkillContractError(
+                    "child spawn for_each cannot be combined with a non-default count"
+                )
 
 
 @dataclass(frozen=True, slots=True)
@@ -233,7 +241,12 @@ class SkillSemanticPlan:
         payload: dict[str, object] = {
             "schema_version": self.schema_version,
             "child_spawns": tuple(
-                {"role": item.role, "count": item.count} for item in self.child_spawns
+                {
+                    "role": item.role,
+                    "count": item.count,
+                    **({"for_each": item.for_each} if item.for_each is not None else {}),
+                }
+                for item in self.child_spawns
             ),
             "concurrency": (
                 {"required": self.concurrency.required} if self.concurrency is not None else None

--- a/src/autoskillit/core/types/_type_skill_semantics.py
+++ b/src/autoskillit/core/types/_type_skill_semantics.py
@@ -87,7 +87,9 @@ class ChildSpawnSpec:
         if self.count < 1:
             raise SkillContractError("child spawn count must be positive")
         if self.for_each is not None:
-            if not isinstance(self.for_each, str) or not self.for_each.strip():
+            if not isinstance(self.for_each, str):
+                raise SkillContractError("child spawn for_each must be a string")
+            if not self.for_each.strip():
                 raise SkillContractError("child spawn for_each must be non-empty")
             if self.count != 1:
                 raise SkillContractError(

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -947,10 +947,16 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
                 if spawn_policy is not None and spawn_policy.reasoning_effort is not None
                 else ""
             )
-            fragments.append(
-                f"Issue {spawn.count} Agent(subagent_type={spawn.role!r}{model_arg}) "
-                f"call{'s' if spawn.count != 1 else ''}{effort_text}."
-            )
+            if spawn.for_each is not None:
+                fragments.append(
+                    f"Issue one Agent(subagent_type={spawn.role!r}{model_arg}) call per "
+                    f"runtime item in {spawn.for_each!r}{effort_text}."
+                )
+            else:
+                fragments.append(
+                    f"Issue {spawn.count} Agent(subagent_type={spawn.role!r}{model_arg}) "
+                    f"call{'s' if spawn.count != 1 else ''}{effort_text}."
+                )
         if plan.concurrency is not None and plan.concurrency.required:
             fragments.append("Issue all independent child calls in one message so they overlap.")
         if plan.join is not None and plan.join.required:

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -50,6 +50,7 @@ from autoskillit.core import (
     SESSION_TYPE_ORCHESTRATOR,
     SESSION_TYPE_SKILL,
     SKILL_SESSION_REQUIRED_ENV,
+    WEB_EVIDENCE_RESEARCHER_ROLE,
     AgentDef,
     BackendCapabilities,
     BackendConventions,
@@ -889,7 +890,11 @@ def _preflight_agent_projection(
     configured_agents = config.get("agents", {})
     if not isinstance(configured_agents, dict):
         raise ValueError("Codex config agents table must be a mapping")
-    protected_names = set(names) if exact_definitions else set(BUNDLED_EXPLORER_ROLES)
+    protected_names = (
+        set(names)
+        if exact_definitions
+        else {*BUNDLED_EXPLORER_ROLES, WEB_EVIDENCE_RESEARCHER_ROLE}
+    )
     ambient_collisions = sorted(set(names) & set(configured_agents) & protected_names)
     if ambient_collisions:
         raise ValueError(f"ambient Codex agent name collision: {ambient_collisions}")
@@ -2261,11 +2266,18 @@ class CodexBackend(BackendCmdBuilderBase):
                 policy_text += f", model={model_id!r}"
             if effort:
                 policy_text += f", reasoning_effort={effort!r}"
-            fragments.append(
-                f"Call spawn_agent {spawn.count} time{'s' if spawn.count != 1 else ''} "
-                f"with agent_type={native_role!r}, fork_turns='none'{policy_text}; "
-                "retain every returned child ID."
-            )
+            if spawn.for_each is not None:
+                fragments.append(
+                    "Call spawn_agent once per runtime item in "
+                    f"{spawn.for_each!r} with agent_type={native_role!r}, "
+                    f"fork_turns='none'{policy_text}; retain every returned child ID."
+                )
+            else:
+                fragments.append(
+                    f"Call spawn_agent {spawn.count} time{'s' if spawn.count != 1 else ''} "
+                    f"with agent_type={native_role!r}, fork_turns='none'{policy_text}; "
+                    "retain every returned child ID."
+                )
         if plan.concurrency is not None and plan.concurrency.required:
             fragments.append("Spawn all independent children before awaiting any result.")
         if plan.join is not None and plan.join.required:

--- a/src/autoskillit/skills_extended/audit-docs/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-docs/SKILL.md
@@ -15,20 +15,6 @@ hooks:
     - type: command
       command: 'echo ''[SKILL: audit-docs] Auditing documentation for staleness and drift...'''
       once: true
-semantic_version: 1
-semantic_requirements:
-  logical_roles:
-  - name: delegated-worker
-    purpose: perform the named independent responsibility and return bounded evidence
-  child_spawns:
-  - role: delegated-worker
-  concurrency:
-    required: true
-  join:
-    required: true
-  evidence:
-    required: true
-    independent: true
 ---
 
 # Documentation Audit Skill
@@ -53,7 +39,7 @@ Audit all documentation sources for drift, staleness, and inconsistency against 
 **ALWAYS:**
 - Ground every cross-reference finding in what the code actually does (not what other docs say)
 - Start all independent child delegations before awaiting any result to maximize concurrency
-- Use subagents for parallel exploration
+- Dispatch all ready deterministic exploration vectors in one wave and join every leaf
 - Write report to `{{AUTOSKILLIT_TEMP}}/audit-docs/docs_audit_{YYYY-MM-DD_HHMMSS}.md`
 - Provide file:line references for every finding
 - Categorize findings by severity (CRITICAL, HIGH, MEDIUM, LOW)
@@ -92,37 +78,61 @@ Flag findings in these categories (maps to REQ-SKILL-004):
 
 1. **Pre-flight**: Verify `{{AUTOSKILLIT_TEMP}}/audit-docs/` directory exists; create it if not.
 
-2. **Familiarization wave (SINGLE MESSAGE)** — spawn 6 parallel subagents, one per subsystem group. Each subagent reports: actual module/component names, exported symbols, behavioral summary (2–5 sentences per module). If any subagent fails, record the gap and continue.
+2. **Familiarization wave (SINGLE MESSAGE)** — dispatch the six ready evidence-only vectors below through the deterministic exploration router in one wave. Leaves collect facts only. If any leaf fails, record the gap and continue.
 
    **Start ALL independent child delegations before awaiting any result — one per item — and join every child before synthesis.**
 
    Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-   | Agent | Subsystems | Focus |
-   |---|---|---|
-   | Agent 1 | `core/`, `config/` | What these modules actually expose and do |
-   | Agent 2 | `execution/`, `workspace/` | Runtime orchestration and workspace lifecycle |
-   | Agent 3 | `recipe/`, `migration/` | Recipe schema, rules, validation, migration engine |
-   | Agent 4 | `server/` | MCP tool surface, gating, lifespan, factory |
-   | Agent 5 | `cli/`, `hooks/` | CLI commands, hook scripts, what each does |
-   | Agent 6 | `skills/`, `skills_extended/` | Bundled skills, categories, tiers |
+<!-- autoskillit:exploration-vector id="familiarize-core-config" -->
+   **Objective:** Establish what `src/autoskillit/core/` and `config/` expose and do. **Entry point:** their package gateways and registries. **Tool/source guidance:** trace definitions, imports, calls, and direct consumers; cite `file:line` evidence. **Scope boundary:** facts only, no documentation judgment or mutation. **Ignore list:** tests, generated files, temp artifacts, and unrelated packages. **Expected typed output:** `Verdict: answered | partial | blocked`, evidence records with symbol, behavior, and `file:line`, plus coverage gaps.
+<!-- /autoskillit:exploration-vector -->
+
+<!-- autoskillit:exploration-vector id="familiarize-execution-workspace" -->
+   **Objective:** Establish runtime orchestration and workspace lifecycle behavior in `execution/` and `workspace/`. **Entry point:** package gateways and backend/session/worktree entry paths. **Tool/source guidance:** trace imports, calls, references, and affected consumers with `file:line` evidence. **Scope boundary:** facts only; no severity, consolidation, or mutation. **Ignore list:** tests, logs, generated files, and unrelated packages. **Expected typed output:** `Verdict: answered | partial | blocked`, evidence records, and coverage gaps.
+<!-- /autoskillit:exploration-vector -->
+
+<!-- autoskillit:exploration-vector id="familiarize-recipe-migration" -->
+   **Objective:** Establish recipe schema, validation, rules, and migration behavior. **Entry point:** `recipe/` and `migration/` package gateways. **Tool/source guidance:** trace definitions, imports, calls, and consumers with `file:line` evidence. **Scope boundary:** facts only; no documentation comparison or mutation. **Ignore list:** tests, generated recipe artifacts, temp files, and unrelated packages. **Expected typed output:** `Verdict: answered | partial | blocked`, evidence records, and coverage gaps.
+<!-- /autoskillit:exploration-vector -->
+
+<!-- autoskillit:exploration-vector id="familiarize-server" -->
+   **Objective:** Establish the MCP tool surface, visibility gates, lifespan, and factory wiring in `server/`. **Entry point:** server factory, state, and tool registration modules. **Tool/source guidance:** trace declarations, definitions, imports, calls, and consumers with `file:line` evidence. **Scope boundary:** facts only; no severity or mutation. **Ignore list:** tests, generated schemas, temp files, and non-server implementation detail. **Expected typed output:** `Verdict: answered | partial | blocked`, evidence records, and coverage gaps.
+<!-- /autoskillit:exploration-vector -->
+
+<!-- autoskillit:exploration-vector id="familiarize-cli-hooks" -->
+   **Objective:** Establish CLI commands and hook-script behavior. **Entry point:** CLI registration and the hook registry. **Tool/source guidance:** trace definitions, calls, references, and affected consumers with `file:line` evidence. **Scope boundary:** facts only; no documentation judgment or mutation. **Ignore list:** tests, generated files, temp artifacts, and unrelated packages. **Expected typed output:** `Verdict: answered | partial | blocked`, evidence records, and coverage gaps.
+<!-- /autoskillit:exploration-vector -->
+
+<!-- autoskillit:exploration-vector id="familiarize-skills" -->
+   **Objective:** Establish the bundled `skills/` and `skills_extended/` catalog, categories, tiers, and consumers. **Entry point:** skill directories and catalog loaders. **Tool/source guidance:** trace declarations, references, and affected consumers with `file:line` evidence. **Scope boundary:** facts only; no cross-document judgment or mutation. **Ignore list:** tests, temp projections, generated files, and project-local skills. **Expected typed output:** `Verdict: answered | partial | blocked`, evidence records, and coverage gaps.
+<!-- /autoskillit:exploration-vector -->
 
 3. **Doc inventory** — enumerate all documentation sources (list files found under each source category above).
 
-4. **Cross-reference wave** — spawn 4 parallel subagents, each checking one doc domain against the familiarization findings:
+4. **Cross-reference wave** — after the parent assembles the documentation inventory, dispatch the four ready evidence-only vectors below through the deterministic router in one wave. Each leaf checks one domain against code-grounded familiarization evidence:
 
-   | Agent | Domain | What to check |
-   |---|---|---|
-   | Agent A | `AGENTS.md` (and physical `CLAUDE.md` for Claude-only overlay) | Architecture tree accuracy, file path references, tool/skill counts, layer descriptions |
-   | Agent B | `docs/architecture/**` | Component names, module paths, layer assignments |
-   | Agent C | `docs/requirements/**` and `docs/specs/**` | API surface, behavioral contracts |
-   | Agent D | Recipe YAML descriptions + docstrings | Step descriptions, ingredient names, parameter docs |
+<!-- autoskillit:exploration-vector id="crossref-agent-guides" -->
+   **Objective:** Collect code-grounded evidence for claims in `AGENTS.md` and the physical `CLAUDE.md` overlay. **Entry point:** those guide files and the symbols/paths they name. **Tool/source guidance:** trace references and affected consumers; return both claim and actual `file:line` evidence. **Scope boundary:** evidence only; the parent decides absence, severity, and findings. **Ignore list:** tests, generated files, temp artifacts, and stylistic wording differences. **Expected typed output:** `Verdict: answered | partial | blocked`, claim/evidence associations, and coverage gaps.
+<!-- /autoskillit:exploration-vector -->
 
-5. **Consolidate** — merge findings from all 4 agents, deduplicate by file:line, assign severity.
+<!-- autoskillit:exploration-vector id="crossref-architecture" -->
+   **Objective:** Collect code-grounded evidence for component, module-path, and layer claims in `docs/architecture/**`. **Entry point:** architecture documents and named package gateways. **Tool/source guidance:** trace imports, references, and affected consumers with paired `file:line` evidence. **Scope boundary:** evidence only; no consolidation, severity, or mutation. **Ignore list:** tests, generated files, temp artifacts, and prose-only differences. **Expected typed output:** `Verdict: answered | partial | blocked`, claim/evidence associations, and coverage gaps.
+<!-- /autoskillit:exploration-vector -->
 
-6. **Self-validation pass** — for every CRITICAL or HIGH finding, re-read the cited file line to confirm the claim; downgrade or remove if not confirmed.
+<!-- autoskillit:exploration-vector id="crossref-requirements-specs" -->
+   **Objective:** Collect code-grounded evidence for API and behavior claims in `docs/requirements/**` and `docs/specs/**`. **Entry point:** requirement/specification identifiers and their named definitions. **Tool/source guidance:** trace definitions, references, and affected consumers with paired `file:line` evidence. **Scope boundary:** evidence only; the parent decides contradictions and severity. **Ignore list:** tests, generated files, temp artifacts, and requirements without an implemented scope. **Expected typed output:** `Verdict: answered | partial | blocked`, claim/evidence associations, and coverage gaps.
+<!-- /autoskillit:exploration-vector -->
 
-7. **Write report** to `{{AUTOSKILLIT_TEMP}}/audit-docs/docs_audit_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory) using the format below.
+<!-- autoskillit:exploration-vector id="crossref-recipes-docstrings" -->
+   **Objective:** Collect code-grounded evidence for recipe YAML descriptions and Python docstrings. **Entry point:** recipe `description`, `summary`, and `note` fields plus public module/class/function docstrings under `src/`. **Tool/source guidance:** trace declarations, definitions, references, and affected consumers with paired `file:line` evidence. **Scope boundary:** evidence only; no deduplication, severity, report writing, or mutation. **Ignore list:** tests, generated recipe artifacts, temp files, and comments that are not docstrings. **Expected typed output:** `Verdict: answered | partial | blocked`, claim/evidence associations, and coverage gaps.
+<!-- /autoskillit:exploration-vector -->
+
+5. **Consolidate (parent only)** — assemble the doc inventory, run secondary absence checks against collector completeness, merge all leaf evidence, deduplicate by file:line, and assign severity. Preserve conflicts and every `partial` or `blocked` coverage gap.
+
+6. **Self-validation pass (parent only)** — for every CRITICAL or HIGH finding, re-read the cited file line to confirm the claim; downgrade or remove if not confirmed.
+
+7. **Write report (parent only)** to `{{AUTOSKILLIT_TEMP}}/audit-docs/docs_audit_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory) using the format below. Every mutation remains in the parent.
 
 8. **Output summary** — print finding counts by severity to terminal.
 

--- a/src/autoskillit/skills_extended/audit-docs/exploration.yaml
+++ b/src/autoskillit/skills_extended/audit-docs/exploration.yaml
@@ -1,0 +1,41 @@
+vectors:
+- id: familiarize-core-config
+  role: semantic-code-navigator
+  relationship_classes: [declares, defines, imports, calls, references]
+  rationale: Symbol and call evidence establishes the public core/config behavior that documentation must match.
+- id: familiarize-execution-workspace
+  role: semantic-code-navigator
+  relationship_classes: [imports, calls, references, affects]
+  rationale: Import, call, and impact evidence establishes runtime orchestration and workspace lifecycle behavior.
+- id: familiarize-recipe-migration
+  role: semantic-code-navigator
+  relationship_classes: [defines, imports, calls, references]
+  rationale: Definition and call evidence establishes recipe validation and migration behavior.
+- id: familiarize-server
+  role: semantic-code-navigator
+  relationship_classes: [declares, defines, imports, calls, references]
+  rationale: Symbol and call evidence establishes the MCP surface, visibility gates, lifespan, and factory wiring.
+- id: familiarize-cli-hooks
+  role: semantic-code-navigator
+  relationship_classes: [defines, imports, calls, references, affects]
+  rationale: Definition, call, and impact evidence establishes CLI commands and hook behavior.
+- id: familiarize-skills
+  role: repository-impact-profiler
+  relationship_classes: [declares, references, affects]
+  rationale: Repository-wide declaration and impact evidence establishes the bundled skill catalog and consumers.
+- id: crossref-agent-guides
+  role: repository-impact-profiler
+  relationship_classes: [references, affects]
+  rationale: Reference and impact evidence connects agent-guide claims to their concrete code consumers.
+- id: crossref-architecture
+  role: repository-impact-profiler
+  relationship_classes: [imports, references, affects]
+  rationale: Import and impact evidence checks architecture claims against package boundaries and consumers.
+- id: crossref-requirements-specs
+  role: repository-impact-profiler
+  relationship_classes: [defines, references, affects]
+  rationale: Definition and impact evidence checks requirement and specification claims against implemented contracts.
+- id: crossref-recipes-docstrings
+  role: repository-impact-profiler
+  relationship_classes: [declares, defines, references, affects]
+  rationale: Declaration and impact evidence checks recipe descriptions and docstrings against their runtime consumers.

--- a/src/autoskillit/skills_extended/review-approach/SKILL.md
+++ b/src/autoskillit/skills_extended/review-approach/SKILL.md
@@ -57,12 +57,15 @@ failure, not something to work around.
 
 - Modify any source code files
 - Create files outside `${AUTOSKILLIT_ALLOWED_WRITE_PREFIX:-{{AUTOSKILLIT_TEMP}}/review-approach}`
+- Launch more than five top-level children or allow a child to launch Agent or Skill children
+- Exceed eight web searches for one child or forty web searches across the review
 - Detach child delegations instead of joining them (joining every child is required)
 - Start independent child delegations sequentially
 
 **ALWAYS:**
 - Use subagents with web search for parallel research
 - Spawn all subagents via `child delegation under the declared `sonnet` model-class policy`
+- Track every selected topic and exact child ID to a terminal result
 - Keep findings concise and actionable
 - Present options with trade-offs
 - Make recommendations based on technical merit and project fit
@@ -81,7 +84,9 @@ failure, not something to work around.
 
 ### Step 1: Extract Research Targets
 
-From the plan file path argument (or, outside pipeline context, the report/conversation context provided), identify the core problems and proposed features that need external research. Break them into distinct research topics.
+From the plan file path argument (or, outside pipeline context, the report/conversation context provided), identify the core problems and proposed features that need external research. Select at most five distinct research topics. The limits below are a total-work budget, not only a concurrency limit: at most five top-level children, zero nested Agent or Skill launches, at most eight web searches per child and forty total.
+
+Create one ledger row for every selected topic before dispatch. Each row records the topic, dispatch state, exact child ID once spawned, terminal verdict, citations, unknowns, and coverage. A row starts as `pending`; after dispatch it may be `running` only until its child is joined.
 
 ### Step 2: Launch Parallel Web Search Subagents (SINGLE MESSAGE)
 
@@ -89,7 +94,9 @@ From the plan file path argument (or, outside pipeline context, the report/conve
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-Spawn general-purpose subagents (with web search) for each research topic. Each subagent should investigate:
+Spawn all topic children concurrently, then join every child before synthesis. Spawn one general-purpose subagent (with web search) for each selected research topic. Each self-contained task packet must include the topic, its relevance to the reviewed plan, suggested search angles, the eight-search limit, and this instruction: the child must not launch Agent or Skill children.
+
+Each child should investigate:
 
 - What modern solutions exist for this problem class
 - How mature projects and frameworks approach it
@@ -97,6 +104,20 @@ Spawn general-purpose subagents (with web search) for each research topic. Each 
 - Known pitfalls and trade-offs of common approaches
 
 Tailor the search queries to the specific technologies and constraints of the project.
+
+Every child returns this terminal envelope, including on an early stop or contract violation:
+
+```text
+Topic: {selected topic}
+Verdict: answered | partial | blocked
+Coverage: {what was and was not established}
+Citations: {source URLs associated with supported findings}
+Unknowns: {named unresolved questions}
+Web searches used: {0..8}
+Failure: {none, or a concise retryable/terminal failure reason}
+```
+
+Nested delegation is a contract violation: stop that child's research and return `Verdict: blocked` through the same envelope. After joining, accept only the three exact verdict values, treat a missing or malformed envelope as `blocked`, and update each row exactly once to its terminal result. Joined, failed, and completed work must never be described as active.
 
 ### Step 3: Synthesize
 
@@ -107,6 +128,16 @@ Consolidate subagent findings into a concise review. For each research topic:
 - **Relevance**: How each option relates to the proposed direction
 
 Drop anything that doesn't meaningfully inform the decision.
+
+Apply these deterministic completion rules and include the terminal ledger in the report:
+
+- **all-success:** when every row is `answered`, synthesize normally.
+- **partial-success:** when at least one row has usable cited evidence, synthesize every usable cited result, name every coverage gap and unknown, and do not convert unsupported material into a finding.
+- **all-failed:** when all rows are `blocked`, write an honest bounded review containing the failure evidence and terminal ledger; do not invent a recommendation.
+- **nested-delegation-attempt:** nested delegation is a contract violation; treat the affected row as `blocked` as specified above, then apply the partial-success or all-failed rule.
+- **incomplete-evidence:** when the available evidence cannot support an honest bounded review, return a structured retryable failure naming `insufficient_evidence`, the gaps, and the complete terminal ledger.
+
+Every completion branch, including retryable failure, writes the review report and emits the literal `review_path` output token. No branch returns while a ledger row is non-terminal or silently omits the report.
 
 ### Step 4: Write Review
 

--- a/src/autoskillit/skills_extended/review-approach/SKILL.md
+++ b/src/autoskillit/skills_extended/review-approach/SKILL.md
@@ -13,10 +13,11 @@ hooks:
 semantic_version: 1
 semantic_requirements:
   logical_roles:
-  - name: delegated-worker
-    purpose: perform the named independent responsibility and return bounded evidence
+  - name: autoskillit:web-evidence-researcher
+    purpose: collect bounded external web evidence for one runtime research topic
   child_spawns:
-  - role: delegated-worker
+  - role: autoskillit:web-evidence-researcher
+    for_each: research_topics
   concurrency:
     required: true
   join:
@@ -24,9 +25,6 @@ semantic_requirements:
   evidence:
     required: true
     independent: true
-  child_model_policies:
-  - role: delegated-worker
-    model_class: sonnet
 ---
 
 # Review Approach Skill
@@ -64,7 +62,7 @@ failure, not something to work around.
 
 **ALWAYS:**
 - Use subagents with web search for parallel research
-- Spawn all subagents via `child delegation under the declared `sonnet` model-class policy`
+- Spawn every topic child as `autoskillit:web-evidence-researcher`; do not pass a model or reasoning-effort override
 - Track every selected topic and exact child ID to a terminal result
 - Keep findings concise and actionable
 - Present options with trade-offs
@@ -94,30 +92,17 @@ Create one ledger row for every selected topic before dispatch. Each row records
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-Spawn all topic children concurrently, then join every child before synthesis. Spawn one general-purpose subagent (with web search) for each selected research topic. Each self-contained task packet must include the topic, its relevance to the reviewed plan, suggested search angles, the eight-search limit, and this instruction: the child must not launch Agent or Skill children.
+Spawn all topic children concurrently through `autoskillit:web-evidence-researcher`, then join every child before synthesis. The source skill must not pass a Claude or Codex model override.
 
-Each child should investigate:
+Each self-contained task packet contains:
 
-- What modern solutions exist for this problem class
-- How mature projects and frameworks approach it
-- Recent developments, libraries, or patterns worth considering
-- Known pitfalls and trade-offs of common approaches
+- the selected topic;
+- why that topic matters to the reviewed plan;
+- two or three suggested search angles tailored to the project's technologies and constraints;
+- a pointer to the named role's common `Verdict: answered | partial | blocked` return format; and
+- the explicit boundary `do not research adjacent topics`.
 
-Tailor the search queries to the specific technologies and constraints of the project.
-
-Every child returns this terminal envelope, including on an early stop or contract violation:
-
-```text
-Topic: {selected topic}
-Verdict: answered | partial | blocked
-Coverage: {what was and was not established}
-Citations: {source URLs associated with supported findings}
-Unknowns: {named unresolved questions}
-Web searches used: {0..8}
-Failure: {none, or a concise retryable/terminal failure reason}
-```
-
-Nested delegation is a contract violation: stop that child's research and return `Verdict: blocked` through the same envelope. After joining, accept only the three exact verdict values, treat a missing or malformed envelope as `blocked`, and update each row exactly once to its terminal result. Joined, failed, and completed work must never be described as active.
+The named role owns only bounded evidence collection for its packet and must not launch Agent or Skill children. Topic selection, cross-topic comparison, project-level recommendations, synthesis, report writing, and `review_path` remain parent responsibilities. Nested delegation is a contract violation handled by the role's common blocked envelope. After joining, accept only the three exact verdict values, treat a missing or malformed terminal `Verdict:` as `blocked`, preserve each child's source URLs, freshness, coverage, conflicts, unusable sources, and unknowns, and update each row exactly once to its terminal result. Joined, failed, and completed work must never be described as active.
 
 ### Step 3: Synthesize
 

--- a/src/autoskillit/workspace/skill_capabilities.py
+++ b/src/autoskillit/workspace/skill_capabilities.py
@@ -1009,7 +1009,11 @@ def parse_skill_semantic_plan(
             for item in _mapping_list(raw_requirements.get("logical_roles", []), "logical_roles")
         )
         child_spawns = tuple(
-            ChildSpawnSpec(role=str(item.get("role", "")), count=int(item.get("count", 1)))
+            ChildSpawnSpec(
+                role=str(item.get("role", "")),
+                count=int(item.get("count", 1)),
+                for_each=(str(item["for_each"]) if item.get("for_each") is not None else None),
+            )
             for item in _mapping_list(raw_requirements.get("child_spawns", []), "child_spawns")
         )
         child_model_policies = tuple(

--- a/src/autoskillit/workspace/skill_capabilities.py
+++ b/src/autoskillit/workspace/skill_capabilities.py
@@ -1008,19 +1008,14 @@ def parse_skill_semantic_plan(
             )
             for item in _mapping_list(raw_requirements.get("logical_roles", []), "logical_roles")
         )
-        child_spawns_list: list[ChildSpawnSpec] = []
-        for item in _mapping_list(raw_requirements.get("child_spawns", []), "child_spawns"):
-            for_each = item.get("for_each")
-            if for_each is not None and not isinstance(for_each, str):
-                raise SkillContractError("child spawn for_each must be a string")
-            child_spawns_list.append(
-                ChildSpawnSpec(
-                    role=str(item.get("role", "")),
-                    count=int(item.get("count", 1)),
-                    for_each=for_each,
-                )
+        child_spawns = tuple(
+            ChildSpawnSpec(
+                role=str(item.get("role", "")),
+                count=int(item.get("count", 1)),
+                for_each=item.get("for_each"),
             )
-        child_spawns = tuple(child_spawns_list)
+            for item in _mapping_list(raw_requirements.get("child_spawns", []), "child_spawns")
+        )
         child_model_policies = tuple(
             ChildModelPolicySpec(
                 role=str(item.get("role", "")),

--- a/src/autoskillit/workspace/skill_capabilities.py
+++ b/src/autoskillit/workspace/skill_capabilities.py
@@ -1008,14 +1008,19 @@ def parse_skill_semantic_plan(
             )
             for item in _mapping_list(raw_requirements.get("logical_roles", []), "logical_roles")
         )
-        child_spawns = tuple(
-            ChildSpawnSpec(
-                role=str(item.get("role", "")),
-                count=int(item.get("count", 1)),
-                for_each=(str(item["for_each"]) if item.get("for_each") is not None else None),
+        child_spawns_list: list[ChildSpawnSpec] = []
+        for item in _mapping_list(raw_requirements.get("child_spawns", []), "child_spawns"):
+            for_each = item.get("for_each")
+            if for_each is not None and not isinstance(for_each, str):
+                raise SkillContractError("child spawn for_each must be a string")
+            child_spawns_list.append(
+                ChildSpawnSpec(
+                    role=str(item.get("role", "")),
+                    count=int(item.get("count", 1)),
+                    for_each=for_each,
+                )
             )
-            for item in _mapping_list(raw_requirements.get("child_spawns", []), "child_spawns")
-        )
+        child_spawns = tuple(child_spawns_list)
         child_model_policies = tuple(
             ChildModelPolicySpec(
                 role=str(item.get("role", "")),

--- a/tests/_test_env_parity.py
+++ b/tests/_test_env_parity.py
@@ -66,4 +66,13 @@ TEST_HARNESS_ENV_OVERRIDES: dict[str, HarnessEnvOverride] = {
         ),
         parity_fixture=None,
     ),
+    "AUTOSKILLIT_WEB_AGENT_LIVE_GATE": HarnessEnvOverride(
+        var="AUTOSKILLIT_WEB_AGENT_LIVE_GATE",
+        value="1",
+        justification=(
+            "Enables only the authenticated live-web AgentDef conformance test; "
+            "ordinary test tasks leave the production gate disabled."
+        ),
+        parity_fixture=None,
+    ),
 }

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1260,7 +1260,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "run_skill launch denial paths before command construction (+139 net lines)",
     ),
     "execution/backends/codex.py": (
-        2371,
+        2383,
         "REQ-CNST-010-E9: Codex backend — skill_sigil capability threading adds multi-line "
         "keyword args to _ensure_skill_prefix call sites and _has_prefix guard; "
         "write_guard_tool_names env injection adds 7 lines to _codex_exec_extras; "
@@ -1305,10 +1305,11 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "prompt-injection composition (+14 net lines)"
         "; #4488/#4489/#4492 explorer surface authority: setup_session_dir gains "
         "explorer-role TOML exclusion filter for unbound sessions (+7 net lines) and "
-        "explicit session-scoped capability disposition (+1 net line)",
+        "explicit session-scoped capability disposition (+1 net line); #4507 adds runtime "
+        "child cardinality rendering and protects the live-web bundled role (+12 net lines)",
     ),
     "execution/backends/claude.py": (
-        1108,
+        1114,
         "REQ-CNST-010-E19: Claude backend protocol parity keeps managed native-shell "
         "decision/reference disposition beside executable launch-binding validation; "
         "both are shared builder-interface obligations even though Claude deliberately "
@@ -1318,13 +1319,14 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "parent sandbox authority through the shared no-op setup boundary and explorer "
         "dispatch rendering preserves the same backend-owned syntax authority; #4480 adds "
         "the plugin_dir launch-binding validation parameter for cross-backend signature "
-        "parity.",
+        "parity; #4507 renders one named child per runtime topic (+6 net lines).",
     ),
     "workspace/skill_capabilities.py": (
-        1100,
+        1104,
         "REQ-SEM-SCHEMA-001: versioned semantic declarations, closed-operation parsing, "
         "retired-key rejection, and precise per-skill diagnostics remain co-located at "
-        "the sole skill-frontmatter validation boundary.",
+        "the sole skill-frontmatter validation boundary; #4507 parses runtime child "
+        "cardinality at that same boundary (+4 net lines).",
     ),
     "workspace/skills.py": (
         1550,

--- a/tests/contracts/test_skill_semantic_authenticity.py
+++ b/tests/contracts/test_skill_semantic_authenticity.py
@@ -64,7 +64,8 @@ def test_bundled_parallel_child_instructions_have_semantic_plans() -> None:
             assert parsed.is_valid, path
             if any(marker in parsed.body for marker in markers):
                 data = parsed.data or {}
-                if data.get("semantic_version") is None:
+                has_exploration_plan = (path.parent / "exploration.yaml").is_file()
+                if data.get("semantic_version") is None and not has_exploration_plan:
                     violations.append(path.parent.name)
     assert not violations, "parallel child instructions without semantic plans:\n" + "\n".join(
         violations

--- a/tests/core/test_agent_definition.py
+++ b/tests/core/test_agent_definition.py
@@ -14,6 +14,7 @@ from autoskillit.core import (
     EXPLORATION_TOOLS,
     REPOSITORY_IMPACT_PROFILER_ROLE,
     SEMANTIC_CODE_NAVIGATOR_ROLE,
+    WEB_EVIDENCE_RESEARCHER_ROLE,
     AgentDef,
     AgentDefinitionError,
     CodexAgentProjectionDef,
@@ -57,6 +58,35 @@ def test_specialized_explorers_are_terminal_luna_broker_roles(
     assert "spawn peers" in definition.body
     assert "synthesis" in definition.body
     assert "select a backend" in definition.body
+
+
+def test_web_evidence_researcher_is_a_terminal_live_web_leaf() -> None:
+    definition = load_agent_definition(
+        pkg_root() / "agents" / f"{WEB_EVIDENCE_RESEARCHER_ROLE}.md"
+    )
+    explorer = load_agent_definition(pkg_root() / "agents" / f"{SEMANTIC_CODE_NAVIGATOR_ROLE}.md")
+
+    assert definition.tools == ("WebSearch", "WebFetch")
+    assert definition.model is None
+    assert definition.max_turns == 80
+    assert definition.codex.model == "gpt-5.6-luna"
+    assert definition.codex.reasoning_effort == "xhigh"
+    assert definition.codex.sandbox_mode == "read-only"
+    assert definition.codex.web_search == "live"
+    assert definition.codex.agents_enabled is False
+    assert set(definition.codex.disabled_features) == (
+        set(explorer.codex.disabled_features) - {"standalone_web_search"}
+    )
+    assert not (set(RETIRED_CODEX_FEATURES) & set(definition.codex.disabled_features))
+    for contract in (
+        "Never construct, complete, or guess a URL",
+        "SOURCE_UNREACHABLE",
+        "explicit source conflicts",
+        "Verdict: answered | partial | blocked",
+        "CONTRACT VIOLATION",
+        "stop only further search/fetch calls",
+    ):
+        assert contract in definition.body
 
 
 def test_bundled_agent_catalog_loads_with_unique_digests() -> None:
@@ -162,15 +192,27 @@ def test_invalid_native_projection_fails_closed(projection: tuple[str, str, str]
         CodexAgentProjectionDef(*projection)
 
 
-@pytest.mark.parametrize("web_search", ["enabled", False, 1])
+@pytest.mark.parametrize("web_search", ["enabled", "LIVE", False, 1])
 def test_invalid_web_search_policy_fails_closed(web_search: object) -> None:
-    with pytest.raises(AgentDefinitionError, match="web_search must be 'disabled'"):
+    with pytest.raises(AgentDefinitionError, match="web_search must be one of"):
         CodexAgentProjectionDef(
             "gpt-5.6-luna",
             "max",
             "read-only",
             web_search=web_search,  # type: ignore[arg-type]
         )
+
+
+@pytest.mark.parametrize("web_search", ["disabled", "cached", "indexed", "live"])
+def test_valid_codex_web_search_modes(web_search: str) -> None:
+    projection = CodexAgentProjectionDef(
+        "gpt-5.6-luna",
+        "max",
+        "read-only",
+        web_search=web_search,  # type: ignore[arg-type]
+    )
+
+    assert projection.web_search == web_search
 
 
 def test_web_search_policy_is_optional_and_positional_arguments_remain_stable() -> None:
@@ -350,8 +392,25 @@ def test_definition_digest_is_domain_separated_and_content_bound() -> None:
             web_search="disabled",
         ),
     )
+    changed_live_web_search = AgentDef(
+        name=definition.name,
+        description=definition.description,
+        tools=definition.tools,
+        model=definition.model,
+        max_turns=definition.max_turns,
+        body=definition.body,
+        codex=CodexAgentProjectionDef(
+            "gpt-5.6-luna",
+            "max",
+            "read-only",
+            web_search="live",
+        ),
+    )
     assert digest.startswith("sha256:")
     assert digest != agent_definition_digest(changed)
     assert digest != agent_definition_digest(changed_features)
     assert digest != agent_definition_digest(changed_agents_enabled)
     assert digest != agent_definition_digest(changed_web_search)
+    assert agent_definition_digest(changed_web_search) != agent_definition_digest(
+        changed_live_web_search
+    )

--- a/tests/core/test_agent_definition.py
+++ b/tests/core/test_agent_definition.py
@@ -83,10 +83,18 @@ def test_web_evidence_researcher_is_a_terminal_live_web_leaf() -> None:
         "SOURCE_UNREACHABLE",
         "explicit source conflicts",
         "Verdict: answered | partial | blocked",
-        "CONTRACT VIOLATION",
         "stop only further search/fetch calls",
+        "view_image",
+        "Never actually call a shell or terminal tool",
+        "mutate repository or other files",
+        "control a browser or computer",
+        "spawn another agent",
     ):
         assert contract in definition.body
+    assert "First verify" not in definition.body
+    assert "effective surface includes" not in definition.body
+    assert "inventory or inspect advertised tools" not in definition.body
+    assert "unrelated tools are visible" not in definition.body
 
 
 def test_bundled_agent_catalog_loads_with_unique_digests() -> None:

--- a/tests/core/test_skill_semantic_plan.py
+++ b/tests/core/test_skill_semantic_plan.py
@@ -67,6 +67,35 @@ def test_skill_semantic_plan_is_frozen_slotted_and_derives_operations() -> None:
     )
 
     assert plan.operations == frozenset(SkillSemanticOperation)
+
+
+def test_child_spawn_for_each_is_dynamic_and_mutually_exclusive_with_count() -> None:
+    from autoskillit.core import (
+        ChildSpawnSpec,
+        LogicalRoleSpec,
+        SkillContractError,
+        SkillSemanticPlan,
+    )
+
+    dynamic = ChildSpawnSpec(role="researcher", for_each="research_topics")
+    logical_roles = (LogicalRoleSpec(name="researcher", purpose="research one topic"),)
+    plan = SkillSemanticPlan(
+        schema_version=1, child_spawns=(dynamic,), logical_roles=logical_roles
+    )
+
+    assert plan.canonical_payload["child_spawns"] == (
+        {"role": "researcher", "count": 1, "for_each": "research_topics"},
+    )
+    fixed = SkillSemanticPlan(
+        schema_version=1,
+        child_spawns=(ChildSpawnSpec(role="researcher"),),
+        logical_roles=logical_roles,
+    )
+    assert "for_each" not in fixed.canonical_payload["child_spawns"][0]
+    with pytest.raises(SkillContractError, match="for_each must be non-empty"):
+        ChildSpawnSpec(role="researcher", for_each=" ")
+    with pytest.raises(SkillContractError, match="non-default count"):
+        ChildSpawnSpec(role="researcher", count=2, for_each="research_topics")
     assert not hasattr(plan, "__dict__")
     with pytest.raises(FrozenInstanceError):
         plan.schema_version = 2  # type: ignore[misc]

--- a/tests/execution/backends/_live_codex_parent.py
+++ b/tests/execution/backends/_live_codex_parent.py
@@ -132,6 +132,7 @@ def run_live_codex_parent(
     stderr: Any,
     text: bool,
     resume_thread_id: str | None = None,
+    extra_overrides: tuple[str, ...] = (),
 ) -> subprocess.CompletedProcess[Any]:
     """Execute or resume the common real-Codex parent used by both live gates."""
     invocation = [
@@ -143,6 +144,8 @@ def run_live_codex_parent(
         "--model",
         model,
     ]
+    for override in extra_overrides:
+        invocation.extend(("-c", override))
     if resume_thread_id is not None:
         if not resume_thread_id.strip():
             raise ValueError("resume_thread_id must be a non-empty string")

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -22,6 +22,7 @@ from autoskillit.core import (
     MCP_CLIENT_BACKEND_ENV_VAR,
     SESSION_TYPE_ORCHESTRATOR,
     SESSION_TYPE_SKILL,
+    WEB_EVIDENCE_RESEARCHER_ROLE,
     AgentDef,
     BackendCapabilities,
     BackendConventions,
@@ -1764,6 +1765,10 @@ class TestCodexBackendSetupSessionDir:
     def test_agent_toml_required_fields_present_and_nonempty(self) -> None:
         self._write_all_source_files()
         CodexBackend().setup_session_dir(self.session_dir)
+        definitions = {
+            definition.name: definition
+            for definition in load_agent_definitions(pkg_root() / "agents")
+        }
         for toml_path in sorted((self.session_dir / "agents").glob("*.toml")):
             data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
             assert data["name"], f"{toml_path.name}: name empty"
@@ -1780,15 +1785,7 @@ class TestCodexBackendSetupSessionDir:
                 .endswith(codex_discipline_suffix().rstrip())
             )
             assert "AutoSkillit agent definition digest: sha256:" in data["developer_instructions"]
-            expected_sandbox = (
-                "read-only"
-                if toml_path.stem
-                in {
-                    "pr-review-auditor-reachability",
-                    "pr-review-auditor-abstraction-surface",
-                }
-                else "workspace-write"
-            )
+            expected_sandbox = definitions[toml_path.stem].codex.sandbox_mode
             assert data["sandbox_mode"] == expected_sandbox, (
                 f"{toml_path.name}: wrong sandbox_mode"
             )
@@ -1796,13 +1793,15 @@ class TestCodexBackendSetupSessionDir:
     def test_read_only_agent_tools_project_to_read_only_sandbox(self) -> None:
         self._write_all_source_files()
         CodexBackend().setup_session_dir(self.session_dir)
-        # Explorer roles (semantic-code-navigator, repository-impact-profiler)
-        # are excluded from unbound generation — verify only the always-present
-        # read-only roles.
-        for name in (
-            "pr-review-auditor-reachability",
-            "pr-review-auditor-abstraction-surface",
-        ):
+        definitions = load_agent_definitions(pkg_root() / "agents")
+        read_only_names = {
+            definition.name
+            for definition in definitions
+            if definition.name not in BUNDLED_EXPLORER_ROLES
+            and definition.codex.sandbox_mode == "read-only"
+        }
+        assert WEB_EVIDENCE_RESEARCHER_ROLE in read_only_names
+        for name in read_only_names:
             data = tomllib.loads(
                 (self.session_dir / "agents" / f"{name}.toml").read_text(encoding="utf-8")
             )
@@ -2408,6 +2407,33 @@ class TestCodexBackendSetupSessionDir:
         assert parsed["agents"] == {"enabled": False}
         assert generated_text.index("developer_instructions") < generated_text.index("[agents]")
 
+    def test_web_evidence_role_renders_live_web_leaf_policy(self) -> None:
+        definition = next(
+            definition
+            for definition in load_agent_definitions(pkg_root() / "agents")
+            if definition.name == WEB_EVIDENCE_RESEARCHER_ROLE
+        )
+        CodexBackend().setup_session_dir(
+            self.session_dir,
+            parent_sandbox_mode="read-only",
+            agent_defs=(definition,),
+        )
+
+        generated = self.session_dir / "agents" / f"{WEB_EVIDENCE_RESEARCHER_ROLE}.toml"
+        generated_text = generated.read_text(encoding="utf-8")
+        parsed = tomllib.loads(generated_text)
+        assert parsed["model"] == "gpt-5.6-luna"
+        assert parsed["model_reasoning_effort"] == "xhigh"
+        assert parsed["sandbox_mode"] == "read-only"
+        assert parsed["web_search"] == "live"
+        assert parsed["agents"] == {"enabled": False}
+        assert parsed["features"] == {
+            feature: False for feature in definition.codex.disabled_features
+        }
+        assert agent_definition_digest(definition) in generated_text
+        assert generated_text.index('web_search = "live"') < generated_text.index("[features]")
+        assert generated_text.index('web_search = "live"') < generated_text.index("[agents]")
+
     def test_injected_luna_definition_rejects_writable_parent_before_mutation(self) -> None:
         self._write_all_source_files()
         config_path = self.session_dir / "config.toml"
@@ -2462,9 +2488,13 @@ class TestCodexBackendSetupSessionDir:
 
     @pytest.mark.parametrize(
         "role",
-        ("semantic-code-navigator", "repository-impact-profiler"),
+        (
+            "semantic-code-navigator",
+            "repository-impact-profiler",
+            WEB_EVIDENCE_RESEARCHER_ROLE,
+        ),
     )
-    def test_bundled_explorer_ambient_collision_fails_before_mutation(self, role: str) -> None:
+    def test_protected_bundled_agent_collision_fails_before_mutation(self, role: str) -> None:
         (self.session_dir / "config.toml").write_text(
             f'[agents."{role}"]\n'
             'description = "ambient explorer"\n'

--- a/tests/execution/backends/test_codex_explorer_registration.py
+++ b/tests/execution/backends/test_codex_explorer_registration.py
@@ -31,10 +31,13 @@ class TestExplorerRegistrationDerivesFromBindings:
             f"but found: {toml_names & BUNDLED_EXPLORER_ROLES}"
         )
         all_defs = load_bundled_agent_definitions()
+        definitions = {definition.name: definition for definition in all_defs}
         non_explorer_count = sum(1 for d in all_defs if d.name not in BUNDLED_EXPLORER_ROLES)
         assert count == non_explorer_count
         for path in (tmp_path / "agents").glob("*.toml"):
-            assert "web_search" not in tomllib.loads(path.read_text(encoding="utf-8"))
+            data = tomllib.loads(path.read_text(encoding="utf-8"))
+            expected = definitions[path.stem].codex.web_search
+            assert data.get("web_search") == expected
 
     def test_bound_includes_explorer_roles(self, tmp_path: Path) -> None:
         from autoskillit.execution.backends._codex.explorer_projection import (

--- a/tests/execution/backends/test_skill_semantic_trace_conformance.py
+++ b/tests/execution/backends/test_skill_semantic_trace_conformance.py
@@ -365,6 +365,53 @@ def test_codex_semantic_policy_matches_generated_native_role_toml(tmp_path: Path
     )
 
 
+def test_dynamic_child_spawn_adapters_preserve_runtime_cardinality() -> None:
+    role = "autoskillit:web-evidence-researcher"
+    plan = SkillSemanticPlan(
+        schema_version=1,
+        logical_roles=(LogicalRoleSpec(name=role, purpose="research one topic"),),
+        child_spawns=(ChildSpawnSpec(role=role, for_each="research_topics"),),
+    )
+
+    claude = ClaudeCodeBackend().adapt_skill_semantics(plan)
+    codex = CodexBackend().adapt_skill_semantics(plan)
+
+    claude_text = "\n".join(claude.instruction_fragments)
+    codex_text = "\n".join(codex.instruction_fragments)
+    assert "per runtime item in 'research_topics'" in claude_text
+    assert "subagent_type='autoskillit:web-evidence-researcher'" in claude_text
+    assert "model=" not in claude_text
+    assert "once per runtime item in 'research_topics'" in codex_text
+    assert "agent_type='web-evidence-researcher'" in codex_text
+    assert "fork_turns='none'" in codex_text
+    assert "model=" not in codex_text
+    assert "reasoning_effort=" not in codex_text
+
+
+def test_review_approach_projects_the_real_named_web_role() -> None:
+    skill_md = pkg_root() / "skills_extended" / "review-approach" / "SKILL.md"
+    info = _skill_info_from_frontmatter("review-approach", SkillSource.BUNDLED, skill_md)
+
+    assert not info.invalidities
+    assert info.semantic_plan is not None
+    plan = info.semantic_plan
+    role = "autoskillit:web-evidence-researcher"
+    assert tuple(item.name for item in plan.logical_roles) == (role,)
+    assert plan.child_spawns == (ChildSpawnSpec(role=role, for_each="research_topics"),)
+    assert not plan.child_model_policies
+
+    claude_text = "\n".join(ClaudeCodeBackend().adapt_skill_semantics(plan).instruction_fragments)
+    codex_text = "\n".join(CodexBackend().adapt_skill_semantics(plan).instruction_fragments)
+    assert "subagent_type='autoskillit:web-evidence-researcher'" in claude_text
+    assert "per runtime item in 'research_topics'" in claude_text
+    assert "model=" not in claude_text
+    assert "agent_type='web-evidence-researcher'" in codex_text
+    assert "once per runtime item in 'research_topics'" in codex_text
+    assert "fork_turns='none'" in codex_text
+    assert "model=" not in codex_text
+    assert "reasoning_effort=" not in codex_text
+
+
 @pytest.mark.parametrize("skill_name", ["review-pr", "enrich-issues"])
 def test_real_semantic_skill_materializes_through_codex_adapter(skill_name: str) -> None:
     skill_md = pkg_root() / "skills_extended" / skill_name / "SKILL.md"

--- a/tests/execution/backends/test_web_agent_live_gate.py
+++ b/tests/execution/backends/test_web_agent_live_gate.py
@@ -46,6 +46,7 @@ _FORBIDDEN_TOOL_FRAGMENTS = (
     "spawn_agent",
     "write_stdin",
 )
+_NESTED_TOOL_CALL = re.compile(r"\btools\.([A-Za-z0-9_]+)\s*\(")
 
 
 def _assistant_text(events: list[dict]) -> str:
@@ -77,9 +78,62 @@ def _observed_tool_names(events: list[dict]) -> set[str]:
             continue
         payload_type = str(payload.get("type", ""))
         name = str(payload.get("name", ""))
-        if "call" in payload_type:
+        if "call" not in payload_type or payload_type.endswith("_output"):
+            continue
+        if payload_type == "custom_tool_call" and name == "exec":
+            source = str(payload.get("input") or payload.get("arguments") or "")
+            names.update(_NESTED_TOOL_CALL.findall(source))
+        else:
             names.add(name or payload_type)
     return names
+
+
+def _forbidden_called_tools(tool_names: set[str]) -> set[str]:
+    return {
+        name
+        for name in tool_names
+        if any(fragment in name.lower() for fragment in _FORBIDDEN_TOOL_FRAGMENTS)
+    }
+
+
+def _nested_exec_call(source: str) -> dict:
+    return {
+        "type": "response_item",
+        "payload": {"type": "custom_tool_call", "name": "exec", "input": source},
+    }
+
+
+def test_observed_tool_names_records_nested_calls_not_gateway_or_catalog() -> None:
+    events = [
+        _nested_exec_call(
+            "const result = await tools.web__run({search_query: [{q: 'Python'}]}); "
+            "text(JSON.stringify(result));"
+        ),
+        {
+            "type": "response_item",
+            "payload": {"type": "custom_tool_call_output", "output": "search results"},
+        },
+        {
+            "type": "tool_catalog",
+            "payload": {"tools": ["exec_command", "spawn_agent", "computer_use"]},
+        },
+    ]
+
+    assert _observed_tool_names(events) == {"web__run"}
+
+
+def test_view_image_is_an_allowed_nested_call() -> None:
+    tool_names = _observed_tool_names(
+        [_nested_exec_call("await tools.view_image({path: '/tmp/chart.png'});")]
+    )
+    assert tool_names == {"view_image"}
+    assert not _forbidden_called_tools(tool_names)
+
+
+@pytest.mark.parametrize("tool_name", ["exec_command", "browser_control", "spawn_agent"])
+def test_forbidden_nested_calls_are_rejected(tool_name: str) -> None:
+    event = _nested_exec_call(f"await tools.{tool_name}({{}});")
+    assert _forbidden_called_tools(_observed_tool_names([event])) == {tool_name}
 
 
 @pytest.mark.smoke
@@ -135,7 +189,9 @@ def test_live_web_agent_is_luna_xhigh_read_only_leaf(
 Spawn exactly one child with agent_type={WEB_EVIDENCE_RESEARCHER_ROLE!r},
 fork_turns='none', and task_name='live_web_evidence'. Do not pass model or
 reasoning_effort. Ask it to use live web search to identify the current stable
-Python release from an official Python source and return at least one exact
+Python release from an official Python source. Require it to make at least one
+shared functions.exec gateway call whose cell directly awaits tools.web__run
+with a search_query, and return at least one exact
 https://docs.python.org/ URL through its terminal verdict envelope. Wait for the
 child, then return its URL and the marker WEB_AGENT_GATE_COMPLETE. Do not search
 the web in the parent.
@@ -168,12 +224,8 @@ the web in the parent.
         expected_definition_digest=digest,
     )
     tool_names = _observed_tool_names(rollout.child_events)
-    assert any("web_search" in name.lower() for name in tool_names), tool_names
-    assert not {
-        name
-        for name in tool_names
-        if any(fragment in name.lower() for fragment in _FORBIDDEN_TOOL_FRAGMENTS)
-    }
+    assert "web__run" in tool_names, tool_names
+    assert not _forbidden_called_tools(tool_names)
     child_text = _assistant_text(rollout.child_events)
     returned_urls = sorted(set(re.findall(r"https://docs\.python\.org/[^\s)>\]]+", child_text)))
     assert returned_urls, child_text[-4000:]

--- a/tests/execution/backends/test_web_agent_live_gate.py
+++ b/tests/execution/backends/test_web_agent_live_gate.py
@@ -128,6 +128,9 @@ def test_live_web_agent_is_luna_xhigh_read_only_leaf(
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
+    subprocess.run(  # noqa: S603
+        ["git", "init", "--quiet"], cwd=workspace, check=True, timeout=30
+    )
     prompt = f"""
 Spawn exactly one child with agent_type={WEB_EVIDENCE_RESEARCHER_ROLE!r},
 fork_turns='none', and task_name='live_web_evidence'. Do not pass model or

--- a/tests/execution/backends/test_web_agent_live_gate.py
+++ b/tests/execution/backends/test_web_agent_live_gate.py
@@ -1,0 +1,204 @@
+"""Authenticated conformance gate for the terminal live-web Codex role."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tomllib
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core import (
+    OUTPUT_DISCIPLINE_DIGEST,
+    WEB_EVIDENCE_RESEARCHER_ROLE,
+    agent_definition_digest,
+    load_agent_definitions,
+    pkg_root,
+)
+from tests.execution.backends._explorer_conformance_assertions import (
+    assert_generated_codex_child_delivery,
+)
+from tests.execution.backends._live_codex_parent import (
+    prepare_live_codex_parent,
+    run_live_codex_parent,
+)
+from tests.execution.backends.test_cli_conformance_probes import (
+    _collect_generated_child_rollout,
+)
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.large, pytest.mark.timeout(1200)]
+
+_GATE_ENV = "AUTOSKILLIT_WEB_AGENT_LIVE_GATE"
+_ARTIFACT_DIR_ENV = "AUTOSKILLIT_WEB_AGENT_LIVE_GATE_ARTIFACT_DIR"
+_CODEX_AUTH_PATH = Path("~/.codex/auth.json").expanduser()
+_EXPECTED_CLI_VERSION = "codex-cli 0.147.0"
+_FORBIDDEN_TOOL_FRAGMENTS = (
+    "apply_patch",
+    "browser",
+    "computer",
+    "exec_command",
+    "imagegen",
+    "shell",
+    "spawn_agent",
+    "write_stdin",
+)
+
+
+def _assistant_text(events: list[dict]) -> str:
+    fragments: list[str] = []
+    for event in events:
+        payload = event.get("payload", {})
+        if not isinstance(payload, dict):
+            continue
+        if event.get("type") == "response_item" and payload.get("type") == "message":
+            if payload.get("role") != "assistant":
+                continue
+            content = payload.get("content", [])
+            if isinstance(content, str):
+                fragments.append(content)
+            elif isinstance(content, list):
+                fragments.extend(
+                    str(block.get("text", "")) for block in content if isinstance(block, dict)
+                )
+        elif event.get("type") == "agent_message":
+            fragments.append(str(payload.get("text") or payload.get("message") or ""))
+    return "\n".join(fragments)
+
+
+def _observed_tool_names(events: list[dict]) -> set[str]:
+    names: set[str] = set()
+    for event in events:
+        payload = event.get("payload", {})
+        if not isinstance(payload, dict):
+            continue
+        payload_type = str(payload.get("type", ""))
+        name = str(payload.get("name", ""))
+        if "call" in payload_type:
+            names.add(name or payload_type)
+    return names
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(
+    not os.environ.get(_GATE_ENV)
+    or (
+        not os.environ.get("CODEX_API_KEY")
+        and not os.environ.get("OPENAI_API_KEY")
+        and not _CODEX_AUTH_PATH.exists()
+    ),
+    reason="run through task test-smoke-codex-web-agent-live-gate with Codex auth",
+)
+def test_live_web_agent_is_luna_xhigh_read_only_leaf(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cli_version = subprocess.run(  # noqa: S603
+        ["codex", "--version"],
+        capture_output=True,
+        check=True,
+        text=True,
+        timeout=30,
+    ).stdout.strip()
+    assert cli_version == _EXPECTED_CLI_VERSION
+
+    definition = next(
+        definition
+        for definition in load_agent_definitions(pkg_root() / "agents")
+        if definition.name == WEB_EVIDENCE_RESEARCHER_ROLE
+    )
+    digest = agent_definition_digest(definition)
+    prepared = prepare_live_codex_parent(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        source_auth=_CODEX_AUTH_PATH,
+        agent_defs=(definition,),
+    )
+    session_config = tomllib.loads(
+        (prepared.session_home / "config.toml").read_text(encoding="utf-8")
+    )
+    registered = session_config["agents"][WEB_EVIDENCE_RESEARCHER_ROLE]
+    assert registered["config_file"] == (f"agents/{WEB_EVIDENCE_RESEARCHER_ROLE}.toml")
+    role_config_path = prepared.session_home / registered["config_file"]
+    role_config = tomllib.loads(role_config_path.read_text(encoding="utf-8"))
+    assert role_config["web_search"] == "live"
+    assert role_config["agents"] == {"enabled": False}
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    prompt = f"""
+Spawn exactly one child with agent_type={WEB_EVIDENCE_RESEARCHER_ROLE!r},
+fork_turns='none', and task_name='live_web_evidence'. Do not pass model or
+reasoning_effort. Ask it to use live web search to identify the current stable
+Python release from an official Python source and return at least one exact
+https://docs.python.org/ URL through its terminal verdict envelope. Wait for the
+child, then return its URL and the marker WEB_AGENT_GATE_COMPLETE. Do not search
+the web in the parent.
+""".strip()
+    result = run_live_codex_parent(
+        env=prepared.env,
+        cwd=workspace,
+        model="gpt-5.6-sol",
+        prompt=prompt,
+        timeout=int(os.environ.get("WEB_AGENT_LIVE_GATE_TIMEOUT", "900")),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        extra_overrides=("web_search=disabled",),
+    )
+    assert result.returncode == 0, (result.stdout + "\n" + result.stderr)[-16000:]
+
+    rollout = _collect_generated_child_rollout(result, session_home=prepared.session_home)
+    identity = assert_generated_codex_child_delivery(
+        rollout.parent_events,
+        rollout.child_events,
+        parent_id=rollout.parent_id,
+        agent_role=WEB_EVIDENCE_RESEARCHER_ROLE,
+        output_discipline_digest=OUTPUT_DISCIPLINE_DIGEST,
+        expected_parent_model="gpt-5.6-sol",
+        expected_parent_sandbox_mode="read-only",
+        expected_model="gpt-5.6-luna",
+        expected_reasoning_effort="xhigh",
+        expected_sandbox_mode="read-only",
+        expected_definition_digest=digest,
+    )
+    tool_names = _observed_tool_names(rollout.child_events)
+    assert any("web_search" in name.lower() for name in tool_names), tool_names
+    assert not {
+        name
+        for name in tool_names
+        if any(fragment in name.lower() for fragment in _FORBIDDEN_TOOL_FRAGMENTS)
+    }
+    child_text = _assistant_text(rollout.child_events)
+    returned_urls = sorted(set(re.findall(r"https://docs\.python\.org/[^\s)>\]]+", child_text)))
+    assert returned_urls, child_text[-4000:]
+
+    artifact_dir = Path(os.environ[_ARTIFACT_DIR_ENV])
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    evidence = {
+        "schema_version": 1,
+        "contract": "live-web-agent-codex-0.147.0",
+        "generated_at": datetime.now(UTC).isoformat(),
+        "cli_version": cli_version,
+        "parent_id": identity.parent_id,
+        "child_id": identity.child_id,
+        "agent_role": identity.agent_role,
+        "agent_config_path": registered["config_file"],
+        "definition_digest": digest,
+        "parent_model": identity.parent_model,
+        "parent_web_search": "disabled",
+        "child_model": identity.model,
+        "child_reasoning_effort": identity.reasoning_effort,
+        "child_sandbox_mode": identity.sandbox_mode,
+        "child_web_search": role_config["web_search"],
+        "child_agents_enabled": role_config["agents"]["enabled"],
+        "disabled_features": sorted(definition.codex.disabled_features),
+        "observed_tool_names": sorted(tool_names),
+        "returned_urls": returned_urls[:10],
+    }
+    (artifact_dir / "live-web-agent-gate.json").write_text(
+        json.dumps(evidence, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )

--- a/tests/infra/test_conformance_probes_workflow.py
+++ b/tests/infra/test_conformance_probes_workflow.py
@@ -149,8 +149,55 @@ class TestVersionResolution:
         resolve = next(step for step in steps if step.get("id") == "resolve-version")
         assert '"$CLAUDE_CODE_EXECPATH" --version' in resolve["run"]
 
+    def test_codex_probe_installs_and_verifies_exact_pinned_cli(self, workflow: dict) -> None:
+        steps = workflow["jobs"]["codex-probe"]["steps"]
+        install_index, install = next(
+            (index, step)
+            for index, step in enumerate(steps)
+            if step.get("name") == "Install pinned Codex CLI"
+        )
+        resolve_index, resolve = next(
+            (index, step)
+            for index, step in enumerate(steps)
+            if step.get("id") == "resolve-version"
+        )
+
+        assert install["run"] == "npm install --global @openai/codex@0.147.0"
+        assert '"codex-cli 0.147.0"' in resolve["run"]
+        assert install_index < resolve_index
+
 
 class TestCacheGate:
+    def test_live_web_agent_gate_is_required_uncached_and_uploads_evidence(
+        self, workflow: dict
+    ) -> None:
+        steps = workflow["jobs"]["codex-probe"]["steps"]
+        gate_index, gate = next(
+            (index, step)
+            for index, step in enumerate(steps)
+            if step.get("name") == "Run authenticated live-web agent gate"
+        )
+        upload_index, upload = next(
+            (index, step)
+            for index, step in enumerate(steps)
+            if step.get("name") == "Upload live-web agent gate evidence"
+        )
+        restore_index = next(
+            index
+            for index, step in enumerate(steps)
+            if "cache/restore" in (step.get("uses") or "")
+        )
+
+        assert "if" not in gate
+        assert gate.get("continue-on-error") is not True
+        assert "task test-smoke-codex-web-agent-live-gate" in gate["run"]
+        assert gate_index < upload_index < restore_index
+        assert upload["if"] == "always()"
+        assert upload["with"]["name"] == "codex-live-web-agent-gate-0.147.0"
+        assert upload["with"]["path"].endswith("/live-web-agent-gate.json")
+        assert upload["with"]["if-no-files-found"] == "error"
+        assert upload["with"]["retention-days"] == 7
+
     def test_live_explorer_mcp_gate_is_required_before_attestation_upload(
         self, workflow: dict
     ) -> None:

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -1009,6 +1009,7 @@ def _served_content(
     return result.get("content")
 
 
+@pytest.mark.timeout(120)
 def test_compact_recipe_display_preserves_execution_semantics(tmp_path, monkeypatch):
     """compact_recipe_display() must not alter any parsed value except the
     explicitly allowlisted presentation-only fields, for every runtime-discoverable
@@ -1044,6 +1045,7 @@ def test_compact_recipe_display_preserves_execution_semantics(tmp_path, monkeypa
     assert remediation_note_checked, "remediation recipe was not exercised by this test"
 
 
+@pytest.mark.timeout(120)
 def test_canonical_recipe_responses_fit_independent_registry_ceilings(tmp_path, monkeypatch):
     """Measure the same pre-backstop string in characters and UTF-8 bytes."""
 

--- a/tests/infra/test_taskfile.py
+++ b/tests/infra/test_taskfile.py
@@ -181,6 +181,24 @@ class TestTaskfile:
         assert "codex-explorer-conformance-v7.json" in commands
         assert "codex-explorer-conformance-v6.json" not in commands
 
+    def test_live_web_agent_gate_is_pinned_non_skippable_and_fresh(self) -> None:
+        data = self._load()
+        task = data["tasks"]["test-smoke-codex-web-agent-live-gate"]
+        commands = "\n".join(str(command) for command in task.get("cmds", []))
+        preconditions = "\n".join(
+            str(precondition) for precondition in task.get("preconditions", [])
+        )
+
+        assert "tests/execution/backends/test_web_agent_live_gate.py" in commands
+        assert "test_explorer_live_gate.py" not in commands
+        assert "codex-cli 0.147.0" in preconditions
+        assert task["env"]["AUTOSKILLIT_WEB_AGENT_LIVE_GATE"] == "1"
+        assert 'rm -f "$EVIDENCE"' in commands
+        assert "requires exactly one non-skipped test" in commands
+        assert "live-web-agent-gate.json" in commands
+        assert '"child_web_search":"live"' in commands
+        assert '"parent_web_search":"disabled"' in commands
+
     def test_claude_startup_target_selects_exact_interactive_probe(self) -> None:
         data = self._load()
         task = data["tasks"]["test-smoke-claude-startup"]

--- a/tests/infra/test_taskfile.py
+++ b/tests/infra/test_taskfile.py
@@ -174,6 +174,13 @@ class TestTaskfile:
         assert "CODEX_SMOKE_TEST" in preconditions
         assert "CLAUDE_CODE_SMOKE_TEST" in preconditions
 
+    def test_explorer_gate_consumes_current_attestation_version(self) -> None:
+        data = self._load()
+        task = data["tasks"]["test-smoke-codex-explorer-gate"]
+        commands = "\n".join(str(command) for command in task.get("cmds", []))
+        assert "codex-explorer-conformance-v7.json" in commands
+        assert "codex-explorer-conformance-v6.json" not in commands
+
     def test_claude_startup_target_selects_exact_interactive_probe(self) -> None:
         data = self._load()
         task = data["tasks"]["test-smoke-claude-startup"]

--- a/tests/server/test_tools_agents.py
+++ b/tests/server/test_tools_agents.py
@@ -261,8 +261,22 @@ def test_agent_definition_frontmatter_valid():
             parts = content.split("---", 2)
             assert len(parts) >= 3, f"{md_file.name}: missing YAML frontmatter"
             frontmatter = load_yaml(parts[1])
-            for field in ("name", "description", "tools", "model", "maxTurns"):
+            for field in ("name", "description", "tools", "maxTurns"):
                 assert field in frontmatter, f"{md_file.name}: missing frontmatter field '{field}'"
+
+
+def test_web_evidence_researcher_omits_model_and_is_packless() -> None:
+    from autoskillit.core import pkg_root
+    from autoskillit.core.io import load_yaml
+    from autoskillit.server.tools.tools_agents import get_plan_review_agent
+
+    content = (pkg_root() / "agents" / "web-evidence-researcher.md").read_text()
+    frontmatter = load_yaml(content.split("---", 2)[1])
+    assert "model" not in frontmatter
+    assert frontmatter["name"] == "web-evidence-researcher"
+
+    with pytest.raises(ResourceError, match="Unknown agent"):
+        get_plan_review_agent("web-evidence-researcher")
 
 
 def test_overengineering_agent_frontmatter_is_read_only() -> None:

--- a/tests/skills/test_audit_docs_exploration_contract.py
+++ b/tests/skills/test_audit_docs_exploration_contract.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("skills"), pytest.mark.medium]
+
+SKILL_PATH = (
+    Path(__file__).parents[2]
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "audit-docs"
+    / "SKILL.md"
+)
+
+
+def test_audit_docs_routes_exactly_ten_closed_world_evidence_vectors() -> None:
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    vector_ids = re.findall(r'autoskillit:exploration-vector id="([^"]+)"', text)
+
+    assert len(vector_ids) == 10
+    assert len(set(vector_ids)) == 10
+    assert "delegated-worker" not in text
+    for vector_id in vector_ids:
+        body = text.split(f'<!-- autoskillit:exploration-vector id="{vector_id}" -->', maxsplit=1)[
+            1
+        ].split("<!-- /autoskillit:exploration-vector -->", maxsplit=1)[0]
+        for field in (
+            "**Objective:**",
+            "**Entry point:**",
+            "**Tool/source guidance:**",
+            "**Scope boundary:**",
+            "**Ignore list:**",
+            "**Expected typed output:**",
+            "answered | partial | blocked",
+        ):
+            assert field in body, f"{vector_id} is missing {field}"
+
+
+def test_audit_docs_keeps_judgment_and_writes_in_parent() -> None:
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    assert "assemble the doc inventory" in text
+    assert "secondary absence checks" in text
+    assert "deduplicate by file:line" in text
+    assert "Self-validation pass (parent only)" in text
+    assert "Write report (parent only)" in text
+    assert "Every mutation remains in the parent" in text

--- a/tests/skills/test_review_approach_web_evidence_contract.py
+++ b/tests/skills/test_review_approach_web_evidence_contract.py
@@ -40,6 +40,32 @@ def test_every_topic_has_one_terminal_ledger_entry(skill_text: str) -> None:
     assert "must never be described as active" in skill_text
 
 
+def test_named_web_role_receives_one_bounded_packet_per_topic(skill_text: str) -> None:
+    frontmatter = skill_text.split("---", maxsplit=2)[1]
+    assert "name: autoskillit:web-evidence-researcher" in frontmatter
+    assert "role: autoskillit:web-evidence-researcher" in frontmatter
+    assert "for_each: research_topics" in frontmatter
+    assert "child_model_policies" not in frontmatter
+    assert "why that topic matters to the reviewed plan" in skill_text
+    assert "two or three suggested search angles" in skill_text
+    assert "common `Verdict: answered | partial | blocked` return format" in skill_text
+    assert "do not research adjacent topics" in skill_text
+
+
+def test_parent_keeps_synthesis_and_validates_terminal_verdict(skill_text: str) -> None:
+    for responsibility in (
+        "Topic selection",
+        "cross-topic comparison",
+        "project-level recommendations",
+        "synthesis",
+        "report writing",
+        "`review_path`",
+    ):
+        assert responsibility in skill_text
+    assert "missing or malformed terminal `Verdict:` as `blocked`" in skill_text
+    assert "source URLs, freshness, coverage, conflicts" in skill_text
+
+
 @pytest.mark.parametrize(
     ("outcome", "required_contract"),
     [

--- a/tests/skills/test_review_approach_web_evidence_contract.py
+++ b/tests/skills/test_review_approach_web_evidence_contract.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("skills"), pytest.mark.medium]
+
+
+SKILL_PATH = (
+    Path(__file__).parents[2]
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "review-approach"
+    / "SKILL.md"
+)
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+def test_research_budget_is_total_and_non_recursive(skill_text: str) -> None:
+    assert "at most five distinct research topics" in skill_text
+    assert "at most five top-level children" in skill_text
+    assert "at most eight web searches per child and forty total" in skill_text
+    assert "must not launch Agent or Skill children" in skill_text
+    assert "Spawn all topic children concurrently" in skill_text
+    assert "join every child" in skill_text
+
+
+def test_every_topic_has_one_terminal_ledger_entry(skill_text: str) -> None:
+    assert "Create one ledger row for every selected topic before dispatch" in skill_text
+    assert "exact child ID" in skill_text
+    assert "update each row exactly once" in skill_text
+    assert "answered | partial | blocked" in skill_text
+    assert "must never be described as active" in skill_text
+
+
+@pytest.mark.parametrize(
+    ("outcome", "required_contract"),
+    [
+        ("all-success", "synthesize normally"),
+        ("partial-success", "synthesize every usable cited result"),
+        ("all-failed", "all rows are `blocked`"),
+        ("nested-delegation-attempt", "nested delegation is a contract violation"),
+        ("incomplete-evidence", "structured retryable failure"),
+    ],
+)
+def test_completion_outcomes_are_explicit(
+    skill_text: str, outcome: str, required_contract: str
+) -> None:
+    completion = skill_text.split("### Step 3: Synthesize", maxsplit=1)[1]
+    assert outcome in completion
+    assert required_contract in completion
+
+
+def test_every_exit_preserves_report_and_output_token(skill_text: str) -> None:
+    assert "Every completion branch, including retryable failure" in skill_text
+    assert "writes the review report" in skill_text
+    assert re.search(r"review_path\s*=\s*\{absolute_path_to_review_file\}", skill_text)

--- a/tests/skills_extended/test_explorer_adoption_inventory.py
+++ b/tests/skills_extended/test_explorer_adoption_inventory.py
@@ -2011,7 +2011,7 @@ def test_phase_d_inventory_and_architecture_recipe_step_pins_are_explicit() -> N
 def test_migration_completeness_census_total_vector_count() -> None:
     """No skill carries the retired `exploration_vectors` frontmatter key, and
     every `exploration.yaml` sidecar under `skills/` and `skills_extended/`
-    sums to the reviewed migration census: 264 migrated + 37 retained = 301."""
+    sums to the reviewed migration census: 274 migrated + 37 retained = 311."""
     skill_roots = (pkg_root() / "skills", pkg_root() / "skills_extended")
     skill_md_paths = tuple(
         sorted(path for root in skill_roots for path in root.glob("*/SKILL.md"))
@@ -2047,6 +2047,6 @@ def test_migration_completeness_census_total_vector_count() -> None:
                 pytest.fail(f"unexpected disposition {vector.disposition} in {skill_md_path}")
 
     assert sidecar_count > 0
-    assert migrated_count == 264
+    assert migrated_count == 274
     assert retained_count == 37
-    assert migrated_count + retained_count == 301
+    assert migrated_count + retained_count == 311

--- a/tests/workspace/test_agent_definition_rendering.py
+++ b/tests/workspace/test_agent_definition_rendering.py
@@ -210,9 +210,7 @@ class TestRenderAgentDefinitionsByteIdentity:
             if not any(tool.startswith("mcp__") for tool in defn.tools):
                 originals[f"{defn.name}.md"] = (agents_dir / f"{defn.name}.md").read_bytes()
 
-        assert len(originals) >= 13, (
-            f"Expected at least 13 built-in-only agents, got {len(originals)}"
-        )
+        assert len(originals) == 14, f"Expected 14 built-in-only agents, got {len(originals)}"
 
         _render_agent_definitions(agents_dir, MARKETPLACE_PREFIX)
 

--- a/tests/workspace/test_audit_docs_exploration.py
+++ b/tests/workspace/test_audit_docs_exploration.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core import SkillSource, load_bundled_agent_definitions
+from autoskillit.workspace.skills import _skill_info_from_frontmatter
+
+pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
+
+ROOT = Path(__file__).parents[2]
+SKILL_PATH = ROOT / "src" / "autoskillit" / "skills_extended" / "audit-docs" / "SKILL.md"
+
+
+def test_audit_docs_sidecar_routes_the_ten_existing_evidence_vectors() -> None:
+    info = _skill_info_from_frontmatter("audit-docs", SkillSource.BUNDLED_EXTENDED, SKILL_PATH)
+
+    assert not info.invalidities, info.invalidities
+    assert len(info.exploration_vectors) == 10
+    by_role = {role: [] for role in ("semantic-code-navigator", "repository-impact-profiler")}
+    for vector in info.exploration_vectors:
+        assert vector.role in by_role
+        by_role[vector.role].append(vector.id)
+        assert vector.task.task_id == f"audit-docs-{vector.id}"
+        assert vector.relationship_classes
+    assert by_role["semantic-code-navigator"] == [
+        "familiarize-core-config",
+        "familiarize-execution-workspace",
+        "familiarize-recipe-migration",
+        "familiarize-server",
+        "familiarize-cli-hooks",
+    ]
+    assert by_role["repository-impact-profiler"] == [
+        "familiarize-skills",
+        "crossref-agent-guides",
+        "crossref-architecture",
+        "crossref-requirements-specs",
+        "crossref-recipes-docstrings",
+    ]
+
+
+def test_audit_docs_uses_existing_read_only_luna_explorer_definitions() -> None:
+    definitions = {definition.name: definition for definition in load_bundled_agent_definitions()}
+
+    for role in ("semantic-code-navigator", "repository-impact-profiler"):
+        projection = definitions[role].codex
+        assert projection is not None
+        assert projection.model == "gpt-5.6-luna"
+        assert projection.reasoning_effort == "max"
+        assert projection.sandbox_mode == "read-only"
+        assert projection.agents_enabled is False

--- a/tests/workspace/test_skill_semantics.py
+++ b/tests/workspace/test_skill_semantics.py
@@ -74,6 +74,26 @@ def test_all_skill_sources_parse_the_same_semantic_plan(
     assert info.semantic_plan.operations == frozenset(SkillSemanticOperation)
 
 
+def test_for_each_child_spawn_parses_without_a_fixed_count(tmp_path: Path) -> None:
+    skill_md = tmp_path / "dynamic" / "SKILL.md"
+    declarations = """semantic_version: 1
+semantic_requirements:
+  logical_roles:
+    - name: researcher
+      purpose: research one topic
+  child_spawns:
+    - role: researcher
+      for_each: research_topics
+"""
+    _write_skill(skill_md, declarations=declarations)
+
+    info = _skill_info_from_frontmatter("dynamic", SkillSource.PROJECT_LOCAL, skill_md)
+
+    assert not info.invalidities
+    assert info.semantic_plan is not None
+    assert info.semantic_plan.child_spawns[0].for_each == "research_topics"
+
+
 def test_child_model_policy_rejects_unregistered_logical_class(tmp_path: Path) -> None:
     skill_md = tmp_path / "unknown-model-class" / "SKILL.md"
     declarations = """semantic_version: 1

--- a/tests/workspace/test_skill_semantics.py
+++ b/tests/workspace/test_skill_semantics.py
@@ -94,6 +94,28 @@ semantic_requirements:
     assert info.semantic_plan.child_spawns[0].for_each == "research_topics"
 
 
+@pytest.mark.parametrize("for_each", ["false", "0", "[topic_a, topic_b]"])
+def test_for_each_child_spawn_rejects_non_string_yaml_values(
+    tmp_path: Path, for_each: str
+) -> None:
+    skill_md = tmp_path / "malformed-dynamic" / "SKILL.md"
+    declarations = f"""semantic_version: 1
+semantic_requirements:
+  logical_roles:
+    - name: researcher
+      purpose: research one topic
+  child_spawns:
+    - role: researcher
+      for_each: {for_each}
+"""
+    _write_skill(skill_md, declarations=declarations)
+
+    info = _skill_info_from_frontmatter("malformed-dynamic", SkillSource.PROJECT_LOCAL, skill_md)
+
+    assert info.semantic_plan is None
+    assert "child spawn for_each must be a string" in render_skill_invalidities(info.invalidities)
+
+
 def test_child_model_policy_rejects_unregistered_logical_class(tmp_path: Path) -> None:
     skill_md = tmp_path / "unknown-model-class" / "SKILL.md"
     declarations = """semantic_version: 1


### PR DESCRIPTION
## Summary

Implement the work required by #4257 and the #4506 `audit-docs` pilot as the first two phases of this plan, then implement #4507 as the second specialized-agent pilot. The result is self-contained on the current branch: `review-approach` first gains bounded per-topic dispatch and deterministic terminal-result synthesis, `audit-docs` then migrates its ten evidence-only vectors to the existing explorers and publishes its pilot result, and finally one ordinary, packless `web-evidence-researcher` AgentDef routes every `review-approach` research-topic child through the named role. Reuse the existing AgentDef catalog, deterministic exploration router, and portable skill-semantic adapters; do not add the web role to the broker-bound explorer registry or create a new routing/model-policy subsystem.

## Requirements

- `review-approach` consistently uses the named web-research role for its research-topic children instead of generic delegated workers.
- The Codex projection uses Luna with a read-only web-search surface and no mutation or nested-agent capability.
- Claude dispatch selects the same named role without passing a model override.
- Returned factual claims retain directly supporting URLs and enough date/freshness context for the parent to judge relevance.
- The role and skill respect the bounded fan-out and partial-result behavior being addressed in #4257.
- Tests prove the selected role and effective backend-specific model behavior, while leaving implementation details flexible.

Closes #4507

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/make-plan/add_luna_web_evidence_agent_plan_2026-08-09_030804.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
