### PR TITLE
Rectify: Skill/Recipe Namespace Conflation in Model-Driven Recipe Surfaces

### DIFF
--- a/src/autoskillit/cli/session/_session_cook.py
+++ b/src/autoskillit/cli/session/_session_cook.py
@@ -39,7 +39,10 @@ _COOK_PRE_REVEALED_KITCHEN_PROMPT = (
     "pre-revealed. Do not call open_kitchen() with no arguments solely to gain tool "
     "access. open_kitchen remains valid when the user explicitly requests activation "
     "or promotion, to load a named recipe with open_kitchen(name=...), or to reopen "
-    "the kitchen after close_kitchen()."
+    "the kitchen after close_kitchen(). $<name> or /<name> denotes an in-session skill "
+    "invocation. Do not pass a skill name to open_kitchen, load_recipe, migrate_recipe, "
+    "or recipe://; those surfaces accept recipe identities only. A name defined as both "
+    "a recipe and a skill is rejected until one artifact is renamed."
 )
 
 

--- a/src/autoskillit/recipes/bem-wrapper.json
+++ b/src/autoskillit/recipes/bem-wrapper.json
@@ -1,6 +1,6 @@
 {
   "name": "bem-wrapper",
-  "description": "Compute issue distribution for promote-to-main-campaign dispatch and compact dispatch plan. Used by the promote-to-main-campaign campaign to compute issue distribution before dispatching implementation L3s.",
+  "description": "Compute issue distribution for promote-to-main-campaign dispatch and compact dispatch plan. Used by promote-to-main-campaign to compute issue distribution before dispatching implementation L3s.",
   "dispatch_only": true,
   "kind": "food-truck",
   "recipe_version": "1.0.0",

--- a/src/autoskillit/recipes/bem-wrapper.json
+++ b/src/autoskillit/recipes/bem-wrapper.json
@@ -1,6 +1,6 @@
 {
   "name": "bem-wrapper",
-  "description": "Compute issue distribution for promote-to-main dispatch and compact dispatch plan. Used by the promote-to-main campaign to compute issue distribution before dispatching implementation L3s.",
+  "description": "Compute issue distribution for promote-to-main-campaign dispatch and compact dispatch plan. Used by the promote-to-main-campaign campaign to compute issue distribution before dispatching implementation L3s.",
   "dispatch_only": true,
   "kind": "food-truck",
   "recipe_version": "1.0.0",

--- a/src/autoskillit/recipes/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/bem-wrapper.yaml
@@ -1,7 +1,7 @@
 name: bem-wrapper
 description: >-
   Compute issue distribution for promote-to-main-campaign dispatch
-  and compact dispatch plan. Used by the promote-to-main-campaign campaign to compute
+  and compact dispatch plan. Used by promote-to-main-campaign to compute
   issue distribution before dispatching implementation L3s.
 dispatch_only: true
 kind: food-truck

--- a/src/autoskillit/recipes/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/bem-wrapper.yaml
@@ -1,7 +1,7 @@
 name: bem-wrapper
 description: >-
-  Compute issue distribution for promote-to-main dispatch
-  and compact dispatch plan. Used by the promote-to-main campaign to compute
+  Compute issue distribution for promote-to-main-campaign dispatch
+  and compact dispatch plan. Used by the promote-to-main-campaign campaign to compute
   issue distribution before dispatching implementation L3s.
 dispatch_only: true
 kind: food-truck

--- a/src/autoskillit/recipes/campaigns/promote-to-main-campaign.json
+++ b/src/autoskillit/recipes/campaigns/promote-to-main-campaign.json
@@ -1,5 +1,5 @@
 {
-  "name": "promote-to-main",
+  "name": "promote-to-main-campaign",
   "description": "Full promotion lifecycle: audit integration branch, human review gate, implement audit findings with BEM-guided distribution, promote to main.",
   "kind": "campaign",
   "recipe_version": "1.0.0",

--- a/src/autoskillit/recipes/campaigns/promote-to-main-campaign.yaml
+++ b/src/autoskillit/recipes/campaigns/promote-to-main-campaign.yaml
@@ -1,4 +1,4 @@
-name: promote-to-main
+name: promote-to-main-campaign
 description: >-
   Full promotion lifecycle: audit integration branch, human review gate,
   implement audit findings with BEM-guided distribution, promote to main.

--- a/src/autoskillit/server/tools/_serve_helpers.py
+++ b/src/autoskillit/server/tools/_serve_helpers.py
@@ -17,6 +17,8 @@ from autoskillit.core import (
     RESPONSE_BACKSTOP_EXEMPTION_REGISTRY,
     RESPONSE_BACKSTOP_EXEMPTION_REGISTRY_DIGEST,
     FinalizedRecipeProjection,
+    RecipeLoadError,
+    RecipeNotFoundError,
     SkillExecutionRole,
 )
 from autoskillit.server._misc import SkillProjectionContext, project_agent_skill_document
@@ -27,6 +29,31 @@ if TYPE_CHECKING:
         CodingAgentBackend,
     )
     from autoskillit.pipeline.context import ToolContext
+    from autoskillit.recipe import RecipeInfo
+
+
+def _admit_recipe_name(tool_ctx: ToolContext, name: str) -> RecipeInfo:
+    """Admit an unambiguous recipe name against the effective skill namespace."""
+    if tool_ctx.recipes is None:
+        raise RuntimeError("recipe repository is not configured")
+    if tool_ctx.skill_resolver is None:
+        raise RuntimeError("skill resolver is not configured")
+
+    recipe_info = tool_ctx.recipes.find(name, tool_ctx.project_dir)
+    skill_spec = tool_ctx.skill_resolver.resolve_effective(name, tool_ctx.project_dir)
+    if recipe_info is not None and skill_spec is None:
+        return recipe_info
+    if recipe_info is None and skill_spec is not None:
+        raise RecipeNotFoundError(
+            f"'{name}' is an in-session skill, not a recipe. Follow the current "
+            "session's native skill instructions and do not call recipe tools."
+        )
+    if recipe_info is not None and skill_spec is not None:
+        raise RecipeLoadError(
+            f"Name '{name}' is ambiguous because it is defined as both a recipe and "
+            "a skill; rename one artifact before using recipe tools."
+        )
+    raise RecipeNotFoundError(f"No recipe named '{name}' found")
 
 
 def build_backend_capabilities_map(
@@ -203,6 +230,7 @@ def serve_recipe(
     backend_origin_map: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Unified recipe serve path. Only legal caller of load_and_validate in server/tools/."""
+    _admit_recipe_name(ctx, name)
     ingredient_overrides = _build_serve_override_stack(
         ctx,
         caller_overrides,
@@ -233,7 +261,7 @@ def serve_recipe(
         kwargs["temp_dir"] = temp_dir
     if temp_dir_relpath is not None:
         kwargs["temp_dir_relpath"] = temp_dir_relpath
-    if ctx.recipes is None:
+    if ctx.recipes is None:  # narrowed by _admit_recipe_name
         raise RuntimeError("serve_recipe() called with ctx.recipes=None")
     return ctx.recipes.load_and_validate(
         name,

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -992,8 +992,9 @@ def _close_kitchen_handler() -> None:
 def get_recipe(name: str) -> str:
     """Return composed recipe YAML for the orchestrating agent to follow.
 
-    ``$<name>`` or ``/<name>`` denotes an in-session skill invocation. Do not
-    pass a skill name to recipe-serving tools; they accept recipe identities only.
+    ``$<name>`` or ``/<name>`` denotes an in-session skill invocation. Do not pass
+    a skill name to ``open_kitchen``, ``load_recipe``, ``migrate_recipe``, or
+    ``recipe://``; those surfaces accept recipe identities only.
     A name defined as both a recipe and a skill is rejected until one artifact
     is renamed.
     """
@@ -1168,8 +1169,9 @@ async def open_kitchen(
     When ``name`` is provided, the kitchen is opened AND the named recipe is
     loaded in a single call, reducing terminal noise from two tool calls to one.
 
-    ``$<name>`` or ``/<name>`` denotes an in-session skill invocation. Do not
-    pass a skill name to recipe-serving tools; they accept recipe identities only.
+    ``$<name>`` or ``/<name>`` denotes an in-session skill invocation. Do not pass
+    a skill name to ``open_kitchen``, ``load_recipe``, ``migrate_recipe``, or
+    ``recipe://``; those surfaces accept recipe identities only.
     A name defined as both a recipe and a skill is rejected until one artifact
     is renamed.
 

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -1214,6 +1214,18 @@ async def open_kitchen(
         _ctx_pre = _get_ctx()
         _admitted_recipe_info = None
         if name is not None:
+            if _ctx_pre.recipes is None or _ctx_pre.skill_resolver is None:
+                missing_service = (
+                    "recipe repository" if _ctx_pre.recipes is None else "skill resolver"
+                )
+                return _kitchen_failure_envelope(
+                    RuntimeError(f"{missing_service} is not configured"),
+                    stage="recipe_context",
+                    user_hint=(
+                        "open_kitchen cannot load a recipe because the server is not "
+                        "initialized. Run 'autoskillit doctor' to diagnose."
+                    ),
+                )
             try:
                 _admitted_recipe_info = _admit_recipe_name(_ctx_pre, name)
             except RecipeLoadError as exc:
@@ -1221,15 +1233,6 @@ async def open_kitchen(
                     exc,
                     stage="recipe_namespace",
                     user_hint=str(exc),
-                )
-            except RuntimeError as exc:
-                return _kitchen_failure_envelope(
-                    exc,
-                    stage="recipe_context",
-                    user_hint=(
-                        "open_kitchen cannot load a recipe because the server is not "
-                        "initialized. Run 'autoskillit doctor' to diagnose."
-                    ),
                 )
 
         disabled_subsets = _ctx_pre.config.subsets.disabled

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -34,6 +34,7 @@ from autoskillit.core import (
     PIPELINE_FORBIDDEN_TOOLS,
     ProcessStaleError,
     RecipeDeliveryRequest,
+    RecipeLoadError,
     _collect_disabled_feature_tags,
     atomic_write,
     clear_kitchens_for_pid,
@@ -127,6 +128,7 @@ from autoskillit.server.tools._preflight import (
     filter_steps_by_post_prune,
 )
 from autoskillit.server.tools._serve_helpers import (
+    _admit_recipe_name,
     build_backend_capabilities_map,
     build_open_kitchen_recipe_payload,
     pop_finalized_recipe_projection,
@@ -988,23 +990,26 @@ def _close_kitchen_handler() -> None:
 
 @mcp.resource("recipe://{name}")
 def get_recipe(name: str) -> str:
-    """Return composed recipe YAML for the orchestrating agent to follow."""
+    """Return composed recipe YAML for the orchestrating agent to follow.
+
+    ``$<name>`` or ``/<name>`` denotes an in-session skill invocation. Do not
+    pass a skill name to recipe-serving tools; they accept recipe identities only.
+    A name defined as both a recipe and a skill is rejected until one artifact
+    is renamed.
+    """
     from autoskillit.server._state import _get_ctx_or_none  # circular-break
 
     ctx = _get_ctx_or_none()
     if ctx is None or ctx.recipes is None:
         return json.dumps({"error": "Kitchen not open."})
-    match = ctx.recipes.find(name, ctx.project_dir)
-    if match is None:
-        return json.dumps({"error": f"No recipe named '{name}'."})
-
-    _defaults = resolve_ingredient_defaults(ctx.project_dir)
-    _config_layer = build_config_authoritative_layer(_defaults)
-    _session_overrides: dict[str, str] = {
-        "kitchen_id": ctx.kitchen_id,
-        "diagnostics_log_dir": str(resolve_log_dir(ctx.config.linux_tracing.log_dir)),
-    }
     try:
+        match = _admit_recipe_name(ctx, name)
+        _defaults = resolve_ingredient_defaults(ctx.project_dir)
+        _config_layer = build_config_authoritative_layer(_defaults)
+        _session_overrides: dict[str, str] = {
+            "kitchen_id": ctx.kitchen_id,
+            "diagnostics_log_dir": str(resolve_log_dir(ctx.config.linux_tracing.log_dir)),
+        }
         _raw_recipe = ctx.recipes.load(match.path)
         _effective_backend_map, _backend_origin_map = _compute_effective_backend_map(
             _raw_recipe.steps,
@@ -1035,6 +1040,8 @@ def get_recipe(name: str) -> str:
     except ProcessStaleError:
         logger.warning("get_recipe_failure", recipe=name, stage="process_stale", exc_info=True)
         return json.dumps({"error": f"Recipe '{name}' composition failed — process stale."})
+    except RecipeLoadError as exc:
+        return json.dumps({"error": str(exc)})
     except Exception:
         logger.warning("get_recipe_failure", recipe=name, stage="load_and_validate", exc_info=True)
         return json.dumps({"error": f"Recipe '{name}' composition failed."})
@@ -1161,6 +1168,11 @@ async def open_kitchen(
     When ``name`` is provided, the kitchen is opened AND the named recipe is
     loaded in a single call, reducing terminal noise from two tool calls to one.
 
+    ``$<name>`` or ``/<name>`` denotes an in-session skill invocation. Do not
+    pass a skill name to recipe-serving tools; they accept recipe identities only.
+    A name defined as both a recipe and a skill is rejected until one artifact
+    is renamed.
+
     Args:
         name: Optional recipe name to load immediately after opening.
         overrides: Optional dict of ingredient name → value to override recipe defaults.
@@ -1197,9 +1209,28 @@ async def open_kitchen(
 
         from autoskillit.server import _get_ctx  # circular-break
 
-        disabled_subsets = _get_ctx().config.subsets.disabled
-
         _ctx_pre = _get_ctx()
+        _admitted_recipe_info = None
+        if name is not None:
+            try:
+                _admitted_recipe_info = _admit_recipe_name(_ctx_pre, name)
+            except RecipeLoadError as exc:
+                return _kitchen_failure_envelope(
+                    exc,
+                    stage="recipe_namespace",
+                    user_hint=str(exc),
+                )
+            except RuntimeError as exc:
+                return _kitchen_failure_envelope(
+                    exc,
+                    stage="recipe_context",
+                    user_hint=(
+                        "open_kitchen cannot load a recipe because the server is not "
+                        "initialized. Run 'autoskillit doctor' to diagnose."
+                    ),
+                )
+
+        disabled_subsets = _ctx_pre.config.subsets.disabled
         _skip_handler = _ctx_pre.gate_infrastructure_ready
         tool_ctx = _get_ctx()
 
@@ -1354,14 +1385,9 @@ async def open_kitchen(
                 )
             suppressed = tool_ctx.config.migration.suppressed
             _defaults = resolve_ingredient_defaults(tool_ctx.project_dir)
-            try:
-                _recipe_info = tool_ctx.recipes.find(name, tool_ctx.project_dir)
-            except Exception:
-                logger.warning("open_kitchen_early_find_failed", recipe=name, exc_info=True)
-                _recipe_info = None
-            _raw_recipe = (
-                tool_ctx.recipes.load(_recipe_info.path) if _recipe_info is not None else None
-            )
+            assert _admitted_recipe_info is not None
+            _recipe_info = _admitted_recipe_info
+            _raw_recipe = tool_ctx.recipes.load(_recipe_info.path)
             _session_overrides: dict[str, str] = {
                 "kitchen_id": tool_ctx.kitchen_id,
                 "diagnostics_log_dir": str(resolve_log_dir(tool_ctx.config.linux_tracing.log_dir)),
@@ -1436,32 +1462,19 @@ async def open_kitchen(
                 tool_ctx.recipe_content_hash = result.get("content_hash", "")
                 tool_ctx.recipe_composite_hash = result.get("composite_hash", "")
                 tool_ctx.recipe_version = result.get("recipe_version") or ""
-                recipe_info = None
+                recipe_info = _recipe_info
                 _deferred_recipe_obj = None
                 try:
-                    recipe_info = tool_ctx.recipes.find(name, tool_ctx.project_dir)
+                    recipe_obj = tool_ctx.recipes.load(recipe_info.path)
+                    _deferred_recipe_obj = recipe_obj
+                    tool_ctx.active_recipe_steps = filter_steps_by_post_prune(
+                        recipe_obj.steps, result.get("post_prune_step_names", [])
+                    )
+                    tool_ctx.active_recipe_ingredients = frozenset(recipe_obj.ingredients.keys())
                 except Exception:
-                    logger.warning("open_kitchen_failure", stage="recipe_find", exc_info=True)
+                    logger.warning("open_kitchen_recipe_steps_cache_failed", exc_info=True)
                     tool_ctx.active_recipe_steps = None
                     tool_ctx.active_recipe_ingredients = None
-                else:
-                    if recipe_info is not None:
-                        try:
-                            recipe_obj = tool_ctx.recipes.load(recipe_info.path)
-                            _deferred_recipe_obj = recipe_obj
-                            tool_ctx.active_recipe_steps = filter_steps_by_post_prune(
-                                recipe_obj.steps, result.get("post_prune_step_names", [])
-                            )
-                            tool_ctx.active_recipe_ingredients = frozenset(
-                                recipe_obj.ingredients.keys()
-                            )
-                        except Exception:
-                            logger.warning("open_kitchen_recipe_steps_cache_failed", exc_info=True)
-                            tool_ctx.active_recipe_steps = None
-                            tool_ctx.active_recipe_ingredients = None
-                    else:
-                        tool_ctx.active_recipe_steps = None
-                        tool_ctx.active_recipe_ingredients = None
                 # Default to False for missing 'valid' so a absent key is treated as invalid
                 if not result.get("valid", False) or not result.get("content", ""):
                     transition_abort(tool_ctx, KITCHEN_EFFECT_RECIPE_SERVING)
@@ -1601,26 +1614,18 @@ async def open_kitchen(
             if rerun_suggestion:
                 result.setdefault("suggestions", []).append(rerun_suggestion)
 
-            try:
-                recipe_info = tool_ctx.recipes.find(name, tool_ctx.project_dir)
-            except Exception as exc:
-                logger.warning("open_kitchen_failure", stage="recipe_find", exc_info=True)
-                return _kitchen_failure_envelope(exc, stage="recipe_find")
+            recipe_info = _recipe_info
 
             _normal_recipe_obj = None
-            if recipe_info is not None:
-                try:
-                    recipe_obj = tool_ctx.recipes.load(recipe_info.path)
-                    _normal_recipe_obj = recipe_obj
-                    tool_ctx.active_recipe_steps = filter_steps_by_post_prune(
-                        recipe_obj.steps, result.get("post_prune_step_names", [])
-                    )
-                    tool_ctx.active_recipe_ingredients = frozenset(recipe_obj.ingredients.keys())
-                except Exception:
-                    logger.warning("open_kitchen_recipe_steps_cache_failed", exc_info=True)
-                    tool_ctx.active_recipe_steps = None
-                    tool_ctx.active_recipe_ingredients = None
-            else:
+            try:
+                recipe_obj = tool_ctx.recipes.load(recipe_info.path)
+                _normal_recipe_obj = recipe_obj
+                tool_ctx.active_recipe_steps = filter_steps_by_post_prune(
+                    recipe_obj.steps, result.get("post_prune_step_names", [])
+                )
+                tool_ctx.active_recipe_ingredients = frozenset(recipe_obj.ingredients.keys())
+            except Exception:
+                logger.warning("open_kitchen_recipe_steps_cache_failed", exc_info=True)
                 tool_ctx.active_recipe_steps = None
                 tool_ctx.active_recipe_ingredients = None
 

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -23,6 +23,7 @@ from autoskillit.core import (
     BackendCapabilities,
     RecipeArtifactGeneration,
     RecipeDeliveryRequest,
+    RecipeLoadError,
     fast_dumps,
     get_logger,
     load_yaml,
@@ -81,6 +82,7 @@ from autoskillit.server.tools._auto_overrides import (
 )
 from autoskillit.server.tools._cancellation_shield import _cancellation_shield
 from autoskillit.server.tools._serve_helpers import (
+    _admit_recipe_name,
     build_backend_capabilities_map,
     pop_finalized_recipe_projection,
     render_served_response,
@@ -332,6 +334,11 @@ async def load_recipe(
     tool, then follow the YAML steps. Recipes live in .autoskillit/recipes/
     as .yaml files (NOT in .autoskillit/skills/ or any other directory).
 
+    ``$<name>`` or ``/<name>`` denotes an in-session skill invocation. Do not
+    pass a skill name to recipe-serving tools; they accept recipe identities only.
+    A name defined as both a recipe and a skill is rejected until one artifact
+    is renamed.
+
     This tool is strictly read-only. It discovers, parses, and validates recipe
     YAML. To run migrations, use migrate_recipe.
 
@@ -351,12 +358,8 @@ async def load_recipe(
                 return json.dumps({"error": "Server not initialized"})
             suppressed = tool_ctx.config.migration.suppressed
             _defaults = resolve_ingredient_defaults(tool_ctx.project_dir)
-            _recipe_info_pre = tool_ctx.recipes.find(name, tool_ctx.project_dir)
-            _raw_recipe_obj = (
-                tool_ctx.recipes.load(_recipe_info_pre.path)
-                if _recipe_info_pre is not None
-                else None
-            )
+            _recipe_info_pre = _admit_recipe_name(tool_ctx, name)
+            _raw_recipe_obj = tool_ctx.recipes.load(_recipe_info_pre.path)
             _session_overrides: dict[str, str] = {
                 "kitchen_id": tool_ctx.kitchen_id,
                 "diagnostics_log_dir": str(resolve_log_dir(tool_ctx.config.linux_tracing.log_dir)),
@@ -904,6 +907,11 @@ async def migrate_recipe(name: str, ctx: Context = CurrentContext()) -> str:
     Args:
         name: The recipe name (without .yaml extension) to migrate.
 
+    ``$<name>`` or ``/<name>`` denotes an in-session skill invocation. Do not
+    pass a skill name to recipe-serving tools; they accept recipe identities only.
+    A name defined as both a recipe and a skill is rejected until one artifact
+    is renamed.
+
     Never raises.
     """
     if (gate := _require_enabled()) is not None:
@@ -926,19 +934,18 @@ async def migrate_recipe(name: str, ctx: Context = CurrentContext()) -> str:
 
             tool_ctx = _get_ctx()
 
+            try:
+                recipe_info = _admit_recipe_name(tool_ctx, name)
+            except RecipeLoadError as exc:
+                return json.dumps({"error": str(exc), "name": name})
+
             # Check suppression list before attempting migration
             if name in _get_config().migration.suppressed:
                 return json.dumps({"status": "up_to_date", "name": name})
 
-            if tool_ctx.recipes is None:
-                return json.dumps({"error": "Recipe repository not configured"})
-            recipe = tool_ctx.recipes.find(name, tool_ctx.project_dir)
-            if recipe is None:
-                return json.dumps({"error": f"No recipe named '{name}' found"})
-
             if tool_ctx.migrations is None:
                 return json.dumps({"error": "Migration service not configured", "name": name})
-            result = await tool_ctx.migrations.migrate(recipe.path)
+            result = await tool_ctx.migrations.migrate(recipe_info.path)
             return json.dumps(result)
     except Exception as exc:
         logger.error("migrate_recipe unhandled exception", exc_info=True)

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -334,8 +334,9 @@ async def load_recipe(
     tool, then follow the YAML steps. Recipes live in .autoskillit/recipes/
     as .yaml files (NOT in .autoskillit/skills/ or any other directory).
 
-    ``$<name>`` or ``/<name>`` denotes an in-session skill invocation. Do not
-    pass a skill name to recipe-serving tools; they accept recipe identities only.
+    ``$<name>`` or ``/<name>`` denotes an in-session skill invocation. Do not pass
+    a skill name to ``open_kitchen``, ``load_recipe``, ``migrate_recipe``, or
+    ``recipe://``; those surfaces accept recipe identities only.
     A name defined as both a recipe and a skill is rejected until one artifact
     is renamed.
 
@@ -907,8 +908,9 @@ async def migrate_recipe(name: str, ctx: Context = CurrentContext()) -> str:
     Args:
         name: The recipe name (without .yaml extension) to migrate.
 
-    ``$<name>`` or ``/<name>`` denotes an in-session skill invocation. Do not
-    pass a skill name to recipe-serving tools; they accept recipe identities only.
+    ``$<name>`` or ``/<name>`` denotes an in-session skill invocation. Do not pass
+    a skill name to ``open_kitchen``, ``load_recipe``, ``migrate_recipe``, or
+    ``recipe://``; those surfaces accept recipe identities only.
     A name defined as both a recipe and a skill is rejected until one artifact
     is renamed.
 

--- a/src/autoskillit/skills/open-kitchen/SKILL.md
+++ b/src/autoskillit/skills/open-kitchen/SKILL.md
@@ -34,3 +34,8 @@ Activate the AutoSkillit kitchen when the host has not already made its tools av
 The kitchen state is session-scoped. `open_kitchen(name=...)` remains valid for named
 recipe loading, and a no-argument call remains valid to reopen the kitchen after
 `close_kitchen`.
+
+`$<name>` or `/<name>` denotes an in-session skill invocation. Do not pass a skill name
+to `open_kitchen`, `load_recipe`, `migrate_recipe`, or `recipe://`; those surfaces accept
+recipe identities only. A name defined as both a recipe and a skill is rejected until one
+artifact is renamed.

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -797,6 +797,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
         {
             "workspace",
             "migration",
+            "server/test_recipe_namespace_admission.py",
             # recipe direct-import entries (import autoskillit.workspace at AST level):
             "recipe/test_contracts.py",
             "recipe/test_recipe_backend_composition_matrix.py",

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -288,6 +288,9 @@ def test_codex_cook_adds_pre_reveal_developer_guidance(
     assert "explicitly requests activation or promotion" in guidance
     assert "open_kitchen(name=...)" in guidance
     assert "after close_kitchen()" in guidance
+    assert "$<name>" in guidance and "/<name>" in guidance
+    assert "skill name" in guidance and "recipe identities only" in guidance
+    assert "defined as both" in guidance and "rejected" in guidance
 
 
 def test_notification_capable_cook_has_no_pre_reveal_guidance(

--- a/tests/contracts/test_tools_recipe_contracts.py
+++ b/tests/contracts/test_tools_recipe_contracts.py
@@ -16,7 +16,9 @@ def test_model_facing_recipe_surfaces_define_namespace_boundary():
     for surface in (open_kitchen, load_recipe, migrate_recipe, get_recipe):
         doc = inspect.getdoc(surface) or ""
         assert "$<name>" in doc and "/<name>" in doc
-        assert "skill name" in doc and "recipe identities only" in doc
+        assert "skill name" in doc and "those surfaces accept recipe identities only" in doc
+        for recipe_surface in ("open_kitchen", "load_recipe", "migrate_recipe", "recipe://"):
+            assert recipe_surface in doc
         assert "defined as both" in doc and "rejected" in doc
 
 

--- a/tests/contracts/test_tools_recipe_contracts.py
+++ b/tests/contracts/test_tools_recipe_contracts.py
@@ -7,6 +7,35 @@ import pytest
 pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
 
 
+def test_model_facing_recipe_surfaces_define_namespace_boundary():
+    import inspect
+
+    from autoskillit.server.tools.tools_kitchen import get_recipe, open_kitchen
+    from autoskillit.server.tools.tools_recipe import load_recipe, migrate_recipe
+
+    for surface in (open_kitchen, load_recipe, migrate_recipe, get_recipe):
+        doc = inspect.getdoc(surface) or ""
+        assert "$<name>" in doc and "/<name>" in doc
+        assert "skill name" in doc and "recipe identities only" in doc
+        assert "defined as both" in doc and "rejected" in doc
+
+
+def test_bundled_recipe_and_skill_names_are_disjoint() -> None:
+    from pathlib import Path
+
+    from autoskillit.recipe import all_validated_recipe_names
+    from autoskillit.workspace import DefaultSkillResolver
+
+    project_root = Path(__file__).resolve().parent.parent.parent
+    recipe_names = set(all_validated_recipe_names(project_root))
+    skill_names = {skill.name for skill in DefaultSkillResolver().list_all()}
+
+    assert recipe_names.isdisjoint(skill_names), (
+        "Bundled recipe and skill names must be disjoint; collisions: "
+        f"{sorted(recipe_names & skill_names)}"
+    )
+
+
 def test_load_recipe_instructs_step_name_exact_yaml_key():
     """
     The load_recipe docstring must explicitly instruct that step_name

--- a/tests/fleet/test_gate_state_persistence.py
+++ b/tests/fleet/test_gate_state_persistence.py
@@ -544,7 +544,7 @@ class TestCampaignStateFieldCompleteness:
 
 
 # ---------------------------------------------------------------------------
-# Test 11: resume chain for promote-to-main shape
+# Test 11: resume chain for promote-to-main-campaign shape
 # ---------------------------------------------------------------------------
 
 

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -17,6 +18,7 @@ from autoskillit.core import (
     RESPONSE_BACKSTOP_EXEMPTION_REGISTRY,
     RESPONSE_BACKSTOP_EXEMPTION_REGISTRY_DIGEST,
     RecipeFlowGeneration,
+    SkillResolver,
 )
 from autoskillit.execution import CODEX_RECIPE_DELIVERY_BUDGET
 from autoskillit.hooks.formatters.pretty_output_hook import _format_response
@@ -1074,10 +1076,12 @@ def test_canonical_recipe_responses_fit_independent_registry_ceilings(tmp_path, 
             monkeypatch.setattr(_api_cache, "_LOAD_CACHE", LoadCache())
             tool_ctx = SimpleNamespace(
                 recipes=DefaultRecipeRepository(),
+                skill_resolver=MagicMock(spec=SkillResolver),
                 project_dir=project_root,
                 session_serve_overrides=None,
                 session_serve_defer_unresolved=False,
             )
+            tool_ctx.skill_resolver.resolve_effective.return_value = None
             resolved = dict(overrides, source_dir=str(project_root))
             preview = load_and_validate(
                 recipe_name,

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -123,9 +123,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # same rationale and format as the _lifespan.py site above)
     ("src/autoskillit/workspace/_projected_artifact/_hook_repair.py", 178),
     # tools_kitchen.py — hook config, quota guard, and git_ops_policy
-    ("src/autoskillit/server/tools/tools_kitchen.py", 546),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 565),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 597),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 548),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 567),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 599),
     # _overlay_state.py — session-scoped hook config overlay (not schema-versioned)
     ("src/autoskillit/server/tools/_overlay_state.py", 114),
     # tools_pipeline_tracker.py — tracker_data dict (init) and mark_step_complete write

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -260,27 +260,27 @@ def test_bundled_example_campaign_parseable():
 
 
 # ---------------------------------------------------------------------------
-# promote-to-main campaign
+# promote-to-main-campaign campaign
 # ---------------------------------------------------------------------------
 
 
 def test_promote_to_main_campaign_parseable():
-    path = pkg_root() / "recipes" / "campaigns" / "promote-to-main.yaml"
+    path = pkg_root() / "recipes" / "campaigns" / "promote-to-main-campaign.yaml"
     recipe = load_recipe(path)
-    assert recipe.name == "promote-to-main"
+    assert recipe.name == "promote-to-main-campaign"
     assert recipe.kind == RecipeKind.CAMPAIGN
     assert recipe.recipe_version == "1.0.0"
 
 
 def test_promote_to_main_campaign_passes_validation():
-    path = pkg_root() / "recipes" / "campaigns" / "promote-to-main.yaml"
+    path = pkg_root() / "recipes" / "campaigns" / "promote-to-main-campaign.yaml"
     recipe = load_recipe(path)
     findings = validate_recipe_structure(recipe)
     assert findings == [], f"Unexpected findings: {findings}"
 
 
 def test_promote_to_main_campaign_dispatch_chain():
-    path = pkg_root() / "recipes" / "campaigns" / "promote-to-main.yaml"
+    path = pkg_root() / "recipes" / "campaigns" / "promote-to-main-campaign.yaml"
     recipe = load_recipe(path)
     names = [d.name for d in recipe.dispatches]
     assert names == [
@@ -305,14 +305,14 @@ def test_promote_to_main_campaign_in_list_campaign_recipes(tmp_path: Path):
     result = list_campaign_recipes(tmp_path)
     assert result.errors == []
     names = [r.name for r in result.items]
-    assert "promote-to-main" in names
+    assert "promote-to-main-campaign" in names
 
 
 def test_campaign_dispatch_capture_value_type_checked() -> None:
     """dispatch-capture-type-matches-contract-optionality: string on optional field → ERROR."""
     import dataclasses
 
-    path = pkg_root() / "recipes" / "campaigns" / "promote-to-main.yaml"
+    path = pkg_root() / "recipes" / "campaigns" / "promote-to-main-campaign.yaml"
     recipe = load_recipe(path)
     project_dir = pkg_root() / "recipes"
     available_recipes = frozenset(p.stem for p in project_dir.glob("*.yaml"))
@@ -361,7 +361,8 @@ def test_campaign_dispatch_capture_value_type_checked() -> None:
         and f.severity == Severity.ERROR
     ]
     assert not fixed_findings, (
-        "promote-to-main.yaml must not trigger dispatch-capture-type-matches-contract-optionality "
+        "promote-to-main-campaign.yaml must not trigger "
+        "dispatch-capture-type-matches-contract-optionality "
         "after the optional_string fix: " + "; ".join(f.message for f in fixed_findings)
     )
 

--- a/tests/recipe/test_rules_rate_limit_parity.py
+++ b/tests/recipe/test_rules_rate_limit_parity.py
@@ -82,7 +82,7 @@ class TestRateLimitRuleFiring:
         dataclass instance.
 
         Recipes without any run_skill steps (e.g. consolidate-health-reports,
-        research-archive, promote-to-main, research-campaign) are inherently
+        research-archive, promote-to-main-campaign, research-campaign) are inherently
         compliant — the rule has nothing to flag and zero findings is correct.
         """
         stem = recipe_path.stem

--- a/tests/server/_helpers.py
+++ b/tests/server/_helpers.py
@@ -79,7 +79,7 @@ BUNDLED_RECIPE_STEP_BACKEND_PIN_CASES = (
 
 
 def _configure_admitted_recipe(ctx: Any, path: Path) -> None:
-    """Configure the recipe repository mocks for successful namespace admission."""
+    """Admit a recipe and load it with empty steps and ingredients by default."""
     ctx.recipes.find.return_value = MagicMock(path=path)
     ctx.recipes.load.return_value = MagicMock(steps={}, ingredients={})
 

--- a/tests/server/_helpers.py
+++ b/tests/server/_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -75,6 +76,12 @@ BUNDLED_RECIPE_STEP_BACKEND_PIN_CASES = (
         "agent_backend.recipe_overrides.research-review.run_experiment_lenses",
     ),
 )
+
+
+def _configure_admitted_recipe(ctx: Any, path: Path) -> None:
+    """Configure the recipe repository mocks for successful namespace admission."""
+    ctx.recipes.find.return_value = MagicMock(path=path)
+    ctx.recipes.load.return_value = MagicMock(steps={}, ingredients={})
 
 
 def _bundled_backend() -> AgentBackendConfig:

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -145,7 +145,7 @@ def _make_mock_ctx(config=None) -> MagicMock:
     from threading import RLock
 
     from autoskillit.config import AutomationConfig, OutputBudgetConfig, QuotaGuardConfig
-    from autoskillit.core import InstallationVersion
+    from autoskillit.core import InstallationVersion, SkillResolver
     from autoskillit.pipeline import NoActiveRecipe
     from autoskillit.server._factory import make_recipe_execution
 
@@ -163,6 +163,8 @@ def _make_mock_ctx(config=None) -> MagicMock:
     )
     ctx.project_dir = ctx.temp_dir / "project"
     ctx.project_dir.mkdir(parents=True, exist_ok=True)
+    ctx.skill_resolver = MagicMock(spec=SkillResolver)
+    ctx.skill_resolver.resolve_effective.return_value = None
     ctx.kitchen_id = f"test-{uuid4().hex}"
     ctx.config.output_budget = OutputBudgetConfig()
     ctx.config.quota_guard = QuotaGuardConfig()
@@ -254,6 +256,7 @@ def build_ctx(tmp_path):
     from autoskillit.core import (
         AuditAdmissionStoreAuthority,
         ContextAdmissionStoreAuthority,
+        SkillResolver,
     )
     from autoskillit.pipeline.audit import DefaultAuditLog
     from autoskillit.pipeline.audit_admission_ledger import DefaultAuditAdmissionLedger
@@ -334,6 +337,8 @@ def build_ctx(tmp_path):
             ),
             run_skill_completion=DefaultRunSkillCompletionAuthority(),
         )
+        ctx.skill_resolver = MagicMock(spec=SkillResolver)
+        ctx.skill_resolver.resolve_effective.return_value = None
         for field_name, value in overrides.items():
             setattr(ctx, field_name, value)
         return ctx

--- a/tests/server/test_mcp_overrides.py
+++ b/tests/server/test_mcp_overrides.py
@@ -20,7 +20,8 @@ def _make_mock_recipes(load_result: dict) -> MagicMock:
     if load_result.get("valid") is True:
         load_result = _with_finalized_projection(load_result)
     mock.load_and_validate.return_value = load_result
-    mock.find.return_value = None
+    mock.find.return_value = MagicMock(path=Path("/fake/test-recipe.yaml"))
+    mock.load.return_value = MagicMock(steps={}, ingredients={})
     mock.list_all.return_value = {"recipes": [], "count": 0}
     return mock
 
@@ -29,12 +30,15 @@ def _make_mock_ctx(recipes: MagicMock, temp_dir: Path) -> MagicMock:
     from threading import RLock
 
     from autoskillit.config import OutputBudgetConfig
-    from autoskillit.core import InstallationVersion
+    from autoskillit.core import InstallationVersion, SkillResolver
     from autoskillit.pipeline import NoActiveRecipe
     from autoskillit.server._factory import make_recipe_execution
 
     mock_ctx = MagicMock()
     mock_ctx.recipes = recipes
+    mock_ctx.skill_resolver = MagicMock(spec=SkillResolver)
+    mock_ctx.skill_resolver.resolve_effective.return_value = None
+    mock_ctx.project_dir = temp_dir
     mock_ctx.temp_dir = temp_dir
     mock_ctx.kitchen_id = "test-mcp-overrides"
     mock_ctx.config.migration.suppressed = []

--- a/tests/server/test_open_kitchen_deferred_recall.py
+++ b/tests/server/test_open_kitchen_deferred_recall.py
@@ -73,7 +73,8 @@ async def test_recipe_open_atomically_installs_compiled_execution(
     tool_ctx.kitchen_id = f"test-open-{deferred_recall}"
     tool_ctx.recipe_name = "test-recipe" if deferred_recall else ""
     recipes = MagicMock()
-    recipes.find.return_value = None
+    recipes.find.return_value = MagicMock(path=Path("/fake/test-recipe.yaml"))
+    recipes.load.return_value = MagicMock(steps={}, ingredients={})
     tool_ctx.recipes = recipes
     request_ctx = MagicMock()
     request_ctx.enable_components = AsyncMock()
@@ -158,66 +159,6 @@ async def test_deferred_recall_sets_active_recipe_steps_from_recipe():
         "build": {"cmd": "task build"},
         "test": {"cmd": "task test"},
     }
-
-
-@pytest.mark.anyio
-async def test_deferred_recall_sets_active_recipe_steps_none_when_find_raises():
-    """When recipes.find raises, active_recipe_steps is set to None and the call still succeeds."""
-    from autoskillit.server.tools.tools_kitchen import open_kitchen
-
-    mock_ctx = _make_deferred_recall_ctx("test-recipe")
-    mock_ctx.recipes.load_and_validate.return_value = {
-        "content": "name: test-recipe\nsteps:\n  build:\n    cmd: task build\n",
-        "valid": True,
-        "errors": [],
-        "requires_packs": [],
-        "requires_features": [],
-        "content_hash": "abc",
-        "composite_hash": "def",
-        "recipe_version": "1.0",
-        "suggestions": [],
-    }
-    mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
-        mock_ctx.recipes.load_and_validate.return_value
-    )
-    mock_ctx.recipes.find.side_effect = RuntimeError("disk error")
-
-    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
-        result = await open_kitchen(name="test-recipe", ctx=mock_ctx)
-
-    parsed = json.loads(result)
-    assert parsed["success"] is True
-    assert mock_ctx.active_recipe_steps is None
-
-
-@pytest.mark.anyio
-async def test_deferred_recall_sets_active_recipe_steps_none_when_find_returns_none():
-    """When recipes.find returns None (recipe not on disk), active_recipe_steps is None."""
-    from autoskillit.server.tools.tools_kitchen import open_kitchen
-
-    mock_ctx = _make_deferred_recall_ctx("test-recipe")
-    mock_ctx.recipes.load_and_validate.return_value = {
-        "content": "name: test-recipe\nsteps:\n  build:\n    cmd: task build\n",
-        "valid": True,
-        "errors": [],
-        "requires_packs": [],
-        "requires_features": [],
-        "content_hash": "abc",
-        "composite_hash": "def",
-        "recipe_version": "1.0",
-        "suggestions": [],
-    }
-    mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
-        mock_ctx.recipes.load_and_validate.return_value
-    )
-    mock_ctx.recipes.find.return_value = None
-
-    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
-        result = await open_kitchen(name="test-recipe", ctx=mock_ctx)
-
-    parsed = json.loads(result)
-    assert parsed["success"] is True
-    assert mock_ctx.active_recipe_steps is None
 
 
 @pytest.mark.anyio

--- a/tests/server/test_open_kitchen_deferred_recall.py
+++ b/tests/server/test_open_kitchen_deferred_recall.py
@@ -161,6 +161,44 @@ async def test_deferred_recall_sets_active_recipe_steps_from_recipe():
 
 
 @pytest.mark.anyio
+async def test_deferred_recall_clears_recipe_cache_when_cache_load_fails():
+    """A non-authoritative cache failure does not retain stale recipe data."""
+    from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+    mock_ctx = _make_deferred_recall_ctx("test-recipe")
+    mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
+        {
+            "content": "name: test-recipe\nsteps: {}\n",
+            "valid": True,
+            "errors": [],
+            "requires_packs": [],
+            "requires_features": [],
+            "content_hash": "abc123",
+            "composite_hash": "def456",
+            "recipe_version": "1.0",
+            "suggestions": [],
+            "post_prune_step_names": [],
+        }
+    )
+    _configure_admitted_recipe(mock_ctx, Path("/fake/.autoskillit/recipes/test-recipe.yaml"))
+    admitted_recipe = mock_ctx.recipes.load.return_value
+    mock_ctx.recipes.load.side_effect = [
+        admitted_recipe,
+        RuntimeError("cache load failed"),
+    ]
+    mock_ctx.active_recipe_steps = {"stale": {"cmd": "old"}}
+    mock_ctx.active_recipe_ingredients = frozenset({"stale"})
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        result = await open_kitchen(name="test-recipe", ctx=mock_ctx)
+
+    assert json.loads(result)["success"] is True
+    assert mock_ctx.recipes.load.call_count == 2
+    assert mock_ctx.active_recipe_steps is None
+    assert mock_ctx.active_recipe_ingredients is None
+
+
+@pytest.mark.anyio
 async def test_deferred_recall_fails_closed_when_valid_false_empty_content():
     """Guard fires when load_and_validate returns valid=False with empty content."""
     from autoskillit.server.tools.tools_kitchen import open_kitchen

--- a/tests/server/test_open_kitchen_deferred_recall.py
+++ b/tests/server/test_open_kitchen_deferred_recall.py
@@ -12,7 +12,7 @@ from autoskillit.core import RecipeExecutionId
 from autoskillit.recipe._binding import bind_recipe
 from autoskillit.recipe.schema import Recipe, RecipeStep
 from autoskillit.server._recipe_execution import get_recipe_execution
-from tests.server._helpers import _with_finalized_projection
+from tests.server._helpers import _configure_admitted_recipe, _with_finalized_projection
 from tests.server.conftest import _make_mock_ctx
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
@@ -73,9 +73,8 @@ async def test_recipe_open_atomically_installs_compiled_execution(
     tool_ctx.kitchen_id = f"test-open-{deferred_recall}"
     tool_ctx.recipe_name = "test-recipe" if deferred_recall else ""
     recipes = MagicMock()
-    recipes.find.return_value = MagicMock(path=Path("/fake/test-recipe.yaml"))
-    recipes.load.return_value = MagicMock(steps={}, ingredients={})
     tool_ctx.recipes = recipes
+    _configure_admitted_recipe(tool_ctx, Path("/fake/test-recipe.yaml"))
     request_ctx = MagicMock()
     request_ctx.enable_components = AsyncMock()
     request_ctx.disable_components = AsyncMock()

--- a/tests/server/test_recipe_namespace_admission.py
+++ b/tests/server/test_recipe_namespace_admission.py
@@ -1,0 +1,106 @@
+"""Recipe-name admission tests for model-facing recipe surfaces."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from autoskillit.core import (
+    RecipeLoadError,
+    RecipeNotFoundError,
+    RecipeRepository,
+    SkillResolver,
+)
+from autoskillit.server.tools._serve_helpers import _admit_recipe_name, serve_recipe
+from autoskillit.workspace import DefaultSkillResolver
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.mark.parametrize(
+    ("recipe_present", "skill_present", "expected_error"),
+    [
+        pytest.param(True, False, None, id="recipe-only"),
+        pytest.param(False, True, RecipeNotFoundError, id="skill-only"),
+        pytest.param(True, True, RecipeLoadError, id="ambiguous"),
+        pytest.param(False, False, RecipeNotFoundError, id="neither"),
+    ],
+)
+def test_admit_recipe_name_has_four_namespace_outcomes(
+    tmp_path,
+    recipe_present: bool,
+    skill_present: bool,
+    expected_error: type[Exception] | None,
+) -> None:
+    recipe_info = object() if recipe_present else None
+    skill_spec = object() if skill_present else None
+    recipes = MagicMock(spec=RecipeRepository)
+    recipes.find.return_value = recipe_info
+    resolver = MagicMock(spec=SkillResolver)
+    resolver.resolve_effective.return_value = skill_spec
+    ctx = SimpleNamespace(
+        recipes=recipes,
+        skill_resolver=resolver,
+        project_dir=tmp_path,
+    )
+
+    if expected_error is None:
+        assert _admit_recipe_name(ctx, "shared-name") is recipe_info
+    else:
+        with pytest.raises(expected_error) as raised:
+            _admit_recipe_name(ctx, "shared-name")
+        if skill_present and not recipe_present:
+            assert "skill" in str(raised.value).lower()
+            assert "current session" in str(raised.value).lower()
+        elif recipe_present and skill_present:
+            assert "ambiguous" in str(raised.value).lower()
+            assert "rename" in str(raised.value).lower()
+        else:
+            assert str(raised.value) == "No recipe named 'shared-name' found"
+
+    recipes.find.assert_called_once_with("shared-name", tmp_path)
+    resolver.resolve_effective.assert_called_once_with("shared-name", tmp_path)
+
+
+def test_admit_recipe_name_rejects_project_local_collision(tmp_path) -> None:
+    skill_dir = tmp_path / ".claude" / "skills" / "project-collision"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: project-collision\ndescription: Project collision\n---\n# Project collision\n"
+    )
+    recipes = MagicMock(spec=RecipeRepository)
+    recipes.find.return_value = object()
+    ctx = SimpleNamespace(
+        recipes=recipes,
+        skill_resolver=DefaultSkillResolver(),
+        project_dir=tmp_path,
+    )
+
+    with pytest.raises(RecipeLoadError, match="ambiguous"):
+        _admit_recipe_name(ctx, "project-collision")
+
+
+def test_serve_recipe_admits_before_recipe_delivery(tmp_path) -> None:
+    recipes = MagicMock(spec=RecipeRepository)
+    recipes.find.return_value = None
+    resolver = MagicMock(spec=SkillResolver)
+    resolver.resolve_effective.return_value = object()
+    ctx = SimpleNamespace(
+        recipes=recipes,
+        skill_resolver=resolver,
+        project_dir=tmp_path,
+    )
+
+    with pytest.raises(RecipeNotFoundError, match="current session"):
+        serve_recipe(
+            ctx,
+            "skill-only",
+            caller_overrides=None,
+            config_default={},
+            session_overrides={},
+            config_layer={},
+        )
+
+    recipes.load_and_validate.assert_not_called()

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -11,17 +11,12 @@ import pytest
 from tests.server._helpers import (
     _PATCHED_DEFAULTS,
     _SERVER_ONLY_KEYS,
+    _configure_admitted_recipe,
     _with_finalized_projection,
 )
 from tests.server.conftest import _make_mock_ctx
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
-
-
-def _configure_admitted_recipe(mock_ctx, path: Path) -> None:
-    mock_ctx.recipes.find.return_value = MagicMock(path=path)
-    mock_ctx.recipes.load.return_value = MagicMock(steps={}, ingredients={})
-
 
 # ---------------------------------------------------------------------------
 # Group E — hook drift / diagnostic warnings

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -18,6 +18,11 @@ from tests.server.conftest import _make_mock_ctx
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
+def _configure_admitted_recipe(mock_ctx, path: Path) -> None:
+    mock_ctx.recipes.find.return_value = MagicMock(path=path)
+    mock_ctx.recipes.load.return_value = MagicMock(steps={}, ingredients={})
+
+
 # ---------------------------------------------------------------------------
 # Group E — hook drift / diagnostic warnings
 # ---------------------------------------------------------------------------
@@ -48,7 +53,7 @@ async def test_named_delivery_preserves_finalized_bytes_across_anonymous_guidanc
     mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
         mock_ctx.recipes.load_and_validate.return_value
     )
-    mock_ctx.recipes.find.return_value = None
+    _configure_admitted_recipe(mock_ctx, tmp_path / "demo.yaml")
     mock_ctx.config.migration.suppressed = []
     finalized = FinalizedRecipeResponse(
         rendered=f"{delivery_mode}:byte-identical",
@@ -350,7 +355,7 @@ async def test_open_kitchen_recipe_found_returns_envelope_with_content_and_ingre
     mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
         mock_ctx.recipes.load_and_validate.return_value
     )
-    mock_ctx.recipes.find.return_value = None
+    _configure_admitted_recipe(mock_ctx, tmp_path / "demo.yaml")
     mock_ctx.config.migration.suppressed = []
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
@@ -388,7 +393,7 @@ async def test_open_kitchen_injects_hidden_ingredient_overrides(tmp_path, monkey
         "diagram": None,
         "ingredients_table": "--- INGREDIENTS TABLE ---\n  task  required\n--- END TABLE ---",
     }
-    mock_ctx.recipes.find.return_value = None
+    _configure_admitted_recipe(mock_ctx, tmp_path / "demo.yaml")
     mock_ctx.config.migration.suppressed = []
     mock_ctx.kitchen_id = "test-kitchen-abc"
 
@@ -440,7 +445,7 @@ async def test_config_layer_keys_match_server_authoritative_ingredients(tmp_path
         "diagram": None,
         "ingredients_table": "--- INGREDIENTS TABLE ---\n  task  required\n--- END TABLE ---",
     }
-    mock_ctx.recipes.find.return_value = None
+    _configure_admitted_recipe(mock_ctx, tmp_path / "demo.yaml")
     mock_ctx.config.migration.suppressed = []
     mock_ctx.kitchen_id = "test-kitchen-abc"
 
@@ -544,7 +549,7 @@ async def test_open_kitchen_config_authority_overrides_caller(tmp_path, monkeypa
             "--- INGREDIENTS TABLE ---\n  base_branch  develop\n--- END TABLE ---"
         ),
     }
-    mock_ctx.recipes.find.return_value = None
+    _configure_admitted_recipe(mock_ctx, tmp_path / "demo.yaml")
     mock_ctx.config.migration.suppressed = []
     mock_ctx.kitchen_id = "test-kitchen-abc"
     mock_ctx.config.linux_tracing.log_dir = ""
@@ -962,7 +967,7 @@ async def test_open_kitchen_apply_triage_gate_raises_returns_failure_envelope(
         "valid": True,
         "suggestions": [],
     }
-    mock_ctx.recipes.find.return_value = None
+    _configure_admitted_recipe(mock_ctx, tmp_path / "demo.yaml")
     mock_ctx.config.migration.suppressed = []
 
     async def raise_apply(*a, **kw):

--- a/tests/server/test_tools_kitchen_gate_features.py
+++ b/tests/server/test_tools_kitchen_gate_features.py
@@ -507,8 +507,27 @@ def test_missing_recipe_resource_preserves_active_execution():
 
         result = json.loads(get_recipe("missing"))
 
-    assert result == {"error": "No recipe named 'missing'."}
+    assert result == {"error": "No recipe named 'missing' found"}
     assert mock_ctx.active_recipe_execution is previous
+
+
+@pytest.mark.parametrize("recipe_present", [False, True], ids=["skill-only", "ambiguous"])
+def test_recipe_resource_preserves_namespace_error_before_composition(recipe_present):
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.recipes = MagicMock()
+    mock_ctx.recipes.find.return_value = object() if recipe_present else None
+    mock_ctx.skill_resolver.resolve_effective.return_value = object()
+
+    with patch("autoskillit.server._state._get_ctx_or_none", return_value=mock_ctx):
+        from autoskillit.server.tools.tools_kitchen import get_recipe
+
+        result = json.loads(get_recipe("shared-name"))
+
+    assert "skill" in result["error"].lower()
+    if recipe_present:
+        assert "ambiguous" in result["error"].lower()
+    mock_ctx.recipes.load.assert_not_called()
+    mock_ctx.recipes.load_and_validate.assert_not_called()
 
 
 # 1h: get_recipe resource returns error for invalid recipe

--- a/tests/server/test_tools_kitchen_visibility.py
+++ b/tests/server/test_tools_kitchen_visibility.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from autoskillit.core import KITCHEN_GATED_TOOLS
+from autoskillit.core import KITCHEN_GATED_TOOLS, RecipeNotFoundError
 from autoskillit.core.types._type_constants import SOUS_CHEF_MANDATORY_SECTIONS
 from tests.server._helpers import _with_finalized_projection
 from tests.server.conftest import _make_mock_ctx
@@ -365,7 +365,8 @@ async def test_open_kitchen_with_recipe_returns_combined_response(tmp_path, monk
     mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
         mock_ctx.recipes.load_and_validate.return_value
     )
-    mock_ctx.recipes.find.return_value = None
+    mock_ctx.recipes.find.return_value = MagicMock(path=recipes_dir / "test-recipe.yaml")
+    mock_ctx.recipes.load.return_value = MagicMock(steps={}, ingredients={})
     mock_ctx.config.migration.suppressed = []
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
@@ -395,13 +396,11 @@ async def test_open_kitchen_with_recipe_not_found(tmp_path, monkeypatch):
     mock_ctx = _make_mock_ctx()
     mock_ctx.enable_components = AsyncMock()
     mock_ctx.recipes = MagicMock()
-    mock_ctx.recipes.load_and_validate.return_value = {
-        "content": "",
-        "valid": False,
-        "errors": ["No recipe named 'nonexistent' found"],
-        "suggestions": [],
-    }
-    mock_ctx.recipes.find.return_value = None
+    mock_ctx.recipes.find.return_value = MagicMock(path=tmp_path / "nonexistent.yaml")
+    mock_ctx.recipes.load.return_value = MagicMock(steps={}, ingredients={})
+    mock_ctx.recipes.load_and_validate.side_effect = RecipeNotFoundError(
+        "No recipe named 'nonexistent' found"
+    )
     mock_ctx.config.migration.suppressed = []
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
@@ -416,8 +415,43 @@ async def test_open_kitchen_with_recipe_not_found(tmp_path, monkeypatch):
 
     result = json.loads(result_str)
     assert result["success"] is False
-    assert "nonexistent" in result["error"]
+    assert result["stage"] == "load_and_validate"
+    assert result["error"] == "RecipeNotFoundError: No recipe named 'nonexistent' found"
     assert result["kitchen"] == "failed"
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_rejects_skill_before_operational_mutation(tmp_path, monkeypatch):
+    """A skill-only name fails before the kitchen or active recipe is mutated."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.recipes = MagicMock()
+    mock_ctx.recipes.find.return_value = None
+    mock_ctx.skill_resolver.resolve_effective.return_value = object()
+    mock_ctx.recipe_name = "existing-recipe"
+    previous_execution = mock_ctx.recipe_initialization_state
+
+    handler = AsyncMock()
+    with (
+        patch("autoskillit.server._get_ctx", return_value=mock_ctx),
+        patch("autoskillit.server.tools.tools_kitchen._open_kitchen_handler", handler),
+        patch("autoskillit.server.tools.tools_kitchen.clear_recipe_execution") as clear,
+        patch("autoskillit.server.tools.tools_kitchen.mcp") as mock_mcp,
+    ):
+        from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+        result = json.loads(await open_kitchen(name="dry-walkthrough", ctx=mock_ctx))
+
+    assert result["stage"] == "recipe_namespace"
+    assert "skill" in result["user_visible_message"].lower()
+    assert "current session" in result["user_visible_message"].lower()
+    handler.assert_not_awaited()
+    clear.assert_not_called()
+    mock_mcp.enable.assert_not_called()
+    mock_ctx.recipes.load.assert_not_called()
+    mock_ctx.recipes.load_and_validate.assert_not_called()
+    assert mock_ctx.recipe_name == "existing-recipe"
+    assert mock_ctx.recipe_initialization_state is previous_execution
 
 
 @pytest.mark.anyio
@@ -585,7 +619,8 @@ async def test_sous_chef_discipline_not_in_open_kitchen_result(tmp_path, monkeyp
     mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
         mock_ctx.recipes.load_and_validate.return_value
     )
-    mock_ctx.recipes.find.return_value = None
+    mock_ctx.recipes.find.return_value = MagicMock(path=tmp_path / "implementation.yaml")
+    mock_ctx.recipes.load.return_value = MagicMock(steps={}, ingredients={})
     mock_ctx.config.migration.suppressed = []
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
@@ -625,7 +660,8 @@ async def test_open_kitchen_result_keys_match_typed_dict(tmp_path, monkeypatch):
     mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
         mock_ctx.recipes.load_and_validate.return_value
     )
-    mock_ctx.recipes.find.return_value = None
+    mock_ctx.recipes.find.return_value = MagicMock(path=tmp_path / "implementation.yaml")
+    mock_ctx.recipes.load.return_value = MagicMock(steps={}, ingredients={})
     mock_ctx.config.migration.suppressed = []
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):

--- a/tests/server/test_tools_kitchen_visibility.py
+++ b/tests/server/test_tools_kitchen_visibility.py
@@ -394,8 +394,8 @@ async def test_open_kitchen_with_recipe_returns_combined_response(tmp_path, monk
 
 
 @pytest.mark.anyio
-async def test_open_kitchen_with_recipe_not_found(tmp_path, monkeypatch):
-    """open_kitchen(name='nonexistent') fails closed when recipe is not found."""
+async def test_open_kitchen_reports_admitted_recipe_missing_during_load(tmp_path, monkeypatch):
+    """An admitted recipe that disappears during loading fails closed."""
     monkeypatch.chdir(tmp_path)
     mock_ctx = _make_mock_ctx()
     mock_ctx.enable_components = AsyncMock()

--- a/tests/server/test_tools_kitchen_visibility.py
+++ b/tests/server/test_tools_kitchen_visibility.py
@@ -426,13 +426,26 @@ async def test_open_kitchen_with_recipe_not_found(tmp_path, monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_open_kitchen_rejects_skill_before_operational_mutation(tmp_path, monkeypatch):
-    """A skill-only name fails before the kitchen or active recipe is mutated."""
+@pytest.mark.parametrize(
+    ("recipe_name", "skill_match", "expected_message"),
+    [
+        ("dry-walkthrough", object(), "current session"),
+        ("missing-recipe", None, "No recipe named 'missing-recipe' found"),
+    ],
+)
+async def test_open_kitchen_rejects_non_recipe_before_operational_mutation(
+    tmp_path,
+    monkeypatch,
+    recipe_name,
+    skill_match,
+    expected_message,
+):
+    """Skill-only and unknown names fail before operational state is mutated."""
     monkeypatch.chdir(tmp_path)
     mock_ctx = _make_mock_ctx()
     mock_ctx.recipes = MagicMock()
     mock_ctx.recipes.find.return_value = None
-    mock_ctx.skill_resolver.resolve_effective.return_value = object()
+    mock_ctx.skill_resolver.resolve_effective.return_value = skill_match
     mock_ctx.recipe_name = "existing-recipe"
     previous_execution = mock_ctx.recipe_initialization_state
     previous_quota_task = mock_ctx.quota_refresh_task
@@ -459,11 +472,10 @@ async def test_open_kitchen_rejects_skill_before_operational_mutation(tmp_path, 
     ):
         from autoskillit.server.tools.tools_kitchen import open_kitchen
 
-        result = json.loads(await open_kitchen(name="dry-walkthrough", ctx=mock_ctx))
+        result = json.loads(await open_kitchen(name=recipe_name, ctx=mock_ctx))
 
     assert result["stage"] == "recipe_namespace"
-    assert "skill" in result["user_visible_message"].lower()
-    assert "current session" in result["user_visible_message"].lower()
+    assert expected_message in result["user_visible_message"]
     handler.assert_not_awaited()
     clear.assert_not_called()
     create_task.assert_not_called()

--- a/tests/server/test_tools_kitchen_visibility.py
+++ b/tests/server/test_tools_kitchen_visibility.py
@@ -9,6 +9,11 @@ import pytest
 
 from autoskillit.core import KITCHEN_GATED_TOOLS, RecipeNotFoundError
 from autoskillit.core.types._type_constants import SOUS_CHEF_MANDATORY_SECTIONS
+from autoskillit.pipeline import (
+    bind_kitchen_intent,
+    claim_kitchen_request,
+    release_kitchen_request,
+)
 from tests.server._helpers import _with_finalized_projection
 from tests.server.conftest import _make_mock_ctx
 
@@ -430,12 +435,26 @@ async def test_open_kitchen_rejects_skill_before_operational_mutation(tmp_path, 
     mock_ctx.skill_resolver.resolve_effective.return_value = object()
     mock_ctx.recipe_name = "existing-recipe"
     previous_execution = mock_ctx.recipe_initialization_state
+    previous_quota_task = mock_ctx.quota_refresh_task
 
     handler = AsyncMock()
     with (
         patch("autoskillit.server._get_ctx", return_value=mock_ctx),
         patch("autoskillit.server.tools.tools_kitchen._open_kitchen_handler", handler),
         patch("autoskillit.server.tools.tools_kitchen.clear_recipe_execution") as clear,
+        patch("autoskillit.server.tools.tools_kitchen.create_background_task") as create_task,
+        patch(
+            "autoskillit.server.tools.tools_kitchen.bind_kitchen_intent",
+            wraps=bind_kitchen_intent,
+        ) as bind_request,
+        patch(
+            "autoskillit.server.tools.tools_kitchen.claim_kitchen_request",
+            wraps=claim_kitchen_request,
+        ) as claim_request,
+        patch(
+            "autoskillit.server.tools.tools_kitchen.release_kitchen_request",
+            wraps=release_kitchen_request,
+        ) as release_request,
         patch("autoskillit.server.tools.tools_kitchen.mcp") as mock_mcp,
     ):
         from autoskillit.server.tools.tools_kitchen import open_kitchen
@@ -447,11 +466,20 @@ async def test_open_kitchen_rejects_skill_before_operational_mutation(tmp_path, 
     assert "current session" in result["user_visible_message"].lower()
     handler.assert_not_awaited()
     clear.assert_not_called()
+    create_task.assert_not_called()
     mock_mcp.enable.assert_not_called()
     mock_ctx.recipes.load.assert_not_called()
     mock_ctx.recipes.load_and_validate.assert_not_called()
+    bind_request.assert_called_once()
+    claim_request.assert_called_once()
+    release_request.assert_called_once()
     assert mock_ctx.recipe_name == "existing-recipe"
     assert mock_ctx.recipe_initialization_state is previous_execution
+    assert mock_ctx.quota_refresh_task is previous_quota_task
+    assert mock_ctx.kitchen_open_state.phase.value == "request_bound"
+    assert mock_ctx.kitchen_open_state.request_active is False
+    effects = [(effect.name, effect.phase.value) for effect in mock_ctx.kitchen_open_state.effects]
+    assert effects == [("request_binding", "confirmed")]
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_kitchen_visibility.py
+++ b/tests/server/test_tools_kitchen_visibility.py
@@ -483,11 +483,15 @@ async def test_open_kitchen_rejects_skill_before_operational_mutation(tmp_path, 
 
 
 @pytest.mark.anyio
-async def test_open_kitchen_without_recipe_returns_json_envelope(tmp_path, monkeypatch):
-    """open_kitchen() without name returns JSON envelope with success=True."""
+async def test_open_kitchen_without_recipe_bypasses_namespace_admission(tmp_path, monkeypatch):
+    """open_kitchen(name=None) activates without consulting recipe or skill names."""
     monkeypatch.chdir(tmp_path)
     mock_ctx = _make_mock_ctx()
     mock_ctx.enable_components = AsyncMock()
+    mock_ctx.recipes.find.side_effect = AssertionError("anonymous activation admitted a recipe")
+    mock_ctx.skill_resolver.resolve_effective.side_effect = AssertionError(
+        "anonymous activation resolved a skill"
+    )
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
         with patch("autoskillit.server.logger"):
@@ -505,6 +509,8 @@ async def test_open_kitchen_without_recipe_returns_json_envelope(tmp_path, monke
     assert parsed["kitchen"] == "open"
     assert "Kitchen is open" in parsed["content"]
     assert parsed["ingredients_table"] is None
+    mock_ctx.recipes.find.assert_not_called()
+    mock_ctx.skill_resolver.resolve_effective.assert_not_called()
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_kitchen_visibility.py
+++ b/tests/server/test_tools_kitchen_visibility.py
@@ -495,6 +495,24 @@ async def test_open_kitchen_rejects_non_recipe_before_operational_mutation(
 
 
 @pytest.mark.anyio
+async def test_open_kitchen_does_not_misclassify_resolver_runtime_error(tmp_path, monkeypatch):
+    """A resolver failure is not reported as missing server configuration."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.recipes = MagicMock()
+    mock_ctx.recipes.find.return_value = None
+    mock_ctx.skill_resolver.resolve_effective.side_effect = RuntimeError("resolver failed")
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+        result = json.loads(await open_kitchen(name="broken-recipe", ctx=mock_ctx))
+
+    assert result["stage"] == "unhandled"
+    assert result["error"] == "RuntimeError: resolver failed"
+
+
+@pytest.mark.anyio
 async def test_open_kitchen_without_recipe_bypasses_namespace_admission(tmp_path, monkeypatch):
     """open_kitchen(name=None) activates without consulting recipe or skill names."""
     monkeypatch.chdir(tmp_path)

--- a/tests/server/test_tools_kitchen_visibility.py
+++ b/tests/server/test_tools_kitchen_visibility.py
@@ -14,7 +14,7 @@ from autoskillit.pipeline import (
     claim_kitchen_request,
     release_kitchen_request,
 )
-from tests.server._helpers import _with_finalized_projection
+from tests.server._helpers import _configure_admitted_recipe, _with_finalized_projection
 from tests.server.conftest import _make_mock_ctx
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
@@ -370,8 +370,7 @@ async def test_open_kitchen_with_recipe_returns_combined_response(tmp_path, monk
     mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
         mock_ctx.recipes.load_and_validate.return_value
     )
-    mock_ctx.recipes.find.return_value = MagicMock(path=recipes_dir / "test-recipe.yaml")
-    mock_ctx.recipes.load.return_value = MagicMock(steps={}, ingredients={})
+    _configure_admitted_recipe(mock_ctx, recipes_dir / "test-recipe.yaml")
     mock_ctx.config.migration.suppressed = []
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
@@ -401,8 +400,7 @@ async def test_open_kitchen_with_recipe_not_found(tmp_path, monkeypatch):
     mock_ctx = _make_mock_ctx()
     mock_ctx.enable_components = AsyncMock()
     mock_ctx.recipes = MagicMock()
-    mock_ctx.recipes.find.return_value = MagicMock(path=tmp_path / "nonexistent.yaml")
-    mock_ctx.recipes.load.return_value = MagicMock(steps={}, ingredients={})
+    _configure_admitted_recipe(mock_ctx, tmp_path / "nonexistent.yaml")
     mock_ctx.recipes.load_and_validate.side_effect = RecipeNotFoundError(
         "No recipe named 'nonexistent' found"
     )
@@ -683,8 +681,7 @@ async def test_sous_chef_discipline_not_in_open_kitchen_result(tmp_path, monkeyp
     mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
         mock_ctx.recipes.load_and_validate.return_value
     )
-    mock_ctx.recipes.find.return_value = MagicMock(path=tmp_path / "implementation.yaml")
-    mock_ctx.recipes.load.return_value = MagicMock(steps={}, ingredients={})
+    _configure_admitted_recipe(mock_ctx, tmp_path / "implementation.yaml")
     mock_ctx.config.migration.suppressed = []
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
@@ -724,8 +721,7 @@ async def test_open_kitchen_result_keys_match_typed_dict(tmp_path, monkeypatch):
     mock_ctx.recipes.load_and_validate.return_value = _with_finalized_projection(
         mock_ctx.recipes.load_and_validate.return_value
     )
-    mock_ctx.recipes.find.return_value = MagicMock(path=tmp_path / "implementation.yaml")
-    mock_ctx.recipes.load.return_value = MagicMock(steps={}, ingredients={})
+    _configure_admitted_recipe(mock_ctx, tmp_path / "implementation.yaml")
     mock_ctx.config.migration.suppressed = []
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from autoskillit.config import AutomationConfig
-from autoskillit.core import SkillResult
+from autoskillit.core import SkillResolver, SkillResult
 from autoskillit.core.types import RetryReason
 from autoskillit.pipeline.gate import DefaultGateState
 from autoskillit.server.tools.tools_recipe import load_recipe
@@ -20,6 +20,44 @@ from tests.server._helpers import (
 )
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.fixture(autouse=True)
+def _default_recipe_names_do_not_resolve_as_skills(tool_ctx) -> None:
+    tool_ctx.skill_resolver = MagicMock(spec=SkillResolver)
+    tool_ctx.skill_resolver.resolve_effective.return_value = None
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("recipe_present", [False, True], ids=["skill-only", "ambiguous"])
+async def test_load_recipe_rejects_skill_names_before_recipe_work(
+    tmp_path, recipe_present: bool
+) -> None:
+    from tests.server.conftest import _make_mock_ctx
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.recipes = MagicMock()
+    mock_ctx.recipes.find.return_value = object() if recipe_present else None
+    mock_ctx.skill_resolver.resolve_effective.return_value = object()
+
+    with (
+        patch(
+            "autoskillit.server.tools.tools_recipe._get_ctx_or_none",
+            return_value=mock_ctx,
+        ),
+        patch(
+            "autoskillit.server.tools.tools_recipe._require_enabled",
+            return_value=None,
+        ),
+    ):
+        result = json.loads(await load_recipe(name="shared-name"))
+
+    assert result["success"] is False
+    assert "skill" in result["error"].lower()
+    if recipe_present:
+        assert "ambiguous" in result["error"].lower()
+    mock_ctx.recipes.load.assert_not_called()
+    mock_ctx.recipes.load_and_validate.assert_not_called()
 
 
 def _write_minimal_script(scripts_dir: Path, name: str = "test-script") -> Path:
@@ -590,7 +628,8 @@ class TestLoadRecipeAuthorityClobber:
                 "ingredients_table": "--- TABLE ---",
             }
         )
-        mock_ctx.recipes.find.return_value = None
+        mock_ctx.recipes.find.return_value = MagicMock(path=tmp_path / "demo.yaml")
+        mock_ctx.recipes.load.return_value = mock_recipe_obj
         mock_ctx.config.migration.suppressed = []
         mock_ctx.kitchen_id = "test-kitchen"
         mock_ctx.config.linux_tracing.log_dir = ""
@@ -689,7 +728,13 @@ class TestLoadRecipeFailClosed:
         _LOAD_CACHE.clear()
         test_result = {"valid": True, "content": "", "dispatch_feasible": True}
         monkeypatch.setattr(self.ctx.recipes, "load_and_validate", lambda *a, **kw: test_result)
-        monkeypatch.setattr(self.ctx.recipes, "find", lambda *a, **kw: None)
+        recipe_info = MagicMock(path=tmp_path / "test-recipe.yaml")
+        monkeypatch.setattr(self.ctx.recipes, "find", lambda *a, **kw: recipe_info)
+        monkeypatch.setattr(
+            self.ctx.recipes,
+            "load",
+            lambda *_a, **_kw: MagicMock(steps={}, ingredients={}),
+        )
         with patch(
             "autoskillit.server.tools.tools_recipe._apply_triage_gate",
             new=AsyncMock(return_value=test_result),
@@ -707,7 +752,13 @@ class TestLoadRecipeFailClosed:
         _LOAD_CACHE.clear()
         test_result = {"valid": True, "dispatch_feasible": True}
         monkeypatch.setattr(self.ctx.recipes, "load_and_validate", lambda *a, **kw: test_result)
-        monkeypatch.setattr(self.ctx.recipes, "find", lambda *a, **kw: None)
+        recipe_info = MagicMock(path=tmp_path / "test-recipe.yaml")
+        monkeypatch.setattr(self.ctx.recipes, "find", lambda *a, **kw: recipe_info)
+        monkeypatch.setattr(
+            self.ctx.recipes,
+            "load",
+            lambda *_a, **_kw: MagicMock(steps={}, ingredients={}),
+        )
         with patch(
             "autoskillit.server.tools.tools_recipe._apply_triage_gate",
             new=AsyncMock(return_value=test_result),
@@ -730,7 +781,13 @@ class TestLoadRecipeFailClosed:
             "dispatch_feasible": True,
         }
         monkeypatch.setattr(self.ctx.recipes, "load_and_validate", lambda *a, **kw: test_result)
-        monkeypatch.setattr(self.ctx.recipes, "find", lambda *a, **kw: None)
+        recipe_info = MagicMock(path=tmp_path / "test-recipe.yaml")
+        monkeypatch.setattr(self.ctx.recipes, "find", lambda *a, **kw: recipe_info)
+        monkeypatch.setattr(
+            self.ctx.recipes,
+            "load",
+            lambda *_a, **_kw: MagicMock(steps={}, ingredients={}),
+        )
         with patch(
             "autoskillit.server.tools.tools_recipe._apply_triage_gate",
             new=AsyncMock(return_value=test_result),

--- a/tests/server/test_tools_migrate_recipe.py
+++ b/tests/server/test_tools_migrate_recipe.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -233,6 +233,21 @@ class TestMigrateRecipe:
 
         mock_headless.assert_not_called()
         assert result.get("status") == "up_to_date"
+
+    @pytest.mark.anyio
+    async def test_suppressed_skill_name_is_rejected_before_suppression(self, tool_ctx):
+        tool_ctx.config.migration.suppressed = ["suppressed-skill"]
+        tool_ctx.recipes = MagicMock()
+        tool_ctx.recipes.find.return_value = None
+        tool_ctx.skill_resolver = MagicMock()
+        tool_ctx.skill_resolver.resolve_effective.return_value = object()
+        tool_ctx.migrations = AsyncMock()
+
+        result = json.loads(await migrate_recipe(name="suppressed-skill"))
+
+        assert "skill" in result["error"].lower()
+        assert result["name"] == "suppressed-skill"
+        tool_ctx.migrations.migrate.assert_not_awaited()
 
     # LR8
     @pytest.mark.anyio

--- a/tests/server/test_tools_recipe.py
+++ b/tests/server/test_tools_recipe.py
@@ -533,7 +533,9 @@ def test_tools_recipe_does_not_import_raw_ctx():
 
 # DIAG_C5
 @pytest.mark.anyio
-async def test_load_recipe_injects_hidden_ingredient_overrides(tool_ctx_kitchen_open, monkeypatch):
+async def test_load_recipe_injects_hidden_ingredient_overrides(
+    tool_ctx_kitchen_open, monkeypatch, tmp_path
+):
     """load_recipe injects all SERVER_AUTHORITATIVE_INGREDIENTS keys into ingredient_overrides."""
     from unittest.mock import MagicMock, patch
 
@@ -547,7 +549,8 @@ async def test_load_recipe_injects_hidden_ingredient_overrides(tool_ctx_kitchen_
         "diagram": None,
         "ingredients_table": "--- INGREDIENTS TABLE ---\n  task  required\n--- END TABLE ---",
     }
-    tool_ctx_kitchen_open.recipes.find.return_value = None
+    tool_ctx_kitchen_open.recipes.find.return_value = MagicMock(path=tmp_path / "demo.yaml")
+    tool_ctx_kitchen_open.recipes.load.return_value = MagicMock(steps={}, ingredients={})
     tool_ctx_kitchen_open.kitchen_id = "test-kitchen-xyz"
 
     with patch(
@@ -566,7 +569,7 @@ async def test_load_recipe_injects_hidden_ingredient_overrides(tool_ctx_kitchen_
 
 
 @pytest.mark.anyio
-async def test_load_recipe_config_authority_overrides_caller(tool_ctx_kitchen_open):
+async def test_load_recipe_config_authority_overrides_caller(tool_ctx_kitchen_open, tmp_path):
     """load_recipe: _config_layer overrides caller-supplied overrides for
     config-authoritative keys."""
     from unittest.mock import MagicMock, patch
@@ -583,7 +586,8 @@ async def test_load_recipe_config_authority_overrides_caller(tool_ctx_kitchen_op
             "--- INGREDIENTS TABLE ---\n  base_branch  develop\n--- END TABLE ---"
         ),
     }
-    tool_ctx_kitchen_open.recipes.find.return_value = None
+    tool_ctx_kitchen_open.recipes.find.return_value = MagicMock(path=tmp_path / "demo.yaml")
+    tool_ctx_kitchen_open.recipes.load.return_value = MagicMock(steps={}, ingredients={})
     tool_ctx_kitchen_open.kitchen_id = "test-kitchen-xyz"
 
     with patch(
@@ -609,7 +613,7 @@ async def test_load_recipe_config_authority_overrides_caller(tool_ctx_kitchen_op
 
 
 @pytest.mark.anyio
-async def test_load_recipe_with_config_authority_ingredient(tool_ctx_kitchen_open):
+async def test_load_recipe_with_config_authority_ingredient(tool_ctx_kitchen_open, tmp_path):
     """load_recipe integration: config-authority keys override caller values end-to-end."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -629,7 +633,8 @@ async def test_load_recipe_with_config_authority_ingredient(tool_ctx_kitchen_ope
     )
     tool_ctx_kitchen_open.recipes = MagicMock()
     tool_ctx_kitchen_open.recipes.load_and_validate.return_value = _load_result
-    tool_ctx_kitchen_open.recipes.find.return_value = None
+    tool_ctx_kitchen_open.recipes.find.return_value = MagicMock(path=tmp_path / "demo.yaml")
+    tool_ctx_kitchen_open.recipes.load.return_value = MagicMock(steps={}, ingredients={})
     tool_ctx_kitchen_open.recipes.apply_triage_gate = AsyncMock(return_value=_load_result)
     tool_ctx_kitchen_open.kitchen_id = "test-kitchen-xyz"
 

--- a/tests/server/test_tools_recipe.py
+++ b/tests/server/test_tools_recipe.py
@@ -9,7 +9,11 @@ import pytest
 
 from autoskillit.server.tools.tools_recipe import list_recipes as list_recipes_tool
 from autoskillit.server.tools.tools_recipe import validate_recipe
-from tests.server._helpers import _PATCHED_DEFAULTS, _with_finalized_projection
+from tests.server._helpers import (
+    _PATCHED_DEFAULTS,
+    _configure_admitted_recipe,
+    _with_finalized_projection,
+)
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
@@ -549,8 +553,7 @@ async def test_load_recipe_injects_hidden_ingredient_overrides(
         "diagram": None,
         "ingredients_table": "--- INGREDIENTS TABLE ---\n  task  required\n--- END TABLE ---",
     }
-    tool_ctx_kitchen_open.recipes.find.return_value = MagicMock(path=tmp_path / "demo.yaml")
-    tool_ctx_kitchen_open.recipes.load.return_value = MagicMock(steps={}, ingredients={})
+    _configure_admitted_recipe(tool_ctx_kitchen_open, tmp_path / "demo.yaml")
     tool_ctx_kitchen_open.kitchen_id = "test-kitchen-xyz"
 
     with patch(
@@ -586,8 +589,7 @@ async def test_load_recipe_config_authority_overrides_caller(tool_ctx_kitchen_op
             "--- INGREDIENTS TABLE ---\n  base_branch  develop\n--- END TABLE ---"
         ),
     }
-    tool_ctx_kitchen_open.recipes.find.return_value = MagicMock(path=tmp_path / "demo.yaml")
-    tool_ctx_kitchen_open.recipes.load.return_value = MagicMock(steps={}, ingredients={})
+    _configure_admitted_recipe(tool_ctx_kitchen_open, tmp_path / "demo.yaml")
     tool_ctx_kitchen_open.kitchen_id = "test-kitchen-xyz"
 
     with patch(
@@ -633,8 +635,7 @@ async def test_load_recipe_with_config_authority_ingredient(tool_ctx_kitchen_ope
     )
     tool_ctx_kitchen_open.recipes = MagicMock()
     tool_ctx_kitchen_open.recipes.load_and_validate.return_value = _load_result
-    tool_ctx_kitchen_open.recipes.find.return_value = MagicMock(path=tmp_path / "demo.yaml")
-    tool_ctx_kitchen_open.recipes.load.return_value = MagicMock(steps={}, ingredients={})
+    _configure_admitted_recipe(tool_ctx_kitchen_open, tmp_path / "demo.yaml")
     tool_ctx_kitchen_open.recipes.apply_triage_gate = AsyncMock(return_value=_load_result)
     tool_ctx_kitchen_open.kitchen_id = "test-kitchen-xyz"
 

--- a/tests/skills/test_phase2_skills.py
+++ b/tests/skills/test_phase2_skills.py
@@ -36,6 +36,9 @@ def test_open_kitchen_skill_respects_host_declared_visibility() -> None:
     assert "promotion remains valid even when the tools are pre-revealed" in content
     assert "name=" in content
     assert "close_kitchen" in content and "reopen" in content
+    assert "$<name>" in content and "/<name>" in content
+    assert "skill name" in content and "recipe identities only" in content
+    assert "defined as both" in content and "rejected" in content
 
 
 def test_close_kitchen_skill_has_disable_model_invocation() -> None:


### PR DESCRIPTION
## Summary

Three incidents show that model-facing selection text is not an enforcement boundary: after one wrong tool is discouraged, Codex can select the adjacent recipe tool instead. The architectural remedy is one server-side recipe-name admission authority, called by every model-facing bare recipe-name surface before that surface performs consequential work.

Closes #4532

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/rectify/rectify_skill_recipe_namespace_conflation_2026-08-09_184509.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
