### PR TITLE
Rectify: Pytest Tmpdir Lifecycle — Generation-Unique Basetemp + Liveness-Verified Reaping

### DIFF
--- a/.claude/skills/audit-tests/SKILL.md
+++ b/.claude/skills/audit-tests/SKILL.md
@@ -184,7 +184,7 @@ Test files or supporting files exceeding 750 lines. Flag files approaching the t
 Tests that are unsafe for parallel execution under pytest-xdist (`-n 4 --dist load`). This project runs tests in parallel by default with explicit safety rules defined in `tests/CLAUDE.md`.
 
 **What to look for:**
-- Tests that create temporary files or directories at fixed paths instead of using `tmp_path` (pytest provides unique per-test paths; on Linux these should land under `/dev/shm/pytest-tmp` per `tests/CLAUDE.md` guidance)
+- Tests that create temporary files or directories at fixed paths instead of using `tmp_path` (pytest provides unique per-test paths; on Linux these should land under the Taskfile-managed `/dev/shm/autoskillit-pytest-<uid>/pytest-<worktree-hash>-<run-id>/tmp` generation per `tests/AGENTS.md` guidance)
 - `scope="module"` or `scope="session"` fixtures that mutate state (module-level dicts, cached objects, singletons) without full teardown via `yield` — these can leak state across workers
 - Tests that use `monkeypatch.setattr()` on a fixture but the fixture itself has `scope != "function"` — the patch won't be reverted between tests that share the fixture instance
 - Tests that bind to fixed network ports; use `port=0` and capture the OS-assigned port via fixture

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,16 +3,22 @@ version: '3'
 set: ['pipefail']
 
 vars:
-  PYTEST_TMPDIR: '{{if eq OS "linux"}}/dev/shm/pytest-tmp-{{else}}/tmp/pytest-tmp-{{end}}{{ substr 0 8 (sha256sum .ROOT_DIR) }}'
-  PYTEST_CACHEDIR: '{{if eq OS "linux"}}/dev/shm/pytest-cache-{{else}}/tmp/pytest-cache-{{end}}{{ substr 0 8 (sha256sum .ROOT_DIR) }}'
+  PYTEST_TMP_ROOT: '{{if eq OS "linux"}}/dev/shm{{else}}/tmp{{end}}'
+  WORKTREE_HASH: '{{ substr 0 8 (sha256sum .ROOT_DIR) }}'
+  AUTOSKILLIT_UID:
+    sh: id -u
+  PYTEST_RUN_ID:
+    sh: echo "$$-$(date +%s)"
+  PYTEST_GEN_DIR: '{{.PYTEST_TMP_ROOT}}/autoskillit-pytest-{{.AUTOSKILLIT_UID}}/pytest-{{.WORKTREE_HASH}}-{{.PYTEST_RUN_ID}}'
+  PYTEST_TMPDIR: '{{.PYTEST_GEN_DIR}}/tmp'
+  PYTEST_CACHEDIR: '{{.PYTEST_GEN_DIR}}/cache'
 
 tasks:
   _tmpdir-setup:
     internal: true
-    desc: Wipe and recreate pytest tmpdir so each run starts clean (platform-aware)
+    desc: Reap dead-owner pytest generations, then create this generation's unique basetemp (never wipes)
     cmds:
-      - rm -rf {{.PYTEST_TMPDIR}}
-      - mkdir -p {{.PYTEST_TMPDIR}} {{.PYTEST_CACHEDIR}}
+      - python3 scripts/pytest_tmp_lifecycle.py setup --root {{.PYTEST_TMP_ROOT}} --dir {{.PYTEST_TMPDIR}} --cache-dir {{.PYTEST_CACHEDIR}}
 
   test-all:
     desc: Run all tests with parallel workers
@@ -758,24 +764,7 @@ tasks:
     cmds:
       - |
         echo "Cleaning stale /dev/shm directories..."
-
-        # pytest-tmp dirs older than 2 hours
-        PYTEST_COUNT=$(find /dev/shm -maxdepth 1 -name 'pytest-tmp-*' -mmin +120 -type d 2>/dev/null | wc -l)
-        if [ "$PYTEST_COUNT" -gt 0 ]; then
-          find /dev/shm -maxdepth 1 -name 'pytest-tmp-*' -mmin +120 -type d -exec rm -rf {} +
-          echo "  Removed $PYTEST_COUNT stale pytest-tmp dirs (>2h old)"
-        else
-          echo "  No stale pytest-tmp dirs found"
-        fi
-
-        # pytest-cache dirs older than 2 hours
-        CACHE_COUNT=$(find /dev/shm -maxdepth 1 -name 'pytest-cache-*' -mmin +120 -type d 2>/dev/null | wc -l)
-        if [ "$CACHE_COUNT" -gt 0 ]; then
-          find /dev/shm -maxdepth 1 -name 'pytest-cache-*' -mmin +120 -type d -exec rm -rf {} +
-          echo "  Removed $CACHE_COUNT stale pytest-cache dirs (>2h old)"
-        else
-          echo "  No stale pytest-cache dirs found"
-        fi
+        python3 scripts/pytest_tmp_lifecycle.py reap --root /dev/shm
 
         # headless session dirs older than 4 hours
         HEADLESS_COUNT=$(find /dev/shm/autoskillit-sessions -maxdepth 1 -name 'headless-*' -mmin +240 -type d 2>/dev/null | wc -l)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -589,8 +589,11 @@ tasks:
 
   refresh-codex-hook-fixture:
     desc: Regenerate the deterministic Codex hook-event snapshot
+    deps: [_tmpdir-setup]
+    env:
+      TMPDIR: "{{.PYTEST_TMPDIR}}"
     cmds:
-      - uv run pytest --update-fixtures -n0 tests/execution/backends/test_codex_deterministic_conformance.py -k test_update_fixtures_writes_snapshot
+      - uv run pytest --update-fixtures -n0 --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" tests/execution/backends/test_codex_deterministic_conformance.py -k test_update_fixtures_writes_snapshot
 
   regen-contracts:
     desc: Regenerate all bundled recipe contract cards

--- a/scripts/pytest_tmp_lifecycle.py
+++ b/scripts/pytest_tmp_lifecycle.py
@@ -258,6 +258,11 @@ def _safe_candidates(platform_root: Path, user_root: Path) -> list[Path]:
                 _log(f"skipping private root owned by uid {root_stat.st_uid}: {user_root}")
             else:
                 try:
+                    user_root.chmod(0o700)
+                except OSError as exc:
+                    _log(f"cannot normalize private root permissions for {user_root}: {exc}")
+                    return candidates
+                try:
                     candidates.extend(
                         child for child in user_root.iterdir() if child.name.startswith("pytest-")
                     )
@@ -308,6 +313,9 @@ def _reap(
             continue
         if stat.S_ISLNK(candidate_stat.st_mode) or not stat.S_ISDIR(candidate_stat.st_mode):
             _log(f"skipping non-directory or symlink candidate {candidate}")
+            continue
+        if candidate_stat.st_uid != os.getuid():
+            _log(f"skipping candidate owned by uid {candidate_stat.st_uid}: {candidate}")
             continue
         if _contains_reference(candidate, references):
             continue

--- a/scripts/pytest_tmp_lifecycle.py
+++ b/scripts/pytest_tmp_lifecycle.py
@@ -239,11 +239,21 @@ def _older_than(path: Path, minutes: float) -> bool:
 
 def _contains_reference(candidate: Path, references: set[Path]) -> bool:
     candidate = _absolute(candidate)
+    try:
+        resolved_candidate = candidate.resolve()
+    except (OSError, RuntimeError):
+        return True
     for reference in references:
+        reference = _absolute(reference)
         try:
-            _absolute(reference).relative_to(candidate)
+            reference.relative_to(candidate)
         except ValueError:
-            continue
+            try:
+                reference.resolve().relative_to(resolved_candidate)
+            except ValueError:
+                continue
+            except (OSError, RuntimeError):
+                return True
         return True
     return False
 

--- a/scripts/pytest_tmp_lifecycle.py
+++ b/scripts/pytest_tmp_lifecycle.py
@@ -195,10 +195,8 @@ def _pid_exists(pid: int) -> bool:
         os.kill(pid, 0)
     except ProcessLookupError:
         return False
-    except PermissionError:
-        return True
     except OSError:
-        return False
+        return True
     return True
 
 

--- a/scripts/pytest_tmp_lifecycle.py
+++ b/scripts/pytest_tmp_lifecycle.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""Create invocation-unique pytest temp generations and reap provably dead ones."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import shutil
+import stat
+import subprocess
+import sys
+import time
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+_GENERATION_RE = re.compile(r"^pytest-[0-9a-f]{8}-.+$")
+_LEGACY_PREFIXES = ("pytest-tmp-", "pytest-cache-")
+
+
+class LifecycleError(Exception):
+    """A setup safety invariant was violated."""
+
+
+class LivenessScanUnavailable(Exception):
+    """The process-wide liveness scan could not be completed."""
+
+
+def _log(message: str) -> None:
+    print(f"pytest tmp lifecycle: {message}", file=sys.stderr)
+
+
+def _absolute(path: Path) -> Path:
+    return Path(os.path.abspath(os.path.normpath(os.fspath(path))))
+
+
+def _user_root(platform_root: Path) -> Path:
+    return _absolute(platform_root) / f"autoskillit-pytest-{os.getuid()}"
+
+
+def _validate_setup_paths(
+    platform_root: Path, tmp_dir: Path, cache_dir: Path
+) -> tuple[Path, Path]:
+    expected_root = _user_root(platform_root)
+    tmp_dir = _absolute(tmp_dir)
+    cache_dir = _absolute(cache_dir)
+    if tmp_dir.name != "tmp" or cache_dir.name != "cache":
+        raise LifecycleError("--dir and --cache-dir must end in tmp and cache")
+    if tmp_dir.parent != cache_dir.parent:
+        raise LifecycleError("tmp and cache must belong to the same generation")
+    generation = tmp_dir.parent
+    if generation.parent != expected_root or not _GENERATION_RE.fullmatch(generation.name):
+        raise LifecycleError(
+            "generation must be pytest-<8-hex-worktree-hash>-<run-id> "
+            f"directly under {expected_root}"
+        )
+    return expected_root, generation
+
+
+def _require_safe_rmtree() -> None:
+    if not getattr(shutil.rmtree, "avoids_symlink_attacks", False):
+        raise LifecycleError("this interpreter does not provide symlink-safe shutil.rmtree")
+
+
+def _ensure_private_root(path: Path) -> None:
+    try:
+        path.mkdir(mode=0o700, parents=False, exist_ok=True)
+    except OSError as exc:
+        raise LifecycleError(f"cannot create private root {path}: {exc}") from exc
+    try:
+        root_stat = path.lstat()
+    except OSError as exc:
+        raise LifecycleError(f"cannot inspect private root {path}: {exc}") from exc
+    if stat.S_ISLNK(root_stat.st_mode) or not stat.S_ISDIR(root_stat.st_mode):
+        raise LifecycleError(f"private root is not a real directory: {path}")
+    if root_stat.st_uid != os.getuid():
+        raise LifecycleError(f"private root is not owned by uid {os.getuid()}: {path}")
+    try:
+        path.chmod(0o700)
+    except OSError as exc:
+        raise LifecycleError(f"cannot normalize private root permissions: {exc}") from exc
+
+
+def _paths_from_tokens(tokens: Iterable[str]) -> set[Path]:
+    references: set[Path] = set()
+    for token in tokens:
+        for prefix in ("TMPDIR=", "--basetemp=", "cache_dir="):
+            marker_index = token.find(prefix)
+            if marker_index < 0:
+                continue
+            value = token[marker_index + len(prefix) :].strip().strip("'\"")
+            if value:
+                references.add(_absolute(Path(value)))
+    return references
+
+
+def parse_ps_live_references(output: str) -> set[Path]:
+    """Extract lifecycle path references from one macOS ps environment sweep."""
+    references: set[Path] = set()
+    for line in output.splitlines():
+        try:
+            tokens = shlex.split(line)
+        except ValueError:
+            tokens = line.split()
+        references.update(_paths_from_tokens(tokens))
+    return references
+
+
+def scan_linux_live_references(proc_root: Path) -> set[Path]:
+    """Read every accessible process environment and command line exactly once."""
+    try:
+        process_dirs = list(proc_root.iterdir())
+    except OSError as exc:
+        raise LivenessScanUnavailable(f"cannot enumerate {proc_root}: {exc}") from exc
+    references: set[Path] = set()
+    for process_dir in process_dirs:
+        if not process_dir.name.isdigit() or not process_dir.is_dir():
+            continue
+        for filename in ("environ", "cmdline"):
+            try:
+                raw = (process_dir / filename).read_bytes()
+            except OSError:
+                continue
+            tokens = [part.decode(errors="surrogateescape") for part in raw.split(b"\0") if part]
+            references.update(_paths_from_tokens(tokens))
+    return references
+
+
+def _scan_live_references(proc_root: Path) -> set[Path]:
+    if sys.platform == "linux":
+        return scan_linux_live_references(proc_root)
+    try:
+        result = subprocess.run(
+            ["ps", "axww", "-E", "-o", "pid=,command="],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise LivenessScanUnavailable(f"macOS ps scan failed: {exc}") from exc
+    if result.returncode != 0:
+        raise LivenessScanUnavailable(
+            f"macOS ps scan exited {result.returncode}: {result.stderr.strip()}"
+        )
+    return parse_ps_live_references(result.stdout)
+
+
+def _linux_start_id(pid: int, proc_root: Path) -> str:
+    raw = (proc_root / str(pid) / "stat").read_text()
+    close_paren = raw.rfind(")")
+    if close_paren < 0:
+        raise OSError(f"malformed stat record for pid {pid}")
+    fields_after_comm = raw[close_paren + 1 :].split()
+    if len(fields_after_comm) <= 19:
+        raise OSError(f"short stat record for pid {pid}")
+    return fields_after_comm[19]
+
+
+def _macos_start_id(pid: int) -> str:
+    result = subprocess.run(
+        ["ps", "-p", str(pid), "-o", "lstart="],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        raise OSError(f"cannot read process start identity for pid {pid}")
+    return result.stdout.strip()
+
+
+def _start_id(pid: int, proc_root: Path) -> str:
+    if sys.platform == "linux":
+        return _linux_start_id(pid, proc_root)
+    return _macos_start_id(pid)
+
+
+def _boot_id(proc_root: Path) -> str:
+    if sys.platform != "linux":
+        return ""
+    return (proc_root / "sys" / "kernel" / "random" / "boot_id").read_text().strip()
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _owner_is_alive(owner: dict[str, object], proc_root: Path) -> bool:
+    pid = owner["pid"]
+    if not isinstance(pid, int) or pid <= 0 or not _pid_exists(pid):
+        return False
+    try:
+        return owner["boot_id"] == _boot_id(proc_root) and owner["start_id"] == _start_id(
+            pid, proc_root
+        )
+    except (OSError, subprocess.SubprocessError):
+        return True
+
+
+def _load_owner(marker: Path) -> dict[str, object] | None:
+    try:
+        payload = json.loads(marker.read_text())
+    except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if not isinstance(payload.get("pid"), int):
+        return None
+    if not isinstance(payload.get("start_id"), str):
+        return None
+    if not isinstance(payload.get("boot_id"), str):
+        return None
+    if not isinstance(payload.get("created_at"), (int, float)):
+        return None
+    return payload
+
+
+def _older_than(path: Path, minutes: float) -> bool:
+    try:
+        return time.time() - path.stat().st_mtime > minutes * 60
+    except OSError:
+        return False
+
+
+def _contains_reference(candidate: Path, references: set[Path]) -> bool:
+    candidate = _absolute(candidate)
+    for reference in references:
+        try:
+            _absolute(reference).relative_to(candidate)
+        except ValueError:
+            continue
+        return True
+    return False
+
+
+def _safe_candidates(platform_root: Path, user_root: Path) -> list[Path]:
+    candidates: list[Path] = []
+    if os.path.lexists(user_root):
+        try:
+            root_stat = user_root.lstat()
+        except OSError as exc:
+            _log(f"cannot inspect private root {user_root}: {exc}")
+        else:
+            if stat.S_ISLNK(root_stat.st_mode) or not stat.S_ISDIR(root_stat.st_mode):
+                _log(f"skipping unsafe private root {user_root}")
+            elif root_stat.st_uid != os.getuid():
+                _log(f"skipping private root owned by uid {root_stat.st_uid}: {user_root}")
+            else:
+                try:
+                    candidates.extend(
+                        child for child in user_root.iterdir() if child.name.startswith("pytest-")
+                    )
+                except OSError as exc:
+                    _log(f"cannot enumerate private root {user_root}: {exc}")
+    try:
+        candidates.extend(
+            child for child in platform_root.iterdir() if child.name.startswith(_LEGACY_PREFIXES)
+        )
+    except OSError as exc:
+        _log(f"cannot enumerate platform root {platform_root}: {exc}")
+    return candidates
+
+
+def _remove_candidate(candidate: Path) -> None:
+    try:
+        shutil.rmtree(candidate)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        _log(f"could not remove {candidate}: {exc}")
+
+
+def _reap(
+    platform_root: Path,
+    *,
+    grace_minutes: float,
+    legacy_age_minutes: float,
+    proc_root: Path,
+    excluded: set[Path] | None = None,
+) -> None:
+    try:
+        references = _scan_live_references(proc_root)
+    except LivenessScanUnavailable as exc:
+        _log(f"liveness scan unavailable; reaping skipped: {exc}")
+        return
+    user_root = _user_root(platform_root)
+    excluded_paths = {_absolute(path) for path in (excluded or set())}
+    for candidate in _safe_candidates(_absolute(platform_root), user_root):
+        if _absolute(candidate) in excluded_paths:
+            continue
+        try:
+            candidate_stat = candidate.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            _log(f"cannot inspect {candidate}: {exc}")
+            continue
+        if stat.S_ISLNK(candidate_stat.st_mode) or not stat.S_ISDIR(candidate_stat.st_mode):
+            _log(f"skipping non-directory or symlink candidate {candidate}")
+            continue
+        if _contains_reference(candidate, references):
+            continue
+        marker = candidate / "owner.json"
+        owner = _load_owner(marker)
+        if owner is not None:
+            if _owner_is_alive(owner, proc_root) or not _older_than(marker, grace_minutes):
+                continue
+        elif not _older_than(candidate, legacy_age_minutes):
+            continue
+        _remove_candidate(candidate)
+
+
+def _write_owner(marker: Path, owner_pid: int, proc_root: Path) -> None:
+    payload = {
+        "pid": owner_pid,
+        "start_id": _start_id(owner_pid, proc_root),
+        "boot_id": _boot_id(proc_root),
+        "created_at": time.time(),
+    }
+    descriptor = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "w") as stream:
+        json.dump(payload, stream, separators=(",", ":"))
+
+
+def _setup(args: argparse.Namespace) -> int:
+    _require_safe_rmtree()
+    platform_root = _absolute(args.root)
+    user_root, generation = _validate_setup_paths(platform_root, args.tmp_dir, args.cache_dir)
+    _ensure_private_root(user_root)
+    _reap(
+        platform_root,
+        grace_minutes=args.grace_minutes,
+        legacy_age_minutes=args.legacy_age_minutes,
+        proc_root=args.proc_root,
+        excluded={generation},
+    )
+    try:
+        generation.mkdir(mode=0o700)
+    except FileExistsError:
+        raise LifecycleError(f"generation collision at {generation}")
+    except OSError as exc:
+        raise LifecycleError(f"cannot claim generation {generation}: {exc}") from exc
+    try:
+        (generation / "tmp").mkdir(mode=0o700)
+        (generation / "cache").mkdir(mode=0o700)
+        _write_owner(generation / "owner.json", args.owner_pid or os.getppid(), args.proc_root)
+    except (OSError, subprocess.SubprocessError) as exc:
+        try:
+            shutil.rmtree(generation)
+        except OSError as cleanup_exc:
+            _log(f"could not clean partially-created generation {generation}: {cleanup_exc}")
+        raise LifecycleError(f"could not initialize generation {generation}: {exc}") from exc
+    return 0
+
+
+def _reap_command(args: argparse.Namespace) -> int:
+    try:
+        _require_safe_rmtree()
+    except LifecycleError as exc:
+        _log(str(exc))
+        return 0
+    _reap(
+        _absolute(args.root),
+        grace_minutes=args.grace_minutes,
+        legacy_age_minutes=args.legacy_age_minutes,
+        proc_root=args.proc_root,
+    )
+    return 0
+
+
+def _add_reap_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--grace-minutes", type=float, default=5)
+    parser.add_argument("--legacy-age-minutes", type=float, default=120)
+    parser.add_argument("--proc-root", type=Path, default=Path("/proc"))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    setup_parser = subparsers.add_parser("setup")
+    _add_reap_options(setup_parser)
+    setup_parser.add_argument("--dir", dest="tmp_dir", type=Path, required=True)
+    setup_parser.add_argument("--cache-dir", type=Path, required=True)
+    setup_parser.add_argument("--owner-pid", type=int)
+    setup_parser.set_defaults(handler=_setup)
+    reap_parser = subparsers.add_parser("reap")
+    _add_reap_options(reap_parser)
+    reap_parser.set_defaults(handler=_reap_command)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        return int(args.handler(args))
+    except LifecycleError as exc:
+        _log(str(exc))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pytest_tmp_lifecycle.py
+++ b/scripts/pytest_tmp_lifecycle.py
@@ -118,6 +118,12 @@ def scan_linux_live_references(proc_root: Path) -> set[Path]:
     for process_dir in process_dirs:
         if not process_dir.name.isdigit() or not process_dir.is_dir():
             continue
+        try:
+            cwd = Path(os.readlink(process_dir / "cwd"))
+        except OSError:
+            pass
+        else:
+            references.add(_absolute(cwd))
         for filename in ("environ", "cmdline"):
             try:
                 raw = (process_dir / filename).read_bytes()

--- a/src/autoskillit/server/tools/tools_clone.py
+++ b/src/autoskillit/server/tools/tools_clone.py
@@ -619,6 +619,22 @@ async def bootstrap_clone(
                     "autoskillit.bootstrap_clone",
                     extra={"stderr": stderr},
                 )
+                try:
+                    cleanup = await asyncio.to_thread(
+                        tool_ctx.clone_mgr.remove_clone, clone_path, "false"
+                    )
+                    if cleanup.get("removed") != "true":
+                        logger.warning(
+                            "bootstrap_clone cleanup failed",
+                            clone_path=clone_path,
+                            reason=cleanup.get("reason", "unknown"),
+                        )
+                except Exception:
+                    logger.warning(
+                        "bootstrap_clone cleanup raised",
+                        clone_path=clone_path,
+                        exc_info=True,
+                    )
                 return json.dumps({"error": f"rev-parse failed: {stderr.strip()}"})
 
             base_sha = stdout.strip()

--- a/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
@@ -214,7 +214,9 @@ Where practical, delegate test updates to subagents to keep main conversation co
 cd "${WORKTREE_PATH}" && pre-commit run --all-files
 ```
 
-Fix any formatting or linting issues. Do NOT run any tests — NEVER invoke pytest, python -m pytest, or any test runner directly. Use `task test-check` if explicitly instructed to verify tests.
+Fix any formatting or linting issues. Do NOT run tests in the shell — NEVER invoke pytest,
+python -m pytest, or a test runner directly. When verification is explicitly required, call
+the `test_check` MCP tool with the worktree path.
 
 If pre-commit auto-fixes files, stage them and create a **new** commit (do NOT use `--amend`):
 ```bash

--- a/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: implement-worktree-no-merge
-uses_capabilities: []
+uses_capabilities:
+- test_check
 activate_deps:
 - write-recipe
 description: Implementation executor. ALWAYS invoke this skill when instructed to implement a plan in a worktree. Do not read
@@ -217,6 +218,10 @@ cd "${WORKTREE_PATH}" && pre-commit run --all-files
 Fix any formatting or linting issues. Do NOT run tests in the shell — NEVER invoke pytest,
 python -m pytest, or a test runner directly. When verification is explicitly required, call
 the `test_check` MCP tool with the worktree path.
+
+```
+test_check(worktree_path="${WORKTREE_PATH}")
+```
 
 If pre-commit auto-fixes files, stage them and create a **new** commit (do NOT use `--amend`):
 ```bash

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -193,25 +193,23 @@ Before running the test suite, confirm the following to prevent avoidable test-f
   or a component count (e.g., in AGENTS.md, README, or API docs), update it to reflect
   new components added during this implementation.
 - [ ] **Count-based test assertions** — if tool, skill, or rule counts have changed, update any
-  `assert len(...) ==` assertions in the test suite before running `{test_command}`
+  `assert len(...) ==` assertions in the test suite before running the `test_check` gate
 
 This checklist exists because these categories produce avoidable test-fix cycles: a single
 missed registration generates 5–30 cascading test failures that require a second commit to fix.
 
 ### Step 5: Final Verification
 
-Read the configured test command(s) from `.autoskillit/config.yaml`: check `test_check.commands` (ordered list of commands, if set) or `test_check.command` (single command, default: `task test-check`). The `test_check` MCP tool runs all configured commands automatically.
+The `test_check` MCP tool owns configured test-command resolution and execution.
 
 Run the project's code quality checks and test suite from the worktree.
 
 ```bash
 cd "${WORKTREE_PATH}" && pre-commit run --all-files
-cd "${WORKTREE_PATH}" && \
-  AUTOSKILLIT_TEST_FILTER="${AUTOSKILLIT_TEST_FILTER:-conservative}" \
-  AUTOSKILLIT_TEST_BASE_REF=$(cat "{{AUTOSKILLIT_TEMP}}/worktrees/${WORKTREE_NAME}/base-branch") \
-  {test_command}
-# Note: {{AUTOSKILLIT_TEMP}}/worktrees/ is sidecar metadata inside the main repo — not the worktree path.
 ```
+
+Then call the `test_check` MCP tool with `worktree_path=${WORKTREE_PATH}`. Do not invoke the
+configured test command directly in the shell.
 
 If tests fail, fix the issue and re-run.
 

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: implement-worktree
-uses_capabilities: []
+uses_capabilities:
+- test_check
 activate_deps:
 - write-recipe
 description: Worktree implementation executor. ALWAYS invoke this skill when instructed to implement a plan in a worktree
@@ -209,7 +210,8 @@ cd "${WORKTREE_PATH}" && pre-commit run --all-files
 ```
 
 Then call the `test_check` MCP tool with `worktree_path=${WORKTREE_PATH}`. Do not invoke the
-configured test command directly in the shell.
+configured test command directly in the shell. `AUTOSKILLIT_TEST_FILTER` and
+`AUTOSKILLIT_TEST_BASE_REF` remain server-managed filter inputs, not shell exports here.
 
 If tests fail, fix the issue and re-run.
 

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -49,7 +49,7 @@ for actionable findings, commit each fix, and verify tests still pass.
     addressed threads.
   - `mode=local`: read `local_findings_{pr_number}.json`; skip publication and all GitHub
     API fetching; accumulate DISCUSS/REJECT to persistent local files; skip thread resolution
-    and all review-comment publication; still run `task test-check`.
+    and all review-comment publication; still run the `test_check` MCP gate.
 
 The `cwd` is provided by the recipe step's `cwd:` field — the clone with the feature
 branch already checked out.
@@ -81,7 +81,7 @@ branch already checked out.
 - Fetch both inline comments (`pulls/{number}/comments`) and top-level review
   bodies (`pulls/{number}/reviews`) via the GitHub API
 - Commit each distinct fix separately with a message describing what was addressed
-- Run `{test_command}` (from config, default: `task test-check`) after applying all fixes to catch regressions
+- Run the `test_check` MCP gate after applying all fixes to catch regressions
 - Gracefully degrade (exit 0, report skip) if `gh` is unavailable or no PR is found
 - Report a structured summary: findings fetched, fixes applied, fixes skipped (with reasons)
 - **Read before editing**: Before issuing an `Edit` call on any file, ensure you have issued a `Read` on that file earlier in this session. Claude Code rejects `Edit` on unread files — the retry wastes a full API turn at current context size. If you are uncertain whether a file was read, issue a targeted `Read` (offset + limit to the region you plan to edit) rather than risk an error. **Note:** Reads performed by subagents (Task/Agent) do NOT satisfy this requirement — they run in a child session whose reads are invisible to the parent. If a file was only read inside a subagent, you must Read it again in this main session before calling Edit.
@@ -104,8 +104,7 @@ review fixes are committed and the downstream push step receives a clean branch.
 
 ## Workflow
 
-Read test configuration from `.autoskillit/config.yaml`: check `test_check.commands` (ordered list, if set) or `test_check.command` (single command, default: `task test-check`).
-The `test_check` MCP tool runs all configured commands automatically.
+The `test_check` MCP tool owns configured test-command resolution and execution.
 
 ### Step 0: Validate Arguments
 
@@ -680,9 +679,8 @@ Record each skip with: `(file, line, reason)`.
 
 ### Step 5: Run Tests
 
-```bash
-{test_command}
-```
+Call the `test_check` MCP tool with `worktree_path` set to the current clone. Do not invoke
+the configured test command directly in the shell.
 
 - Pass → proceed to Step 6 (Resolve Addressed Review Threads)
 - Fail (iteration < 3): analyze failures against the fixes applied, revert/adjust the
@@ -818,7 +816,7 @@ Log: `"Saved N reject patterns"`.
 
 ### Step 7: Report
 
-**MODE INDEPENDENCE:** `task test-check` (Step 5) runs identically in both modes.
+**MODE INDEPENDENCE:** the `test_check` MCP gate (Step 5) runs identically in both modes.
 Gate token emission is mode-independent.
 
 Print a structured summary to terminal:

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -5,6 +5,7 @@ categories:
 uses_capabilities:
 - commit_files
 - github_api_write
+- test_check
 description: Fetch PR review comments, run intent validation (ACCEPT/REJECT/DISCUSS) before applying fixes, publish deferred observations through the structured review tool, and resolve addressed threads. MCP-only — used exclusively by recipe orchestration via run_skill after review_pr reports changes_requested or needs_human verdict.
 hooks:
   PreToolUse:

--- a/src/autoskillit/skills_extended/retry-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/retry-worktree/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: retry-worktree
-uses_capabilities: []
+uses_capabilities:
+- test_check
 description: Worktree retry executor. ALWAYS invoke this skill when instructed to continue or retry an implementation in an
   existing worktree. Do not resume editing files directly — use this skill first to load the retry workflow.
 hooks:

--- a/src/autoskillit/skills_extended/retry-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/retry-worktree/SKILL.md
@@ -202,11 +202,12 @@ Run the project's code quality checks and test suite from the worktree.
 
 ```bash
 cd {WORKTREE_PATH} && pre-commit run --all-files
-cd {WORKTREE_PATH} && \
-  AUTOSKILLIT_TEST_FILTER="${AUTOSKILLIT_TEST_FILTER:-conservative}" \
-  AUTOSKILLIT_TEST_BASE_REF="${BASE_BRANCH:-}" \
-  task test-check
 ```
+
+Then call the `test_check` MCP tool with `worktree_path={WORKTREE_PATH}`. The server-owned
+gate applies project configuration and captures output; do not run the configured command
+in the shell. `AUTOSKILLIT_TEST_FILTER` and `AUTOSKILLIT_TEST_BASE_REF` remain server-managed
+filter inputs, not shell exports in this skill.
 
 If tests fail, fix the issue and re-run.
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -116,12 +116,16 @@ in `tests/conftest.py` named by the registry's `parity_fixture` field, e.g.
 
 - `PYTHONDONTWRITEBYTECODE=1` is set via Taskfile — no `.pyc` disk writes (registered
   in `TEST_HARNESS_ENV_OVERRIDES` with `production_interpreter_env` as parity fixture)
-- Test temp I/O is routed to platform-resolved paths:
-  - **Linux / WSL2**: `/dev/shm/pytest-tmp` (kernel tmpfs, RAM-backed)
-  - **macOS**: `/tmp/pytest-tmp` (disk-backed system default)
-- `TMPDIR` is set to the platform path via Taskfile — all `tempfile` calls are routed there
-- `--basetemp` is passed to pytest — `tmp_path` fixtures resolve to the platform path
-- `cache_dir` is redirected to the platform cache path — no stray pytest cache writes
+- Test temp I/O uses one generation per Taskfile invocation under
+  `<platform-root>/autoskillit-pytest-<uid>/pytest-<worktree-hash>-<run-id>`:
+  - **Linux / WSL2**: `<platform-root>` is `/dev/shm` (kernel tmpfs, RAM-backed)
+  - **macOS**: `<platform-root>` is `/tmp` (disk-backed system default)
+- Each generation contains sibling `tmp/` (`TMPDIR` and `--basetemp`), `cache/`
+  (`cache_dir`), and `owner.json`. The marker stays outside `tmp/` because pytest clears
+  its basetemp.
+- `scripts/pytest_tmp_lifecycle.py` reaps only dead-owner or sufficiently old unmarked
+  generations after a live-process reference scan. Scan failure skips all deletion.
+- Never use bare `rm -rf /dev/shm/pytest-tmp-*`; `task cleanup-shm` invokes the safe reaper.
 - `test_tmp_path_is_ram_backed` in `tests/arch/test_ast_rules.py` enforces the `/dev/shm` prefix
   on Linux; on macOS it is a no-op (disk temp is acceptable there)
 

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -187,22 +187,35 @@ def test_tmp_path_is_ram_backed(tmp_path: Path) -> None:
         )
 
 
-def test_tmp_path_has_worktree_hash(tmp_path: Path) -> None:
-    """tmp_path must contain a .ROOT_DIR-derived hash to prevent cross-worktree collision.
+def test_tmp_and_cache_share_generation_parent(
+    tmp_path: Path, request: pytest.FixtureRequest
+) -> None:
+    """Tmp and cache paths must be siblings in one invocation-unique generation."""
+    if sys.platform == "linux":
+        cwd_hash = hashlib.sha256(os.getcwd().encode()).hexdigest()[:8]
+        tmp_root = next(path for path in (tmp_path, *tmp_path.parents) if path.name == "tmp")
+        generation = tmp_root.parent
+        cache_dir = Path(str(request.config.getini("cache_dir"))).resolve()
+        assert cache_dir.parent == generation
+        assert generation.name.startswith(f"pytest-{cwd_hash}-")
 
-    Fails when pytest is invoked with --basetemp=/dev/shm/pytest-tmp (static path).
-    Passes only when Taskfile.yml derives PYTEST_TMPDIR from .ROOT_DIR via the
-    slim-sprig sha256sum template function.
-    """
+
+def test_tmpdir_env_matches_basetemp(tmp_path: Path) -> None:
+    """TMPDIR must resolve to the basetemp ancestor rendered for this invocation."""
+    configured_tmpdir = Path(os.environ["TMPDIR"]).resolve()
+    assert (
+        configured_tmpdir == tmp_path.resolve() or configured_tmpdir in tmp_path.resolve().parents
+    )
+
+
+def test_tmp_path_has_worktree_hash(tmp_path: Path) -> None:
+    """tmp_path must contain the worktree hash followed by a generation suffix."""
     if sys.platform == "linux":
         cwd_hash = hashlib.sha256(os.getcwd().encode()).hexdigest()[:8]
         path_str = str(tmp_path)
-        assert f"pytest-tmp-{cwd_hash}" in path_str, (
-            f"tmp_path ({path_str!r}) does not contain the expected worktree hash "
-            f"'{cwd_hash}'. PYTEST_TMPDIR must be derived from .ROOT_DIR. "
-            f"Expected /dev/shm/pytest-tmp-{cwd_hash} as the base. "
-            "Update Taskfile.yml PYTEST_TMPDIR to use a .ROOT_DIR-derived hash suffix "
-            "(use slim-sprig: {{ substr 0 8 (sha256sum .ROOT_DIR) }})."
+        assert f"pytest-{cwd_hash}-" in path_str, (
+            f"tmp_path ({path_str!r}) does not contain invocation-unique worktree identity "
+            f"pytest-{cwd_hash}-. Run tests through the Taskfile test gate."
         )
 
 

--- a/tests/contracts/test_filter_env_var_coverage.py
+++ b/tests/contracts/test_filter_env_var_coverage.py
@@ -9,6 +9,16 @@ pytestmark = [pytest.mark.layer("contracts"), pytest.mark.medium]
 SKILLS_EXTENDED = Path(__file__).resolve().parents[2] / "src" / "autoskillit" / "skills_extended"
 
 
+@pytest.mark.parametrize(
+    "skill_name",
+    ["retry-worktree", "implement-worktree", "implement-worktree-no-merge", "resolve-review"],
+)
+def test_worktree_test_gates_use_server_owned_tool(skill_name: str) -> None:
+    skill_md = (SKILLS_EXTENDED / skill_name / "SKILL.md").read_text()
+    assert "`test_check` MCP" in skill_md
+    assert "task test-check" not in skill_md
+
+
 @pytest.mark.parametrize("env_var", ["AUTOSKILLIT_TEST_FILTER", "AUTOSKILLIT_TEST_BASE_REF"])
 def test_retry_worktree_step4_sets_env_var(env_var: str) -> None:
     """retry-worktree Step 4 must set AUTOSKILLIT_TEST_FILTER and AUTOSKILLIT_TEST_BASE_REF."""

--- a/tests/contracts/test_filter_env_var_coverage.py
+++ b/tests/contracts/test_filter_env_var_coverage.py
@@ -15,6 +15,8 @@ SKILLS_EXTENDED = Path(__file__).resolve().parents[2] / "src" / "autoskillit" / 
 )
 def test_worktree_test_gates_use_server_owned_tool(skill_name: str) -> None:
     skill_md = (SKILLS_EXTENDED / skill_name / "SKILL.md").read_text()
+    frontmatter = skill_md.split("---", 2)[1]
+    assert "- test_check" in frontmatter
     assert "`test_check` MCP" in skill_md
     assert "task test-check" not in skill_md
 

--- a/tests/contracts/test_test_env_parity.py
+++ b/tests/contracts/test_test_env_parity.py
@@ -78,8 +78,9 @@ tasks:
     assert _taskfile_env_vars(content) == {"COMPLEX_ENV", "FIRST_ENV", "SECOND_ENV"}
 
 
-# Taskfile vars that are NOT parity concerns — paths, feature toggles,
-# and test-specific configuration that never masks a production failure class.
+# Taskfile vars exempt from production parity because they are harness-scoped paths,
+# feature toggles, or test-only configuration. Pytest path lifecycle safety is enforced
+# separately by scripts/pytest_tmp_lifecycle.py; the paths have masked failures before.
 _TASKFILE_NON_PARITY_VARS: frozenset[str] = frozenset(
     {
         "AUTOSKILLIT_EXPLORER_LIVE_GATE",

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -1141,8 +1141,8 @@ def test_canonical_recipe_responses_fit_independent_registry_ceilings(tmp_path, 
         for ingredients_only in (False, True)
     }
     assert maxima == {
-        "load_recipe": (173_040, "remediation", "all_truthy"),
-        "open_kitchen": (173_093, "remediation", "all_truthy"),
+        "load_recipe": (173_024, "remediation", "all_truthy"),
+        "open_kitchen": (173_077, "remediation", "all_truthy"),
     }
 
 

--- a/tests/infra/test_pytest_tmp_lifecycle.py
+++ b/tests/infra/test_pytest_tmp_lifecycle.py
@@ -407,6 +407,17 @@ def test_pid_probe_fails_closed_on_unexpected_oserror(monkeypatch: pytest.Monkey
     assert module._pid_exists(12345)
 
 
+def test_reference_containment_resolves_symlinked_paths(tmp_path: Path) -> None:
+    module = _load_lifecycle_module()
+    real_root = tmp_path / "real"
+    candidate = real_root / "generation"
+    candidate.mkdir(parents=True)
+    alias = tmp_path / "alias"
+    alias.symlink_to(real_root, target_is_directory=True)
+
+    assert module._contains_reference(candidate, {alias / "generation" / "tmp"})
+
+
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux /proc fail-closed behavior")
 def test_reap_fails_closed_when_liveness_scan_unavailable(tmp_path: Path) -> None:
     platform_root, generation, _, _ = _layout(tmp_path)

--- a/tests/infra/test_pytest_tmp_lifecycle.py
+++ b/tests/infra/test_pytest_tmp_lifecycle.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("infra"), pytest.mark.medium]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "pytest_tmp_lifecycle.py"
+
+
+def _run(*args: object) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *(str(arg) for arg in args)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+
+def _layout(tmp_path: Path, run_id: str = "run-a") -> tuple[Path, Path, Path, Path]:
+    platform_root = tmp_path / "platform"
+    platform_root.mkdir(exist_ok=True)
+    user_root = platform_root / f"autoskillit-pytest-{os.getuid()}"
+    generation = user_root / f"pytest-deadbeef-{run_id}"
+    return platform_root, generation, generation / "tmp", generation / "cache"
+
+
+def _setup(
+    platform_root: Path,
+    tmp_dir: Path,
+    cache_dir: Path,
+    *,
+    owner_pid: int | None = None,
+) -> subprocess.CompletedProcess[str]:
+    args: list[object] = [
+        "setup",
+        "--root",
+        platform_root,
+        "--dir",
+        tmp_dir,
+        "--cache-dir",
+        cache_dir,
+    ]
+    if owner_pid is not None:
+        args.extend(["--owner-pid", owner_pid])
+    return _run(*args)
+
+
+def _reap(platform_root: Path, *extra: object) -> subprocess.CompletedProcess[str]:
+    return _run(
+        "reap",
+        "--root",
+        platform_root,
+        "--grace-minutes",
+        0,
+        "--legacy-age-minutes",
+        0,
+        *extra,
+    )
+
+
+def _backdate(path: Path, seconds: int = 300) -> None:
+    old = time.time() - seconds
+    os.utime(path, (old, old), follow_symlinks=False)
+
+
+def _dead_pid() -> int:
+    process = subprocess.run([sys.executable, "-c", "pass"], check=True)
+    return process.returncode + 99_000_000
+
+
+def _write_dead_marker(generation: Path, *, start_id: str = "dead") -> Path:
+    marker = generation / "owner.json"
+    marker.write_text(
+        json.dumps(
+            {
+                "pid": _dead_pid(),
+                "start_id": start_id,
+                "boot_id": "dead-boot",
+                "created_at": time.time() - 300,
+            }
+        )
+    )
+    _backdate(marker)
+    return marker
+
+
+def _stop(process: subprocess.Popen[str]) -> None:
+    if process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+
+def test_setup_creates_generation_dir(tmp_path: Path) -> None:
+    platform_root, generation, tmp_dir, cache_dir = _layout(tmp_path)
+    result = _setup(platform_root, tmp_dir, cache_dir, owner_pid=os.getpid())
+
+    assert result.returncode == 0, result.stderr
+    assert {path.name for path in generation.iterdir()} == {"tmp", "cache", "owner.json"}
+    assert stat.S_IMODE(generation.parent.stat().st_mode) == 0o700
+    marker = json.loads((generation / "owner.json").read_text())
+    assert marker["pid"] == os.getpid()
+    assert marker["start_id"]
+    assert "boot_id" in marker
+    assert isinstance(marker["created_at"], float)
+
+
+@pytest.mark.parametrize("entry_kind", ["directory", "file"])
+def test_setup_fails_loudly_on_existing_generation(tmp_path: Path, entry_kind: str) -> None:
+    platform_root, generation, tmp_dir, cache_dir = _layout(tmp_path)
+    generation.parent.mkdir(mode=0o700)
+    if entry_kind == "directory":
+        generation.mkdir()
+        sentinel = generation / "sentinel"
+        sentinel.write_text("preserve")
+    else:
+        generation.write_text("preserve")
+
+    result = _setup(platform_root, tmp_dir, cache_dir)
+
+    assert result.returncode == 2
+    assert "collision" in result.stderr.lower()
+    if entry_kind == "directory":
+        assert sentinel.read_text() == "preserve"
+    else:
+        assert generation.read_text() == "preserve"
+
+
+def test_marker_survives_basetemp_clearing(tmp_path: Path) -> None:
+    platform_root, generation, tmp_dir, cache_dir = _layout(tmp_path)
+    assert _setup(platform_root, tmp_dir, cache_dir, owner_pid=os.getpid()).returncode == 0
+    shutil.rmtree(tmp_dir)
+    tmp_dir.mkdir()
+
+    assert (generation / "owner.json").exists()
+    assert _reap(platform_root).returncode == 0
+    assert generation.exists()
+    _write_dead_marker(generation)
+    assert _reap(platform_root).returncode == 0
+    assert not generation.exists()
+
+
+def test_reap_skips_live_owner(tmp_path: Path) -> None:
+    platform_root, generation, tmp_dir, cache_dir = _layout(tmp_path)
+    sleeper = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"], text=True)
+    try:
+        assert _setup(platform_root, tmp_dir, cache_dir, owner_pid=sleeper.pid).returncode == 0
+        _backdate(generation / "owner.json")
+        assert _reap(platform_root).returncode == 0
+        assert generation.exists()
+    finally:
+        _stop(sleeper)
+
+
+def test_reap_removes_dead_owner_after_grace(tmp_path: Path) -> None:
+    platform_root, generation, _, _ = _layout(tmp_path)
+    generation.mkdir(parents=True)
+    _write_dead_marker(generation)
+
+    assert _reap(platform_root).returncode == 0
+    assert not generation.exists()
+
+
+def test_reap_keeps_recent_dead_owner_within_grace(tmp_path: Path) -> None:
+    platform_root, generation, _, _ = _layout(tmp_path)
+    generation.mkdir(parents=True)
+    marker = _write_dead_marker(generation)
+    os.utime(marker, None)
+
+    result = _run("reap", "--root", platform_root, "--grace-minutes", 5)
+
+    assert result.returncode == 0
+    assert generation.exists()
+
+
+def test_reap_treats_recycled_pid_as_dead(tmp_path: Path) -> None:
+    platform_root, generation, tmp_dir, cache_dir = _layout(tmp_path)
+    assert _setup(platform_root, tmp_dir, cache_dir, owner_pid=os.getpid()).returncode == 0
+    marker = generation / "owner.json"
+    payload = json.loads(marker.read_text())
+    payload["start_id"] = f"wrong-{payload['start_id']}"
+    marker.write_text(json.dumps(payload))
+    _backdate(marker)
+
+    assert _reap(platform_root).returncode == 0
+    assert not generation.exists()
+
+
+def test_reap_age_gates_markerless_and_legacy_dirs(tmp_path: Path) -> None:
+    platform_root, generation, _, _ = _layout(tmp_path)
+    generation.mkdir(parents=True)
+    legacy_tmp = platform_root / "pytest-tmp-phase-a-full"
+    legacy_cache = platform_root / "pytest-cache-deadbeef"
+    legacy_tmp.mkdir()
+    legacy_cache.mkdir()
+
+    fresh = _run("reap", "--root", platform_root, "--legacy-age-minutes", 120)
+    assert fresh.returncode == 0
+    assert generation.exists() and legacy_tmp.exists() and legacy_cache.exists()
+
+    for path in (generation, legacy_tmp, legacy_cache):
+        _backdate(path, seconds=3 * 60 * 60)
+    assert _reap(platform_root).returncode == 0
+    assert not generation.exists() and not legacy_tmp.exists() and not legacy_cache.exists()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux /proc live-reference behavior")
+def test_reap_vetoes_dirs_referenced_by_live_processes(tmp_path: Path) -> None:
+    platform_root, generation, tmp_dir, _ = _layout(tmp_path)
+    tmp_dir.mkdir(parents=True)
+    _backdate(generation)
+    env = os.environ.copy()
+    env["TMPDIR"] = str(tmp_dir)
+    sleeper = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(60)"], env=env, text=True
+    )
+    try:
+        assert _reap(platform_root).returncode == 0
+        assert generation.exists()
+    finally:
+        _stop(sleeper)
+    _backdate(generation)
+    assert _reap(platform_root).returncode == 0
+    assert not generation.exists()
+
+
+def test_reap_errors_are_nonfatal(tmp_path: Path) -> None:
+    platform_root, blocked, _, _ = _layout(tmp_path, "blocked")
+    other = blocked.parent / "pytest-deadbeef-other"
+    blocked_child = blocked / "locked"
+    blocked_child.mkdir(parents=True)
+    other.mkdir()
+    _backdate(blocked)
+    _backdate(other)
+    blocked_child.chmod(0)
+    try:
+        result = _reap(platform_root)
+        assert result.returncode == 0
+        assert not other.exists()
+    finally:
+        if blocked_child.exists():
+            blocked_child.chmod(0o700)
+            shutil.rmtree(blocked)
+
+
+def test_sequential_generations_with_surviving_straggler(tmp_path: Path) -> None:
+    platform_root, generation_a, tmp_a, cache_a = _layout(tmp_path, "run-a")
+    _, generation_b, tmp_b, cache_b = _layout(tmp_path, "run-b")
+    assert _setup(platform_root, tmp_a, cache_a, owner_pid=os.getpid()).returncode == 0
+    env = os.environ.copy()
+    env["TMPDIR"] = str(tmp_a)
+    writer_code = """
+import os
+import pathlib
+import time
+
+root = pathlib.Path(os.environ["TMPDIR"])
+index = 0
+while True:
+    (root / f"writer-{index}").write_text("alive")
+    index += 1
+    time.sleep(0.01)
+"""
+    writer = subprocess.Popen([sys.executable, "-c", writer_code], env=env, text=True)
+    try:
+        deadline = time.monotonic() + 5
+        while not any(tmp_a.glob("writer-*")) and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert any(tmp_a.glob("writer-*"))
+        result = _setup(platform_root, tmp_b, cache_b, owner_pid=os.getpid())
+        assert result.returncode == 0, result.stderr
+        assert generation_a.exists() and generation_b.exists()
+        assert not any(tmp_b.iterdir())
+    finally:
+        _stop(writer)
+    _write_dead_marker(generation_a)
+    assert _reap(platform_root).returncode == 0
+    assert not generation_a.exists()
+    assert generation_b.exists()
+
+
+def test_setup_runs_reap_first(tmp_path: Path) -> None:
+    platform_root, old_generation, _, _ = _layout(tmp_path, "old")
+    _, new_generation, new_tmp, new_cache = _layout(tmp_path, "new")
+    old_generation.mkdir(parents=True)
+    _backdate(old_generation, seconds=3 * 60 * 60)
+
+    result = _setup(platform_root, new_tmp, new_cache, owner_pid=os.getpid())
+
+    assert result.returncode == 0, result.stderr
+    assert not old_generation.exists()
+    assert new_generation.exists()
+
+
+def test_setup_rejects_split_generation_paths(tmp_path: Path) -> None:
+    platform_root, _, tmp_dir, _ = _layout(tmp_path, "run-a")
+    _, _, _, cache_dir = _layout(tmp_path, "run-b")
+
+    result = _setup(platform_root, tmp_dir, cache_dir)
+
+    assert result.returncode == 2
+    assert "same generation" in result.stderr.lower()
+
+
+def test_root_safety(tmp_path: Path) -> None:
+    platform_root, generation, tmp_dir, cache_dir = _layout(tmp_path)
+    target = tmp_path / "target"
+    target.mkdir()
+    generation.parent.symlink_to(target, target_is_directory=True)
+
+    setup = _setup(platform_root, tmp_dir, cache_dir)
+    reap = _reap(platform_root)
+
+    assert setup.returncode == 2
+    assert reap.returncode == 0
+    assert not any(target.iterdir())
+
+    generation.parent.unlink()
+    generation.parent.mkdir(mode=0o700)
+    protected = tmp_path / "protected"
+    protected.mkdir()
+    (protected / "sentinel").write_text("preserve")
+    generation.symlink_to(protected, target_is_directory=True)
+    legacy_link = platform_root / "pytest-tmp-link"
+    legacy_link.symlink_to(protected, target_is_directory=True)
+    assert _reap(platform_root).returncode == 0
+    assert (protected / "sentinel").read_text() == "preserve"
+
+
+def test_live_reference_parser(tmp_path: Path) -> None:
+    spec = importlib.util.spec_from_file_location("pytest_tmp_lifecycle", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    proc_root = tmp_path / "proc"
+    process_dir = proc_root / "123"
+    process_dir.mkdir(parents=True)
+    (process_dir / "environ").write_bytes(b"A=1\0TMPDIR=/one/tmp\0")
+    (process_dir / "cmdline").write_bytes(
+        b"pytest\0--basetemp=/two/tmp\0-o\0cache_dir=/two/cache\0"
+    )
+
+    assert module.scan_linux_live_references(proc_root) == {
+        Path("/one/tmp"),
+        Path("/two/tmp"),
+        Path("/two/cache"),
+    }
+    assert module.parse_ps_live_references(
+        "123 pytest TMPDIR=/three/tmp --basetemp=/four/tmp -o cache_dir=/four/cache"
+    ) == {Path("/three/tmp"), Path("/four/tmp"), Path("/four/cache")}
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux /proc fail-closed behavior")
+def test_reap_fails_closed_when_liveness_scan_unavailable(tmp_path: Path) -> None:
+    platform_root, generation, _, _ = _layout(tmp_path)
+    generation.mkdir(parents=True)
+    _backdate(generation)
+
+    result = _reap(platform_root, "--proc-root", tmp_path / "missing-proc")
+
+    assert result.returncode == 0
+    assert generation.exists()
+    assert "liveness scan" in result.stderr.lower()

--- a/tests/infra/test_pytest_tmp_lifecycle.py
+++ b/tests/infra/test_pytest_tmp_lifecycle.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -16,6 +17,14 @@ pytestmark = [pytest.mark.layer("infra"), pytest.mark.medium]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "pytest_tmp_lifecycle.py"
+
+
+def _load_lifecycle_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("pytest_tmp_lifecycle", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _run(*args: object) -> subprocess.CompletedProcess[str]:
@@ -366,10 +375,7 @@ def test_root_safety(tmp_path: Path) -> None:
 
 
 def test_live_reference_parser(tmp_path: Path) -> None:
-    spec = importlib.util.spec_from_file_location("pytest_tmp_lifecycle", SCRIPT)
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    module = _load_lifecycle_module()
     proc_root = tmp_path / "proc"
     process_dir = proc_root / "123"
     process_dir.mkdir(parents=True)
@@ -388,6 +394,17 @@ def test_live_reference_parser(tmp_path: Path) -> None:
     assert module.parse_ps_live_references(
         "123 pytest TMPDIR=/three/tmp --basetemp=/four/tmp -o cache_dir=/four/cache"
     ) == {Path("/three/tmp"), Path("/four/tmp"), Path("/four/cache")}
+
+
+def test_pid_probe_fails_closed_on_unexpected_oserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_lifecycle_module()
+
+    def fail_probe(pid: int, signal: int) -> None:
+        raise OSError("transient probe failure")
+
+    monkeypatch.setattr(module.os, "kill", fail_probe)
+
+    assert module._pid_exists(12345)
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux /proc fail-closed behavior")

--- a/tests/infra/test_pytest_tmp_lifecycle.py
+++ b/tests/infra/test_pytest_tmp_lifecycle.py
@@ -240,6 +240,28 @@ def test_reap_vetoes_dirs_referenced_by_live_processes(tmp_path: Path) -> None:
     assert not generation.exists()
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux /proc cwd behavior")
+def test_reap_vetoes_generation_used_as_live_cwd(tmp_path: Path) -> None:
+    platform_root, generation, tmp_dir, _ = _layout(tmp_path)
+    tmp_dir.mkdir(parents=True)
+    _backdate(generation)
+    env = {key: value for key, value in os.environ.items() if key != "TMPDIR"}
+    sleeper = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        cwd=tmp_dir,
+        env=env,
+        text=True,
+    )
+    try:
+        assert _reap(platform_root).returncode == 0
+        assert generation.exists()
+    finally:
+        _stop(sleeper)
+    _backdate(generation)
+    assert _reap(platform_root).returncode == 0
+    assert not generation.exists()
+
+
 def test_reap_errors_are_nonfatal(tmp_path: Path) -> None:
     platform_root, blocked, _, _ = _layout(tmp_path, "blocked")
     other = blocked.parent / "pytest-deadbeef-other"
@@ -355,11 +377,13 @@ def test_live_reference_parser(tmp_path: Path) -> None:
     (process_dir / "cmdline").write_bytes(
         b"pytest\0--basetemp=/two/tmp\0-o\0cache_dir=/two/cache\0"
     )
+    (process_dir / "cwd").symlink_to("/five/tmp")
 
     assert module.scan_linux_live_references(proc_root) == {
         Path("/one/tmp"),
         Path("/two/tmp"),
         Path("/two/cache"),
+        Path("/five/tmp"),
     }
     assert module.parse_ps_live_references(
         "123 pytest TMPDIR=/three/tmp --basetemp=/four/tmp -o cache_dir=/four/cache"

--- a/tests/infra/test_taskfile.py
+++ b/tests/infra/test_taskfile.py
@@ -58,6 +58,14 @@ class TestTaskfile:
         commands = "\n".join(str(command) for command in task["cmds"])
         assert "python3 scripts/pytest_tmp_lifecycle.py reap" in commands
 
+    def test_refresh_codex_hook_fixture_uses_tmp_lifecycle(self) -> None:
+        task = self._load()["tasks"]["refresh-codex-hook-fixture"]
+        commands = "\n".join(str(command) for command in task["cmds"])
+        assert "_tmpdir-setup" in task["deps"]
+        assert task["env"]["TMPDIR"] == "{{.PYTEST_TMPDIR}}"
+        assert "--basetemp={{.PYTEST_TMPDIR}}" in commands
+        assert "cache_dir={{.PYTEST_CACHEDIR}}" in commands
+
     def test_status_uses_local_venv_paths_only(self):
         """T4 — status: sentinels use only local relative paths (no absolute/home paths)."""
         data = self._load()

--- a/tests/infra/test_taskfile.py
+++ b/tests/infra/test_taskfile.py
@@ -36,6 +36,28 @@ class TestTaskfile:
         deps = data["tasks"]["test-check"].get("deps", [])
         assert "install-worktree" in deps, "test-check.deps must include install-worktree"
 
+    def test_tmpdir_setup_delegates_without_recursive_delete(self) -> None:
+        task = self._load()["tasks"]["_tmpdir-setup"]
+        commands = "\n".join(str(command) for command in task["cmds"])
+        assert "python3 scripts/pytest_tmp_lifecycle.py setup" in commands
+        assert "rm " not in commands
+
+    def test_pytest_paths_share_generation_template(self) -> None:
+        variables = self._load()["vars"]
+        assert "{{.PYTEST_RUN_ID}}" in variables["PYTEST_GEN_DIR"]
+        assert "{{.PYTEST_GEN_DIR}}" in variables["PYTEST_TMPDIR"]
+        assert "{{.PYTEST_GEN_DIR}}" in variables["PYTEST_CACHEDIR"]
+
+    def test_pytest_generation_uses_dynamic_run_and_user_ids(self) -> None:
+        variables = self._load()["vars"]
+        assert variables["PYTEST_RUN_ID"]["sh"]
+        assert variables["AUTOSKILLIT_UID"]["sh"] == "id -u"
+
+    def test_cleanup_shm_delegates_pytest_reaping(self) -> None:
+        task = self._load()["tasks"]["cleanup-shm"]
+        commands = "\n".join(str(command) for command in task["cmds"])
+        assert "python3 scripts/pytest_tmp_lifecycle.py reap" in commands
+
     def test_status_uses_local_venv_paths_only(self):
         """T4 — status: sentinels use only local relative paths (no absolute/home paths)."""
         data = self._load()

--- a/tests/infra/test_taskfile_destructive_ops.py
+++ b/tests/infra/test_taskfile_destructive_ops.py
@@ -20,7 +20,7 @@ AUDITED_DESTRUCTIVE_TASKFILE_OPS: dict[str, str] = {
         "and scan failures prevent deletion."
     ),
     "install-worktree::uv venv --clear": (
-        "Per-worktree environment rebuild; same-worktree concurrency remains tracked separately."
+        "Per-worktree environment rebuild with an accepted same-worktree concurrency residual."
     ),
 }
 

--- a/tests/infra/test_taskfile_destructive_ops.py
+++ b/tests/infra/test_taskfile_destructive_ops.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core.io import load_yaml
+
+pytestmark = [pytest.mark.layer("infra"), pytest.mark.small]
+
+TASKFILE = Path(__file__).resolve().parents[2] / "Taskfile.yml"
+
+AUDITED_DESTRUCTIVE_TASKFILE_OPS: dict[str, str] = {
+    "cleanup-shm::headless-*": (
+        "Age-gated cleanup for session artifacts owned by the #3214 session lifecycle."
+    ),
+    "install-worktree::uv venv --clear": (
+        "Per-worktree environment rebuild; same-worktree concurrency remains tracked separately."
+    ),
+}
+
+_RECURSIVE_RM = re.compile(r"(?:^|\s)rm\s+-[A-Za-z]*r[A-Za-z]*(?:\s|$)")
+_FIND_EXEC_RM = re.compile(r"\bfind\b.*\s-exec\s+rm\s+-[A-Za-z]*r[A-Za-z]*")
+
+
+def _destructive_operations() -> set[str]:
+    taskfile = load_yaml(TASKFILE)
+    findings: set[str] = set()
+    for task_name, task in taskfile["tasks"].items():
+        for command in task.get("cmds", []):
+            for line in str(command).splitlines():
+                if "uv venv --clear" in line:
+                    findings.add(f"{task_name}::uv venv --clear")
+                if _FIND_EXEC_RM.search(line) or _RECURSIVE_RM.search(line):
+                    marker = "headless-*" if "headless-*" in line else line.strip()
+                    findings.add(f"{task_name}::{marker}")
+    return findings
+
+
+def test_every_destructive_taskfile_operation_is_audited() -> None:
+    """Recursive deletion must be explicit, justified, and bidirectionally registered."""
+    actual = _destructive_operations()
+    audited = set(AUDITED_DESTRUCTIVE_TASKFILE_OPS)
+    assert actual == audited, (
+        "Taskfile destructive-operation invariant violated. Pytest lifecycle cleanup must "
+        "route through scripts/pytest_tmp_lifecycle.py; every other recursive deletion "
+        "needs an exact AUDITED_DESTRUCTIVE_TASKFILE_OPS entry. "
+        f"Unaudited: {sorted(actual - audited)}; stale entries: {sorted(audited - actual)}"
+    )
+
+
+def test_destructive_operation_justifications_are_specific() -> None:
+    assert all(len(reason.split()) >= 6 for reason in AUDITED_DESTRUCTIVE_TASKFILE_OPS.values())

--- a/tests/infra/test_taskfile_destructive_ops.py
+++ b/tests/infra/test_taskfile_destructive_ops.py
@@ -15,6 +15,10 @@ AUDITED_DESTRUCTIVE_TASKFILE_OPS: dict[str, str] = {
     "cleanup-shm::headless-*": (
         "Age-gated cleanup for session artifacts owned by the #3214 session lifecycle."
     ),
+    "cleanup-shm::pytest_tmp_lifecycle.py reap": (
+        "Liveness-verified pytest reaper; macOS ps environment visibility is narrower, "
+        "and scan failures prevent deletion."
+    ),
     "install-worktree::uv venv --clear": (
         "Per-worktree environment rebuild; same-worktree concurrency remains tracked separately."
     ),
@@ -32,6 +36,8 @@ def _destructive_operations() -> set[str]:
             for line in str(command).splitlines():
                 if "uv venv --clear" in line:
                     findings.add(f"{task_name}::uv venv --clear")
+                if "pytest_tmp_lifecycle.py reap" in line:
+                    findings.add(f"{task_name}::pytest_tmp_lifecycle.py reap")
                 if _FIND_EXEC_RM.search(line) or _RECURSIVE_RM.search(line):
                     marker = "headless-*" if "headless-*" in line else line.strip()
                     findings.add(f"{task_name}::{marker}")

--- a/tests/server/test_tools_bootstrap.py
+++ b/tests/server/test_tools_bootstrap.py
@@ -71,6 +71,7 @@ class TestBootstrapClone:
         )
         assert "error" in result
         assert "rev-parse" in result["error"]
+        mock_mgr.remove_clone.assert_called_once_with(str(tmp_path), "false")
 
     @pytest.mark.anyio
     async def test_bootstrap_clone_timing(self, tool_ctx_kitchen_open, tmp_path):


### PR DESCRIPTION
## Summary

Replace shared deterministic pytest tmp/cache paths with a generation-unique directory per task invocation, containing isolated `tmp/`, `cache/`, and owner-identity metadata. Each setup now reaps only generations whose owners are provably dead and which are not referenced by live processes, failing closed if liveness scanning fails. Add focused lifecycle coverage and a repository-wide Taskfile guard requiring explicit registration of recursive-delete commands.

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/rectify/rectify_tmpdir_lifecycle_immunity_2026-08-10_152609.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
