### PR TITLE
Rectify: GitHub Mutation Batching Contracts

### DIFF
--- a/docs/safety/hooks.md
+++ b/docs/safety/hooks.md
@@ -72,8 +72,9 @@ looped, dynamic, or otherwise unresolved GitHub mutations. Classification
 resolves relative `gh api --input FILE` payloads against the command's own
 *execution cwd* — a run_cmd tool call's own required target-directory
 argument, or a Bash call's payload cwd — never against an unrelated session-
-level field, and fails closed when no absolute execution cwd is available or
-the request/`comments[]` count cannot be proven. Review publication must use
+level field, and fails closed when no absolute execution cwd is available,
+the request/`comments[]` count cannot be proven, or classification raises an
+unexpected runtime error. Review publication must use
 the typed `post_pr_review` tool; proven single non-review mutations retain
 their existing policy. See "Fail Modes" below for the guard's exhaustive
 deny-trigger vocabulary.
@@ -485,7 +486,7 @@ as a defense-in-depth measure against privilege escalation:
 | `open_kitchen_guard.py` | Unrecognized `AUTOSKILLIT_SESSION_TYPE` | Unknown session type should not gain kitchen access |
 | `skill_orchestration_guard.py` | Unrecognized `AUTOSKILLIT_SESSION_TYPE` | Unknown session type should not call orchestration tools (`run_skill`, `run_cmd`, `run_python`) |
 | `background_exec_guard.py` | Unrecognized `AUTOSKILLIT_SESSION_TYPE` | Unknown session type should not bypass `run_in_background` prohibition |
-| `github_mutation_guard.py` | Ambiguous or unresolved GitHub mutation command | Unknown mutation scope must not bypass the structured review publisher |
+| `github_mutation_guard.py` | Ambiguous or unresolved GitHub mutation command, or unexpected classifier error | Unknown mutation scope must not bypass the structured review publisher |
 | `exploration_request_identity_guard.py` | A supported exploration event lacks bounded native identity or its one-shot record cannot be written | A Claude exploration call must not execute without request-correlated authority |
 
 **Design principle:** Garbage-in (malformed hook input) = fail-open. Unknown-tier

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -1480,6 +1480,7 @@ def _analyze_gh_api(
         return (None, "GitHub API method is dynamic")
 
     payload: dict[str, Any] = {}
+    query_from_literal_input = input_value is not None
     if input_value is not None:
         if not input_context_safe:
             return (None, "a prior command may rewrite the inspected GitHub --input file")
@@ -1501,13 +1502,15 @@ def _analyze_gh_api(
 
     if graphql:
         query = payload.get("query")
-        if query is None:
+        if query is None and not query_from_literal_input:
             for field in field_values:
                 key, separator, value = field.partition("=")
                 if separator and key == "query":
                     query = value
                     break
-        if not isinstance(query, str) or _is_dynamic_shell_value(query):
+        if not isinstance(query, str) or (
+            not query_from_literal_input and _is_dynamic_shell_value(query)
+        ):
             return (None, "GraphQL mutation document is unresolved")
         if not re.search(r"\bmutation\b", query):
             return (None, "")
@@ -1543,15 +1546,95 @@ _GH_KNOWN_VALUE_FLAGS: frozenset[str] = frozenset(
     {
         "--body",
         "-b",
+        "--body-file",
+        "-F",
         "--add-label",
         "--remove-label",
         "--add-assignee",
         "--remove-assignee",
+        "--add-project",
+        "--remove-project",
+        "--milestone",
+        "-m",
+        "--repo",
+        "-R",
+        "--title",
+        "-t",
         "--reason",
         "--target",
         "--visibility",
     }
 )
+
+_GH_ISSUE_EDIT_LONG_VALUE_FLAGS: frozenset[str] = frozenset(
+    {
+        "--add-assignee",
+        "--add-label",
+        "--add-project",
+        "--body",
+        "--body-file",
+        "--milestone",
+        "--remove-assignee",
+        "--remove-label",
+        "--remove-project",
+        "--repo",
+        "--title",
+    }
+)
+_GH_ISSUE_EDIT_SHORT_VALUE_FLAGS: frozenset[str] = frozenset({"-b", "-F", "-m", "-R", "-t"})
+_GH_ISSUE_URL_RE = re.compile(r"^/[^/\s]+/[^/\s]+/issues/\d+/?$")
+
+
+def _is_static_issue_edit_target(value: str) -> bool:
+    if not value or _is_dynamic_shell_value(value):
+        return False
+    if value.isdecimal():
+        return True
+    parsed = urlsplit(value)
+    return bool(
+        parsed.scheme in {"http", "https"}
+        and parsed.netloc
+        and _GH_ISSUE_URL_RE.fullmatch(parsed.path)
+    )
+
+
+def _issue_edit_request_count(args: Sequence[str]) -> tuple[int | None, str]:
+    targets = 0
+    options_ended = False
+    i = 0
+    while i < len(args):
+        token = args[i]
+        if not options_ended and token == "--":
+            options_ended = True
+            i += 1
+            continue
+        if not options_ended:
+            if token in _GH_ISSUE_EDIT_LONG_VALUE_FLAGS or token in (
+                _GH_ISSUE_EDIT_SHORT_VALUE_FLAGS
+            ):
+                if i + 1 >= len(args):
+                    return (None, f"gh issue edit flag {token} is missing a value")
+                i += 2
+                continue
+            if any(token.startswith(f"{flag}=") for flag in _GH_ISSUE_EDIT_LONG_VALUE_FLAGS):
+                i += 1
+                continue
+            if any(
+                token.startswith(flag) and token != flag
+                for flag in _GH_ISSUE_EDIT_SHORT_VALUE_FLAGS
+            ):
+                i += 1
+                continue
+            if token.startswith("-"):
+                return (None, f"gh issue edit flag {token} is unresolved")
+        if not _is_static_issue_edit_target(token):
+            return (None, "gh issue edit target is unresolved")
+        targets += 1
+        i += 1
+
+    if targets == 0:
+        return (None, "gh issue edit target is missing")
+    return (targets, "")
 
 
 _GH_MUTATION_SUBCOMMANDS: dict[str, frozenset[str]] = {
@@ -1613,6 +1696,20 @@ def _analyze_gh_segment(
                 route="/gh/pr/review",
                 kind=GitHubMutationKind.PULL_REVIEW,
                 request_count=1,
+                review_comment_count=None,
+            ),
+            "",
+        )
+    if args[:2] == ["issue", "edit"]:
+        request_count, reason = _issue_edit_request_count(args[2:])
+        if request_count is None:
+            return (None, reason)
+        return (
+            GitHubMutationRecord(
+                method="POST",
+                route="/gh/issue/edit",
+                kind=GitHubMutationKind.OTHER,
+                request_count=request_count,
                 review_comment_count=None,
             ),
             "",

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -1609,8 +1609,9 @@ def _issue_edit_request_count(args: Sequence[str]) -> tuple[int | None, str]:
             i += 1
             continue
         if not options_ended:
-            if token in _GH_ISSUE_EDIT_LONG_VALUE_FLAGS or token in (
-                _GH_ISSUE_EDIT_SHORT_VALUE_FLAGS
+            if (
+                token in _GH_ISSUE_EDIT_LONG_VALUE_FLAGS
+                or token in _GH_ISSUE_EDIT_SHORT_VALUE_FLAGS
             ):
                 if i + 1 >= len(args):
                     return (None, f"gh issue edit flag {token} is missing a value")

--- a/src/autoskillit/hooks/guards/github_mutation_guard.py
+++ b/src/autoskillit/hooks/guards/github_mutation_guard.py
@@ -11,6 +11,7 @@ stdlib-only; no autoskillit imports.
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from enum import StrEnum
 from pathlib import Path
@@ -53,6 +54,7 @@ _REVIEW_KINDS: frozenset[GitHubMutationKind] = frozenset(
 )
 
 GITHUB_MUTATION_DENY_TRIGGER: str = "Unsafe raw GitHub mutation is prohibited"
+_LOGGER = logging.getLogger(__name__)  # noqa: TID251 - standalone stdlib guard
 
 
 class DenyTrigger(StrEnum):
@@ -158,7 +160,11 @@ def main() -> None:
     if not isinstance(loaded, dict):
         raise SystemExit(0)
 
-    decision = decide(parse_hook_command(loaded))
+    try:
+        decision = decide(parse_hook_command(loaded))
+    except Exception:
+        _LOGGER.error("GitHub mutation classification failed", exc_info=True)
+        _deny(DenyTrigger.UNRESOLVED_MUTATION)
     if not decision.allow and decision.trigger is not None:
         _deny(decision.trigger)
     raise SystemExit(0)

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -20,6 +20,7 @@ from autoskillit.recipe._skill_placeholder_parser import (
     extract_blockquote_placeholders,
     extract_blockquote_sections,
     extract_declared_ingredients,
+    extract_fenced_blocks,
     extract_graphql_blocks,
     extract_python_blocks,
     extract_sections,
@@ -835,6 +836,60 @@ def _check_reviews_post_requires_input_flag(ctx: ValidationContext) -> list[Rule
 
 _GRAPHQL_VARIABLE_RE = re.compile(r"\$([a-zA-Z_]\w*)")
 _GH_API_GRAPHQL_BLOCK_RE = re.compile(r"gh\s+api\s+graphql\b")
+_GRAPHQL_MUTATION_SECTION_RE = re.compile(
+    r"(?i:\bmutation\b)|"
+    r"\b(?:add|close|convert|create|delete|mark|merge|remove|reopen|resolve|submit|"
+    r"unresolve|update)[A-Z]\w*\b"
+)
+_GRAPHQL_INPUT_PATH_RE = re.compile(r"--input(?:\s+|=)(?:\"([^\"]+)\"|'([^']+)'|([^\s]+))")
+_GRAPHQL_INLINE_LITERAL_MUTATION_RE = re.compile(
+    r"(?:-[fF]|--field|--raw-field)\s+query='([^']*\bmutation\b[^']*)'",
+    re.IGNORECASE | re.DOTALL,
+)
+_GRAPHQL_DYNAMIC_TOKEN_RE = re.compile(r"\$|`|\*|\?|\[")
+_GRAPHQL_VARIABLES_BLOB_RE = re.compile(
+    r"(?:-[fF]|--field|--raw-field)\s+variables=",
+    re.IGNORECASE,
+)
+
+
+def _literal_graphql_input_path(block: str) -> str | None:
+    match = _GRAPHQL_INPUT_PATH_RE.search(block)
+    if match is None:
+        return None
+    path = next(value for value in match.groups() if value is not None)
+    if path == "-" or _GRAPHQL_DYNAMIC_TOKEN_RE.search(path):
+        return None
+    if not (path.startswith("/") or path.startswith("{{AUTOSKILLIT_TEMP}}/")):
+        return None
+    prefix = block[: match.start()]
+    if path in prefix:
+        return None
+    return path
+
+
+def _has_guard_compatible_graphql_mutation(section: str, block: str) -> bool:
+    input_path = _literal_graphql_input_path(block)
+    if input_path is not None:
+        return bool(
+            re.search(
+                r"(?:separate|prior|earlier)\s+(?:completed\s+)?tool\s+call",
+                section,
+                re.IGNORECASE,
+            )
+        )
+    match = _GRAPHQL_INLINE_LITERAL_MUTATION_RE.search(block)
+    return bool(match and not _GRAPHQL_DYNAMIC_TOKEN_RE.search(match.group(1)))
+
+
+def _json_payload_binds_variable(section: str, variable: str) -> bool:
+    return any(
+        re.search(r'"query"\s*:', block)
+        and re.search(r'"variables"\s*:', block)
+        and re.search(rf'"{re.escape(variable)}"\s*:', block)
+        for block in extract_fenced_blocks(section, "json")
+    )
+
 
 _SOURCE_PROHIBITION_RE = re.compile(
     r"(?:NOT|NEVER|DO NOT)[\s\S]{0,120}?"
@@ -904,9 +959,9 @@ def _check_source_attribution_directive(ctx: ValidationContext) -> list[RuleFind
     name="graphql-query-requires-shell-invocation",
     description=(
         "A SKILL.md contains a ```graphql block with parameterized $variables "
-        "but no ```bash block with a concrete `gh api graphql` invocation. "
-        "Agents will improvise the invocation and may use the wrong variable-passing "
-        "pattern (-f variables=<json blob> instead of individual -F key=value flags)."
+        "but no guard-compatible `gh api graphql` invocation. Mutations must use either "
+        "a fully literal inline document or a literal inspected JSON payload written in "
+        "a prior tool call; variables use individual fields or that payload's variables object."
     ),
     severity=Severity.ERROR,
 )
@@ -939,6 +994,40 @@ def _check_graphql_query_requires_shell_invocation(ctx: ValidationContext) -> li
             section_graphql = extract_graphql_blocks(section)
             section_bash = extract_bash_blocks(section)
             section_bash_graphql = [b for b in section_bash if _GH_API_GRAPHQL_BLOCK_RE.search(b)]
+            section_is_mutation = (
+                any(_GRAPHQL_MUTATION_SECTION_RE.search(block) for block in section_graphql)
+                if section_graphql
+                else bool(_GRAPHQL_MUTATION_SECTION_RE.search(section))
+            )
+
+            for bash_block in section_bash_graphql:
+                if _GRAPHQL_VARIABLES_BLOB_RE.search(bash_block):
+                    findings.append(
+                        make_finding(
+                            rule_name="graphql-query-requires-shell-invocation",
+                            step_name=step_name,
+                            message=(
+                                f"Skill '{skill_name}' uses a single variables blob binding; "
+                                "use individual fields or a validated JSON payload "
+                                "variables object."
+                            ),
+                        )
+                    )
+                block_is_mutation = bool(_GRAPHQL_MUTATION_SECTION_RE.search(bash_block))
+                if (
+                    block_is_mutation or (section_is_mutation and len(section_bash_graphql) == 1)
+                ) and not _has_guard_compatible_graphql_mutation(section, bash_block):
+                    findings.append(
+                        make_finding(
+                            rule_name="graphql-query-requires-shell-invocation",
+                            step_name=step_name,
+                            message=(
+                                f"Skill '{skill_name}' prescribes a GraphQL mutation that is "
+                                "not guard-compatible: use a fully literal inline mutation or "
+                                "a literal JSON --input path written in a prior tool call."
+                            ),
+                        )
+                    )
 
             for block in section_graphql:
                 if not section_bash_graphql:
@@ -959,7 +1048,10 @@ def _check_graphql_query_requires_shell_invocation(ctx: ValidationContext) -> li
                     flag_found = any(
                         re.search(rf"-[Ff]\s*{re.escape(var)}=", b) for b in section_bash_graphql
                     )
-                    if not flag_found:
+                    payload_found = any(
+                        _literal_graphql_input_path(b) is not None for b in section_bash_graphql
+                    ) and _json_payload_binds_variable(section, var)
+                    if not flag_found and not payload_found:
                         findings.append(
                             make_finding(
                                 rule_name="graphql-query-requires-shell-invocation",

--- a/src/autoskillit/recipe/rules/rules_skill_content.py
+++ b/src/autoskillit/recipe/rules/rules_skill_content.py
@@ -863,7 +863,10 @@ def _literal_graphql_input_path(block: str) -> str | None:
     if not (path.startswith("/") or path.startswith("{{AUTOSKILLIT_TEMP}}/")):
         return None
     prefix = block[: match.start()]
-    if path in prefix:
+    if re.search(
+        rf"(?:^|[\s'\"=<>|&;()]){re.escape(path)}(?=$|[\s'\"<>|&;()])",
+        prefix,
+    ):
         return None
     return path
 

--- a/src/autoskillit/server/tools/tools_issue_headless.py
+++ b/src/autoskillit/server/tools/tools_issue_headless.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import TYPE_CHECKING, Any
 
@@ -10,7 +11,7 @@ import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit.core import RetryReason, get_logger
+from autoskillit.core import RetryReason, _parse_issue_ref, get_logger
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
 from autoskillit.server._misc import _extract_block
@@ -194,7 +195,6 @@ def _build_prepare_skill_command(
     title: str,
     body: str,
     repo: str,
-    labels: list[str] | None,
     dry_run: bool,
     split: bool,
 ) -> str:
@@ -202,9 +202,6 @@ def _build_prepare_skill_command(
     parts = [f"/prepare-issue\n\nTitle: {title}\n\nBody:\n{body}"]
     if repo:
         parts.append(f"--repo {repo}")
-    if labels:
-        for lbl in labels:
-            parts.append(f"--label {lbl}")
     if dry_run:
         parts.append("--dry-run")
     if split:
@@ -221,6 +218,34 @@ def _parse_prepare_result(response_text: str) -> dict[str, Any]:
         return json.loads("\n".join(block_lines))
     except json.JSONDecodeError:
         return {"success": False, "error": "result block contained invalid JSON"}
+
+
+def _add_labels_result_error(
+    label_result: object,
+    requested_labels: list[str],
+) -> str | None:
+    if not isinstance(label_result, dict):
+        return "GitHub returned a malformed label result"
+    if label_result.get("success") is not True:
+        error = label_result.get("error")
+        return str(error) if error else "GitHub label application failed"
+    returned_labels = label_result.get("labels")
+    if (
+        not isinstance(returned_labels, list)
+        or not all(isinstance(label, str) for label in returned_labels)
+        or not set(requested_labels).issubset(returned_labels)
+    ):
+        return "GitHub returned a malformed label result"
+    return None
+
+
+def _merge_applied_labels(existing: object, additions: list[str]) -> list[str]:
+    ordered = (
+        [label for label in existing if isinstance(label, str)]
+        if isinstance(existing, list)
+        else []
+    )
+    return list(dict.fromkeys([*ordered, *additions]))
 
 
 def _build_enrich_skill_command(
@@ -306,12 +331,21 @@ async def prepare_issue(
             tool_ctx = _get_ctx()
             if tool_ctx.executor is None:
                 return json.dumps({"success": False, "error": "Executor not configured"})
+            github_client = tool_ctx.github_client
 
             if labels:
                 if err := tool_ctx.config.github.check_labels_allowed(labels):
                     return json.dumps({"success": False, "error": err})
+            additional_labels = list(dict.fromkeys(labels or []))
+            if additional_labels and not dry_run and github_client is None:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": "GitHub client not configured for additional label application",
+                    }
+                )
 
-            skill_command = _build_prepare_skill_command(title, body, repo, labels, dry_run, split)
+            skill_command = _build_prepare_skill_command(title, body, repo, dry_run, split)
 
             expected_output_patterns: list[str] = []
             if tool_ctx.output_pattern_resolver:
@@ -373,6 +407,48 @@ async def prepare_issue(
                         success=True,
                         extra_fields=extra,
                     )
+                )
+
+            if additional_labels and not dry_run:
+                issue_url = parsed.get("issue_url")
+                issue_number = parsed.get("issue_number")
+                try:
+                    if not isinstance(issue_url, str) or type(issue_number) is not int:
+                        raise ValueError("result lacks a valid issue URL and integer number")
+                    owner, issue_repo, url_number = _parse_issue_ref(issue_url)
+                    canonical_url = f"https://github.com/{owner}/{issue_repo}/issues/{url_number}"
+                    if issue_url.strip() != canonical_url or url_number != issue_number:
+                        raise ValueError("result issue URL and issue number are inconsistent")
+                except ValueError as exc:
+                    return json.dumps(
+                        _build_headless_error_response(
+                            result,
+                            error=f"Additional labels were not applied: {exc}",
+                            extra_fields=_without_success_key(parsed),
+                        )
+                    )
+
+                await asyncio.sleep(1)
+                assert github_client is not None
+                label_result = await github_client.add_labels(
+                    owner,
+                    issue_repo,
+                    issue_number,
+                    additional_labels,
+                )
+                if error := _add_labels_result_error(label_result, additional_labels):
+                    return json.dumps(
+                        _build_headless_error_response(
+                            result,
+                            error=f"Additional labels were not applied: {error}",
+                            extra_fields=_without_success_key(parsed),
+                        )
+                    )
+
+            if additional_labels:
+                parsed["labels_applied"] = _merge_applied_labels(
+                    parsed.get("labels_applied"),
+                    additional_labels,
                 )
 
             # Block parsed successfully. result.success=True is the authoritative signal —

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -412,10 +412,12 @@ When dispatching from an execution map:
    }
    ```
 
-   Build the alias query from the `gated_by` issue numbers and invoke:
+   Build the alias query and its variables object from the `gated_by` issue numbers. Use a
+   file-write tool in a separate completed tool call to write the bounded JSON payload under
+   the resolved absolute project temp directory. Use `/absolute/project-temp/sous-chef/`
+   below as the placeholder for that directory, then invoke that literal path:
    ```bash
-   LABEL_QUERY="query { $(for NUM in $BLOCKER_NUMS; do echo "i${NUM}: repository(owner:\"$OWNER\", name:\"$REPO\") { issue(number:${NUM}) { labels(first:20) { nodes { name } } } }"; done) }"
-   gh api graphql -f query="$LABEL_QUERY"
+   gh api graphql --input "/absolute/project-temp/sous-chef/blocker_labels.json"
    ```
 
    For each blocker, check whether the `in-progress` label is still present. If a
@@ -632,37 +634,36 @@ produced by a single pipeline or by N parallel pipelines.
 
 ### 1. Detect merge queue availability — once per orchestration session
 
-Before initiating any merge, run the following detection step via `run_cmd` (not a
-headless session):
+Before initiating any merge, use a file-write tool in a separate completed tool call to
+write a bounded GraphQL JSON payload to
+`/absolute/project-temp/sous-chef/merge_queue_query.json`, where `/absolute/project-temp`
+stands for the resolved absolute project temp directory. Its `query` requests
+`repository(owner:$owner,name:$repo){mergeQueue(branch:$branch){id}}` and its `variables`
+object supplies the resolved owner, repository, and target branch. Then run the detection
+via `run_cmd` (not a headless session):
 
 ```bash
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner) &&
-OWNER=${REPO%%/*} && REPO_NAME=${REPO##*/} &&
-BRANCH="<base_branch>" &&    # substitute the PR's target branch (e.g. "main", "develop")
-gh api graphql -f query="query {
-  repository(owner:\"$OWNER\", name:\"$REPO_NAME\") {
-    mergeQueue(branch:\"$BRANCH\") { id }
-  }
-}" | jq -r 'if .data.repository.mergeQueue != null then "true" else "false" end' || echo false
+gh api graphql --input "/absolute/project-temp/sous-chef/merge_queue_query.json"
 ```
 
-Capture the result as `queue_available`. If `gh api graphql` fails (auth error, network
-error), the `|| echo false` fallback ensures `queue_available` defaults to `"false"`,
-routing to the safe sequential (non-queue) path rather than leaving the variable unset.
+In a later local-processing call, parse the response with
+`jq -r 'if .data.repository.mergeQueue != null then "true" else "false" end'` and capture
+the result as `queue_available`. If `gh api graphql` fails (auth error, network error), set
+`queue_available` to `"false"`, routing to the safe sequential (non-queue) path.
 
 Run this **once per orchestration run**, not per-PR.
 
-After detecting queue availability, also detect auto-merge availability:
+After detecting queue availability, use a file-write tool in a separate completed tool call
+to write `/absolute/project-temp/sous-chef/auto_merge_query.json`, with a parameterized
+read-only query for `repository(owner:$owner,name:$repo){autoMergeAllowed}` and a complete
+`variables` object. Then detect auto-merge availability:
 
 ```bash
-gh api graphql -f query="query {
-  repository(owner:\"$OWNER\", name:\"$REPO_NAME\") {
-    autoMergeAllowed
-  }
-}" | jq -r '.data.repository.autoMergeAllowed // false' || echo false
+gh api graphql --input "/absolute/project-temp/sous-chef/auto_merge_query.json"
 ```
 
-Capture the result as `auto_merge_available`. If detection fails, default to `"false"`.
+In a later local-processing call, parse `.data.repository.autoMergeAllowed // false` and
+capture the result as `auto_merge_available`. If detection fails, default to `"false"`.
 
 **Note:** All three recipes (`implementation`, `implementation-groups`, `remediation`)
 perform both detections automatically via `check_merge_queue` + `check_auto_merge` —

--- a/src/autoskillit/skills_extended/analyze-prs/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-prs/SKILL.md
@@ -173,75 +173,25 @@ Do not output any prose between subagent dispatches. Immediately proceed to the 
   (1 API call regardless of PR count, instead of 2N sequential REST calls). Chunk into
   batches of 20 PRs to stay within GraphQL complexity limits.
 
+  Initialize `ELIGIBLE_PRS`, `CI_BLOCKED_PRS`, and `REVIEW_BLOCKED_PRS` as empty arrays.
+  Do not output prose between payload-write and GitHub calls or between chunks; immediately
+  proceed to the next required call.
+  For each batch, build one aliased query plus a `variables` object containing the owner,
+  repository, and PR numbers. Use a file-write tool in a separate completed tool call to
+  write the bounded JSON payload to
+  `{{AUTOSKILLIT_TEMP}}/analyze-prs/pr_status_batch_0.json`, changing
+  only the numeric suffix for later chunks (relative to the current working directory).
+  Invoke each chunk as its own tool call, never
+  from inside a shell loop:
+
   ```bash
-  ELIGIBLE_PRS=()
-  CI_BLOCKED_PRS=()      # [{number, title, reason}]
-  REVIEW_BLOCKED_PRS=()  # [{number, title, reason}]
-
-  # Build GraphQL alias query for all PRs in batches of 20
-  ALL_PR_NUMS=($(echo "$ALL_PRS" | jq -r '.[].number'))
-  BATCH_SIZE=20
-  for batch_start in $(seq 0 $BATCH_SIZE $((${#ALL_PR_NUMS[@]} - 1))); do
-    BATCH_NUMS=("${ALL_PR_NUMS[@]:$batch_start:$BATCH_SIZE}")
-
-    QUERY="query { "
-    for i in $(seq 0 $((${#BATCH_NUMS[@]} - 1))); do
-      NUM="${BATCH_NUMS[$i]}"
-      QUERY="${QUERY} pr${i}: repository(owner: \"${OWNER}\", name: \"${REPO}\") {
-        pullRequest(number: ${NUM}) {
-          number
-          reviews(last: 20) { nodes { state } }
-          commits(last: 1) { nodes { commit { statusCheckRollup {
-            state
-            contexts(last: 100) { nodes { ... on CheckRun { name status conclusion } } }
-          } } } }
-        }
-      }"
-    done
-    QUERY="${QUERY} }"
-    BATCH_RESULT=$(gh api graphql -f query="${QUERY}")
-
-    # Parse per-PR results from BATCH_RESULT
-    for i in $(seq 0 $((${#BATCH_NUMS[@]} - 1))); do
-      NUM="${BATCH_NUMS[$i]}"
-      PR_TITLE=$(echo "$ALL_PRS" | jq -r --argjson n "$NUM" '.[] | select(.number == $n) | .title')
-      PR_DATA=$(echo "$BATCH_RESULT" | jq --arg key "pr${i}" '.data[$key].pullRequest')
-
-      # --- CI Gate ---
-      FAILING=$(echo "$PR_DATA" | jq '
-        [(.commits.nodes[0].commit.statusCheckRollup.contexts.nodes // [])[] |
-         select(.conclusion != null and
-                .conclusion != "success" and
-                .conclusion != "skipped" and
-                .conclusion != "neutral")] | length')
-      IN_PROGRESS=$(echo "$PR_DATA" | jq '
-        [(.commits.nodes[0].commit.statusCheckRollup.contexts.nodes // [])[] |
-         select(.conclusion == null)] | length')
-
-      if [ "${FAILING:-0}" -gt 0 ] || [ "${IN_PROGRESS:-0}" -gt 0 ]; then
-        REASON="CI failing: ${FAILING} failed, ${IN_PROGRESS} in-progress"
-        CI_BLOCKED_PRS+=("{\"number\":${NUM},\"title\":\"${PR_TITLE}\",\"reason\":\"${REASON}\"}")
-        continue
-      fi
-
-      # --- Review Gate ---
-      CHANGES_REQUESTED=$(echo "$PR_DATA" | jq '
-        [.reviews.nodes |
-         group_by(.author.login)[] |
-         last |
-         select(.state == "CHANGES_REQUESTED")] | length')
-
-      if [ "${CHANGES_REQUESTED:-0}" -gt 0 ]; then
-        REASON="${CHANGES_REQUESTED} unresolved CHANGES_REQUESTED review(s)"
-        REVIEW_BLOCKED_PRS+=("{\"number\":${NUM},\"title\":\"${PR_TITLE}\",\"reason\":\"${REASON}\"}")
-        continue
-      fi
-
-      mapfile -t _pr_entry < <(echo "$ALL_PRS" | jq -c --argjson n "$NUM" '.[] | select(.number == $n)')
-      ELIGIBLE_PRS+=("${_pr_entry[@]}")
-    done
-  done
+  gh api graphql --input "{{AUTOSKILLIT_TEMP}}/analyze-prs/pr_status_batch_0.json"
   ```
+
+  Parse each alias from the response. Preserve the existing gates exactly: add PRs with
+  failed or in-progress checks to `CI_BLOCKED_PRS`; add PRs whose latest review per author
+  is `CHANGES_REQUESTED` to `REVIEW_BLOCKED_PRS`; add all remaining PRs to `ELIGIBLE_PRS`.
+  Process chunks sequentially with the same batch size of 20.
 
   All subsequent steps (overlap matrix, topo sort, PR ordering) operate on `ELIGIBLE_PRS` only.
   `CI_BLOCKED_PRS` and `REVIEW_BLOCKED_PRS` are written to the manifest in Step 5.

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -87,21 +87,12 @@ implemented. Identify review debt before it compounds.
 
 2. Resolve `OWNER` and `REPO` from `git remote get-url origin`.
 
-3. Query the most recent `[AUDIT]` sentinel comment across recently merged PRs:
+3. Query the most recent `[AUDIT]` sentinel comment across recently merged PRs. Use a
+   file-write tool in a separate completed tool call to write the bounded query and its
+   `owner`/`name` variables object to
+   `{{AUTOSKILLIT_TEMP}}/audit-review-decisions/watermark_query.json`, then invoke it:
    ```bash
-   gh api graphql -f query='
-     query($owner:String!, $name:String!) {
-       rateLimit { cost remaining resetAt }
-       repository(owner:$owner, name:$name) {
-         pullRequests(first:500, states:MERGED, orderBy:{field:UPDATED_AT,direction:DESC}) {
-           nodes { number
-             reviewThreads(first:50) {
-               nodes { comments(first:10) { nodes { body createdAt } } }
-             }
-           }
-         }
-       }
-     }' -f owner="${OWNER}" -f name="${REPO}"
+   gh api graphql --input "{{AUTOSKILLIT_TEMP}}/audit-review-decisions/watermark_query.json"
    ```
    Extract the most recent `createdAt` from any comment whose `body` starts with
    `[AUDIT]`. Store as `LAST_AUDIT_TS` (empty string if none — first run).
@@ -146,10 +137,13 @@ implemented. Identify review debt before it compounds.
      }
    }
    ```
-   Build the alias query string in a shell variable and invoke:
+   Do not output prose between payload-write and GitHub calls or between chunks; immediately
+   proceed to the next required call.
+   Build the alias query and variables object for each batch. Use a file-write tool in a
+   separate completed tool call to write the bounded JSON payload, then invoke its literal
+   path in a later call:
    ```bash
-   BATCH_QUERY="query { rateLimit { cost remaining resetAt } pr1: repository(owner:\"$OWNER\", name:\"$REPO\") { pullRequest(number:$N1) { number title mergedAt reviews(first:100){nodes{author { login } body state submittedAt}} reviewThreads(first:100){pageInfo{hasNextPage endCursor}nodes{isResolved comments(first:100){nodes{databaseId author { login } body path line createdAt}}}} } } pr2: repository(owner:\"$OWNER\", name:\"$REPO\") { pullRequest(number:$N2) { ... } } }"
-   gh api graphql -f query="$BATCH_QUERY"
+   gh api graphql --input "{{AUTOSKILLIT_TEMP}}/audit-review-decisions/pr_batch_0.json"
    ```
    Include `rateLimit { cost remaining resetAt }` at query root.
    After the initial fetch, for each PR where `reviewThreads.pageInfo.hasNextPage` is

--- a/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
@@ -131,11 +131,10 @@ list in the payload's `variables` object:
 ```
 
 For each chunk, use a file-write tool in a separate completed tool call to write the bounded JSON
-payload under the absolute run directory. Invoke it in a later call through the exact literal
-absolute path:
+payload under the absolute run directory. Before every chunk after the first, run `sleep 1` in its
+own tool call. Invoke the payload in a later call through the exact literal absolute path:
 
 ```bash
-sleep 1
 gh api graphql --input "/absolute/audit-run/apply_labels_chunk_0.json"
 ```
 

--- a/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/file-audit-issues/SKILL.md
@@ -53,48 +53,94 @@ For each non-duplicate ticket body file, check its size:
 
 ## Step 5 — Batch-Create Issues via GraphQL
 
+Do not output prose between payload-write and GitHub calls or between chunks; immediately
+proceed to the next required call.
+
 Resolve repo identity: use `gh repo view --json owner,name` to get the canonical owner and repo name, then fetch `gh api repos/{owner}/{repo} --jq '.node_id'`.
 If this call fails or returns an empty node_id (missing `GH_TOKEN`, wrong remote, insufficient
 permissions), abort immediately with a clear error message: `"Error: could not resolve repo node_id
 — check GH_TOKEN and remote URL. Aborting."` Do not proceed with GraphQL mutations using an empty node_id.
-Resolve label IDs for `audit` and `recipe:implementation` labels (ensure they exist via `gh label create --force`).
-Build batched GraphQL `createIssue` mutations with aliases (`issue0`, `issue1`, ...), chunked at 20 per request.
+Before any label mutation, read the complete repository label inventory with
+`gh label list --limit 1000 --json name,id`. Build the required set from `audit`,
+`recipe:implementation`, and every source-specific label derived from the ticket filenames.
+Determine the genuinely missing definitions. If any are missing, use a file-write tool in a
+separate completed tool call to create one bounded GraphQL JSON payload under the absolute run
+directory. The payload contains one aliased `createLabel` operation per missing label and a
+`variables` object with the repository ID, name, color, and description. Invoke that payload
+once using the exact absolute path written in the prior call; this concrete command illustrates
+the required shape:
 
-```graphql
-mutation {
-  issue0: createIssue(input: {repositoryId: "<REPO_ID>", title: "<TITLE>", body: "<BODY>"}) {
-    issue { number url }
-  }
-  issue1: createIssue(input: {repositoryId: "<REPO_ID>", title: "<TITLE>", body: "<BODY>"}) {
-    issue { number url }
+```bash
+gh api graphql --input "/absolute/audit-run/create_missing_labels.json"
+```
+
+Do not create or rewrite definitions already present. After the mutation, refresh the inventory
+and build an explicit label-name-to-node-ID map. Abort before issue creation if any required
+label still lacks a node ID. When the missing-definition request ran, sleep one second before
+the next mutating call.
+
+Build `createIssue` mutations with aliases (`issue0`, `issue1`, ...), chunked at 20 issues per
+request. Put titles and bodies in the JSON payload's `variables` object rather than interpolating
+them into the GraphQL document. Each alias must return the issue node ID as well as its number
+and URL:
+
+```json
+{
+  "query": "mutation CreateIssues($repositoryId: ID!, $title0: String!, $body0: String!) { issue0: createIssue(input: {repositoryId: $repositoryId, title: $title0, body: $body0}) { issue { id number url } } }",
+  "variables": {
+    "repositoryId": "R_1",
+    "title0": "Validated audit finding",
+    "body0": "Full validated ticket body"
   }
 }
 ```
 
+For every chunk, use a file-write tool in a separate completed tool call to write a bounded JSON
+object under the absolute run directory, then invoke its literal absolute path in a later call:
+
 ```bash
-echo "$MUTATION_JSON" | gh api graphql --input -
+gh api graphql --input "/absolute/audit-run/create_issues_chunk_0.json"
 ```
 
-Sleep 1 second between chunks (per GitHub API discipline).
-Collect created issue URLs and numbers.
+Parse each response by alias. Store both an alias-to-issue-ID map and a ticket-body-file-to-issue-ID
+map alongside the issue number and URL. Abort the chunk on a missing alias, missing `id`, `number`,
+or `url`, or any GraphQL error. Sleep one second between consecutive mutating chunks.
 
 ## Step 6 — Apply Source-Specific Labels
 
-Parse the source from each ticket body filename (`ticket_body_{source}_{N}_{ts}.md`). For each unique
-source, ensure a label exists (e.g., `audit:tests`, `audit:arch`, `audit:cohesion`, etc.).
-Batch-apply source labels via GraphQL `addLabelsToLabelable` mutation with aliases.
+Do not output prose between payload-write and GitHub calls or between chunks; immediately
+proceed to the next required call.
 
-```graphql
-mutation {
-  l0: addLabelsToLabelable(input: {labelableId: "<ISSUE_ID>", labelIds: ["<LABEL_ID>"]}) {
-    labelable { ... on Issue { number } }
+Parse the source from each ticket body filename (`ticket_body_{source}_{N}_{ts}.md`). For each unique
+source, look up its source-label node ID in the refreshed inventory map from Step 5 (for example,
+`audit:tests`, `audit:arch`, or `audit:cohesion`). Never construct a label mutation from a label
+name alone. For each created ticket, combine the node IDs for `audit`,
+`recipe:implementation`, and its actual source label with the issue node ID stored by Step 5.
+
+Build aliased `addLabelsToLabelable` operations in chunks of 20. Put every issue ID and label-ID
+list in the payload's `variables` object:
+
+```json
+{
+  "query": "mutation ApplyLabels($issue0: ID!, $labels0: [ID!]!) { l0: addLabelsToLabelable(input: {labelableId: $issue0, labelIds: $labels0}) { labelable { ... on Issue { id number } } } }",
+  "variables": {
+    "issue0": "I_1",
+    "labels0": ["LA_audit", "LA_recipe", "LA_source"]
   }
 }
 ```
 
+For each chunk, use a file-write tool in a separate completed tool call to write the bounded JSON
+payload under the absolute run directory. Invoke it in a later call through the exact literal
+absolute path:
+
 ```bash
-echo "$LABEL_MUTATION" | gh api graphql --input -
+sleep 1
+gh api graphql --input "/absolute/audit-run/apply_labels_chunk_0.json"
 ```
+
+Treat a missing issue/label ID, missing alias, or GraphQL error as a chunk failure. Preserve the
+existing one-second pacing between every consecutive mutating GitHub API call.
 
 ## Step 7 — Write Filed Issues Manifest
 

--- a/src/autoskillit/skills_extended/merge-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/merge-pr/SKILL.md
@@ -189,18 +189,17 @@ code** from the PR's changes, not to restore it. The base branch's deletion is a
 
 ### Step 1.8: Detect Auto-Merge Availability
 
+Resolve the repository identity, then use a file-write tool in a separate completed tool call
+to write a bounded parameterized query and `owner`/`repo` variables object to
+`{{AUTOSKILLIT_TEMP}}/merge-pr/auto_merge_query.json` (relative to the current working directory).
+
 ```bash
-REPO=$( { git remote get-url upstream 2>/dev/null || git remote get-url origin; } | sed 's|.*github\.com[:/]||; s|\.git$||')
-OWNER=${REPO%%/*} && REPO_NAME=${REPO##*/}
-AUTO_MERGE_ALLOWED=$(gh api graphql -f query="query {
-  repository(owner:\"$OWNER\", name:\"$REPO_NAME\") {
-    autoMergeAllowed
-  }
-}" 2>/dev/null | jq -r '.data.repository.autoMergeAllowed // false')
+gh api graphql --input "{{AUTOSKILLIT_TEMP}}/merge-pr/auto_merge_query.json"
 ```
 
-Capture `AUTO_MERGE_ALLOWED` ("true" or "false"). On gh failure, default to "false"
-(the safe path: use plain `--squash`, not `--squash --auto`).
+In a later local-processing call, parse `.data.repository.autoMergeAllowed // false` and
+capture `AUTO_MERGE_ALLOWED` ("true" or "false"). On gh failure, default to "false" (the
+safe path: use plain `--squash`, not `--squash --auto`).
 
 ### Step 1.9: Pre-flight Mergeability Check
 

--- a/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
@@ -107,25 +107,17 @@ Read the JSON file. Extract: `prs` array (each: `number`, `title`, `branch`,
 Fetch all PR bodies in a single GraphQL alias query (1 API call instead of N sequential
 REST calls). Chunk into batches of 20 to stay within GraphQL complexity limits.
 
+For each chunk, build one aliased query plus a `variables` object for the owner, repository,
+and PR numbers. Use a file-write tool in a separate completed tool call to write the bounded
+JSON payload to `{{AUTOSKILLIT_TEMP}}/open-integration-pr/pr_bodies_batch_0.json`, changing
+numeric suffix for later chunks. Invoke each chunk separately, not from a shell loop:
+
 ```bash
-# Build GraphQL alias query for all PRs
-PR_NUMS=($(echo "$pr_list" | jq -r '.[].number'))
-BODIES_JSON="{}"
-BATCH_SIZE=20
-for batch_start in $(seq 0 $BATCH_SIZE $((${#PR_NUMS[@]} - 1))); do
-    BATCH_NUMS=("${PR_NUMS[@]:$batch_start:$BATCH_SIZE}")
-    QUERY="query { "
-    for i in $(seq 0 $((${#BATCH_NUMS[@]} - 1))); do
-        NUM="${BATCH_NUMS[$i]}"
-        QUERY="${QUERY} pr${i}: repository(owner: \"${OWNER}\", name: \"${REPO}\") {
-            pullRequest(number: ${NUM}) { number body }
-        }"
-    done
-    QUERY="${QUERY} }"
-    BATCH=$(gh api graphql -f query="${QUERY}" 2>/dev/null || echo "{}")
-    BODIES_JSON=$(echo "${BODIES_JSON} ${BATCH}" | jq -s 'add // {}')
-done
+gh api graphql --input "{{AUTOSKILLIT_TEMP}}/open-integration-pr/pr_bodies_batch_0.json"
 ```
+
+Merge each response into `BODIES_JSON`; on a failed chunk, use `{}` and continue so
+`source_issue_urls` remains best-effort. Preserve the existing 20-PR chunk size.
 
 Extract every canonical full URL matching
 `(Closes|Fixes|Resolves)\s+https://github.com/{owner}/{repo}/issues/{number}`

--- a/src/autoskillit/skills_extended/prepare-issue/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-issue/SKILL.md
@@ -412,32 +412,41 @@ block, exit.
 
 Otherwise:
 
-```bash
-# Ensure labels exist (idempotent)
-gh label create "recipe:implementation" --force \
-    --description "Route: proceed directly to implementation" \
-    --color "0E8A16"
-sleep 1  # Rate-limit discipline: 1s between mutating calls
-gh label create "recipe:remediation" --force \
-    --description "Route: investigate/decompose before implementation" \
-    --color "D93F0B"
-sleep 1  # Rate-limit discipline: 1s between mutating calls
-gh label create "bug" --force \
-    --description "Existing behavior is broken" \
-    --color "d73a4a"
-sleep 1  # Rate-limit discipline: 1s between mutating calls
-gh label create "enhancement" --force \
-    --description "New feature or request" \
-    --color "a2eeef"
-sleep 1  # Rate-limit discipline: 1s between mutating calls
+1. Read the complete repository label inventory before any label mutation:
 
-# Apply triage labels (use the route determined in Step 6)
-gh issue edit {issue_number} --add-label "recipe:implementation"
-sleep 1  # Rate-limit discipline: 1s between mutating calls
-# or, for remediation route:
-gh issue edit {issue_number} --add-label "recipe:remediation"
-sleep 1  # Rate-limit discipline: 1s between mutating calls
-gh issue edit {issue_number} --add-label "{issue_type}"
+```bash
+gh label list --limit 1000 --json name
+```
+
+2. Compare that inventory with the four definitions below and retain only genuinely
+   missing labels:
+   - `recipe:implementation` — color `0E8A16`, description
+     `Route: proceed directly to implementation`
+   - `recipe:remediation` — color `D93F0B`, description
+     `Route: investigate/decompose before implementation`
+   - `bug` — color `d73a4a`, description `Existing behavior is broken`
+   - `enhancement` — color `a2eeef`, description `New feature or request`
+3. If labels are missing, use a file-write tool in a separate completed tool call to write
+   one bounded JSON object to the expanded absolute path
+   `{{AUTOSKILLIT_TEMP}}/prepare-issue/label_definitions.json`. Its `query`
+   contains one aliased `createLabel` operation per missing definition, and its `variables`
+   object supplies the repository ID plus each label's name, color, and description. Do not
+   include labels already present in the inventory. Then invoke that payload once:
+
+```bash
+gh api graphql --input "{{AUTOSKILLIT_TEMP}}/prepare-issue/label_definitions.json"
+```
+
+4. After the definition request completes, wait one second, then apply the selected route
+   and issue-type labels in one request using repeated flags:
+
+```bash
+ROUTE_LABEL="recipe:implementation"  # or recipe:remediation, from Step 6
+ISSUE_TYPE_LABEL="bug"  # or enhancement, from Step 6
+sleep 1
+gh issue edit {issue_number} \
+    --add-label "${ROUTE_LABEL}" \
+    --add-label "${ISSUE_TYPE_LABEL}"
 ```
 
 ## Critical Constraints
@@ -459,7 +468,7 @@ gh issue edit {issue_number} --add-label "{issue_type}"
 
 **ALWAYS:**
 - Confirm repo access with `gh repo view` before any issue operations
-- Use `--force` on all `gh label create` calls for idempotency
+- Create only definitions proven missing by the complete label inventory
 - Emit the result block (`---prepare-issue-result---`) even on dry-run
 - Respect `--dry-run`: never create or edit anything when this flag is set
 

--- a/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
@@ -160,15 +160,13 @@ gh api repos/{owner}/{repo}/pulls/{number}/reviews --paginate
 ```
 
 Fetch review thread node IDs using cursor-based pagination to handle PRs with more than
-100 threads:
+100 threads. Before each page, use a file-write tool in a separate completed tool call to
+write the bounded parameterized query and its `owner`, `repo`, `number`, and `after`
+variables object to `{{AUTOSKILLIT_TEMP}}/resolve-claims-review/thread_query.json`.
+Invoke the exact literal path in a later call:
 
 ```bash
-gh api graphql \
-  -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor}nodes{id isResolved comments(first:1){nodes{databaseId}}}}}}}' \
-  -F owner="$owner" \
-  -F repo="$repo" \
-  -F number=$number \
-  -F after=""
+gh api graphql --input "{{AUTOSKILLIT_TEMP}}/resolve-claims-review/thread_query.json"
 ```
 
 Build `comment_id_to_thread_id: dict[int, str]` map. Skip threads where `isResolved`
@@ -374,17 +372,16 @@ When configured, enforce max 3 iteration retry loop before exiting non-zero.
 Batch all thread resolutions into a single GraphQL request using aliased mutations.
 This reduces N requests (5 pts each = 5N pts) to 1 request (5 pts total).
 If `addressed_thread_ids` has more than 50 threads, chunk into batches of 50.
+Do not output prose between payload-write and GitHub calls or between chunks; immediately
+proceed to the next required call. For each chunk, build aliased `resolveReviewThread`
+mutations and a `variables` object containing the actual thread node IDs. Use a file-write
+tool in a separate completed tool call to write the
+bounded JSON payload to
+`{{AUTOSKILLIT_TEMP}}/resolve-claims-review/resolve_threads_chunk_0.json`, changing only
+the numeric suffix for later chunks. Invoke each literal path in a later tool call:
 
 ```bash
-# Build aliased mutation query for all addressed threads
-MUTATION_QUERY="mutation {"
-for i in $(seq 0 $((${#ADDRESSED_THREAD_IDS[@]} - 1))); do
-    tid="${ADDRESSED_THREAD_IDS[$i]}"
-    MUTATION_QUERY="${MUTATION_QUERY} resolve${i}: resolveReviewThread(input: {threadId: \"${tid}\"}) { thread { isResolved } }"
-done
-MUTATION_QUERY="${MUTATION_QUERY} }"
-
-gh api graphql -f query="${MUTATION_QUERY}"
+gh api graphql --input "{{AUTOSKILLIT_TEMP}}/resolve-claims-review/resolve_threads_chunk_0.json"
 ```
 
 Parse the response: for each `resolve${i}` alias key, check `thread.isResolved`.

--- a/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
@@ -136,16 +136,13 @@ gh api repos/{owner}/{repo}/pulls/{number}/reviews --paginate
 ```
 
 Fetch review thread node IDs using cursor-based pagination to handle PRs with more than
-100 threads:
+100 threads. Before each page, use a file-write tool in a separate completed tool call to
+write the bounded parameterized query and its `owner`, `repo`, `number`, and `after`
+variables object to `{{AUTOSKILLIT_TEMP}}/resolve-research-review/thread_query.json`.
+Invoke the exact literal path in a later call:
 
 ```bash
-# Fetch all pages; repeat with after=$endCursor while hasNextPage is true
-gh api graphql \
-  -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor}nodes{id isResolved comments(first:1){nodes{databaseId}}}}}}}' \
-  -F owner="$owner" \
-  -F repo="$repo" \
-  -F number=$number \
-  -F after=""
+gh api graphql --input "{{AUTOSKILLIT_TEMP}}/resolve-research-review/thread_query.json"
 ```
 
 Build `comment_id_to_thread_id: dict[int, str]` map. Skip threads where `isResolved`
@@ -359,17 +356,16 @@ When configured, enforce max 3 iteration retry loop before exiting non-zero.
 Batch all thread resolutions into a single GraphQL request using aliased mutations.
 This reduces N requests (5 pts each = 5N pts) to 1 request (5 pts total).
 If `addressed_thread_ids` has more than 50 threads, chunk into batches of 50.
+Do not output prose between payload-write and GitHub calls or between chunks; immediately
+proceed to the next required call. For each chunk, build aliased `resolveReviewThread`
+mutations and a `variables` object containing the actual thread node IDs. Use a file-write
+tool in a separate completed tool call to write the
+bounded JSON payload to
+`{{AUTOSKILLIT_TEMP}}/resolve-research-review/resolve_threads_chunk_0.json`, changing only
+the numeric suffix for later chunks. Invoke each literal path in a later tool call:
 
 ```bash
-# Build aliased mutation query for all addressed threads
-MUTATION_QUERY="mutation {"
-for i in $(seq 0 $((${#ADDRESSED_THREAD_IDS[@]} - 1))); do
-    tid="${ADDRESSED_THREAD_IDS[$i]}"
-    MUTATION_QUERY="${MUTATION_QUERY} resolve${i}: resolveReviewThread(input: {threadId: \"${tid}\"}) { thread { isResolved } }"
-done
-MUTATION_QUERY="${MUTATION_QUERY} }"
-
-gh api graphql -f query="${MUTATION_QUERY}"
+gh api graphql --input "{{AUTOSKILLIT_TEMP}}/resolve-research-review/resolve_threads_chunk_0.json"
 ```
 
 Parse the response: for each `resolve${i}` alias key, check `thread.isResolved`.

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -240,16 +240,20 @@ gh api repos/{owner}/{repo}/pulls/{number}/reviews --paginate
 ```
 
 Fetch review thread node IDs (needed for thread resolution in Step 6) using
-cursor-based pagination to handle PRs with more than 100 threads:
+cursor-based pagination to handle PRs with more than 100 threads. Before each page, use a
+file-write tool in a separate completed tool call to write the bounded parameterized query
+and its `owner`, `repo`, `number`, and `after` variables object to
+`{{AUTOSKILLIT_TEMP}}/resolve-review/thread_query.json`. Invoke the literal path later:
+
+```json
+{
+  "query": "query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor}nodes{isResolved comments(first:5){nodes{databaseId body}}}}}}}",
+  "variables": {"owner": "owner", "repo": "repo", "number": 1, "after": null}
+}
+```
 
 ```bash
-# Fetch all pages; repeat with after=$endCursor while hasNextPage is true
-gh api graphql \
-  -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor}nodes{id isResolved comments(first:5){nodes{databaseId body}}}}}}}' \
-  -F owner="$owner" \
-  -F repo="$repo" \
-  -F number=$number \
-  -F after=""
+gh api graphql --input "{{AUTOSKILLIT_TEMP}}/resolve-review/thread_query.json"
 ```
 
 Collect all `nodes` across pages into a single list. Continue fetching while
@@ -698,7 +702,7 @@ Batch all thread resolutions into a single GraphQL request using aliased mutatio
 This reduces N requests (5 pts each = 5N pts) to 1 request (5 pts total).
 If `addressed_thread_ids` has more than 50 threads, chunk into batches of 50.
 
-```text
+```bash
 gh api graphql -f query='mutation {
   resolve0: resolveReviewThread(input: {threadId: "PRRT_literal_node_id_0"}) {
     thread { isResolved }

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1114,7 +1114,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "(issue #4479).",
     ),
     "hooks/_command_classification.py": (
-        1900,
+        2050,
         "REQ-CNST-010-E10: shared command-classification primitive consumed by all "
         "command-inspecting guards — tokenization, shell-payload extraction, "
         "interpreter-write detection, protected-path reads, recursive payload "
@@ -1125,7 +1125,9 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "_segment_has_possible_github_exec_token, "
         "_segments_have_possible_github_exec_token, "
         "_segments_have_dispatch_word_exec_risk, and _gh_args_have_bare_help_flag "
-        "must stay adjacent to the tokenizer they share.",
+        "must stay adjacent to the tokenizer they share. Bumped to 2050 so gh issue "
+        "edit's target/flag grammar and statically proven fan-out count remain beside "
+        "the mutation aggregation authority they feed.",
     ),
     "session.py": (
         1060,

--- a/tests/contracts/test_prepare_issue_contracts.py
+++ b/tests/contracts/test_prepare_issue_contracts.py
@@ -25,7 +25,11 @@ def _lines():
 
 def _label_step() -> str:
     text = SKILL_MD.read_text()
-    return text.split("### Step 9: Label Application", 1)[1].split("## Critical Constraints", 1)[0]
+    _, start, remainder = text.partition("### Step 9: Label Application")
+    assert start, "prepare-issue label application section is missing"
+    step, end, _ = remainder.partition("## Critical Constraints")
+    assert end, "prepare-issue critical constraints section is missing"
+    return step
 
 
 def test_label_step_inventories_then_batches_only_missing_definitions():

--- a/tests/contracts/test_prepare_issue_contracts.py
+++ b/tests/contracts/test_prepare_issue_contracts.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
 import pytest
 
 from autoskillit.core.io import load_yaml
+from autoskillit.hooks._command_classification import (
+    GitHubMutationStatus,
+    analyze_github_mutations,
+)
 
 pytestmark = [pytest.mark.layer("contracts"), pytest.mark.medium]
 
@@ -18,11 +23,76 @@ def _lines():
     return SKILL_MD.read_text().splitlines()
 
 
-def test_label_create_calls_include_force():
-    """All gh label create calls in prepare-issue must include --force."""
-    for line in _lines():
-        if "gh label create" in line:
-            assert "--force" in line, f"Missing --force in: {line}"
+def _label_step() -> str:
+    text = SKILL_MD.read_text()
+    return text.split("### Step 9: Label Application", 1)[1].split("## Critical Constraints", 1)[0]
+
+
+def test_label_step_inventories_then_batches_only_missing_definitions():
+    step = _label_step()
+
+    assert step.index("gh label list") < step.index("createLabel")
+    assert "gh label create" not in step
+    assert "--force" not in step
+    assert step.count("gh api graphql --input") == 1
+    assert "separate completed tool call" in step
+
+
+def test_label_step_applies_route_and_type_in_one_issue_edit():
+    step = _label_step()
+
+    assert step.count("gh issue edit") == 1
+    assert step.count("--add-label") == 2
+    assert '"${ROUTE_LABEL}"' in step
+    assert '"${ISSUE_TYPE_LABEL}"' in step
+
+
+def test_old_six_write_shape_is_denied() -> None:
+    command = " && ".join(
+        [
+            'gh label create "recipe:implementation" --force',
+            'gh label create "recipe:remediation" --force',
+            'gh label create "bug" --force',
+            'gh label create "enhancement" --force',
+            'gh issue edit 42 --add-label "recipe:implementation"',
+            'gh issue edit 42 --add-label "bug"',
+        ]
+    )
+
+    analysis = analyze_github_mutations(command)
+
+    assert analysis.status is GitHubMutationStatus.MULTIPLE
+    assert analysis.request_count == 6
+
+
+def test_revised_label_mutations_are_independently_guard_compatible(tmp_path: Path) -> None:
+    payload = tmp_path / "labels.json"
+    payload.write_text(
+        json.dumps(
+            {
+                "query": (
+                    "mutation Labels($repo: ID!, $name: String!) { "
+                    "missing: createLabel(input: {repositoryId: $repo, name: $name, "
+                    'color: "d73a4a"}) { label { id } } }'
+                ),
+                "variables": {"repo": "R_1", "name": "bug"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    definition = analyze_github_mutations(
+        f"gh api graphql --input {payload}",
+        cwd=str(tmp_path),
+    )
+    application = analyze_github_mutations(
+        'gh issue edit 42 --add-label "recipe:implementation" --add-label "bug"'
+    )
+
+    assert definition.status is GitHubMutationStatus.SINGLE_RESOLVED
+    assert definition.request_count == 1
+    assert application.status is GitHubMutationStatus.SINGLE_RESOLVED
+    assert application.request_count == 1
 
 
 def test_no_batch_labels_applied():

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -1142,6 +1142,92 @@ class TestAnalyzeGitHubMutations:
         assert analysis.status is GitHubMutationStatus.SINGLE_RESOLVED
         assert analysis.mutations[0].kind is GitHubMutationKind.OTHER
 
+    @pytest.mark.parametrize(
+        ("document", "expected_status", "expected_kind"),
+        [
+            (
+                "mutation Batch($ids: [ID!]!, $body: String!) { "
+                "first: addComment(input: {subjectId: $ids, body: $body}) "
+                "{ clientMutationId } second: addComment(input: "
+                "{subjectId: $ids, body: $body}) { clientMutationId } }",
+                GitHubMutationStatus.SINGLE_RESOLVED,
+                GitHubMutationKind.OTHER,
+            ),
+            (
+                "mutation Publish($id: ID!) { review: submitPullRequestReview("
+                "input: {pullRequestReviewId: $id, event: COMMENT}) "
+                "{ clientMutationId } }",
+                GitHubMutationStatus.SINGLE_RESOLVED,
+                GitHubMutationKind.GRAPHQL_REVIEW,
+            ),
+            (
+                "query Nodes($ids: [ID!]!) { nodes(ids: $ids) { id } }",
+                GitHubMutationStatus.NONE,
+                None,
+            ),
+        ],
+        ids=["aliased-mutation", "review-mutation", "read-only-query"],
+    )
+    def test_literal_graphql_input_preserves_document_provenance(
+        self,
+        document: str,
+        expected_status: GitHubMutationStatus,
+        expected_kind: GitHubMutationKind | None,
+        tmp_path: Path,
+    ) -> None:
+        payload = tmp_path / "graphql.json"
+        payload.write_text(
+            json.dumps(
+                {
+                    "query": document,
+                    "variables": {"ids": ["I_1", "I_2"], "body": "[literal] $value"},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        analysis = analyze_github_mutations(
+            "gh api graphql --input graphql.json",
+            cwd=str(tmp_path),
+        )
+
+        assert analysis.status is expected_status
+        if expected_kind is None:
+            assert analysis.request_count == 0
+        else:
+            assert analysis.request_count == 1
+            assert analysis.mutations[0].kind is expected_kind
+
+    def test_input_without_query_does_not_authorize_inline_graphql(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / "variables.json").write_text(
+            json.dumps({"variables": {"id": "I_1"}}),
+            encoding="utf-8",
+        )
+
+        analysis = analyze_github_mutations(
+            "gh api graphql --input variables.json "
+            "'-f' 'query=mutation($id: ID!) { deleteIssue(input: {issueId: $id}) "
+            "{ clientMutationId } }'",
+            cwd=str(tmp_path),
+        )
+
+        assert analysis.status is GitHubMutationStatus.UNRESOLVED
+        assert analysis.request_count is None
+
+    def test_fully_literal_inline_aliased_graphql_mutation_remains_resolved(self) -> None:
+        document = (
+            'mutation { one: deleteIssue(input:{issueId:"I1"}) { clientMutationId } '
+            'two: deleteIssue(input:{issueId:"I2"}) { clientMutationId } }'
+        )
+
+        analysis = analyze_github_mutations(f"gh api graphql -f query={json.dumps(document)}")
+
+        assert analysis.status is GitHubMutationStatus.SINGLE_RESOLVED
+        assert analysis.request_count == 1
+
     def test_review_input_file_counts_comments_exactly(self, tmp_path: Path) -> None:
         payload = tmp_path / "review.json"
         payload.write_text(
@@ -1208,6 +1294,58 @@ class TestAnalyzeGitHubMutations:
         assert analysis.status is GitHubMutationStatus.SINGLE_RESOLVED
         assert analysis.mutations[0].kind is GitHubMutationKind.OTHER
         assert analysis.request_count == 1
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh issue edit 23 34 --add-label bug",
+            (
+                "gh issue edit https://github.com/o/r/issues/23 "
+                "https://github.com/o/r/issues/34 --title fixed"
+            ),
+        ],
+        ids=["numeric-targets", "url-targets"],
+    )
+    def test_issue_edit_counts_each_static_target(self, command: str) -> None:
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.status is GitHubMutationStatus.MULTIPLE
+        assert analysis.request_count == 2
+        assert analysis.mutations[0].request_count == 2
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh issue edit 23 --add-label bug --add-label urgent",
+            "gh issue edit --repo o/r 23 --body text --body-file path --milestone v1",
+            "gh issue edit -Ro/r 23 -bbody -Fpath -mv1 -ttitle",
+            "gh issue edit 23 --title=fixed --remove-project=Roadmap",
+            "gh issue edit --repo o/r -- 23",
+        ],
+        ids=["repeated", "separated", "attached-short", "equals", "terminator"],
+    )
+    def test_issue_edit_single_target_flag_grammar_is_one_request(self, command: str) -> None:
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.status is GitHubMutationStatus.SINGLE_RESOLVED
+        assert analysis.request_count == 1
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh issue edit --add-label bug",
+            "gh issue edit 23 --title",
+            "gh issue edit $ISSUE --title fixed",
+            "gh issue edit 23 --unknown value",
+            "gh issue edit -- --not-an-issue",
+        ],
+        ids=["zero-targets", "missing-value", "dynamic-target", "unknown-flag", "bad-target"],
+    )
+    def test_issue_edit_ambiguous_grammar_is_unresolved(self, command: str) -> None:
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.status is GitHubMutationStatus.UNRESOLVED
+        assert analysis.request_count is None
 
     def test_pr_review_stays_pull_review_kind_alongside_widened_verbs(self) -> None:
         analysis = analyze_github_mutations("gh pr review 5 --approve")

--- a/tests/hooks/test_github_mutation_guard.py
+++ b/tests/hooks/test_github_mutation_guard.py
@@ -251,6 +251,87 @@ def test_graphql_thread_resolution_remains_a_proven_nonpublication_mutation(
     assert _decision(event_factory(command, cwd=str(tmp_path)), monkeypatch) is None
 
 
+@pytest.mark.parametrize(
+    ("document", "expected_decision"),
+    [
+        (
+            "mutation Batch($ids: [ID!]!) { first: deleteIssue(input: "
+            "{issueId: $ids}) { clientMutationId } second: deleteIssue(input: "
+            "{issueId: $ids}) { clientMutationId } }",
+            None,
+        ),
+        (
+            "mutation Publish($id: ID!) { submitPullRequestReview(input: "
+            "{pullRequestReviewId: $id, event: COMMENT}) { clientMutationId } }",
+            "deny",
+        ),
+    ],
+    ids=["non-review", "review"],
+)
+def test_literal_graphql_input_file_uses_inspected_document_provenance(
+    document: str,
+    expected_decision: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "graphql.json").write_text(
+        json.dumps({"query": document, "variables": {"ids": ["I1", "I2"]}}),
+        encoding="utf-8",
+    )
+
+    decision = _decision(
+        _run_cmd_event("gh api graphql --input graphql.json", cwd=str(tmp_path)),
+        monkeypatch,
+    )
+
+    assert decision == expected_decision
+
+
+def test_multi_target_issue_edit_is_denied(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    result = _run_hook(
+        _run_cmd_event("gh issue edit 23 34 --add-label bug", cwd=str(tmp_path)),
+        monkeypatch,
+    )
+
+    assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "multiple_mutations" in result["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_unexpected_classifier_error_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from autoskillit.hooks.guards import github_mutation_guard
+
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("classifier failed")
+
+    monkeypatch.setattr(github_mutation_guard, "analyze_github_mutations", _raise)
+
+    result = _run_hook(_bash_event("gh issue edit 23 --title x", cwd=str(tmp_path)), monkeypatch)
+
+    assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "unresolved_mutation" in result["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+@pytest.mark.parametrize("raw", ["{bad", "[]"], ids=["malformed-json", "non-object"])
+def test_malformed_hook_input_remains_fail_open(
+    raw: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from autoskillit.hooks.guards.github_mutation_guard import main
+
+    monkeypatch.setattr("sys.stdin", io.StringIO(raw))
+    stdout = io.StringIO()
+    with pytest.raises(SystemExit), redirect_stdout(stdout):
+        main()
+
+    assert stdout.getvalue() == ""
+
+
 @pytest.mark.parametrize("event_factory", [_bash_event, _run_cmd_event], ids=["bash", "run-cmd"])
 def test_literal_review_input_file_is_still_denied(
     event_factory,

--- a/tests/recipe/test_rules_skill_content.py
+++ b/tests/recipe/test_rules_skill_content.py
@@ -3,6 +3,7 @@ hardcoded-origin-remote, and no-autoskillit-import-in-skill-python-block."""
 
 from __future__ import annotations
 
+import json
 import textwrap
 from pathlib import Path
 from unittest.mock import patch
@@ -1704,7 +1705,7 @@ def test_graphql_rule_fires_for_prose_without_same_section_invocation(tmp_path: 
     assert _GRAPHQL_RULE_ID in rule_ids
 
 
-def test_graphql_rule_does_not_fire_for_prose_with_same_section_invocation(
+def test_graphql_rule_fires_for_prose_with_stdin_invocation(
     tmp_path: Path,
 ) -> None:
     skill_md = textwrap.dedent(
@@ -1722,7 +1723,184 @@ def test_graphql_rule_does_not_fire_for_prose_with_same_section_invocation(
     )
     findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
     rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+    assert _GRAPHQL_RULE_ID in rule_ids
+
+
+def test_graphql_rule_accepts_literal_payload_with_variables_object(tmp_path: Path) -> None:
+    query = (
+        "mutation Create($repo: ID!, $title: String!) { "
+        "createIssue(input: {repositoryId: $repo, title: $title}) { issue { id } } }"
+    )
+    skill_md = textwrap.dedent(
+        """\
+        # graphql-skill
+
+        ## Workflow
+
+        Use a file-write tool in a separate completed tool call before invoking the payload.
+
+        ```graphql
+        mutation Create($repo: ID!, $title: String!) {
+          createIssue(input: {repositoryId: $repo, title: $title}) { issue { id } }
+        }
+        ```
+
+        ```json
+        {
+          "query": <QUERY_JSON>,
+          "variables": {"repo": "R_1", "title": "Issue"}
+        }
+        ```
+
+        ```bash
+        gh api graphql --input "/absolute/run/create.json"
+        ```
+        """
+    ).replace("<QUERY_JSON>", json.dumps(query))
+
+    findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+    rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+
     assert _GRAPHQL_RULE_ID not in rule_ids
+
+
+@pytest.mark.parametrize(
+    "bash_block",
+    [
+        'echo "$PAYLOAD" | gh api graphql --input -',
+        'QUERY="mutation { deleteIssue(input: {}) { clientMutationId } }"\n'
+        'gh api graphql -f query="$QUERY"',
+        'echo \'{"query":"mutation { deleteIssue(input: {}) { clientMutationId } }"}\' '
+        "> /absolute/run/payload.json && "
+        'gh api graphql --input "/absolute/run/payload.json"',
+        "cp /absolute/run/source.json /absolute/run/payload.json && "
+        'gh api graphql --input "/absolute/run/payload.json"',
+    ],
+    ids=["stdin", "shell-query", "same-command-write", "same-command-copy"],
+)
+def test_graphql_rule_rejects_unsafe_mutation_shapes(
+    tmp_path: Path,
+    bash_block: str,
+) -> None:
+    skill_md = textwrap.dedent(
+        f"""\
+        # graphql-skill
+
+        ## Workflow
+
+        Build a GraphQL mutation, using a separate completed tool call when a file is needed.
+
+        ```bash
+        {bash_block}
+        ```
+        """
+    )
+
+    findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+    rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+
+    assert _GRAPHQL_RULE_ID in rule_ids
+
+
+def test_graphql_rule_accepts_fully_literal_inline_mutation(tmp_path: Path) -> None:
+    skill_md = textwrap.dedent(
+        """\
+        # graphql-skill
+
+        ## Workflow
+
+        ```bash
+        gh api graphql \
+          -f query='mutation { deleteIssue(input: {issueId: "I_1"}) { clientMutationId } }'
+        ```
+        """
+    )
+
+    findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+    rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+
+    assert _GRAPHQL_RULE_ID not in rule_ids
+
+
+def test_graphql_rule_rejects_generated_named_mutation_with_dynamic_query(
+    tmp_path: Path,
+) -> None:
+    skill_md = textwrap.dedent(
+        """\
+        # graphql-skill
+
+        ## Workflow
+
+        Generate aliased GraphQL `deleteIssue` operations.
+
+        ```bash
+        gh api graphql -f query="$QUERY"
+        ```
+        """
+    )
+
+    findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+    rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+
+    assert _GRAPHQL_RULE_ID in rule_ids
+
+
+def test_graphql_rule_does_not_bind_variables_from_json_without_query(
+    tmp_path: Path,
+) -> None:
+    skill_md = textwrap.dedent(
+        """\
+        # graphql-skill
+
+        ## Workflow
+
+        Use a file-write tool in a separate completed tool call before invoking the payload.
+
+        ```graphql
+        mutation Delete($issue: ID!) {
+          deleteIssue(input: {issueId: $issue}) { clientMutationId }
+        }
+        ```
+
+        ```json
+        {"variables": {"issue": "I_1"}}
+        ```
+
+        ```bash
+        gh api graphql --input "/absolute/run/delete.json"
+        ```
+        """
+    )
+
+    findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+    rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+
+    assert _GRAPHQL_RULE_ID in rule_ids
+
+
+def test_graphql_rule_rejects_single_variables_blob(tmp_path: Path) -> None:
+    skill_md = textwrap.dedent(
+        """\
+        # graphql-skill
+
+        ## Workflow
+
+        ```graphql
+        query($owner: String!) { repository(owner: $owner, name: "repo") { id } }
+        ```
+
+        ```bash
+        gh api graphql \
+          -f query='query($owner: String!) { repository(owner: $owner, name: "repo") { id } }' \
+          -f variables='{"owner":"o"}'
+        ```
+        """
+    )
+
+    findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
+    rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
+
+    assert _GRAPHQL_RULE_ID in rule_ids
 
 
 def test_graphql_rule_fires_for_prose_in_different_section_than_invocation(

--- a/tests/recipe/test_rules_skill_content.py
+++ b/tests/recipe/test_rules_skill_content.py
@@ -1726,13 +1726,25 @@ def test_graphql_rule_fires_for_prose_with_stdin_invocation(
     assert _GRAPHQL_RULE_ID in rule_ids
 
 
-def test_graphql_rule_accepts_literal_payload_with_variables_object(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "bash_block",
+    [
+        'gh api graphql --input "/absolute/run/create.json"',
+        'echo "/absolute/run/create.json.bak"\ngh api graphql --input "/absolute/run/create.json"',
+    ],
+    ids=["literal-path", "longer-earlier-token"],
+)
+def test_graphql_rule_accepts_literal_payload_with_variables_object(
+    tmp_path: Path,
+    bash_block: str,
+) -> None:
     query = (
         "mutation Create($repo: ID!, $title: String!) { "
         "createIssue(input: {repositoryId: $repo, title: $title}) { issue { id } } }"
     )
-    skill_md = textwrap.dedent(
-        """\
+    skill_md = (
+        textwrap.dedent(
+            """\
         # graphql-skill
 
         ## Workflow
@@ -1753,10 +1765,13 @@ def test_graphql_rule_accepts_literal_payload_with_variables_object(tmp_path: Pa
         ```
 
         ```bash
-        gh api graphql --input "/absolute/run/create.json"
+        <BASH_BLOCK>
         ```
         """
-    ).replace("<QUERY_JSON>", json.dumps(query))
+        )
+        .replace("<QUERY_JSON>", json.dumps(query))
+        .replace("<BASH_BLOCK>", bash_block)
+    )
 
     findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
     rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -214,16 +214,15 @@ def test_without_success_key_no_success_is_noop() -> None:
 
 def test_build_prepare_skill_command_basic() -> None:
     """No labels, no dry_run → '/prepare-issue\\n\\nTitle: T\\n\\nBody:\\nB'."""
-    cmd = _build_prepare_skill_command("T", "B", "", None, False, False)
+    cmd = _build_prepare_skill_command("T", "B", "", False, False)
     assert cmd == "/prepare-issue\n\nTitle: T\n\nBody:\nB"
 
 
 def test_build_prepare_skill_command_with_flags() -> None:
-    """labels + dry_run + split → all flags in output."""
-    cmd = _build_prepare_skill_command("T", "B", "owner/repo", ["bug", "needs-triage"], True, True)
+    """repo + dry_run + split → supported flags in output."""
+    cmd = _build_prepare_skill_command("T", "B", "owner/repo", True, True)
     assert "--repo owner/repo" in cmd
-    assert "--label bug" in cmd
-    assert "--label needs-triage" in cmd
+    assert "--label" not in cmd
     assert "--dry-run" in cmd
     assert "--split" in cmd
 
@@ -390,6 +389,153 @@ async def test_prepare_issue_success(tool_ctx_kitchen_open) -> None:
     assert result["success"] is True
     assert result["status"] == "complete"
     assert result["issue_url"] == "https://github.com/o/r/issues/1"
+
+
+@pytest.mark.anyio
+async def test_prepare_issue_requires_client_before_creating_issue_for_additional_labels(
+    tool_ctx_kitchen_open,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_executor = AsyncMock()
+    monkeypatch.setattr(tool_ctx_kitchen_open, "executor", mock_executor)
+    monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", None)
+
+    result = json.loads(await prepare_issue("Title", "Body", labels=["bug"]))
+
+    assert result["success"] is False
+    assert "GitHub client not configured" in result["error"]
+    mock_executor.run.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_prepare_issue_applies_deduplicated_additional_labels_once(
+    tool_ctx_kitchen_open,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    block_data = {
+        "issue_url": "https://github.com/o/r/issues/7",
+        "issue_number": 7,
+        "labels_applied": ["recipe:implementation", "bug"],
+    }
+    output = f"---prepare-issue-result---\n{json.dumps(block_data)}\n---/prepare-issue-result---\n"
+    mock_executor = AsyncMock()
+    mock_executor.run.return_value = _make_skill_result(success=True, result=output)
+    mock_client = AsyncMock()
+    mock_client.add_labels.return_value = {
+        "success": True,
+        "labels": ["urgent", "recipe:implementation", "bug"],
+    }
+    mock_sleep = AsyncMock()
+    monkeypatch.setattr(tool_ctx_kitchen_open, "executor", mock_executor)
+    monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_issue_headless.asyncio.sleep",
+        mock_sleep,
+    )
+
+    result = json.loads(await prepare_issue("Title", "Body", labels=["bug", "urgent", "bug"]))
+
+    assert result["success"] is True
+    assert result["labels_applied"] == ["recipe:implementation", "bug", "urgent"]
+    mock_sleep.assert_awaited_once_with(1)
+    mock_client.add_labels.assert_awaited_once_with("o", "r", 7, ["bug", "urgent"])
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("issue_url", "issue_number"),
+    [
+        ("not-an-issue-url", 7),
+        ("https://github.com/o/r/issues/7/extra", 7),
+        ("https://github.com/o/r/issues/7", 8),
+    ],
+    ids=["malformed", "trailing-path", "number-mismatch"],
+)
+async def test_prepare_issue_rejects_invalid_created_issue_identity_before_labeling(
+    issue_url: str,
+    issue_number: int,
+    tool_ctx_kitchen_open,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    block_data = {"issue_url": issue_url, "issue_number": issue_number}
+    output = f"---prepare-issue-result---\n{json.dumps(block_data)}\n---/prepare-issue-result---\n"
+    mock_executor = AsyncMock()
+    mock_executor.run.return_value = _make_skill_result(success=True, result=output)
+    mock_client = AsyncMock()
+    monkeypatch.setattr(tool_ctx_kitchen_open, "executor", mock_executor)
+    monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
+
+    result = json.loads(await prepare_issue("Title", "Body", labels=["bug"]))
+
+    assert result["success"] is False
+    assert result["issue_url"] == issue_url
+    assert result["issue_number"] == issue_number
+    mock_client.add_labels.assert_not_called()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "label_result",
+    [
+        {"success": False, "error": "denied"},
+        {"success": True},
+        {"success": True, "labels": ["other"]},
+    ],
+    ids=["failure", "missing-labels", "requested-label-missing"],
+)
+async def test_prepare_issue_reports_post_creation_label_failure(
+    label_result: dict[str, object],
+    tool_ctx_kitchen_open,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    block_data = {
+        "issue_url": "https://github.com/o/r/issues/7",
+        "issue_number": 7,
+        "labels_applied": ["recipe:implementation"],
+    }
+    output = f"---prepare-issue-result---\n{json.dumps(block_data)}\n---/prepare-issue-result---\n"
+    mock_executor = AsyncMock()
+    mock_executor.run.return_value = _make_skill_result(success=True, result=output)
+    mock_client = AsyncMock()
+    mock_client.add_labels.return_value = label_result
+    monkeypatch.setattr(tool_ctx_kitchen_open, "executor", mock_executor)
+    monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_issue_headless.asyncio.sleep",
+        AsyncMock(),
+    )
+
+    result = json.loads(await prepare_issue("Title", "Body", labels=["bug"]))
+
+    assert result["success"] is False
+    assert result["status"] == "failed"
+    assert result["issue_url"] == "https://github.com/o/r/issues/7"
+    assert result["issue_number"] == 7
+
+
+@pytest.mark.anyio
+async def test_prepare_issue_dry_run_with_labels_needs_no_client_or_sleep(
+    tool_ctx_kitchen_open,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    block_data = {"dry_run": True, "labels_applied": ["recipe:implementation"]}
+    output = f"---prepare-issue-result---\n{json.dumps(block_data)}\n---/prepare-issue-result---\n"
+    mock_executor = AsyncMock()
+    mock_executor.run.return_value = _make_skill_result(success=True, result=output)
+    mock_sleep = AsyncMock()
+    monkeypatch.setattr(tool_ctx_kitchen_open, "executor", mock_executor)
+    monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", None)
+    monkeypatch.setattr(
+        "autoskillit.server.tools.tools_issue_headless.asyncio.sleep",
+        mock_sleep,
+    )
+
+    result = json.loads(await prepare_issue("Title", "Body", labels=["bug", "bug"], dry_run=True))
+
+    assert result["success"] is True
+    assert result["labels_applied"] == ["recipe:implementation", "bug"]
+    assert "--label" not in mock_executor.run.await_args.args[0]
+    mock_sleep.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -509,6 +509,7 @@ async def test_prepare_issue_reports_post_creation_label_failure(
 
     assert result["success"] is False
     assert result["status"] == "failed"
+    assert result["error"].startswith("Additional labels were not applied:")
     assert result["issue_url"] == "https://github.com/o/r/issues/7"
     assert result["issue_number"] == 7
 

--- a/tests/server/test_tools_label_validation.py
+++ b/tests/server/test_tools_label_validation.py
@@ -194,7 +194,13 @@ class TestPrepareIssueWhitelist:
 
         tool_ctx_kitchen_open.config.github.allowed_labels = ["bug", "enhancement"]
         mock_executor = AsyncMock()
-        payload = _json.dumps({"issue_url": "https://github.com/x/y/issues/1", "route": "impl"})
+        payload = _json.dumps(
+            {
+                "issue_url": "https://github.com/x/y/issues/1",
+                "issue_number": 1,
+                "route": "impl",
+            }
+        )
         mock_executor.run.return_value = SkillResult(
             success=True,
             result=f"{_PREPARE_RESULT_START}\n{payload}\n{_PREPARE_RESULT_END}",
@@ -207,6 +213,13 @@ class TestPrepareIssueWhitelist:
             stderr="",
         )
         tool_ctx_kitchen_open.executor = mock_executor
+        mock_client = AsyncMock()
+        mock_client.add_labels.return_value = {"success": True, "labels": ["bug"]}
+        monkeypatch.setattr(tool_ctx_kitchen_open, "github_client", mock_client)
+        monkeypatch.setattr(
+            "autoskillit.server.tools.tools_issue_headless.asyncio.sleep",
+            AsyncMock(),
+        )
 
         result = json.loads(
             await prepare_issue(
@@ -217,6 +230,7 @@ class TestPrepareIssueWhitelist:
         )
         assert result["success"] is True
         mock_executor.run.assert_awaited_once()
+        mock_client.add_labels.assert_awaited_once_with("x", "y", 1, ["bug"])
 
     @pytest.mark.anyio
     async def test_prepare_issue_no_labels_skips_validation(

--- a/tests/skills/test_file_audit_issues_contracts.py
+++ b/tests/skills/test_file_audit_issues_contracts.py
@@ -54,3 +54,39 @@ class TestFileAuditIssuesBodyDiscipline:
             "file-audit-issues must document a body size ceiling "
             "to prevent oversized issues from reaching GitHub"
         )
+
+
+class TestFileAuditIssuesMutationContracts:
+    def test_issue_creation_produces_node_id_maps(self) -> None:
+        text = _skill_text()
+
+        assert "issue { id number url }" in text
+        assert "alias-to-issue-ID map" in text
+        assert "ticket-body-file-to-issue-ID" in text
+
+    def test_label_ids_have_inventory_producers(self) -> None:
+        text = _skill_text()
+
+        inventory = text.index("gh label list --limit 1000 --json name,id")
+        creation = text.index("createLabel")
+        application = text.index("addLabelsToLabelable")
+        assert inventory < creation < application
+        assert "label-name-to-node-ID map" in text
+        assert "actual source label" in text
+
+    def test_graphql_mutations_use_prior_bounded_payload_files(self) -> None:
+        text = _skill_text()
+
+        assert "--input -" not in text
+        assert 'echo "$MUTATION_JSON"' not in text
+        assert 'echo "$LABEL_MUTATION"' not in text
+        assert text.count("separate completed tool call") >= 3
+        assert text.count('gh api graphql --input "/absolute/audit-run/') == 3
+
+    def test_mutation_chunks_retain_pacing_and_size(self) -> None:
+        text = _skill_text()
+
+        assert "chunked at 20 issues per" in text
+        assert "chunks of 20" in text
+        assert "sleep 1" in text
+        assert "one-second pacing between every consecutive mutating" in text

--- a/tests/skills/test_graphql_invocation_completeness.py
+++ b/tests/skills/test_graphql_invocation_completeness.py
@@ -12,6 +12,7 @@ Both detectors operate at ##-level section granularity.
 
 from __future__ import annotations
 
+import json
 import re
 import textwrap
 from pathlib import Path
@@ -21,6 +22,11 @@ import pytest
 
 import autoskillit.recipe._skill_helpers as _sh
 from autoskillit.core.paths import pkg_root
+from autoskillit.hooks._command_classification import (
+    GitHubMutationStatus,
+    analyze_github_mutations,
+)
+from autoskillit.hooks.guards.github_mutation_guard import ParsedHookCommand, decide
 from autoskillit.recipe._skill_placeholder_parser import (
     extract_bash_blocks,
     extract_graphql_blocks,
@@ -35,6 +41,27 @@ pytestmark = [pytest.mark.layer("skills"), pytest.mark.medium]
 _SKILLS_DIRS = [pkg_root() / "skills", pkg_root() / "skills_extended"]
 
 _GH_API_GRAPHQL_RE = re.compile(r"gh\s+api\s+graphql\b")
+_GRAPHQL_INPUT_RE = re.compile(r'--input(?:\s+|=)["\']?([^"\'\s]+)')
+
+_INPUT_PAYLOAD_STATUSES: dict[str, GitHubMutationStatus] = {
+    "apply_labels_chunk_0.json": GitHubMutationStatus.SINGLE_RESOLVED,
+    "auto_merge_query.json": GitHubMutationStatus.NONE,
+    "blocker_labels.json": GitHubMutationStatus.SINGLE_RESOLVED,
+    "create_issues_chunk_0.json": GitHubMutationStatus.SINGLE_RESOLVED,
+    "create_missing_labels.json": GitHubMutationStatus.SINGLE_RESOLVED,
+    "label_definitions.json": GitHubMutationStatus.SINGLE_RESOLVED,
+    "merge_queue_query.json": GitHubMutationStatus.NONE,
+    "pr_batch_0.json": GitHubMutationStatus.NONE,
+    "pr_bodies_batch_0.json": GitHubMutationStatus.NONE,
+    "pr_status_batch_0.json": GitHubMutationStatus.NONE,
+    "resolve_threads_chunk_0.json": GitHubMutationStatus.SINGLE_RESOLVED,
+    "thread_query.json": GitHubMutationStatus.NONE,
+    "watermark_query.json": GitHubMutationStatus.NONE,
+}
+_INLINE_GRAPHQL_STATUSES: dict[str, GitHubMutationStatus] = {
+    "resolve-review": GitHubMutationStatus.SINGLE_RESOLVED,
+    "review-pr": GitHubMutationStatus.NONE,
+}
 
 
 def _all_skill_dirs() -> list[Path]:
@@ -43,6 +70,70 @@ def _all_skill_dirs() -> list[Path]:
         if base.exists():
             dirs.extend(d for d in base.iterdir() if d.is_dir())
     return dirs
+
+
+def _materialize_graphql_input(
+    block: str,
+    *,
+    tmp_path: Path,
+) -> tuple[str, GitHubMutationStatus]:
+    substitutions: dict[str, str] = {
+        "{{AUTOSKILLIT_TEMP}}": str(tmp_path),
+        "/absolute/audit-run": str(tmp_path / "audit-run"),
+        "/absolute/project-temp": str(tmp_path),
+    }
+    command = block
+    for placeholder, replacement in substitutions.items():
+        command = command.replace(placeholder, replacement)
+
+    match = _GRAPHQL_INPUT_RE.search(command)
+    assert match is not None
+    payload_path = Path(match.group(1))
+    expected_status = _INPUT_PAYLOAD_STATUSES[payload_path.name]
+    query = (
+        'mutation { deleteIssue(input: {issueId: "I_1"}) { clientMutationId } }'
+        if expected_status is GitHubMutationStatus.SINGLE_RESOLVED
+        else "query { viewer { login } }"
+    )
+    payload_path.parent.mkdir(parents=True, exist_ok=True)
+    payload_path.write_text(json.dumps({"query": query, "variables": {}}), encoding="utf-8")
+    return command, expected_status
+
+
+def test_bundled_graphql_invocations_pass_runtime_guard(tmp_path: Path) -> None:
+    failures: list[str] = []
+
+    for skill_dir in _all_skill_dirs():
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.exists():
+            continue
+        for block in extract_bash_blocks(skill_md.read_text(encoding="utf-8")):
+            if not _GH_API_GRAPHQL_RE.search(block):
+                continue
+            match = _GRAPHQL_INPUT_RE.search(block)
+            if match is not None:
+                command, expected_status = _materialize_graphql_input(block, tmp_path=tmp_path)
+            else:
+                command = block
+                expected_status = _INLINE_GRAPHQL_STATUSES[skill_dir.name]
+
+            analysis = analyze_github_mutations(command, cwd=str(tmp_path))
+            decision = decide(ParsedHookCommand("bash", command, str(tmp_path), str(tmp_path), ()))
+            expected_count = 1 if expected_status is GitHubMutationStatus.SINGLE_RESOLVED else 0
+            if (
+                analysis.status is not expected_status
+                or analysis.request_count != expected_count
+                or not decision.allow
+            ):
+                failures.append(
+                    f"{skill_dir.name}: status={analysis.status.value}, "
+                    f"count={analysis.request_count}, reason={analysis.reason}, "
+                    f"decision={decision}"
+                )
+
+    assert not failures, "Bundled GraphQL invocations must pass the runtime guard:\n" + "\n".join(
+        f"  - {failure}" for failure in failures
+    )
 
 
 def test_graphql_blocks_have_matching_bash_invocations() -> None:
@@ -260,7 +351,7 @@ class TestProseGraphqlDetection:
         rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
         assert _GRAPHQL_RULE_ID in rule_ids
 
-    def test_prose_graphql_with_invocation_passes(self, tmp_path: Path) -> None:
+    def test_prose_graphql_with_stdin_invocation_fails(self, tmp_path: Path) -> None:
         skill_md = textwrap.dedent("""\
             # graphql-skill
 
@@ -274,7 +365,7 @@ class TestProseGraphqlDetection:
         """)
         findings = _write_graphql_skill_and_run_rules(tmp_path, skill_md)
         rule_ids = [f.rule for f in findings]  # type: ignore[union-attr]
-        assert _GRAPHQL_RULE_ID not in rule_ids
+        assert _GRAPHQL_RULE_ID in rule_ids
 
     def test_prose_graphql_under_h2_heading_detected(self, tmp_path: Path) -> None:
         """Prose GraphQL under a ## heading (not ### Step N) is caught."""


### PR DESCRIPTION
## Summary

The failure is a contract split, not a reason to weaken the mutation guard. Runtime enforcement counts statically proven GitHub mutation executions, bundled skills independently prescribe shell commands, recipe validation checks only whether GraphQL has a nearby invocation, and structured tool schemas can pass values that their delegated skills never consume. Those authorities currently disagree.

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/rectify/rectify_github_mutation_batching_contracts_2026-08-10_182737.md`

## Tracking Issue

Resolved [#4565](https://github.com/TalonT-Org/AutoSkillit/issues/4565). The issue was backfilled after this PR merged to preserve the completed work's tracking history.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
