### PR TITLE
Rectify: Codex `order` Runtime-Home Authority

### DIFF
--- a/src/autoskillit/cli/session/_session_cook.py
+++ b/src/autoskillit/cli/session/_session_cook.py
@@ -258,8 +258,8 @@ def cook(
         render_skill_contract_composition_failure(exc)
         raise SystemExit(1) from exc
     render_skill_catalog_exclusions(session_catalog.exclusions)
-    catalog_compilation = compile_session_skill_catalog(session_catalog, backend)
-    session_catalog = catalog_compilation.catalog
+    skill_compilation = compile_session_skill_catalog(session_catalog, backend)
+    session_catalog = skill_compilation.catalog
     requires_resolved_exploration_profile = any(
         vector.disposition is ExplorationVectorDisposition.MIGRATED
         and vector.applicability is ExplorationVectorApplicabilityId.ALWAYS
@@ -301,7 +301,7 @@ def cook(
         ) as projection_binding,
         session_mgr.managed_session(
             launch_id,
-            catalog_compilation,
+            skill_compilation,
             _build_cook_projection_context(
                 skills_provider,
                 session_catalog,

--- a/src/autoskillit/cli/session/_session_cook.py
+++ b/src/autoskillit/cli/session/_session_cook.py
@@ -122,7 +122,6 @@ def cook(
         resolve_ephemeral_root,
         resolve_persistent_session_roots,
         validate_skill_tier_roles,
-        write_skill_unavailability_metadata,
     )
 
     config = load_config()
@@ -302,7 +301,7 @@ def cook(
         ) as projection_binding,
         session_mgr.managed_session(
             launch_id,
-            session_catalog,
+            catalog_compilation,
             _build_cook_projection_context(
                 skills_provider,
                 session_catalog,
@@ -316,12 +315,6 @@ def cook(
             ),
         ) as managed_home,
     ):
-        write_skill_unavailability_metadata(
-            Path(managed_home.skills_dir.path),
-            backend=backend.name,
-            unavailable=catalog_compilation.unavailable,
-        )
-
         if isinstance(resume_spec, BareResume):
             backend.recover_cook_history()
             from autoskillit.cli.session._session_picker import pick_session

--- a/src/autoskillit/cli/session/_session_launch.py
+++ b/src/autoskillit/cli/session/_session_launch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -17,11 +17,19 @@ from autoskillit.core import (
     executable_binding_matches_current_file,
     plugin_launch_binding_scope,
     resolve_executable_launch_binding,
+    resolve_temp_dir,
+    temp_dir_display_str,
 )
 
 if TYPE_CHECKING:
-    from autoskillit.core import CodingAgentBackend, ResumeSpec
-    from autoskillit.workspace import EffectiveSkillCatalog, SkillExclusion
+    from autoskillit.cli.session._session_startup_trace import StartupTrace
+    from autoskillit.core import (
+        CodingAgentBackend,
+        ManagedSessionHome,
+        PluginLaunchBinding,
+        ResumeSpec,
+    )
+    from autoskillit.workspace import CompiledSessionSkillCatalog, SkillExclusion
 
 
 def render_skill_contract_composition_failure(exc: SkillContractError) -> None:
@@ -61,8 +69,13 @@ def _run_interactive_session(
     project_dir: Path | None = None,
     required_env: frozenset[str] | None = None,
     backend: CodingAgentBackend | None = None,
-    skill_catalog: EffectiveSkillCatalog | None = None,
+    skill_compilation: CompiledSessionSkillCatalog | None = None,
     default_base_branch: str = "main",
+    managed_home: ManagedSessionHome | None = None,
+    plugin_binding: PluginLaunchBinding | None = None,
+    retained_projection_binding: PluginLaunchBinding | None = None,
+    startup_trace: StartupTrace | None = None,
+    attempt: int | None = None,
 ) -> str | _InfraExitSignal | None:
     """Launch an interactive Claude Code session.
 
@@ -84,59 +97,51 @@ def _run_interactive_session(
             default_base_branch = configured_base_branch
 
     from autoskillit.cli.session._session_reload import consume_reload_sentinel
-    from autoskillit.cli.ui._terminal import terminal_guard
     from autoskillit.core import InfraExitCategory
 
-    _project_dir = project_dir if project_dir is not None else Path.cwd()
+    managed = managed_home is not None
+    if managed != (attempt is not None):
+        raise ValueError("managed home and attempt must be supplied together")
+    if managed and (attempt is None or attempt <= 0):
+        raise ValueError("managed attempt must be positive")
+    if managed and skill_compilation is None:
+        raise ValueError("managed home requires its retained skill compilation")
+    if managed and retained_projection_binding is None:
+        raise ValueError("managed home requires a retained projection binding")
+    if managed and startup_trace is None:
+        raise ValueError("managed home requires a launch-scoped startup trace")
+    if not managed and any(
+        value is not None for value in (plugin_binding, retained_projection_binding, startup_trace)
+    ):
+        raise ValueError("managed launch inputs are invalid for a raw session")
+
+    _project_dir = (project_dir if project_dir is not None else Path.cwd()).resolve()
     # Injected so PreToolUse guards can locate `.autoskillit/` state from the
     # orchestrating project root even when a command's own cwd points into a
     # sibling worktree with its own checked-in `.autoskillit/` — the production
     # signal resolve_state_root() (hooks/_hook_payload.py) checks first.
     extra_env = {**(extra_env or {}), AUTOSKILLIT_STATE_ROOT_ENV_VAR: str(_project_dir)}
-    if skill_catalog is not None:
-        from autoskillit.workspace import compile_session_skill_catalog
-
-        compilation = compile_session_skill_catalog(skill_catalog, backend)
-        skill_catalog = compilation.catalog
-        if compilation.unavailable:
-            unavailable_json = json.dumps(
-                compilation.unavailability_payload,
-                sort_keys=True,
-                separators=(",", ":"),
-            )
-            system_prompt = (
-                f"{system_prompt.rstrip()}\n\n"
-                f"<autoskillit_skill_unavailability>{unavailable_json}"
-                "</autoskillit_skill_unavailability>"
-            )
-    from autoskillit.cli._plugin_artifact import interactive_plugin_authority
-
-    artifact_authority, load_mode = interactive_plugin_authority(
-        backend=backend,
-        project_dir=_project_dir,
-        default_base_branch=default_base_branch,
-        skill_catalog=skill_catalog,
-        generated_home_available=False,
-    )
     tools_arg: tuple[str, ...] = (
         ("AskUserQuestion",) if backend.capabilities.skill_injection_capable else ()
     )
 
     from autoskillit.execution import assert_interactive_ordering
 
-    with plugin_launch_binding_scope(
-        authority=artifact_authority,
-        backend=backend,
-        load_mode=load_mode,
-    ) as binding:
-        final_resume_spec = resume_spec if resume_spec is not None else NoResume()
+    final_resume_spec = resume_spec if resume_spec is not None else NoResume()
+    if managed:
+        assert managed_home is not None
+        assert attempt is not None
+        assert retained_projection_binding is not None
+        assert startup_trace is not None
         candidate_spec = backend.build_interactive_cmd(
             initial_prompt=initial_message,
             resume_spec=final_resume_spec,
             system_prompt=system_prompt,
             env_extras=extra_env,
             required_env=required_env,
-            plugin_binding=binding,
+            plugin_binding=plugin_binding,
+            add_dirs=[managed_home.skills_dir],
+            generated_home=managed_home.generated_home,
             tools=tools_arg,
         )
         try:
@@ -153,21 +158,19 @@ def _run_interactive_session(
         except ValueError as exc:
             print(f"ERROR: {exc}", file=sys.stderr)
             sys.exit(1)
-        pre_launch_errors = backend.ensure_pre_launch(executable=executable)
-        if pre_launch_errors:
-            for err in pre_launch_errors:
-                print(f"ERROR: {err}", file=sys.stderr)
-            sys.exit(1)
-        spec = backend.build_interactive_cmd(
+        built_spec = backend.build_interactive_cmd(
             initial_prompt=initial_message,
             executable=executable,
             resume_spec=final_resume_spec,
             system_prompt=system_prompt,
             env_extras=extra_env,
             required_env=required_env,
-            plugin_binding=binding,
+            plugin_binding=plugin_binding,
+            add_dirs=[managed_home.skills_dir],
+            generated_home=managed_home.generated_home,
             tools=tools_arg,
         )
+        spec = replace(built_spec, cwd=str(_project_dir))
         assert_interactive_ordering(spec=spec)
         if not executable_binding_matches_current_file(executable):
             print(
@@ -175,18 +178,119 @@ def _run_interactive_session(
                 file=sys.stderr,
             )
             sys.exit(1)
-        cmd = [*spec.cmd]
-        with terminal_guard():
-            result = subprocess.run(
-                cmd,
-                env=spec.env,
-                cwd=str(executable.cwd),
-                pass_fds=spec.inherited_fds,
+        validation_errors = backend.validate_interactive_invocation(spec)
+        if validation_errors:
+            for error in validation_errors:
+                print(f"ERROR: {error}", file=sys.stderr)
+            sys.exit(1)
+
+        from autoskillit.cli.session._session_process import run_cook_attempt
+
+        with backend.cook_session_context(
+            session_home=managed_home.generated_home,
+            project_dir=_project_dir,
+            launch_id=managed_home.launch_id,
+            attempt=attempt,
+            current_resume_spec=final_resume_spec,
+        ) as attempt_handle:
+            startup_trace.record_attempt_anchor(
+                attempt=attempt,
+                view_id=attempt_handle.view_id,
             )
+            pass_fds = tuple(
+                dict.fromkeys(
+                    (
+                        *spec.inherited_fds,
+                        *managed_home.pass_fds,
+                        *retained_projection_binding.inherited_fds,
+                        *attempt_handle.pass_fds,
+                    )
+                )
+            )
+            managed_result = run_cook_attempt(
+                spec,
+                pass_fds=pass_fds,
+                on_spawn=attempt_handle.record_spawn,
+                on_reaped=attempt_handle.record_reaped,
+                trace=startup_trace,
+                observer=None,
+            )
+        returncode = managed_result.returncode
+    else:
+        from autoskillit.cli._plugin_artifact import interactive_plugin_authority
+        from autoskillit.cli.ui._terminal import terminal_guard
+
+        skill_catalog = skill_compilation.catalog if skill_compilation is not None else None
+        artifact_authority, load_mode = interactive_plugin_authority(
+            backend=backend,
+            project_dir=_project_dir,
+            default_base_branch=default_base_branch,
+            skill_catalog=skill_catalog,
+            generated_home_available=False,
+        )
+
+        with plugin_launch_binding_scope(
+            authority=artifact_authority,
+            backend=backend,
+            load_mode=load_mode,
+        ) as binding:
+            candidate_spec = backend.build_interactive_cmd(
+                initial_prompt=initial_message,
+                resume_spec=final_resume_spec,
+                system_prompt=system_prompt,
+                env_extras=extra_env,
+                required_env=required_env,
+                plugin_binding=binding,
+                tools=tools_arg,
+            )
+            try:
+                executable = resolve_executable_launch_binding(
+                    binary_name=backend.binary_name(),
+                    environment=candidate_spec.env,
+                    cwd=_project_dir,
+                    explicit_path_env=(
+                        "CLAUDE_CODE_EXECPATH"
+                        if "CLAUDE_CODE_EXECPATH" in candidate_spec.env
+                        else None
+                    ),
+                )
+            except ValueError as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                sys.exit(1)
+            pre_launch_errors = backend.ensure_pre_launch(executable=executable)
+            if pre_launch_errors:
+                for err in pre_launch_errors:
+                    print(f"ERROR: {err}", file=sys.stderr)
+                sys.exit(1)
+            spec = backend.build_interactive_cmd(
+                initial_prompt=initial_message,
+                executable=executable,
+                resume_spec=final_resume_spec,
+                system_prompt=system_prompt,
+                env_extras=extra_env,
+                required_env=required_env,
+                plugin_binding=binding,
+                tools=tools_arg,
+            )
+            assert_interactive_ordering(spec=spec)
+            if not executable_binding_matches_current_file(executable):
+                print(
+                    "ERROR: interactive executable changed after capability probing",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            with terminal_guard():
+                raw_result = subprocess.run(
+                    [*spec.cmd],
+                    env=spec.env,
+                    cwd=str(executable.cwd),
+                    pass_fds=spec.inherited_fds,
+                )
+        returncode = raw_result.returncode
     reload_session_id = consume_reload_sentinel(_project_dir)
     if reload_session_id is not None:
         return reload_session_id
-    if result.returncode != 0:
+    if returncode != 0:
         from autoskillit.core import ensure_project_temp
 
         state_dir = ensure_project_temp(_project_dir) / "session_state"
@@ -200,11 +304,11 @@ def _run_interactive_session(
             return _InfraExitSignal(
                 session_id=state.session_id, category=state.infra_exit_category
             )
-        sys.exit(result.returncode)
+        sys.exit(returncode)
     return None
 
 
-def _write_order_entry(project_dir: Path, recipe_name: str | None) -> dict[str, str]:
+def _write_order_entry(project_dir: Path, recipe_name: str | None) -> tuple[str, dict[str, str]]:
     import uuid
 
     from autoskillit.cli.session._session_constants import SESSION_TYPE_ORDER
@@ -217,7 +321,10 @@ def _write_order_entry(project_dir: Path, recipe_name: str | None) -> dict[str, 
 
     lid = uuid.uuid4().hex[:16]
     write_registry_entry(project_dir, lid, SESSION_TYPE_ORDER, recipe_name)
-    return {SESSION_TYPE_ENV_VAR: SessionType.ORCHESTRATOR.value, LAUNCH_ID_ENV_VAR: lid}
+    return lid, {
+        SESSION_TYPE_ENV_VAR: SessionType.ORCHESTRATOR.value,
+        LAUNCH_ID_ENV_VAR: lid,
+    }
 
 
 def _launch_cook_session(
@@ -228,43 +335,154 @@ def _launch_cook_session(
     resume_spec: ResumeSpec = NoResume(),
     project_dir: Path | None = None,
     required_env: frozenset[str],
-    backend: CodingAgentBackend | None = None,
-    skill_catalog: EffectiveSkillCatalog | None = None,
+    backend: CodingAgentBackend,
+    skill_compilation: CompiledSessionSkillCatalog,
+    launch_id: str,
+    default_base_branch: str,
+    workspace_temp_dir: str | None,
 ) -> None:
     """Launch an interactive Claude Code cook session with reload and infra-resume support."""
     _max_reloads = 10
     _max_infra_resumes = 3
+    launch_project_dir = (project_dir if project_dir is not None else Path.cwd()).resolve()
+    if skill_compilation.unavailable:
+        unavailable_json = json.dumps(
+            skill_compilation.unavailability_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        system_prompt = (
+            f"{system_prompt.rstrip()}\n\n"
+            f"<autoskillit_skill_unavailability>{unavailable_json}"
+            "</autoskillit_skill_unavailability>"
+        )
+
     current_resume_spec: ResumeSpec = resume_spec
     _current_initial_message = initial_message
     seen_reload_ids: set[str] = set()
     infra_resume_count = 0
-    while True:
-        session_signal = _run_interactive_session(
-            system_prompt,
-            initial_message=_current_initial_message,
-            extra_env=extra_env,
-            resume_spec=current_resume_spec,
-            project_dir=project_dir,
-            required_env=required_env,
-            backend=backend,
-            skill_catalog=skill_catalog,
-        )
-        if session_signal is None:
-            break
-        if isinstance(session_signal, _InfraExitSignal):
-            infra_resume_count += 1
-            if infra_resume_count >= _max_infra_resumes:
+
+    def run_loop(
+        *,
+        managed_home: ManagedSessionHome | None = None,
+        launch_binding: PluginLaunchBinding | None = None,
+        retained_binding: PluginLaunchBinding | None = None,
+        trace: StartupTrace | None = None,
+    ) -> None:
+        nonlocal current_resume_spec, _current_initial_message, infra_resume_count
+        attempt = 0
+        while True:
+            if managed_home is not None:
+                attempt += 1
+            session_signal = _run_interactive_session(
+                system_prompt,
+                initial_message=_current_initial_message,
+                extra_env=extra_env,
+                resume_spec=current_resume_spec,
+                project_dir=launch_project_dir,
+                required_env=required_env,
+                backend=backend,
+                skill_compilation=skill_compilation,
+                default_base_branch=default_base_branch,
+                managed_home=managed_home,
+                plugin_binding=launch_binding,
+                retained_projection_binding=retained_binding,
+                startup_trace=trace,
+                attempt=attempt if managed_home is not None else None,
+            )
+            if session_signal is None:
+                return
+            if isinstance(session_signal, _InfraExitSignal):
+                infra_resume_count += 1
+                if infra_resume_count >= _max_infra_resumes:
+                    raise SystemExit(
+                        f"Too many infrastructure resumes ({_max_infra_resumes} max). "
+                        f"Last exit: {session_signal.category}"
+                    )
+                current_resume_spec = NamedResume(session_id=session_signal.session_id)
+                _current_initial_message = None
+                continue
+            if len(seen_reload_ids) >= _max_reloads:
                 raise SystemExit(
-                    f"Too many infrastructure resumes ({_max_infra_resumes} max). "
-                    f"Last exit: {session_signal.category}"
+                    f"Too many reloads ({_max_reloads} max). Check for infinite loop."
                 )
-            current_resume_spec = NamedResume(session_id=session_signal.session_id)
+            if session_signal in seen_reload_ids:
+                raise SystemExit(f"Repeated reload_id {session_signal!r} — aborting.")
+            seen_reload_ids.add(session_signal)
+            current_resume_spec = NamedResume(session_id=session_signal)
             _current_initial_message = None
-            continue
-        if len(seen_reload_ids) >= _max_reloads:
-            raise SystemExit(f"Too many reloads ({_max_reloads} max). Check for infinite loop.")
-        if session_signal in seen_reload_ids:
-            raise SystemExit(f"Repeated reload_id {session_signal!r} — aborting.")
-        seen_reload_ids.add(session_signal)
-        current_resume_spec = NamedResume(session_id=session_signal)
-        _current_initial_message = None
+
+    if not backend.capabilities.session_dir_persistent:
+        run_loop()
+        return
+
+    from autoskillit.cli._plugin_artifact import interactive_plugin_authority
+    from autoskillit.cli.session._session_startup_trace import StartupTrace
+    from autoskillit.core import PluginLoadMode
+    from autoskillit.execution import all_backends
+    from autoskillit.workspace import (
+        DefaultSessionSkillManager,
+        SkillsDirectoryProvider,
+        resolve_ephemeral_root,
+        resolve_persistent_session_roots,
+    )
+
+    resolved_temp_dir = resolve_temp_dir(launch_project_dir, workspace_temp_dir)
+    persistent_roots = resolve_persistent_session_roots(
+        resolved_temp_dir,
+        all_backends(),
+        required_backend_names={backend.name},
+    )
+    provider = SkillsDirectoryProvider(
+        temp_dir_relpath=temp_dir_display_str(workspace_temp_dir),
+        default_base_branch=default_base_branch,
+    )
+    manager = DefaultSessionSkillManager(
+        provider,
+        resolve_ephemeral_root(),
+        persistent_roots=persistent_roots,
+    )
+    manager.cleanup_stale()
+    artifact_authority, launch_load_mode = interactive_plugin_authority(
+        backend=backend,
+        project_dir=launch_project_dir,
+        default_base_branch=default_base_branch,
+        skill_catalog=skill_compilation.catalog,
+        generated_home_available=True,
+        retain_projection_source=True,
+    )
+    projection_load_mode = (
+        launch_load_mode if launch_load_mode.consumes_artifact else PluginLoadMode.PROJECTED_HOME
+    )
+    with plugin_launch_binding_scope(
+        authority=artifact_authority,
+        backend=backend,
+        load_mode=projection_load_mode,
+    ) as projection_binding:
+        if projection_binding is None:
+            raise RuntimeError("retained projection mode did not produce a binding")
+        projection_context = provider.catalog_projection_context(
+            skill_compilation.catalog,
+            launch_project_dir,
+            backend=backend,
+            durable_scripts_root=projection_binding.identity.managed_path,
+        )
+        with manager.managed_session(
+            launch_id,
+            skill_compilation,
+            projection_context,
+        ) as managed_home:
+            trace = StartupTrace(launch_project_dir, launch_id, enabled=False)
+            trace.record_launch_anchor()
+            launch_binding = projection_binding if launch_load_mode.consumes_artifact else None
+            try:
+                run_loop(
+                    managed_home=managed_home,
+                    launch_binding=launch_binding,
+                    retained_binding=projection_binding,
+                    trace=trace,
+                )
+            except BaseException:
+                trace.close(status="failed")
+                raise
+            trace.close(status="success")

--- a/src/autoskillit/cli/session/_session_order.py
+++ b/src/autoskillit/cli/session/_session_order.py
@@ -31,7 +31,11 @@ from autoskillit.core import (
     pkg_root,
     resume_spec_from_cli,
 )
-from autoskillit.workspace import DefaultSkillResolver, validate_skill_tier_roles
+from autoskillit.workspace import (
+    DefaultSkillResolver,
+    compile_session_skill_catalog,
+    validate_skill_tier_roles,
+)
 
 if TYPE_CHECKING:
     from autoskillit.recipe import Recipe, RecipeInfo
@@ -167,6 +171,8 @@ def order(
         render_skill_contract_composition_failure(exc)
         raise SystemExit(1) from exc
     render_skill_catalog_exclusions(skill_catalog.exclusions)
+    skill_compilation = compile_session_skill_catalog(skill_catalog, backend)
+    skill_catalog = skill_compilation.catalog
     _resume = resume or (session_id is not None)
     resume_spec = resume_spec_from_cli(resume=_resume, session_id=session_id)
 
@@ -198,15 +204,19 @@ def order(
             if isinstance(resume_spec, NoResume)
             else ""
         )
+        launch_id, launch_env = _write_order_entry(project_dir, None)
         _launch_cook_session(
             system_prompt,
             initial_message=random.choice(_OPEN_KITCHEN_GREETINGS),
             resume_spec=resume_spec,
             project_dir=project_dir,
-            extra_env=_write_order_entry(project_dir, None),
+            extra_env=launch_env,
             required_env=ORDER_INTERACTIVE_REQUIRED_ENV,
             backend=backend,
-            skill_catalog=skill_catalog,
+            skill_compilation=skill_compilation,
+            launch_id=launch_id,
+            default_base_branch=config.branching.default_base_branch,
+            workspace_temp_dir=config.workspace.temp_dir,
         )
         return
 
@@ -249,15 +259,19 @@ def order(
                 if isinstance(resume_spec, NoResume)
                 else ""
             )
+            launch_id, launch_env = _write_order_entry(project_dir, None)
             _launch_cook_session(
                 system_prompt,
                 initial_message=random.choice(_OPEN_KITCHEN_GREETINGS),
                 resume_spec=resume_spec,
                 project_dir=project_dir,
-                extra_env=_write_order_entry(project_dir, None),
+                extra_env=launch_env,
                 required_env=ORDER_INTERACTIVE_REQUIRED_ENV,
                 backend=backend,
-                skill_catalog=skill_catalog,
+                skill_compilation=skill_compilation,
+                launch_id=launch_id,
+                default_base_branch=config.branching.default_base_branch,
+                workspace_temp_dir=config.workspace.temp_dir,
             )
             return
         elif resolved is None:
@@ -372,7 +386,8 @@ def order(
     if confirm.lower() in ("n", "no"):
         return
     greeting = random.choice(_COOK_GREETINGS).format(recipe_name=recipe)
-    _extra_env |= _write_order_entry(Path.cwd(), recipe)
+    launch_id, launch_env = _write_order_entry(project_dir, recipe)
+    _extra_env |= launch_env
     system_prompt = (
         _build_orchestrator_prompt(
             recipe,
@@ -394,5 +409,8 @@ def order(
         project_dir=project_dir,
         required_env=ORDER_INTERACTIVE_REQUIRED_ENV,
         backend=backend,
-        skill_catalog=skill_catalog,
+        skill_compilation=skill_compilation,
+        launch_id=launch_id,
+        default_base_branch=config.branching.default_base_branch,
+        workspace_temp_dir=config.workspace.temp_dir,
     )

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -734,6 +734,7 @@ from .types import CodexEventType as CodexEventType
 from .types import CodexItemType as CodexItemType
 from .types import CodingAgentBackend as CodingAgentBackend
 from .types import CommittedDispositionResolver as CommittedDispositionResolver
+from .types import CompiledSessionSkillCatalogAuthority as CompiledSessionSkillCatalogAuthority
 from .types import CompletionRequiredResolver as CompletionRequiredResolver
 from .types import ConcurrencySpec as ConcurrencySpec
 from .types import ConflictRejectedEffect as ConflictRejectedEffect
@@ -770,7 +771,6 @@ from .types import DispatchIdentity as DispatchIdentity
 from .types import DispatchRequestEvent as DispatchRequestEvent
 from .types import DurableArtifactWriterDef as DurableArtifactWriterDef
 from .types import DurableContextAdmissionPayload as DurableContextAdmissionPayload
-from .types import CompiledSessionSkillCatalogAuthority as CompiledSessionSkillCatalogAuthority
 from .types import EffectiveSkillCatalogAuthority as EffectiveSkillCatalogAuthority
 from .types import EffectiveSkillInvocationAuthority as EffectiveSkillInvocationAuthority
 from .types import EnvPolicy as EnvPolicy

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -770,6 +770,7 @@ from .types import DispatchIdentity as DispatchIdentity
 from .types import DispatchRequestEvent as DispatchRequestEvent
 from .types import DurableArtifactWriterDef as DurableArtifactWriterDef
 from .types import DurableContextAdmissionPayload as DurableContextAdmissionPayload
+from .types import CompiledSessionSkillCatalogAuthority as CompiledSessionSkillCatalogAuthority
 from .types import EffectiveSkillCatalogAuthority as EffectiveSkillCatalogAuthority
 from .types import EffectiveSkillInvocationAuthority as EffectiveSkillInvocationAuthority
 from .types import EnvPolicy as EnvPolicy

--- a/src/autoskillit/core/types/_type_protocols_backend.py
+++ b/src/autoskillit/core/types/_type_protocols_backend.py
@@ -21,7 +21,7 @@ from ._type_backend import (
     SkillSessionConfig,
 )
 from ._type_checkpoint import SessionCheckpoint
-from ._type_enums import ObserverStatus, OutputFormat
+from ._type_enums import ObserverStatus, OutputFormat, SkillExecutionRole
 from ._type_execution_identity import ExecutionIdentity
 from ._type_exploration import ExplorationRouterPlan
 from ._type_native_shell_capture import (
@@ -352,6 +352,7 @@ class CodingAgentBackend(Protocol):
         *,
         parent_sandbox_mode: str = "workspace-write",
         explorer_binding_env: Mapping[str, Mapping[str, str]] | None = None,
+        execution_role: SkillExecutionRole = SkillExecutionRole.SESSION,
     ) -> None: ...
 
     def refresh_explorer_binding_env(

--- a/src/autoskillit/core/types/_type_protocols_workspace.py
+++ b/src/autoskillit/core/types/_type_protocols_workspace.py
@@ -36,6 +36,7 @@ __all__ = [
     "PluginArtifactRetirementOwner",
     "PluginRetirementCoordinator",
     "CloneManager",
+    "CompiledSessionSkillCatalogAuthority",
     "EffectiveSkillCatalogAuthority",
     "EffectiveSkillInvocationAuthority",
     "ResolvedSkillAuthority",
@@ -221,6 +222,20 @@ class EffectiveSkillCatalogAuthority(Protocol):
 
 
 @runtime_checkable
+class CompiledSessionSkillCatalogAuthority(Protocol):
+    """Backend-filtered catalog plus deterministic omission metadata."""
+
+    @property
+    def backend(self) -> str: ...
+
+    @property
+    def catalog(self) -> EffectiveSkillCatalogAuthority: ...
+
+    @property
+    def unavailability_payload(self) -> Mapping[str, object]: ...
+
+
+@runtime_checkable
 class EffectiveSkillInvocationAuthority(Protocol):
     """Resolved root and complete executable closure crossing the IL-0 boundary."""
 
@@ -346,7 +361,7 @@ class SessionSkillManager(Protocol):
     def managed_session(
         self,
         session_id: str,
-        catalog: EffectiveSkillCatalogAuthority,
+        compilation: CompiledSessionSkillCatalogAuthority,
         projection_context: SkillProjectionContextAuthority,
     ) -> AbstractContextManager[ManagedSessionHome]: ...
 

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -59,6 +59,7 @@ from autoskillit.core import (
     SessionEvent,
     SessionLocator,
     SessionSummary,
+    SkillExecutionRole,
     SkillSemanticAdaptationResult,
     SkillSemanticPlan,
     SkillSessionConfig,
@@ -523,7 +524,9 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
         *,
         parent_sandbox_mode: str = "workspace-write",
         explorer_binding_env: Mapping[str, Mapping[str, str]] | None = None,
+        execution_role: SkillExecutionRole = SkillExecutionRole.SESSION,
     ) -> None:
+        del execution_role
         if explorer_binding_env:
             raise ValueError(_EXPLORER_BINDING_REJECTION_MESSAGE)
 

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -1352,9 +1352,7 @@ def _render_cli_auth_store(config_text: str, execution_role: SkillExecutionRole)
         )
     if key_indexes:
         del lines[key_indexes[0]]
-    table_start = next(
-        (i for i, line in enumerate(lines) if line.lstrip().startswith("[")), len(lines)
-    )
+        table_start -= 1
     lines.insert(table_start, 'cli_auth_credentials_store = "file"')
     updated = "\n".join(lines) + "\n"
     if tomllib.loads(updated).get("cli_auth_credentials_store") != "file":

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -2223,6 +2223,12 @@ class CodexBackend(BackendCmdBuilderBase):
                 explorer_mcp_transport=explorer_mcp_transport,
                 explorer_binding_env=shared_binding,
             )
+        finalized_config = tomllib.loads(rendered_parent_config)
+        if (
+            execution_role is SkillExecutionRole.ORCHESTRATOR
+            and finalized_config.get("cli_auth_credentials_store") != "file"
+        ):
+            raise ValueError("finalized ORCHESTRATOR config lost the file credential store")
         atomic_write(config_path, rendered_parent_config)
 
         auth_source = codex_home_source / "auth.json"
@@ -2261,12 +2267,6 @@ class CodexBackend(BackendCmdBuilderBase):
                 session_dir,
                 source_codex_home=codex_home_source,
             )
-        finalized_config = tomllib.loads(config_path.read_text(encoding="utf-8"))
-        if (
-            execution_role is SkillExecutionRole.ORCHESTRATOR
-            and finalized_config.get("cli_auth_credentials_store") != "file"
-        ):
-            raise ValueError("finalized ORCHESTRATOR config lost the file credential store")
 
     def refresh_explorer_binding_env(
         self,

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -75,6 +75,7 @@ from autoskillit.core import (
     SessionCheckpoint,
     SessionLocator,
     SessionSummary,
+    SkillExecutionRole,
     SkillSemanticAdaptationResult,
     SkillSemanticPlan,
     SkillSessionConfig,
@@ -1332,6 +1333,35 @@ def _render_parent_sandbox_config(config_text: str, sandbox_mode: str) -> str:
     return updated
 
 
+def _render_cli_auth_store(config_text: str, execution_role: SkillExecutionRole) -> str:
+    """Pin ORCHESTRATOR homes to the durable file credential store."""
+    if execution_role is not SkillExecutionRole.ORCHESTRATOR:
+        return config_text
+    lines = config_text.splitlines()
+    table_start = next(
+        (i for i, line in enumerate(lines) if line.lstrip().startswith("[")), len(lines)
+    )
+    key_indexes = [
+        i
+        for i, line in enumerate(lines[:table_start])
+        if line.split("=", 1)[0].strip() == "cli_auth_credentials_store"
+    ]
+    if len(key_indexes) > 1:
+        raise ValueError(
+            "generated Codex config has duplicate top-level cli_auth_credentials_store keys"
+        )
+    if key_indexes:
+        del lines[key_indexes[0]]
+    table_start = next(
+        (i for i, line in enumerate(lines) if line.lstrip().startswith("[")), len(lines)
+    )
+    lines.insert(table_start, 'cli_auth_credentials_store = "file"')
+    updated = "\n".join(lines) + "\n"
+    if tomllib.loads(updated).get("cli_auth_credentials_store") != "file":
+        raise ValueError("generated Codex config did not retain the file credential store")
+    return updated
+
+
 def _materialize_profile_skills(
     session_dir: Path,
     *,
@@ -2156,6 +2186,7 @@ class CodexBackend(BackendCmdBuilderBase):
         parent_sandbox_mode: str = "workspace-write",
         agent_defs: tuple[AgentDef, ...] | None = None,
         explorer_binding_env: Mapping[str, Mapping[str, str]] | None = None,
+        execution_role: SkillExecutionRole = SkillExecutionRole.SESSION,
     ) -> None:
         assert self.source_codex_home is not None
         codex_home_source = self.source_codex_home
@@ -2180,6 +2211,10 @@ class CodexBackend(BackendCmdBuilderBase):
             config_path.read_text(encoding="utf-8"),
             parent_sandbox_mode,
         )
+        rendered_parent_config = _render_cli_auth_store(
+            rendered_parent_config,
+            execution_role,
+        )
         if explorer_binding_envs:
             assert explorer_mcp_transport is not None
             shared_binding = next(iter(explorer_binding_envs.values()))
@@ -2192,13 +2227,13 @@ class CodexBackend(BackendCmdBuilderBase):
 
         auth_source = codex_home_source / "auth.json"
         auth_dest = session_dir / "auth.json"
-        if auth_source.exists():
-            auth_dest.symlink_to(auth_source.resolve(strict=True))
-            logger.debug(
-                "codex_auth_symlink",
-                src=str(auth_source),
-                dest=str(auth_dest),
-            )
+        auth_target = auth_source.resolve(strict=False)
+        auth_dest.symlink_to(auth_target)
+        logger.debug(
+            "codex_auth_symlink",
+            src=str(auth_target),
+            dest=str(auth_dest),
+        )
 
         env_source = codex_home_source / ".env"
         if env_source.exists():
@@ -2221,10 +2256,17 @@ class CodexBackend(BackendCmdBuilderBase):
             explorer_binding_envs=explorer_binding_envs,
         )
         logger.debug("codex_agents_registered", count=registered)
-        _materialize_profile_skills(
-            session_dir,
-            source_codex_home=codex_home_source,
-        )
+        if execution_role is SkillExecutionRole.SESSION:
+            _materialize_profile_skills(
+                session_dir,
+                source_codex_home=codex_home_source,
+            )
+        finalized_config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        if (
+            execution_role is SkillExecutionRole.ORCHESTRATOR
+            and finalized_config.get("cli_auth_credentials_store") != "file"
+        ):
+            raise ValueError("finalized ORCHESTRATOR config lost the file credential store")
 
     def refresh_explorer_binding_env(
         self,

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -937,10 +937,9 @@ class DefaultSessionSkillManager:
             effective_catalog = compilation.catalog
             records = tuple(effective_catalog.skills)
         elif backend is not None and effective_catalog is not None:
-            local_compilation = compile_session_skill_catalog(effective_catalog, backend)
-            effective_catalog = local_compilation.catalog
+            compilation = compile_session_skill_catalog(effective_catalog, backend)
+            effective_catalog = compilation.catalog
             records = tuple(effective_catalog.skills)
-            compilation = local_compilation
         elif backend is not None and projection_context.invocation is not None:
             for record in records:
                 plan = record.semantic_plan

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -24,6 +24,7 @@ from autoskillit.core import (
     ArtifactLease,
     ArtifactLeaseContention,
     ClaudeDirectoryConventions,
+    CompiledSessionSkillCatalogAuthority,
     EffectiveSkillCatalogAuthority,
     EffectiveSkillInvocationAuthority,
     ManagedSessionHome,
@@ -83,6 +84,7 @@ _ExplorerBindingEnvFactory: TypeAlias = Callable[[Path], _ExplorerBindingEnv | N
 
 class _SessionSetupKwargs(TypedDict):
     parent_sandbox_mode: str
+    execution_role: SkillExecutionRole
     explorer_binding_env: NotRequired[_ExplorerBindingEnv]
 
 
@@ -284,14 +286,15 @@ def compile_session_skill_catalog(
 def write_skill_unavailability_metadata(
     add_dir: Path,
     *,
-    backend: str | None,
-    unavailable: tuple[SkillUnavailableMetadata, ...],
+    compilation: CompiledSessionSkillCatalogAuthority | None,
+    backend: str | None = None,
 ) -> None:
     """Publish deterministic machine-readable SESSION catalog omissions."""
-    metadata = {
-        "backend": backend,
-        "unavailable": tuple(item.to_payload() for item in unavailable),
-    }
+    metadata = (
+        dict(compilation.unavailability_payload)
+        if compilation is not None
+        else {"backend": backend, "unavailable": ()}
+    )
     write_versioned_json(
         add_dir / "skill-unavailability.json",
         metadata,
@@ -379,6 +382,7 @@ def _link_generated_home_skill_view(
     projected_skills: Path,
     *,
     skills_subdir: Path,
+    execution_role: SkillExecutionRole,
 ) -> int:
     """Expose projected skills at a persistent backend's home discovery root."""
     discovery_root = generated_home / skills_subdir
@@ -390,6 +394,8 @@ def _link_generated_home_skill_view(
             raise SkillContractError(f"invalid projected session skill directory: {source}")
         target = discovery_root / source.name
         if os.path.lexists(target):
+            if execution_role is SkillExecutionRole.ORCHESTRATOR:
+                raise SkillContractError(f"orchestrator skill discovery collision at {target}")
             logger.debug(
                 "generated_home_skill_collision_preserved",
                 skill=source.name,
@@ -705,25 +711,32 @@ class DefaultSessionSkillManager:
     def managed_session(
         self,
         session_id: str,
-        catalog: EffectiveSkillCatalogAuthority,
+        compilation: CompiledSessionSkillCatalogAuthority,
         projection_context: SkillProjectionContextAuthority,
     ) -> Iterator[ManagedSessionHome]:
         """Yield an already-owned generated home and clean it exactly once."""
         self._validate_session_id(session_id)
-        if catalog.execution_role is not SkillExecutionRole.SESSION:
-            raise SkillContractError("L1 catalog materialization requires SESSION contracts")
+        catalog = compilation.catalog
+        if catalog.execution_role not in {
+            SkillExecutionRole.SESSION,
+            SkillExecutionRole.ORCHESTRATOR,
+        }:
+            raise SkillContractError(
+                "managed catalog materialization requires SESSION or ORCHESTRATOR contracts"
+            )
         for member in catalog.skills:
             if member.invalidities:
                 raise SkillContractError(
                     f"invalid materialization contract for {member.name!r}: "
                     f"{render_skill_invalidities(member.invalidities)}"
                 )
-            if member.execution_role is not SkillExecutionRole.SESSION:
+            if member.execution_role is not catalog.execution_role:
                 actual = (
                     member.execution_role.value if member.execution_role is not None else "invalid"
                 )
                 raise SkillContractError(
-                    f"L1 catalog materialization requires SESSION members; "
+                    f"managed catalog materialization requires {catalog.execution_role.value} "
+                    f"members; "
                     f"{member.name!r} is {actual}"
                 )
             validate_skill_capability_roles(
@@ -739,6 +752,7 @@ class DefaultSessionSkillManager:
             session_id,
             catalog.skills,
             projection_context,
+            compilation=compilation,
         )
         lease_fd = initialized.lease.fd if initialized.lease is not None else None
         if lease_fd is None:
@@ -799,6 +813,7 @@ class DefaultSessionSkillManager:
         records: tuple[SkillAuthority, ...],
         projection_context: SkillProjectionContextAuthority,
         *,
+        compilation: CompiledSessionSkillCatalogAuthority | None = None,
         explorer_binding_env: _ExplorerBindingEnv | None = None,
         explorer_binding_env_factory: _ExplorerBindingEnvFactory | None = None,
     ) -> _InitializedSession:
@@ -864,6 +879,7 @@ class DefaultSessionSkillManager:
                 records,
                 projection_context,
                 skills_subdir=skills_subdir,
+                compilation=compilation,
                 explorer_binding_env=explorer_binding_env,
                 explorer_binding_env_factory=explorer_binding_env_factory,
             )
@@ -907,6 +923,7 @@ class DefaultSessionSkillManager:
         projection_context: SkillProjectionContextAuthority,
         *,
         skills_subdir: Path,
+        compilation: CompiledSessionSkillCatalogAuthority | None = None,
         explorer_binding_env: _ExplorerBindingEnv | None = None,
         explorer_binding_env_factory: _ExplorerBindingEnvFactory | None = None,
     ) -> ValidatedAddDir:
@@ -915,13 +932,15 @@ class DefaultSessionSkillManager:
         skills_base = add_dir / skills_subdir
         skills_base.mkdir(parents=True, exist_ok=True)
 
-        unavailable: tuple[SkillUnavailableMetadata, ...] = ()
         effective_catalog = projection_context.catalog
-        if backend is not None and effective_catalog is not None:
-            compilation = compile_session_skill_catalog(effective_catalog, backend)
+        if compilation is not None:
             effective_catalog = compilation.catalog
             records = tuple(effective_catalog.skills)
-            unavailable = compilation.unavailable
+        elif backend is not None and effective_catalog is not None:
+            local_compilation = compile_session_skill_catalog(effective_catalog, backend)
+            effective_catalog = local_compilation.catalog
+            records = tuple(effective_catalog.skills)
+            compilation = local_compilation
         elif backend is not None and projection_context.invocation is not None:
             for record in records:
                 plan = record.semantic_plan
@@ -932,8 +951,14 @@ class DefaultSessionSkillManager:
 
         write_skill_unavailability_metadata(
             add_dir,
+            compilation=compilation,
             backend=backend.name if backend is not None else None,
-            unavailable=unavailable,
+        )
+
+        execution_role = (
+            effective_catalog.execution_role
+            if effective_catalog is not None
+            else SkillExecutionRole.SESSION
         )
 
         if backend is not None and backend.capabilities.mcp_config_capable:
@@ -945,6 +970,7 @@ class DefaultSessionSkillManager:
         if backend is not None:
             setup_kwargs: _SessionSetupKwargs = {
                 "parent_sandbox_mode": projection_context.parent_sandbox_mode,
+                "execution_role": execution_role,
             }
             if explorer_binding_env is not None:
                 setup_kwargs["explorer_binding_env"] = explorer_binding_env
@@ -972,17 +998,18 @@ class DefaultSessionSkillManager:
             ),
             projection_version=projection_context.projection_version,
         )
-        session_records = (
-            records
-            if backend is None
-            else tuple(record for record in records if record.source is not SkillSource.BUNDLED)
-        )
+        session_records = records
+        if backend is not None and execution_role is SkillExecutionRole.SESSION:
+            session_records = tuple(
+                record for record in records if record.source is not SkillSource.BUNDLED
+            )
         materialize_agent_skill_tree(skills_base, session_records, ungated_context)
         if backend is not None and backend.capabilities.session_dir_persistent:
             linked = _link_generated_home_skill_view(
                 generated_home,
                 skills_base,
                 skills_subdir=skills_subdir,
+                execution_role=execution_role,
             )
             logger.debug("generated_home_skill_view_linked", count=linked)
         if backend is not None and backend.capabilities.session_dir_persistent:

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -1522,6 +1522,9 @@ def test_default_classes_only_instantiated_inside_factory_or_allowlist() -> None
         Path("cli/session/_session_order.py"): {
             "DefaultSkillResolver"
         },  # interactive order launch composition
+        Path("cli/session/_session_launch.py"): {
+            "DefaultSessionSkillManager"
+        },  # managed order generated-home composition
         Path("cli/session/_session_backend.py"): {
             "DefaultLaunchResolver"
         },  # interactive backend-authority composition root

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1289,7 +1289,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "run_skill launch denial paths before command construction (+139 net lines)",
     ),
     "execution/backends/codex.py": (
-        2392,
+        2433,
         "REQ-CNST-010-E9: Codex backend — skill_sigil capability threading adds multi-line "
         "keyword args to _ensure_skill_prefix call sites and _has_prefix guard; "
         "write_guard_tool_names env injection adds 7 lines to _codex_exec_extras; "
@@ -1336,7 +1336,9 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "; #4488/#4489/#4492 explorer surface authority: setup_session_dir gains "
         "explorer-role TOML exclusion filter for unbound sessions (+7 net lines) and "
         "explicit session-scoped capability disposition (+1 net line); #4507 adds runtime "
-        "child cardinality rendering and protects the live-web bundled role (+12 net lines)",
+        "child cardinality rendering and protects the live-web bundled role (+12 net lines)"
+        "; #4566 pins ORCHESTRATOR file auth, durable auth linkage, and role-exact profile "
+        "materialization at the backend-owned generated-home setup boundary (+42 net lines)",
     ),
     "execution/backends/claude.py": (
         1250,
@@ -1353,7 +1355,8 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "#4233 keeps Claude task lifecycle normalization and immutable skill-session "
         "async hardening beside the backend parser and command builder that own them. "
         "#4557 adds Claude-only host-attestation env, version-derived annotation support, "
-        "and frozen attestation env at all 4 launch sites.",
+        "and frozen attestation env at all 4 launch sites; #4566 "
+        "adds execution-role protocol parity while preserving Claude behavior (+3 net lines).",
     ),
     "execution/headless/_headless_result.py": (
         1033,

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -16,22 +16,19 @@ import pytest
 
 @pytest.fixture
 def launch_kwargs() -> dict[str, object]:
-    """Return the canonical empty compiled-catalog launch inputs."""
+    """Return canonical launch inputs backed by the real session catalog."""
     from autoskillit.execution.backends.claude import ClaudeCodeBackend
-    from autoskillit.workspace import CompiledSessionSkillCatalog, EffectiveSkillCatalog
+    from autoskillit.workspace import (
+        DefaultSkillResolver,
+        compile_session_skill_catalog,
+    )
     from autoskillit.workspace.skills import SkillExecutionRole
 
     backend = ClaudeCodeBackend()
+    catalog = DefaultSkillResolver().list_effective(None, SkillExecutionRole.SESSION)
     return {
         "backend": backend,
-        "skill_compilation": CompiledSessionSkillCatalog(
-            backend=backend.name,
-            catalog=EffectiveSkillCatalog(
-                skills=(),
-                execution_role=SkillExecutionRole.SESSION,
-            ),
-            unavailable=(),
-        ),
+        "skill_compilation": compile_session_skill_catalog(catalog, backend),
         "launch_id": "test-order",
         "default_base_branch": "main",
         "workspace_temp_dir": None,

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -14,6 +14,30 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture
+def launch_kwargs() -> dict[str, object]:
+    """Return the canonical empty compiled-catalog launch inputs."""
+    from autoskillit.execution.backends.claude import ClaudeCodeBackend
+    from autoskillit.workspace import CompiledSessionSkillCatalog, EffectiveSkillCatalog
+    from autoskillit.workspace.skills import SkillExecutionRole
+
+    backend = ClaudeCodeBackend()
+    return {
+        "backend": backend,
+        "skill_compilation": CompiledSessionSkillCatalog(
+            backend=backend.name,
+            catalog=EffectiveSkillCatalog(
+                skills=(),
+                execution_role=SkillExecutionRole.SESSION,
+            ),
+            unavailable=(),
+        ),
+        "launch_id": "test-order",
+        "default_base_branch": "main",
+        "workspace_temp_dir": None,
+    }
+
+
 @pytest.fixture(autouse=True)
 def _patch_worktree_guard_for_hooks(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent the worktree guard and plugin-installed check from firing in tests."""

--- a/tests/cli/test_cook_env_scrub.py
+++ b/tests/cli/test_cook_env_scrub.py
@@ -17,7 +17,6 @@ import pytest
 
 from autoskillit.core import CmdSpec, ManagedSessionHome, ValidatedAddDir
 from autoskillit.execution.backends._backend_cmd_builder_base import SHARED_BASELINE_ENV
-from autoskillit.execution.backends.claude import ClaudeCodeBackend
 
 pytestmark = [
     pytest.mark.layer("cli"),
@@ -26,18 +25,10 @@ pytestmark = [
 ]
 
 
-def _launch_kwargs() -> dict[str, object]:
-    return {
-        "backend": ClaudeCodeBackend(),
-        "skill_compilation": SimpleNamespace(unavailable=(), catalog=None),
-        "launch_id": "test-order",
-        "default_base_branch": "main",
-        "workspace_temp_dir": None,
-    }
-
-
 def test_launch_cook_session_env_excludes_ide_vars(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    launch_kwargs: dict[str, object],
 ) -> None:
     monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
     monkeypatch.setenv("ENABLE_IDE_INTEGRATION", "true")
@@ -58,7 +49,7 @@ def test_launch_cook_session_env_excludes_ide_vars(
             "system prompt",
             initial_message="hello",
             required_env=frozenset(),
-            **_launch_kwargs(),
+            **launch_kwargs,
         )
 
     mock_run.assert_called_once()
@@ -71,7 +62,9 @@ def test_launch_cook_session_env_excludes_ide_vars(
 
 
 def test_launch_cook_session_extra_env_still_applied(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    launch_kwargs: dict[str, object],
 ) -> None:
     monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
 
@@ -89,7 +82,7 @@ def test_launch_cook_session_extra_env_still_applied(
             "system prompt",
             extra_env={"AUTOSKILLIT_SUBSETS__DISABLED": "@json []"},
             required_env=frozenset(),
-            **_launch_kwargs(),
+            **launch_kwargs,
         )
 
     env = mock_run.call_args.kwargs["env"]
@@ -99,6 +92,7 @@ def test_launch_cook_session_extra_env_still_applied(
 
 def test_launch_cook_session_env_has_max_mcp_output_tokens(
     monkeypatch: pytest.MonkeyPatch,
+    launch_kwargs: dict[str, object],
 ) -> None:
     """_launch_cook_session (order path) must produce env with MAX_MCP_OUTPUT_TOKENS."""
     from autoskillit.cli.session._session_launch import _launch_cook_session
@@ -115,7 +109,7 @@ def test_launch_cook_session_env_has_max_mcp_output_tokens(
             "system prompt",
             initial_message="hello",
             required_env=frozenset(),
-            **_launch_kwargs(),
+            **launch_kwargs,
         )
 
     env = mock_run.call_args.kwargs["env"]
@@ -124,6 +118,7 @@ def test_launch_cook_session_env_has_max_mcp_output_tokens(
 
 def test_launch_cook_session_env_has_mcp_connection_nonblocking(
     monkeypatch: pytest.MonkeyPatch,
+    launch_kwargs: dict[str, object],
 ) -> None:
     """_launch_cook_session (order path) must produce env with MCP_CONNECTION_NONBLOCKING=0."""
     from autoskillit.cli.session._session_launch import _launch_cook_session
@@ -140,7 +135,7 @@ def test_launch_cook_session_env_has_mcp_connection_nonblocking(
             "system prompt",
             initial_message="hello",
             required_env=frozenset(),
-            **_launch_kwargs(),
+            **launch_kwargs,
         )
 
     env = mock_run.call_args.kwargs["env"]

--- a/tests/cli/test_cook_env_scrub.py
+++ b/tests/cli/test_cook_env_scrub.py
@@ -17,12 +17,23 @@ import pytest
 
 from autoskillit.core import CmdSpec, ManagedSessionHome, ValidatedAddDir
 from autoskillit.execution.backends._backend_cmd_builder_base import SHARED_BASELINE_ENV
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 
 pytestmark = [
     pytest.mark.layer("cli"),
     pytest.mark.small,
     pytest.mark.usefixtures("_stub_interactive_prelaunch"),
 ]
+
+
+def _launch_kwargs() -> dict[str, object]:
+    return {
+        "backend": ClaudeCodeBackend(),
+        "skill_compilation": SimpleNamespace(unavailable=(), catalog=None),
+        "launch_id": "test-order",
+        "default_base_branch": "main",
+        "workspace_temp_dir": None,
+    }
 
 
 def test_launch_cook_session_env_excludes_ide_vars(
@@ -43,7 +54,12 @@ def test_launch_cook_session_env_excludes_ide_vars(
             return_value=MagicMock(returncode=0),
         ) as mock_run,
     ):
-        _launch_cook_session("system prompt", initial_message="hello", required_env=frozenset())
+        _launch_cook_session(
+            "system prompt",
+            initial_message="hello",
+            required_env=frozenset(),
+            **_launch_kwargs(),
+        )
 
     mock_run.assert_called_once()
     env = mock_run.call_args.kwargs["env"]
@@ -73,6 +89,7 @@ def test_launch_cook_session_extra_env_still_applied(
             "system prompt",
             extra_env={"AUTOSKILLIT_SUBSETS__DISABLED": "@json []"},
             required_env=frozenset(),
+            **_launch_kwargs(),
         )
 
     env = mock_run.call_args.kwargs["env"]
@@ -94,7 +111,12 @@ def test_launch_cook_session_env_has_max_mcp_output_tokens(
             return_value=MagicMock(returncode=0),
         ) as mock_run,
     ):
-        _launch_cook_session("system prompt", initial_message="hello", required_env=frozenset())
+        _launch_cook_session(
+            "system prompt",
+            initial_message="hello",
+            required_env=frozenset(),
+            **_launch_kwargs(),
+        )
 
     env = mock_run.call_args.kwargs["env"]
     assert env["MAX_MCP_OUTPUT_TOKENS"] == SHARED_BASELINE_ENV["MAX_MCP_OUTPUT_TOKENS"]
@@ -114,7 +136,12 @@ def test_launch_cook_session_env_has_mcp_connection_nonblocking(
             return_value=MagicMock(returncode=0),
         ) as mock_run,
     ):
-        _launch_cook_session("system prompt", initial_message="hello", required_env=frozenset())
+        _launch_cook_session(
+            "system prompt",
+            initial_message="hello",
+            required_env=frozenset(),
+            **_launch_kwargs(),
+        )
 
     env = mock_run.call_args.kwargs["env"]
     assert env["MCP_CONNECTION_NONBLOCKING"] == "0"

--- a/tests/cli/test_cook_ide_isolation.py
+++ b/tests/cli/test_cook_ide_isolation.py
@@ -15,12 +15,9 @@ the child must NOT attach to the IDE channel via either discovery path:
 from __future__ import annotations
 
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-from autoskillit.execution.backends.claude import ClaudeCodeBackend
 
 pytestmark = [
     pytest.mark.layer("cli"),
@@ -30,7 +27,9 @@ pytestmark = [
 
 
 def test_cook_session_ignores_ide_lock_file(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    launch_kwargs: dict[str, object],
 ) -> None:
     """Launch cook under simulated IDE state; assert env scrub + auto-connect disable."""
     fake_home = tmp_path / "home"
@@ -59,11 +58,7 @@ def test_cook_session_ignores_ide_lock_file(
             "system prompt",
             initial_message="hello",
             required_env=frozenset(),
-            backend=ClaudeCodeBackend(),
-            skill_compilation=SimpleNamespace(unavailable=(), catalog=None),
-            launch_id="test-order",
-            default_base_branch="main",
-            workspace_temp_dir=None,
+            **launch_kwargs,
         )
 
     # (1) Env scrub

--- a/tests/cli/test_cook_ide_isolation.py
+++ b/tests/cli/test_cook_ide_isolation.py
@@ -15,9 +15,12 @@ the child must NOT attach to the IDE channel via either discovery path:
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 
 pytestmark = [
     pytest.mark.layer("cli"),
@@ -52,7 +55,16 @@ def test_cook_session_ignores_ide_lock_file(
             return_value=MagicMock(returncode=0),
         ) as mock_run,
     ):
-        _launch_cook_session("system prompt", initial_message="hello", required_env=frozenset())
+        _launch_cook_session(
+            "system prompt",
+            initial_message="hello",
+            required_env=frozenset(),
+            backend=ClaudeCodeBackend(),
+            skill_compilation=SimpleNamespace(unavailable=(), catalog=None),
+            launch_id="test-order",
+            default_base_branch="main",
+            workspace_temp_dir=None,
+        )
 
     # (1) Env scrub
     env = mock_run.call_args.kwargs["env"]

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -19,8 +19,8 @@ from autoskillit.core import (
     SESSION_TYPE_ENV_VAR,
     BackendConventions,
     CmdSpec,
+    CompiledSessionSkillCatalogAuthority,
     CookSessionHandle,
-    EffectiveSkillCatalogAuthority,
     HookTrustPolicy,
     ManagedSessionHome,
     NamedResume,
@@ -163,11 +163,11 @@ def _install_harness(
     @contextmanager
     def managed_session(
         launch_id: str,
-        catalog: EffectiveSkillCatalogAuthority,
+        compilation: CompiledSessionSkillCatalogAuthority,
         projection_context: SkillProjectionContextAuthority,
     ):
-        events.append(("managed-enter", launch_id, catalog, projection_context))
-        assert projection_context.catalog == catalog
+        events.append(("managed-enter", launch_id, compilation.catalog, projection_context))
+        assert projection_context.catalog == compilation.catalog
         try:
             yield ManagedSessionHome(
                 launch_id=launch_id,
@@ -529,10 +529,10 @@ def test_cook_final_confirmation_precedes_registry_and_attempt(
     @contextmanager
     def managed_session(
         launch_id: str,
-        catalog: EffectiveSkillCatalogAuthority,
+        compilation: CompiledSessionSkillCatalogAuthority,
         projection_context: SkillProjectionContextAuthority,
     ):
-        assert projection_context.catalog == catalog
+        assert projection_context.catalog == compilation.catalog
         events.append(("managed-enter", launch_id))
         try:
             yield ManagedSessionHome(

--- a/tests/cli/test_cook_order_command.py
+++ b/tests/cli/test_cook_order_command.py
@@ -592,6 +592,20 @@ def test_session_order_launch_calls_pass_order_interactive_required_env() -> Non
         )
 
 
+def test_session_order_launch_calls_pass_explicit_home_authorities() -> None:
+    required = {
+        "skill_compilation",
+        "launch_id",
+        "default_base_branch",
+        "workspace_temp_dir",
+    }
+    for call in _launch_cook_session_calls():
+        supplied = {keyword.arg for keyword in call.keywords}
+        assert required <= supplied, (
+            f"Call at line {call.lineno} is missing {sorted(required - supplied)}"
+        )
+
+
 def test_launch_cook_session_required_env_is_required_keyword_only() -> None:
     """required_env must be a keyword-only parameter with no default — omission must be
     a language/type-checking error, not silently accepted as None."""

--- a/tests/cli/test_cook_order_command.py
+++ b/tests/cli/test_cook_order_command.py
@@ -631,17 +631,27 @@ def test_session_order_launch_calls_pass_order_interactive_required_env() -> Non
 
 
 def test_session_order_launch_calls_pass_explicit_home_authorities() -> None:
-    required = {
-        "skill_compilation",
-        "launch_id",
-        "default_base_branch",
-        "workspace_temp_dir",
+    import ast
+
+    expected_values = {
+        "skill_compilation": "skill_compilation",
+        "launch_id": "launch_id",
+        "default_base_branch": "config.branching.default_base_branch",
+        "workspace_temp_dir": "config.workspace.temp_dir",
     }
     for call in _launch_cook_session_calls():
-        supplied = {keyword.arg for keyword in call.keywords}
-        assert required <= supplied, (
-            f"Call at line {call.lineno} is missing {sorted(required - supplied)}"
+        supplied = {keyword.arg: keyword.value for keyword in call.keywords}
+        assert expected_values.keys() <= supplied.keys(), (
+            f"Call at line {call.lineno} is missing "
+            f"{sorted(expected_values.keys() - supplied.keys())}"
         )
+        for keyword, expression in expected_values.items():
+            expected = ast.parse(expression, mode="eval").body
+            actual = supplied[keyword]
+            assert ast.dump(actual) == ast.dump(expected), (
+                f"Call at line {call.lineno} must pass {keyword}={expression}, "
+                f"got {ast.dump(actual)}"
+            )
 
 
 def test_launch_cook_session_required_env_is_required_keyword_only() -> None:

--- a/tests/cli/test_cook_order_command.py
+++ b/tests/cli/test_cook_order_command.py
@@ -480,7 +480,10 @@ class TestCLIOrderCommand:
         scripts_dir = tmp_path / ".autoskillit" / "recipes"
         scripts_dir.mkdir(parents=True)
         (scripts_dir / "my-script.yaml").write_text(_SCRIPT_YAML)
-        monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/fake-binary")
+        fake_binary = tmp_path / real_backend.binary_name()
+        fake_binary.write_text("#!/bin/sh\nexit 0\n")
+        fake_binary.chmod(0o755)
+        monkeypatch.setattr(shutil, "which", lambda _: str(fake_binary))
         monkeypatch.setattr("builtins.input", lambda _prompt="": "")
 
         mock_config = MagicMock()
@@ -490,16 +493,25 @@ class TestCLIOrderCommand:
         mock_config.providers.profiles = {}
         mock_config.subsets.disabled = []
         mock_config.packs.enabled = []
+        mock_config.branching.default_base_branch = "develop"
+        mock_config.workspace.temp_dir = ".autoskillit/temp"
         monkeypatch.setattr("autoskillit.config.load_config", lambda *_a, **_kw: mock_config)
         monkeypatch.setattr(
             "autoskillit.cli.session._session_backend.resolve_global_backend",
             lambda name: _real_get_backend(name),
         )
-        monkeypatch.setattr(
-            CodexBackend,
-            "ensure_pre_launch",
-            lambda _self, *, session_dir=None, executable=None: [],
-        )
+
+        def fake_pre_launch(_self, *, session_dir=None, executable=None, plugin_dir=None):
+            del executable, plugin_dir
+            if session_dir is not None:
+                session_dir.mkdir(parents=True, exist_ok=True)
+                (session_dir / "config.toml").write_text(
+                    '[mcp_servers.autoskillit]\ncommand = "autoskillit"\nargs = ["mcp"]\n'
+                )
+            return []
+
+        monkeypatch.setattr(CodexBackend, "ensure_pre_launch", fake_pre_launch)
+        monkeypatch.setattr(CodexBackend, "validate_interactive_invocation", lambda *_: [])
 
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-canary-key")
 
@@ -509,6 +521,18 @@ class TestCLIOrderCommand:
             return type("R", (), {"returncode": 0})()
 
         monkeypatch.setattr(subprocess, "run", fake_run)
+
+        def fake_cook_attempt(spec, **kwargs):
+            captured["cmd"] = list(spec.cmd)
+            captured["env"] = dict(spec.env)
+            kwargs["on_spawn"](12345, 12345)
+            kwargs["on_reaped"](12345, 12345)
+            return type("R", (), {"returncode": 0})()
+
+        monkeypatch.setattr(
+            "autoskillit.cli.session._session_process.run_cook_attempt",
+            fake_cook_attempt,
+        )
 
         cli.order("test-script")
 

--- a/tests/cli/test_cook_order_command.py
+++ b/tests/cli/test_cook_order_command.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+from contextlib import nullcontext
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -469,6 +470,7 @@ class TestCLIOrderCommand:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """order() produces a valid command for each registered backend."""
+        from autoskillit.core import CookSessionHandle
         from autoskillit.execution.backends import get_backend as _real_get_backend
         from autoskillit.execution.backends.codex import CodexBackend, CodexFlags
 
@@ -512,6 +514,18 @@ class TestCLIOrderCommand:
 
         monkeypatch.setattr(CodexBackend, "ensure_pre_launch", fake_pre_launch)
         monkeypatch.setattr(CodexBackend, "validate_interactive_invocation", lambda *_: [])
+        monkeypatch.setattr(
+            CodexBackend,
+            "cook_session_context",
+            lambda _self, **_kwargs: nullcontext(
+                CookSessionHandle(
+                    view_id="test-view",
+                    pass_fds=(),
+                    _record_spawn=lambda _pid, _pgid: None,
+                    _record_reaped=lambda _pid, _pgid: None,
+                )
+            ),
+        )
 
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-canary-key")
 

--- a/tests/cli/test_cook_order_picker.py
+++ b/tests/cli/test_cook_order_picker.py
@@ -523,7 +523,10 @@ class TestOrderResumeParsing:
             resume_spec=NoResume(),
             project_dir=None,
             required_env=None,
-            skill_catalog=None,
+            skill_compilation=None,
+            launch_id=None,
+            default_base_branch=None,
+            workspace_temp_dir=None,
             backend=None,
         ):
             captured["prompt"] = prompt
@@ -575,7 +578,10 @@ class TestOrderResumeParsing:
             resume_spec=NoResume(),
             project_dir=None,
             required_env=None,
-            skill_catalog=None,
+            skill_compilation=None,
+            launch_id=None,
+            default_base_branch=None,
+            workspace_temp_dir=None,
             backend=None,
         ):
             captured["prompt"] = prompt
@@ -617,7 +623,10 @@ class TestOrderResumeParsing:
             resume_spec=NoResume(),
             project_dir=None,
             required_env=None,
-            skill_catalog=None,
+            skill_compilation=None,
+            launch_id=None,
+            default_base_branch=None,
+            workspace_temp_dir=None,
             backend=None,
         ):
             captured["prompt"] = prompt

--- a/tests/cli/test_cook_profile.py
+++ b/tests/cli/test_cook_profile.py
@@ -14,8 +14,8 @@ from autoskillit.config import AutomationConfig
 from autoskillit.core import (
     BackendConventions,
     CmdSpec,
+    CompiledSessionSkillCatalogAuthority,
     CookSessionHandle,
-    EffectiveSkillCatalogAuthority,
     HookTrustPolicy,
     ManagedSessionHome,
     RepositoryProfileId,
@@ -93,10 +93,10 @@ def _run_cook(profile, cfg, mock_mgr, generated_home: Path):
     @contextmanager
     def managed_session(
         launch_id: str,
-        catalog: EffectiveSkillCatalogAuthority,
+        compilation: CompiledSessionSkillCatalogAuthority,
         projection_context: SkillProjectionContextAuthority,
     ):
-        assert projection_context.catalog == catalog
+        assert projection_context.catalog == compilation.catalog
         yield ManagedSessionHome(
             launch_id=launch_id,
             generated_home=generated_home,
@@ -275,10 +275,10 @@ def test_finalized_profile_spec_is_shared_by_validator_context_and_child(
     @contextmanager
     def managed_session(
         launch_id: str,
-        catalog: EffectiveSkillCatalogAuthority,
+        compilation: CompiledSessionSkillCatalogAuthority,
         projection_context: SkillProjectionContextAuthority,
     ):
-        assert projection_context.catalog == catalog
+        assert projection_context.catalog == compilation.catalog
         yield ManagedSessionHome(
             launch_id=launch_id,
             generated_home=generated_home,

--- a/tests/cli/test_fleet_session.py
+++ b/tests/cli/test_fleet_session.py
@@ -22,6 +22,77 @@ def _make_campaign_recipe(name: str = "test-campaign") -> MagicMock:
     return recipe
 
 
+@pytest.mark.parametrize("campaign_mode", [False, True], ids=("dispatch", "campaign"))
+def test_fleet_call_sites_omit_managed_order_inputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    campaign_mode: bool,
+) -> None:
+    from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
+    from autoskillit.core import FLEET_SESSION_REQUIRED_ENV, NoResume
+
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def capture_session(prompt: str, **kwargs: object) -> None:
+        calls.append((prompt, kwargs))
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_launch._run_interactive_session",
+        capture_session,
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._prompts._build_fleet_dispatch_prompt",
+        lambda *args, **kwargs: "dispatch-prompt",
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._prompts._build_fleet_campaign_prompt",
+        lambda *args, **kwargs: "campaign-prompt",
+    )
+    monkeypatch.chdir(tmp_path)
+    state_path = tmp_path / "state.json"
+    state_path.write_text("{}", encoding="utf-8")
+
+    if campaign_mode:
+        _launch_fleet_session(
+            _make_campaign_recipe(),
+            "campaign-id",
+            state_path,
+            None,
+            fleet_mode="campaign",
+            initial_message="hello",
+        )
+    else:
+        _launch_fleet_session(
+            None,
+            None,
+            None,
+            None,
+            fleet_mode="dispatch",
+            initial_message="hello",
+        )
+
+    assert len(calls) == 1
+    prompt, kwargs = calls[0]
+    assert prompt == ("campaign-prompt" if campaign_mode else "dispatch-prompt")
+    assert kwargs["initial_message"] == "hello"
+    assert kwargs["project_dir"] == tmp_path
+    assert kwargs["required_env"] == FLEET_SESSION_REQUIRED_ENV
+    assert kwargs["backend"] is not None
+    assert isinstance(kwargs["resume_spec"], NoResume)
+    extra_env = kwargs["extra_env"]
+    assert isinstance(extra_env, dict)
+    assert extra_env["AUTOSKILLIT_PROJECT_DIR"] == str(tmp_path)
+    managed_order_inputs = {
+        "skill_compilation",
+        "managed_home",
+        "plugin_binding",
+        "retained_projection_binding",
+        "startup_trace",
+        "attempt",
+    }
+    assert managed_order_inputs.isdisjoint(kwargs)
+
+
 class TestLaunchFleetSessionIngredientsTable:
     def _call(
         self,

--- a/tests/cli/test_input_tty_contracts.py
+++ b/tests/cli/test_input_tty_contracts.py
@@ -134,7 +134,7 @@ def test_cook_noninteractive_exits(tmp_path: Path, monkeypatch: pytest.MonkeyPat
 
     from autoskillit.cli.session._session_cook import cook
     from autoskillit.core import (
-        EffectiveSkillCatalogAuthority,
+        CompiledSessionSkillCatalogAuthority,
         ManagedSessionHome,
         SkillProjectionContextAuthority,
         ValidatedAddDir,
@@ -149,10 +149,10 @@ def test_cook_noninteractive_exits(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     @contextmanager
     def managed_session(
         launch_id: str,
-        catalog: EffectiveSkillCatalogAuthority,
+        compilation: CompiledSessionSkillCatalogAuthority,
         projection_context: SkillProjectionContextAuthority,
     ):
-        assert projection_context.catalog == catalog
+        assert projection_context.catalog == compilation.catalog
         yield ManagedSessionHome(
             launch_id=launch_id,
             generated_home=generated_home,

--- a/tests/cli/test_installed_plugin_selector_integration.py
+++ b/tests/cli/test_installed_plugin_selector_integration.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager, nullcontext
 from dataclasses import replace
 from pathlib import Path
@@ -15,7 +15,10 @@ import pytest
 
 from autoskillit import cli
 from autoskillit.cli._plugin_artifact import interactive_plugin_authority
-from autoskillit.cli.session._session_launch import _run_interactive_session
+from autoskillit.cli.session._session_launch import (
+    _launch_cook_session,
+    _run_interactive_session,
+)
 from autoskillit.core import (
     CLAUDE_CODE_CAPABILITIES,
     BackendConventions,
@@ -25,13 +28,17 @@ from autoskillit.core import (
     ManagedSessionHome,
     PluginLaunchBinding,
     PluginLoadMode,
+    SkillExecutionRole,
     SkillProjectionContextAuthority,
     ValidatedAddDir,
+    plugin_launch_binding_scope,
 )
 from autoskillit.core._plugin_ids import (
     detect_autoskillit_mcp_prefix as _production_mcp_prefix,
 )
 from autoskillit.execution.backends import ClaudeCodeBackend, CodexBackend
+from autoskillit.workspace import DefaultSkillResolver, compile_session_skill_catalog
+from autoskillit.workspace._projection_cache import projected_plugin_artifact_digest
 from tests.fakes import adapt_test_skill_semantics
 from tests.fixtures.plugin_artifact_state import (
     INVALID_PLUGIN_ARTIFACT_STATE_KINDS,
@@ -137,6 +144,12 @@ class _RecordingBackend:
         )
 
 
+class _PersistentCodexRecordingBackend(_RecordingBackend):
+    @property
+    def capabilities(self):
+        return CodexBackend().capabilities
+
+
 class _CookSessionManager:
     def __init__(self, generated_home: Path, events: list[tuple[object, ...]]) -> None:
         self._generated_home = generated_home
@@ -170,6 +183,8 @@ class _CookSessionManager:
 def _install_cook_harness(
     monkeypatch: pytest.MonkeyPatch,
     project_dir: Path,
+    *,
+    during_attempt: Callable[[Path], None] | None = None,
 ) -> dict[str, object]:
     generated_home = project_dir / "managed-home"
     events: list[tuple[object, ...]] = []
@@ -187,12 +202,14 @@ def _install_cook_harness(
         trace = kwargs["trace"]
         on_spawn(101, 101)  # type: ignore[operator]
         trace.record_spawn()  # type: ignore[attr-defined]
+        if during_attempt is not None:
+            during_attempt(generated_home)
         on_reaped(101, 101)  # type: ignore[operator]
         return SimpleNamespace(pid=101, pgid=101, returncode=0)
 
     generated_home.mkdir(parents=True, exist_ok=True)
     monkeypatch.chdir(project_dir)
-    monkeypatch.setattr(shutil, "which", lambda _binary: "/usr/bin/agent")
+    monkeypatch.setattr(shutil, "which", lambda _binary, **_kwargs: "/usr/bin/agent")
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     monkeypatch.setattr(
         "autoskillit.workspace.DefaultSessionSkillManager",
@@ -379,6 +396,113 @@ def test_codex_cook_remains_generated_home_and_ignores_claude_artifacts(
     assert len(backend.build_calls) == 1
     assert backend.build_calls[0]["plugin_binding"] is None
     assert backend.build_calls[0]["generated_home"] == generated_home
+
+
+def test_codex_managed_order_runtime_writes_do_not_mutate_projection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = build_plugin_artifact_state(
+        tmp_path / "home",
+        PluginArtifactStateKind.VALID_CURRENT,
+    )
+    _activate_production_selector(monkeypatch, state)
+    project_dir = state.home / "project"
+    project_dir.mkdir(parents=True)
+    backend = _PersistentCodexRecordingBackend("codex")
+    catalog = DefaultSkillResolver().list_effective(
+        project_dir,
+        SkillExecutionRole.ORCHESTRATOR,
+    )
+    compilation = compile_session_skill_catalog(catalog, backend)
+    authority, load_mode = interactive_plugin_authority(
+        backend=backend,
+        project_dir=project_dir,
+        default_base_branch="main",
+        skill_catalog=compilation.catalog,
+        generated_home_available=True,
+        retain_projection_source=True,
+    )
+    assert authority is not None
+    assert load_mode is PluginLoadMode.GENERATED_HOME
+
+    with plugin_launch_binding_scope(
+        authority=authority,
+        backend=backend,
+        load_mode=PluginLoadMode.PROJECTED_HOME,
+    ) as before_binding:
+        assert before_binding is not None
+        before_identity = before_binding.identity
+        projection_root = before_identity.managed_path
+        before_digest = projected_plugin_artifact_digest(projection_root)
+        assert before_identity.artifact_digest == before_digest
+        before_tree = tuple(
+            sorted(
+                path.relative_to(projection_root).as_posix() for path in projection_root.rglob("*")
+            )
+        )
+
+    def write_runtime_artifacts(generated_home: Path) -> None:
+        (generated_home / "auth.json").write_bytes(b"runtime auth marker")
+        (generated_home / "state_5.sqlite").write_bytes(b"runtime sqlite marker")
+        session_file = generated_home / "sessions" / "2026" / "08" / "rollout-test.jsonl"
+        session_file.parent.mkdir(parents=True)
+        session_file.write_text('{"type":"runtime marker"}\n')
+
+    captured = _install_cook_harness(
+        monkeypatch,
+        project_dir,
+        during_attempt=write_runtime_artifacts,
+    )
+    launch_id = "projection-immutability"
+    _launch_cook_session(
+        "projection immutability integration",
+        project_dir=project_dir,
+        required_env=frozenset(),
+        backend=backend,
+        skill_compilation=compilation,
+        launch_id=launch_id,
+        default_base_branch="main",
+        workspace_temp_dir=None,
+    )
+
+    generated_home = cast(Path, captured["generated_home"])
+    assert captured["events"] == [
+        ("managed-enter", launch_id),
+        ("run",),
+        ("managed-exit", launch_id),
+    ]
+    assert len(backend.build_calls) == 1
+    assert backend.build_calls[0]["generated_home"] == generated_home
+    assert backend.build_calls[0]["plugin_binding"] is None
+    assert not generated_home.is_relative_to(projection_root)
+    assert (generated_home / "auth.json").is_file()
+    assert (generated_home / "state_5.sqlite").is_file()
+    assert (generated_home / "sessions" / "2026" / "08" / "rollout-test.jsonl").is_file()
+
+    with plugin_launch_binding_scope(
+        authority=authority,
+        backend=backend,
+        load_mode=PluginLoadMode.PROJECTED_HOME,
+    ) as after_binding:
+        assert after_binding is not None
+        assert after_binding.identity == before_identity
+        assert after_binding.identity.artifact_digest == before_digest
+        assert projected_plugin_artifact_digest(projection_root) == before_digest
+        assert (
+            tuple(
+                sorted(
+                    path.relative_to(projection_root).as_posix()
+                    for path in projection_root.rglob("*")
+                )
+            )
+            == before_tree
+        )
+
+    for runtime_path in ("auth.json", "state_5.sqlite", "sessions", "archived_sessions"):
+        projection_runtime_path = projection_root / runtime_path
+        assert not projection_runtime_path.exists()
+        assert not projection_runtime_path.is_symlink()
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_installed_plugin_selector_integration.py
+++ b/tests/cli/test_installed_plugin_selector_integration.py
@@ -20,8 +20,8 @@ from autoskillit.core import (
     CLAUDE_CODE_CAPABILITIES,
     BackendConventions,
     CmdSpec,
+    CompiledSessionSkillCatalogAuthority,
     CookSessionHandle,
-    EffectiveSkillCatalogAuthority,
     ManagedSessionHome,
     PluginLaunchBinding,
     PluginLoadMode,
@@ -149,11 +149,11 @@ class _CookSessionManager:
     def managed_session(
         self,
         launch_id: str,
-        catalog: EffectiveSkillCatalogAuthority,
+        compilation: CompiledSessionSkillCatalogAuthority,
         projection_context: SkillProjectionContextAuthority,
     ) -> Iterator[ManagedSessionHome]:
         self._events.append(("managed-enter", launch_id))
-        assert projection_context.catalog == catalog
+        assert projection_context.catalog == compilation.catalog
         skills_dir = self._generated_home / "skills"
         skills_dir.mkdir(parents=True, exist_ok=True)
         try:

--- a/tests/cli/test_installed_plugin_selector_integration.py
+++ b/tests/cli/test_installed_plugin_selector_integration.py
@@ -472,9 +472,9 @@ def test_codex_managed_order_runtime_writes_do_not_mutate_projection(
         ("run",),
         ("managed-exit", launch_id),
     ]
-    assert len(backend.build_calls) == 1
-    assert backend.build_calls[0]["generated_home"] == generated_home
-    assert backend.build_calls[0]["plugin_binding"] is None
+    assert len(backend.build_calls) == 2
+    assert backend.build_calls[-1]["generated_home"] == generated_home
+    assert backend.build_calls[-1]["plugin_binding"] is None
     assert not generated_home.is_relative_to(projection_root)
     assert (generated_home / "auth.json").is_file()
     assert (generated_home / "state_5.sqlite").is_file()

--- a/tests/cli/test_installed_plugin_selector_integration.py
+++ b/tests/cli/test_installed_plugin_selector_integration.py
@@ -454,7 +454,7 @@ def test_codex_managed_order_runtime_writes_do_not_mutate_projection(
         project_dir,
         during_attempt=write_runtime_artifacts,
     )
-    launch_id = "projection-immutability"
+    launch_id = "0123456789abcdef"
     _launch_cook_session(
         "projection immutability integration",
         project_dir=project_dir,

--- a/tests/cli/test_installed_plugin_selector_integration.py
+++ b/tests/cli/test_installed_plugin_selector_integration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import sys
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, nullcontext
 from dataclasses import replace
@@ -209,7 +210,7 @@ def _install_cook_harness(
 
     generated_home.mkdir(parents=True, exist_ok=True)
     monkeypatch.chdir(project_dir)
-    monkeypatch.setattr(shutil, "which", lambda _binary, **_kwargs: "/usr/bin/agent")
+    monkeypatch.setattr(shutil, "which", lambda _binary, **_kwargs: sys.executable)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     monkeypatch.setattr(
         "autoskillit.workspace.DefaultSessionSkillManager",

--- a/tests/cli/test_interactive_subprocess_contracts.py
+++ b/tests/cli/test_interactive_subprocess_contracts.py
@@ -212,6 +212,12 @@ def test_cook_attempt_uses_only_the_shared_spawn_bound_owner() -> None:
     assert "subprocess.run(" not in cook_source
     assert "subprocess.Popen(" not in cook_source
 
+    shared_launch_source = (session_dir / "_session_launch.py").read_text(encoding="utf-8")
+    assert "run_cook_attempt(" in shared_launch_source
+    assert "subprocess.run(" in shared_launch_source, (
+        "fleet and nonpersistent backends retain the raw interactive process owner"
+    )
+
 
 def test_cook_owner_spawn_returns_before_the_single_spawn_callback() -> None:
     process_path = CLI_DIR / "session" / "_session_process.py"

--- a/tests/cli/test_order_resume.py
+++ b/tests/cli/test_order_resume.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -12,23 +11,12 @@ from autoskillit.cli.session._session_launch import (
     _launch_cook_session,
 )
 from autoskillit.core import NamedResume
-from autoskillit.execution.backends.claude import ClaudeCodeBackend
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
-def _launch_kwargs() -> dict[str, object]:
-    return {
-        "backend": ClaudeCodeBackend(),
-        "skill_compilation": SimpleNamespace(unavailable=(), catalog=None),
-        "launch_id": "test-order",
-        "default_base_branch": "main",
-        "workspace_temp_dir": None,
-    }
-
-
 class TestLaunchCookSessionInfraResume:
-    def test_infra_exit_triggers_resume(self) -> None:
+    def test_infra_exit_triggers_resume(self, launch_kwargs: dict[str, object]) -> None:
         call_count = 0
 
         def mock_run_interactive(system_prompt, **kwargs):
@@ -42,11 +30,11 @@ class TestLaunchCookSessionInfraResume:
             "autoskillit.cli.session._session_launch._run_interactive_session",
             side_effect=mock_run_interactive,
         ):
-            _launch_cook_session("prompt", required_env=frozenset(), **_launch_kwargs())
+            _launch_cook_session("prompt", required_env=frozenset(), **launch_kwargs)
 
         assert call_count == 2
 
-    def test_infra_exit_uses_named_resume(self) -> None:
+    def test_infra_exit_uses_named_resume(self, launch_kwargs: dict[str, object]) -> None:
         resume_specs: list = []
 
         def mock_run_interactive(system_prompt, **kwargs):
@@ -59,12 +47,12 @@ class TestLaunchCookSessionInfraResume:
             "autoskillit.cli.session._session_launch._run_interactive_session",
             side_effect=mock_run_interactive,
         ):
-            _launch_cook_session("prompt", required_env=frozenset(), **_launch_kwargs())
+            _launch_cook_session("prompt", required_env=frozenset(), **launch_kwargs)
 
         assert isinstance(resume_specs[1], NamedResume)
         assert resume_specs[1].session_id == "sess-42"
 
-    def test_max_infra_resumes_exceeded(self) -> None:
+    def test_max_infra_resumes_exceeded(self, launch_kwargs: dict[str, object]) -> None:
         def mock_run_interactive(system_prompt, **kwargs):
             return _InfraExitSignal(session_id="sess-loop", category="process_killed")
 
@@ -75,9 +63,9 @@ class TestLaunchCookSessionInfraResume:
             ),
             pytest.raises(SystemExit, match="Too many infrastructure resumes"),
         ):
-            _launch_cook_session("prompt", required_env=frozenset(), **_launch_kwargs())
+            _launch_cook_session("prompt", required_env=frozenset(), **launch_kwargs)
 
-    def test_no_resume_on_clean_exit(self) -> None:
+    def test_no_resume_on_clean_exit(self, launch_kwargs: dict[str, object]) -> None:
         call_count = 0
 
         def mock_run_interactive(system_prompt, **kwargs):
@@ -89,6 +77,6 @@ class TestLaunchCookSessionInfraResume:
             "autoskillit.cli.session._session_launch._run_interactive_session",
             side_effect=mock_run_interactive,
         ):
-            _launch_cook_session("prompt", required_env=frozenset(), **_launch_kwargs())
+            _launch_cook_session("prompt", required_env=frozenset(), **launch_kwargs)
 
         assert call_count == 1

--- a/tests/cli/test_order_resume.py
+++ b/tests/cli/test_order_resume.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -11,8 +12,19 @@ from autoskillit.cli.session._session_launch import (
     _launch_cook_session,
 )
 from autoskillit.core import NamedResume
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
+
+
+def _launch_kwargs() -> dict[str, object]:
+    return {
+        "backend": ClaudeCodeBackend(),
+        "skill_compilation": SimpleNamespace(unavailable=(), catalog=None),
+        "launch_id": "test-order",
+        "default_base_branch": "main",
+        "workspace_temp_dir": None,
+    }
 
 
 class TestLaunchCookSessionInfraResume:
@@ -30,7 +42,7 @@ class TestLaunchCookSessionInfraResume:
             "autoskillit.cli.session._session_launch._run_interactive_session",
             side_effect=mock_run_interactive,
         ):
-            _launch_cook_session("prompt", required_env=frozenset())
+            _launch_cook_session("prompt", required_env=frozenset(), **_launch_kwargs())
 
         assert call_count == 2
 
@@ -47,7 +59,7 @@ class TestLaunchCookSessionInfraResume:
             "autoskillit.cli.session._session_launch._run_interactive_session",
             side_effect=mock_run_interactive,
         ):
-            _launch_cook_session("prompt", required_env=frozenset())
+            _launch_cook_session("prompt", required_env=frozenset(), **_launch_kwargs())
 
         assert isinstance(resume_specs[1], NamedResume)
         assert resume_specs[1].session_id == "sess-42"
@@ -63,7 +75,7 @@ class TestLaunchCookSessionInfraResume:
             ),
             pytest.raises(SystemExit, match="Too many infrastructure resumes"),
         ):
-            _launch_cook_session("prompt", required_env=frozenset())
+            _launch_cook_session("prompt", required_env=frozenset(), **_launch_kwargs())
 
     def test_no_resume_on_clean_exit(self) -> None:
         call_count = 0
@@ -77,6 +89,6 @@ class TestLaunchCookSessionInfraResume:
             "autoskillit.cli.session._session_launch._run_interactive_session",
             side_effect=mock_run_interactive,
         ):
-            _launch_cook_session("prompt", required_env=frozenset())
+            _launch_cook_session("prompt", required_env=frozenset(), **_launch_kwargs())
 
         assert call_count == 1

--- a/tests/cli/test_reload_loop.py
+++ b/tests/cli/test_reload_loop.py
@@ -87,8 +87,8 @@ def test_cook_keeps_managed_home_across_reload_and_transfers_resume_after_attemp
     from autoskillit.core import (
         BackendConventions,
         CmdSpec,
+        CompiledSessionSkillCatalogAuthority,
         CookSessionHandle,
-        EffectiveSkillCatalogAuthority,
         HookTrustPolicy,
         ManagedSessionHome,
         NamedResume,
@@ -106,10 +106,10 @@ def test_cook_keeps_managed_home_across_reload_and_transfers_resume_after_attemp
     @contextmanager
     def managed_session(
         launch_id: str,
-        catalog: EffectiveSkillCatalogAuthority,
+        compilation: CompiledSessionSkillCatalogAuthority,
         projection_context: SkillProjectionContextAuthority,
     ):
-        assert projection_context.catalog == catalog
+        assert projection_context.catalog == compilation.catalog
         events.append(("managed-enter", launch_id, projection_context))
         try:
             yield ManagedSessionHome(
@@ -314,8 +314,8 @@ def test_cook_rejects_repeated_and_excessive_reload_requests(
     from autoskillit.core import (
         BackendConventions,
         CmdSpec,
+        CompiledSessionSkillCatalogAuthority,
         CookSessionHandle,
-        EffectiveSkillCatalogAuthority,
         HookTrustPolicy,
         ManagedSessionHome,
         SkillProjectionContextAuthority,
@@ -332,10 +332,10 @@ def test_cook_rejects_repeated_and_excessive_reload_requests(
     @contextmanager
     def managed_session(
         launch_id: str,
-        catalog: EffectiveSkillCatalogAuthority,
+        compilation: CompiledSessionSkillCatalogAuthority,
         projection_context: SkillProjectionContextAuthority,
     ):
-        assert projection_context.catalog == catalog
+        assert projection_context.catalog == compilation.catalog
         try:
             yield ManagedSessionHome(
                 launch_id=launch_id,

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -6,6 +6,8 @@ import shutil
 import subprocess
 from contextlib import nullcontext
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 from packaging.version import Version
@@ -1023,7 +1025,13 @@ def test_launch_cook_session_accepts_backend_param(monkeypatch: pytest.MonkeyPat
     )
     _stub_plugin_installed(monkeypatch, installed=True)
     _launch_cook_session(
-        system_prompt="test", backend=_CapturingBackend(), required_env=frozenset()
+        system_prompt="test",
+        backend=_CapturingBackend(),
+        required_env=frozenset(),
+        skill_compilation=MagicMock(unavailable=(), catalog=None),
+        launch_id="test-order",
+        default_base_branch="main",
+        workspace_temp_dir=None,
     )
     assert build_calls, "backend.build_interactive_cmd must be called via _launch_cook_session"
 
@@ -1307,3 +1315,69 @@ def test_run_interactive_session_aborts_when_pre_launch_returns_errors(
     monkeypatch.setattr(subprocess, "run", _must_not_call)
     with pytest.raises(SystemExit, match="1"):
         _run_interactive_session(system_prompt="test", backend=_FailingCodexBackend())
+
+
+def test_managed_interactive_session_validates_before_shared_process_owner(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from autoskillit.core import (
+        CLAUDE_CODE_CAPABILITIES,
+        CmdSpec,
+        ManagedSessionHome,
+        ValidatedAddDir,
+    )
+
+    events: list[str] = []
+
+    class _ManagedBackend(_BackendLifecycleStub):
+        @property
+        def capabilities(self):
+            return CLAUDE_CODE_CAPABILITIES
+
+        def binary_name(self) -> str:
+            return "claude"
+
+        def build_interactive_cmd(self, **kwargs):
+            return CmdSpec(cmd=("claude",), env={}, inherited_fds=(3,))
+
+        def validate_interactive_invocation(self, spec):
+            events.append("validated")
+            assert spec.cwd == str(tmp_path.resolve())
+            return []
+
+    def run_attempt(spec, **kwargs):
+        events.append("spawned")
+        assert kwargs["observer"] is None
+        assert kwargs["pass_fds"] == (3, 7, 8)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_process.run_cook_attempt",
+        run_attempt,
+    )
+    generated_home = tmp_path / "generated"
+    generated_home.mkdir()
+    managed_home = ManagedSessionHome(
+        launch_id="launch-id",
+        generated_home=generated_home,
+        skills_dir=ValidatedAddDir(str(generated_home / "add-dir")),
+        pass_fds=(7,),
+    )
+    retained_binding = MagicMock(inherited_fds=(8,))
+    trace = MagicMock()
+
+    result = _run_interactive_session(
+        system_prompt="test",
+        backend=_ManagedBackend(),
+        project_dir=tmp_path,
+        skill_compilation=MagicMock(),
+        managed_home=managed_home,
+        retained_projection_binding=retained_binding,
+        startup_trace=trace,
+        attempt=1,
+    )
+
+    assert result is None
+    assert events == ["validated", "spawned"]
+    trace.record_attempt_anchor.assert_called_once_with(attempt=1, view_id="launch-id-1")

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -1018,7 +1018,10 @@ def test_feature_flag_gate_allows_codex_backend_when_feature_enabled(
 # ---------------------------------------------------------------------------
 
 
-def test_launch_cook_session_accepts_backend_param(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_launch_cook_session_accepts_backend_param(
+    monkeypatch: pytest.MonkeyPatch,
+    launch_kwargs: dict[str, object],
+) -> None:
     """_launch_cook_session must accept a backend= kwarg and forward it to
     _run_interactive_session, which calls backend.build_interactive_cmd."""
     from autoskillit.cli.session._session_launch import _launch_cook_session
@@ -1046,10 +1049,10 @@ def test_launch_cook_session_accepts_backend_param(monkeypatch: pytest.MonkeyPat
         system_prompt="test",
         backend=_CapturingBackend(),
         required_env=frozenset(),
-        skill_compilation=MagicMock(unavailable=(), catalog=None),
-        launch_id="test-order",
-        default_base_branch="main",
-        workspace_temp_dir=None,
+        skill_compilation=launch_kwargs["skill_compilation"],
+        launch_id=launch_kwargs["launch_id"],
+        default_base_branch=launch_kwargs["default_base_branch"],
+        workspace_temp_dir=launch_kwargs["workspace_temp_dir"],
     )
     assert build_calls, "backend.build_interactive_cmd must be called via _launch_cook_session"
 
@@ -1338,6 +1341,7 @@ def test_run_interactive_session_aborts_when_pre_launch_returns_errors(
 def test_managed_interactive_session_validates_before_shared_process_owner(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    launch_kwargs: dict[str, object],
 ) -> None:
     from autoskillit.core import (
         CLAUDE_CODE_CAPABILITIES,
@@ -1389,7 +1393,7 @@ def test_managed_interactive_session_validates_before_shared_process_owner(
         system_prompt="test",
         backend=_ManagedBackend(),
         project_dir=tmp_path,
-        skill_compilation=MagicMock(),
+        skill_compilation=launch_kwargs["skill_compilation"],
         managed_home=managed_home,
         retained_projection_binding=retained_binding,
         startup_trace=trace,

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -4,18 +4,36 @@ from __future__ import annotations
 
 import shutil
 import subprocess
-from contextlib import nullcontext
+import tomllib
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
 from packaging.version import Version
 
-from autoskillit.cli.session._session_launch import _run_interactive_session
+from autoskillit.cli._plugin_artifact import (
+    interactive_plugin_authority as _production_interactive_plugin_authority,
+)
+from autoskillit.cli.session._session_launch import (
+    _launch_cook_session,
+    _run_interactive_session,
+)
 from autoskillit.core import BackendConventions, ClaudeFlags, HookTrustPolicy
+from autoskillit.core._plugin_ids import (
+    detect_autoskillit_mcp_prefix as _production_mcp_prefix,
+)
 from autoskillit.execution.backends import claude as _claude_mod
 from autoskillit.execution.backends.codex import CodexFlags
+from autoskillit.workspace import (
+    project_default_plugin_authority as _production_project_default_plugin_authority,
+)
+from tests.fixtures.plugin_artifact_state import (
+    PluginArtifactStateKind,
+    build_plugin_artifact_state,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -34,7 +52,7 @@ def _pre_freeze_attestation_env(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
 
 
 class _TestBinding:
@@ -1381,3 +1399,487 @@ def test_managed_interactive_session_validates_before_shared_process_owner(
     assert result is None
     assert events == ["validated", "spawned"]
     trace.record_attempt_anchor.assert_called_once_with(attempt=1, view_id="launch-id-1")
+
+
+def _write_codex_mcp_probe_executable(path: Path) -> None:
+    path.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+import tomllib
+
+if "--version" in sys.argv:
+    print("codex-cli 0.147.0")
+    raise SystemExit(0)
+
+config = tomllib.loads((Path(os.environ["CODEX_HOME"]) / "config.toml").read_text())
+transport = dict(config["mcp_servers"]["autoskillit"])
+project_config = Path.cwd() / ".codex" / "config.toml"
+if project_config.is_file():
+    project = tomllib.loads(project_config.read_text())
+    override = project.get("mcp_servers", {}).get("autoskillit", {})
+    if "command" in override:
+        transport["command"] = override["command"]
+transport["type"] = "stdio"
+entry = {"name": "autoskillit", "enabled": True, "transport": transport}
+for key in ("startup_timeout_sec", "tool_timeout_sec"):
+    if key in transport:
+        entry[key] = transport.pop(key)
+print(json.dumps([entry]))
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def _prepare_codex_order_composition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    project_mcp_command: str | None = None,
+) -> tuple[dict[str, object], object]:
+    from autoskillit.core import SkillExecutionRole
+    from autoskillit.execution.backends.codex import CodexBackend
+    from autoskillit.workspace import DefaultSkillResolver, compile_session_skill_catalog
+
+    state = build_plugin_artifact_state(
+        tmp_path / "home",
+        PluginArtifactStateKind.VALID_CURRENT,
+    )
+    _production_mcp_prefix.cache_clear()
+    monkeypatch.setattr(
+        "autoskillit.core.detect_autoskillit_mcp_prefix",
+        _production_mcp_prefix,
+    )
+    monkeypatch.setattr(
+        "autoskillit.workspace.project_default_plugin_authority",
+        _production_project_default_plugin_authority,
+    )
+    monkeypatch.setattr(Path, "home", lambda: state.home)
+    monkeypatch.setenv("HOME", str(state.home))
+    monkeypatch.setenv("MCP_CLIENT_BACKEND", "codex")
+
+    source_home = state.home / ".codex"
+    source_home.mkdir(parents=True)
+    (source_home / "config.toml").write_text(
+        'cli_auth_credentials_store = "keyring"\n',
+        encoding="utf-8",
+    )
+    project_dir = state.home / "project"
+    project_config = project_dir / ".codex" / "config.toml"
+    project_config.parent.mkdir(parents=True)
+    project_toml = 'sqlite_home = "/project-level-conflict"\n'
+    if project_mcp_command is not None:
+        project_toml += f'\n[mcp_servers.autoskillit]\ncommand = "{project_mcp_command}"\n'
+    project_config.write_text(project_toml, encoding="utf-8")
+
+    executable = tmp_path / "bin" / "codex"
+    executable.parent.mkdir(exist_ok=True)
+    _write_codex_mcp_probe_executable(executable)
+    monkeypatch.setattr(shutil, "which", lambda _name, **_kwargs: str(executable))
+    monkeypatch.setattr(
+        "autoskillit.execution.backends.codex.default_log_dir",
+        lambda: tmp_path / "logs",
+    )
+
+    backend = CodexBackend(source_codex_home=source_home)
+    catalog = DefaultSkillResolver().list_effective(
+        project_dir,
+        SkillExecutionRole.ORCHESTRATOR,
+    )
+    compilation = compile_session_skill_catalog(catalog, backend)
+    captured: dict[str, object] = {
+        "events": [],
+        "pre_launch_dirs": [],
+        "process_calls": [],
+        "projection_roots": [],
+        "validation_errors": [],
+    }
+
+    original_ensure_pre_launch = CodexBackend.ensure_pre_launch
+
+    def ensure_pre_launch(self, **kwargs):  # type: ignore[no-untyped-def]
+        session_dir = kwargs.get("session_dir")
+        if session_dir is not None:
+            cast(list[Path], captured["pre_launch_dirs"]).append(Path(session_dir))
+        return original_ensure_pre_launch(self, **kwargs)
+
+    monkeypatch.setattr(CodexBackend, "ensure_pre_launch", ensure_pre_launch)
+    original_validate = CodexBackend.validate_interactive_invocation
+
+    def validate_interactive_invocation(self, spec):  # type: ignore[no-untyped-def]
+        cast(list[str], captured["events"]).append("validated")
+        captured["spec"] = spec
+        generated_home = Path(spec.env["CODEX_HOME"])
+        captured["config_text"] = (generated_home / "config.toml").read_text()
+        captured["config"] = tomllib.loads(cast(str, captured["config_text"]))
+        errors = original_validate(self, spec)
+        cast(list[list[str]], captured["validation_errors"]).append(errors)
+        return errors
+
+    monkeypatch.setattr(
+        CodexBackend,
+        "validate_interactive_invocation",
+        validate_interactive_invocation,
+    )
+
+    class _CapturingAuthority:
+        def __init__(self, delegate: object) -> None:
+            self._delegate = delegate
+
+        def acquire_launch_binding(self, **kwargs):  # type: ignore[no-untyped-def]
+            binding = self._delegate.acquire_launch_binding(**kwargs)  # type: ignore[attr-defined]
+            cast(list[Path], captured["projection_roots"]).append(binding.identity.managed_path)
+            return binding
+
+    def capture_interactive_authority(**kwargs):  # type: ignore[no-untyped-def]
+        authority, load_mode = _production_interactive_plugin_authority(**kwargs)
+        assert authority is not None
+        return _CapturingAuthority(authority), load_mode
+
+    monkeypatch.setattr(
+        "autoskillit.cli._plugin_artifact.interactive_plugin_authority",
+        capture_interactive_authority,
+    )
+
+    def record_final_process(spec, **kwargs):  # type: ignore[no-untyped-def]
+        cast(list[str], captured["events"]).append("spawned")
+        cast(list[tuple[object, dict[str, object]]], captured["process_calls"]).append(
+            (spec, kwargs)
+        )
+        return SimpleNamespace(pid=101, pgid=101, returncode=0)
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_process.run_cook_attempt",
+        record_final_process,
+    )
+
+    def launch() -> None:
+        _launch_cook_session(
+            "composition contract",
+            project_dir=project_dir,
+            required_env=frozenset(),
+            backend=backend,
+            skill_compilation=compilation,
+            launch_id="0123456789abcdef",
+            default_base_branch="main",
+            workspace_temp_dir=None,
+        )
+
+    return captured, launch
+
+
+def test_codex_order_composition_produces_canonical_generated_home(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from autoskillit.core import CmdSpec
+
+    captured, launch = _prepare_codex_order_composition(tmp_path, monkeypatch)
+    launch()  # type: ignore[operator]
+
+    assert captured["events"] == ["validated", "spawned"]
+    assert captured["validation_errors"] == [[]]
+    assert len(cast(list[object], captured["process_calls"])) == 1
+    spec = cast(CmdSpec, captured["spec"])
+    generated_home = Path(spec.env["CODEX_HOME"])
+    assert generated_home == generated_home.resolve()
+    assert spec.env["CODEX_SQLITE_HOME"] == str(generated_home)
+    assert captured["pre_launch_dirs"] == [generated_home]
+
+    assert spec.origin is not None
+    config_overrides = [
+        value for flag, value in spec.origin.kv_flags if flag == CodexFlags.CONFIG_OVERRIDE
+    ]
+    assert config_overrides[-1] == f'sqlite_home="{generated_home}"'
+
+    config = cast(dict[str, object], captured["config"])
+    config_text = cast(str, captured["config_text"])
+    assert config["cli_auth_credentials_store"] == "file"
+    assert config_text.count('cli_auth_credentials_store = "file"') == 1
+    assert all(
+        f'cli_auth_credentials_store = "{value}"' not in config_text
+        for value in ("keyring", "auto", "ephemeral")
+    )
+    mcp = cast(dict[str, object], cast(dict[str, object], config["mcp_servers"])["autoskillit"])
+    assert mcp["command"] == "autoskillit"
+    assert mcp.get("args", []) == []
+    assert isinstance(mcp["env_vars"], list)
+    assert mcp["startup_timeout_sec"] > 0  # type: ignore[operator]
+    assert mcp["tool_timeout_sec"] > 0  # type: ignore[operator]
+
+    add_dirs = [
+        Path(value) for flag, value in spec.origin.variadic_pairs if flag == CodexFlags.ADD_DIR
+    ]
+    assert len(add_dirs) == 1
+    assert add_dirs[0].is_relative_to(generated_home)
+    projection_roots = cast(list[Path], captured["projection_roots"])
+    assert len(projection_roots) == 1
+    assert not add_dirs[0].is_relative_to(projection_roots[0])
+
+
+def test_codex_order_composition_rejects_effective_mcp_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    captured, launch = _prepare_codex_order_composition(
+        tmp_path,
+        monkeypatch,
+        project_mcp_command="conflicting-command",
+    )
+
+    with pytest.raises(SystemExit, match="1"):
+        launch()  # type: ignore[operator]
+
+    assert captured["events"] == ["validated"]
+    assert captured["process_calls"] == []
+    errors = cast(list[list[str]], captured["validation_errors"])
+    assert len(errors) == 1
+    assert any("command does not match final config" in error for error in errors[0])
+    assert "command does not match final config" in capsys.readouterr().err
+
+
+def test_order_managed_session_keeps_home_across_reload_and_infra_resume(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from autoskillit.core import (
+        CmdSpec,
+        CompiledSessionSkillCatalogAuthority,
+        CookSessionHandle,
+        InfraExitCategory,
+        ManagedSessionHome,
+        NamedResume,
+        NoResume,
+        PluginLoadMode,
+        SkillExecutionRole,
+        SkillProjectionContextAuthority,
+        ValidatedAddDir,
+    )
+    from autoskillit.execution import SessionState
+    from autoskillit.execution.backends.codex import CodexBackend
+    from autoskillit.workspace import DefaultSkillResolver, compile_session_skill_catalog
+
+    events: list[tuple[object, ...]] = []
+    generated_home = tmp_path / "managed-home"
+    skills_dir = generated_home / "autoskillit-add-dir"
+    skills_dir.mkdir(parents=True)
+    projection_root = tmp_path / "projection"
+    projection_root.mkdir()
+    launch_id = "fedcba9876543210"
+
+    class _LifecycleManager:
+        def cleanup_stale(self) -> None:
+            return None
+
+        @contextmanager
+        def managed_session(
+            self,
+            session_id: str,
+            compilation: CompiledSessionSkillCatalogAuthority,
+            projection_context: SkillProjectionContextAuthority,
+        ):
+            assert projection_context.catalog == compilation.catalog
+            events.append(("managed-enter", session_id))
+            try:
+                yield ManagedSessionHome(
+                    launch_id=session_id,
+                    generated_home=generated_home,
+                    skills_dir=ValidatedAddDir(str(skills_dir)),
+                    pass_fds=(7,),
+                )
+            finally:
+                events.append(("managed-exit", session_id))
+
+    class _LifecycleBinding:
+        def __init__(self) -> None:
+            self.identity = SimpleNamespace(managed_path=projection_root)
+            self.inherited_fds = (5, 7)
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+            events.append(("projection-exit",))
+
+    binding = _LifecycleBinding()
+
+    class _LifecycleAuthority:
+        def acquire_launch_binding(self, **_kwargs):  # type: ignore[no-untyped-def]
+            events.append(("projection-enter",))
+            return binding
+
+    class _LifecycleCodexBackend(CodexBackend):
+        def binary_name(self) -> str:
+            return "true"
+
+        def build_interactive_cmd(self, **kwargs):  # type: ignore[no-untyped-def]
+            return CmdSpec(
+                cmd=("true",),
+                env={
+                    "INITIAL": kwargs.get("initial_prompt") or "",
+                    "RESUME": type(kwargs["resume_spec"]).__name__,
+                },
+                inherited_fds=(3,),
+            )
+
+        def validate_interactive_invocation(self, spec: CmdSpec) -> list[str]:
+            events.append(("validated", spec.env["RESUME"]))
+            return []
+
+        @contextmanager
+        def cook_session_context(
+            self,
+            *,
+            session_home: Path,
+            project_dir: Path,
+            launch_id: str,
+            attempt: int,
+            current_resume_spec: object,
+        ):
+            events.append(
+                (
+                    "attempt-enter",
+                    attempt,
+                    current_resume_spec,
+                    session_home,
+                    project_dir,
+                    launch_id,
+                )
+            )
+            try:
+                yield CookSessionHandle(
+                    view_id=f"{launch_id}-{attempt}",
+                    pass_fds=(11,),
+                    _record_spawn=lambda pid, pgid: events.append(("spawn", attempt, pid, pgid)),
+                    _record_reaped=lambda pid, pgid: events.append(("reaped", attempt, pid, pgid)),
+                )
+            finally:
+                events.append(("attempt-exit", attempt, current_resume_spec))
+
+    source_home = tmp_path / "source-codex"
+    source_home.mkdir()
+    backend = _LifecycleCodexBackend(source_codex_home=source_home)
+    catalog = DefaultSkillResolver().list_effective(
+        tmp_path,
+        SkillExecutionRole.ORCHESTRATOR,
+    )
+    compilation = compile_session_skill_catalog(catalog, backend)
+    monkeypatch.setattr(shutil, "which", lambda _name, **_kwargs: "/usr/bin/true")
+    monkeypatch.setattr(
+        "autoskillit.workspace.DefaultSessionSkillManager",
+        lambda *args, **kwargs: _LifecycleManager(),
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._plugin_artifact.interactive_plugin_authority",
+        lambda **_kwargs: (_LifecycleAuthority(), PluginLoadMode.GENERATED_HOME),
+    )
+
+    results = iter(
+        (
+            SimpleNamespace(pid=101, pgid=101, returncode=17),
+            SimpleNamespace(pid=102, pgid=102, returncode=42),
+            SimpleNamespace(pid=103, pgid=103, returncode=0),
+        )
+    )
+
+    def run_attempt(
+        spec: CmdSpec,
+        *,
+        pass_fds: tuple[int, ...],
+        on_spawn,
+        on_reaped,
+        trace,
+        **_kwargs: object,
+    ) -> object:
+        attempt = sum(event[0] == "run" for event in events) + 1
+        events.append(
+            (
+                "run",
+                attempt,
+                spec.env["INITIAL"],
+                spec.env["RESUME"],
+                pass_fds,
+            )
+        )
+        on_spawn(100 + attempt, 100 + attempt)
+        trace.record_spawn()
+        on_reaped(100 + attempt, 100 + attempt)
+        return next(results)
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_process.run_cook_attempt",
+        run_attempt,
+    )
+    sentinels = iter(("reload-id", None, None))
+
+    def consume_sentinel(_project_dir: Path) -> str | None:
+        value = next(sentinels)
+        events.append(("sentinel", value))
+        return value
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_reload.consume_reload_sentinel",
+        consume_sentinel,
+    )
+    infra_state = SessionState(
+        session_id="infra-id",
+        pid=102,
+        boot_id="boot",
+        starttime_ticks=1,
+        infra_exit_category=InfraExitCategory.API_ERROR,
+    )
+
+    def read_state(_state_dir: Path) -> SessionState:
+        events.append(("infra-classified", infra_state.infra_exit_category))
+        return infra_state
+
+    monkeypatch.setattr("autoskillit.execution.read_session_state", read_state)
+
+    _launch_cook_session(
+        "lifecycle contract",
+        initial_message="greeting",
+        project_dir=tmp_path,
+        required_env=frozenset(),
+        backend=backend,
+        skill_compilation=compilation,
+        launch_id=launch_id,
+        default_base_branch="main",
+        workspace_temp_dir=None,
+    )
+
+    attempt_enters = [event for event in events if event[0] == "attempt-enter"]
+    assert [event[1] for event in attempt_enters] == [1, 2, 3]
+    assert {event[5] for event in attempt_enters} == {launch_id}
+    assert all(event[3] == generated_home for event in attempt_enters)
+    assert isinstance(attempt_enters[0][2], NoResume)
+    assert [cast(NamedResume, event[2]).session_id for event in attempt_enters[1:]] == [
+        "reload-id",
+        "infra-id",
+    ]
+
+    run_events = [event for event in events if event[0] == "run"]
+    assert [event[2] for event in run_events] == ["greeting", "", ""]
+    assert [event[3] for event in run_events] == ["NoResume", "NamedResume", "NamedResume"]
+    assert [event[4] for event in run_events] == [(3, 7, 5, 11)] * 3
+    assert len([event for event in events if event[0] == "spawn"]) == 3
+    assert len([event for event in events if event[0] == "reaped"]) == 3
+    for attempt in (1, 2, 3):
+        assert events.index(("attempt-enter", *attempt_enters[attempt - 1][1:])) < events.index(
+            next(event for event in events if event[:2] == ("run", attempt))
+        )
+
+    first_exit = events.index(next(event for event in events if event[:2] == ("attempt-exit", 1)))
+    first_sentinel = events.index(("sentinel", "reload-id"))
+    second_exit = events.index(next(event for event in events if event[:2] == ("attempt-exit", 2)))
+    infra_classified = events.index(("infra-classified", InfraExitCategory.API_ERROR))
+    assert first_exit < first_sentinel
+    assert second_exit < infra_classified
+    assert events.index(("managed-enter", launch_id)) < events.index(("run", *run_events[0][1:]))
+    assert events.index(("managed-exit", launch_id)) > events.index(
+        next(event for event in events if event[:2] == ("attempt-exit", 3))
+    )
+    assert events.index(("projection-exit",)) > events.index(("managed-exit", launch_id))
+    assert binding.closed

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -1405,6 +1405,66 @@ def test_managed_interactive_session_validates_before_shared_process_owner(
     trace.record_attempt_anchor.assert_called_once_with(attempt=1, view_id="launch-id-1")
 
 
+@pytest.mark.parametrize(
+    ("managed_kwargs", "message"),
+    [
+        ({"managed_home": MagicMock()}, "managed home and attempt must be supplied together"),
+        ({"attempt": 1}, "managed home and attempt must be supplied together"),
+        (
+            {
+                "managed_home": MagicMock(),
+                "attempt": 0,
+                "skill_compilation": MagicMock(),
+                "retained_projection_binding": MagicMock(),
+                "startup_trace": MagicMock(),
+            },
+            "managed attempt must be positive",
+        ),
+        (
+            {
+                "managed_home": MagicMock(),
+                "attempt": 1,
+                "retained_projection_binding": MagicMock(),
+                "startup_trace": MagicMock(),
+            },
+            "managed home requires its retained skill compilation",
+        ),
+        (
+            {
+                "managed_home": MagicMock(),
+                "attempt": 1,
+                "skill_compilation": MagicMock(),
+                "startup_trace": MagicMock(),
+            },
+            "managed home requires a retained projection binding",
+        ),
+        (
+            {
+                "managed_home": MagicMock(),
+                "attempt": 1,
+                "skill_compilation": MagicMock(),
+                "retained_projection_binding": MagicMock(),
+            },
+            "managed home requires a launch-scoped startup trace",
+        ),
+        (
+            {"plugin_binding": MagicMock()},
+            "managed launch inputs are invalid for a raw session",
+        ),
+    ],
+)
+def test_interactive_session_rejects_invalid_managed_inputs(
+    managed_kwargs: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _run_interactive_session(
+            system_prompt="test",
+            backend=_BackendLifecycleStub(),
+            **managed_kwargs,
+        )
+
+
 def _write_codex_mcp_probe_executable(path: Path) -> None:
     path.write_text(
         """#!/usr/bin/env python3

--- a/tests/cli/test_subprocess_env_contracts.py
+++ b/tests/cli/test_subprocess_env_contracts.py
@@ -435,6 +435,8 @@ class _ClaudeLaunchWalker:
         return False, f"env= has unrecognised shape: {ast.dump(env_val)[:60]}"
 
     def _check_call(self, call: ast.Call) -> None:
+        if _call_func_name(call.func) in _CLAUDE_ENV_TYPED_FORWARDERS:
+            return
         cmd_arg = self._cmd_arg_of(call)
         if cmd_arg is None:
             return
@@ -497,6 +499,10 @@ _CLAUDE_ENV_RULE_ALLOWED: frozenset[tuple[str, str]] = frozenset(
         ("_session_cook.py", "cook"),
     }
 )
+
+# Typed forwarders receive a complete CmdSpec and consume ``spec.env`` at their
+# owned process boundary. They are not raw subprocess calls themselves.
+_CLAUDE_ENV_TYPED_FORWARDERS = frozenset({"replace", "run_cook_attempt"})
 
 
 def test_no_raw_claude_env() -> None:

--- a/tests/cli/test_terminal.py
+++ b/tests/cli/test_terminal.py
@@ -14,6 +14,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from autoskillit.cli.ui._terminal import _RESET_SPEC
+from autoskillit.execution.backends.claude import ClaudeCodeBackend
 
 pytestmark = [
     pytest.mark.layer("cli"),
@@ -489,6 +490,14 @@ class TestCookTerminalGuard:
         monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/claude")
 
         with pytest.raises(KeyboardInterrupt):
-            app_mod._launch_cook_session("system prompt", required_env=frozenset())
+            app_mod._launch_cook_session(
+                "system prompt",
+                required_env=frozenset(),
+                backend=ClaudeCodeBackend(),
+                skill_compilation=Mock(unavailable=(), catalog=None),
+                launch_id="test-order",
+                default_base_branch="main",
+                workspace_temp_dir=None,
+            )
 
         assert tcsetattr_calls, "terminal must be restored by _launch_cook_session on exception"

--- a/tests/cli/test_terminal.py
+++ b/tests/cli/test_terminal.py
@@ -14,7 +14,6 @@ from unittest.mock import Mock, patch
 import pytest
 
 from autoskillit.cli.ui._terminal import _RESET_SPEC
-from autoskillit.execution.backends.claude import ClaudeCodeBackend
 
 pytestmark = [
     pytest.mark.layer("cli"),
@@ -461,7 +460,11 @@ class TestCookTerminalGuard:
             "tcsetattr must be called even when subprocess raises KeyboardInterrupt"
         )
 
-    def test_launch_cook_session_restores_terminal_on_keyboard_interrupt(self, monkeypatch):
+    def test_launch_cook_session_restores_terminal_on_keyboard_interrupt(
+        self,
+        monkeypatch,
+        launch_kwargs: dict[str, object],
+    ):
         """_launch_cook_session() must restore terminal on exception."""
         import importlib
 
@@ -493,11 +496,7 @@ class TestCookTerminalGuard:
             app_mod._launch_cook_session(
                 "system prompt",
                 required_env=frozenset(),
-                backend=ClaudeCodeBackend(),
-                skill_compilation=Mock(unavailable=(), catalog=None),
-                launch_id="test-order",
-                default_base_branch="main",
-                workspace_temp_dir=None,
+                **launch_kwargs,
             )
 
         assert tcsetattr_calls, "terminal must be restored by _launch_cook_session on exception"

--- a/tests/core/test_type_protocol_shards.py
+++ b/tests/core/test_type_protocol_shards.py
@@ -94,6 +94,7 @@ def test_workspace_shard_all():
         "PluginArtifactRetirementOwner",
         "PluginRetirementCoordinator",
         "CloneManager",
+        "CompiledSessionSkillCatalogAuthority",
         "EffectiveSkillCatalogAuthority",
         "EffectiveSkillInvocationAuthority",
         "ResolvedSkillAuthority",
@@ -114,7 +115,7 @@ def test_session_skill_manager_managed_session_signature():
     from contextlib import AbstractContextManager
 
     from autoskillit.core import (
-        EffectiveSkillCatalogAuthority,
+        CompiledSessionSkillCatalogAuthority,
         ManagedSessionHome,
         SessionSkillManager,
         SkillProjectionContextAuthority,
@@ -124,15 +125,15 @@ def test_session_skill_manager_managed_session_signature():
     assert tuple(signature.parameters) == (
         "self",
         "session_id",
-        "catalog",
+        "compilation",
         "projection_context",
     )
-    for name in ("session_id", "catalog", "projection_context"):
+    for name in ("session_id", "compilation", "projection_context"):
         assert signature.parameters[name].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
         assert signature.parameters[name].default is inspect.Parameter.empty
     assert typing.get_type_hints(SessionSkillManager.managed_session) == {
         "session_id": str,
-        "catalog": EffectiveSkillCatalogAuthority,
+        "compilation": CompiledSessionSkillCatalogAuthority,
         "projection_context": SkillProjectionContextAuthority,
         "return": AbstractContextManager[ManagedSessionHome],
     }

--- a/tests/execution/backends/test_codex_backend.py
+++ b/tests/execution/backends/test_codex_backend.py
@@ -36,6 +36,7 @@ from autoskillit.core import (
     ResultParser,
     SessionCheckpoint,
     SessionLocator,
+    SkillExecutionRole,
     SkillSessionConfig,
     StreamParser,
     ValidatedAddDir,
@@ -1774,9 +1775,52 @@ class TestCodexBackendSetupSessionDir:
         with pytest.raises(FileNotFoundError):
             CodexBackend().setup_session_dir(self.session_dir)
 
-    def test_absent_auth_is_allowed(self) -> None:
+    def test_absent_auth_creates_durable_absolute_link(self) -> None:
         CodexBackend().setup_session_dir(self.session_dir)
-        assert not (self.session_dir / "auth.json").exists()
+        auth_link = self.session_dir / "auth.json"
+        assert auth_link.is_symlink()
+        assert auth_link.readlink().is_absolute()
+        assert auth_link.readlink() == (self.codex_home / "auth.json").resolve(strict=False)
+        assert not auth_link.exists()
+
+    def test_orchestrator_auth_is_file_backed_across_generated_homes(self) -> None:
+        (self.session_dir / "config.toml").write_text(
+            'cli_auth_credentials_store = "keyring"\n' + self._CANONICAL_AUTOSKILLIT_MCP_CONFIG
+        )
+        backend = CodexBackend()
+        backend.setup_session_dir(
+            self.session_dir,
+            execution_role=SkillExecutionRole.ORCHESTRATOR,
+        )
+
+        first_config = (self.session_dir / "config.toml").read_text()
+        assert first_config.count('cli_auth_credentials_store = "file"') == 1
+        assert tomllib.loads(first_config)["cli_auth_credentials_store"] == "file"
+        first_link = self.session_dir / "auth.json"
+        target = (self.codex_home / "auth.json").resolve(strict=False)
+        assert first_link.is_symlink()
+        assert first_link.readlink() == target
+
+        fd = os.open(first_link, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        os.close(fd)
+        assert target.is_file()
+        assert target.stat().st_mode & 0o777 == 0o600
+        assert first_link.is_symlink()
+
+        second_home = self.session_dir.parent / "second-session"
+        second_home.mkdir()
+        (second_home / "config.toml").write_text(self._CANONICAL_AUTOSKILLIT_MCP_CONFIG)
+        backend.setup_session_dir(
+            second_home,
+            execution_role=SkillExecutionRole.ORCHESTRATOR,
+        )
+        assert (
+            tomllib.loads((second_home / "config.toml").read_text())["cli_auth_credentials_store"]
+            == "file"
+        )
+        assert (second_home / "auth.json").is_symlink()
+        assert (second_home / "auth.json").readlink() == target
+        assert target.is_file()
 
     def test_auth_destination_collision_fails_closed(self) -> None:
         (self.codex_home / "auth.json").write_text("{}")

--- a/tests/infra/test_plugin_source_ratchets.py
+++ b/tests/infra/test_plugin_source_ratchets.py
@@ -322,6 +322,10 @@ PASS_FDS_ALLOWLIST: dict[tuple[str, str, str], tuple[int, str]] = {
         1,
         "Direct interactive launch forwards the command-derived descriptor tuple exactly.",
     ),
+    ("cli/session/_session_launch.py", "_run_interactive_session", "pass_fds"): (
+        1,
+        "Managed order forwards the deduplicated command, home, projection, and attempt leases.",
+    ),
     ("cli/session/_session_process.py", "run_cook_attempt", "inherited_fds"): (
         1,
         "Direct PTY-free cook launch forwards the normalized owned descriptor tuple.",

--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -14,6 +14,7 @@ from autoskillit.core import (
     ClaudeDirectoryConventions,
     ManagedSessionHome,
     RepositoryProfileId,
+    SkillContractError,
     SkillExecutionRole,
     ValidatedAddDir,
     pkg_root,
@@ -54,23 +55,24 @@ def _catalog_context(
     *,
     backend=None,
     names: frozenset[str] | None = None,
+    role: SkillExecutionRole = SkillExecutionRole.SESSION,
 ):
     from autoskillit.workspace import DefaultSkillResolver, EffectiveSkillCatalog
 
     project_root = manager._root
     catalog = DefaultSkillResolver().list_effective(
         project_root,
-        SkillExecutionRole.SESSION,
+        role,
     )
     if names is not None:
         catalog = EffectiveSkillCatalog(
             skills=tuple(member for member in catalog.skills if member.name in names),
-            execution_role=SkillExecutionRole.SESSION,
+            execution_role=role,
         )
     else:
         catalog = EffectiveSkillCatalog(
             skills=tuple(member for member in catalog.skills if not member.exploration_vectors),
-            execution_role=SkillExecutionRole.SESSION,
+            execution_role=role,
         )
     resolved_exploration_profile = (
         RepositoryProfileId.AUTOSKILLIT
@@ -98,9 +100,18 @@ def _materialize(
     return manager.init_session(session_id, catalog, context)
 
 
-def _managed(manager, session_id: str, *, backend):
-    catalog, context = _catalog_context(manager, backend=backend)
-    return manager.managed_session(session_id, catalog, context)
+def _managed(
+    manager,
+    session_id: str,
+    *,
+    backend,
+    role: SkillExecutionRole = SkillExecutionRole.SESSION,
+):
+    from autoskillit.workspace import compile_session_skill_catalog
+
+    catalog, context = _catalog_context(manager, backend=backend, role=role)
+    compilation = compile_session_skill_catalog(catalog, backend)
+    return manager.managed_session(session_id, compilation, context)
 
 
 @pytest.fixture
@@ -310,7 +321,9 @@ def test_codex_generated_home_preserves_existing_profile_skill_on_collision(
         session_dir: Path,
         *,
         parent_sandbox_mode: str = "workspace-write",
+        execution_role: SkillExecutionRole = SkillExecutionRole.SESSION,
     ) -> None:
+        del parent_sandbox_mode, execution_role
         profile_skill = session_dir / "skills" / "investigate"
         profile_skill.mkdir(parents=True)
         (profile_skill / "SKILL.md").write_text(profile_content)
@@ -340,7 +353,71 @@ def test_codex_init_session_delegates_to_setup_session_dir(
     codex_env.backend.setup_session_dir.assert_called_once_with(
         Path(str(session_path)).parent,
         parent_sandbox_mode="workspace-write",
+        execution_role=SkillExecutionRole.SESSION,
     )
+
+
+def test_codex_managed_orchestrator_materializes_exact_catalog(
+    make_session_skill_manager,
+    codex_env,
+) -> None:
+    mgr = make_session_skill_manager()
+    catalog, _ = _catalog_context(
+        mgr,
+        backend=codex_env.backend,
+        role=SkillExecutionRole.ORCHESTRATOR,
+    )
+
+    with _managed(
+        mgr,
+        "orchestrator",
+        backend=codex_env.backend,
+        role=SkillExecutionRole.ORCHESTRATOR,
+    ) as managed:
+        projected_root = Path(managed.skills_dir.path) / "skills"
+        discovery_root = managed.generated_home / "skills"
+        assert {entry.name for entry in projected_root.iterdir()} == {
+            member.name for member in catalog.skills
+        }
+        for member in catalog.skills:
+            discovery = discovery_root / member.name
+            assert discovery.is_symlink()
+            assert (discovery.resolve() / "SKILL.md").is_file()
+            assert not (discovery.resolve() / "SKILL.md").is_symlink()
+
+
+def test_codex_managed_orchestrator_rejects_discovery_collision(
+    make_session_skill_manager,
+    codex_env,
+) -> None:
+    mgr = make_session_skill_manager()
+    catalog, _ = _catalog_context(
+        mgr,
+        backend=codex_env.backend,
+        role=SkillExecutionRole.ORCHESTRATOR,
+    )
+    collision_name = catalog.skills[0].name
+
+    def setup_session_dir(
+        session_dir: Path,
+        *,
+        parent_sandbox_mode: str = "workspace-write",
+        execution_role: SkillExecutionRole = SkillExecutionRole.SESSION,
+    ) -> None:
+        del parent_sandbox_mode, execution_role
+        collision = session_dir / "skills" / collision_name
+        collision.mkdir(parents=True)
+        (collision / "SKILL.md").write_text("profile collision")
+
+    codex_env.backend.setup_session_dir.side_effect = setup_session_dir
+    with pytest.raises(SkillContractError, match="orchestrator skill discovery collision"):
+        with _managed(
+            mgr,
+            "orchestrator",
+            backend=codex_env.backend,
+            role=SkillExecutionRole.ORCHESTRATOR,
+        ):
+            pass
 
 
 def test_no_backend_skips_setup_session_dir(make_session_skill_manager) -> None:

--- a/tests/workspace/test_session_skills_stale_path.py
+++ b/tests/workspace/test_session_skills_stale_path.py
@@ -54,8 +54,14 @@ def _materialize(manager, session_id: str, *, backend=None):
 
 
 def _managed(manager, session_id: str, *, backend):
+    from autoskillit.workspace import compile_session_skill_catalog
+
     catalog, context = _catalog_context(manager, backend=backend)
-    return manager.managed_session(session_id, catalog, context)
+    return manager.managed_session(
+        session_id,
+        compile_session_skill_catalog(catalog, backend),
+        context,
+    )
 
 
 def test_validate_session_exists_true_for_live_session(make_session_skill_manager) -> None:


### PR DESCRIPTION
## Summary

Codex `order` previously split authority across two directories: pre-launch setup wrote the AutoSkillit MCP registration to the source Codex home while the child read a projected plugin directory as `CODEX_HOME`. This change gives each persistent Codex `order` launch one leased generated home as the mutable authority for configuration, authentication, SQLite, rollouts, history, and the exact compiled ORCHESTRATOR skill catalog, while retaining the plugin projection only as immutable content authority.

The generated orchestrator home pins file-based authentication through a durable absolute `auth.json` link, validates the finalized invocation before spawn, and remains leased across reload and infrastructure-resume attempts. Focused coverage now includes authentication durability, ORCHESTRATOR catalog isolation and collision behavior, managed process ownership and attempt sequencing, and projection immutability under representative runtime writes.

Closes https://github.com/TalonT-Org/AutoSkillit/issues/4566

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/rectify/rectify_codex_order_runtime_home_authority_2026-08-12_112132.md`

## Verification

- `pre-commit run --all-files`
- Configured conservative test gate: 26,538 passed, 570 skipped, 27 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
