### PR TITLE
Rectify: Codex Single-Worker Adaptation and Adaptive Exploration Authority

### DIFF
--- a/.autoskillit/skills/audit-feature-gates/SKILL.md
+++ b/.autoskillit/skills/audit-feature-gates/SKILL.md
@@ -19,6 +19,7 @@ semantic_requirements:
       purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
     - role: delegated-worker
+      count: 6
   concurrency:
     required: true
   join:

--- a/.autoskillit/skills/eval-agent/SKILL.md
+++ b/.autoskillit/skills/eval-agent/SKILL.md
@@ -12,6 +12,7 @@ semantic_requirements:
       purpose: run the named agent definition under evaluation against the prepared prompt and return its full output
   child_spawns:
     - role: evaluated-agent
+      count: 1
   join:
     required: true
 ---

--- a/.claude/skills/chart-course/SKILL.md
+++ b/.claude/skills/chart-course/SKILL.md
@@ -16,6 +16,7 @@ semantic_requirements:
       purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
     - role: delegated-worker
+      for_each: selected_direction_explorations
   concurrency:
     required: true
   join:
@@ -141,7 +142,9 @@ If `compass_path` was provided:
 
 #### Step 1.3: Launch Parallel Exploration Subagents
 
-Launch ALL concurrently in a single message. Every subagent is spawned via `child delegation under the declared `sonnet` model-class policy`.
+Set `selected_direction_explorations` to the independent direction-analysis tasks selected
+for the current round. Launch them concurrently in a single message. Every subagent is
+spawned via `child delegation under the declared `sonnet` model-class policy`.
 
 **Subagent A: Architecture & Extension Points**
 Explore protocol definitions, plugin points, layering (L0/L1/L2/L3),

--- a/.claude/skills/check-bearing/SKILL.md
+++ b/.claude/skills/check-bearing/SKILL.md
@@ -16,6 +16,7 @@ semantic_requirements:
       purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
     - role: delegated-worker
+      for_each: selected_bearing_assessments
   concurrency:
     required: true
   join:
@@ -194,6 +195,10 @@ Classify each direction:
 - **NO_SIGNAL** — zero signals matched. Gets lightweight bulk assessment only.
 
 ### Step 4: Launch Parallel Direction Assessment Subagents
+
+Set `selected_bearing_assessments` to the SIGNAL_HIT direction tasks, NO_SIGNAL batch
+tasks, and any dependency-ready holistic review task selected by the workflow below.
+Retain child IDs keyed by assessment through each join.
 
 #### 4a: Full Assessment (SIGNAL_HIT directions)
 

--- a/.claude/skills/promote-to-main/SKILL.md
+++ b/.claude/skills/promote-to-main/SKILL.md
@@ -14,6 +14,7 @@ semantic_requirements:
       purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
     - role: delegated-worker
+      for_each: selected_promotion_responsibilities
   concurrency:
     required: true
   join:
@@ -169,6 +170,10 @@ EOF
   section — graceful degradation with no error.
 
 ### Phase 1: Pre-flight Checks (parallel, blocking)
+
+Set `selected_promotion_responsibilities` to the dependency-ready pre-flight, inventory,
+domain, and synthesis responsibilities selected across the phases below. Dispatch only
+the current independent frontier and join it before dependent work.
 
 Spawn three parallel subagents via child delegation under the declared `sonnet` model-class
 policy to validate promotion readiness.

--- a/.claude/skills/review-promotion/SKILL.md
+++ b/.claude/skills/review-promotion/SKILL.md
@@ -14,6 +14,7 @@ semantic_requirements:
       purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
     - role: delegated-worker
+      for_each: selected_review_responsibilities
   concurrency:
     required: true
   join:
@@ -32,6 +33,10 @@ Perform deep reviewer-facing analysis of an integration-to-main promotion. This 
 partitions all changed files by domain, runs parallel domain risk analysis, assesses
 test coverage and breaking changes, synthesizes a reviewer verdict, and optionally
 posts the review report as a PR comment.
+
+Set `selected_review_responsibilities` to each dependency-ready domain, quality,
+cross-domain, and synthesis responsibility selected during the phases below. Dispatch
+only the currently independent frontier and join every launched responsibility.
 
 ## Arguments
 

--- a/.claude/skills/validate-audit/SKILL.md
+++ b/.claude/skills/validate-audit/SKILL.md
@@ -17,6 +17,7 @@ semantic_requirements:
       purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
     - role: delegated-worker
+      for_each: validation_responsibilities
   concurrency:
     required: true
   join:
@@ -134,6 +135,10 @@ Collect all findings into a flat list. Record the source audit skill (`arch`, `t
 `cohesion`) for use in output filenames.
 
 ### Step 2 — Group into Thematic Batches
+
+Set `validation_responsibilities` to the code-area batches plus the history research
+responsibility. Append the two post-validation responsibilities when their input
+artifacts are ready; retain child IDs keyed by responsibility and join every launch.
 
 Cluster findings by **code area**: inspect `file:line` references in each finding and group
 by the top-level package touched (e.g., `pipeline/`, `execution/`, `server/`, `core/`,

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -710,6 +710,7 @@ from .types import ChildExecutionIdentity as ChildExecutionIdentity
 from .types import ChildExecutionIdentityDict as ChildExecutionIdentityDict
 from .types import ChildModelPolicySpec as ChildModelPolicySpec
 from .types import ChildSpawnSpec as ChildSpawnSpec
+from .types import ChildSpawnCardinalityError as ChildSpawnCardinalityError
 from .types import CIRunScope as CIRunScope
 from .types import CIWatcher as CIWatcher
 from .types import ClaudeContentBlockType as ClaudeContentBlockType

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -709,8 +709,8 @@ from .types import CharsToTokensPolicy as CharsToTokensPolicy
 from .types import ChildExecutionIdentity as ChildExecutionIdentity
 from .types import ChildExecutionIdentityDict as ChildExecutionIdentityDict
 from .types import ChildModelPolicySpec as ChildModelPolicySpec
-from .types import ChildSpawnSpec as ChildSpawnSpec
 from .types import ChildSpawnCardinalityError as ChildSpawnCardinalityError
+from .types import ChildSpawnSpec as ChildSpawnSpec
 from .types import CIRunScope as CIRunScope
 from .types import CIWatcher as CIWatcher
 from .types import ClaudeContentBlockType as ClaudeContentBlockType

--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -394,6 +394,15 @@ _SKILL_CONTRACT_REMEDIATION_DEFS = (
         ),
     ),
     SkillContractRemediationDef(
+        kind=SkillInvalidityKind.SEMANTIC_CHILD_CARDINALITY_INVALID,
+        introduced_in="0.10.964",
+        action=RemediationAction.DETERMINISTIC,
+        hint=(
+            "give each semantic_requirements.child_spawns entry exactly one authority: "
+            "count: <positive integer> or for_each: <runtime collection>"
+        ),
+    ),
+    SkillContractRemediationDef(
         kind=SkillInvalidityKind.SEMANTIC_PLAN_INVALID,
         introduced_in="0.10.929",
         action=RemediationAction.ADVISORY,

--- a/src/autoskillit/core/types/_type_enums.py
+++ b/src/autoskillit/core/types/_type_enums.py
@@ -173,6 +173,7 @@ class SkillInvalidityKind(StrEnum):
     SEMANTIC_UNDECLARED_TOKENS = "semantic_undeclared_tokens"
     SEMANTIC_MISSING_VERSION = "semantic_missing_version"
     SEMANTIC_VERSION_MISMATCH = "semantic_version_mismatch"
+    SEMANTIC_CHILD_CARDINALITY_INVALID = "semantic_child_cardinality_invalid"
     SEMANTIC_PLAN_INVALID = "semantic_plan_invalid"
 
 

--- a/src/autoskillit/core/types/_type_exceptions.py
+++ b/src/autoskillit/core/types/_type_exceptions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 __all__ = [
     "BoundedDeliveryRoundTripBudgetExceededError",
     "CapabilityNotSupportedError",
+    "ChildSpawnCardinalityError",
     "PluginArtifactContentionError",
     "PluginArtifactPublicationError",
     "PluginArtifactUnavailableError",
@@ -91,6 +92,10 @@ class CapabilityNotSupportedError(Exception):
 
 class SkillContractError(ValueError):
     """A skill machine contract is malformed or exceeds its execution role."""
+
+
+class ChildSpawnCardinalityError(SkillContractError):
+    """A child spawn does not declare exactly one valid cardinality authority."""
 
 
 class PluginArtifactContentionError(RuntimeError):

--- a/src/autoskillit/core/types/_type_skill_contract.py
+++ b/src/autoskillit/core/types/_type_skill_contract.py
@@ -47,11 +47,9 @@ MACHINE_ONLY_SKILL_FRONTMATTER_KEYS = frozenset(
         "uses_capabilities",
     }
 )
-# Bumped when: applicability enum narrowed (INVESTIGATE_STANDARD, INVESTIGATE_DEEP,
-# SCOPE_SOFTWARE, SCOPE_NON_SOFTWARE removed); vector metadata moved to per-skill
-# exploration.yaml sidecars; vector schema slimmed (max_results, max_report_bytes,
-# native_dispatch removed). Stale contracts may carry removed enum values/fields.
-SKILL_PROJECTION_VERSION = 6
+# Bumped because child cardinality now emits exactly one explicit authority and
+# migrated exploration calls are guarded by the parent-selected ready set.
+SKILL_PROJECTION_VERSION = 7
 SKILL_SESSION_CONTRACT_SCHEMA_VERSION = 5
 PARENT_SANDBOX_MODES: frozenset[str] = frozenset({"read-only", "workspace-write"})
 _CANONICAL_IDENTIFIER_RE = re.compile(r"[a-z][a-z0-9]*(?:-[a-z0-9]+)*\Z")

--- a/src/autoskillit/core/types/_type_skill_semantics.py
+++ b/src/autoskillit/core/types/_type_skill_semantics.py
@@ -9,7 +9,7 @@ from enum import StrEnum
 from hashlib import sha256
 from types import MappingProxyType
 
-from ._type_exceptions import SkillContractError
+from ._type_exceptions import ChildSpawnCardinalityError, SkillContractError
 
 __all__ = [
     "SKILL_MODEL_CLASS_REGISTRY",
@@ -79,22 +79,29 @@ class ChildSpawnSpec:
     """Spawn one or more children that perform a named logical role."""
 
     role: str
-    count: int = 1
+    count: int | None = None
     for_each: str | None = None
 
     def __post_init__(self) -> None:
         _require_nonempty(self.role, "child spawn role")
-        if self.count < 1:
-            raise SkillContractError("child spawn count must be positive")
-        if self.for_each is not None:
-            if not isinstance(self.for_each, str):
-                raise SkillContractError("child spawn for_each must be a string")
-            if not self.for_each.strip():
-                raise SkillContractError("child spawn for_each must be non-empty")
-            if self.count != 1:
-                raise SkillContractError(
-                    "child spawn for_each cannot be combined with a non-default count"
+        has_count = self.count is not None
+        has_for_each = self.for_each is not None
+        if has_count == has_for_each:
+            raise ChildSpawnCardinalityError(
+                "child spawn requires exactly one cardinality authority: "
+                "count: <positive integer> or for_each: <runtime collection>"
+            )
+        if self.count is not None:
+            if type(self.count) is not int or self.count <= 0:
+                raise ChildSpawnCardinalityError(
+                    "child spawn count must be a positive integer; use "
+                    "count: <positive integer> or for_each: <runtime collection>"
                 )
+        if has_for_each and (not isinstance(self.for_each, str) or not self.for_each.strip()):
+            raise ChildSpawnCardinalityError(
+                "child spawn for_each must be a non-empty runtime collection name; use "
+                "count: <positive integer> or for_each: <runtime collection>"
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -243,11 +250,9 @@ class SkillSemanticPlan:
         payload: dict[str, object] = {
             "schema_version": self.schema_version,
             "child_spawns": tuple(
-                {
-                    "role": item.role,
-                    "count": item.count,
-                    **({"for_each": item.for_each} if item.for_each is not None else {}),
-                }
+                dict[str, object](role=item.role, for_each=item.for_each)
+                if item.for_each is not None
+                else dict[str, object](role=item.role, count=item.count)
                 for item in self.child_spawns
             ),
             "concurrency": (

--- a/src/autoskillit/execution/backends/_explorer_dispatch.py
+++ b/src/autoskillit/execution/backends/_explorer_dispatch.py
@@ -18,13 +18,19 @@ from autoskillit.core import (
 
 _PARENT_ROUTING_INSTRUCTIONS = (
     "Parent routing contract:\n"
-    "1. Submit this typed task packet to the deterministic exploration router and merge API.\n"
-    "2. Reclassify every newly discovered cross-leaf frontier explicitly; do not let leaves "
-    "spawn peers.\n"
-    "3. Run only scope-disjoint ready tasks concurrently and keep dependency chains sequential.\n"
-    "4. Wait for every dispatched leaf, preserve conflicts and unresolved frontiers, then "
-    "merge evidence.\n"
-    "5. Retain final synthesis and every artifact or repository write in the parent session."
+    "1. Projection and static applicability make tasks available only; rendered marker or "
+    "call count is never a spawn obligation.\n"
+    "2. The parent sets selected_exploration_task_ids to the relevant and affordable "
+    "dependency-ready task IDs after reserving synthesis/report/validation context and "
+    "checking current child capacity.\n"
+    "3. Submit only selected typed task packets to the deterministic exploration router and "
+    "merge API; reclassify newly discovered cross-leaf frontiers explicitly and never let "
+    "leaves spawn peers.\n"
+    "4. Run only selected, scope-disjoint, dependency-ready tasks concurrently and keep "
+    "dependency chains sequential.\n"
+    "5. Join every dispatched leaf, preserve conflicts and unresolved frontiers, then merge "
+    "evidence. Retain final synthesis and every artifact or repository write in the parent "
+    "session."
 )
 
 
@@ -121,7 +127,16 @@ class _NativeExplorationDispatchRenderer:
                 role_definition_digest=definition_digest,
                 launch_context_ref=launch_context_ref,
             )
-            replacements[vector.id] = self._native_call(definition, prompt)
+            native_call = self._native_call(definition, prompt)
+            task_id = vector.task.task_id
+            replacements[vector.id] = (
+                f"Candidate exploration task {task_id!r}:\n"
+                f"Execute if and only if {task_id!r} is in "
+                "selected_exploration_task_ids:\n"
+                f"{native_call}\n"
+                "Otherwise skip this candidate; omission from the parent-selected ready set "
+                "is not a failure."
+            )
             definition_digests[vector.id] = definition_digest
         context_ref = launch_context_ref or "runtime-bound"
         provisioning = (

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -1070,6 +1070,7 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
                     f"runtime item in {spawn.for_each!r}{effort_text}."
                 )
             else:
+                assert spawn.count is not None
                 fragments.append(
                     f"Issue {spawn.count} Agent(subagent_type={spawn.role!r}{model_arg}) "
                     f"call{'s' if spawn.count != 1 else ''}{effort_text}."

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -2281,6 +2281,7 @@ class CodexBackend(BackendCmdBuilderBase):
                     f"fork_turns='none'{policy_text}; retain every returned child ID."
                 )
             else:
+                assert spawn.count is not None
                 fragments.append(
                     f"Call spawn_agent {spawn.count} time{'s' if spawn.count != 1 else ''} "
                     f"with agent_type={native_role!r}, fork_turns='none'{policy_text}; "

--- a/src/autoskillit/migration/engine.py
+++ b/src/autoskillit/migration/engine.py
@@ -53,6 +53,45 @@ def _skill_project_dir(skill_md_path: Path) -> Path:
     )
 
 
+def _normalize_legacy_child_spawn_cardinality(data: dict[str, Any]) -> str | None:
+    """Preserve cardinalities accepted by the pre-explicit-authority parser."""
+    requirements = data.get("semantic_requirements")
+    if not isinstance(requirements, dict):
+        return "semantic_requirements must be a mapping"
+    raw_spawns = requirements.get("child_spawns")
+    if not isinstance(raw_spawns, list):
+        return "semantic_requirements.child_spawns must be a list"
+
+    normalized: list[dict[str, Any]] = []
+    for raw_spawn in raw_spawns:
+        if not isinstance(raw_spawn, dict):
+            return "semantic_requirements.child_spawns entries must be mappings"
+        spawn = dict(raw_spawn)
+        raw_count = spawn.get("count", 1)
+        try:
+            legacy_count = int(raw_count)
+        except (TypeError, ValueError, OverflowError):
+            return f"legacy child spawn count {raw_count!r} was not coercible to an integer"
+        if legacy_count < 1:
+            return f"legacy child spawn count {raw_count!r} was not positive"
+
+        for_each = spawn.get("for_each")
+        if for_each is not None:
+            if not isinstance(for_each, str) or not for_each.strip():
+                return "legacy child spawn for_each was not a non-empty string"
+            if legacy_count != 1:
+                return "legacy child spawn combined for_each with a non-default count"
+            spawn.pop("count", None)
+        else:
+            spawn["count"] = legacy_count
+        normalized.append(spawn)
+
+    requirements = dict(requirements)
+    requirements["child_spawns"] = normalized
+    data["semantic_requirements"] = requirements
+    return None
+
+
 MIGRATE_RECIPES_MAX_RETRIES: int = 3
 """Max validation-retry attempts for LLM-driven recipe migration (matches SKILL.md)."""
 
@@ -419,13 +458,14 @@ class DiagramMigrationAdapter(AdvisoryMigrationAdapter):
 class SkillMigrationAdapter(DeterministicMigrationAdapter):
     """Deterministic, frontmatter-only migration for stale project-local skills.
 
-    Handles the three SkillInvalidityKind members registered as
+    Handles the SkillInvalidityKind members registered as
     ``DETERMINISTIC`` in ``SKILL_CONTRACT_REMEDIATIONS``: UNDECLARED_CAPABILITY,
-    SEMANTIC_MISSING_VERSION, and SEMANTIC_UNDECLARED_TOKENS. Every other kind
-    is ``ADVISORY`` and left to the operator — see the hint surfaced by
-    doctor/composition-root warnings. Frontmatter is edited in-memory and
-    re-serialized as a whole block; the body is carried through byte-for-byte
-    from the parsed result and never touched.
+    SEMANTIC_MISSING_VERSION, SEMANTIC_UNDECLARED_TOKENS, and
+    SEMANTIC_CHILD_CARDINALITY_INVALID. Every other kind is ``ADVISORY`` and
+    left to the operator — see the hint surfaced by doctor/composition-root
+    warnings. Frontmatter is edited in-memory and re-serialized as a whole
+    block; the body is carried through byte-for-byte from the parsed result and
+    never touched.
     """
 
     file_type = "skill"
@@ -554,6 +594,14 @@ class SkillMigrationAdapter(DeterministicMigrationAdapter):
                     field = RETIRED_SEMANTIC_CAPABILITIES[capability].rsplit(".", 1)[-1]
                     requirements.setdefault(field, [])
                 data["semantic_requirements"] = requirements
+            elif kind is SkillInvalidityKind.SEMANTIC_CHILD_CARDINALITY_INVALID:
+                migration_error = _normalize_legacy_child_spawn_cardinality(data)
+                if migration_error is not None:
+                    return MigrationResult(
+                        success=False,
+                        name=file.name,
+                        error=migration_error,
+                    )
             else:
                 raise SkillContractError(
                     f"SkillMigrationAdapter has no migration for invalidity kind {kind.value!r}"

--- a/src/autoskillit/skills_extended/analyze-prs/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-prs/SKILL.md
@@ -19,7 +19,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: candidate_pr_numbers
   concurrency:
     required: true
   join:
@@ -127,6 +127,10 @@ is active on `{base_branch}` with `MERGEABLE` entries.
 | `QUEUE_ENTRIES` | list[dict] | Sorted queue entries `{position, state, pr_number, pr_title}` when `QUEUE_MODE = true`; empty list when `false` |
 
 ### Step 1: Fetch PR Data (SINGLE MESSAGE)
+
+Set `candidate_pr_numbers` to the PR numbers selected in Step 0 or the merge-queue
+entries selected in Step 0.5. Use that exact collection for prompts, child IDs, results,
+and joins.
 
 **Start ALL independent child delegations before awaiting any result — one per item — and join every child before synthesis.**
 

--- a/src/autoskillit/skills_extended/analyze-prs/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-prs/SKILL.md
@@ -19,6 +19,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/apply-review-dimensions/SKILL.md
+++ b/src/autoskillit/skills_extended/apply-review-dimensions/SKILL.md
@@ -19,6 +19,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/audit-arch/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-arch/SKILL.md
@@ -19,6 +19,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/audit-bugs/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-bugs/SKILL.md
@@ -21,6 +21,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/audit-claims/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-claims/SKILL.md
@@ -20,7 +20,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: claim_analysis_responsibilities
   concurrency:
     required: true
   join:
@@ -128,6 +128,10 @@ Do NOT run deterministic diff annotation — claim positions are report-level, n
 line-level. Subagents use section structure, not line markers.
 
 ### Step 3: Two-Phase Claim Analysis
+
+Set `claim_analysis_responsibilities` to the non-empty report-section extraction tasks
+and, once extraction completes, the non-empty claim-type evidence tasks. Dispatch each
+dependency-ready phase concurrently and retain IDs keyed by responsibility.
 
 #### Phase 1 — Claim Extraction (parallel subagents by report section) (SINGLE MESSAGE)
 

--- a/src/autoskillit/skills_extended/audit-claims/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-claims/SKILL.md
@@ -20,6 +20,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/audit-cohesion/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-cohesion/SKILL.md
@@ -20,6 +20,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 5
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/audit-defense-standards/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-defense-standards/SKILL.md
@@ -20,6 +20,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/audit-friction/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-friction/SKILL.md
@@ -23,7 +23,9 @@ semantic_requirements:
     purpose: independently validate one friction category and return bounded evidence
   child_spawns:
   - role: friction-batch-scanner
+    count: 1
   - role: friction-category-analyzer
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/audit-impl/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-impl/SKILL.md
@@ -23,9 +23,9 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: audit-impl-deviation-evaluator
-    count: 1
+    for_each: deviation_entries
   - role: audit-impl-slice-auditor
-    count: 1
+    for_each: audit_slices
   concurrency:
     required: true
   join:
@@ -363,6 +363,9 @@ logic (Step 4).
 
 ### Step 3 — Audit via Parallel Subagents (SINGLE MESSAGE)
 
+Set `audit_slices` to the requirement slices produced from the exact-cycle inventory.
+Retain slice-auditor child IDs keyed by slice through the join.
+
 **Start ALL independent child delegations before awaiting any result — one per item — and join every child before synthesis.**
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
@@ -396,6 +399,10 @@ Each subagent returns structured findings:
 - `CONFLICT` — two plans' implementations interfere with each other
 
 ### Step 3.5 — Deviation Evaluation
+
+Set `deviation_entries` to the validated manifest's `deviations` array, or an empty
+collection when no valid deviation manifest was supplied. Retain evaluator child IDs
+keyed by deviation entry through the join.
 
 **Skip this step entirely when no valid deviation manifest was provided in Step 0.**
 

--- a/src/autoskillit/skills_extended/audit-impl/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-impl/SKILL.md
@@ -23,7 +23,9 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: audit-impl-deviation-evaluator
+    count: 1
   - role: audit-impl-slice-auditor
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -24,6 +24,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -24,7 +24,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: review_decision_batches
   concurrency:
     required: true
   join:
@@ -161,6 +161,9 @@ implemented. Identify review debt before it compounds.
 ---
 
 ### Step 2: Triage (Haiku — Broad Pass) (SINGLE MESSAGE)
+
+Set `review_decision_batches` to the non-empty triage batches and, after triage completes,
+the non-empty validation batches. Retain child IDs keyed by phase and batch through joins.
 
 **Start ALL independent child delegations before awaiting any result — one per item — and join every child before synthesis.**
 

--- a/src/autoskillit/skills_extended/audit-tests/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-tests/SKILL.md
@@ -20,6 +20,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 6
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -18,6 +18,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -18,7 +18,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: issue_numbers
   concurrency:
     required: true
   join:
@@ -93,6 +93,9 @@ with `"Error: --max-parallel must be a positive integer"`. Validate the issue co
 - **Zero issues**: abort immediately with `"Error: build-execution-map requires at least 1 issue number"` and exit non-zero.
 - **One issue**: emit a warning and write a trivial single-group map (single issue always gets `parallel: false`).
 - **Two or more issues**: proceed to Step 1.
+
+Store the validated issue-number collection as `issue_numbers`; it is the authority for
+child prompts, IDs, result association, and joins in Step 1.
 
 ### Step 1 — Fetch Issue Data (parallel subagents) (SINGLE MESSAGE)
 

--- a/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
+++ b/src/autoskillit/skills_extended/classify-experiment-type/SKILL.md
@@ -19,6 +19,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/compose-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-pr/SKILL.md
@@ -22,7 +22,9 @@ semantic_requirements:
     purpose: synthesize the overall PR summary from collected evidence
   child_spawns:
   - role: pr-source-reader
+    count: 1
   - role: pr-synthesizer
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/compose-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-research-pr/SKILL.md
@@ -22,6 +22,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/design-guards/SKILL.md
+++ b/src/autoskillit/skills_extended/design-guards/SKILL.md
@@ -18,6 +18,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/download-data/SKILL.md
+++ b/src/autoskillit/skills_extended/download-data/SKILL.md
@@ -21,6 +21,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
+++ b/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
@@ -17,6 +17,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/enrich-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/enrich-issues/SKILL.md
@@ -23,6 +23,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/generate-report/SKILL.md
+++ b/src/autoskillit/skills_extended/generate-report/SKILL.md
@@ -19,6 +19,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/implement-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-experiment/SKILL.md
@@ -19,6 +19,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
@@ -20,6 +20,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    for_each: exploration_responsibilities
   concurrency:
     required: true
   join:
@@ -181,6 +182,9 @@ Before implementing ANY code, launch parallel child delegations to understand af
 - **Test coverage** — existing tests, patterns, fixtures for affected code
 - **Integration points** — entry/exit points, contracts that must be maintained
 - **Data flow** — state management, source of truth
+
+Set `exploration_responsibilities` to these four named responsibilities and retain child
+IDs keyed by responsibility through the join.
 
 ### Step 3: Set Up Worktree Environment
 

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -21,6 +21,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    for_each: exploration_responsibilities
   concurrency:
     required: true
   join:
@@ -149,6 +150,9 @@ Before implementing ANY code, launch parallel child delegations to understand af
 - **Test coverage** — existing tests, patterns, fixtures for affected code
 - **Integration points** — entry/exit points, contracts that must be maintained
 - **Data flow** — state management, source of truth
+
+Set `exploration_responsibilities` to these four named responsibilities and retain child
+IDs keyed by responsibility through the join.
 
 ### Step 3: Set Up Worktree Environment
 

--- a/src/autoskillit/skills_extended/investigate/SKILL.md
+++ b/src/autoskillit/skills_extended/investigate/SKILL.md
@@ -16,8 +16,13 @@ semantic_requirements:
   logical_roles:
   - name: delegated-worker
     purpose: perform the named independent responsibility and return bounded evidence
+  - name: autoskillit:web-evidence-researcher
+    purpose: research one selected external evidence topic
   child_spawns:
   - role: delegated-worker
+    for_each: selected_reasoning_responsibilities
+  - role: autoskillit:web-evidence-researcher
+    for_each: selected_web_research_topics
   concurrency:
     required: true
   join:
@@ -154,9 +159,28 @@ Identify what needs investigation:
 - **Module Investigation**: Identify the module/component to understand
 - **Question Investigation**: Clarify the specific question being asked
 
+Select exactly one runtime mode: standard or deep. Although projection makes both
+marker families available, they are mutually exclusive for an invocation. Before any
+semantic child dispatch, define:
+
+- `selected_reasoning_responsibilities`: retained non-local reasoning tasks selected
+  from the target, mode, available evidence, dependency readiness, remaining context
+  after reserving synthesis/report/validation capacity, and current child capacity.
+- `selected_web_research_topics`: relevant external questions under the same budget and
+  readiness constraints; this may be empty when external evidence cannot resolve an
+  open question.
+
+The exploration markers below are candidate evidence packets governed by the shared
+parent routing contract. Dispatch only the selected, dependency-ready independent
+frontier, and join every launched child before dependent reasoning or synthesis. Stop
+when further work is irrelevant, redundant, unaffordable, or cannot resolve an open
+question.
+
 ### Step 2: Launch Parallel Exploration (SINGLE READY WAVE)
 
-Dispatch all ready standard-mode packets and independent retained agents before awaiting any result. Join every leaf before synthesis. A reasoning agent that consumes typed packet evidence is not ready until those packets complete.
+Dispatch the selected ready standard-mode packets and independent retained agents before
+awaiting any result. A reasoning agent that consumes typed packet evidence is not ready
+until those packets complete.
 
 Do not output prose between ready dispatches. Immediately proceed to the next launch.
 
@@ -414,7 +438,7 @@ When deep analysis mode is activated, Steps D1–D6 replace standard Steps 1–3
 Parse the investigation target (same as Step 1). Then propose an adaptive batch plan:
 
 - Before authorizing each batch, reserve enough remaining context budget for synthesis, report writing, and post-report validation. Stop gathering and proceed to synthesis when another batch would cross that reserve.
-- Minimum 2 batches; typically 3–4 for complex investigations
+- Authorize another batch only when it can resolve an open question within the reserved context budget
 - State the planned batch count and scope for each batch
 - Present as "Proposed investigation plan: Batch 1 — {scope}, Batch 2 — {scope}, ..."
 
@@ -422,7 +446,10 @@ Parse the investigation target (same as Step 1). Then propose an adaptive batch 
 
 ### Step D2: Batch 1 — Broad Parallel Exploration
 
-Launch a minimum of 5 parallel subagents/packets using the five ready vectors below in one parallel wave. Run the historical recurrence check from Step 3.5 in parallel with Batch 1 through the log/history packet. Native explorer leaves return typed evidence only; they never name a root cause, generate a solution, rank candidates, or select a fix.
+Select the relevant and affordable dependency-ready packets from the candidates below.
+Launch the selected independent frontier concurrently. Run recurrence work only when
+provenance evidence is relevant. Native explorer leaves return typed evidence only; they
+never name a root cause, generate a solution, rank candidates, or select a fix.
 
 <!-- autoskillit:exploration-vector id="deep-code-paths" -->
 - **Code path tracing packet**: Trace execution paths, symbols, imports, and local data flow through the primary affected components. Return bounded typed evidence with locations and direct/inferred status only.
@@ -463,14 +490,14 @@ Do not output prose between the ready dispatches in a batch; issue them in a sin
 For each subsequent batch (Batch 2, Batch 3, ...):
 
 1. Open with an explicit synthesis from prior batches — what was confirmed, what remains uncertain
-2. Dispatch both ready vectors below before awaiting either result:
+2. Dispatch the relevant selected ready vectors below before awaiting any result:
 
 <!-- autoskillit:exploration-vector id="deep-code-deepening" -->
-   - **Mandatory local code packet**: Adapt the open questions into a batch-specific semantic navigation task covering code search, file/symbol tracing, imports, calls, and local data flow. Return bounded typed evidence only; do not choose the primary hypothesis or a fix.
+   - **Local code packet**: When local evidence is still needed, adapt the open questions into a batch-specific semantic navigation task covering code search, file/symbol tracing, imports, calls, and local data flow. Return bounded typed evidence only; do not choose the primary hypothesis or a fix.
 <!-- /autoskillit:exploration-vector -->
 
 <!-- autoskillit:exploration-vector id="deep-informed-web-research" -->
-   - **Mandatory web research agent**: Spawn the existing web-capable subagent under the declared `sonnet` model-class policy to research external documentation, known issues, and library behavior relevant to the open questions.
+   - **Web research agent**: When external evidence can resolve an open question, add that topic to `selected_web_research_topics` and research external documentation, known issues, and library behavior.
 <!-- /autoskillit:exploration-vector -->
 
 3. After each batch completes, produce inter-batch synthesis (confirmed findings, open questions, new leads)
@@ -484,7 +511,9 @@ For each subsequent batch (Batch 2, Batch 3, ...):
 
 **Empty batch handling:** If a batch produces no new findings (all subagents report the same conclusions as prior batches), treat it as an early termination signal and proceed to D4.
 
-Deep mode must execute at least two completed agent waves. Do not begin a later wave until every launch in the preceding wave has a terminal result and its `Inter-batch synthesis:` progress message has been emitted.
+Do not begin a later wave until every launch in the preceding wave has a terminal result
+and its `Inter-batch synthesis:` progress message has been emitted. Stop when the quality
+gate above says another wave is not useful or affordable.
 
 ### Step D4: Challenge Round
 
@@ -538,7 +567,8 @@ If the recommendation does not propose removal or change of an existing mechanis
 
 ### Step D6: Post-Report Validation
 
-After writing the report (Step 4), spawn 2–3 independent validator subagents through child delegation under the declared `sonnet` model-class policy with distinct roles:
+After writing the report (Step 4), select only validators needed for claims that remain
+high-risk or insufficiently cross-checked, subject to the reserved validation budget:
 
 <!-- autoskillit:exploration-vector id="deep-factual-validation" -->
 - **Validator 1 — Factual accuracy**: Cross-check every claim in the report against actual code/evidence. Flag any factual inaccuracy.

--- a/src/autoskillit/skills_extended/make-groups/SKILL.md
+++ b/src/autoskillit/skills_extended/make-groups/SKILL.md
@@ -18,6 +18,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -24,8 +24,11 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: plan-foundation-auditor
+    count: 1
   - role: plan-interface-mapper
+    count: 1
   - role: plan-registry-tracer
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/make-req/SKILL.md
+++ b/src/autoskillit/skills_extended/make-req/SKILL.md
@@ -17,6 +17,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/merge-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/merge-pr/SKILL.md
@@ -21,6 +21,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
@@ -25,6 +25,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -18,6 +18,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/plan-visualization/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-visualization/SKILL.md
@@ -15,6 +15,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/planner-analyze/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-analyze/SKILL.md
@@ -17,6 +17,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/planner-assess-review-approach/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-assess-review-approach/SKILL.md
@@ -21,6 +21,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/planner-assess-review-approach/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-assess-review-approach/SKILL.md
@@ -21,7 +21,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: wp_assessment_batches
   concurrency:
     required: true
   join:
@@ -83,6 +83,9 @@ established conventions. This context informs whether a WP is "following establi
 (no-benefit) versus "introducing something new" (benefit signal).
 
 ### Step 3: Evaluate each WP (SINGLE MESSAGE)
+
+Set `wp_assessment_batches` to the one or two non-empty WP batches selected from the
+validated input. Retain child IDs keyed by batch through the join.
 
 **Start ALL independent child delegations before awaiting any result — one per item — and join every child before synthesis.**
 

--- a/src/autoskillit/skills_extended/planner-consolidate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-consolidate-wps/SKILL.md
@@ -17,6 +17,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/planner-consolidate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-consolidate-wps/SKILL.md
@@ -17,7 +17,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: phase_ids
   concurrency:
     required: true
   join:
@@ -85,6 +85,9 @@ FATAL: failed to parse {path}: {error_detail}
 ```
 
 Group WPs by `phase_id` (always populated; read directly from the field).
+
+Set `phase_ids` to the ordered keys of those groups. Use it for packets, batches, child
+IDs, result association, and joins.
 Build a map `phase_id → [WPElaborated, ...]`.
 
 ### Step 2: Create output directory

--- a/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
@@ -14,6 +14,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    for_each: assignment_ids
   concurrency:
     required: true
   join:
@@ -74,6 +75,9 @@ Read the context file at `$1`. Extract:
 - `metadata.assignment_names` — parallel list of assignment names
 - `prior_results` — list of paths to result files from completed prior items
 
+Set `assignment_ids = metadata.assignment_ids`. This exact collection is the launch
+authority used for packet construction, child-ID tracking, result association, and joins.
+
 ### Step 2: Load phase context
 
 Read `$2/phases/{id}_result.json` (the elaborated phase result). Extract:
@@ -90,7 +94,7 @@ instruct L0s to read the file from disk for scope creep verification.
 
 ### Step 3: Build per-L0 context packets
 
-For each assignment in the phase, build a self-contained context packet:
+For each assignment ID in `assignment_ids`, build a self-contained context packet:
 - Assignment ID, name, goal (from the phase result's assignments array)
 - All other phase assignments in short-form (id, name, goal only — for overlap detection)
 - Prior result file paths (from `prior_results`) for cross-phase dependency detection
@@ -103,7 +107,8 @@ For each assignment in the phase, build a self-contained context packet:
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
-Use the backend-adapted child delegation to spawn one L0 per assignment simultaneously.
+Use the backend-adapted child delegation to spawn one L0 per item in `assignment_ids`
+simultaneously, retaining child IDs keyed by assignment ID.
 All L0s must be launched in a single batch — do NOT wait for one before starting the next.
 
 Each L0 receives a self-contained prompt that:

--- a/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
@@ -17,6 +17,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
@@ -14,6 +14,7 @@ semantic_requirements:
     purpose: elaborate one work package and return a bounded JSON result
   child_spawns:
   - role: wp-elaborator
+    for_each: pending_wp_ids
   concurrency:
     required: true
   join:
@@ -117,12 +118,17 @@ Before spawning any L0, filter the WP list to skip any WP whose `$2/work_package
 already exists on disk. This idempotency guard prevents redundant L0 re-spawns on retry after
 partial completion (e.g., when an L1 session is resumed after context recovery).
 
+Set `pending_wp_ids` to the WP IDs remaining after that filter. This exact collection,
+not unfiltered `metadata.wp_ids`, controls batching, prompts, child-ID tracking, result
+association, and joins.
+
 **Start ALL independent child delegations before awaiting any result — one per item — and join every child before synthesis.**
 
 Do not output any prose between subagent dispatches. Immediately proceed to the next tool call.
 
 Use the native child delegation with `subagent_type: "autoskillit:wp-elaborator"` to spawn one
-agent per WP simultaneously. If WP count > 6, spawn in sequential batches of 6 — await
+agent per item in `pending_wp_ids`. If its count exceeds 6, spawn sequential batches of
+at most 6 — await
 each batch before starting the next.
 
 Each agent receives its variable-data packet (from Step 3) as the `prompt` parameter.

--- a/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
@@ -17,7 +17,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: selected_domain_exploration_task_ids
   concurrency:
     required: true
   join:
@@ -71,6 +71,10 @@ Extract domain knowledge, naming conventions, and structural patterns specific t
 Read the `analysis.json` file from argument $1. Use its `language`, `framework`, `architecture_style`, and `key_patterns` fields to focus subagent queries.
 
 ### Step 2: Launch 4–7 parallel exploration vectors
+
+Set `selected_domain_exploration_task_ids` to the four always-applicable task IDs plus
+the deep task IDs only when their module-count or architecture-style predicate holds.
+Use that exact collection for dispatch and joins.
 
 Dispatch all ready, scope-disjoint vectors together. Do not iterate across multiple turns.
 

--- a/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
@@ -17,6 +17,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
@@ -18,7 +18,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: assignment_ids
   concurrency:
     required: true
   join:
@@ -94,6 +94,9 @@ parse/validation error string:
 ```
 FATAL: failed to parse {path}: {error_detail}
 ```
+
+Set `assignment_ids` to the IDs in `assignments`; use it for packets, batches, child IDs,
+result association, and joins.
 
 Read `$2` (refined_plan.json). Build a map `phase_id → PhaseElaborated` for L0 context.
 

--- a/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
@@ -18,6 +18,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
@@ -17,6 +17,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
@@ -17,7 +17,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: phase_ids
   concurrency:
     required: true
   join:
@@ -78,6 +78,9 @@ conflicts, applies field-level edits to the plan, and writes `refined_plan.json`
 Read `$1` (combined_plan.json). Parse as a `PlanDocument`. Extract all phase IDs
 from `phases[*].id`. Fail immediately (exit non-zero) if `phases` is empty or the
 file is malformed — do not proceed to spawn L0s.
+
+Store the extracted collection as `phase_ids`; it controls packets, batching, child IDs,
+result association, and joins.
 
 Input schema (PlanDocument with PhaseElaborated phases):
 ```json

--- a/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
@@ -17,6 +17,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
@@ -17,7 +17,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: phase_ids
   concurrency:
     required: true
   join:
@@ -82,6 +82,10 @@ directory.
 ### Step 1: Parse inputs and validate
 
 Read `$1` (per-phase context file: `wp_refine_contexts/context_{phase_id}.json`). Extract:
+
+Set `phase_ids` to the phase IDs represented by the validated contexts. Use it for
+packets, batches, child IDs, result association, and joins; never use WP IDs as launch
+cardinality.
 - `phase_id` — the phase this session handles
 - `work_packages` — full `WPElaborated` objects for this phase
 - `peer_summaries` — stub dicts for WPs in all other phases

--- a/src/autoskillit/skills_extended/planner-refine/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine/SKILL.md
@@ -16,6 +16,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
@@ -18,7 +18,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: alignment_responsibilities
   concurrency:
     required: true
   join:
@@ -75,6 +75,9 @@ Read `refined_wps.json` from $1 and `refined_plan.json` from $2. Extract:
 - All WP `name`, `deliverables`, and `acceptance_criteria` fields from $1
 
 ### Step 2: Spawn alignment-check subagents (SINGLE MESSAGE)
+
+Set `alignment_responsibilities` to the one or two independent plan/WP alignment checks
+selected for this input. Retain child IDs keyed by responsibility through the join.
 
 **Start ALL independent child delegations before awaiting any result — one per item — and join every child before synthesis.**
 

--- a/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
@@ -18,6 +18,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/prepare-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-pr/SKILL.md
@@ -19,6 +19,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/prepare-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-research-pr/SKILL.md
@@ -22,7 +22,9 @@ semantic_requirements:
     purpose: synthesize research evidence and recommend lenses
   child_spawns:
   - role: research-source-reader
+    count: 1
   - role: research-synthesizer
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -21,6 +21,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/promote-to-main/SKILL.md
+++ b/src/autoskillit/skills_extended/promote-to-main/SKILL.md
@@ -16,6 +16,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/rectify/SKILL.md
+++ b/src/autoskillit/skills_extended/rectify/SKILL.md
@@ -22,8 +22,11 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: plan-foundation-auditor
+    count: 1
   - role: plan-interface-mapper
+    count: 1
   - role: plan-registry-tracer
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
@@ -23,7 +23,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: intent_validation_groups
   concurrency:
     required: true
   join:
@@ -227,6 +227,9 @@ findings in `audit-claims`.
 Save `dimension_groups_{pr}.json` with findings keyed by group. Use `jq -n` or the Write tool. If the file already exists from a prior retry, either read it first (to satisfy the Write tool guard) or use a Bash redirect (`jq -n ... > path`).
 
 ### Step 3.5: Intent Validation (Parallel Sub-Agents — BEFORE any code changes) (SINGLE MESSAGE)
+
+Set `intent_validation_groups` to the non-empty dimension groups produced in Step 3.
+Use the same keys for prompts, child IDs, verdict association, and joins.
 
 **Start ALL independent child delegations before awaiting any result — one per item — and join every child before synthesis.**
 

--- a/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
@@ -23,6 +23,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
@@ -22,6 +22,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
@@ -24,7 +24,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: intent_validation_groups
   concurrency:
     required: true
   join:
@@ -207,6 +207,9 @@ Apply `DIMENSION_PATTERN` to each comment body to extract the dimension label.
 Save `dimension_groups_{pr}.json` with findings keyed by group. Use `jq -n` or the Write tool. If the file already exists from a prior retry, either read it first (to satisfy the Write tool guard) or use a Bash redirect (`jq -n ... > path`).
 
 ### Step 3.5: Intent Validation (Parallel Sub-Agents — BEFORE any code changes) (SINGLE MESSAGE)
+
+Set `intent_validation_groups` to the non-empty dimension groups produced in Step 3.
+Use the same keys for prompts, child IDs, verdict association, and joins.
 
 **Start ALL independent child delegations before awaiting any result — one per item — and join every child before synthesis.**
 

--- a/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
@@ -24,6 +24,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -21,6 +21,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -21,7 +21,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: intent_validation_groups
   concurrency:
     required: true
   join:
@@ -382,6 +382,9 @@ When a finding matches multiple tiers, use the highest severity.
 Critical and warning findings proceed to intent validation (Step 3.5). Info findings are classified with `verdict="INFO"` — they do not enter Step 3.5. Only `ACCEPT`, `REJECT`, and `DISCUSS` verdicts are assigned by Step 3.5 sub-agents; `INFO` is assigned at classification time.
 
 ### Step 3.5: Intent Validation (Parallel Sub-Agents — BEFORE any code changes) (SINGLE MESSAGE)
+
+Set `intent_validation_groups` to the non-empty critical/warning domain groups produced
+in Step 3. Use the same keys for prompts, child IDs, verdict association, and joins.
 
 **Start ALL independent child delegations before awaiting any result — one per item — and join every child before synthesis.**
 

--- a/src/autoskillit/skills_extended/retry-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/retry-worktree/SKILL.md
@@ -18,6 +18,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/review-design/SKILL.md
+++ b/src/autoskillit/skills_extended/review-design/SKILL.md
@@ -19,6 +19,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/review-design/SKILL.md
+++ b/src/autoskillit/skills_extended/review-design/SKILL.md
@@ -19,7 +19,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: selected_review_dimensions
   concurrency:
     required: true
   join:
@@ -162,6 +162,10 @@ absent. The recipe routes to `on_context_limit`, abandoning the partial review.
    and included in the evaluation dashboard.
 
 ### Step 1: Triage Dispatcher
+
+Set `selected_review_dimensions` to the triage responsibility and each non-SILENT,
+foothold-supported dimension selected by triage. Dispatch dependency-ready levels in
+their stated waves and retain child IDs keyed by dimension.
 
 Launch one subagent. Receives full plan text plus parsed fields. Returns:
 - `experiment_type`: one of the type names in the loaded registry (from Step 0)

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -19,7 +19,9 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: pr-review-auditor-abstraction-surface
+    count: 1
   - role: pr-review-auditor-reachability
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/review-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-research-pr/SKILL.md
@@ -17,6 +17,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/run-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/run-experiment/SKILL.md
@@ -18,6 +18,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/scope/SKILL.md
+++ b/src/autoskillit/skills_extended/scope/SKILL.md
@@ -19,6 +19,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/select-vis-lenses/SKILL.md
+++ b/src/autoskillit/skills_extended/select-vis-lenses/SKILL.md
@@ -17,6 +17,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/setup-environment/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-environment/SKILL.md
@@ -15,6 +15,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/setup-project/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-project/SKILL.md
@@ -20,7 +20,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: project_exploration_responsibilities
   concurrency:
     required: true
   join:
@@ -106,6 +106,10 @@ Then prompt the user:
 Store the answer for Step 1.
 
 ### Step 1: Explore Target Project (Parallel Subagents) (SINGLE MESSAGE)
+
+Set `project_exploration_responsibilities` to Subagents A–D, Subagent E when applicable,
+and one responsibility per non-empty history-file batch when history mining is enabled.
+Use the same keys for prompts, child IDs, result association, and joins.
 
 **Start ALL independent child delegations before awaiting any result — one per item — and join every child before synthesis.**
 

--- a/src/autoskillit/skills_extended/setup-project/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-project/SKILL.md
@@ -20,6 +20,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/stage-data/SKILL.md
+++ b/src/autoskillit/skills_extended/stage-data/SKILL.md
@@ -22,7 +22,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: stageable_data_entries
   concurrency:
     required: true
   join:
@@ -99,6 +99,9 @@ Create any data directories for entries with non-null `location`. Emit
 `fixture`, `literature`, `database`, or `wet_lab` source types.
 
 ### Step 3 — Launch Parallel Resource Probe Subagents (SINGLE MESSAGE)
+
+Set `stageable_data_entries` to the `external` and `gitignored` manifest entries remaining
+after Step 2. Use that collection for prompts, child IDs, result association, and joins.
 
 **Start ALL independent child delegations before awaiting any result — one per item — and join every child before synthesis.**
 

--- a/src/autoskillit/skills_extended/stage-data/SKILL.md
+++ b/src/autoskillit/skills_extended/stage-data/SKILL.md
@@ -22,6 +22,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/triage-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/triage-issues/SKILL.md
@@ -21,7 +21,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: issue_analysis_responsibilities
   concurrency:
     required: true
   join:
@@ -111,6 +111,10 @@ If `gh auth status` fails, abort with a clear error message.
 If there are zero open issues (after filtering), skip to Step 7 and output an empty report.
 
 ### Step 2a: Parallel Split Analysis (SINGLE MESSAGE)
+
+Set `issue_analysis_responsibilities` to the split-analysis and issue-analysis
+responsibilities derived from the fetched issue list. Dispatch each dependency-ready
+wave from this collection and retain child IDs keyed by issue and analysis kind.
 
 **Start ALL independent child delegations before awaiting any result — one per item — and join every child before synthesis.**
 

--- a/src/autoskillit/skills_extended/triage-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/triage-issues/SKILL.md
@@ -21,6 +21,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -21,6 +21,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/validate-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-review-decisions/SKILL.md
@@ -21,6 +21,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-test-audit/SKILL.md
@@ -20,6 +20,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/verify-diag/SKILL.md
+++ b/src/autoskillit/skills_extended/verify-diag/SKILL.md
@@ -19,6 +19,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
+    count: 1
   concurrency:
     required: true
   join:

--- a/src/autoskillit/skills_extended/verify-diag/SKILL.md
+++ b/src/autoskillit/skills_extended/verify-diag/SKILL.md
@@ -19,7 +19,7 @@ semantic_requirements:
     purpose: perform the named independent responsibility and return bounded evidence
   child_spawns:
   - role: delegated-worker
-    count: 1
+    for_each: diagram_paths
   concurrency:
     required: true
   join:
@@ -225,6 +225,9 @@ Common patterns and how to represent them:
 ---
 
 ## Launching Verification (SINGLE MESSAGE)
+
+Set `diagram_paths` to the validated diagrams selected for verification. Retain child IDs
+keyed by path and join every launched verifier.
 
 **Start ALL independent child delegations before awaiting any result — one per item — and join every child before synthesis.**
 

--- a/src/autoskillit/workspace/skill_capabilities.py
+++ b/src/autoskillit/workspace/skill_capabilities.py
@@ -21,6 +21,7 @@ from autoskillit.core import (
     SKILL_CAPABILITY_REGISTRY,
     SKILL_SEMANTIC_SCHEMA_VERSION,
     ChildModelPolicySpec,
+    ChildSpawnCardinalityError,
     ChildSpawnSpec,
     ConcurrencySpec,
     EvidenceSpec,
@@ -1011,7 +1012,7 @@ def parse_skill_semantic_plan(
         child_spawns = tuple(
             ChildSpawnSpec(
                 role=str(item.get("role", "")),
-                count=int(item.get("count", 1)),
+                count=item.get("count"),
                 for_each=item.get("for_each"),
             )
             for item in _mapping_list(raw_requirements.get("child_spawns", []), "child_spawns")
@@ -1064,6 +1065,19 @@ def parse_skill_semantic_plan(
             sibling_skills=sibling_skills,
             git_metadata_writes=git_metadata_writes,
         )
+    except ChildSpawnCardinalityError as exc:
+        diagnostics.append(
+            (
+                SkillInvalidityKind.SEMANTIC_CHILD_CARDINALITY_INVALID,
+                _semantic_error(
+                    path,
+                    schema_version=schema_version,
+                    offending="semantic_requirements.child_spawns cardinality",
+                    replacement=str(exc),
+                ),
+            )
+        )
+        return None, tuple(diagnostics)
     except (SkillContractError, TypeError, ValueError) as exc:
         diagnostics.append(
             (

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1289,7 +1289,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "run_skill launch denial paths before command construction (+139 net lines)",
     ),
     "execution/backends/codex.py": (
-        2391,
+        2392,
         "REQ-CNST-010-E9: Codex backend — skill_sigil capability threading adds multi-line "
         "keyword args to _ensure_skill_prefix call sites and _has_prefix guard; "
         "write_guard_tool_names env injection adds 7 lines to _codex_exec_extras; "
@@ -1361,11 +1361,12 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "the existing stale, idle, timeout, and content adjudication order it must preempt",
     ),
     "workspace/skill_capabilities.py": (
-        1104,
+        1120,
         "REQ-SEM-SCHEMA-001: versioned semantic declarations, closed-operation parsing, "
         "retired-key rejection, and precise per-skill diagnostics remain co-located at "
         "the sole skill-frontmatter validation boundary; #4507 parses runtime child "
-        "cardinality at that same boundary (+4 net lines).",
+        "cardinality at that same boundary and classifies its dedicated typed invalidity "
+        "before the general semantic-plan failure path.",
     ),
     "workspace/skills.py": (
         1550,

--- a/tests/contracts/fixtures/skill_contract_corpus/legacy_child_spawn_cardinality.md
+++ b/tests/contracts/fixtures/skill_contract_corpus/legacy_child_spawn_cardinality.md
@@ -1,0 +1,14 @@
+---
+name: legacy-child-spawn-cardinality
+description: A previously valid skill whose child cardinality was implicit.
+semantic_version: 1
+semantic_requirements:
+  logical_roles:
+    - name: worker
+      purpose: Process one fixed task.
+  child_spawns:
+    - role: worker
+---
+# legacy-child-spawn-cardinality
+
+Delegates one fixed task and joins the result.

--- a/tests/contracts/test_backend_protocol.py
+++ b/tests/contracts/test_backend_protocol.py
@@ -83,7 +83,7 @@ def test_registered_backends_adapt_every_skill_semantic_operation() -> None:
 
     plan = SkillSemanticPlan(
         schema_version=1,
-        child_spawns=(ChildSpawnSpec(role="reviewer"),),
+        child_spawns=(ChildSpawnSpec(role="reviewer", count=1),),
         concurrency=ConcurrencySpec(required=True),
         join=JoinSpec(required=True),
         evidence=EvidenceSpec(required=True, independent=True),
@@ -122,7 +122,7 @@ def test_codex_adaptation_maps_namespaced_role_to_registered_agent() -> None:
     logical_role = "autoskillit:pr-review-auditor-reachability"
     plan = SkillSemanticPlan(
         schema_version=1,
-        child_spawns=(ChildSpawnSpec(role=logical_role),),
+        child_spawns=(ChildSpawnSpec(role=logical_role, count=1),),
         child_model_policies=(ChildModelPolicySpec(role=logical_role, model_class="sonnet"),),
         logical_roles=(LogicalRoleSpec(name=logical_role, purpose="prove reachability"),),
     )

--- a/tests/contracts/test_skill_contract_remediations.py
+++ b/tests/contracts/test_skill_contract_remediations.py
@@ -105,6 +105,7 @@ def test_migration_adapter_covers_every_deterministic_remediation() -> None:
     }
     handled = {
         SkillInvalidityKind.UNDECLARED_CAPABILITY,
+        SkillInvalidityKind.SEMANTIC_CHILD_CARDINALITY_INVALID,
         SkillInvalidityKind.SEMANTIC_MISSING_VERSION,
         SkillInvalidityKind.SEMANTIC_UNDECLARED_TOKENS,
     }
@@ -176,12 +177,14 @@ _CORPUS_FIXTURES = (
     "precontract_audit_bugs.md",
     "missing_semantic_version.md",
     "legacy_spawner.md",
+    "legacy_child_spawn_cardinality.md",
 )
 # Filename -> the `name:` value declared in that fixture's own frontmatter.
 _CORPUS_SKILL_NAMES = {
     "precontract_audit_bugs.md": "audit-bugs",
     "missing_semantic_version.md": "research-helper",
     "legacy_spawner.md": "legacy-spawner",
+    "legacy_child_spawn_cardinality.md": "legacy-child-spawn-cardinality",
 }
 
 
@@ -232,3 +235,102 @@ async def test_corpus_is_valid_or_deterministically_migratable(
         f"{render_skill_invalidities(revalidated.invalidities)}"
     )
     assert revalidated.execution_role is SkillExecutionRole.SESSION
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("cardinality", "expected_count", "expected_for_each"),
+    [
+        ("", 1, None),
+        ("      count: true\n", 1, None),
+        ("      count: 2.9\n", 2, None),
+        ('      count: "3"\n', 3, None),
+        ("      count: 1\n      for_each: work_items\n", None, "work_items"),
+    ],
+)
+async def test_cardinality_migration_preserves_old_parser_meaning(
+    tmp_path: Path,
+    cardinality: str,
+    expected_count: int | None,
+    expected_for_each: str | None,
+) -> None:
+    skill_name = "legacy-cardinality"
+    skill_path = tmp_path / ".claude" / "skills" / skill_name / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text(
+        f"""---
+name: {skill_name}
+description: Legacy cardinality fixture.
+semantic_version: 1
+semantic_requirements:
+  logical_roles:
+    - name: worker
+      purpose: Process one work item.
+  child_spawns:
+    - role: worker
+{cardinality}---
+Delegates selected work.
+""",
+        encoding="utf-8",
+    )
+    adapter = SkillMigrationAdapter()
+    result = await adapter.migrate(
+        MigrationFile(
+            name=skill_name,
+            path=skill_path,
+            file_type="skill",
+            current_version=None,
+        ),
+        temp_dir=tmp_path / "temp",
+    )
+
+    assert result.success
+    assert result.migrated_content is not None
+    skill_path.write_text(result.migrated_content, encoding="utf-8")
+    migrated = _skill_info_from_frontmatter(skill_name, SkillSource.PROJECT_LOCAL, skill_path)
+    assert not migrated.invalidities
+    assert migrated.semantic_plan is not None
+    spawn = migrated.semantic_plan.child_spawns[0]
+    assert spawn.count == expected_count
+    assert spawn.for_each == expected_for_each
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "cardinality",
+    ["      count: 0\n", "      count: null\n", "      count: 2\n      for_each: work_items\n"],
+)
+async def test_cardinality_migration_rejects_old_invalid_shapes(
+    tmp_path: Path, cardinality: str
+) -> None:
+    skill_name = "old-invalid-cardinality"
+    skill_path = tmp_path / ".claude" / "skills" / skill_name / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text(
+        f"""---
+name: {skill_name}
+description: Old-invalid cardinality fixture.
+semantic_version: 1
+semantic_requirements:
+  logical_roles:
+    - name: worker
+      purpose: Process one work item.
+  child_spawns:
+    - role: worker
+{cardinality}---
+Delegates selected work.
+""",
+        encoding="utf-8",
+    )
+
+    result = await SkillMigrationAdapter().migrate(
+        MigrationFile(
+            name=skill_name,
+            path=skill_path,
+            file_type="skill",
+            current_version=None,
+        ),
+        temp_dir=tmp_path / "temp",
+    )
+
+    assert not result.success

--- a/tests/core/test_skill_semantic_plan.py
+++ b/tests/core/test_skill_semantic_plan.py
@@ -48,7 +48,7 @@ def test_skill_semantic_plan_is_frozen_slotted_and_derives_operations() -> None:
 
     plan = SkillSemanticPlan(
         schema_version=1,
-        child_spawns=(ChildSpawnSpec(role="implementation-auditor"),),
+        child_spawns=(ChildSpawnSpec(role="implementation-auditor", count=1),),
         concurrency=ConcurrencySpec(required=True),
         join=JoinSpec(required=True),
         evidence=EvidenceSpec(required=True, independent=True),
@@ -69,7 +69,7 @@ def test_skill_semantic_plan_is_frozen_slotted_and_derives_operations() -> None:
     assert plan.operations == frozenset(SkillSemanticOperation)
 
 
-def test_child_spawn_for_each_is_dynamic_and_mutually_exclusive_with_count() -> None:
+def test_child_spawn_cardinality_is_explicit_and_canonical() -> None:
     from autoskillit.core import (
         ChildSpawnSpec,
         LogicalRoleSpec,
@@ -83,22 +83,39 @@ def test_child_spawn_for_each_is_dynamic_and_mutually_exclusive_with_count() -> 
         schema_version=1, child_spawns=(dynamic,), logical_roles=logical_roles
     )
 
+    assert dynamic.count is None
     assert plan.canonical_payload["child_spawns"] == (
-        {"role": "researcher", "count": 1, "for_each": "research_topics"},
+        {"role": "researcher", "for_each": "research_topics"},
     )
     fixed = SkillSemanticPlan(
         schema_version=1,
-        child_spawns=(ChildSpawnSpec(role="researcher"),),
+        child_spawns=(ChildSpawnSpec(role="researcher", count=1),),
         logical_roles=logical_roles,
     )
+    assert fixed.canonical_payload["child_spawns"] == ({"role": "researcher", "count": 1},)
     assert "for_each" not in fixed.canonical_payload["child_spawns"][0]
-    with pytest.raises(SkillContractError, match="for_each must be non-empty"):
+    with pytest.raises(SkillContractError, match="for_each must be a non-empty"):
         ChildSpawnSpec(role="researcher", for_each=" ")
-    with pytest.raises(SkillContractError, match="non-default count"):
-        ChildSpawnSpec(role="researcher", count=2, for_each="research_topics")
     assert not hasattr(plan, "__dict__")
     with pytest.raises(FrozenInstanceError):
         plan.schema_version = 2  # type: ignore[misc]
+
+
+@pytest.mark.parametrize("count", [True, 1.5, "1", 0, -1])
+def test_child_spawn_rejects_non_positive_integer_counts(count: object) -> None:
+    from autoskillit.core import ChildSpawnCardinalityError, ChildSpawnSpec
+
+    with pytest.raises(ChildSpawnCardinalityError, match="positive integer"):
+        ChildSpawnSpec(role="researcher", count=count)  # type: ignore[arg-type]
+
+
+def test_child_spawn_rejects_missing_or_competing_authorities() -> None:
+    from autoskillit.core import ChildSpawnCardinalityError, ChildSpawnSpec
+
+    with pytest.raises(ChildSpawnCardinalityError, match="exactly one"):
+        ChildSpawnSpec(role="researcher")
+    with pytest.raises(ChildSpawnCardinalityError, match="exactly one"):
+        ChildSpawnSpec(role="researcher", count=1, for_each="research_topics")
 
 
 def test_skill_semantic_plan_rejects_incoherent_payloads() -> None:

--- a/tests/execution/backends/_conformance_assertions.py
+++ b/tests/execution/backends/_conformance_assertions.py
@@ -252,6 +252,7 @@ def assert_generated_child_delivery(
     backend: str = "codex",
     semantic_plan: SkillSemanticPlan | None = None,
     semantic_adaptation: SkillSemanticAdaptationResult | None = None,
+    runtime_cardinalities: Mapping[str, int] | None = None,
     child_terminal_sentinel: str | None = None,
     sibling_result_sentinel: str | None = None,
     parent_terminal_sentinel: str | None = None,
@@ -352,11 +353,19 @@ def assert_generated_child_delivery(
     if semantic_plan is not None and semantic_adaptation is not None:
         assert semantic_adaptation.unsupported_operation is None
         semantic_adaptation.validate_for(semantic_plan, backend=backend)
-        expected_roles = tuple(
-            semantic_adaptation.logical_role_mapping[spawn.role]
-            for spawn in semantic_plan.child_spawns
-            for _ in range(spawn.count)
-        )
+        expected_roles_list: list[str] = []
+        for spawn in semantic_plan.child_spawns:
+            if spawn.for_each is not None:
+                assert runtime_cardinalities is not None
+                assert spawn.for_each in runtime_cardinalities
+                cardinality = runtime_cardinalities[spawn.for_each]
+            else:
+                assert spawn.count is not None
+                cardinality = spawn.count
+            expected_roles_list.extend(
+                semantic_adaptation.logical_role_mapping[spawn.role] for _ in range(cardinality)
+            )
+        expected_roles = tuple(expected_roles_list)
     else:
         expected_roles = (agent_role,)
 

--- a/tests/execution/backends/test_session_skills_provider_integration.py
+++ b/tests/execution/backends/test_session_skills_provider_integration.py
@@ -40,6 +40,7 @@ def _child_spawn_skill(tmp_path: Path) -> SkillInfo:
         "      purpose: perform delegated work\n"
         "  child_spawns:\n"
         "    - role: worker\n"
+        "      count: 1\n"
         "---\n"
         "Delegate to the worker.\n",
         encoding="utf-8",

--- a/tests/execution/backends/test_skill_semantic_trace_conformance.py
+++ b/tests/execution/backends/test_skill_semantic_trace_conformance.py
@@ -50,8 +50,8 @@ def _semantic_plan() -> SkillSemanticPlan:
             LogicalRoleSpec(name=_WORKER_ROLE, purpose="collect independent evidence"),
         ),
         child_spawns=(
-            ChildSpawnSpec(role=_REVIEW_ROLE),
-            ChildSpawnSpec(role=_WORKER_ROLE),
+            ChildSpawnSpec(role=_REVIEW_ROLE, count=1),
+            ChildSpawnSpec(role=_WORKER_ROLE, count=1),
         ),
         concurrency=ConcurrencySpec(required=True),
         join=JoinSpec(required=True),
@@ -347,7 +347,7 @@ def test_codex_semantic_policy_matches_generated_native_role_toml(tmp_path: Path
     plan = SkillSemanticPlan(
         schema_version=1,
         logical_roles=(LogicalRoleSpec(name=_REVIEW_ROLE, purpose="audit a PR"),),
-        child_spawns=(ChildSpawnSpec(role=_REVIEW_ROLE),),
+        child_spawns=(ChildSpawnSpec(role=_REVIEW_ROLE, count=1),),
         child_model_policies=(
             ChildModelPolicySpec(
                 role=_REVIEW_ROLE,
@@ -438,6 +438,41 @@ def test_analyze_pipeline_health_projects_the_real_terminal_reader() -> None:
     assert "fork_turns='none'" in codex_text
     assert "model=" not in codex_text
     assert "reasoning_effort=" not in codex_text
+
+
+@pytest.mark.parametrize(
+    ("skill_name", "role", "collection", "source_text"),
+    [
+        (
+            "planner-elaborate-assignments",
+            "delegated-worker",
+            "assignment_ids",
+            "assignment_ids = metadata.assignment_ids",
+        ),
+        (
+            "planner-elaborate-wps",
+            "wp-elaborator",
+            "pending_wp_ids",
+            "Set `pending_wp_ids` to the WP IDs remaining after that filter",
+        ),
+    ],
+)
+def test_real_planner_workflows_project_their_runtime_collections(
+    skill_name: str, role: str, collection: str, source_text: str
+) -> None:
+    skill_md = pkg_root() / "skills_extended" / skill_name / "SKILL.md"
+    info = _skill_info_from_frontmatter(skill_name, SkillSource.BUNDLED, skill_md)
+
+    assert not info.invalidities
+    assert info.semantic_plan is not None
+    assert info.semantic_plan.child_spawns == (ChildSpawnSpec(role=role, for_each=collection),)
+    assert source_text in skill_md.read_text(encoding="utf-8")
+    for backend in (ClaudeCodeBackend(), CodexBackend()):
+        rendered = "\n".join(
+            backend.adapt_skill_semantics(info.semantic_plan).instruction_fragments
+        )
+        assert collection in rendered
+        assert " 1 " not in rendered
 
 
 @pytest.mark.parametrize("skill_name", ["review-pr", "enrich-issues"])

--- a/tests/execution/backends/test_skill_semantic_trace_conformance.py
+++ b/tests/execution/backends/test_skill_semantic_trace_conformance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import tomllib
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -299,6 +300,45 @@ def test_shared_oracle_accepts_backend_native_semantic_trace(
         backend=backend_name,
         semantic_plan=plan,
         semantic_adaptation=adaptation,
+        child_terminal_sentinel="child-delivery-complete",
+        sibling_result_sentinel="sibling-delivery-complete",
+        parent_terminal_sentinel="parent-delivery-complete",
+    )
+
+
+@pytest.mark.parametrize(
+    ("backend_name", "backend_type", "trace_factory"),
+    [
+        ("codex", CodexBackend, _codex_trace),
+        ("claude", ClaudeCodeBackend, _claude_trace),
+    ],
+)
+def test_shared_oracle_resolves_runtime_child_cardinality(
+    backend_name: str,
+    backend_type: type[CodexBackend] | type[ClaudeCodeBackend],
+    trace_factory,
+) -> None:
+    plan = _semantic_plan()
+    plan = replace(
+        plan,
+        child_spawns=(
+            ChildSpawnSpec(role=_REVIEW_ROLE, for_each="review_topics"),
+            plan.child_spawns[1],
+        ),
+    )
+    adaptation = backend_type().adapt_skill_semantics(plan)
+    parent_events, child_events = trace_factory(adaptation)
+
+    assert_generated_child_delivery(
+        parent_events,
+        child_events,
+        parent_id="parent",
+        agent_role=adaptation.logical_role_mapping[_REVIEW_ROLE],
+        output_discipline_digest=_DISCIPLINE_DIGEST,
+        backend=backend_name,
+        semantic_plan=plan,
+        semantic_adaptation=adaptation,
+        runtime_cardinalities={"review_topics": 1},
         child_terminal_sentinel="child-delivery-complete",
         sibling_result_sentinel="sibling-delivery-complete",
         parent_terminal_sentinel="parent-delivery-complete",

--- a/tests/execution/test_explorer_dispatch.py
+++ b/tests/execution/test_explorer_dispatch.py
@@ -194,19 +194,23 @@ def test_phase_d_neutral_plan_renders_each_backend_native_form(
 
     assert rendered.router_plan_digest == plan.digest
     assert set(rendered.replacements) == {vector.id for vector in _VECTORS}
-    assert (
-        "Submit this typed task packet to the deterministic exploration router"
-        in rendered.preamble
-    )
+    assert "Projection and static applicability make tasks available only" in rendered.preamble
+    assert "selected_exploration_task_ids" in rendered.preamble
+    assert "rendered marker or call count is never a spawn obligation" in rendered.preamble
+    assert "Join every dispatched leaf" in rendered.preamble
     for vector in _VECTORS:
         replacement = rendered.replacements[vector.id]
         assert native_prefix in replacement
         assert f"task_id: {vector.task.task_id}" in replacement
-        assert "profile: autoskillit" in replacement
+        assert f"Candidate exploration task '{vector.task.task_id}'" in replacement
         assert (
-            "Submit this typed task packet to the deterministic exploration router"
-            not in replacement
+            f"if and only if '{vector.task.task_id}' is in selected_exploration_task_ids"
+            in replacement
         )
+        assert "Otherwise skip this candidate" in replacement
+        assert "is not a failure" in replacement
+        assert "profile: autoskillit" in replacement
+        assert "Projection and static applicability make tasks available only" not in replacement
         assert "Return bounded typed evidence only" in replacement
 
 

--- a/tests/execution/test_skill_session_contract_store.py
+++ b/tests/execution/test_skill_session_contract_store.py
@@ -17,7 +17,7 @@ pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 def test_exploration_vector_contract_versions_invalidate_stale_artifacts() -> None:
     from autoskillit.core import SKILL_SESSION_CONTRACT_SCHEMA_VERSION
 
-    assert SKILL_PROJECTION_VERSION == 6
+    assert SKILL_PROJECTION_VERSION == 7
     assert SKILL_SESSION_CONTRACT_SCHEMA_VERSION == 5
 
 
@@ -435,5 +435,5 @@ def test_stale_projection_version_rejected_before_enum_construction(tmp_path: Pa
     manifest["contract_digest"] = _digest_json(contract_data)
     store._write_manifest(entry, manifest)  # noqa: SLF001
 
-    with pytest.raises(ValueError, match="unsupported projection_version 5; expected 6"):
+    with pytest.raises(ValueError, match="unsupported projection_version 5; expected 7"):
         store.finalize(correlation_key, "stale-projection")

--- a/tests/server/test_explorer_dispatch.py
+++ b/tests/server/test_explorer_dispatch.py
@@ -128,8 +128,14 @@ def test_claude_and_codex_bind_identical_neutral_and_role_digests() -> None:
 
     assert claude.router_plan_digest == codex.router_plan_digest == plan.digest
     assert claude.role_definition_digests == codex.role_definition_digests
-    claude_call = claude.replacements[vector.id].splitlines()[-1]
-    codex_call = codex.replacements[vector.id].splitlines()[-1]
+    claude_call = next(
+        line for line in claude.replacements[vector.id].splitlines() if line.startswith("Agent(")
+    )
+    codex_call = next(
+        line
+        for line in codex.replacements[vector.id].splitlines()
+        if line.startswith("spawn_agent(")
+    )
     assert claude_call.startswith(
         'Agent(subagent_type="autoskillit:semantic-code-navigator", description='
     )
@@ -150,17 +156,17 @@ def test_projection_materializes_only_after_backend_binding(tmp_path: Path) -> N
         _context(tmp_path, skill, ClaudeCodeBackend()),
     )
     assert 'Agent(subagent_type="autoskillit:semantic-code-navigator"' in document.content
-    assert (
-        "Submit this typed task packet to the deterministic exploration router" in document.content
-    )
-    assert "Reclassify every newly discovered cross-leaf frontier explicitly" in document.content
-    assert "Wait for every dispatched leaf" in document.content
+    assert "Projection and static applicability make tasks available only" in document.content
+    assert "reclassify newly discovered cross-leaf frontiers explicitly" in document.content
+    assert "Join every dispatched leaf" in document.content
     assert "Retain final synthesis" in document.content
+    assert "selected_exploration_task_ids" in document.content
     marker_body = document.content.split(vector.marker_line, 1)[1].split(
         "<!-- /autoskillit:exploration-vector -->", 1
     )[0]
     assert f"\n{vector.body}\n" not in marker_body
-    assert marker_body.rstrip().splitlines()[-1].startswith("Agent(")
+    assert any(line.startswith("Agent(") for line in marker_body.splitlines())
+    assert marker_body.rstrip().endswith("is not a failure.")
 
 
 def test_backendless_projection_remains_valid_for_skill_without_vectors(tmp_path: Path) -> None:

--- a/tests/server/test_tools_report_bug.py
+++ b/tests/server/test_tools_report_bug.py
@@ -386,6 +386,7 @@ async def test_report_bug_delivers_winning_override_identity_and_projection(
         "    purpose: investigate the report independently\n"
         "  child_spawns:\n"
         "  - role: report-investigator\n"
+        "    count: 1\n"
         "  child_model_policies:\n"
         "  - role: report-investigator\n"
         "    model_class: sonnet\n"

--- a/tests/skills/test_investigate_deep_mode_contracts.py
+++ b/tests/skills/test_investigate_deep_mode_contracts.py
@@ -202,13 +202,16 @@ def test_deep_waves_complete_before_inter_batch_progress(
     assert "every launch has a terminal result" in normalized
     assert "before launching batch 2" in normalized
     assert "inter-batch synthesis:" in normalized
-    assert "stop when the quality gate" in normalized
+    assert "stop when" in normalized
+    assert "quality gate" in normalized
 
 
 def test_d2_historical_recurrence_parallel(deep_workflow_section: str) -> None:
     """Step D2 must make recurrence work conditional on relevance."""
     d2 = extract_step_section(deep_workflow_section, "Step D2")
-    assert "recurrence work only when provenance evidence is relevant" in d2.lower()
+    normalized = d2.lower()
+    assert "recurrence work" in normalized
+    assert "provenance evidence is relevant" in normalized
 
 
 def test_d3_mandatory_web_research(deep_workflow_section: str) -> None:

--- a/tests/skills/test_investigate_deep_mode_contracts.py
+++ b/tests/skills/test_investigate_deep_mode_contracts.py
@@ -198,7 +198,7 @@ def test_d2_inter_batch_synthesis(deep_workflow_section: str) -> None:
 def test_deep_waves_complete_before_inter_batch_progress(
     deep_workflow_section: str,
 ) -> None:
-    normalized = deep_workflow_section.lower()
+    normalized = " ".join(deep_workflow_section.lower().split())
     assert "every launch has a terminal result" in normalized
     assert "before launching batch 2" in normalized
     assert "inter-batch synthesis:" in normalized

--- a/tests/skills/test_investigate_deep_mode_contracts.py
+++ b/tests/skills/test_investigate_deep_mode_contracts.py
@@ -178,14 +178,13 @@ def test_d1_reserves_completion_budget_before_each_batch(
     assert "would cross that reserve" in normalized
 
 
-def test_d2_broad_exploration_minimum_subagents(deep_workflow_section: str) -> None:
-    """Step D2 must specify a minimum of 5 parallel subagents."""
+def test_d2_broad_exploration_is_adaptively_selected(deep_workflow_section: str) -> None:
+    """Step D2 must select relevant, affordable, dependency-ready candidates."""
     d2 = extract_step_section(deep_workflow_section, "Step D2")
-    has_minimum = "minimum" in d2.lower()
-    has_five = "5" in d2
-    assert has_minimum and has_five, (
-        "Step D2 must specify a 'minimum' of '5' parallel subagents for broad exploration"
-    )
+    normalized = d2.lower()
+    assert "relevant and affordable dependency-ready" in normalized
+    assert "selected independent frontier" in normalized
+    assert "minimum of 5" not in normalized
 
 
 def test_d2_inter_batch_synthesis(deep_workflow_section: str) -> None:
@@ -200,20 +199,16 @@ def test_deep_waves_complete_before_inter_batch_progress(
     deep_workflow_section: str,
 ) -> None:
     normalized = deep_workflow_section.lower()
-    assert "at least two completed agent waves" in normalized
     assert "every launch has a terminal result" in normalized
     assert "before launching batch 2" in normalized
     assert "inter-batch synthesis:" in normalized
+    assert "stop when the quality gate" in normalized
 
 
 def test_d2_historical_recurrence_parallel(deep_workflow_section: str) -> None:
-    """Step D2 must reference Step 3.5 or historical check running in parallel."""
+    """Step D2 must make recurrence work conditional on relevance."""
     d2 = extract_step_section(deep_workflow_section, "Step D2")
-    has_35 = "3.5" in d2
-    has_historical = "historical" in d2.lower()
-    assert has_35 or has_historical, (
-        "Step D2 must reference '3.5' or 'historical' check running in parallel with Batch 1"
-    )
+    assert "recurrence work only when provenance evidence is relevant" in d2.lower()
 
 
 def test_d3_mandatory_web_research(deep_workflow_section: str) -> None:

--- a/tests/skills/test_investigate_design_intent_contracts.py
+++ b/tests/skills/test_investigate_design_intent_contracts.py
@@ -138,15 +138,11 @@ def test_d2_includes_design_intent_subagent(deep_workflow_section: str) -> None:
     assert "Design Intent" in d2, "Step D2 must include 'Design Intent' as a parallel subagent"
 
 
-def test_d2_minimum_subagents_increased(deep_workflow_section: str) -> None:
-    """Step D2 must specify a minimum of 5 parallel subagents."""
+def test_d2_uses_adaptive_candidate_selection(deep_workflow_section: str) -> None:
+    """Step D2 must not turn the rendered candidate inventory into a minimum."""
     d2 = extract_step_section(deep_workflow_section, "Step D2")
-    has_minimum = "minimum" in d2.lower()
-    has_five = "5" in d2
-    assert has_minimum and has_five, (
-        "Step D2 must specify a 'minimum' of '5' parallel subagents"
-        " (was 4, increased for Design Intent)"
-    )
+    assert "selected independent frontier" in d2.lower()
+    assert "minimum of 5" not in d2.lower()
 
 
 def test_d3_design_intent_redispatch(d3_section: str) -> None:

--- a/tests/skills_extended/test_explorer_adoption_inventory.py
+++ b/tests/skills_extended/test_explorer_adoption_inventory.py
@@ -1552,6 +1552,9 @@ def test_all_actual_migrated_phase_d_vectors_render_each_native_backend_form(
             assert vector.profile is RepositoryProfileId.AUTO
             assert f'{native_prefix}{vector.role}"' in body, (skill_name, vector.id)
             assert f"task_id: {vector.task.task_id}" in body, (skill_name, vector.id)
+            assert f"Candidate exploration task '{vector.task.task_id}'" in body
+            assert "selected_exploration_task_ids" in body
+            assert "Otherwise skip this candidate" in body
             assert "profile: autoskillit" in body, (skill_name, vector.id)
             assert (
                 "relationship_classes: "
@@ -1561,6 +1564,45 @@ def test_all_actual_migrated_phase_d_vectors_render_each_native_backend_form(
             assert json.dumps(vector.body)[1:-1] in body, (skill_name, vector.id)
 
     assert migrated_count == 34
+
+
+def test_investigate_projects_adaptive_semantic_collections_and_guarded_candidates() -> None:
+    skill = _load_phase_d_skill("investigate")
+    assert skill.semantic_plan is not None
+    spawns = skill.semantic_plan.child_spawns
+    assert [(spawn.role, spawn.count, spawn.for_each) for spawn in spawns] == [
+        ("delegated-worker", None, "selected_reasoning_responsibilities"),
+        (
+            "autoskillit:web-evidence-researcher",
+            None,
+            "selected_web_research_topics",
+        ),
+    ]
+    assert tuple(policy.role for policy in skill.semantic_plan.child_model_policies) == (
+        "delegated-worker",
+    )
+
+    for backend in (ClaudeCodeBackend(), CodexBackend()):
+        projected = _project_phase_d_skill(
+            skill,
+            backend,
+            frozenset(ExplorationVectorApplicabilityId),
+        )
+        assert projected.count("Candidate exploration task") == 15
+        assert projected.count("selected_exploration_task_ids") >= 16
+        assert "rendered marker or call count is never a spawn obligation" in projected
+        assert projected.index("selected_reasoning_responsibilities") < projected.rindex(
+            "Backend-adapted semantic execution contract"
+        )
+        assert projected.index("selected_web_research_topics") < projected.rindex(
+            "Backend-adapted semantic execution contract"
+        )
+        assert "Call spawn_agent 1 time" not in projected
+        assert "Issue 1 Agent(" not in projected
+        assert "Minimum 2 batches" not in projected
+        assert "minimum of 5 parallel" not in projected
+        assert "Mandatory web research" not in projected
+        assert "spawn 2–3 independent validator" not in projected
 
 
 @pytest.mark.parametrize("skill_name", sorted(_PHASE_D_INVENTORY))

--- a/tests/workspace/test_session_skills_codex.py
+++ b/tests/workspace/test_session_skills_codex.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import replace
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -124,6 +125,60 @@ def test_codex_init_session_creates_skills_subdir(make_session_skill_manager, co
     )
     assert len(skill_files) > 0
     assert not (session_path / ClaudeDirectoryConventions.ADD_DIR_SKILLS_SUBDIR).exists()
+
+
+def test_codex_materializes_exact_guarded_investigate_document(
+    make_session_skill_manager,
+) -> None:
+    from autoskillit.core import ExplorationVectorApplicabilityId
+    from autoskillit.workspace import (
+        DefaultSkillResolver,
+        SkillProjectionContext,
+        project_agent_skill_document,
+    )
+
+    manager = make_session_skill_manager()
+    backend = _make_codex_backend()
+    invocation = DefaultSkillResolver().resolve_invocation(
+        "investigate",
+        manager._root,
+        SkillExecutionRole.SESSION,
+    )
+    context = SkillProjectionContext(
+        cwd=manager._root,
+        invocation=invocation,
+        backend=backend,
+        resolved_exploration_profile=RepositoryProfileId.AUTOSKILLIT,
+        active_exploration_applicabilities=frozenset(ExplorationVectorApplicabilityId),
+        parent_sandbox_mode="read-only",
+    )
+    expected = project_agent_skill_document(invocation.root, context)
+
+    add_dir = manager.materialize_invocation("investigate-materialized", invocation, context)
+    written = (
+        add_dir / ClaudeDirectoryConventions.PLUGIN_DIR_SKILLS_SUBDIR / "investigate" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert written == expected.content
+    assert expected.semantic_payload["child_spawns"] == (
+        {
+            "role": "delegated-worker",
+            "for_each": "selected_reasoning_responsibilities",
+        },
+        {
+            "role": "autoskillit:web-evidence-researcher",
+            "for_each": "selected_web_research_topics",
+        },
+    )
+    fragments = expected.adaptation_payload["instruction_fragments"]
+    assert any("selected_reasoning_responsibilities" in item for item in fragments)
+    assert any("selected_web_research_topics" in item for item in fragments)
+    assert expected.semantic_digest in written
+    assert expected.adaptation_digest in written
+    assert hashlib.sha256(written.encode()).hexdigest() == expected.projected_digest
+    assert "Candidate exploration task" in written
+    assert "selected_exploration_task_ids" in written
+    assert "Call spawn_agent 1 time" not in written
 
 
 def test_materialization_forwards_only_server_explorer_binding_env(

--- a/tests/workspace/test_session_skills_provider.py
+++ b/tests/workspace/test_session_skills_provider.py
@@ -104,6 +104,7 @@ def _child_spawn_skill(tmp_path: Path) -> SkillInfo:
         "      purpose: perform delegated work\n"
         "  child_spawns:\n"
         "    - role: worker\n"
+        "      count: 1\n"
         "---\n"
         "Delegate to the worker.\n",
         encoding="utf-8",

--- a/tests/workspace/test_skill_semantics.py
+++ b/tests/workspace/test_skill_semantics.py
@@ -8,6 +8,8 @@ from types import SimpleNamespace
 import pytest
 
 from autoskillit.core import SkillSemanticOperation, SkillSource
+from autoskillit.core.paths import pkg_root
+from autoskillit.workspace.skill_format import read_skill_frontmatter
 from autoskillit.workspace.skills import (
     _skill_info_from_frontmatter,
     render_skill_invalidities,
@@ -40,6 +42,88 @@ semantic_requirements:
   git_metadata_writes:
     - purpose: create the requested commit
 """
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DECLARED_SKILL_ROOTS = (
+    pkg_root() / "skills",
+    pkg_root() / "skills_extended",
+    _REPO_ROOT / ".autoskillit" / "skills",
+    _REPO_ROOT / ".claude" / "skills",
+)
+
+
+def _declared_child_spawn_cases() -> tuple[object, ...]:
+    cases: list[object] = []
+    for root in _DECLARED_SKILL_ROOTS:
+        if not root.is_dir():
+            continue
+        for skill_path in sorted(root.glob("*/SKILL.md")):
+            parsed = read_skill_frontmatter(skill_path)
+            requirements = (parsed.data or {}).get("semantic_requirements", {})
+            if not isinstance(requirements, dict):
+                continue
+            spawns = requirements.get("child_spawns", ())
+            if not isinstance(spawns, list):
+                continue
+            relative_path = skill_path.relative_to(_REPO_ROOT)
+            for index, spawn in enumerate(spawns):
+                role = spawn.get("role", "unknown") if isinstance(spawn, dict) else "unknown"
+                cases.append(
+                    pytest.param(
+                        skill_path,
+                        spawn,
+                        id=f"{relative_path}::{role}[{index}]",
+                    )
+                )
+    return tuple(cases)
+
+
+@pytest.mark.parametrize(("skill_path", "spawn"), _declared_child_spawn_cases())
+def test_declared_child_spawn_has_exactly_one_cardinality_authority(
+    skill_path: Path,
+    spawn: object,
+) -> None:
+    assert isinstance(spawn, dict), f"child spawn in {skill_path} must be a mapping"
+    assert sum(authority in spawn for authority in ("count", "for_each")) == 1
+
+
+_VARIABLE_CARDINALITY_SKILLS = {
+    "analyze-prs": (("delegated-worker", "candidate_pr_numbers"),),
+    "audit-claims": (("delegated-worker", "claim_analysis_responsibilities"),),
+    "audit-impl": (
+        ("audit-impl-deviation-evaluator", "deviation_entries"),
+        ("audit-impl-slice-auditor", "audit_slices"),
+    ),
+    "audit-review-decisions": (("delegated-worker", "review_decision_batches"),),
+    "build-execution-map": (("delegated-worker", "issue_numbers"),),
+    "planner-assess-review-approach": (("delegated-worker", "wp_assessment_batches"),),
+    "planner-consolidate-wps": (("delegated-worker", "phase_ids"),),
+    "planner-extract-domain": (("delegated-worker", "selected_domain_exploration_task_ids"),),
+    "planner-refine-assignments": (("delegated-worker", "assignment_ids"),),
+    "planner-refine-phases": (("delegated-worker", "phase_ids"),),
+    "planner-refine-wps": (("delegated-worker", "phase_ids"),),
+    "planner-validate-task-alignment": (("delegated-worker", "alignment_responsibilities"),),
+    "resolve-claims-review": (("delegated-worker", "intent_validation_groups"),),
+    "resolve-research-review": (("delegated-worker", "intent_validation_groups"),),
+    "resolve-review": (("delegated-worker", "intent_validation_groups"),),
+    "review-design": (("delegated-worker", "selected_review_dimensions"),),
+    "setup-project": (("delegated-worker", "project_exploration_responsibilities"),),
+    "stage-data": (("delegated-worker", "stageable_data_entries"),),
+    "triage-issues": (("delegated-worker", "issue_analysis_responsibilities"),),
+    "verify-diag": (("delegated-worker", "diagram_paths"),),
+}
+
+
+@pytest.mark.parametrize("skill_name", _VARIABLE_CARDINALITY_SKILLS)
+def test_variable_workflow_names_its_runtime_collection(skill_name: str) -> None:
+    skill_path = pkg_root() / "skills_extended" / skill_name / "SKILL.md"
+    parsed = read_skill_frontmatter(skill_path)
+    requirements = (parsed.data or {})["semantic_requirements"]
+
+    actual = tuple((spawn["role"], spawn["for_each"]) for spawn in requirements["child_spawns"])
+    expected = _VARIABLE_CARDINALITY_SKILLS[skill_name]
+    assert actual == expected
+    assert all(collection in parsed.body for _, collection in expected)
 
 
 def _write_skill(path: Path, *, declarations: str = _VALID_SEMANTICS, body: str = "Body.") -> None:

--- a/tests/workspace/test_skill_semantics.py
+++ b/tests/workspace/test_skill_semantics.py
@@ -23,6 +23,7 @@ semantic_requirements:
       purpose: review one independent concern
   child_spawns:
     - role: reviewer
+      count: 1
   concurrency:
     required: true
   join:
@@ -113,7 +114,48 @@ semantic_requirements:
     info = _skill_info_from_frontmatter("malformed-dynamic", SkillSource.PROJECT_LOCAL, skill_md)
 
     assert info.semantic_plan is None
-    assert "child spawn for_each must be a string" in render_skill_invalidities(info.invalidities)
+    assert {item.kind.value for item in info.invalidities} == {
+        "semantic_child_cardinality_invalid"
+    }
+    assert "for_each must be a non-empty runtime collection name" in render_skill_invalidities(
+        info.invalidities
+    )
+
+
+@pytest.mark.parametrize(
+    "cardinality",
+    [
+        "",
+        "      count: null\n",
+        "      count: true\n",
+        "      count: 1.5\n",
+        '      count: "1"\n',
+        "      count: 1\n      for_each: research_topics\n",
+    ],
+)
+def test_child_spawn_rejects_invalid_cardinality_authority(
+    tmp_path: Path, cardinality: str
+) -> None:
+    skill_md = tmp_path / "invalid-cardinality" / "SKILL.md"
+    declarations = f"""semantic_version: 1
+semantic_requirements:
+  logical_roles:
+    - name: researcher
+      purpose: research one topic
+  child_spawns:
+    - role: researcher
+{cardinality}"""
+    _write_skill(skill_md, declarations=declarations)
+
+    info = _skill_info_from_frontmatter("invalid-cardinality", SkillSource.PROJECT_LOCAL, skill_md)
+
+    assert info.semantic_plan is None
+    assert {item.kind.value for item in info.invalidities} == {
+        "semantic_child_cardinality_invalid"
+    }
+    reason = render_skill_invalidities(info.invalidities)
+    assert "semantic_requirements.child_spawns cardinality" in reason
+    assert "count: <positive integer> or for_each: <runtime collection>" in reason
 
 
 def test_child_model_policy_rejects_unregistered_logical_class(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

The defect is caused by two independent authorities being composed into one generated skill document without a shared cardinality contract: portable child semantics silently turns an omitted `count` into exact cardinality `1`, while exploration projection turns every statically applicable migrated vector into a bare native launch template.

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/rectify/rectify_codex_single_worker_adaptation_2026-08-12_151816.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
