### PR TITLE
[FIX] Rectify: Parent-Owned Audit Admission Across Projected-Plugin Children

### DIFF
--- a/tests/recipe/test_rules_audit_outcome_routing.py
+++ b/tests/recipe/test_rules_audit_outcome_routing.py
@@ -157,6 +157,7 @@ def test_implementation_semantic_rejection_uses_bounded_remediation_loop() -> No
         "callable": "autoskillit.smoke_utils.check_loop_iteration",
         "current_iteration": "${{ context.audit_remediation_count }}",
         "max_iterations": "${{ inputs.audit_remediation_max_retries }}",
+        "step_name": "check_audit_remediation_loop",
     }
     loop_routes = loop_step.on_result.conditions
     assert loop_routes[0].when == "${{ result.max_exceeded }} == true"

--- a/tests/server/test_audit_admission_production_seam.py
+++ b/tests/server/test_audit_admission_production_seam.py
@@ -234,7 +234,11 @@ async def test_substantive_go_without_semantic_publication_is_rejected(
     tmp_path: Path,
     tool_ctx_kitchen_open,
 ) -> None:
-    credential, step = await _install_attested_recipe(monkeypatch, tmp_path)
+    credential, step = await _install_attested_recipe(
+        monkeypatch,
+        tmp_path,
+        tool_ctx_kitchen_open,
+    )
     work_dir = tmp_path / "worktree"
     audit_root = resolve_temp_dir(
         work_dir,

--- a/tests/server/test_audit_admission_projected_plugin_process.py
+++ b/tests/server/test_audit_admission_projected_plugin_process.py
@@ -28,6 +28,7 @@ from tests.server._helpers import (
     _credit_initialization_sections,
     _open_kitchen_patched,
     _pull_step_section,
+    _ready_recipe_segment_step,
     _skill_ok,
 )
 from tests.server._pipeline_test_helpers import _ack_direct_run_skill_result
@@ -64,16 +65,20 @@ def _initialize_git_root(path: Path) -> None:
 async def _install_attested_recipe(
     monkeypatch: pytest.MonkeyPatch,
     parent_project: Path,
+    tool_ctx,
 ) -> tuple[dict[str, object], dict[str, object]]:
     monkeypatch.chdir(parent_project)
     envelope = await _open_kitchen_patched(_RECIPE, _OVERRIDES, monkeypatch)
     assert envelope["success"] is True
     await _credit_initialization_sections(envelope)
-    step = await _pull_step_section(envelope, _STEP)
     receipt = json.loads(await complete_recipe_initialization(envelope["initialization_id"]))
     assert receipt["success"] is True
     credential = receipt[RECIPE_EXECUTION_CREDENTIAL_WIRE_KEY]
     assert isinstance(credential, dict)
+    if "recipe_segment" in envelope:
+        step, credential = _ready_recipe_segment_step(tool_ctx, _STEP)
+    else:
+        step = await _pull_step_section(envelope, _STEP)
     return credential, step
 
 
@@ -103,7 +108,11 @@ async def test_projected_plugin_child_publishes_through_parent_audit_authority(
     )
     _initialize_git_root(parent_project)
     _initialize_git_root(clone)
-    credential, step = await _install_attested_recipe(monkeypatch, parent_project)
+    credential, step = await _install_attested_recipe(
+        monkeypatch,
+        parent_project,
+        tool_ctx_kitchen_open,
+    )
 
     installed = get_recipe_execution(tool_ctx_kitchen_open)
     assert installed is not None


### PR DESCRIPTION
## Summary

An attested `run_skill` call reserves audit admission in the parent server's ledger, but a child launched from a recipe clone starts a projected-plugin MCP server whose composition root currently opens a second ledger beneath the clone. The opaque handle is valid in the parent ledger and absent from the child ledger, so successful audit analysis is misreported as a stale-handle failure.

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/rectify/rectify_audit_parent_authority_2026-08-14_144010.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
