### PR TITLE
Pin Claude opus alias to claude-opus-5

### DIFF
--- a/.github/workflows/conformance-probes.yml
+++ b/.github/workflows/conformance-probes.yml
@@ -191,16 +191,10 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            claude-version: "2.1.142"
-            probe-tmpdir: /dev/shm/pytest-probes
-          - os: ubuntu-22.04
-            claude-version: "2.1.197"
+            claude-version: "2.1.219"
             probe-tmpdir: /dev/shm/pytest-probes
           - os: macos-14
-            claude-version: "2.1.142"
-            probe-tmpdir: /tmp/pytest-probes
-          - os: macos-14
-            claude-version: "2.1.197"
+            claude-version: "2.1.219"
             probe-tmpdir: /tmp/pytest-probes
     env:
       CLAUDE_CODE_SMOKE_TEST: "1"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,14 @@ model:
 
 Recipe steps can also specify a `model` field per-step in their YAML definition.
 
+The logical `opus` class resolves to the canonical `claude-opus-5` model ID by
+default. Projects that route Claude through a provider whose deployment does
+not accept that raw ID (Amazon Bedrock, Microsoft Foundry, or a custom
+gateway) should supply the provider's own accepted deployment/model
+identifier via a `providers.profiles` entry and a matching `step_overrides` /
+`recipe_overrides` / `model_overrides` binding — those overrides are resolved
+before this alias and always take precedence.
+
 ## Specialized Explorer Agents
 
 `semantic-code-navigator` and `repository-impact-profiler` are built-in terminal Codex explorer

--- a/docs/execution/claude-startup-readiness.md
+++ b/docs/execution/claude-startup-readiness.md
@@ -18,7 +18,7 @@ Claude interactive launches seal these values after caller environment overlays:
 |---|---:|---|
 | `MCP_CONNECTION_NONBLOCKING` | `0` | Ask Claude to wait for the connection batch |
 | `MCP_CONNECT_TIMEOUT_MS` | `30000` | Bound the connection batch and tool-list snapshot |
-| minimum Claude Code version | `2.1.142` | First supported nonblocking-startup contract |
+| minimum Claude Code version | `2.1.219` | Anthropic's documented floor for launching Claude Opus 5, which is now the pinned `opus` target |
 | fresh prompt attempts | `3` | Defense-in-depth dispatch cap after a pre-dispatch failure |
 
 `MCP_CONNECT_TIMEOUT_MS` is the connection batch/list-snapshot deadline. It is
@@ -73,8 +73,8 @@ The weekly `conformance-probes.yml` workflow runs these pinned rows:
 
 | Platform | Claude Code |
 |---|---|
-| Ubuntu 22.04 | 2.1.142 and 2.1.197 |
-| macOS 14 | 2.1.142 and 2.1.197 |
+| Ubuntu 22.04 | 2.1.219 |
+| macOS 14 | 2.1.219 |
 
 Each row installs the named version, exports its canonical path as
 `CLAUDE_CODE_EXECPATH`, and runs the exact restricted interactive surface with

--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -250,7 +250,7 @@ _CONTEXT_WINDOW_SUFFIX_RE: _re.Pattern[str] = _re.compile(r"\[\d+[mk]?\]$", _re.
 
 CLAUDE_MODEL_ALIASES: dict[str, str] = {
     "sonnet": "claude-sonnet-5",
-    "opus": "opus",
+    "opus": "claude-opus-5",
     "haiku": "haiku",
 }
 
@@ -364,7 +364,7 @@ CLAUDE_CODE_CAPABILITIES: BackendCapabilities = BackendCapabilities(
     applicable_guards=frozenset({"skill_load_guard"}),
     write_guard_tool_names=frozenset({"Write", "Edit", "Bash", "apply_patch"}),
     env_denylist_prefixes=(),
-    min_version="2.1.142",
+    min_version="2.1.219",
     version_check_command="claude --version",
     process_name="claude",
     process_name_aliases=frozenset({"claude"}),

--- a/tests/cli/test_doctor_backend_guards.py
+++ b/tests/cli/test_doctor_backend_guards.py
@@ -593,14 +593,14 @@ class TestCheckBackendVersion:
         monkeypatch.setattr(
             subprocess,
             "run",
-            lambda *a, **kw: self._codex_result("2.1.141 (Claude Code)\n"),
+            lambda *a, **kw: self._codex_result("2.1.218 (Claude Code)\n"),
         )
 
         result = _check_backend_version(backend=ClaudeCodeBackend())
 
         assert result.severity == Severity.WARNING
-        assert "Claude Code 2.1.141" in result.message
-        assert "2.1.142" in result.message
+        assert "Claude Code 2.1.218" in result.message
+        assert "2.1.219" in result.message
         assert "Codex CLI" not in result.message
 
 

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -161,7 +161,7 @@ def _capture_subprocess(monkeypatch: pytest.MonkeyPatch) -> dict:
                 (),
                 {
                     "returncode": 0,
-                    "stdout": "2.1.197 (Claude Code)",
+                    "stdout": "2.1.219 (Claude Code)",
                     "stderr": "",
                 },
             )()
@@ -1180,7 +1180,7 @@ def test_multi_backend_no_cross_flag_contamination(monkeypatch: pytest.MonkeyPat
             return type(
                 "Result",
                 (),
-                {"returncode": 0, "stdout": "2.1.197", "stderr": ""},
+                {"returncode": 0, "stdout": "2.1.219", "stderr": ""},
             )()
         captured["cmd"] = list(cmd)
         return type("Result", (), {"returncode": 0})()
@@ -1224,7 +1224,7 @@ def test_real_backend_no_foreign_flags(monkeypatch: pytest.MonkeyPatch, backend_
             return type(
                 "Result",
                 (),
-                {"returncode": 0, "stdout": "2.1.197", "stderr": ""},
+                {"returncode": 0, "stdout": "2.1.219", "stderr": ""},
             )()
         captured["cmd"] = list(cmd)
         return type("Result", (), {"returncode": 0})()
@@ -1270,7 +1270,7 @@ def test_cross_validation_contract_all_flags_known(
             return type(
                 "Result",
                 (),
-                {"returncode": 0, "stdout": "2.1.197", "stderr": ""},
+                {"returncode": 0, "stdout": "2.1.219", "stderr": ""},
             )()
         captured["cmd"] = list(cmd)
         return type("Result", (), {"returncode": 0})()

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -233,7 +233,7 @@ def test_claude_code_capabilities_field_values():
         {"Write", "Edit", "Bash", "apply_patch"}
     )
     assert CLAUDE_CODE_CAPABILITIES.env_denylist_prefixes == ()
-    assert CLAUDE_CODE_CAPABILITIES.min_version == "2.1.142"
+    assert CLAUDE_CODE_CAPABILITIES.min_version == "2.1.219"
     assert CLAUDE_CODE_CAPABILITIES.version_check_command == "claude --version"
     assert CLAUDE_CODE_CAPABILITIES.process_name == "claude"
     assert CLAUDE_CODE_CAPABILITIES.process_name_aliases == frozenset({"claude"})

--- a/tests/execution/backends/test_claude_startup_readiness.py
+++ b/tests/execution/backends/test_claude_startup_readiness.py
@@ -118,7 +118,7 @@ def test_pre_launch_probes_bound_executable_with_bound_environment(
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
         captured["cmd"] = cmd
         captured.update(kwargs)
-        return subprocess.CompletedProcess(cmd, 0, stdout="2.1.197 (Claude Code)\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="2.1.219 (Claude Code)\n", stderr="")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
@@ -136,7 +136,7 @@ def test_pre_launch_probes_bound_executable_with_bound_environment(
         (1, "", "failed"),
         (0, "", "empty"),
         (0, "Claude Code unknown", "unparseable"),
-        (0, "2.1.141 (Claude Code)", "requires Claude Code"),
+        (0, "2.1.218 (Claude Code)", "requires Claude Code"),
     ],
 )
 def test_pre_launch_fails_closed_for_unusable_capability_probe(

--- a/tests/execution/backends/test_model_translation.py
+++ b/tests/execution/backends/test_model_translation.py
@@ -39,8 +39,14 @@ class TestClaudeTranslateModel:
     def test_sonnet_alias(self) -> None:
         assert ClaudeCodeBackend().translate_model("sonnet") == CLAUDE_MODEL_ALIASES["sonnet"]
 
-    def test_preserves_context_suffix(self) -> None:
-        assert ClaudeCodeBackend().translate_model("opus[1m]") == "opus[1m]"
+    def test_opus_alias(self) -> None:
+        assert ClaudeCodeBackend().translate_model("opus") == CLAUDE_MODEL_ALIASES["opus"]
+
+    def test_translates_opus_and_preserves_context_suffix(self) -> None:
+        assert (
+            ClaudeCodeBackend().translate_model("opus[1m]")
+            == f"{CLAUDE_MODEL_ALIASES['opus']}[1m]"
+        )
 
     def test_unknown_passthrough(self) -> None:
         assert ClaudeCodeBackend().translate_model("custom-model-xyz") == "custom-model-xyz"
@@ -49,7 +55,10 @@ class TestClaudeTranslateModel:
         assert ClaudeCodeBackend().translate_model("haiku") == "haiku"
 
     def test_suffix_case_insensitive(self) -> None:
-        assert ClaudeCodeBackend().translate_model("opus[1M]") == "opus[1M]"
+        assert (
+            ClaudeCodeBackend().translate_model("opus[1M]")
+            == f"{CLAUDE_MODEL_ALIASES['opus']}[1M]"
+        )
 
 
 class TestCodexBuildCmdTranslatesModel:
@@ -85,7 +94,7 @@ class TestClaudeBuildCmdTranslatesModel:
     def test_build_headless_cmd_preserves_suffix(self) -> None:
         spec = ClaudeCodeBackend().build_headless_cmd("test prompt", model="opus[1m]")
         model_idx = list(spec.cmd).index("--model")
-        assert spec.cmd[model_idx + 1] == "opus[1m]"
+        assert spec.cmd[model_idx + 1] == f"{CLAUDE_MODEL_ALIASES['opus']}[1m]"
 
     def test_build_interactive_cmd_preserves_suffix(self) -> None:
         spec = ClaudeCodeBackend().build_interactive_cmd(model="sonnet[1m]")
@@ -109,7 +118,7 @@ class TestClaudeBuildCmdTranslatesModel:
             model="opus[1m]",
         )
         model_idx = list(spec.cmd).index("--model")
-        assert spec.cmd[model_idx + 1] == "opus[1m]"
+        assert spec.cmd[model_idx + 1] == f"{CLAUDE_MODEL_ALIASES['opus']}[1m]"
 
 
 class TestCodexModelConfigOverrides:

--- a/tests/execution/test_model_alias_registry.py
+++ b/tests/execution/test_model_alias_registry.py
@@ -6,7 +6,7 @@ import pytest
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
-VALID_CLAUDE_MODEL_IDS: frozenset[str] = frozenset({"claude-sonnet-5", "opus", "haiku"})
+VALID_CLAUDE_MODEL_IDS: frozenset[str] = frozenset({"claude-sonnet-5", "claude-opus-5", "haiku"})
 
 
 def test_anomaly_detection_aliases_keys_match_shared() -> None:
@@ -72,6 +72,12 @@ def test_claude_sonnet_alias_uses_sonnet_5() -> None:
     from autoskillit.core.types._type_backend import CLAUDE_MODEL_ALIASES
 
     assert CLAUDE_MODEL_ALIASES["sonnet"] == "claude-sonnet-5"
+
+
+def test_claude_opus_alias_uses_opus_5() -> None:
+    from autoskillit.core.types._type_backend import CLAUDE_MODEL_ALIASES
+
+    assert CLAUDE_MODEL_ALIASES["opus"] == "claude-opus-5"
 
 
 def test_codex_alias_values_differ_from_keys() -> None:

--- a/tests/infra/test_conformance_probes_workflow.py
+++ b/tests/infra/test_conformance_probes_workflow.py
@@ -134,10 +134,8 @@ class TestVersionResolution:
         matrix = workflow["jobs"]["claude-probe"]["strategy"]["matrix"]["include"]
         rows = {(row["os"], row["claude-version"], row["probe-tmpdir"]) for row in matrix}
         assert rows == {
-            ("ubuntu-22.04", "2.1.142", "/dev/shm/pytest-probes"),
-            ("ubuntu-22.04", "2.1.197", "/dev/shm/pytest-probes"),
-            ("macos-14", "2.1.142", "/tmp/pytest-probes"),
-            ("macos-14", "2.1.197", "/tmp/pytest-probes"),
+            ("ubuntu-22.04", "2.1.219", "/dev/shm/pytest-probes"),
+            ("macos-14", "2.1.219", "/tmp/pytest-probes"),
         }
 
     def test_claude_probe_installs_and_exports_exact_pinned_binary(self, workflow: dict) -> None:


### PR DESCRIPTION
## Summary

Pins the logical `opus` model class to the physical `claude-opus-5` model ID instead of
the previous floating `opus -> opus` alias, matching the existing Sonnet 5 pin pattern.
Raises the enforced Claude Code CLI floor from `2.1.142` to `2.1.219`, which Anthropic
documents as the minimum Claude Code version required to launch Opus 5. Updates the
alias-registry, translation, capability, doctor, startup-readiness, and session-launch
tests to match the new deterministic mapping and floor, collapses the
`conformance-probes.yml` CI matrix from four pinned-version rows to two (both prior
pinned versions now fall below the new floor) plus its workflow-shape test, and
documents the new floor/matrix and default in `docs/execution/claude-startup-readiness.md`
and `docs/configuration.md`.

Logical `opus`/`opus[1m]` references in recipe/skill YAML, historical `claude-opus-4-6`
telemetry/parser/drift fixtures, and the family-level drift-normalization logic are
deliberately left unchanged, as are the unrelated `2.1.197`/`2.1.91` references in
`docs/verification/review-pr-immunity.md` and `tests/arch/test_recipe_delivery_provenance.py`.

Verified with `task test-check` (26315 passed, 502 skipped, 13 xfailed, 0 failed) and a
clean `pre-commit run --all-files`.

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/pin_claude_opus_5.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
