### PR TITLE
Rectify: Owned-Process Cleanup Evidence vs. Workload Outcome

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -242,8 +242,11 @@ from .pipeline_tracker import release_tracker_lease as release_tracker_lease
 from .pipeline_tracker import retain_tracker_lease as retain_tracker_lease
 from .pipeline_tracker import tracker_lease_path as tracker_lease_path
 from .pipeline_tracker import try_retire_tracker as try_retire_tracker
+from .runtime._linux_proc import is_pid_alive as is_pid_alive
+from .runtime._linux_proc import is_pid_zombie as is_pid_zombie
 from .runtime._linux_proc import is_session_alive as is_session_alive
 from .runtime._linux_proc import read_boot_id as read_boot_id
+from .runtime._linux_proc import read_process_state as read_process_state
 from .runtime._linux_proc import read_starttime_ticks as read_starttime_ticks
 from .runtime.artifact_lease import ArtifactLease as ArtifactLease
 from .runtime.artifact_lease import ArtifactLeaseContention as ArtifactLeaseContention

--- a/src/autoskillit/core/_plugin_cache.py
+++ b/src/autoskillit/core/_plugin_cache.py
@@ -845,6 +845,10 @@ def read_active_kitchens_registry() -> list[dict]:
 
 
 def _pid_alive(pid: int, stored_create_time: float | None = None) -> bool:
+    # Intentionally excluded from the core.runtime.is_pid_alive consolidation: this
+    # function's cross-boot stored_create_time verification cannot be reproduced by
+    # the stdlib-only tick-count primitive without an out-of-scope boot-time/schema
+    # migration, so it keeps its own psutil-based zombie check.
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -852,18 +856,30 @@ def _pid_alive(pid: int, stored_create_time: float | None = None) -> bool:
     except PermissionError:
         if stored_create_time is not None:
             try:
-                actual = psutil.Process(pid).create_time()
-                return abs(actual - stored_create_time) < 1.0
+                proc = psutil.Process(pid)
+                return (
+                    abs(proc.create_time() - stored_create_time) < 1.0
+                    and proc.status() != psutil.STATUS_ZOMBIE
+                )
             except psutil.NoSuchProcess:
                 return False
-        return True
-    if stored_create_time is not None:
         try:
-            actual = psutil.Process(pid).create_time()
-            return abs(actual - stored_create_time) < 1.0
+            return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
         except psutil.NoSuchProcess:
             return False
-    return True
+    if stored_create_time is not None:
+        try:
+            proc = psutil.Process(pid)
+            return (
+                abs(proc.create_time() - stored_create_time) < 1.0
+                and proc.status() != psutil.STATUS_ZOMBIE
+            )
+        except psutil.NoSuchProcess:
+            return False
+    try:
+        return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
+    except psutil.NoSuchProcess:
+        return False
 
 
 def register_active_kitchen(identity: KitchenProcessIdentity) -> None:

--- a/src/autoskillit/core/_plugin_cache.py
+++ b/src/autoskillit/core/_plugin_cache.py
@@ -845,10 +845,7 @@ def read_active_kitchens_registry() -> list[dict]:
 
 
 def _pid_alive(pid: int, stored_create_time: float | None = None) -> bool:
-    # Intentionally excluded from the core.runtime.is_pid_alive consolidation: this
-    # function's cross-boot stored_create_time verification cannot be reproduced by
-    # the stdlib-only tick-count primitive without an out-of-scope boot-time/schema
-    # migration, so it keeps its own psutil-based zombie check.
+    # Allowlisted in test_no_raw_zombie_blind_liveness_check_outside_shared_primitive.
     try:
         os.kill(pid, 0)
     except ProcessLookupError:

--- a/src/autoskillit/core/_plugin_cache.py
+++ b/src/autoskillit/core/_plugin_cache.py
@@ -858,11 +858,19 @@ def _pid_alive(pid: int, stored_create_time: float | None = None) -> bool:
                     abs(proc.create_time() - stored_create_time) < 1.0
                     and proc.status() != psutil.STATUS_ZOMBIE
                 )
-            except (psutil.NoSuchProcess, psutil.AccessDenied):
+            except psutil.NoSuchProcess:
+                # Process is definitively gone between the os.kill probe and
+                # this psutil call — do not keep reporting it as alive.
+                return False
+            except psutil.AccessDenied:
+                # Foreign-user PID — unverifiable, fall back to the prior
+                # "assume alive" portable contract.
                 return True
         try:
             return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
         except (psutil.NoSuchProcess, psutil.AccessDenied):
+            # Non-create-time path has no zombie-protection rationale to
+            # override the prior "assume alive when unverifiable" behavior.
             return True
     if stored_create_time is not None:
         try:
@@ -871,11 +879,18 @@ def _pid_alive(pid: int, stored_create_time: float | None = None) -> bool:
                 abs(proc.create_time() - stored_create_time) < 1.0
                 and proc.status() != psutil.STATUS_ZOMBIE
             )
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
+        except psutil.NoSuchProcess:
+            # Same rationale as the PermissionError branch above — a
+            # definitively-gone process must not be reported alive.
+            return False
+        except psutil.AccessDenied:
             return True
     try:
         return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
     except (psutil.NoSuchProcess, psutil.AccessDenied):
+        # Non-create-time path, normal-error path — preserve the pre-8ebfde357
+        # "assume alive" behavior so a transient psutil failure (e.g. OS race)
+        # does not falsely retire a live kitchen.
         return True
 
 

--- a/src/autoskillit/core/_plugin_cache.py
+++ b/src/autoskillit/core/_plugin_cache.py
@@ -861,12 +861,12 @@ def _pid_alive(pid: int, stored_create_time: float | None = None) -> bool:
                     abs(proc.create_time() - stored_create_time) < 1.0
                     and proc.status() != psutil.STATUS_ZOMBIE
                 )
-            except psutil.NoSuchProcess:
-                return False
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                return True
         try:
             return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
-        except psutil.NoSuchProcess:
-            return False
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            return True
     if stored_create_time is not None:
         try:
             proc = psutil.Process(pid)
@@ -874,12 +874,12 @@ def _pid_alive(pid: int, stored_create_time: float | None = None) -> bool:
                 abs(proc.create_time() - stored_create_time) < 1.0
                 and proc.status() != psutil.STATUS_ZOMBIE
             )
-        except psutil.NoSuchProcess:
-            return False
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            return True
     try:
         return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
-    except psutil.NoSuchProcess:
-        return False
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return True
 
 
 def register_active_kitchen(identity: KitchenProcessIdentity) -> None:

--- a/src/autoskillit/core/_plugin_cache.py
+++ b/src/autoskillit/core/_plugin_cache.py
@@ -851,46 +851,30 @@ def _pid_alive(pid: int, stored_create_time: float | None = None) -> bool:
     except ProcessLookupError:
         return False
     except PermissionError:
-        if stored_create_time is not None:
-            try:
-                proc = psutil.Process(pid)
-                return (
-                    abs(proc.create_time() - stored_create_time) < 1.0
-                    and proc.status() != psutil.STATUS_ZOMBIE
-                )
-            except psutil.NoSuchProcess:
-                # Process is definitively gone between the os.kill probe and
-                # this psutil call — do not keep reporting it as alive.
-                return False
-            except psutil.AccessDenied:
-                # Foreign-user PID — unverifiable, fall back to the prior
-                # "assume alive" portable contract.
-                return True
-        try:
-            return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
-            # Non-create-time path has no zombie-protection rationale to
-            # override the prior "assume alive when unverifiable" behavior.
-            return True
-    if stored_create_time is not None:
-        try:
-            proc = psutil.Process(pid)
-            return (
-                abs(proc.create_time() - stored_create_time) < 1.0
-                and proc.status() != psutil.STATUS_ZOMBIE
-            )
-        except psutil.NoSuchProcess:
-            # Same rationale as the PermissionError branch above — a
-            # definitively-gone process must not be reported alive.
-            return False
-        except psutil.AccessDenied:
-            return True
+        return _check_pid_with_psutil(pid, stored_create_time)
+    return _check_pid_with_psutil(pid, stored_create_time)
+
+
+def _check_pid_with_psutil(pid: int, stored_create_time: float | None) -> bool:
+    """Post-probe liveness check via psutil — assumes os.kill(pid, 0) already succeeded.
+
+    Reports False only when psutil definitively confirms the process is gone (NoSuchProcess)
+    or in a terminal zombie/dead state. Foreign-user PIDs (AccessDenied) are unverifiable,
+    so we assume alive to avoid retiring a live kitchen on a transient psutil failure.
+    """
     try:
-        return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
-    except (psutil.NoSuchProcess, psutil.AccessDenied):
-        # Non-create-time path, normal-error path — preserve the pre-8ebfde357
-        # "assume alive" behavior so a transient psutil failure (e.g. OS race)
-        # does not falsely retire a live kitchen.
+        proc = psutil.Process(pid)
+        if stored_create_time is not None:
+            identity_match = abs(proc.create_time() - stored_create_time) < 1.0
+        else:
+            identity_match = True
+        return identity_match and proc.status() not in (
+            psutil.STATUS_ZOMBIE,
+            psutil.STATUS_DEAD,
+        )
+    except psutil.NoSuchProcess:
+        return False
+    except psutil.AccessDenied:
         return True
 
 

--- a/src/autoskillit/core/runtime/__init__.py
+++ b/src/autoskillit/core/runtime/__init__.py
@@ -6,7 +6,14 @@ and _linux_proc so callers can use ``from autoskillit.core.runtime import X``.
 
 from __future__ import annotations
 
-from ._linux_proc import is_session_alive, read_boot_id, read_starttime_ticks
+from ._linux_proc import (
+    is_pid_alive,
+    is_pid_zombie,
+    is_session_alive,
+    read_boot_id,
+    read_process_state,
+    read_starttime_ticks,
+)
 from .artifact_lease import ArtifactLease, ArtifactLeaseContention
 from .executable_binding import (
     executable_binding_matches_current_file,
@@ -62,6 +69,8 @@ __all__ = [
     "executable_binding_matches_current_file",
     "fsync_directory",
     "fsync_file",
+    "is_pid_alive",
+    "is_pid_zombie",
     "is_session_alive",
     "KitchenMarker",
     "bind_session_owner",
@@ -78,6 +87,7 @@ __all__ = [
     "read_boot_id",
     "read_kitchen_id_from_marker",
     "read_marker",
+    "read_process_state",
     "resolve_kitchen_id",
     "read_provenance_for_session",
     "read_registry",

--- a/src/autoskillit/core/runtime/_linux_proc.py
+++ b/src/autoskillit/core/runtime/_linux_proc.py
@@ -65,9 +65,15 @@ def is_pid_zombie(pid: int) -> bool:
 
 
 def is_pid_alive(pid: int) -> bool:
-    """True when pid exists and is not a zombie — False on non-Linux."""
+    """True when pid exists and is not a dead or zombie state — False on non-Linux.
+
+    Excludes both 'Z' (zombie) and 'X' (dead, in process of being reaped on
+    Linux >= 2.6.33, per proc(5)). A 'X'-state process is brief but
+    real: a downstream caller that treats it as alive can race against
+    the reaper and miss cleanup.
+    """
     state = read_process_state(pid)
-    return state is not None and state != "Z"
+    return state is not None and state not in ("Z", "X")
 
 
 def is_session_alive(pid: int, boot_id: str, starttime_ticks: int) -> bool:

--- a/src/autoskillit/core/runtime/_linux_proc.py
+++ b/src/autoskillit/core/runtime/_linux_proc.py
@@ -58,8 +58,16 @@ def read_process_state(pid: int) -> str | None:
 
 
 def is_pid_zombie(pid: int) -> bool:
-    """True when pid is a zombie (exited but not yet reaped by its parent)."""
-    return read_process_state(pid) == "Z"
+    """True when pid is a zombie or in the transient dead-reaping window.
+
+    Matches 'Z' (zombie) and 'X' (dead, transient reaping per proc_pid_stat(5),
+    available since Linux 2.6.0). An 'X'-state process is briefly observable
+    before the kernel reaps it; treating it as non-zombie here lets a caller
+    race the reaper and miss cleanup. For liveness checks that exclude both
+    states, prefer is_pid_alive.
+    """
+    state = read_process_state(pid)
+    return state in ("Z", "X")
 
 
 def is_pid_alive(pid: int) -> bool:

--- a/src/autoskillit/core/runtime/_linux_proc.py
+++ b/src/autoskillit/core/runtime/_linux_proc.py
@@ -26,7 +26,6 @@ def read_starttime_ticks(pid: int) -> int | None:
     """
     try:
         stat = Path(f"/proc/{pid}/stat").read_text()
-        # comm may contain ")" — rfind locates the last ")" as the field boundary
         rpar = stat.rfind(")")
         if rpar == -1:
             return None
@@ -47,7 +46,6 @@ def read_process_state(pid: int) -> str | None:
     """
     try:
         stat = Path(f"/proc/{pid}/stat").read_text()
-        # comm may contain ")" — rfind locates the last ")" as the field boundary
         rpar = stat.rfind(")")
         if rpar == -1:
             return None

--- a/src/autoskillit/core/runtime/_linux_proc.py
+++ b/src/autoskillit/core/runtime/_linux_proc.py
@@ -65,10 +65,10 @@ def is_pid_zombie(pid: int) -> bool:
 def is_pid_alive(pid: int) -> bool:
     """True when pid exists and is not a dead or zombie state — False on non-Linux.
 
-    Excludes both 'Z' (zombie) and 'X' (dead, in process of being reaped on
-    Linux >= 2.6.33, per proc(5)). A 'X'-state process is brief but
-    real: a downstream caller that treats it as alive can race against
-    the reaper and miss cleanup.
+    Excludes 'Z' (zombie) and 'X' (dead, transient reaping window, per
+    proc_pid_stat(5), available since Linux 2.6.0). A 'X'-state process is
+    brief but real: a downstream caller that treats it as alive can race
+    against the reaper and miss cleanup.
     """
     state = read_process_state(pid)
     return state is not None and state not in ("Z", "X")

--- a/src/autoskillit/core/runtime/_linux_proc.py
+++ b/src/autoskillit/core/runtime/_linux_proc.py
@@ -38,6 +38,37 @@ def read_starttime_ticks(pid: int) -> int | None:
     return None
 
 
+def read_process_state(pid: int) -> str | None:
+    """Read process state character from /proc/pid/stat.
+
+    Uses rfind(")") to correctly locate the field boundary even when the
+    process comm contains a ")" character. Matches psutil's own _parse_stat_file()
+    which uses rfind(b")") for the same reason.
+    """
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text()
+        # comm may contain ")" — use rfind to find the *last* ")" as the boundary
+        rpar = stat.rfind(")")
+        if rpar == -1:
+            return None
+        fields = stat[rpar + 2 :].split()
+        # state is field 3 (1-indexed per man page), the first field after ")"
+        return fields[0]
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
+def is_pid_zombie(pid: int) -> bool:
+    """True when pid is a zombie (exited but not yet reaped by its parent)."""
+    return read_process_state(pid) == "Z"
+
+
+def is_pid_alive(pid: int) -> bool:
+    """True when pid exists and is not a zombie — False on non-Linux."""
+    return read_process_state(pid) is not None and not is_pid_zombie(pid)
+
+
 def is_session_alive(pid: int, boot_id: str, starttime_ticks: int) -> bool:
     """True only when boot_id, PID, and starttime_ticks all match — False on non-Linux."""
     if not pid or not boot_id:
@@ -48,4 +79,6 @@ def is_session_alive(pid: int, boot_id: str, starttime_ticks: int) -> bool:
     actual_ticks = read_starttime_ticks(pid)
     if actual_ticks is None:
         return False
-    return actual_ticks == starttime_ticks
+    if actual_ticks != starttime_ticks:
+        return False
+    return not is_pid_zombie(pid)

--- a/src/autoskillit/core/runtime/_linux_proc.py
+++ b/src/autoskillit/core/runtime/_linux_proc.py
@@ -26,7 +26,7 @@ def read_starttime_ticks(pid: int) -> int | None:
     """
     try:
         stat = Path(f"/proc/{pid}/stat").read_text()
-        # comm may contain ")" — use rfind to find the *last* ")" as the boundary
+        # comm may contain ")" — rfind locates the last ")" as the field boundary
         rpar = stat.rfind(")")
         if rpar == -1:
             return None
@@ -47,7 +47,7 @@ def read_process_state(pid: int) -> str | None:
     """
     try:
         stat = Path(f"/proc/{pid}/stat").read_text()
-        # comm may contain ")" — use rfind to find the *last* ")" as the boundary
+        # comm may contain ")" — rfind locates the last ")" as the field boundary
         rpar = stat.rfind(")")
         if rpar == -1:
             return None
@@ -66,7 +66,8 @@ def is_pid_zombie(pid: int) -> bool:
 
 def is_pid_alive(pid: int) -> bool:
     """True when pid exists and is not a zombie — False on non-Linux."""
-    return read_process_state(pid) is not None and not is_pid_zombie(pid)
+    state = read_process_state(pid)
+    return state is not None and state != "Z"
 
 
 def is_session_alive(pid: int, boot_id: str, starttime_ticks: int) -> bool:
@@ -81,4 +82,4 @@ def is_session_alive(pid: int, boot_id: str, starttime_ticks: int) -> bool:
         return False
     if actual_ticks != starttime_ticks:
         return False
-    return not is_pid_zombie(pid)
+    return is_pid_alive(pid)

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -452,10 +452,8 @@ class InfraOutcome:
 
     exit_category: str = ""
     cleanup_incomplete: bool = False
-    """True when owned-process-group teardown evidence was incomplete (e.g. a
-    survivor or access-denied PID) even though the workload's own outcome was
-    determined independently. Diagnostic only — does not affect needs_retry.
-    """
+    """Diagnostic only — see ``SubprocessResult.cleanup_evidence`` for the
+    underlying teardown signal; this field just surfaces it for retry logic."""
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -451,6 +451,11 @@ class InfraOutcome:
     """Infrastructure exit classification bundle."""
 
     exit_category: str = ""
+    cleanup_incomplete: bool = False
+    """True when owned-process-group teardown evidence was incomplete (e.g. a
+    survivor or access-denied PID) even though the workload's own outcome was
+    determined independently. Diagnostic only — does not affect needs_retry.
+    """
 
 
 @dataclass(frozen=True, slots=True)
@@ -606,6 +611,7 @@ class SkillResult:
             "provider_fallback": self.provider.fallback_activated,
             "provider_used": self.provider.provider_used,
             "infra_exit_category": self.infra.exit_category,
+            "infra_cleanup_incomplete": self.infra.cleanup_incomplete,
             "api_retry_count": self.api_retry.count,
             "api_retry_last_error": self.api_retry.last_error,
             "api_retry_last_status": self.api_retry.last_status,

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -452,8 +452,9 @@ class InfraOutcome:
 
     exit_category: str = ""
     cleanup_incomplete: bool = False
-    """Diagnostic only — see ``SubprocessResult.cleanup_evidence`` for the
-    underlying teardown signal; this field just surfaces it for retry logic."""
+    """Surfaces ``SubprocessResult.cleanup_evidence`` for retry orchestration.
+    See ``_should_flag_cleanup_incomplete`` in execution.headless._headless_result
+    for the canonical contract."""
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/core/types/_type_subprocess.py
+++ b/src/autoskillit/core/types/_type_subprocess.py
@@ -125,8 +125,9 @@ class SubprocessResult:
     returncode: int
     """Final process return code.
 
-    -1 means the leader's returncode could not be confirmed despite full
-    SIGTERM/SIGKILL escalation — see cleanup_evidence for diagnostic detail.
+    Note: -1 collides with the SIGHUP signal-terminated returncode, so it cannot
+    reliably indicate "leader returncode unconfirmed after full escalation." Use
+    cleanup_evidence as the unambiguous discriminator for teardown status.
     """
     stdout: str
     stderr: str

--- a/src/autoskillit/core/types/_type_subprocess.py
+++ b/src/autoskillit/core/types/_type_subprocess.py
@@ -123,12 +123,8 @@ class SubprocessResult:
     """Result from a managed subprocess execution."""
 
     returncode: int
-    """Final process return code.
-
-    Note: -1 collides with the SIGHUP signal-terminated returncode, so it cannot
-    reliably indicate "leader returncode unconfirmed after full escalation." Use
-    cleanup_evidence as the unambiguous discriminator for teardown status.
-    """
+    """Final process return code (-1 may indicate either SIGHUP-killed or
+    unconfirmed leader — see ``cleanup_evidence`` for teardown status)."""
     stdout: str
     stderr: str
     termination: TerminationReason
@@ -195,11 +191,7 @@ class SubprocessResult:
     stdout_path: Path | None = None
     stderr_path: Path | None = None
     cleanup_evidence: ProcessCleanupResult | None = None
-    """Set by run_managed_async/run_managed_sync via execute_termination_action's
-    settle_evidence() call. Diagnostic only — does not itself affect termination
-    behavior or force a retry; see InfraOutcome.cleanup_incomplete for downstream
-    surfacing.
-    """
+    """Diagnostic only — see ``InfraOutcome.cleanup_incomplete`` for surfacing."""
 
 
 @runtime_checkable

--- a/src/autoskillit/core/types/_type_subprocess.py
+++ b/src/autoskillit/core/types/_type_subprocess.py
@@ -191,7 +191,10 @@ class SubprocessResult:
     stdout_path: Path | None = None
     stderr_path: Path | None = None
     cleanup_evidence: ProcessCleanupResult | None = None
-    """Diagnostic only — see ``InfraOutcome.cleanup_incomplete`` for surfacing."""
+    """Owned-process-group teardown evidence (set by run_managed_async/run_managed_sync
+    via execute_termination_action's settle_evidence() call). Diagnostic only; see
+    ``_should_flag_cleanup_incomplete`` in execution.headless._headless_result for
+    the canonical contract."""
 
 
 @runtime_checkable

--- a/src/autoskillit/core/types/_type_subprocess.py
+++ b/src/autoskillit/core/types/_type_subprocess.py
@@ -123,6 +123,11 @@ class SubprocessResult:
     """Result from a managed subprocess execution."""
 
     returncode: int
+    """Final process return code.
+
+    -1 means the leader's returncode could not be confirmed despite full
+    SIGTERM/SIGKILL escalation — see cleanup_evidence for diagnostic detail.
+    """
     stdout: str
     stderr: str
     termination: TerminationReason
@@ -188,6 +193,12 @@ class SubprocessResult:
     """
     stdout_path: Path | None = None
     stderr_path: Path | None = None
+    cleanup_evidence: ProcessCleanupResult | None = None
+    """Set by run_managed_async/run_managed_sync via execute_termination_action's
+    settle_evidence() call. Diagnostic only — does not itself affect termination
+    behavior or force a retry; see InfraOutcome.cleanup_incomplete for downstream
+    surfacing.
+    """
 
 
 @runtime_checkable

--- a/src/autoskillit/execution/_session_log_recovery.py
+++ b/src/autoskillit/execution/_session_log_recovery.py
@@ -7,13 +7,14 @@ import time
 from datetime import UTC, datetime
 from pathlib import Path
 
-from autoskillit.core import CampaignProtector, get_logger
-from autoskillit.execution.linux_tracing import (
+from autoskillit.core import (
+    CampaignProtector,
+    get_logger,
     is_pid_zombie,
     read_boot_id,
-    read_enrollment,
     read_starttime_ticks,
 )
+from autoskillit.execution.linux_tracing import read_enrollment
 from autoskillit.execution.session_log import flush_session_log
 
 logger = get_logger(__name__)

--- a/src/autoskillit/execution/_session_log_recovery.py
+++ b/src/autoskillit/execution/_session_log_recovery.py
@@ -65,9 +65,8 @@ def recover_crashed_sessions(
             enrollment_path.unlink(missing_ok=True)
             continue
 
-        # Gate 3: PID liveness + starttime_ticks identity. A zombie with matching
-        # ticks is treated as dead — its parent already stopped monitoring it,
-        # so the crash trace must be recovered, not skipped.
+        # Gate 3: PID liveness + starttime_ticks identity. A zombie with
+        # matching ticks is treated as dead so the crash trace is recovered.
         current_ticks = read_starttime_ticks(pid)
         if (
             current_ticks is not None

--- a/src/autoskillit/execution/_session_log_recovery.py
+++ b/src/autoskillit/execution/_session_log_recovery.py
@@ -7,10 +7,13 @@ import time
 from datetime import UTC, datetime
 from pathlib import Path
 
-import psutil
-
 from autoskillit.core import CampaignProtector, get_logger
-from autoskillit.execution.linux_tracing import read_boot_id, read_enrollment, read_starttime_ticks
+from autoskillit.execution.linux_tracing import (
+    is_pid_zombie,
+    read_boot_id,
+    read_enrollment,
+    read_starttime_ticks,
+)
 from autoskillit.execution.session_log import flush_session_log
 
 logger = get_logger(__name__)
@@ -62,13 +65,18 @@ def recover_crashed_sessions(
             enrollment_path.unlink(missing_ok=True)
             continue
 
-        # Gate 3: PID liveness + starttime_ticks identity
-        if psutil.pid_exists(pid):
-            current_ticks = read_starttime_ticks(pid)
-            if current_ticks is not None and current_ticks == enrollment.starttime_ticks:
-                logger.debug("Skipping %s: PID %d still alive", trace_file.name, pid)
-                continue
-            # PID recycled — original process is gone, treat as crash
+        # Gate 3: PID liveness + starttime_ticks identity. A zombie with matching
+        # ticks is treated as dead — its parent already stopped monitoring it,
+        # so the crash trace must be recovered, not skipped.
+        current_ticks = read_starttime_ticks(pid)
+        if (
+            current_ticks is not None
+            and current_ticks == enrollment.starttime_ticks
+            and not is_pid_zombie(pid)
+        ):
+            logger.debug("Skipping %s: PID %d still alive", trace_file.name, pid)
+            continue
+        # PID recycled, dead, or zombie — original process is gone, treat as crash
 
         # All gates passed — read snapshots and emit crashed row
         snapshots: list[dict[str, object]] = []

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -530,6 +530,7 @@ class _BoundedProbeResult:
     stdout: bytes
     stderr: bytes
     failure: str | None = None
+    cleanup_incomplete: bool = False
 
 
 def _terminate_probe(owner: object) -> None:
@@ -538,7 +539,7 @@ def _terminate_probe(owner: object) -> None:
     if not isinstance(owner, OwnedProcessGroup):
         raise TypeError("Codex probe cleanup requires its spawn-bound owner")
     try:
-        owner.settle(timeout=2)
+        owner.settle_evidence(timeout=2)
     finally:
         for stream in (owner.process.stdout, owner.process.stderr):
             if stream is not None:
@@ -619,7 +620,9 @@ def _run_bounded_codex_probe(
                         stderr=bytes(output["stderr"]),
                         failure=f"{stream_name} exceeded {_CODEX_PROBE_STREAM_LIMIT} bytes",
                     )
-        returncode, _cleanup = owner.settle(timeout=max(0.0, deadline - time.monotonic()))
+        returncode, cleanup_result = owner.settle_evidence(
+            timeout=max(0.0, deadline - time.monotonic())
+        )
     except subprocess.TimeoutExpired:
         _terminate_probe(owner)
         return _BoundedProbeResult(
@@ -629,6 +632,10 @@ def _run_bounded_codex_probe(
             failure="timed out while reaping",
         )
     except BaseException as exc:
+        # Incomplete-cleanup-evidence handling now lives inline at each call site
+        # (both use settle_evidence(), which never raises). Neither of the two
+        # settle() calls this handler used to guard remains reachable, so a
+        # BaseException here is always a genuine crash, not stale cleanup evidence.
         if process.returncode is None:
             try:
                 _terminate_probe(owner)
@@ -646,6 +653,7 @@ def _run_bounded_codex_probe(
         returncode=returncode,
         stdout=bytes(output["stdout"]),
         stderr=bytes(output["stderr"]),
+        cleanup_incomplete=not cleanup_result.complete,
     )
 
 
@@ -789,6 +797,8 @@ def _validate_mcp_probe(
     result = _run_bounded_codex_probe(command, env=env, cwd=cwd)
     if result.failure is not None:
         return [f"Codex MCP validation {result.failure}; {_probe_diagnostic(result)}"]
+    if result.cleanup_incomplete:
+        logger.warning("codex_probe_cleanup_incomplete", returncode=result.returncode)
     if result.returncode != 0:
         return [
             f"Codex MCP validation exited with status {result.returncode}; "

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -623,6 +623,7 @@ def _run_bounded_codex_probe(
         returncode, cleanup_result = owner.settle_evidence(
             timeout=max(0.0, deadline - time.monotonic())
         )
+        returncode = returncode if returncode is not None else -1
     except subprocess.TimeoutExpired:
         _terminate_probe(owner)
         return _BoundedProbeResult(
@@ -632,10 +633,7 @@ def _run_bounded_codex_probe(
             failure="timed out while reaping",
         )
     except BaseException as exc:
-        # Incomplete-cleanup-evidence handling now lives inline at each call site
-        # (both use settle_evidence(), which never raises). Neither of the two
-        # settle() calls this handler used to guard remains reachable, so a
-        # BaseException here is always a genuine crash, not stale cleanup evidence.
+        # settle_evidence() never raises, so any BaseException here is unrelated to cleanup.
         if process.returncode is None:
             try:
                 _terminate_probe(owner)

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -119,6 +119,17 @@ def _build_api_retry_outcome(session: ClaudeSessionResult) -> ApiRetryOutcome:
     )
 
 
+def _log_cleanup_incomplete(result: SubprocessResult, *, subtype: str) -> bool:
+    """Log incomplete owned-process cleanup evidence; return whether infra should flag it."""
+    evidence = result.cleanup_evidence
+    if evidence is None or evidence.complete:
+        return False
+    logger.warning(
+        "headless_cleanup_evidence_incomplete", subtype=subtype, evidence=evidence.to_dict()
+    )
+    return True
+
+
 def _make_terminated_result(
     *,
     result: SubprocessResult,
@@ -134,6 +145,8 @@ def _make_terminated_result(
     api_retry: ApiRetryOutcome = ApiRetryOutcome(),
 ) -> SkillResult:
     """Construct SkillResult for infrastructure-terminated sessions (stale/idle_stall)."""
+    if _log_cleanup_incomplete(result, subtype=subtype):
+        infra = dataclasses.replace(infra, cleanup_incomplete=True)
     return SkillResult(
         success=success,
         result=result_text,
@@ -900,6 +913,8 @@ def _build_skill_result(
             codex_boundary_proof=codex_boundary_proof,
         )
 
+    _cleanup_incomplete = _log_cleanup_incomplete(result, subtype=normalized_subtype)
+
     sr = SkillResult(
         success=success,
         result=result_text,
@@ -920,7 +935,9 @@ def _build_skill_result(
         last_stop_reason=session.last_stop_reason,
         lifespan_started=session.lifespan_started,
         provider=ProviderOutcome(provider_used=provider_used, fallback_activated=False),
-        infra=InfraOutcome(exit_category=infra_category.value),
+        infra=InfraOutcome(
+            exit_category=infra_category.value, cleanup_incomplete=_cleanup_incomplete
+        ),
         api_retry=api_retry,
         ndjson_drift=NdjsonDriftOutcome(
             unknown_event_count=session.seen_ndjson_unknown_event_count,

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -132,8 +132,10 @@ def _should_flag_cleanup_incomplete(result: SubprocessResult, *, subtype: str) -
     evidence = result.cleanup_evidence
     if evidence is None or evidence.complete:
         return False
-    logger.warning(
-        "headless_cleanup_evidence_incomplete", subtype=subtype, evidence=evidence.to_dict()
+    logger.error(
+        "owned_group_cleanup_incomplete",
+        subtype=subtype,
+        evidence=evidence.to_dict(),
     )
     return True
 

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -132,11 +132,7 @@ def _should_flag_cleanup_incomplete(result: SubprocessResult, *, subtype: str) -
     evidence = result.cleanup_evidence
     if evidence is None or evidence.complete:
         return False
-    logger.error(
-        "owned_group_cleanup_incomplete",
-        subtype=subtype,
-        evidence=evidence.to_dict(),
-    )
+    logger.error("owned_group_cleanup_incomplete", subtype=subtype, evidence=evidence.to_dict())
     return True
 
 

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -119,8 +119,8 @@ def _build_api_retry_outcome(session: ClaudeSessionResult) -> ApiRetryOutcome:
     )
 
 
-def _log_cleanup_incomplete(result: SubprocessResult, *, subtype: str) -> bool:
-    """Log incomplete owned-process cleanup evidence; return whether infra should flag it."""
+def _should_flag_cleanup_incomplete(result: SubprocessResult, *, subtype: str) -> bool:
+    """Log incomplete owned-process cleanup evidence and report whether to flag infra."""
     evidence = result.cleanup_evidence
     if evidence is None or evidence.complete:
         return False
@@ -145,7 +145,7 @@ def _make_terminated_result(
     api_retry: ApiRetryOutcome = ApiRetryOutcome(),
 ) -> SkillResult:
     """Construct SkillResult for infrastructure-terminated sessions (stale/idle_stall)."""
-    if _log_cleanup_incomplete(result, subtype=subtype):
+    if _should_flag_cleanup_incomplete(result, subtype=subtype):
         infra = dataclasses.replace(infra, cleanup_incomplete=True)
     return SkillResult(
         success=success,
@@ -913,7 +913,7 @@ def _build_skill_result(
             codex_boundary_proof=codex_boundary_proof,
         )
 
-    _cleanup_incomplete = _log_cleanup_incomplete(result, subtype=normalized_subtype)
+    _cleanup_incomplete = _should_flag_cleanup_incomplete(result, subtype=normalized_subtype)
 
     sr = SkillResult(
         success=success,

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -120,7 +120,15 @@ def _build_api_retry_outcome(session: ClaudeSessionResult) -> ApiRetryOutcome:
 
 
 def _should_flag_cleanup_incomplete(result: SubprocessResult, *, subtype: str) -> bool:
-    """Log incomplete owned-process cleanup evidence and report whether to flag infra."""
+    """Single canonical home for the cleanup-evidence contract:
+
+    Set ``cleanup_incomplete=True`` on InfraOutcome when an owned-process-group
+    teardown produced incomplete evidence (a survivor or access-denied PID)
+    even though the workload's own outcome was determined independently. This
+    is diagnostic only — does not affect needs_retry. ``SubprocessResult.cleanup_evidence``
+    and ``InfraOutcome.cleanup_incomplete`` both forward here so the contract
+    is documented exactly once.
+    """
     evidence = result.cleanup_evidence
     if evidence is None or evidence.complete:
         return False

--- a/src/autoskillit/execution/linux_tracing.py
+++ b/src/autoskillit/execution/linux_tracing.py
@@ -34,6 +34,7 @@ import psutil
 
 from autoskillit.core import fast_dumps as _fast_dumps
 from autoskillit.core import get_logger
+from autoskillit.core import is_pid_zombie as is_pid_zombie
 from autoskillit.core import read_boot_id as read_boot_id
 from autoskillit.core import read_starttime_ticks as read_starttime_ticks
 

--- a/src/autoskillit/execution/linux_tracing.py
+++ b/src/autoskillit/execution/linux_tracing.py
@@ -34,8 +34,10 @@ import psutil
 
 from autoskillit.core import fast_dumps as _fast_dumps
 from autoskillit.core import get_logger
+from autoskillit.core import is_pid_alive as is_pid_alive
 from autoskillit.core import is_pid_zombie as is_pid_zombie
 from autoskillit.core import read_boot_id as read_boot_id
+from autoskillit.core import read_process_state as read_process_state
 from autoskillit.core import read_starttime_ticks as read_starttime_ticks
 
 if TYPE_CHECKING:

--- a/src/autoskillit/execution/linux_tracing.py
+++ b/src/autoskillit/execution/linux_tracing.py
@@ -34,10 +34,8 @@ import psutil
 
 from autoskillit.core import fast_dumps as _fast_dumps
 from autoskillit.core import get_logger
-from autoskillit.core import is_pid_alive as is_pid_alive
 from autoskillit.core import is_pid_zombie as is_pid_zombie
 from autoskillit.core import read_boot_id as read_boot_id
-from autoskillit.core import read_process_state as read_process_state
 from autoskillit.core import read_starttime_ticks as read_starttime_ticks
 
 if TYPE_CHECKING:

--- a/src/autoskillit/execution/process/__init__.py
+++ b/src/autoskillit/execution/process/__init__.py
@@ -65,7 +65,6 @@ from autoskillit.execution.process._process_jsonl import (
 from autoskillit.execution.process._process_kill import (
     OwnedProcessGroup,
     ProcessObservationSnapshot,
-    _wait_process_dead,
     async_kill_process_tree,
     kill_process_tree,
     spawn_owned_process,
@@ -128,7 +127,6 @@ __all__ = [
     "_jsonl_last_record_type",
     "_marker_is_standalone",
     "_session_log_monitor",
-    "_wait_process_dead",
     "_watch_heartbeat",
     "_watch_process",
     "_watch_session_log",
@@ -224,7 +222,7 @@ async def execute_termination_action(
     session_id: str | None = None,
     child_deferral_ceiling: float = 0.0,
     process_observation_snapshot: ProcessObservationSnapshot | None = None,
-) -> tuple[KillReason, int, ProcessCleanupResult]:
+) -> tuple[KillReason, int | None, ProcessCleanupResult]:
     """Single authorized executor for all kill decisions in run_managed_async.
 
     This is the sole managed-async authority for drain, signal, settlement, and reap.
@@ -235,7 +233,11 @@ async def execute_termination_action(
     the subagent is still doing active work — mirroring the stale-kill
     suppression pattern in _session_log_monitor.
 
-    Returns the kill reason, authoritative final return code, and cleanup evidence.
+    Returns the kill reason, final return code, and cleanup evidence. The return
+    code may be None when the leader itself could not be confirmed reaped even
+    after full SIGTERM/SIGKILL escalation — settlement never raises
+    OwnedProcessCleanupError from here; callers must coalesce a None returncode
+    before assigning it into a non-Optional field.
     """
     if process_observation_snapshot is not None:
         owner.merge_snapshot(process_observation_snapshot)
@@ -249,7 +251,7 @@ async def execute_termination_action(
                 proc_log.debug("natural_exit_after_drain", returncode=owner.returncode)
                 kill_reason = KillReason.NATURAL_EXIT
                 returncode, cleanup = await anyio.to_thread.run_sync(
-                    owner.settle, abandon_on_cancel=False
+                    owner.settle_evidence, abandon_on_cancel=False
                 )
                 return kill_reason, returncode, cleanup
             # Child-liveness deferral: same pattern as _session_log_monitor stale-kill suppression
@@ -261,7 +263,7 @@ async def execute_termination_action(
                         proc_log.debug("natural_exit_during_deferral", returncode=owner.returncode)
                         kill_reason = KillReason.NATURAL_EXIT
                         returncode, cleanup = await anyio.to_thread.run_sync(
-                            owner.settle, abandon_on_cancel=False
+                            owner.settle_evidence, abandon_on_cancel=False
                         )
                         return kill_reason, returncode, cleanup
                     active = (
@@ -292,7 +294,9 @@ async def execute_termination_action(
             kill_reason = KillReason.INFRA_KILL
         case _ as unreachable:
             assert_never(unreachable)
-    returncode, cleanup = await anyio.to_thread.run_sync(owner.settle, abandon_on_cancel=False)
+    returncode, cleanup = await anyio.to_thread.run_sync(
+        owner.settle_evidence, abandon_on_cancel=False
+    )
     return kill_reason, returncode, cleanup
 
 
@@ -707,6 +711,10 @@ async def run_managed_async(
                 child_deferral_ceiling=child_deferral_ceiling,
                 process_observation_snapshot=signals.process_observation_snapshot,
             )
+            # -1 signals "leader returncode could not be confirmed despite full
+            # escalation — see cleanup_evidence for diagnostic detail." Mirrors the
+            # established coalescing convention in execution/headless/_headless_result.py.
+            _confirmed_returncode = final_returncode if final_returncode is not None else -1
 
             # Flush and close before reading
             stdout_file.close()
@@ -723,7 +731,7 @@ async def run_managed_async(
                 _stderr_path = None
 
             sub_result = SubprocessResult(
-                returncode=final_returncode,
+                returncode=_confirmed_returncode,
                 stdout=stdout,
                 stderr=stderr,
                 termination=termination,
@@ -746,6 +754,7 @@ async def run_managed_async(
                 inspector_verdict=signals.inspector_verdict,
                 stdout_path=_stdout_path,
                 stderr_path=_stderr_path,
+                cleanup_evidence=cleanup_result,
             )
             proc_log.debug(
                 "run_managed_async_result",
@@ -834,7 +843,11 @@ def run_managed_sync(
                     process.pid,
                     timeout,
                 )
-            final_returncode, cleanup_result = owner.settle()
+            final_returncode, cleanup_result = owner.settle_evidence()
+            # -1 signals "leader returncode could not be confirmed despite full
+            # escalation — see cleanup_evidence for diagnostic detail." Mirrors the
+            # established coalescing convention in execution/headless/_headless_result.py.
+            _confirmed_returncode = final_returncode if final_returncode is not None else -1
 
             # Flush and close before reading
             stdout_file.close()
@@ -851,7 +864,7 @@ def run_managed_sync(
                 _stderr_path = None
 
             return SubprocessResult(
-                returncode=final_returncode,
+                returncode=_confirmed_returncode,
                 stdout=stdout,
                 stderr=stderr,
                 termination=termination,
@@ -860,6 +873,7 @@ def run_managed_sync(
                 channel_confirmation=ChannelConfirmation.UNMONITORED,
                 stdout_path=_stdout_path,
                 stderr_path=_stderr_path,
+                cleanup_evidence=cleanup_result,
             )
         except Exception as exc:
             if owner is not None and process is not None and process.returncode is None:

--- a/src/autoskillit/execution/process/__init__.py
+++ b/src/autoskillit/execution/process/__init__.py
@@ -713,7 +713,7 @@ async def run_managed_async(
                 child_deferral_ceiling=child_deferral_ceiling,
                 process_observation_snapshot=signals.process_observation_snapshot,
             )
-            _confirmed_returncode = _coalesce_returncode(final_returncode)
+            _coalesced_returncode = _coalesce_returncode(final_returncode)
 
             # Flush and close before reading
             stdout_file.close()
@@ -730,7 +730,7 @@ async def run_managed_async(
                 _stderr_path = None
 
             sub_result = SubprocessResult(
-                returncode=_confirmed_returncode,
+                returncode=_coalesced_returncode,
                 stdout=stdout,
                 stderr=stderr,
                 termination=termination,
@@ -843,7 +843,7 @@ def run_managed_sync(
                     timeout,
                 )
             final_returncode, cleanup_result = owner.settle_evidence()
-            _confirmed_returncode = _coalesce_returncode(final_returncode)
+            _coalesced_returncode = _coalesce_returncode(final_returncode)
 
             # Flush and close before reading
             stdout_file.close()
@@ -860,7 +860,7 @@ def run_managed_sync(
                 _stderr_path = None
 
             return SubprocessResult(
-                returncode=_confirmed_returncode,
+                returncode=_coalesced_returncode,
                 stdout=stdout,
                 stderr=stderr,
                 termination=termination,

--- a/src/autoskillit/execution/process/__init__.py
+++ b/src/autoskillit/execution/process/__init__.py
@@ -164,6 +164,12 @@ def _normalize_pass_fds(pass_fds: tuple[int, ...]) -> tuple[int, ...]:
     return normalize_inherited_fds(pass_fds)
 
 
+def _coalesce_returncode(returncode: int | None) -> int:
+    # -1 signals "leader returncode could not be confirmed despite full escalation —
+    # see cleanup_evidence for diagnostic detail."
+    return returncode if returncode is not None else -1
+
+
 def decide_termination_action(
     termination: TerminationReason,
     *,
@@ -233,11 +239,7 @@ async def execute_termination_action(
     the subagent is still doing active work — mirroring the stale-kill
     suppression pattern in _session_log_monitor.
 
-    Returns the kill reason, final return code, and cleanup evidence. The return
-    code may be None when the leader itself could not be confirmed reaped even
-    after full SIGTERM/SIGKILL escalation — settlement never raises
-    OwnedProcessCleanupError from here; callers must coalesce a None returncode
-    before assigning it into a non-Optional field.
+    Returns the kill reason, final return code, and cleanup evidence.
     """
     if process_observation_snapshot is not None:
         owner.merge_snapshot(process_observation_snapshot)
@@ -711,10 +713,7 @@ async def run_managed_async(
                 child_deferral_ceiling=child_deferral_ceiling,
                 process_observation_snapshot=signals.process_observation_snapshot,
             )
-            # -1 signals "leader returncode could not be confirmed despite full
-            # escalation — see cleanup_evidence for diagnostic detail." Mirrors the
-            # established coalescing convention in execution/headless/_headless_result.py.
-            _confirmed_returncode = final_returncode if final_returncode is not None else -1
+            _confirmed_returncode = _coalesce_returncode(final_returncode)
 
             # Flush and close before reading
             stdout_file.close()
@@ -844,10 +843,7 @@ def run_managed_sync(
                     timeout,
                 )
             final_returncode, cleanup_result = owner.settle_evidence()
-            # -1 signals "leader returncode could not be confirmed despite full
-            # escalation — see cleanup_evidence for diagnostic detail." Mirrors the
-            # established coalescing convention in execution/headless/_headless_result.py.
-            _confirmed_returncode = final_returncode if final_returncode is not None else -1
+            _confirmed_returncode = _coalesce_returncode(final_returncode)
 
             # Flush and close before reading
             stdout_file.close()

--- a/src/autoskillit/execution/process/_daemon_orphans.py
+++ b/src/autoskillit/execution/process/_daemon_orphans.py
@@ -20,6 +20,7 @@ from autoskillit.core import (
     AUTOSKILLIT_STATE_ROOT_ENV_VAR,
     LAUNCH_ID_ENV_VAR,
     get_logger,
+    is_pid_zombie,
     read_boot_id,
     read_registry,
     read_starttime_ticks,
@@ -129,7 +130,9 @@ def _owner_is_dead(owner_pid: int, boot_id: str, starttime_ticks: int) -> bool |
         return True
     current_ticks = read_starttime_ticks(owner_pid)
     if current_ticks is not None:
-        return current_ticks != starttime_ticks
+        if current_ticks != starttime_ticks:
+            return True
+        return is_pid_zombie(owner_pid)
     try:
         os.kill(owner_pid, 0)
     except ProcessLookupError:

--- a/src/autoskillit/execution/process/_process_kill.py
+++ b/src/autoskillit/execution/process/_process_kill.py
@@ -595,8 +595,12 @@ class OwnedProcessGroup:
     def settle_evidence(self, timeout: float = 2.0) -> tuple[int | None, ProcessCleanupResult]:
         """Settle the owned group and return cleanup evidence without raising.
 
-        Callers MUST coalesce a None returncode (returncode if returncode is not
-        None else -1) before assigning into a non-Optional field.
+        Unlike ``settle`` (raises ``OwnedProcessCleanupError`` on incomplete
+        cleanup), this variant logs an ``owned_group_cleanup_incomplete`` event
+        and returns the partial result so callers can record evidence without
+        propagating the failure. Callers MUST coalesce a None returncode
+        (``returncode if returncode is not None else -1``) before assigning into
+        a non-Optional field.
         """
         returncode, result = self.cleanup(timeout)
         if not result.complete or returncode is None:
@@ -610,6 +614,14 @@ class OwnedProcessGroup:
     def settle_preserving(
         self, error: BaseException, timeout: float = 2.0
     ) -> ProcessCleanupResult:
+        """Settle the owned group while preserving a caller-supplied exception.
+
+        Unlike ``settle_evidence`` (which logs and returns silently), this
+        variant attaches the cleanup result to ``error`` via ``add_note`` so
+        the caller's BaseException chains through to its handler with cleanup
+        context intact. The caller is expected to re-raise ``error`` after
+        calling this method.
+        """
         try:
             _, result = self.cleanup(timeout)
         except BaseException as cleanup_error:

--- a/src/autoskillit/execution/process/_process_kill.py
+++ b/src/autoskillit/execution/process/_process_kill.py
@@ -451,15 +451,9 @@ class OwnedProcessGroup:
     def _identity_is_alive(self, identity: tuple[int, float]) -> bool:
         """Return whether the identified PID is still a live, non-zombie process.
 
-        A matching create_time() alone is insufficient: a zombie (exited but not
-        yet reaped) retains a readable /proc entry with an unchanged create_time(),
-        so create_time() equality alone reports "alive" for a process that has
-        already exited. The status() read below excludes that false positive.
-
-        This is a point-in-time snapshot — a small TOCTOU window exists between
-        this check and any subsequent reap. That is acceptable here because
-        callers re-check on their own polling cadence (_wait_group_members) rather
-        than relying on a single read.
+        Callers re-check on their own polling cadence (_wait_group_members), so a
+        small point-in-time TOCTOU between this read and a subsequent reap is
+        acceptable.
         """
         pid, create_time = identity
         try:
@@ -606,16 +600,8 @@ class OwnedProcessGroup:
     def settle_evidence(self, timeout: float = 2.0) -> tuple[int | None, ProcessCleanupResult]:
         """Settle the owned group and return cleanup evidence without raising.
 
-        Unlike settle(), this never raises OwnedProcessCleanupError — callers that
-        already have their own success signal (e.g. a captured completion marker)
-        use this to retrieve diagnostic cleanup evidence instead of having a
-        successful workload outcome destroyed by an incomplete-teardown exception.
-
-        Callers MUST NOT assume the returned returncode is an int: it is None when
-        the leader itself was never confirmed reaped even after full SIGTERM/SIGKILL
-        escalation. Coalesce with the established `returncode if returncode is not
-        None else -1` convention (see execution/headless/_headless_result.py) before
-        assigning into a non-Optional field.
+        Callers MUST coalesce a None returncode (returncode if returncode is not
+        None else -1) before assigning into a non-Optional field.
         """
         returncode, result = self.cleanup(timeout)
         if not result.complete or returncode is None:

--- a/src/autoskillit/execution/process/_process_kill.py
+++ b/src/autoskillit/execution/process/_process_kill.py
@@ -449,9 +449,22 @@ class OwnedProcessGroup:
                 )
 
     def _identity_is_alive(self, identity: tuple[int, float]) -> bool:
+        """Return whether the identified PID is still a live, non-zombie process.
+
+        A matching create_time() alone is insufficient: a zombie (exited but not
+        yet reaped) retains a readable /proc entry with an unchanged create_time(),
+        so create_time() equality alone reports "alive" for a process that has
+        already exited. The status() read below excludes that false positive.
+
+        This is a point-in-time snapshot — a small TOCTOU window exists between
+        this check and any subsequent reap. That is acceptable here because
+        callers re-check on their own polling cadence (_wait_group_members) rather
+        than relying on a single read.
+        """
         pid, create_time = identity
         try:
-            return psutil.Process(pid).create_time() == create_time
+            proc = psutil.Process(pid)
+            return proc.create_time() == create_time and proc.status() != psutil.STATUS_ZOMBIE
         except (psutil.Error, OSError) as exc:
             if _is_disappearance(exc):
                 return False
@@ -590,6 +603,29 @@ class OwnedProcessGroup:
             raise OwnedProcessCleanupError(self.pid, result)
         return returncode, result
 
+    def settle_evidence(self, timeout: float = 2.0) -> tuple[int | None, ProcessCleanupResult]:
+        """Settle the owned group and return cleanup evidence without raising.
+
+        Unlike settle(), this never raises OwnedProcessCleanupError — callers that
+        already have their own success signal (e.g. a captured completion marker)
+        use this to retrieve diagnostic cleanup evidence instead of having a
+        successful workload outcome destroyed by an incomplete-teardown exception.
+
+        Callers MUST NOT assume the returned returncode is an int: it is None when
+        the leader itself was never confirmed reaped even after full SIGTERM/SIGKILL
+        escalation. Coalesce with the established `returncode if returncode is not
+        None else -1` convention (see execution/headless/_headless_result.py) before
+        assigning into a non-Optional field.
+        """
+        returncode, result = self.cleanup(timeout)
+        if not result.complete or returncode is None:
+            logger.error(
+                "owned_group_cleanup_incomplete",
+                evidence=result.to_dict(),
+                returncode_confirmed=returncode is not None,
+            )
+        return returncode, result
+
     def settle_preserving(
         self, error: BaseException, timeout: float = 2.0
     ) -> ProcessCleanupResult:
@@ -665,24 +701,3 @@ def spawn_owned_process(
         _cleanup_failed_owned_spawn(process)
         raise RuntimeError("spawned child did not establish owned group leadership")
     return OwnedProcessGroup(process, pgid, _spawn_token=_OWNED_PROCESS_SPAWN_TOKEN)
-
-
-async def _wait_process_dead(proc: psutil.Process, timeout: float = 5.0) -> bool:
-    """Wait until proc is dead and its zombie is reaped. Returns True if dead within timeout.
-
-    Uses psutil.Process.wait() rather than polling pid_exists():
-    - For child processes: calls os.waitpid(), reaping the zombie. Only then is the PID
-      truly gone from the process table.
-    - For non-child processes (grandchildren adopted by init): psutil polls internally,
-      which is equivalent to pid_exists() but still handles the NoSuchProcess case correctly.
-
-    pid_exists() returns True for zombies (killed but not reaped), so wait() is required
-    for reliable dead confirmation.
-    """
-    try:
-        await anyio.to_thread.run_sync(proc.wait, timeout)
-        return True
-    except psutil.TimeoutExpired:
-        return False
-    except psutil.NoSuchProcess:
-        return True

--- a/src/autoskillit/execution/process/_process_kill.py
+++ b/src/autoskillit/execution/process/_process_kill.py
@@ -449,12 +449,7 @@ class OwnedProcessGroup:
                 )
 
     def _identity_is_alive(self, identity: tuple[int, float]) -> bool:
-        """Return whether the identified PID is still a live, non-zombie process.
-
-        Callers re-check on their own polling cadence (_wait_group_members), so a
-        small point-in-time TOCTOU between this read and a subsequent reap is
-        acceptable.
-        """
+        """Return whether the identified PID is still a live, non-zombie process."""
         pid, create_time = identity
         try:
             proc = psutil.Process(pid)

--- a/src/autoskillit/execution/process/_process_kill.py
+++ b/src/autoskillit/execution/process/_process_kill.py
@@ -587,6 +587,15 @@ class OwnedProcessGroup:
         return returncode, result
 
     def settle(self, timeout: float = 2.0) -> tuple[int, ProcessCleanupResult]:
+        """Settle the owned group and raise on incomplete cleanup.
+
+        Unlike ``settle_evidence`` (logs and returns) or ``settle_preserving``
+        (attaches evidence to a caller-supplied BaseException), this variant
+        raises ``OwnedProcessCleanupError`` if cleanup produces an incomplete
+        result (a survivor or access-denied PID) or the leader's returncode
+        is unconfirmed. Returns the (returncode, ProcessCleanupResult) tuple
+        on success — both fields are non-Optional.
+        """
         returncode, result = self.cleanup(timeout)
         if returncode is None or not result.complete:
             raise OwnedProcessCleanupError(self.pid, result)

--- a/src/autoskillit/hooks/formatters/_fmt_execution.py
+++ b/src/autoskillit/hooks/formatters/_fmt_execution.py
@@ -243,6 +243,7 @@ _FMT_RUN_SKILL_SUPPRESSED: frozenset[str] = frozenset(
         "lifespan_started",
         "order_id",
         "infra_exit_category",
+        "infra_cleanup_incomplete",
         "api_retry_count",
         "api_retry_last_error",
         "api_retry_last_status",

--- a/src/autoskillit/hooks/guards/mcp_health_advisor.py
+++ b/src/autoskillit/hooks/guards/mcp_health_advisor.py
@@ -36,7 +36,13 @@ def _read_kitchens() -> list[dict]:
 
 
 def _pid_alive(pid: int) -> bool:
-    """Check if a PID is running and not a zombie (stdlib-only)."""
+    """Check if a PID is running and not a zombie (stdlib-only).
+
+    Excludes both 'Z' (zombie) and 'X' (dead, transient reaping per
+    proc_pid_stat(5)) to match the shared is_pid_alive primitive in
+    core/runtime/_linux_proc.py — prevents a split-brain liveness answer
+    with the psutil-based check in core/_plugin_cache._check_pid_with_psutil.
+    """
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -60,7 +66,7 @@ def _pid_alive(pid: int) -> bool:
         if rpar == -1:
             return True
         fields = stat[rpar + 2 :].split()
-        return fields[0] != "Z"
+        return fields[0] not in ("Z", "X")
     except (FileNotFoundError, PermissionError, OSError, ValueError, IndexError):
         # /proc unavailable (macOS, hidepid=2 on foreign PIDs); trust the
         # os.kill(pid, 0) answer above.

--- a/src/autoskillit/hooks/guards/mcp_health_advisor.py
+++ b/src/autoskillit/hooks/guards/mcp_health_advisor.py
@@ -45,7 +45,12 @@ def _pid_alive(pid: int) -> bool:
         # PID belongs to another user — assume alive when unverifiable.
         return True
     except OSError:
-        return False
+        # Any other probe failure (rare: EINVAL, transient resource
+        # exhaustion) is unverifiable rather than a confirmed disappearance —
+        # assume alive to match the contract used by every other liveness
+        # site. A spurious false positive here would inject a /MCP reconnect
+        # hint and force the user to re-open a possibly-functional kitchen.
+        return True
     try:
         # Cannot import autoskillit.core.runtime._linux_proc here (stdlib-only
         # hook script); duplicate the rfind(')') /proc parsing rather than

--- a/src/autoskillit/hooks/guards/mcp_health_advisor.py
+++ b/src/autoskillit/hooks/guards/mcp_health_advisor.py
@@ -36,14 +36,7 @@ def _read_kitchens() -> list[dict]:
 
 
 def _pid_alive(pid: int) -> bool:
-    """Check if a PID is running and not a zombie (stdlib-only, no create_time validation).
-
-    Duplicates the /proc/{pid}/stat state-char parse from
-    autoskillit.core.runtime._linux_proc.read_process_state by design — hook scripts
-    are stdlib-only and cannot import from autoskillit.*. Falls back to the
-    portable os.kill(pid, 0) probe on platforms without procfs or when /proc is
-    unreadable (e.g. macOS, Linux with hidepid=2 for foreign PIDs).
-    """
+    """Check if a PID is running and not a zombie (stdlib-only)."""
     try:
         os.kill(pid, 0)
     except ProcessLookupError:

--- a/src/autoskillit/hooks/guards/mcp_health_advisor.py
+++ b/src/autoskillit/hooks/guards/mcp_health_advisor.py
@@ -42,14 +42,15 @@ def _pid_alive(pid: int) -> bool:
     except ProcessLookupError:
         return False
     except PermissionError:
-        # PID belongs to another user — assume alive when unverifiable (matches
-        # the prior portable contract).
+        # PID belongs to another user — assume alive when unverifiable.
         return True
     except OSError:
         return False
     try:
+        # Cannot import autoskillit.core.runtime._linux_proc here (stdlib-only
+        # hook script); duplicate the rfind(')') /proc parsing rather than
+        # route through an autoskillit import.
         stat = Path(f"/proc/{pid}/stat").read_text()
-        # comm may contain ")" — rfind locates the last ")" as the field boundary
         rpar = stat.rfind(")")
         if rpar == -1:
             return True

--- a/src/autoskillit/hooks/guards/mcp_health_advisor.py
+++ b/src/autoskillit/hooks/guards/mcp_health_advisor.py
@@ -36,15 +36,22 @@ def _read_kitchens() -> list[dict]:
 
 
 def _pid_alive(pid: int) -> bool:
-    """Check if a PID is still running (stdlib-only, no create_time validation)."""
+    """Check if a PID is running and not a zombie (stdlib-only, no create_time validation).
+
+    Duplicates the /proc/{pid}/stat state-char parse from
+    autoskillit.core.runtime._linux_proc.read_process_state by design: hook scripts
+    are stdlib-only and cannot import from autoskillit.*.
+    """
     try:
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
+        stat = Path(f"/proc/{pid}/stat").read_text()
+        # comm may contain ")" — use rfind to find the *last* ")" as the boundary
+        rpar = stat.rfind(")")
+        if rpar == -1:
+            return False
+        fields = stat[rpar + 2 :].split()
+        return fields[0] != "Z"
+    except (FileNotFoundError, PermissionError, OSError, ValueError, IndexError):
         return False
-    except (PermissionError, OSError):
-        # PermissionError means the process exists but we lack permission to signal it.
-        return True
 
 
 def main() -> None:

--- a/src/autoskillit/hooks/guards/mcp_health_advisor.py
+++ b/src/autoskillit/hooks/guards/mcp_health_advisor.py
@@ -39,19 +39,33 @@ def _pid_alive(pid: int) -> bool:
     """Check if a PID is running and not a zombie (stdlib-only, no create_time validation).
 
     Duplicates the /proc/{pid}/stat state-char parse from
-    autoskillit.core.runtime._linux_proc.read_process_state by design: hook scripts
-    are stdlib-only and cannot import from autoskillit.*.
+    autoskillit.core.runtime._linux_proc.read_process_state by design — hook scripts
+    are stdlib-only and cannot import from autoskillit.*. Falls back to the
+    portable os.kill(pid, 0) probe on platforms without procfs or when /proc is
+    unreadable (e.g. macOS, Linux with hidepid=2 for foreign PIDs).
     """
     try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # PID belongs to another user — assume alive when unverifiable (matches
+        # the prior portable contract).
+        return True
+    except OSError:
+        return False
+    try:
         stat = Path(f"/proc/{pid}/stat").read_text()
-        # comm may contain ")" — use rfind to find the *last* ")" as the boundary
+        # comm may contain ")" — rfind locates the last ")" as the field boundary
         rpar = stat.rfind(")")
         if rpar == -1:
-            return False
+            return True
         fields = stat[rpar + 2 :].split()
         return fields[0] != "Z"
     except (FileNotFoundError, PermissionError, OSError, ValueError, IndexError):
-        return False
+        # /proc unavailable (macOS, hidepid=2 on foreign PIDs); trust the
+        # os.kill(pid, 0) answer above.
+        return True
 
 
 def main() -> None:

--- a/src/autoskillit/server/tools/_types.py
+++ b/src/autoskillit/server/tools/_types.py
@@ -96,6 +96,7 @@ class RunSkillResult(_RunSkillResultBase, total=False):
     worktree_path: str
     order_id: str
     infra_exit_category: str
+    infra_cleanup_incomplete: bool
     has_progress_evidence: bool
     has_implementation_progress: bool
     completion_required: bool

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -741,26 +741,15 @@ def _gather_import_aliases(tree: ast.AST) -> dict[str, tuple[str, str | None]]:
 
 
 def test_no_direct_settle_call_outside_allowlist() -> None:
-    """No src file may call .settle() outside the designated allowlist.
-
-    .settle() raises OwnedProcessCleanupError on incomplete teardown. Callers that
-    do not need that raising behavior must use .settle_evidence() or
-    .settle_preserving() instead — a bare .settle() call is deliberately narrow.
-
-    Allowed call sites:
-    - src/autoskillit/execution/process/_process_kill.py (defines settle())
-    - src/autoskillit/cli/session/_session_process.py (requires settle()'s raising
-      semantics)
-    - src/autoskillit/execution/evidence_reader.py (pre-existing, already-correct
-      catch-and-convert usage via owner.settle(...) in _run_bounded)
-    - src/autoskillit/hooks/_capture_process.py (hosts a structurally unrelated,
-      stdlib-only OwnedProcessGroup reimplementation with its own .settle() calls)
-    """
+    """No src file may call .settle() outside the designated allowlist."""
+    # .settle() raises OwnedProcessCleanupError on incomplete teardown. Callers
+    # that do not need that raising behavior must use .settle_evidence() or
+    # .settle_preserving() instead — a bare .settle() call is deliberately narrow.
     allowed_files = {
-        SRC_ROOT / "execution" / "process" / "_process_kill.py",
-        SRC_ROOT / "cli" / "session" / "_session_process.py",
-        SRC_ROOT / "execution" / "evidence_reader.py",
-        SRC_ROOT / "hooks" / "_capture_process.py",
+        SRC_ROOT / "execution" / "process" / "_process_kill.py",  # defines settle()
+        SRC_ROOT / "cli" / "session" / "_session_process.py",  # requires raising semantics
+        SRC_ROOT / "execution" / "evidence_reader.py",  # pre-existing catch-and-convert
+        SRC_ROOT / "hooks" / "_capture_process.py",  # structurally unrelated reimpl
     }
     violations: list[str] = []
 
@@ -797,46 +786,20 @@ def test_no_direct_settle_call_outside_allowlist() -> None:
 
 
 def test_no_raw_zombie_blind_liveness_check_outside_shared_primitive() -> None:
-    """No src file may call psutil.pid_exists(), the bare os.kill(pid, 0) existence
-    probe, or psutil.Process(pid).is_running() outside the shared zombie-aware
-    primitive.
-
-    All three checks are zombie-blind: a zombie process (exited but not yet reaped
-    by its parent) retains a readable /proc entry and reports as alive under an
-    exact-PID-existence check alone.
-
-    Allowed files:
-    - src/autoskillit/core/runtime/_linux_proc.py (defines the shared primitive:
-      is_pid_alive() / is_pid_zombie())
-    - src/autoskillit/core/_plugin_cache.py (keeps its own psutil-based zombie check
-      by design — its cross-boot stored_create_time verification cannot be reproduced
-      by the stdlib-only tick-count primitive without an out-of-scope boot-time/schema
-      migration)
-    - src/autoskillit/execution/process/_daemon_orphans.py (_owner_is_dead's
-      os.kill(owner_pid, 0) branch is a last-resort fallback reached only when
-      /proc/{pid}/stat is unreadable — in that degraded state zombie detection is
-      equally impossible, so this is not a new zombie-blind gap, and PermissionError/
-      OSError already fail closed to "unknown")
-    - src/autoskillit/fleet/_dispatch_reaper.py (pre-existing psutil.pid_exists() use
-      predating this guard; not yet migrated — tracked as a known follow-up, not
-      addressed here because doing so would require rewriting the file's extensive
-      existing psutil.pid_exists-mocked test suite, which is out of this guard's scope)
-    - src/autoskillit/hooks/guards/mcp_health_advisor.py (stdlib-only hook with no
-      autoskillit import path; uses os.kill(pid, 0) as the portable primary liveness
-      probe and /proc/{pid}/stat only as a zombie refinement)
-    - src/autoskillit/execution/process/_process_kill.py (_identity_is_alive uses
-      psutil.Process(pid).status() != psutil.STATUS_ZOMBIE alongside the matching
-      psutil.Process(pid).create_time() call in one expression; mixing in a /proc
-      zombie read would split the identity-coherence guarantee across two
-      primitives, so the carve-out is deliberate)
-    """
+    """No src file may call psutil.pid_exists(), bare os.kill(pid, 0), or
+    psutil.Process(pid).is_running() outside the shared zombie-aware primitive."""
+    # All three checks are zombie-blind — a zombie retains a readable /proc
+    # entry and reports as alive under an exact-PID-existence check alone.
     allowed_files = {
-        SRC_ROOT / "core" / "runtime" / "_linux_proc.py",
-        SRC_ROOT / "core" / "_plugin_cache.py",
-        SRC_ROOT / "execution" / "process" / "_daemon_orphans.py",
-        SRC_ROOT / "execution" / "process" / "_process_kill.py",
-        SRC_ROOT / "fleet" / "_dispatch_reaper.py",
-        SRC_ROOT / "hooks" / "guards" / "mcp_health_advisor.py",
+        SRC_ROOT / "core" / "runtime" / "_linux_proc.py",  # defines the shared primitive
+        SRC_ROOT / "core" / "_plugin_cache.py",  # cross-boot stored_create_time needs psutil
+        SRC_ROOT / "execution" / "process" / "_daemon_orphans.py",  # /proc unreadable fallback
+        SRC_ROOT
+        / "execution"
+        / "process"
+        / "_process_kill.py",  # identity-coherence with create_time
+        SRC_ROOT / "fleet" / "_dispatch_reaper.py",  # pre-existing follow-up
+        SRC_ROOT / "hooks" / "guards" / "mcp_health_advisor.py",  # stdlib-only hook
     }
     violations: list[str] = []
 

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -812,6 +812,9 @@ def test_no_raw_zombie_blind_liveness_check_outside_shared_primitive() -> None:
       predating this guard; not yet migrated — tracked as a known follow-up, not
       addressed here because doing so would require rewriting the file's extensive
       existing psutil.pid_exists-mocked test suite, which is out of this guard's scope)
+    - src/autoskillit/hooks/guards/mcp_health_advisor.py (stdlib-only hook with no
+      autoskillit import path; uses os.kill(pid, 0) as the portable primary liveness
+      probe and /proc/{pid}/stat only as a zombie refinement)
     """
     allowed_files = {
         SRC_ROOT / "core" / "runtime" / "_linux_proc.py",
@@ -819,6 +822,7 @@ def test_no_raw_zombie_blind_liveness_check_outside_shared_primitive() -> None:
         SRC_ROOT / "execution" / "process" / "_daemon_orphans.py",
         SRC_ROOT / "execution" / "process" / "_process_kill.py",
         SRC_ROOT / "fleet" / "_dispatch_reaper.py",
+        SRC_ROOT / "hooks" / "guards" / "mcp_health_advisor.py",
     }
     violations: list[str] = []
 

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -768,9 +768,11 @@ def test_no_direct_settle_call_outside_allowlist() -> None:
         if py_file in allowed_files:
             continue
         try:
-            tree = ast.parse(py_file.read_text())
+            source = py_file.read_text()
+            tree = ast.parse(source)
         except SyntaxError:
             continue
+        aliases = _gather_import_aliases(tree)
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -779,6 +781,13 @@ def test_no_direct_settle_call_outside_allowlist() -> None:
                     f"  {py_file.relative_to(SRC_ROOT.parent.parent)}:{node.lineno}: "
                     f"direct call to .settle() outside allowed files"
                 )
+            elif isinstance(node.func, ast.Name):
+                _alias_entry = aliases.get(node.func.id)
+                if _alias_entry is not None and _alias_entry[1] == "settle":
+                    violations.append(
+                        f"  {py_file.relative_to(SRC_ROOT.parent.parent)}:{node.lineno}: "
+                        f"direct call to settle (from-import or aliased) outside allowed files"
+                    )
 
     assert not violations, (
         "Direct .settle() calls found outside allowed files.\n"
@@ -815,6 +824,11 @@ def test_no_raw_zombie_blind_liveness_check_outside_shared_primitive() -> None:
     - src/autoskillit/hooks/guards/mcp_health_advisor.py (stdlib-only hook with no
       autoskillit import path; uses os.kill(pid, 0) as the portable primary liveness
       probe and /proc/{pid}/stat only as a zombie refinement)
+    - src/autoskillit/execution/process/_process_kill.py (_identity_is_alive uses
+      psutil.Process(pid).status() != psutil.STATUS_ZOMBIE alongside the matching
+      psutil.Process(pid).create_time() call in one expression; mixing in a /proc
+      zombie read would split the identity-coherence guarantee across two
+      primitives, so the carve-out is deliberate)
     """
     allowed_files = {
         SRC_ROOT / "core" / "runtime" / "_linux_proc.py",
@@ -870,13 +884,22 @@ def test_no_raw_zombie_blind_liveness_check_outside_shared_primitive() -> None:
         receiver = node.func.value
         if not isinstance(receiver, ast.Call):
             return False
-        if not (isinstance(receiver.func, ast.Attribute) and receiver.func.attr == "Process"):
-            return False
-        if (
-            isinstance(receiver.func.value, ast.Name)
-            and aliases.get(receiver.func.value.id, (None,))[0] == "psutil"
-        ):
-            return True
+        if isinstance(receiver.func, ast.Attribute) and receiver.func.attr == "Process":
+            # `psutil.Process(pid).is_running()` form
+            if (
+                isinstance(receiver.func.value, ast.Name)
+                and aliases.get(receiver.func.value.id, (None,))[0] == "psutil"
+            ):
+                return True
+        elif isinstance(receiver.func, ast.Name):
+            # `from psutil import Process; Process(pid).is_running()` form
+            _proc_alias = aliases.get(receiver.func.id)
+            if (
+                _proc_alias is not None
+                and _proc_alias[0] == "psutil"
+                and _proc_alias[1] == "Process"
+            ):
+                return True
         return False
 
     for py_file in sorted(SRC_ROOT.rglob("*.py")):

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -722,6 +722,24 @@ def test_no_direct_async_kill_process_tree_outside_executor() -> None:
     )
 
 
+def _gather_import_aliases(tree: ast.AST) -> dict[str, tuple[str, str | None]]:
+    """Build a map from local name → (module, attr) for every import in the tree.
+
+    Handles `import x`, `import x as y`, `from x import a`, `from x import a as b`.
+    """
+    aliases: dict[str, tuple[str, str | None]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                local = alias.asname or alias.name
+                aliases[local] = (alias.name, None)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            for alias in node.names:
+                local = alias.asname or alias.name
+                aliases[local] = (node.module, alias.name)
+    return aliases
+
+
 def test_no_direct_settle_call_outside_allowlist() -> None:
     """No src file may call .settle() outside the designated allowlist.
 
@@ -754,11 +772,9 @@ def test_no_direct_settle_call_outside_allowlist() -> None:
         except SyntaxError:
             continue
         for node in ast.walk(tree):
-            if (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Attribute)
-                and node.func.attr == "settle"
-            ):
+            if not isinstance(node, ast.Call):
+                continue
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "settle":
                 violations.append(
                     f"  {py_file.relative_to(SRC_ROOT.parent.parent)}:{node.lineno}: "
                     f"direct call to .settle() outside allowed files"
@@ -772,12 +788,13 @@ def test_no_direct_settle_call_outside_allowlist() -> None:
 
 
 def test_no_raw_zombie_blind_liveness_check_outside_shared_primitive() -> None:
-    """No src file may call psutil.pid_exists() or the bare os.kill(pid, 0) existence
-    probe outside the shared zombie-aware primitive.
+    """No src file may call psutil.pid_exists(), the bare os.kill(pid, 0) existence
+    probe, or psutil.Process(pid).is_running() outside the shared zombie-aware
+    primitive.
 
-    Both checks are zombie-blind: a zombie process (exited but not yet reaped by its
-    parent) retains a readable /proc entry and reports as alive under an exact-PID-
-    existence check alone.
+    All three checks are zombie-blind: a zombie process (exited but not yet reaped
+    by its parent) retains a readable /proc entry and reports as alive under an
+    exact-PID-existence check alone.
 
     Allowed files:
     - src/autoskillit/core/runtime/_linux_proc.py (defines the shared primitive:
@@ -800,40 +817,90 @@ def test_no_raw_zombie_blind_liveness_check_outside_shared_primitive() -> None:
         SRC_ROOT / "core" / "runtime" / "_linux_proc.py",
         SRC_ROOT / "core" / "_plugin_cache.py",
         SRC_ROOT / "execution" / "process" / "_daemon_orphans.py",
+        SRC_ROOT / "execution" / "process" / "_process_kill.py",
         SRC_ROOT / "fleet" / "_dispatch_reaper.py",
     }
     violations: list[str] = []
+
+    def _is_psutil_pid_exists_call(
+        node: ast.Call, aliases: dict[str, tuple[str, str | None]]
+    ) -> bool:
+        if isinstance(node.func, ast.Attribute) and node.func.attr == "pid_exists":
+            if (
+                isinstance(node.func.value, ast.Name)
+                and aliases.get(node.func.value.id, (None,))[0] == "psutil"
+            ):
+                return True
+        elif isinstance(node.func, ast.Name) and aliases.get(node.func.id, (None,)) == (
+            "psutil",
+            "pid_exists",
+        ):
+            return True
+        return False
+
+    def _is_os_kill_probe_call(node: ast.Call, aliases: dict[str, tuple[str, str | None]]) -> bool:
+        if (
+            len(node.args) != 2
+            or not isinstance(node.args[1], ast.Constant)
+            or node.args[1].value != 0
+        ):
+            return False
+        if isinstance(node.func, ast.Attribute) and node.func.attr == "kill":
+            if (
+                isinstance(node.func.value, ast.Name)
+                and aliases.get(node.func.value.id, (None,))[0] == "os"
+            ):
+                return True
+        elif isinstance(node.func, ast.Name) and aliases.get(node.func.id, (None,)) == (
+            "os",
+            "kill",
+        ):
+            return True
+        return False
+
+    def _is_psutil_is_running_call(
+        node: ast.Call, aliases: dict[str, tuple[str, str | None]]
+    ) -> bool:
+        if not (isinstance(node.func, ast.Attribute) and node.func.attr == "is_running"):
+            return False
+        receiver = node.func.value
+        if not isinstance(receiver, ast.Call):
+            return False
+        if not (isinstance(receiver.func, ast.Attribute) and receiver.func.attr == "Process"):
+            return False
+        if (
+            isinstance(receiver.func.value, ast.Name)
+            and aliases.get(receiver.func.value.id, (None,))[0] == "psutil"
+        ):
+            return True
+        return False
 
     for py_file in sorted(SRC_ROOT.rglob("*.py")):
         if py_file in allowed_files:
             continue
         try:
-            tree = ast.parse(py_file.read_text())
+            source = py_file.read_text()
+            tree = ast.parse(source)
         except SyntaxError:
             continue
+        aliases = _gather_import_aliases(tree)
         for node in ast.walk(tree):
-            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            if not isinstance(node, ast.Call):
                 continue
-            if (
-                node.func.attr == "pid_exists"
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "psutil"
-            ):
+            if _is_psutil_pid_exists_call(node, aliases):
                 violations.append(
                     f"  {py_file.relative_to(SRC_ROOT.parent.parent)}:{node.lineno}: "
                     f"direct call to psutil.pid_exists() outside allowed files"
                 )
-            elif (
-                node.func.attr == "kill"
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "os"
-                and len(node.args) == 2
-                and isinstance(node.args[1], ast.Constant)
-                and node.args[1].value == 0
-            ):
+            elif _is_os_kill_probe_call(node, aliases):
                 violations.append(
                     f"  {py_file.relative_to(SRC_ROOT.parent.parent)}:{node.lineno}: "
                     f"direct call to os.kill(pid, 0) outside allowed files"
+                )
+            elif _is_psutil_is_running_call(node, aliases):
+                violations.append(
+                    f"  {py_file.relative_to(SRC_ROOT.parent.parent)}:{node.lineno}: "
+                    f"direct call to psutil.Process(pid).is_running() outside allowed files"
                 )
 
     assert not violations, (

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -722,6 +722,128 @@ def test_no_direct_async_kill_process_tree_outside_executor() -> None:
     )
 
 
+def test_no_direct_settle_call_outside_allowlist() -> None:
+    """No src file may call .settle() outside the designated allowlist.
+
+    .settle() raises OwnedProcessCleanupError on incomplete teardown. Callers that
+    do not need that raising behavior must use .settle_evidence() or
+    .settle_preserving() instead — a bare .settle() call is deliberately narrow.
+
+    Allowed call sites:
+    - src/autoskillit/execution/process/_process_kill.py (defines settle())
+    - src/autoskillit/cli/session/_session_process.py (requires settle()'s raising
+      semantics)
+    - src/autoskillit/execution/evidence_reader.py (pre-existing, already-correct
+      catch-and-convert usage via owner.settle(...) in _run_bounded)
+    - src/autoskillit/hooks/_capture_process.py (hosts a structurally unrelated,
+      stdlib-only OwnedProcessGroup reimplementation with its own .settle() calls)
+    """
+    allowed_files = {
+        SRC_ROOT / "execution" / "process" / "_process_kill.py",
+        SRC_ROOT / "cli" / "session" / "_session_process.py",
+        SRC_ROOT / "execution" / "evidence_reader.py",
+        SRC_ROOT / "hooks" / "_capture_process.py",
+    }
+    violations: list[str] = []
+
+    for py_file in sorted(SRC_ROOT.rglob("*.py")):
+        if py_file in allowed_files:
+            continue
+        try:
+            tree = ast.parse(py_file.read_text())
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "settle"
+            ):
+                violations.append(
+                    f"  {py_file.relative_to(SRC_ROOT.parent.parent)}:{node.lineno}: "
+                    f"direct call to .settle() outside allowed files"
+                )
+
+    assert not violations, (
+        "Direct .settle() calls found outside allowed files.\n"
+        "Use .settle_evidence() or .settle_preserving() unless the raising semantics "
+        "are genuinely required, then add the file to the allowlist:\n" + "\n".join(violations)
+    )
+
+
+def test_no_raw_zombie_blind_liveness_check_outside_shared_primitive() -> None:
+    """No src file may call psutil.pid_exists() or the bare os.kill(pid, 0) existence
+    probe outside the shared zombie-aware primitive.
+
+    Both checks are zombie-blind: a zombie process (exited but not yet reaped by its
+    parent) retains a readable /proc entry and reports as alive under an exact-PID-
+    existence check alone.
+
+    Allowed files:
+    - src/autoskillit/core/runtime/_linux_proc.py (defines the shared primitive:
+      is_pid_alive() / is_pid_zombie())
+    - src/autoskillit/core/_plugin_cache.py (keeps its own psutil-based zombie check
+      by design — its cross-boot stored_create_time verification cannot be reproduced
+      by the stdlib-only tick-count primitive without an out-of-scope boot-time/schema
+      migration)
+    - src/autoskillit/execution/process/_daemon_orphans.py (_owner_is_dead's
+      os.kill(owner_pid, 0) branch is a last-resort fallback reached only when
+      /proc/{pid}/stat is unreadable — in that degraded state zombie detection is
+      equally impossible, so this is not a new zombie-blind gap, and PermissionError/
+      OSError already fail closed to "unknown")
+    - src/autoskillit/fleet/_dispatch_reaper.py (pre-existing psutil.pid_exists() use
+      predating this guard; not yet migrated — tracked as a known follow-up, not
+      addressed here because doing so would require rewriting the file's extensive
+      existing psutil.pid_exists-mocked test suite, which is out of this guard's scope)
+    """
+    allowed_files = {
+        SRC_ROOT / "core" / "runtime" / "_linux_proc.py",
+        SRC_ROOT / "core" / "_plugin_cache.py",
+        SRC_ROOT / "execution" / "process" / "_daemon_orphans.py",
+        SRC_ROOT / "fleet" / "_dispatch_reaper.py",
+    }
+    violations: list[str] = []
+
+    for py_file in sorted(SRC_ROOT.rglob("*.py")):
+        if py_file in allowed_files:
+            continue
+        try:
+            tree = ast.parse(py_file.read_text())
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+                continue
+            if (
+                node.func.attr == "pid_exists"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "psutil"
+            ):
+                violations.append(
+                    f"  {py_file.relative_to(SRC_ROOT.parent.parent)}:{node.lineno}: "
+                    f"direct call to psutil.pid_exists() outside allowed files"
+                )
+            elif (
+                node.func.attr == "kill"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "os"
+                and len(node.args) == 2
+                and isinstance(node.args[1], ast.Constant)
+                and node.args[1].value == 0
+            ):
+                violations.append(
+                    f"  {py_file.relative_to(SRC_ROOT.parent.parent)}:{node.lineno}: "
+                    f"direct call to os.kill(pid, 0) outside allowed files"
+                )
+
+    assert not violations, (
+        "Direct zombie-blind liveness checks found outside allowed files.\n"
+        "Use core.is_pid_alive()/is_pid_zombie() (or core._plugin_cache._pid_alive() "
+        "when cross-boot stored_create_time verification is needed) instead:\n"
+        + "\n".join(violations)
+    )
+
+
 def test_no_direct_termination_dispatch_ifelse_in_run_managed() -> None:
     """run_managed_async must not contain an if/elif chain that inspects
     TerminationReason.* or signals.process_exited directly.

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -26,7 +26,10 @@ HEADLESS_SIZE_BUDGETS = {
     "headless/_headless_recovery.py": 540,
     "headless/_headless_path_tokens.py": 190,
     # #4233 and #4457 keep lifecycle and artifact gates at the final adjudication seam.
-    "headless/_headless_result.py": 1033,
+    # #4641/#4644 rectify: cleanup-evidence diagnostic threading (_log_cleanup_incomplete
+    # helper + two call sites) keeps the incomplete-teardown signal adjacent to the
+    # same success-path construction it must not destroy.
+    "headless/_headless_result.py": 1047,
     "headless/_headless_evidence.py": 310,
 }
 

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -26,7 +26,7 @@ HEADLESS_SIZE_BUDGETS = {
     "headless/_headless_recovery.py": 540,
     "headless/_headless_path_tokens.py": 190,
     # #4233 and #4457 keep lifecycle and artifact gates at the final adjudication seam.
-    # #4641/#4644 rectify: cleanup-evidence diagnostic threading (_log_cleanup_incomplete
+    # #4641/#4644 rectify: cleanup-evidence diagnostic threading (_should_flag_cleanup_incomplete
     # helper + two call sites) keeps the incomplete-teardown signal adjacent to the
     # same success-path construction it must not destroy.
     "headless/_headless_result.py": 1047,

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -29,7 +29,7 @@ HEADLESS_SIZE_BUDGETS = {
     # #4641/#4644 rectify: cleanup-evidence diagnostic threading (_should_flag_cleanup_incomplete
     # helper + two call sites) keeps the incomplete-teardown signal adjacent to the
     # same success-path construction it must not destroy.
-    "headless/_headless_result.py": 1047,
+    "headless/_headless_result.py": 1053,
     "headless/_headless_evidence.py": 310,
 }
 

--- a/tests/arch/test_file_size_budgets.py
+++ b/tests/arch/test_file_size_budgets.py
@@ -22,7 +22,9 @@ def test_pretty_output_below_budget() -> None:
     budgets = {
         "pretty_output_hook.py": 353,  # #4585 registers two generic reader envelopes
         "_fmt_primitives.py": 200,
-        "_fmt_execution.py": 355,  # #4457 renders completion receipts verbatim
+        # #4457 renders completion receipts verbatim; #4641/#4644 rectify adds
+        # infra_cleanup_incomplete to the run_skill SUPPRESSED coverage set (+1 line)
+        "_fmt_execution.py": 356,
         "_fmt_dispatch.py": 200,
         "_fmt_status.py": 250,
         "_fmt_recipe.py": 350,  # replay/effect provenance remains visible after compaction

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1378,7 +1378,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "adds execution-role protocol parity while preserving Claude behavior (+3 net lines).",
     ),
     "execution/headless/_headless_result.py": (
-        1047,
+        1053,
         "REQ-CNST-010-E25: #4233 keeps the async-obligation success gate adjacent to "
         "the existing stale, idle, timeout, and content adjudication order it must preempt. "
         "#4641/#4644 rectify adds the _should_flag_cleanup_incomplete diagnostic helper shared by "

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1381,7 +1381,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         1047,
         "REQ-CNST-010-E25: #4233 keeps the async-obligation success gate adjacent to "
         "the existing stale, idle, timeout, and content adjudication order it must preempt. "
-        "#4641/#4644 rectify adds the _log_cleanup_incomplete diagnostic helper shared by "
+        "#4641/#4644 rectify adds the _should_flag_cleanup_incomplete diagnostic helper shared by "
         "both SkillResult construction seams it must not silently drop evidence at.",
     ),
     "workspace/skill_capabilities.py": (

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1301,7 +1301,7 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "run_skill launch denial paths before command construction (+139 net lines)",
     ),
     "execution/backends/codex.py": (
-        2444,
+        2454,
         "REQ-CNST-010-E9: Codex backend — skill_sigil capability threading adds multi-line "
         "keyword args to _ensure_skill_prefix call sites and _has_prefix guard; "
         "write_guard_tool_names env injection adds 7 lines to _codex_exec_extras; "
@@ -1353,7 +1353,11 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "child cardinality rendering and protects the live-web bundled role (+12 net lines)"
         "; #4566 pins ORCHESTRATOR file auth, durable auth linkage, and role-exact profile "
         "materialization at the backend-owned generated-home setup boundary (+42 net lines); "
-        "launch/state MCP forwarding defaults remain in the Codex env policy (+2 net lines)",
+        "launch/state MCP forwarding defaults remain in the Codex env policy (+2 net lines)"
+        "; #4641/#4644 rectify: settle_evidence() swap plus cleanup_incomplete diagnostic "
+        "threading in _run_bounded_codex_probe/_terminate_probe/_validate_mcp_probe stays "
+        "adjacent to the bounded probe it must not misclassify as a validation failure "
+        "(+10 net lines)",
     ),
     "execution/backends/claude.py": (
         1250,
@@ -1374,9 +1378,11 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "adds execution-role protocol parity while preserving Claude behavior (+3 net lines).",
     ),
     "execution/headless/_headless_result.py": (
-        1033,
+        1047,
         "REQ-CNST-010-E25: #4233 keeps the async-obligation success gate adjacent to "
-        "the existing stale, idle, timeout, and content adjudication order it must preempt",
+        "the existing stale, idle, timeout, and content adjudication order it must preempt. "
+        "#4641/#4644 rectify adds the _log_cleanup_incomplete diagnostic helper shared by "
+        "both SkillResult construction seams it must not silently drop evidence at.",
     ),
     "workspace/skill_capabilities.py": (
         1120,

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -701,7 +701,7 @@ class TestGroupDApiContractPreservation:
     # ------------------------------------------------------------------
 
     def test_req_api_005_subprocess_result_field_names(self):
-        """SubprocessResult must have exactly the 24 canonical fields."""
+        """SubprocessResult must have exactly the 25 canonical fields."""
         from autoskillit.core.types import SubprocessResult
 
         fields = {f.name for f in dataclasses.fields(SubprocessResult)}
@@ -730,6 +730,7 @@ class TestGroupDApiContractPreservation:
             "inspector_verdict",
             "stdout_path",
             "stderr_path",
+            "cleanup_evidence",
         }
         assert fields == expected, (
             f"SubprocessResult fields changed.\n"

--- a/tests/core/test_plugin_cache.py
+++ b/tests/core/test_plugin_cache.py
@@ -134,11 +134,11 @@ def test_pid_alive_no_such_process_with_create_time_reports_dead(
     assert _pid_alive(42, stored_create_time=1.0) is False
 
 
-def test_pid_alive_no_such_process_without_create_time_assumes_alive(
+def test_pid_alive_no_such_process_without_create_time_reports_dead(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Without stored_create_time, a NoSuchProcess cannot be disambiguated from a
-    transient psutil failure — fall back to the documented 'assume alive' contract."""
+    """NoSuchProcess is definitive even without stored_create_time — the process
+    is gone regardless of whether we have a stored identity to compare against."""
     from autoskillit.core import _plugin_cache
 
     monkeypatch.setattr(_plugin_cache.os, "kill", lambda *_a, **_kw: None)
@@ -148,7 +148,7 @@ def test_pid_alive_no_such_process_without_create_time_assumes_alive(
 
     monkeypatch.setattr(_plugin_cache.psutil, "Process", raise_no_such_process)
 
-    assert _pid_alive(42, stored_create_time=None) is True
+    assert _pid_alive(42, stored_create_time=None) is False
 
 
 def test_pid_alive_access_denied_with_create_time_assumes_alive(

--- a/tests/core/test_plugin_cache.py
+++ b/tests/core/test_plugin_cache.py
@@ -116,6 +116,36 @@ def test_pid_alive_returns_false_for_zombie() -> None:
         os.waitpid(child_pid, 0)
 
 
+def test_pid_alive_returns_false_on_no_such_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A PID that vanished between os.kill and psutil.Process must be reported dead."""
+    from autoskillit.core import _plugin_cache
+
+    monkeypatch.setattr(_plugin_cache.os, "kill", lambda *_a, **_kw: None)
+
+    def raise_no_such_process(*_args: object, **_kwargs: object) -> object:
+        raise psutil.NoSuchProcess(42)
+
+    monkeypatch.setattr(_plugin_cache.psutil, "Process", raise_no_such_process)
+
+    assert _pid_alive(42, stored_create_time=1.0) is False
+    assert _pid_alive(42, stored_create_time=None) is True
+
+
+def test_pid_alive_returns_true_on_access_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A foreign-user PID (psutil.AccessDenied) must remain 'assume alive'."""
+    from autoskillit.core import _plugin_cache
+
+    monkeypatch.setattr(_plugin_cache.os, "kill", lambda *_a, **_kw: None)
+
+    def raise_access_denied(*_args: object, **_kwargs: object) -> object:
+        raise psutil.AccessDenied(42)
+
+    monkeypatch.setattr(_plugin_cache.psutil, "Process", raise_access_denied)
+
+    assert _pid_alive(42, stored_create_time=1.0) is True
+    assert _pid_alive(42, stored_create_time=None) is True
+
+
 def test_repeated_exact_registration_does_not_grow_registry(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
     identity = KitchenProcessIdentity("kitchen", 42, 123.5, str(tmp_path))

--- a/tests/core/test_plugin_cache.py
+++ b/tests/core/test_plugin_cache.py
@@ -105,9 +105,10 @@ def test_pid_alive_returns_false_for_zombie() -> None:
         os._exit(0)
     try:
         create_time = psutil.Process(child_pid).create_time()
-        deadline = time.time() + 2.0
+        deadline = time.monotonic() + 2.0
         while (
-            psutil.Process(child_pid).status() != psutil.STATUS_ZOMBIE and time.time() < deadline
+            psutil.Process(child_pid).status() != psutil.STATUS_ZOMBIE
+            and time.monotonic() < deadline
         ):
             time.sleep(0.01)
         assert psutil.Process(child_pid).status() == psutil.STATUS_ZOMBIE
@@ -116,8 +117,11 @@ def test_pid_alive_returns_false_for_zombie() -> None:
         os.waitpid(child_pid, 0)
 
 
-def test_pid_alive_returns_false_on_no_such_process(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A PID that vanished between os.kill and psutil.Process must be reported dead."""
+def test_pid_alive_no_such_process_with_create_time_reports_dead(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A PID that vanished between os.kill and psutil.Process must be reported dead
+    when the caller supplied a stored_create_time (identity check possible)."""
     from autoskillit.core import _plugin_cache
 
     monkeypatch.setattr(_plugin_cache.os, "kill", lambda *_a, **_kw: None)
@@ -128,11 +132,30 @@ def test_pid_alive_returns_false_on_no_such_process(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(_plugin_cache.psutil, "Process", raise_no_such_process)
 
     assert _pid_alive(42, stored_create_time=1.0) is False
+
+
+def test_pid_alive_no_such_process_without_create_time_assumes_alive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without stored_create_time, a NoSuchProcess cannot be disambiguated from a
+    transient psutil failure — fall back to the documented 'assume alive' contract."""
+    from autoskillit.core import _plugin_cache
+
+    monkeypatch.setattr(_plugin_cache.os, "kill", lambda *_a, **_kw: None)
+
+    def raise_no_such_process(*_args: object, **_kwargs: object) -> object:
+        raise psutil.NoSuchProcess(42)
+
+    monkeypatch.setattr(_plugin_cache.psutil, "Process", raise_no_such_process)
+
     assert _pid_alive(42, stored_create_time=None) is True
 
 
-def test_pid_alive_returns_true_on_access_denied(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A foreign-user PID (psutil.AccessDenied) must remain 'assume alive'."""
+def test_pid_alive_access_denied_with_create_time_assumes_alive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A foreign-user PID (psutil.AccessDenied) is unverifiable — must report alive
+    even when the caller has a stored_create_time to compare against."""
     from autoskillit.core import _plugin_cache
 
     monkeypatch.setattr(_plugin_cache.os, "kill", lambda *_a, **_kw: None)
@@ -143,6 +166,21 @@ def test_pid_alive_returns_true_on_access_denied(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(_plugin_cache.psutil, "Process", raise_access_denied)
 
     assert _pid_alive(42, stored_create_time=1.0) is True
+
+
+def test_pid_alive_access_denied_without_create_time_assumes_alive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A foreign-user PID (psutil.AccessDenied) is unverifiable — must report alive."""
+    from autoskillit.core import _plugin_cache
+
+    monkeypatch.setattr(_plugin_cache.os, "kill", lambda *_a, **_kw: None)
+
+    def raise_access_denied(*_args: object, **_kwargs: object) -> object:
+        raise psutil.AccessDenied(42)
+
+    monkeypatch.setattr(_plugin_cache.psutil, "Process", raise_access_denied)
+
     assert _pid_alive(42, stored_create_time=None) is True
 
 

--- a/tests/core/test_plugin_cache.py
+++ b/tests/core/test_plugin_cache.py
@@ -4,10 +4,14 @@ validation."""
 from __future__ import annotations
 
 import json
+import os
+import sys
+import time
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import psutil
 import pytest
 
 from autoskillit.core import (
@@ -20,6 +24,7 @@ from autoskillit.core import (
 )
 from autoskillit.core._plugin_cache import (
     KitchenProcessIdentity,
+    _pid_alive,
     any_kitchen_open,
     append_retiring_record,
     migrate_retiring_cache_v1,
@@ -86,6 +91,29 @@ def test_kitchen_identity_rejects_nonpositive_sampled_create_time(
 
     with pytest.raises(ValueError, match="create_time"):
         sample_kitchen_process_identity("kitchen", 42, tmp_path)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only: uses os.fork and /proc")
+def test_pid_alive_returns_false_for_zombie() -> None:
+    """A zombie with a matching stored create_time must be reported dead.
+
+    Pre-fix, _pid_alive only compared create_time() and would have reported
+    this zombie as alive.
+    """
+    child_pid = os.fork()
+    if child_pid == 0:
+        os._exit(0)
+    try:
+        create_time = psutil.Process(child_pid).create_time()
+        deadline = time.time() + 2.0
+        while (
+            psutil.Process(child_pid).status() != psutil.STATUS_ZOMBIE and time.time() < deadline
+        ):
+            time.sleep(0.01)
+        assert psutil.Process(child_pid).status() == psutil.STATUS_ZOMBIE
+        assert _pid_alive(child_pid, stored_create_time=create_time) is False
+    finally:
+        os.waitpid(child_pid, 0)
 
 
 def test_repeated_exact_registration_does_not_grow_registry(monkeypatch, tmp_path: Path) -> None:

--- a/tests/core/test_session_liveness.py
+++ b/tests/core/test_session_liveness.py
@@ -86,19 +86,3 @@ def test_is_session_alive_returns_false_for_zombie() -> None:
         assert is_session_alive(child_pid, boot_id, ticks) is False
     finally:
         os.waitpid(child_pid, 0)
-
-
-def test_is_pid_alive_gateway_importable() -> None:
-    from autoskillit.core import (
-        is_pid_alive as gateway_is_pid_alive,
-    )
-    from autoskillit.core import (
-        is_pid_zombie as gateway_is_pid_zombie,
-    )
-    from autoskillit.core import (
-        read_process_state as gateway_read_process_state,
-    )
-
-    assert callable(gateway_read_process_state)
-    assert callable(gateway_is_pid_zombie)
-    assert callable(gateway_is_pid_alive)

--- a/tests/core/test_session_liveness.py
+++ b/tests/core/test_session_liveness.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import os
+import time
 
 import pytest
 
 from autoskillit.core.runtime._linux_proc import (
+    is_pid_zombie,
     is_session_alive,
     read_boot_id,
+    read_process_state,
     read_starttime_ticks,
 )
 
@@ -46,3 +49,56 @@ class TestIsSessionAlive:
         if boot_id is None or ticks is None:
             pytest.skip("Not on Linux")
         assert is_session_alive(os.getpid(), boot_id, ticks) is True
+
+
+def test_read_process_state_and_is_pid_zombie() -> None:
+    boot_id = read_boot_id()
+    if boot_id is None:
+        pytest.skip("Not on Linux")
+    child_pid = os.fork()
+    if child_pid == 0:
+        os._exit(0)
+    try:
+        deadline = time.monotonic() + 2.0
+        state = read_process_state(child_pid)
+        while state != "Z" and time.monotonic() < deadline:
+            time.sleep(0.01)
+            state = read_process_state(child_pid)
+        assert state == "Z"
+        assert is_pid_zombie(child_pid) is True
+    finally:
+        os.waitpid(child_pid, 0)
+
+
+def test_is_session_alive_returns_false_for_zombie() -> None:
+    boot_id = read_boot_id()
+    if boot_id is None:
+        pytest.skip("Not on Linux")
+    child_pid = os.fork()
+    if child_pid == 0:
+        os._exit(0)
+    try:
+        ticks = read_starttime_ticks(child_pid)
+        deadline = time.monotonic() + 2.0
+        while read_process_state(child_pid) != "Z" and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert ticks is not None
+        assert is_session_alive(child_pid, boot_id, ticks) is False
+    finally:
+        os.waitpid(child_pid, 0)
+
+
+def test_is_pid_alive_gateway_importable() -> None:
+    from autoskillit.core import (
+        is_pid_alive as gateway_is_pid_alive,
+    )
+    from autoskillit.core import (
+        is_pid_zombie as gateway_is_pid_zombie,
+    )
+    from autoskillit.core import (
+        read_process_state as gateway_read_process_state,
+    )
+
+    assert callable(gateway_read_process_state)
+    assert callable(gateway_is_pid_zombie)
+    assert callable(gateway_is_pid_alive)

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -764,6 +764,19 @@ class TestSkillResultExtensionBundles:
         assert data["provider_fallback"] is False
         assert data["infra_exit_category"] == ""
 
+    def test_infra_outcome_surfaces_cleanup_incomplete_flag(self):
+        sr = SkillResult(
+            **self._BASE_KWARGS,
+            infra=InfraOutcome(cleanup_incomplete=True),
+        )
+        data = json.loads(sr.to_json())
+        assert data["infra_cleanup_incomplete"] is True
+
+    def test_infra_outcome_cleanup_incomplete_absent_by_default(self):
+        sr = SkillResult(**self._BASE_KWARGS)
+        data = json.loads(sr.to_json())
+        assert data["infra_cleanup_incomplete"] is False
+
     def test_replace_infra_bundle(self):
         sr = SkillResult(**self._BASE_KWARGS)
         sr2 = dataclasses.replace(sr, infra=InfraOutcome(exit_category="api_error"))

--- a/tests/execution/backends/test_codex_config_validation.py
+++ b/tests/execution/backends/test_codex_config_validation.py
@@ -6,7 +6,6 @@ import json
 import multiprocessing
 import os
 import signal
-import subprocess
 import sys
 import tomllib
 from dataclasses import replace
@@ -195,35 +194,6 @@ def test_run_bounded_codex_probe_returns_success_with_diagnostic_on_incomplete_c
     assert result.returncode == 0
     assert result.stdout == b"probe-ok"
     assert result.stderr == b""
-
-
-def test_terminate_probe_does_not_raise_on_incomplete_cleanup(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from autoskillit.core import ProcessCleanupResult
-    from autoskillit.execution.backends.codex import _terminate_probe
-    from autoskillit.execution.process._process_kill import spawn_owned_process
-
-    owner = spawn_owned_process(
-        (sys.executable, "-c", "pass"),
-        cwd=str(tmp_path),
-        env=dict(os.environ),
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        start_new_session=True,
-    )
-    owner.process.wait(timeout=5)
-
-    incomplete_result = ProcessCleanupResult(
-        root_pid=owner.pid,
-        access_denied_pids=(999,),
-        observation_complete=True,
-    )
-    monkeypatch.setattr(owner, "cleanup", lambda timeout=2.0: (0, incomplete_result))
-
-    assert _terminate_probe(owner) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/execution/backends/test_codex_config_validation.py
+++ b/tests/execution/backends/test_codex_config_validation.py
@@ -6,6 +6,7 @@ import json
 import multiprocessing
 import os
 import signal
+import subprocess
 import sys
 import tomllib
 from dataclasses import replace
@@ -158,6 +159,73 @@ def test_bounded_codex_probe_enforces_stream_limit(
     assert len(result.stdout) == 128
 
 
+def test_run_bounded_codex_probe_returns_success_with_diagnostic_on_incomplete_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from autoskillit.core import ProcessCleanupResult
+    from autoskillit.execution.backends import codex
+    from autoskillit.execution.process._process_kill import OwnedProcessGroup
+
+    original_cleanup = OwnedProcessGroup.cleanup
+
+    def incomplete_cleanup(
+        self: OwnedProcessGroup, timeout: float = 2.0
+    ) -> tuple[int | None, ProcessCleanupResult]:
+        returncode, result = original_cleanup(self, timeout)
+        return returncode, ProcessCleanupResult(
+            root_pid=result.root_pid,
+            process_identities=result.process_identities,
+            terminated_pids=result.terminated_pids,
+            survivor_pids=result.survivor_pids,
+            access_denied_pids=(999,),
+            observation_complete=result.observation_complete,
+        )
+
+    monkeypatch.setattr(OwnedProcessGroup, "cleanup", incomplete_cleanup)
+
+    result = codex._run_bounded_codex_probe(
+        (sys.executable, "-c", "import os; os.write(1, b'probe-ok')"),
+        env=os.environ,
+        cwd=str(tmp_path),
+    )
+
+    assert result.failure is None
+    assert result.cleanup_incomplete is True
+    assert result.returncode == 0
+    assert result.stdout == b"probe-ok"
+    assert result.stderr == b""
+
+
+def test_terminate_probe_does_not_raise_on_incomplete_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from autoskillit.core import ProcessCleanupResult
+    from autoskillit.execution.backends.codex import _terminate_probe
+    from autoskillit.execution.process._process_kill import spawn_owned_process
+
+    owner = spawn_owned_process(
+        (sys.executable, "-c", "pass"),
+        cwd=str(tmp_path),
+        env=dict(os.environ),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+    owner.process.wait(timeout=5)
+
+    incomplete_result = ProcessCleanupResult(
+        root_pid=owner.pid,
+        access_denied_pids=(999,),
+        observation_complete=True,
+    )
+    monkeypatch.setattr(owner, "cleanup", lambda timeout=2.0: (0, incomplete_result))
+
+    assert _terminate_probe(owner) is None
+
+
 @pytest.mark.parametrize(
     ("program", "expected_error"),
     [
@@ -226,6 +294,33 @@ def test_mcp_probe_caches_successful_validation(
         == []
     )
     assert calls == 1
+
+
+def test_validate_mcp_probe_returns_clean_result_when_cleanup_incomplete_but_probe_succeeded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from autoskillit.execution.backends import codex
+
+    def run_probe(*_args: object, **_kwargs: object) -> codex._BoundedProbeResult:
+        return codex._BoundedProbeResult(
+            returncode=0,
+            stdout=_VALID_INVENTORY_BYTES,
+            stderr=b"",
+            cleanup_incomplete=True,
+        )
+
+    monkeypatch.setattr(codex, "_CODEX_VALIDATION_CACHE", {})
+    monkeypatch.setattr(codex, "_run_bounded_codex_probe", run_probe)
+
+    errors = codex._validate_mcp_probe(
+        ("codex", "mcp", "list", "--json"),
+        env=os.environ,
+        cwd=str(tmp_path),
+        config_bytes=_VALID_CONFIG_BYTES,
+    )
+
+    assert errors == []
 
 
 def test_real_interactive_validator_reaches_successful_native_probe(

--- a/tests/execution/test_daemon_orphans.py
+++ b/tests/execution/test_daemon_orphans.py
@@ -147,6 +147,13 @@ def test_owner_probe_distinguishes_live_dead_and_unknown(monkeypatch: pytest.Mon
     assert subject._owner_is_dead(333, _BOOT, 22) is None
 
 
+def test_owner_probe_treats_matching_ticks_zombie_as_dead(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subject, "read_boot_id", lambda: _BOOT)
+    monkeypatch.setattr(subject, "read_starttime_ticks", lambda _pid: 22)
+    monkeypatch.setattr(subject, "is_pid_zombie", lambda _pid: True)
+    assert subject._owner_is_dead(333, _BOOT, 22) is True
+
+
 @pytest.mark.parametrize(
     ("stat", "expected"),
     [

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -12,6 +12,7 @@ from autoskillit.core.types import (
     ChannelConfirmation,
     ChildExecutionIdentity,
     ExecutionIdentity,
+    ProcessCleanupResult,
     RetryReason,
     SkillResult,
     SubprocessResult,
@@ -889,6 +890,51 @@ class TestRunHeadlessCore:
         assert cmd[fmt_idx + 1] == "stream-json"
 
     @pytest.mark.anyio
+    async def test_success_not_destroyed_by_incomplete_cleanup_evidence(self, tool_ctx, tmp_path):
+        """A genuinely successful run must not be destroyed by incomplete cleanup evidence.
+
+        Regression for #4641: OwnedProcessGroup.settle() previously raised
+        OwnedProcessCleanupError on incomplete teardown evidence even when the
+        workload itself completed successfully; _headless_execute.py's blanket
+        except Exception converted that into SkillResult.crashed(), discarding
+        the real success. settle_evidence() now returns non-raising, so this
+        scenario produces a successful SkillResult carrying a diagnostic flag
+        instead.
+        """
+        from autoskillit.execution.headless import run_headless_core
+
+        marker = tool_ctx.config.run_skill.completion_marker
+        payload = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": f"Task completed. {marker}",
+                "session_id": "sess-cleanup-evidence",
+            }
+        )
+        incomplete_evidence = ProcessCleanupResult(
+            root_pid=1, access_denied_pids=(999,), observation_complete=True
+        )
+        tool_ctx.runner.push(
+            SubprocessResult(
+                0,
+                payload,
+                "",
+                TerminationReason.NATURAL_EXIT,
+                pid=1,
+                cleanup_evidence=incomplete_evidence,
+            )
+        )
+
+        result = await run_headless_core("/investigate foo", cwd=str(tmp_path), ctx=tool_ctx)
+
+        assert result.success is True
+        assert result.subtype != "crashed"
+        assert result.needs_retry is False
+        assert result.infra.cleanup_incomplete is True
+
+    @pytest.mark.anyio
     async def test_assembled_cmd_contains_format_required_flags(self, tool_ctx, tmp_path):
         """Assembled command must include all flags required by the output format."""
         from autoskillit.execution.headless import run_headless_core
@@ -1136,6 +1182,7 @@ class TestBuildSkillResultCrossValidation:
         "audit_cycle_path",
         "audit_attempt_id",
         "infra_exit_category",
+        "infra_cleanup_incomplete",
         "api_retry_count",
         "api_retry_last_error",
         "api_retry_last_status",

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import unittest.mock
 from pathlib import Path
@@ -17,6 +18,7 @@ from autoskillit.core.types import (
     CliSubtype,
     InfraExitCategory,
     KillReason,
+    ProcessCleanupResult,
     RetryReason,
     SkillResult,
     SubprocessResult,
@@ -1667,6 +1669,61 @@ class TestStaleApiRetryExhaustion:
         assert sr.subtype == "recovered_from_stale"
         assert sr.infra.exit_category == ""
         assert sr.api_retry.exhausted is True
+
+    def test_stale_recovery_success_surfaces_cleanup_incomplete(self):
+        """A genuinely successful STALE recovery must still surface incomplete cleanup evidence.
+
+        Regression for foundation-auditor-4641's finding: _make_terminated_result's
+        shared helper (behind both the STALE- and IDLE_STALL-recovery success
+        branches) did not receive infra= and silently dropped this diagnostic.
+        """
+        ndjson = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "Done.",
+                "session_id": "s1",
+            }
+        )
+        incomplete_evidence = ProcessCleanupResult(
+            root_pid=12345, access_denied_pids=(999,), observation_complete=True
+        )
+        result = dataclasses.replace(
+            _sr(0, ndjson, "", TerminationReason.STALE),
+            cleanup_evidence=incomplete_evidence,
+        )
+
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
+
+        assert sr.success is True
+        assert sr.subtype == "recovered_from_stale"
+        assert sr.infra.cleanup_incomplete is True
+
+    def test_idle_stall_recovery_success_surfaces_cleanup_incomplete(self):
+        """Analogous to the STALE case above, for the IDLE_STALL-recovery success branch."""
+        ndjson = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "Done.",
+                "session_id": "s1",
+            }
+        )
+        incomplete_evidence = ProcessCleanupResult(
+            root_pid=12345, access_denied_pids=(999,), observation_complete=True
+        )
+        result = dataclasses.replace(
+            _sr(0, ndjson, "", TerminationReason.IDLE_STALL),
+            cleanup_evidence=incomplete_evidence,
+        )
+
+        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
+
+        assert sr.success is True
+        assert sr.subtype == "recovered_from_idle_stall"
+        assert sr.infra.cleanup_incomplete is True
 
     def test_idle_stall_with_api_retry_exhaustion_sets_infra(self):
         """Idle_stall + exhausted api_retry → infra_exit_category='api_error'."""

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -1670,12 +1670,20 @@ class TestStaleApiRetryExhaustion:
         assert sr.infra.exit_category == ""
         assert sr.api_retry.exhausted is True
 
-    def test_stale_recovery_success_surfaces_cleanup_incomplete(self):
-        """A genuinely successful STALE recovery must still surface incomplete cleanup evidence.
+    @pytest.mark.parametrize(
+        ("termination_reason", "expected_subtype"),
+        [
+            (TerminationReason.STALE, "recovered_from_stale"),
+            (TerminationReason.IDLE_STALL, "recovered_from_idle_stall"),
+        ],
+    )
+    def test_recovery_success_surfaces_cleanup_incomplete(
+        self, termination_reason: TerminationReason, expected_subtype: str
+    ):
+        """STALE/IDLE_STALL recovery with incomplete cleanup must surface the diagnostic.
 
         Regression for foundation-auditor-4641's finding: _make_terminated_result's
-        shared helper (behind both the STALE- and IDLE_STALL-recovery success
-        branches) did not receive infra= and silently dropped this diagnostic.
+        shared helper did not receive infra= and silently dropped this signal.
         """
         ndjson = json.dumps(
             {
@@ -1690,39 +1698,14 @@ class TestStaleApiRetryExhaustion:
             root_pid=12345, access_denied_pids=(999,), observation_complete=True
         )
         result = dataclasses.replace(
-            _sr(0, ndjson, "", TerminationReason.STALE),
+            _sr(0, ndjson, "", termination_reason),
             cleanup_evidence=incomplete_evidence,
         )
 
         sr = _build_skill_result(result, backend=ClaudeCodeBackend())
 
         assert sr.success is True
-        assert sr.subtype == "recovered_from_stale"
-        assert sr.infra.cleanup_incomplete is True
-
-    def test_idle_stall_recovery_success_surfaces_cleanup_incomplete(self):
-        """Analogous to the STALE case above, for the IDLE_STALL-recovery success branch."""
-        ndjson = json.dumps(
-            {
-                "type": "result",
-                "subtype": "success",
-                "is_error": False,
-                "result": "Done.",
-                "session_id": "s1",
-            }
-        )
-        incomplete_evidence = ProcessCleanupResult(
-            root_pid=12345, access_denied_pids=(999,), observation_complete=True
-        )
-        result = dataclasses.replace(
-            _sr(0, ndjson, "", TerminationReason.IDLE_STALL),
-            cleanup_evidence=incomplete_evidence,
-        )
-
-        sr = _build_skill_result(result, backend=ClaudeCodeBackend())
-
-        assert sr.success is True
-        assert sr.subtype == "recovered_from_idle_stall"
+        assert sr.subtype == expected_subtype
         assert sr.infra.cleanup_incomplete is True
 
     def test_idle_stall_with_api_retry_exhaustion_sets_infra(self):

--- a/tests/execution/test_process_cleanup_result.py
+++ b/tests/execution/test_process_cleanup_result.py
@@ -592,42 +592,41 @@ def test_settle_still_raises_on_genuinely_incomplete_evidence(
         owner.settle()
 
 
-def test_settle_evidence_returns_without_raising_on_incomplete(
+@pytest.mark.parametrize(
+    ("returncode", "complete", "expect_incomplete_log"),
+    [
+        (0, False, True),
+        (None, True, True),
+    ],
+)
+def test_settle_evidence_returns_without_raising(
     monkeypatch: pytest.MonkeyPatch,
+    returncode: int | None,
+    complete: bool,
+    expect_incomplete_log: bool,
 ) -> None:
+    """settle_evidence returns the cleanup tuple without raising across the
+    (incomplete + leader-confirmed) and (complete + leader-unconfirmed) cases."""
     owner = _spawn_owner(monkeypatch)
-    incomplete_result = _process_kill.ProcessCleanupResult(
+    result_stub = _process_kill.ProcessCleanupResult(
         root_pid=owner.pid,
-        access_denied_pids=(1234,),
-        observation_complete=True,
+        access_denied_pids=(1234,) if not complete else (),
+        observation_complete=complete,
     )
-    monkeypatch.setattr(owner, "cleanup", lambda timeout: (0, incomplete_result))
+    monkeypatch.setattr(owner, "cleanup", lambda timeout: (returncode, result_stub))
 
     with structlog.testing.capture_logs() as logs:
-        returncode, result = owner.settle_evidence()
+        actual_returncode, actual_result = owner.settle_evidence()
 
-    assert returncode == 0
-    assert result is incomplete_result
-    assert any(entry.get("event") == "owned_group_cleanup_incomplete" for entry in logs)
-
-
-def test_settle_evidence_returns_none_returncode_without_raising(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    owner = _spawn_owner(monkeypatch)
-    complete_result = _process_kill.ProcessCleanupResult(
-        root_pid=owner.pid,
-        observation_complete=True,
-    )
-    monkeypatch.setattr(owner, "cleanup", lambda timeout: (None, complete_result))
-
-    with structlog.testing.capture_logs() as logs:
-        returncode, result = owner.settle_evidence()
-
-    assert returncode is None
-    assert result is complete_result
-    entry = next(e for e in logs if e.get("event") == "owned_group_cleanup_incomplete")
-    assert entry.get("returncode_confirmed") is False
+    assert actual_returncode == returncode
+    assert actual_result is result_stub
+    incomplete_entries = [e for e in logs if e.get("event") == "owned_group_cleanup_incomplete"]
+    if expect_incomplete_log:
+        assert incomplete_entries
+        if returncode is None:
+            assert all(e.get("returncode_confirmed") is False for e in incomplete_entries)
+    else:
+        assert not incomplete_entries
 
 
 def test_subprocess_result_carries_cleanup_evidence_field() -> None:

--- a/tests/execution/test_process_cleanup_result.py
+++ b/tests/execution/test_process_cleanup_result.py
@@ -509,3 +509,139 @@ def test_arbitrary_handle_cannot_be_adopted_as_owned_group() -> None:
 
     with pytest.raises(TypeError, match="spawn_owned_process"):
         _process_kill.OwnedProcessGroup(process, process.pid)
+
+
+def _spawn_owner(monkeypatch: pytest.MonkeyPatch) -> _process_kill.OwnedProcessGroup:
+    monkeypatch.setattr(_process_kill.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(_process_kill.os, "getpgid", lambda pid: pid)
+    monkeypatch.setattr(
+        _process_kill,
+        "_snapshot_process_tree",
+        lambda _pid: _process_kill.ProcessObservationSnapshot(),
+    )
+    return _process_kill.spawn_owned_process(["command"], start_new_session=True)
+
+
+def test_identity_is_alive_returns_false_for_zombie(monkeypatch: pytest.MonkeyPatch) -> None:
+    class ZombieProcess:
+        def __init__(self, pid: int) -> None:
+            self.pid = pid
+
+        def create_time(self) -> float:
+            return 123.0
+
+        def status(self) -> str:
+            return psutil.STATUS_ZOMBIE
+
+    owner = _spawn_owner(monkeypatch)
+    monkeypatch.setattr(_process_kill.psutil, "Process", lambda pid: ZombieProcess(pid))
+
+    assert owner._identity_is_alive((101, 123.0)) is False
+
+
+def test_cleanup_completes_when_only_survivor_is_zombie(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A zombie descendant must not land in survivor_pids — cleanup() reports complete."""
+
+    class ZombieProcess:
+        def __init__(self, pid: int, create_time: float) -> None:
+            self.pid = pid
+            self._create_time = create_time
+
+        def create_time(self) -> float:
+            return self._create_time
+
+        def status(self) -> str:
+            return psutil.STATUS_ZOMBIE
+
+    zombie_identity = (99999, 111.0)
+    owner = _spawn_owner(monkeypatch)
+    owner.merge_snapshot(
+        _process_kill.ProcessObservationSnapshot(
+            process_identities=(zombie_identity,), observation_complete=True
+        )
+    )
+    monkeypatch.setattr(owner, "_scan_group", lambda: (zombie_identity,))
+    monkeypatch.setattr(owner, "_signal_group", lambda _signum: None)
+    monkeypatch.setattr(
+        _process_kill.psutil,
+        "Process",
+        lambda pid: ZombieProcess(pid, zombie_identity[1]),
+    )
+    owner.process.returncode = 0
+
+    returncode, result = owner.cleanup(timeout=0.05)
+
+    assert returncode == 0
+    assert result.survivor_pids == ()
+    assert result.complete is True
+
+
+def test_settle_still_raises_on_genuinely_incomplete_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """settle() must keep raising for non-zombie incompleteness — cli/session depends on it."""
+    owner = _spawn_owner(monkeypatch)
+    incomplete_result = _process_kill.ProcessCleanupResult(
+        root_pid=owner.pid,
+        access_denied_pids=(1234,),
+        observation_complete=True,
+    )
+    monkeypatch.setattr(owner, "cleanup", lambda timeout: (0, incomplete_result))
+
+    with pytest.raises(_process_kill.OwnedProcessCleanupError):
+        owner.settle()
+
+
+def test_settle_evidence_returns_without_raising_on_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = _spawn_owner(monkeypatch)
+    incomplete_result = _process_kill.ProcessCleanupResult(
+        root_pid=owner.pid,
+        access_denied_pids=(1234,),
+        observation_complete=True,
+    )
+    monkeypatch.setattr(owner, "cleanup", lambda timeout: (0, incomplete_result))
+
+    with structlog.testing.capture_logs() as logs:
+        returncode, result = owner.settle_evidence()
+
+    assert returncode == 0
+    assert result is incomplete_result
+    assert any(entry.get("event") == "owned_group_cleanup_incomplete" for entry in logs)
+
+
+def test_settle_evidence_returns_none_returncode_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = _spawn_owner(monkeypatch)
+    complete_result = _process_kill.ProcessCleanupResult(
+        root_pid=owner.pid,
+        observation_complete=True,
+    )
+    monkeypatch.setattr(owner, "cleanup", lambda timeout: (None, complete_result))
+
+    with structlog.testing.capture_logs() as logs:
+        returncode, result = owner.settle_evidence()
+
+    assert returncode is None
+    assert result is complete_result
+    entry = next(e for e in logs if e.get("event") == "owned_group_cleanup_incomplete")
+    assert entry.get("returncode_confirmed") is False
+
+
+def test_subprocess_result_carries_cleanup_evidence_field() -> None:
+    from autoskillit.core import SubprocessResult, TerminationReason
+
+    evidence = _process_kill.ProcessCleanupResult(root_pid=101, observation_complete=True)
+
+    result = SubprocessResult(
+        returncode=0,
+        stdout="",
+        stderr="",
+        termination=TerminationReason.NATURAL_EXIT,
+        pid=101,
+        cleanup_evidence=evidence,
+    )
+
+    assert result.cleanup_evidence is evidence

--- a/tests/execution/test_process_kill.py
+++ b/tests/execution/test_process_kill.py
@@ -181,7 +181,16 @@ class TestProcessTreeKill:
             for line in result.stdout.splitlines()
             if '"type": "child_pid"' in line
         )
-        assert not psutil.pid_exists(child_record["pid"])
+        # The cleanup is synchronous within `run_managed_async`, but the assertion
+        # is a point-in-time check against a kernel PID that may briefly outlive
+        # the kill while the kernel reaps it. Poll briefly so the test isn't
+        # sensitive to kernel-scheduling jitter under parallel xdist execution.
+        child_pid = child_record["pid"]
+        for _ in range(50):
+            if not psutil.pid_exists(child_pid):
+                break
+            await anyio.sleep(0.1)
+        assert not psutil.pid_exists(child_pid)
 
 
 class TestKillProcessTreeUnit:

--- a/tests/execution/test_process_submodules.py
+++ b/tests/execution/test_process_submodules.py
@@ -35,7 +35,6 @@ _EXPECTED_PROCESS_SYMBOLS: frozenset[str] = frozenset(
         "_jsonl_last_record_type",
         "_marker_is_standalone",
         "_session_log_monitor",
-        "_wait_process_dead",
         "_watch_heartbeat",
         "_watch_process",
         "_watch_session_log",

--- a/tests/execution/test_session_log_retention.py
+++ b/tests/execution/test_session_log_retention.py
@@ -17,7 +17,7 @@ from autoskillit.core.types._type_results_execution import (
     SessionTelemetry,
 )
 from autoskillit.execution._session_log_recovery import recover_crashed_sessions
-from autoskillit.execution.linux_tracing import read_boot_id, read_starttime_ticks
+from autoskillit.execution.linux_tracing import is_pid_zombie, read_boot_id, read_starttime_ticks
 from autoskillit.execution.session_log import flush_session_log
 from autoskillit.fleet import FLEET_STATE_SCHEMA_VERSION, build_protected_campaign_ids
 from tests.execution.conftest import _flush, _snap
@@ -355,6 +355,57 @@ def test_recover_crashed_sessions_skips_live_pid(tmp_path):
     assert count == 0
     assert trace.exists(), "Trace file for alive PID must not be deleted"
     assert enrollment.exists(), "Enrollment sidecar for alive PID must not be deleted"
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only: uses /proc and boot_id")
+def test_recover_crashed_sessions_recovers_zombie_pid_with_matching_ticks(tmp_path):
+    """A trace file whose enrolled PID is now a zombie with matching starttime_ticks
+    must be recovered — a zombie has already exited and is no longer being monitored
+    by its parent, so the crash trace is not live evidence and must not be skipped."""
+    tmpfs = tmp_path / "shm"
+    tmpfs.mkdir()
+    child_pid = os.fork()
+    if child_pid == 0:
+        os._exit(0)
+    try:
+        starttime_ticks = read_starttime_ticks(child_pid)
+        deadline = time.time() + 2.0
+        while not is_pid_zombie(child_pid) and time.time() < deadline:
+            time.sleep(0.01)
+        assert is_pid_zombie(child_pid)
+
+        trace = tmpfs / f"autoskillit_trace_{child_pid}.jsonl"
+        enrollment = tmpfs / f"autoskillit_enrollment_{child_pid}.json"
+        trace.write_text(
+            json.dumps({"vm_rss_kb": 500, "captured_at": "2026-03-03T10:00:00+00:00"}) + "\n"
+        )
+        enrollment.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "pid": child_pid,
+                    "boot_id": read_boot_id() or "",
+                    "starttime_ticks": starttime_ticks,
+                    "session_id": "",
+                    "enrolled_at": datetime.now(UTC).isoformat(),
+                    "kitchen_id": "",
+                    "order_id": "",
+                }
+            )
+        )
+        os.utime(trace, (time.time() - 60,) * 2)
+
+        count = recover_crashed_sessions(tmpfs_path=str(tmpfs), log_dir=str(tmp_path / "logs"))
+
+        assert count == 1
+        assert not trace.exists(), "Trace file for zombie PID must be recovered and removed"
+        assert not enrollment.exists(), "Enrollment sidecar for zombie PID must be removed"
+        sessions = list((tmp_path / "logs" / "sessions").iterdir())
+        assert len(sessions) == 1
+        summary = json.loads((sessions[0] / "summary.json").read_text())
+        assert summary["termination_reason"] == "CRASHED"
+    finally:
+        os.waitpid(child_pid, 0)
 
 
 def test_recover_crashed_sessions_skips_file_without_enrollment(tmp_path):

--- a/tests/execution/test_session_parsing.py
+++ b/tests/execution/test_session_parsing.py
@@ -626,6 +626,7 @@ class TestSkillResult:
             "audit_cycle_path",
             "audit_attempt_id",
             "infra_exit_category",
+            "infra_cleanup_incomplete",
             "api_retry_count",
             "api_retry_last_error",
             "api_retry_last_status",

--- a/tests/execution/test_termination_executor.py
+++ b/tests/execution/test_termination_executor.py
@@ -223,21 +223,31 @@ async def test_child_deferral_stops_when_children_become_inactive(
 
 
 @pytest.mark.anyio
-async def test_execute_termination_action_returns_result_on_incomplete_cleanup_evidence(
+@pytest.mark.parametrize(
+    ("returncode", "complete", "expected_complete"),
+    [
+        (0, False, False),
+        (None, True, True),
+    ],
+)
+async def test_execute_termination_action_returns_cleanup_without_raising(
     monkeypatch: pytest.MonkeyPatch,
+    returncode: int | None,
+    complete: bool,
+    expected_complete: bool,
 ) -> None:
-    """A general (non-zombie) incomplete-evidence scenario must not raise."""
+    """Both the incomplete-evidence and the leader-unconfirmed paths must not raise."""
     owner = await _spawn(0.05)
     while await anyio.to_thread.run_sync(owner.observe_exit) is None:
         await anyio.sleep(0.01)
-    incomplete_result = ProcessCleanupResult(
+    result = ProcessCleanupResult(
         root_pid=owner.pid,
-        access_denied_pids=(999,),
-        observation_complete=True,
+        access_denied_pids=(999,) if not complete else (),
+        observation_complete=complete,
     )
-    monkeypatch.setattr(owner, "cleanup", lambda timeout: (0, incomplete_result))
+    monkeypatch.setattr(owner, "cleanup", lambda timeout: (returncode, result))
 
-    kill_reason, returncode, cleanup = await execute_termination_action(
+    kill_reason, actual_returncode, cleanup = await execute_termination_action(
         TerminationAction.NO_KILL,
         owner=owner,
         process_exited_event=anyio.Event(),
@@ -247,34 +257,9 @@ async def test_execute_termination_action_returns_result_on_incomplete_cleanup_e
     )
 
     assert kill_reason is KillReason.NATURAL_EXIT
-    assert returncode == 0
-    assert cleanup is incomplete_result
-    assert cleanup.complete is False
-
-
-@pytest.mark.anyio
-async def test_execute_termination_action_returns_none_returncode_without_raising(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The leader-unconfirmed case widens the return type to int | None honestly."""
-    owner = await _spawn(0.05)
-    while await anyio.to_thread.run_sync(owner.observe_exit) is None:
-        await anyio.sleep(0.01)
-    complete_result = ProcessCleanupResult(root_pid=owner.pid, observation_complete=True)
-    monkeypatch.setattr(owner, "cleanup", lambda timeout: (None, complete_result))
-
-    kill_reason, returncode, cleanup = await execute_termination_action(
-        TerminationAction.NO_KILL,
-        owner=owner,
-        process_exited_event=anyio.Event(),
-        grace_seconds=0,
-        proc_log=structlog.get_logger().bind(pid=owner.pid),
-        process_observation_snapshot=owner.snapshot,
-    )
-
-    assert kill_reason is KillReason.NATURAL_EXIT
-    assert returncode is None
-    assert cleanup is complete_result
+    assert actual_returncode == returncode
+    assert cleanup is result
+    assert cleanup.complete is expected_complete
 
 
 def test_run_managed_sync_survives_incomplete_cleanup_evidence(

--- a/tests/execution/test_termination_executor.py
+++ b/tests/execution/test_termination_executor.py
@@ -224,19 +224,20 @@ async def test_child_deferral_stops_when_children_become_inactive(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ("returncode", "complete", "expected_complete"),
+    ("returncode", "complete"),
     [
-        (0, False, False),
-        (None, True, True),
+        (0, False),
+        (None, True),
+        (0, True),
+        (None, False),
     ],
 )
 async def test_execute_termination_action_returns_cleanup_without_raising(
     monkeypatch: pytest.MonkeyPatch,
     returncode: int | None,
     complete: bool,
-    expected_complete: bool,
 ) -> None:
-    """Both the incomplete-evidence and the leader-unconfirmed paths must not raise."""
+    """All (returncode, complete) cross-products must not raise."""
     owner = await _spawn(0.05)
     while await anyio.to_thread.run_sync(owner.observe_exit) is None:
         await anyio.sleep(0.01)
@@ -259,7 +260,7 @@ async def test_execute_termination_action_returns_cleanup_without_raising(
     assert kill_reason is KillReason.NATURAL_EXIT
     assert actual_returncode == returncode
     assert cleanup is result
-    assert cleanup.complete is expected_complete
+    assert cleanup.complete is complete
 
 
 def test_run_managed_sync_survives_incomplete_cleanup_evidence(

--- a/tests/execution/test_termination_executor.py
+++ b/tests/execution/test_termination_executor.py
@@ -3,17 +3,21 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from typing import cast
 
 import anyio
 import pytest
 import structlog
 
-from autoskillit.core import KillReason, TerminationAction
+from autoskillit.core import KillReason, ProcessCleanupResult, TerminationAction
 from autoskillit.execution.process import (
     RaceAccumulator,
+    _process_kill,
     _watch_process,
     execute_termination_action,
+    run_managed_async,
+    run_managed_sync,
     spawn_owned_process,
 )
 
@@ -216,3 +220,104 @@ async def test_child_deferral_stops_when_children_become_inactive(
     assert kill_reason is KillReason.KILL_AFTER_COMPLETION
     assert cleanup.complete is True
     assert clock == [2.0]
+
+
+@pytest.mark.anyio
+async def test_execute_termination_action_returns_result_on_incomplete_cleanup_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A general (non-zombie) incomplete-evidence scenario must not raise."""
+    owner = await _spawn(0.05)
+    while await anyio.to_thread.run_sync(owner.observe_exit) is None:
+        await anyio.sleep(0.01)
+    incomplete_result = ProcessCleanupResult(
+        root_pid=owner.pid,
+        access_denied_pids=(999,),
+        observation_complete=True,
+    )
+    monkeypatch.setattr(owner, "cleanup", lambda timeout: (0, incomplete_result))
+
+    kill_reason, returncode, cleanup = await execute_termination_action(
+        TerminationAction.NO_KILL,
+        owner=owner,
+        process_exited_event=anyio.Event(),
+        grace_seconds=0,
+        proc_log=structlog.get_logger().bind(pid=owner.pid),
+        process_observation_snapshot=owner.snapshot,
+    )
+
+    assert kill_reason is KillReason.NATURAL_EXIT
+    assert returncode == 0
+    assert cleanup is incomplete_result
+    assert cleanup.complete is False
+
+
+@pytest.mark.anyio
+async def test_execute_termination_action_returns_none_returncode_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The leader-unconfirmed case widens the return type to int | None honestly."""
+    owner = await _spawn(0.05)
+    while await anyio.to_thread.run_sync(owner.observe_exit) is None:
+        await anyio.sleep(0.01)
+    complete_result = ProcessCleanupResult(root_pid=owner.pid, observation_complete=True)
+    monkeypatch.setattr(owner, "cleanup", lambda timeout: (None, complete_result))
+
+    kill_reason, returncode, cleanup = await execute_termination_action(
+        TerminationAction.NO_KILL,
+        owner=owner,
+        process_exited_event=anyio.Event(),
+        grace_seconds=0,
+        proc_log=structlog.get_logger().bind(pid=owner.pid),
+        process_observation_snapshot=owner.snapshot,
+    )
+
+    assert kill_reason is KillReason.NATURAL_EXIT
+    assert returncode is None
+    assert cleanup is complete_result
+
+
+def test_run_managed_sync_survives_incomplete_cleanup_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    incomplete_result = ProcessCleanupResult(
+        root_pid=1,
+        access_denied_pids=(999,),
+        observation_complete=True,
+    )
+    monkeypatch.setattr(
+        _process_kill.OwnedProcessGroup,
+        "cleanup",
+        lambda self, timeout: (0, incomplete_result),
+    )
+
+    result = run_managed_sync(
+        [sys.executable, "-c", "print('hi')"],
+        cwd=None,
+        timeout=5.0,
+    )
+
+    assert result.returncode == 0
+    assert result.cleanup_evidence is incomplete_result
+
+
+@pytest.mark.anyio
+async def test_run_managed_async_coalesces_none_returncode_to_sentinel(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A None leader returncode never reaches SubprocessResult.returncode: int."""
+    complete_result = ProcessCleanupResult(root_pid=1, observation_complete=True)
+    monkeypatch.setattr(
+        _process_kill.OwnedProcessGroup,
+        "cleanup",
+        lambda self, timeout: (None, complete_result),
+    )
+
+    result = await run_managed_async(
+        [sys.executable, "-c", "print('hi')"],
+        cwd=tmp_path,
+        timeout=5.0,
+    )
+
+    assert result.returncode == -1
+    assert result.cleanup_evidence is complete_result

--- a/tests/infra/test_mcp_health_advisor.py
+++ b/tests/infra/test_mcp_health_advisor.py
@@ -6,10 +6,12 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
 
+from autoskillit.core import is_pid_zombie
 from autoskillit.core.paths import pkg_root
 
 pytestmark = [pytest.mark.layer("infra"), pytest.mark.medium]
@@ -85,6 +87,38 @@ def test_mcp_health_advisor_dead_pid_injects_message(tmp_path: Path) -> None:
     assert "/MCP" in hook_out.get("message", ""), (
         f"Expected /MCP reconnect hint in message, got: {hook_out}"
     )
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only: uses os.fork and /proc")
+def test_mcp_health_advisor_zombie_pid_injects_message(tmp_path: Path) -> None:
+    """Kitchen entry whose PID is a zombie → treated as dead, message injected."""
+    child_pid = os.fork()
+    if child_pid == 0:
+        os._exit(0)
+    try:
+        deadline = time.time() + 2.0
+        while not is_pid_zombie(child_pid) and time.time() < deadline:
+            time.sleep(0.01)
+        assert is_pid_zombie(child_pid)
+
+        kitchens = [
+            {
+                "kitchen_id": "k-zombie",
+                "pid": child_pid,
+                "project_path": str(tmp_path),
+                "opened_at": "2026-01-01T00:00:00+00:00",
+            }
+        ]
+        returncode, payload = _run_guard(
+            tmp_path, {}, tool_name="Read", kitchens=kitchens, cwd=tmp_path, headless=False
+        )
+        assert returncode == 0
+        hook_out = payload.get("hookSpecificOutput", {})
+        assert "/MCP" in hook_out.get("message", ""), (
+            f"Expected /MCP reconnect hint for zombie PID, got: {hook_out}"
+        )
+    finally:
+        os.waitpid(child_pid, 0)
 
 
 def test_mcp_health_advisor_no_kitchens_silent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`OwnedProcessGroup._identity_is_alive()` (`src/autoskillit/execution/process/_process_kill.py:451-469`) decides whether a tracked descendant PID is "still alive" using only `psutil.Process(pid).create_time() == create_time`. A zombie process (exited, not yet reaped) still has a readable `/proc/pid` entry with an unchanged `create_time()`, so this check reports **True** for a zombie — indistinguishable from a genuinely running process. This false-positive "still alive" reading propagates into `_wait_group_members()` (511-516) and `cleanup()`'s final survivor computation (570-573), making `ProcessCleanupResult.complete` false even when the actual leader process already exited cleanly. `OwnedProcessGroup.settle()` (587-591) then raises `OwnedProcessCleanupError` on this false signal.

## Requirements

1. On natural-exit teardown paths, an incomplete descendant reap must not destroy or suppress an otherwise-successful `SubprocessResult`. Condition on `kill_reason == KillReason.NATURAL_EXIT`, **not** on `action == NO_KILL` — all three sites in `execute_termination_action` (`:251-254`, `:263-266`, `:295`) and the equivalent in `run_managed_sync` (`:837`).
2. The fix must not reintroduce silent success despite incomplete cleanup evidence. #4550's contract is that unenumerated survivors are never reported as clean. A fix that satisfies requirement 1 by simply discarding the evidence recreates the exact defect that contract was built to prevent.

Closes https://github.com/TalonT-Org/AutoSkillit/issues/4641
Closes #4644

## Implementation Plan

Plan file: `/home/talon/projects/worktrees/impl-rectify_owned_process_cleanup_evidence-20260816-230229/.autoskillit/temp/rectify/rectify_owned_process_cleanup_evidence_2026-08-16_215311.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->