### PR TITLE
Rectify: GitHub Mutation Guard Argv Parsing Immunity (Combined Plan)

### DIFF
--- a/docs/safety/hooks.md
+++ b/docs/safety/hooks.md
@@ -513,11 +513,17 @@ as a defense-in-depth measure against privilege escalation:
 | `background_exec_guard.py` | Unrecognized `AUTOSKILLIT_SESSION_TYPE` | Unknown session type should not bypass `run_in_background` prohibition |
 | `github_mutation_guard.py` | Ambiguous or unresolved GitHub mutation command, or unexpected classifier error | Unknown mutation scope must not bypass the structured review publisher |
 | `exploration_request_identity_guard.py` | A supported exploration event lacks bounded native identity or its one-shot record cannot be written | A Claude exploration call must not execute without request-correlated authority |
-| `git_ops_guard.py` | Unexpected runtime error during the checked-out-ref preflight (OSError, subprocess.SubprocessError, TypeError, UnicodeDecodeError, ValueError) | An unhandled exception must not silently allow a checked-out ref mutation — use exit 2 + stderr to hard-block |
+| `git_ops_guard.py` | Unexpected runtime error during the checked-out-ref preflight (OSError, subprocess.SubprocessError, TypeError, UnicodeDecodeError, ValueError); or, in the separate headless destructive-op-blocking preflight, an unrecognized global git flag that leaves the real subcommand unresolved | An unhandled exception must not silently allow a checked-out ref mutation — use exit 2 + stderr to hard-block. Separately, `_contains_blocked_git_op` cannot match `_BLOCKED_GIT_OPS`'s literal subcommand tuples against an unresolved subcommand, so it denies unconditionally the moment `extract_git_subcommand_and_flags` reports `"<unresolved>"`, rather than silently falling through to "not blocked" |
 | `pr_create_guard.py` | Hook config unreadable or malformed while the kitchen is open (OSError, JSONDecodeError, AttributeError, TypeError) | An unresolvable `recipe_allows_pr_create` authorization must not be read as permission to bypass the prepare_pr → compose_pr pipeline |
+| `unsafe_install_guard.py` | An unrecognized global pip flag leaves `pip`'s `install` token position unresolved | `_find_pip_install` cannot tell whether the command is a pip install at all; treating that the same as "definitely not an install" would silently skip the editable/system-install checks entirely, so it is threaded through as a distinct `"unresolved-pip-flags"` kind and denied unconditionally, matching the pre-existing `"unresolved-subprocess"` kind's treatment |
 
 **Design principle:** Garbage-in (malformed hook input) = fail-open. Unknown-tier
-(valid input, unrecognized value) = fail-closed.
+(valid input, unrecognized value) = fail-closed. Before adding a fail-closed
+sentinel for an unresolved case, check what the guard's own consumer does with
+an empty/ambiguous result — if the consumer already treats empty-or-`None` as
+allow (e.g. `write_guard.py`'s `if not targets: sys.exit(0)`), a bolted-on
+sentinel does not fail closed, it silently produces an allow; fix the parse so
+the case resolves correctly instead.
 
 All remaining guards (`fleet_dispatch_guard.py`, `quota_guard.py`,
 `mcp_health_advisor.py`, `branch_protection_guard.py`, etc.) fail-open in every
@@ -549,6 +555,28 @@ Every deny routes through one of seven machine-readable triggers
 | `classifier_internal_error` | The classifier failed unexpectedly. This is distinct from expected uncertainty and exposes no exception detail. |
 | `multiple_mutations` | The command issues more than one GitHub mutation request. |
 | `review_mutation` | The command is a raw pull-request review publication. |
+
+`unresolved_mutation` is a family of classifier-internal reason codes, not a single
+condition; two examples surfaced by `_github_mutation_analysis.py`'s `gh api` parser are
+`request_cardinality_unresolved` (more than one candidate route/request was found, e.g.
+multiple positional routes or `--paginate` on a write method) and
+`unrecognized_gh_api_flag` (a `-`-prefixed token absent from the `gh api` flag-arity spec
+table `_GH_API_FLAG_SPEC` — an unrecognized flag fails closed with its own distinguishable
+reason rather than being silently misparsed as a second route).
+
+A third example, `dynamic_target`, is where the classifier proves a value could have been
+shell-expanded before `gh`/`curl` saw it (an unquoted `$`, backtick, `*`, `?`, or `[` in the
+already-dequoted argv token). A value is exempted from this check only when it is provably
+inert by one of two independent routes: **file-content provenance** (the value was read from
+a `--input` file via `_load_literal_github_input`, not shell-parsed argv at all) or
+**full-single-quote provenance** (the value's entire source span in the raw command sat
+inside one unbroken `'...'` single-quote run, provable independent of which characters it
+contains — see `ArgvToken` in `_command_classification.py` and `_is_dynamic_shell_value` in
+`_github_mutation_analysis.py`).
+Neither route weakens the other; a GraphQL document delivered inline via `-f query='...'`
+(fully single-quoted) and one delivered via `--input query.json` (file content) are both
+exempt for different, independently-sufficient reasons, while the identical document
+delivered unquoted or double-quoted remains denied.
 
 The guard is registered globally with `session_scope="any"` and permits only exactly one
 proven non-review mutation. Both expected classifier uncertainty and unexpected internal

--- a/src/autoskillit/core/bash_write_targets.py
+++ b/src/autoskillit/core/bash_write_targets.py
@@ -55,7 +55,16 @@ _WRITE_VERBS: frozenset[str] = frozenset(
     }
 )
 
-_GIT_FLAG_WITH_VALUE: frozenset[str] = frozenset({"-C", "--git-dir", "--work-tree", "-c"})
+# Every value-taking git global flag, mirroring _command_classification.py's
+# _GIT_GLOBAL_FLAG_SPEC (source of truth; kept in sync manually -- this
+# module is an independent re-implementation for IL-0 import, see the
+# module docstring). A flag missing here is misread by the loop below as a
+# 1-token boolean skip, so its value gets mistaken for the git subcommand --
+# e.g. `git --namespace refs/foo checkout -- file` previously stopped the
+# loop at `refs/foo`, never reaching `checkout`.
+_GIT_FLAG_WITH_VALUE: frozenset[str] = frozenset(
+    {"-C", "--git-dir", "--work-tree", "-c", "--namespace", "--config-env"}
+)
 
 _COMMAND_WRAPPERS: frozenset[str] = frozenset({"command", "nice", "time", "sudo", "nohup"})
 _WRAPPERS_WITH_DURATION: frozenset[str] = frozenset({"timeout"})

--- a/src/autoskillit/hook_registry.py
+++ b/src/autoskillit/hook_registry.py
@@ -625,6 +625,7 @@ FAIL_CLOSED_GUARD_BASENAMES: frozenset[str] = frozenset(
         "exploration_request_identity_guard.py",
         "git_ops_guard.py",
         "pr_create_guard.py",
+        "unsafe_install_guard.py",
     }
 )
 

--- a/src/autoskillit/hooks/_command_classification.py
+++ b/src/autoskillit/hooks/_command_classification.py
@@ -8,12 +8,14 @@ _INTERPRETER_LINE_RE.
 from __future__ import annotations
 
 import ast
+import io
 import os
 import re
 import shlex
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Protocol
+from enum import StrEnum, auto
+from typing import Protocol, cast
 
 _INTERPRETER_RE = re.compile(
     r"(?:^|&&|\|\||;)\s*(?:env\s+)?(?:python3?|perl|ruby|node)\s+"
@@ -50,6 +52,12 @@ _WRITE_CALL_SITE_RE = re.compile(
 # Parentheses are tracked by the lexer as fused tokens (`(cmd` or `cmd)`)
 # and handled separately in extract_redirect_targets.
 _SHELL_OPERATORS: frozenset[str] = frozenset({"&&", "||", ";", "|", "&"})
+# Single-character shell operators that shlex.shlex(punctuation_chars=True)
+# leaves sitting inside the previous token's source range. Used as the
+# trailing-strip set for tokenizer span capture so a token followed
+# immediately by an operator (no separating whitespace) does not appear to
+# contain that operator in its raw_span.
+_SHELL_OPERATOR_CHARS: str = ";|&"
 
 # Boundary-adjacency operator set for guards that scan raw shlex.split token
 # streams (pr_create, git_ops, planner_gh_discovery, artifact_download,
@@ -283,9 +291,38 @@ def _normalize_newlines_for_tokenize(command: str) -> str:
 
 
 @dataclass(frozen=True, slots=True)
+class ArgvToken:
+    """One argv token plus whether it was provably shell-inert.
+
+    `fully_single_quoted` is True only when the token's entire source span in
+    the shell command sat inside one unbroken `'...'` run -- nothing else
+    (unquoted text, a second quote group) contributed to it. A substring of
+    a token that was fully single-quoted end-to-end is itself still fully
+    single-quoted (the quotes bounded the whole token, not part of it), so
+    callers that slice `.text` (e.g. an `=`-form or bundled-short flag
+    value) inherit provenance unchanged rather than re-deriving it.
+
+    `raw_span` is the token's own rstripped source span in the shell command
+    (e.g. `"'value'"` for a single-quoted token) -- kept alongside the
+    coarser whole-token `fully_single_quoted` so a caller splitting `.text`
+    on a *bareword* boundary it independently knows about (e.g. gh's
+    `key=value` field syntax, where `key` is never itself quoted) can
+    re-derive the finer-grained provenance of the part *after* that
+    boundary, rather than inheriting the whole token's flag: a `key=` prefix
+    sitting outside any quotes does not disqualify a separately-quoted
+    value (see `_argv_token_value_after_key`).
+    """
+
+    text: str
+    fully_single_quoted: bool
+    raw_span: str
+
+
+@dataclass(frozen=True, slots=True)
 class _CommandSegment:
     tokens: list[str]
     redirect_syntax: list[bool]
+    argv_tokens: list[ArgvToken]
 
 
 def _mark_unquoted_output_redirects(command: str) -> tuple[str, dict[str, str]]:
@@ -371,25 +408,62 @@ def _tokenize_command_segments_with_redirects(command: str) -> list[_CommandSegm
             punctuation_chars=";&|",
         )
         lexer.whitespace_split = True
-        tokens = list(lexer)
+        # Drive the lexer token-by-token (rather than `list(lexer)`) so each
+        # token's own source span in *marked* can be read via instream.tell().
+        # The span must be exactly the characters this lexer itself consumed
+        # to produce the token, so comparing it against `'<token>'` tells us
+        # whether the token was one unbroken single-quote run with nothing
+        # else contributing, independent of shlex's own dequoting.
+        #
+        # With punctuation_chars=True, shlex does not consume operator
+        # characters (`;|&`) as their own tokens until the next call -- it
+        # leaves them sitting in the previous token's source range, so a
+        # naive `marked[start:end]` slice captures e.g. `'foo'` followed by
+        # an unseparated `;` as the single-quote token's span. Strip the
+        # trailing operator chars to recover the real span; this is the
+        # only place that knows about punctuation_chars' bundling quirk,
+        # so it lives here rather than at every consumer. shlex.shlex(str)
+        # always wraps a str instream in io.StringIO; the stub's Protocol
+        # just doesn't declare .tell().
+        instream = cast(io.StringIO, lexer.instream)
+        tokens: list[str] = []
+        fully_single_quoted: list[bool] = []
+        raw_spans: list[str] = []
+        while True:
+            start = instream.tell()
+            token = lexer.get_token()
+            if token is None:
+                break
+            span = marked[start : instream.tell()].rstrip(_SHELL_OPERATOR_CHARS)
+            tokens.append(token)
+            fully_single_quoted.append(span == f"'{token}'")
+            raw_spans.append(span)
     except (ValueError, TypeError):
         return []
 
     segments: list[_CommandSegment] = []
     current_tokens: list[str] = []
     current_redirect_syntax: list[bool] = []
-    for token in tokens:
+    current_argv_tokens: list[ArgvToken] = []
+    for token, quoted, raw_span in zip(tokens, fully_single_quoted, raw_spans, strict=True):
         if token in _SHELL_OPERATORS:
             if current_tokens:
-                segments.append(_CommandSegment(current_tokens, current_redirect_syntax))
+                segments.append(
+                    _CommandSegment(current_tokens, current_redirect_syntax, current_argv_tokens)
+                )
                 current_tokens = []
                 current_redirect_syntax = []
+                current_argv_tokens = []
         else:
             redirect = redirects.get(token)
-            current_tokens.append(redirect if redirect is not None else token)
+            restored = redirect if redirect is not None else token
+            current_tokens.append(restored)
             current_redirect_syntax.append(redirect is not None)
+            current_argv_tokens.append(ArgvToken(restored, quoted, raw_span))
     if current_tokens:
-        segments.append(_CommandSegment(current_tokens, current_redirect_syntax))
+        segments.append(
+            _CommandSegment(current_tokens, current_redirect_syntax, current_argv_tokens)
+        )
     return segments
 
 
@@ -398,15 +472,20 @@ def tokenize_command_segments(command: str) -> list[list[str]]:
     return [segment.tokens for segment in _tokenize_command_segments_with_redirects(command)]
 
 
-def _partition_output_redirects(
+def _partition_output_redirect_indices(
     tokens: Sequence[str],
     *,
     cwd: str,
     redirect_syntax: Sequence[bool] | None = None,
-) -> tuple[list[str], list[str], int]:
-    """Separate depth-zero output control from executable argv."""
+) -> tuple[list[int], list[str], int]:
+    """Core of _partition_output_redirects: which *tokens* indices are executable argv.
+
+    Shared so a caller threading a second, index-aligned parallel array (e.g.
+    ArgvToken quote provenance) can project it onto the same partitioning
+    decision without re-deriving the redirect-syntax logic independently.
+    """
     syntax = redirect_syntax if redirect_syntax is not None else [True] * len(tokens)
-    executable: list[str] = []
+    executable_indices: list[int] = []
     targets: list[str] = []
     file_redirect_count = 0
     depth = 0
@@ -417,23 +496,23 @@ def _partition_output_redirects(
             depth += 1
             if token.endswith(")") and len(token) > 1:
                 depth -= 1
-            executable.append(token)
+            executable_indices.append(i)
             i += 1
             continue
         if token == ")":
             if depth > 0:
                 depth -= 1
-            executable.append(token)
+            executable_indices.append(i)
             i += 1
             continue
         if token.endswith(")") and len(token) > 1:
             if depth > 0:
                 depth -= 1
-            executable.append(token)
+            executable_indices.append(i)
             i += 1
             continue
         if depth > 0 or not syntax[i]:
-            executable.append(token)
+            executable_indices.append(i)
             i += 1
             continue
         if _FD_DUPLICATION_RE.fullmatch(token):
@@ -457,7 +536,7 @@ def _partition_output_redirects(
         else:
             match = _REDIRECT_TOKEN_RE.fullmatch(token)
             if match is None:
-                executable.append(token)
+                executable_indices.append(i)
                 i += 1
                 continue
             file_redirect_count += 1
@@ -470,7 +549,39 @@ def _partition_output_redirects(
             resolved = resolve_write_target(target, cwd)
             if resolved is not None:
                 targets.append(resolved)
-    return (executable, targets, file_redirect_count)
+    return (executable_indices, targets, file_redirect_count)
+
+
+def _partition_output_redirects(
+    tokens: Sequence[str],
+    *,
+    cwd: str,
+    redirect_syntax: Sequence[bool] | None = None,
+) -> tuple[list[str], list[str], int]:
+    """Separate depth-zero output control from executable argv."""
+    executable_indices, targets, file_redirect_count = _partition_output_redirect_indices(
+        tokens, cwd=cwd, redirect_syntax=redirect_syntax
+    )
+    return ([tokens[i] for i in executable_indices], targets, file_redirect_count)
+
+
+def _select_executable_argv_tokens(
+    tokens: Sequence[str],
+    argv_tokens: Sequence[ArgvToken],
+    *,
+    cwd: str,
+    redirect_syntax: Sequence[bool] | None = None,
+) -> list[ArgvToken]:
+    """Project *argv_tokens* onto the same indices _partition_output_redirects
+
+    keeps as executable argv -- for callers threading ArgvToken quote
+    provenance through the same redirect-partitioning decision that
+    _partition_output_redirects already makes from *tokens* alone.
+    """
+    executable_indices, _targets, _count = _partition_output_redirect_indices(
+        tokens, cwd=cwd, redirect_syntax=redirect_syntax
+    )
+    return [argv_tokens[i] for i in executable_indices]
 
 
 def extract_redirect_targets(tokens: list[str], cwd: str = "") -> list[str]:
@@ -586,15 +697,20 @@ def _command_start_index(segment: list[str]) -> int | None:
     return start if start < len(segment) else None
 
 
-def command_verb_and_args(segment: list[str]) -> tuple[str, list[str]]:
-    """Return (verb, args) for *segment*, skipping env/wrappers/assignments.
+def _verb_start_index(segment: list[str]) -> int | None:
+    """Return the index of the command verb in *segment*, skipping shell
 
-    The verb is the raw executable token; args are the tokens after it. If
-    the segment ends inside a wrapper or a required wrapper value is
-    absent, returns ("", []).
+    keywords (do/then/elif/else), POSIX assignments, `env`, and wrapper
+    prefixes (sudo/nice/timeout/...). Returns None when the segment is
+    empty or ends inside a wrapper (missing a required value) -- the same
+    cases command_verb_and_args reports as ("", []). Exposed separately so
+    a caller threading a second, index-aligned parallel array (e.g.
+    ArgvToken quote provenance) can slice it at the same start point
+    command_verb_and_args computes for *segment* itself, rather than
+    re-deriving that decision independently.
     """
     if not segment:
-        return ("", [])
+        return None
     start = 0
     while start < len(segment):
         token = segment[start]
@@ -607,7 +723,7 @@ def command_verb_and_args(segment: list[str]) -> tuple[str, list[str]]:
         if token == "env":
             new_start = _consume_env(start + 1, segment)
             if new_start <= start:
-                return ("", [])
+                return None
             start = new_start
             continue
         if token in _COMMAND_WRAPPERS:
@@ -621,18 +737,29 @@ def command_verb_and_args(segment: list[str]) -> tuple[str, list[str]]:
             continue
         if token in _WRAPPERS_WITH_DURATION:
             if start + 1 >= len(segment):
-                return ("", [])
+                return None
             start += 2
             continue
         if token in _WRAPPERS_WITH_SHORT_FLAG:
             if start + 1 >= len(segment):
-                return ("", [])
+                return None
             if not segment[start + 1].startswith("-"):
-                return ("", [])
+                return None
             start += 2
             continue
         break
-    if start >= len(segment):
+    return start if start < len(segment) else None
+
+
+def command_verb_and_args(segment: list[str]) -> tuple[str, list[str]]:
+    """Return (verb, args) for *segment*, skipping env/wrappers/assignments.
+
+    The verb is the raw executable token; args are the tokens after it. If
+    the segment ends inside a wrapper or a required wrapper value is
+    absent, returns ("", []).
+    """
+    start = _verb_start_index(segment)
+    if start is None:
         return ("", [])
     return (segment[start], segment[start + 1 :])
 
@@ -668,6 +795,15 @@ def extract_git_subcommand_and_flags(
     Skips global git flags (and their value tokens) to find the subcommand,
     then returns (subcommand, remaining_tokens). Returns None if the segment
     is not a git command or has no subcommand.
+
+    Returns ("<unresolved>", []) when an unrecognized `-`-prefixed global
+    flag is encountered before the subcommand -- distinguishable from None
+    (not a git command, or the segment ends before a subcommand appears),
+    since this function's three callers treat the two differently: an
+    unrecognized flag means the real subcommand could not be found (fail
+    closed, ambiguous), not "there is no git subcommand here" (already
+    safe). See is_allowed_protected_path_metadata_command and
+    git_ops_guard.py's _classify_git_segment/_contains_blocked_git_op.
     """
     start = _command_start_index(segment)
     if start is None:
@@ -678,20 +814,234 @@ def extract_git_subcommand_and_flags(
     i = start + 1
     while i < len(segment):
         token = segment[i]
-        if token in _GIT_GLOBAL_FLAGS_WITH_VALUE:
-            i += 2  # skip flag and its value
-            continue
-        if token in _GIT_GLOBAL_FLAGS:
-            i += 1
-            continue
         if token.startswith("-"):
-            i += 1
+            _, next_i, recognized = _consume_str_flag(segment, i, _GIT_GLOBAL_FLAG_SPEC)
+            if not recognized:
+                return ("<unresolved>", [])
+            i = next_i
             continue
         # First non-flag token is the subcommand
         subcommand = token
         remaining = segment[i + 1 :]
         return (subcommand, remaining)
     return None
+
+
+class _FlagArity(StrEnum):
+    """Per-flag arity classification used by every {flag: arity} spec table.
+
+    BOOLEAN — the flag takes no value; the next token is its own argument.
+    VALUE — the flag takes exactly one value in the next token (or joined via
+    `=` for long forms, or glued onto a short form like -XPOST).
+
+    A StrEnum, not a plain Enum: this module is loaded under two different
+    names in the same process (the dotted `autoskillit.hooks.
+    _command_classification` package import, and the bare-name
+    `_command_classification` sys.path import _github_mutation_analysis.py's
+    module-scope cross-import uses -- see that module's docstring). The two
+    loads produce two distinct `_FlagArity` class objects, so an `is`
+    comparison between a value sourced from one and `_FlagArity.VALUE`
+    sourced from the other silently fails even though both represent the
+    same arity. StrEnum members compare equal by their underlying str value
+    across class identities (`A.VALUE == B.VALUE` is True even when `A is
+    not B`), so every comparison against `_FlagArity.VALUE`/`.BOOLEAN`
+    anywhere in the codebase must use `==`, never `is`.
+    """
+
+    BOOLEAN = auto()
+    VALUE = auto()
+
+
+def _argv_token_after_prefix(token: ArgvToken, prefix: str, value_text: str) -> ArgvToken:
+    """Return an ArgvToken for *value_text*, a known suffix of `token.text`
+
+    after a literal *prefix* the caller already knows (a flag name like
+    `--method=`/`-X`, or a gh field's `key=` bareword), with correctly
+    re-derived provenance rather than inheriting the whole token's coarser
+    `fully_single_quoted` flag: a *prefix* sitting outside any quotes does
+    not disqualify a separately-quoted value that follows it (e.g. the
+    common `-f query='...'` or `--jq='.id'` shapes). If the whole token is
+    already provably inert (fully_single_quoted, or an argv-payload/literal
+    token that never passed through shell parsing at all), the value
+    trivially inherits that. Otherwise, re-derive from the value's own raw
+    span directly: this can only ever *undershoot* (return False when the
+    value actually was safely quoted, in unusual prefix-quoting edge cases)
+    since a True result requires the exact bytes `'<value_text>'` to appear
+    literally in the raw command -- only possible if that span really was
+    one unbroken single-quote run, regardless of where *prefix* was assumed
+    to end.
+    """
+    if token.fully_single_quoted:
+        return ArgvToken(value_text, True, token.raw_span)
+    value_raw_span = token.raw_span[len(prefix) :].rstrip()
+    return ArgvToken(value_text, value_raw_span == f"'{value_text}'", value_raw_span)
+
+
+def _argv_token_value_after_key(token: ArgvToken, key: str) -> ArgvToken:
+    """Split `token.text` on its first '=' (with `key` already known to be
+
+    the part before it, e.g. from `token.text.partition("=")`) -- gh's
+    `-f`/`-F key=value` field syntax, where `key` is a bareword the caller
+    already knows. See `_argv_token_after_prefix` for the provenance rule.
+    """
+    _, _, value_text = token.text.partition("=")
+    return _argv_token_after_prefix(token, f"{key}=", value_text)
+
+
+def _consume_argv_flag(
+    tokens: Sequence[ArgvToken], i: int, spec: Mapping[str, _FlagArity]
+) -> tuple[ArgvToken | None, int, bool]:
+    """Consume the flag at tokens[i] against *spec*.
+
+    Returns (value_or_None, next_index, recognized). Handles the same three
+    forms _flag_value already supports for a single named flag -- space
+    (`--flag value`), `=`-joined long form (`--flag=value`), and bundled
+    short form (`-Xvalue`) -- but spec-driven across every flag in *spec* at
+    once, and CLI-agnostic: any consumer with its own {flag: arity} spec
+    table (gh api, curl, git's global flags, pip's global flags) shares this
+    one engine rather than hand-rolling its own argv-walking loop. If the
+    token at i is not '-'-prefixed, or not in spec (in any of its
+    recognized forms), recognized=False and next_index==i -- the caller
+    decides how to handle an unresolved token.
+    """
+    token = tokens[i]
+    if not token.text.startswith("-"):
+        return (None, i, False)
+
+    arity = spec.get(token.text)
+    if arity == _FlagArity.BOOLEAN:
+        return (None, i + 1, True)
+    if arity == _FlagArity.VALUE:
+        if i + 1 >= len(tokens):
+            return (None, i + 1, True)
+        return (tokens[i + 1], i + 2, True)
+
+    if token.text.startswith("--") and "=" in token.text:
+        long_flag, _, value = token.text.partition("=")
+        if spec.get(long_flag) == _FlagArity.VALUE:
+            return (
+                _argv_token_after_prefix(token, f"{long_flag}=", value),
+                i + 1,
+                True,
+            )
+
+    for flag, flag_arity in spec.items():
+        if (
+            flag_arity == _FlagArity.VALUE
+            and len(flag) == 2
+            and not flag.startswith("--")
+            and token.text.startswith(flag)
+            and token.text != flag
+        ):
+            value_text = token.text[len(flag) :]
+            return (
+                _argv_token_after_prefix(token, flag, value_text),
+                i + 1,
+                True,
+            )
+
+    return (None, i, False)
+
+
+def _consume_str_flag(
+    tokens: Sequence[str], i: int, spec: Mapping[str, _FlagArity]
+) -> tuple[str | None, int, bool]:
+    """String-only convenience wrapper around _consume_argv_flag for consumers
+
+    (git global-flag skipping, curl's non-dynamic-value-checked flags, pip's
+    global flags) that only need flag recognition/arity to correctly skip
+    past a flag (and its value, if any) -- not ArgvToken's quote-provenance
+    tracking, since these values never feed a dynamic-value check. Delegates
+    the actual algorithm entirely to _consume_argv_flag rather than
+    re-implementing it for plain strings.
+    """
+    argv_tokens = [ArgvToken(t, False, t) for t in tokens]
+    value, next_i, recognized = _consume_argv_flag(argv_tokens, i, spec)
+    return (value.text if value is not None else None, next_i, recognized)
+
+
+# Complete git global-flag allowlist, verified against a live `git --help`
+# read (its usage synopsis is git's own authoritative, exhaustive list of
+# top-level global options: `git [-v | --version] [-h | --help] [-C <path>]
+# [-c <name>=<value>] [--exec-path[=<path>]] [--html-path] [--man-path]
+# [--info-path] [-p | --paginate | -P | --no-pager] [--no-replace-objects]
+# [--bare] [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]
+# [--config-env=<name>=<envvar>] <command> [<args>]`). Sourced from
+# _GIT_GLOBAL_FLAGS/_GIT_GLOBAL_FLAGS_WITH_VALUE above rather than
+# re-entering their members with a possibly-conflicting arity: 4 of
+# _GIT_GLOBAL_FLAGS's 6 members duplicate _GIT_GLOBAL_FLAGS_WITH_VALUE's
+# value-taking flags -- only --no-pager/--bare are genuinely boolean.
+_GIT_GLOBAL_FLAG_SPEC: Mapping[str, _FlagArity] = {
+    **{flag: _FlagArity.VALUE for flag in _GIT_GLOBAL_FLAGS_WITH_VALUE},
+    **{flag: _FlagArity.BOOLEAN for flag in (_GIT_GLOBAL_FLAGS - _GIT_GLOBAL_FLAGS_WITH_VALUE)},
+    "--namespace": _FlagArity.VALUE,
+    "--config-env": _FlagArity.VALUE,
+    # --exec-path[=<path>] is optional-value (usable bare, or with `=`); this
+    # module's binary arity model can't express "optional". BOOLEAN is the
+    # correct default for its common bare usage; the rare `=`-form
+    # invocation instead fails closed via the unrecognized-flag sentinel
+    # rather than being silently misparsed -- an acceptable trade-off for a
+    # flag that in practice is essentially never used in automation.
+    "--exec-path": _FlagArity.BOOLEAN,
+    "--html-path": _FlagArity.BOOLEAN,
+    "--man-path": _FlagArity.BOOLEAN,
+    "--info-path": _FlagArity.BOOLEAN,
+    "-p": _FlagArity.BOOLEAN,
+    "--paginate": _FlagArity.BOOLEAN,
+    "-P": _FlagArity.BOOLEAN,
+    "--no-replace-objects": _FlagArity.BOOLEAN,
+    "-v": _FlagArity.BOOLEAN,
+    "--version": _FlagArity.BOOLEAN,
+    "-h": _FlagArity.BOOLEAN,
+    "--help": _FlagArity.BOOLEAN,
+}
+
+# pip global-flag spec (flags accepted before the `install` subcommand),
+# verified against a live `pip --help` read. Covers the flags named by this
+# rectify's investigation (--index-url, --proxy, --retries, --timeout,
+# --cache-dir, --log) plus the pre-existing -r/-c/-t/-b/--requirement/
+# --constraint set _find_pip_install already recognized, plus pip's other
+# common general options, to correctly skip past a global flag (and its
+# value) to find the `install` token. Exposed for unsafe_install_guard.py
+# to import (see _find_pip_install).
+_PIP_GLOBAL_FLAG_SPEC: Mapping[str, _FlagArity] = {
+    "-r": _FlagArity.VALUE,
+    "--requirement": _FlagArity.VALUE,
+    "-c": _FlagArity.VALUE,
+    "--constraint": _FlagArity.VALUE,
+    "-t": _FlagArity.VALUE,
+    "-b": _FlagArity.VALUE,
+    "--index-url": _FlagArity.VALUE,
+    "--proxy": _FlagArity.VALUE,
+    "--retries": _FlagArity.VALUE,
+    "--timeout": _FlagArity.VALUE,
+    "--cache-dir": _FlagArity.VALUE,
+    "--log": _FlagArity.VALUE,
+    "--python": _FlagArity.VALUE,
+    "--keyring-provider": _FlagArity.VALUE,
+    "--exists-action": _FlagArity.VALUE,
+    "--trusted-host": _FlagArity.VALUE,
+    "--cert": _FlagArity.VALUE,
+    "--client-cert": _FlagArity.VALUE,
+    "--use-feature": _FlagArity.VALUE,
+    "--use-deprecated": _FlagArity.VALUE,
+    "--resume-retries": _FlagArity.VALUE,
+    "-h": _FlagArity.BOOLEAN,
+    "--help": _FlagArity.BOOLEAN,
+    "--debug": _FlagArity.BOOLEAN,
+    "--isolated": _FlagArity.BOOLEAN,
+    "--require-virtualenv": _FlagArity.BOOLEAN,
+    "-v": _FlagArity.BOOLEAN,
+    "--verbose": _FlagArity.BOOLEAN,
+    "-V": _FlagArity.BOOLEAN,
+    "--version": _FlagArity.BOOLEAN,
+    "-q": _FlagArity.BOOLEAN,
+    "--quiet": _FlagArity.BOOLEAN,
+    "--no-input": _FlagArity.BOOLEAN,
+    "--no-cache-dir": _FlagArity.BOOLEAN,
+    "--disable-pip-version-check": _FlagArity.BOOLEAN,
+    "--no-color": _FlagArity.BOOLEAN,
+}
 
 
 def _is_allowed_wc_flag(token: str) -> bool:

--- a/src/autoskillit/hooks/_github_mutation_analysis.py
+++ b/src/autoskillit/hooks/_github_mutation_analysis.py
@@ -3,12 +3,24 @@
 This module is the consumer of command-segment helpers defined in
 _command_classification (verb extraction, tokenizer, executable
 normalization, redirect partitioning, interpreter-spec extraction, and
-two shell-payload helpers). Each helper is imported lazily inside a thin
+two shell-payload helpers). Most of these are imported lazily inside a thin
 wrapper to defer imports past the module-load boundary — the bare-name
 _command_classification reference resolves once the sibling module is
 fully populated. The bare-name form is also required to satisfy the
 hook-script stdlib-only contract enforced by test_hooks_are_stdlib_only
 (REQ-AST-001).
+
+The quote-provenance/flag-arity primitives this module's own gh-api/curl
+analysis needs (ArgvToken, _FlagArity, _consume_argv_flag, and their
+helpers) are imported once at module scope instead, using the same
+TYPE_CHECKING/bare-name split hooks/guards/github_mutation_guard.py already
+uses for its own cross-hooks-file import of this module: they are used
+pervasively as type annotations and constructors throughout this file
+(every _analyze_gh_api/_analyze_curl_segment call site, the GraphQL
+provenance wrapping), so threading them through a per-call lazy wrapper —
+workable for the handful of simple delegating calls above — would not
+scale, and a plain sibling-module bare-name import carries no runtime cost
+either style of import doesn't already pay.
 """
 
 from __future__ import annotations
@@ -17,11 +29,32 @@ import json
 import os
 import re
 import stat
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
+
+if TYPE_CHECKING:
+    from autoskillit.hooks._command_classification import (
+        ArgvToken,
+        _argv_token_after_prefix,
+        _argv_token_value_after_key,
+        _consume_argv_flag,
+        _FlagArity,
+        _select_executable_argv_tokens,
+        _verb_start_index,
+    )
+else:
+    from _command_classification import (  # noqa: E402
+        ArgvToken,
+        _argv_token_after_prefix,
+        _argv_token_value_after_key,
+        _consume_argv_flag,
+        _FlagArity,
+        _select_executable_argv_tokens,
+        _verb_start_index,
+    )
 
 
 def _command_verb_and_args(segment: Sequence[str]) -> tuple[str, list[str]]:
@@ -241,8 +274,14 @@ def _unresolved_github_analysis(
     )
 
 
-def _is_dynamic_shell_value(value: str) -> bool:
-    return bool(_DYNAMIC_SHELL_TOKEN_RE.search(value))
+def _is_dynamic_shell_value(token: ArgvToken) -> bool:
+    """A token is dynamic unless it was fully single-quoted end-to-end --
+
+    a fact provable from the raw command text independent of which
+    characters the (already-dequoted) token contains -- or its content is
+    otherwise proven inert by its own provenance (see ArgvToken).
+    """
+    return not token.fully_single_quoted and bool(_DYNAMIC_SHELL_TOKEN_RE.search(token.text))
 
 
 def _normalize_github_route(route: str) -> str:
@@ -281,16 +320,16 @@ def _json_object_without_duplicate_keys(raw: bytes) -> dict[str, Any]:
 
 
 def _load_literal_github_input(
-    value: str,
+    value: ArgvToken,
     *,
     cwd: str,
 ) -> tuple[dict[str, Any] | None, str, str]:
-    if value == "-":
+    if value.text == "-":
         return (None, "unsafe_input_provenance", "GitHub --input stdin is unresolved")
-    if not value or _is_dynamic_shell_value(value):
+    if not value.text or _is_dynamic_shell_value(value):
         return (None, "dynamic_target", "GitHub --input path is dynamic")
-    if os.path.isabs(value):
-        path = os.path.normpath(value)
+    if os.path.isabs(value.text):
+        path = os.path.normpath(value.text)
     else:
         if not cwd or not os.path.isabs(cwd):
             return (
@@ -298,7 +337,7 @@ def _load_literal_github_input(
                 "cwd_unresolved",
                 "relative GitHub --input requires an absolute cwd",
             )
-        path = os.path.normpath(os.path.join(cwd, value))
+        path = os.path.normpath(os.path.join(cwd, value.text))
 
     try:
         before = os.lstat(path)
@@ -381,36 +420,89 @@ def _comment_count_from_payload(payload: dict[str, Any]) -> tuple[int | None, st
 
 
 def _flag_value(
-    args: Sequence[str],
+    args: Sequence[ArgvToken],
     index: int,
     *,
     long_name: str,
     short_name: str | None = None,
-) -> tuple[str | None, int, bool]:
+) -> tuple[ArgvToken | None, int, bool]:
     token = args[index]
-    if token == long_name or (short_name is not None and token == short_name):
+    if token.text == long_name or (short_name is not None and token.text == short_name):
         if index + 1 >= len(args):
             return (None, index + 1, False)
+        # Space-form: the value is the next token in full -- return its own
+        # ArgvToken unmodified, full provenance already correct.
         return (args[index + 1], index + 2, True)
-    if token.startswith(f"{long_name}="):
-        return (token.split("=", 1)[1], index + 1, True)
-    if short_name and token.startswith(short_name) and token != short_name:
-        return (token[len(short_name) :], index + 1, True)
+    if token.text.startswith(f"{long_name}="):
+        # `=`-form: the value is a substring of this token, after the known
+        # `long_name=` prefix -- see _argv_token_after_prefix for how
+        # provenance is re-derived rather than inherited wholesale (a
+        # `--flag=` prefix outside any quotes does not disqualify a
+        # separately-quoted value, e.g. `--jq='.id'`).
+        value_text = token.text.split("=", 1)[1]
+        return (
+            _argv_token_after_prefix(token, f"{long_name}=", value_text),
+            index + 1,
+            True,
+        )
+    if short_name and token.text.startswith(short_name) and token.text != short_name:
+        # Bundled-short-form: same prefix-aware provenance re-derivation.
+        value_text = token.text[len(short_name) :]
+        return (
+            _argv_token_after_prefix(token, short_name, value_text),
+            index + 1,
+            True,
+        )
     return (None, index, False)
 
 
+# Complete `gh api` flag allowlist, verified against a live `gh api --help`
+# read (see tests/hooks/test_gh_api_flag_spec_contract.py, which fails the
+# suite if a future `gh` CLI adds a value-taking flag not listed here).
+# Recognizing every flag -- not just the ones _analyze_gh_api special-cases
+# for route/method extraction -- lets an unrecognized flag be denied with
+# its own distinguishable reason code instead of silently misparsed as a
+# second route (see _consume_argv_flag).
+_GH_API_FLAG_SPEC: Mapping[str, _FlagArity] = {
+    "-X": _FlagArity.VALUE,
+    "--method": _FlagArity.VALUE,
+    "--input": _FlagArity.VALUE,
+    "-F": _FlagArity.VALUE,
+    "--field": _FlagArity.VALUE,
+    "-f": _FlagArity.VALUE,
+    "--raw-field": _FlagArity.VALUE,
+    "-H": _FlagArity.VALUE,
+    "--header": _FlagArity.VALUE,
+    "--hostname": _FlagArity.VALUE,
+    "--cache": _FlagArity.VALUE,
+    "-q": _FlagArity.VALUE,
+    "--jq": _FlagArity.VALUE,
+    "-t": _FlagArity.VALUE,
+    "--template": _FlagArity.VALUE,
+    "-p": _FlagArity.VALUE,
+    "--preview": _FlagArity.VALUE,
+    "--paginate": _FlagArity.BOOLEAN,
+    "--silent": _FlagArity.BOOLEAN,
+    "-i": _FlagArity.BOOLEAN,
+    "--include": _FlagArity.BOOLEAN,
+    "--verbose": _FlagArity.BOOLEAN,
+    "-h": _FlagArity.BOOLEAN,
+    "--help": _FlagArity.BOOLEAN,
+}
+
+
 def _analyze_gh_api(
-    args: Sequence[str],
+    args: Sequence[ArgvToken],
     *,
     cwd: str,
     input_context_safe: bool,
     resolved_redirect_targets: Sequence[str],
     file_redirect_count: int,
 ) -> tuple[GitHubMutationRecord | None, str, str]:
-    method: str | None = None
-    route: str | None = None
-    input_value: str | None = None
-    field_values: list[str] = []
+    method: ArgvToken | None = None
+    route: ArgvToken | None = None
+    input_value: ArgvToken | None = None
+    field_values: list[ArgvToken] = []
     has_body_fields = False
     paginate = False
     graphql = False
@@ -418,22 +510,25 @@ def _analyze_gh_api(
 
     while i < len(args):
         token = args[i]
-        if token == "graphql" and route is None:
+        if token.text == "graphql" and route is None:
             graphql = True
-            route = "/graphql"
+            # Hardcoded literal, never shell-parsed -- provably inert by
+            # construction, not "true because we said so": no argv span
+            # exists for it to be dynamic through.
+            route = ArgvToken("/graphql", True, "'/graphql'")
             i += 1
             continue
 
         value, next_i, matched = _flag_value(args, i, long_name="--method", short_name="-X")
-        if matched or token in {"--method", "-X"}:
+        if matched or token.text in {"--method", "-X"}:
             if not matched or value is None:
                 return (None, "missing_required_value", "GitHub API method is missing")
-            method = value.upper()
+            method = value
             i = next_i
             continue
 
         value, next_i, matched = _flag_value(args, i, long_name="--input")
-        if matched or token == "--input":
+        if matched or token.text == "--input":
             if not matched or value is None:
                 return (None, "missing_required_value", "GitHub --input path is missing")
             input_value = value
@@ -449,7 +544,7 @@ def _analyze_gh_api(
             value, next_i, matched = _flag_value(
                 args, i, long_name=long_name, short_name=short_name
             )
-            if matched or token in {long_name, short_name}:
+            if matched or token.text in {long_name, short_name}:
                 if not matched or value is None:
                     return (None, "missing_required_value", f"{long_name} value is missing")
                 field_values.append(value)
@@ -460,20 +555,29 @@ def _analyze_gh_api(
         if field_match:
             continue
 
-        if token == "--paginate":
+        if token.text == "--paginate":
             paginate = True
             i += 1
             continue
-        if token in {"-H", "--header", "--hostname", "--cache"}:
-            if i + 1 >= len(args):
-                return (None, "missing_required_value", f"{token} value is missing")
-            i += 2
-            continue
-        if token.startswith(("--header=", "--hostname=", "--cache=")):
-            i += 1
-            continue
-        if token.startswith("-"):
-            i += 1
+        if token.text.startswith("-"):
+            value, next_i, recognized = _consume_argv_flag(args, i, _GH_API_FLAG_SPEC)
+            if not recognized:
+                return (
+                    None,
+                    "unrecognized_gh_api_flag",
+                    f"unrecognized gh api flag: {token.text!r}",
+                )
+            # _consume_argv_flag returns (None, i + 1, True) for both BOOLEAN
+            # arity and VALUE arity with a missing next token -- distinguish
+            # them here so a stray `-H` (no value) still surfaces as
+            # `missing_required_value` rather than silently passing.
+            if value is None and _GH_API_FLAG_SPEC.get(token.text) == _FlagArity.VALUE:
+                return (
+                    None,
+                    "missing_required_value",
+                    f"{token.text} value is missing",
+                )
+            i = next_i
             continue
         if route is None:
             route = token
@@ -507,9 +611,9 @@ def _analyze_gh_api(
         if loaded is None:
             return (None, reason_code, reason)
         input_path = (
-            os.path.normpath(input_value)
-            if os.path.isabs(input_value)
-            else os.path.normpath(os.path.join(cwd, input_value))
+            os.path.normpath(input_value.text)
+            if os.path.isabs(input_value.text)
+            else os.path.normpath(os.path.join(cwd, input_value.text))
         )
         if file_redirect_count != len(resolved_redirect_targets):
             return (
@@ -542,8 +646,12 @@ def _analyze_gh_api(
             )
         payload = loaded
 
-    effective_method = method or ("POST" if has_body_fields else "GET")
-    normalized_route = _normalize_github_route(route)
+    effective_method = (
+        method.text.upper()
+        if method is not None and method.text
+        else ("POST" if has_body_fields else "GET")
+    )
+    normalized_route = _normalize_github_route(route.text)
     if effective_method not in _GITHUB_WRITE_METHODS:
         return (None, "", "")
     if paginate:
@@ -558,23 +666,35 @@ def _analyze_gh_api(
         return (None, reason_code, reason)
 
     if graphql:
-        query = payload.get("query")
+        query: ArgvToken | None = None
+        raw_query = payload.get("query")
+        if isinstance(raw_query, str):
+            # File-content value (from --input): never shell-parsed, so
+            # quote provenance doesn't apply here -- query_from_literal_input
+            # alone is what proves this branch safe (see the skip condition
+            # below). The wrapper exists only to keep `query` uniformly
+            # typed across both assignment branches.
+            query = ArgvToken(raw_query, False, raw_query)
         if query is None and not query_from_literal_input:
             for field in field_values:
-                key, separator, value = field.partition("=")
-                if separator and key == "query":
-                    query = value
+                field_key, field_separator, _field_value_text = field.text.partition("=")
+                if field_separator and field_key == "query":
+                    # gh's `-f`/`-F key=value` syntax: `key` is a bareword,
+                    # never itself quoted, so a quoted value (the common
+                    # `-f query='...'` shape) must be re-derived from its
+                    # own raw span rather than inheriting `field`'s coarser
+                    # whole-token flag -- see _argv_token_value_after_key.
+                    query = _argv_token_value_after_key(field, field_key)
                     break
-        if not isinstance(query, str) or (
-            not query_from_literal_input and _is_dynamic_shell_value(query)
-        ):
+        if query is None or (not query_from_literal_input and _is_dynamic_shell_value(query)):
             return (None, "dynamic_target", "GraphQL mutation document is unresolved")
-        if not re.search(r"\bmutation\b", query):
+        if not re.search(r"\bmutation\b", query.text):
             return (None, "", "")
         kind = (
             GitHubMutationKind.GRAPHQL_REVIEW
             if any(
-                re.search(rf"\b{re.escape(name)}\b", query) for name in _GRAPHQL_REVIEW_MUTATIONS
+                re.search(rf"\b{re.escape(name)}\b", query.text)
+                for name in _GRAPHQL_REVIEW_MUTATIONS
             )
             else GitHubMutationKind.OTHER
         )
@@ -643,12 +763,12 @@ _GH_ISSUE_EDIT_SHORT_VALUE_FLAGS: frozenset[str] = frozenset({"-b", "-F", "-m", 
 _GH_ISSUE_URL_RE = re.compile(r"^/[^/\s]+/[^/\s]+/issues/\d+/?$")
 
 
-def _is_static_issue_edit_target(value: str) -> bool:
-    if not value or _is_dynamic_shell_value(value):
+def _is_static_issue_edit_target(value: ArgvToken) -> bool:
+    if not value.text or _is_dynamic_shell_value(value):
         return False
-    if value.isdecimal():
+    if value.text.isdecimal():
         return True
-    parsed = urlsplit(value)
+    parsed = urlsplit(value.text)
     return bool(
         parsed.scheme in {"http", "https"}
         and parsed.netloc
@@ -656,43 +776,43 @@ def _is_static_issue_edit_target(value: str) -> bool:
     )
 
 
-def _issue_edit_request_count(args: Sequence[str]) -> tuple[int | None, str, str]:
+def _issue_edit_request_count(args: Sequence[ArgvToken]) -> tuple[int | None, str, str]:
     targets = 0
     options_ended = False
     i = 0
     while i < len(args):
         token = args[i]
-        if not options_ended and token == "--":
+        if not options_ended and token.text == "--":
             options_ended = True
             i += 1
             continue
         if not options_ended:
             if (
-                token in _GH_ISSUE_EDIT_LONG_VALUE_FLAGS
-                or token in _GH_ISSUE_EDIT_SHORT_VALUE_FLAGS
+                token.text in _GH_ISSUE_EDIT_LONG_VALUE_FLAGS
+                or token.text in _GH_ISSUE_EDIT_SHORT_VALUE_FLAGS
             ):
                 if i + 1 >= len(args):
                     return (
                         None,
                         "missing_required_value",
-                        f"gh issue edit flag {token} is missing a value",
+                        f"gh issue edit flag {token.text} is missing a value",
                     )
                 i += 2
                 continue
-            if any(token.startswith(f"{flag}=") for flag in _GH_ISSUE_EDIT_LONG_VALUE_FLAGS):
+            if any(token.text.startswith(f"{flag}=") for flag in _GH_ISSUE_EDIT_LONG_VALUE_FLAGS):
                 i += 1
                 continue
             if any(
-                token.startswith(flag) and token != flag
+                token.text.startswith(flag) and token.text != flag
                 for flag in _GH_ISSUE_EDIT_SHORT_VALUE_FLAGS
             ):
                 i += 1
                 continue
-            if token.startswith("-"):
+            if token.text.startswith("-"):
                 return (
                     None,
                     "unsupported_grammar",
-                    f"gh issue edit flag {token} is unresolved",
+                    f"gh issue edit flag {token.text} is unresolved",
                 )
         if not _is_static_issue_edit_target(token):
             return (None, "dynamic_target", "gh issue edit target is unresolved")
@@ -730,12 +850,41 @@ _GH_READ_ONLY_SUBCOMMANDS: dict[str, frozenset[str]] = {
 
 
 def _gh_args_have_bare_help_flag(args: Sequence[str]) -> bool:
-    """Return True when -h/--help appears as its own flag, not another flag's value."""
+    """Return True when -h/--help appears as its own flag, not another flag's value.
+
+    A --help/-h token immediately following an unrecognized `-`-prefixed
+    flag (one that is neither a curated known-value flag nor --help/-h
+    itself) cannot be trusted as a bare flag -- an unrecognized flag's own
+    arity is unknown, so this token might actually be *its* value instead
+    (e.g. `gh release create v1 --notes '--help'`, where --notes is not in
+    _GH_KNOWN_VALUE_FLAGS). That occurrence is skipped rather than trusted.
+
+    This is deliberately narrower than defaulting every unrecognized flag
+    to value-taking (advance 2): doing so would also mis-skip a *known*
+    value-taking flag immediately following an unrecognized boolean one --
+    e.g. `gh pr review 5 --approve --body --help` (--approve is boolean,
+    unrecognized here; --body is a real _GH_KNOWN_VALUE_FLAGS entry whose
+    own value is the literal review-body text "--help") -- a blanket
+    advance-2 default would jump from --approve straight past --body
+    without ever separately recognizing it, corrupting the scan and
+    wrongly exempting a genuine review mutation. Scoping the fix to only
+    the --help occurrence itself keeps --body's own, already-correct
+    2-token skip intact.
+    """
     i = 0
     n = len(args)
     while i < n:
         token = args[i]
         if token in _GH_HELP_FLAGS:
+            previous = args[i - 1] if i > 0 else None
+            if (
+                previous is not None
+                and previous.startswith("-")
+                and previous not in _GH_HELP_FLAGS
+                and previous not in _GH_KNOWN_VALUE_FLAGS
+            ):
+                i += 1
+                continue
             return True
         if token in _GH_KNOWN_VALUE_FLAGS:
             i += 2
@@ -747,6 +896,7 @@ def _gh_args_have_bare_help_flag(args: Sequence[str]) -> bool:
 def _analyze_gh_segment(
     args: Sequence[str],
     *,
+    argv_args: Sequence[ArgvToken],
     cwd: str,
     input_context_safe: bool,
     resolved_redirect_targets: Sequence[str],
@@ -771,7 +921,7 @@ def _analyze_gh_segment(
             "",
         )
     if args[:2] == ["issue", "edit"]:
-        request_count, reason_code, reason = _issue_edit_request_count(args[2:])
+        request_count, reason_code, reason = _issue_edit_request_count(argv_args[2:])
         if request_count is None:
             return (None, reason_code, reason)
         return (
@@ -811,7 +961,7 @@ def _analyze_gh_segment(
     if args[0] != "api":
         return (None, "", "")
     return _analyze_gh_api(
-        args[1:],
+        argv_args[1:],
         cwd=cwd,
         input_context_safe=input_context_safe,
         resolved_redirect_targets=resolved_redirect_targets,
@@ -819,13 +969,92 @@ def _analyze_gh_segment(
     )
 
 
+# curl flag spec covering every flag _analyze_curl_segment already
+# special-cased, plus the flags named by this rectify's investigation
+# (-A/--user-agent, -b/--cookie, -c/--cookie-jar, -x/--proxy, -w/--write-out,
+# -m/--max-time, --cacert, --cert/-E, --key, --connect-timeout, --retry,
+# --resolve) and a further set of curl's most common boolean flags, verified
+# against a live `curl --help all` read. curl has hundreds of flags in
+# total; this is not exhaustive -- an unrecognized flag now fails closed
+# (see _analyze_curl_segment's catch-all) rather than being silently
+# misparsed, so this list trades some availability for the flags it omits
+# in exchange for closing the overblock-by-misparse bug shape.
+_CURL_FLAG_SPEC: Mapping[str, _FlagArity] = {
+    "-X": _FlagArity.VALUE,
+    "--request": _FlagArity.VALUE,
+    "--url": _FlagArity.VALUE,
+    "-d": _FlagArity.VALUE,
+    "--data": _FlagArity.VALUE,
+    "--data-raw": _FlagArity.VALUE,
+    "--data-binary": _FlagArity.VALUE,
+    "--data-urlencode": _FlagArity.VALUE,
+    "-F": _FlagArity.VALUE,
+    "--form": _FlagArity.VALUE,
+    "-T": _FlagArity.VALUE,
+    "--upload-file": _FlagArity.VALUE,
+    "-H": _FlagArity.VALUE,
+    "--header": _FlagArity.VALUE,
+    "-u": _FlagArity.VALUE,
+    "--user": _FlagArity.VALUE,
+    "-o": _FlagArity.VALUE,
+    "--output": _FlagArity.VALUE,
+    "-A": _FlagArity.VALUE,
+    "--user-agent": _FlagArity.VALUE,
+    "-b": _FlagArity.VALUE,
+    "--cookie": _FlagArity.VALUE,
+    "-c": _FlagArity.VALUE,
+    "--cookie-jar": _FlagArity.VALUE,
+    "-x": _FlagArity.VALUE,
+    "--proxy": _FlagArity.VALUE,
+    "-w": _FlagArity.VALUE,
+    "--write-out": _FlagArity.VALUE,
+    "-m": _FlagArity.VALUE,
+    "--max-time": _FlagArity.VALUE,
+    "--cacert": _FlagArity.VALUE,
+    "-E": _FlagArity.VALUE,
+    "--cert": _FlagArity.VALUE,
+    "--key": _FlagArity.VALUE,
+    "--connect-timeout": _FlagArity.VALUE,
+    "--retry": _FlagArity.VALUE,
+    "--resolve": _FlagArity.VALUE,
+    "-G": _FlagArity.BOOLEAN,
+    "--get": _FlagArity.BOOLEAN,
+    "--next": _FlagArity.BOOLEAN,
+    "-k": _FlagArity.BOOLEAN,
+    "--insecure": _FlagArity.BOOLEAN,
+    "-L": _FlagArity.BOOLEAN,
+    "--location": _FlagArity.BOOLEAN,
+    "-s": _FlagArity.BOOLEAN,
+    "--silent": _FlagArity.BOOLEAN,
+    "-S": _FlagArity.BOOLEAN,
+    "--show-error": _FlagArity.BOOLEAN,
+    "-v": _FlagArity.BOOLEAN,
+    "--verbose": _FlagArity.BOOLEAN,
+    "-i": _FlagArity.BOOLEAN,
+    "--include": _FlagArity.BOOLEAN,
+    "--compressed": _FlagArity.BOOLEAN,
+    "-0": _FlagArity.BOOLEAN,
+    "--http1.0": _FlagArity.BOOLEAN,
+    "--http1.1": _FlagArity.BOOLEAN,
+    "--http2": _FlagArity.BOOLEAN,
+    "-4": _FlagArity.BOOLEAN,
+    "--ipv4": _FlagArity.BOOLEAN,
+    "-6": _FlagArity.BOOLEAN,
+    "--ipv6": _FlagArity.BOOLEAN,
+    "-f": _FlagArity.BOOLEAN,
+    "--fail": _FlagArity.BOOLEAN,
+    "-g": _FlagArity.BOOLEAN,
+    "--globoff": _FlagArity.BOOLEAN,
+}
+
+
 def _analyze_curl_segment(
-    args: Sequence[str],
+    args: Sequence[ArgvToken],
 ) -> tuple[list[GitHubMutationRecord], str, str]:
-    method: str | None = None
+    method: ArgvToken | None = None
     has_data = False
     force_get = False
-    urls: list[str] = []
+    urls: list[ArgvToken] = []
     saw_next = False
     i = 0
     data_flags = (
@@ -840,24 +1069,24 @@ def _analyze_curl_segment(
     while i < len(args):
         token = args[i]
         value, next_i, matched = _flag_value(args, i, long_name="--request", short_name="-X")
-        if matched or token in {"--request", "-X"}:
+        if matched or token.text in {"--request", "-X"}:
             if not matched or value is None:
                 return ([], "missing_required_value", "curl method is missing")
-            method = value.upper()
+            method = value
             i = next_i
             continue
         value, next_i, matched = _flag_value(args, i, long_name="--url")
-        if matched or token == "--url":
+        if matched or token.text == "--url":
             if not matched or value is None:
                 return ([], "missing_required_value", "curl URL is missing")
             urls.append(value)
             i = next_i
             continue
-        if token in {"-G", "--get"}:
+        if token.text in {"-G", "--get"}:
             force_get = True
             i += 1
             continue
-        if token == "--next":
+        if token.text == "--next":
             saw_next = True
             i += 1
             continue
@@ -869,9 +1098,13 @@ def _analyze_curl_segment(
                 long_name=long_name,
                 short_name=short_name,
             )
-            if matched or token == long_name or (short_name is not None and token == short_name):
+            if (
+                matched
+                or token.text == long_name
+                or (short_name is not None and token.text == short_name)
+            ):
                 if not matched or value is None:
-                    return ([], "missing_required_value", f"{token} value is missing")
+                    return ([], "missing_required_value", f"{token.text} value is missing")
                 has_data = True
                 i = next_i
                 matched_value_flag = True
@@ -885,16 +1118,33 @@ def _analyze_curl_segment(
                 long_name=long_name,
                 short_name=short_name,
             )
-            if matched or token == long_name or token == short_name:
+            if matched or token.text == long_name or token.text == short_name:
                 if not matched or value is None:
-                    return ([], "missing_required_value", f"{token} value is missing")
+                    return ([], "missing_required_value", f"{token.text} value is missing")
                 i = next_i
                 matched_value_flag = True
                 break
         if matched_value_flag:
             continue
-        if token.startswith("-"):
-            i += 1
+        if token.text.startswith("-"):
+            value, next_i, recognized = _consume_argv_flag(args, i, _CURL_FLAG_SPEC)
+            if not recognized:
+                return (
+                    [],
+                    "unrecognized_curl_flag",
+                    f"unrecognized curl flag: {token.text!r}",
+                )
+            # _consume_argv_flag returns (None, i + 1, True) for both BOOLEAN
+            # arity and VALUE arity with a missing next token -- distinguish
+            # them here so a stray `-A`/`--proxy` (no value) surfaces as
+            # `missing_required_value` rather than silently passing.
+            if value is None and _CURL_FLAG_SPEC.get(token.text) == _FlagArity.VALUE:
+                return (
+                    [],
+                    "missing_required_value",
+                    f"{token.text} value is missing",
+                )
+            i = next_i
             continue
         urls.append(token)
         i += 1
@@ -905,12 +1155,16 @@ def _analyze_curl_segment(
         return ([], "dynamic_target", "curl URL is dynamic")
     github_urls = []
     for url in urls:
-        hostname = urlsplit(url).hostname
+        hostname = urlsplit(url.text).hostname
         if hostname is not None and hostname.lower() in {"api.github.com", "github.com"}:
             github_urls.append(url)
     if not github_urls:
         return ([], "", "")
-    effective_method = method or ("GET" if force_get else ("POST" if has_data else "GET"))
+    effective_method = (
+        method.text.upper()
+        if method is not None and method.text
+        else ("GET" if force_get else ("POST" if has_data else "GET"))
+    )
     if effective_method not in _GITHUB_WRITE_METHODS:
         return ([], "", "")
     if saw_next or len(github_urls) != 1 or len(urls) != 1:
@@ -919,7 +1173,7 @@ def _analyze_curl_segment(
             "request_cardinality_unresolved",
             "curl mutation request count is indeterminate",
         )
-    route = urlsplit(github_urls[0]).path or "/"
+    route = urlsplit(github_urls[0].text).path or "/"
     return (
         [
             GitHubMutationRecord(
@@ -961,12 +1215,24 @@ def _analyze_github_segment(
     input_context_safe: bool = True,
     resolved_redirect_targets: Sequence[str] = (),
     file_redirect_count: int = 0,
+    argv_tokens: Sequence[ArgvToken] | None = None,
 ) -> tuple[list[GitHubMutationRecord], str, str]:
     verb, args = _command_verb_and_args(list(segment))
     executable = _normalize_executable_call(verb)
+    if argv_tokens is None:
+        # Argv-payload segments (e.g. a parsed `subprocess.run([...])` list)
+        # are Python literal tokens that never passed through shell parsing
+        # at all -- no shell metacharacter interpretation is possible, so
+        # they are provably inert by construction, not a fabricated default.
+        argv_tokens = [ArgvToken(t, True, t) for t in segment]
+    argv_args: list[ArgvToken] = []
+    start = _verb_start_index(list(segment))
+    if start is not None:
+        argv_args = list(argv_tokens[start + 1 :])
     if executable == "gh":
         record, reason_code, reason = _analyze_gh_segment(
             args,
+            argv_args=argv_args,
             cwd=_segment_cwd(segment, cwd),
             input_context_safe=input_context_safe,
             resolved_redirect_targets=resolved_redirect_targets,
@@ -974,7 +1240,7 @@ def _analyze_github_segment(
         )
         return (([record] if record is not None else []), reason_code, reason)
     if executable == "curl":
-        return _analyze_curl_segment(args)
+        return _analyze_curl_segment(argv_args)
     return ([], "", "")
 
 
@@ -1032,6 +1298,12 @@ def analyze_github_mutations(
                     redirect_syntax=command_segment.redirect_syntax,
                 )
             )
+            executable_argv_tokens = _select_executable_argv_tokens(
+                raw_segment,
+                command_segment.argv_tokens,
+                cwd=current_cwd,
+                redirect_syntax=command_segment.redirect_syntax,
+            )
             active_redirect_targets = outer_redirect_targets + tuple(redirect_targets)
             active_file_redirect_count = outer_file_redirect_count + file_redirect_count
             segment_cwd = _segment_cwd(executable_tokens, current_cwd)
@@ -1047,7 +1319,13 @@ def analyze_github_mutations(
             verb, args = _command_verb_and_args(executable_tokens)
             if _normalize_executable_call(verb) == "cd":
                 input_context_safe = input_context_safe and file_redirect_count == 0
-                if len(args) != 1 or _is_dynamic_shell_value(args[0]):
+                # _verb_start_index has been determined to be non-None by
+                # command_verb_and_args above (same list, same algorithm), so
+                # this slice is always taken from the verb+1 position.
+                cd_start = _verb_start_index(executable_tokens)
+                assert cd_start is not None  # implied by verb == "cd" above
+                cd_argv_args = executable_argv_tokens[cd_start + 1 :]
+                if len(args) != 1 or _is_dynamic_shell_value(cd_argv_args[0]):
                     reasons.append(("cwd_unresolved", "shell cwd transition is unresolved"))
                 elif os.path.isabs(args[0]):
                     current_cwd = os.path.normpath(args[0])
@@ -1064,6 +1342,7 @@ def analyze_github_mutations(
                 input_context_safe=input_context_safe,
                 resolved_redirect_targets=active_redirect_targets,
                 file_redirect_count=active_file_redirect_count,
+                argv_tokens=executable_argv_tokens,
             )
             records.extend(found)
             if reason:

--- a/src/autoskillit/hooks/guards/AGENTS.md
+++ b/src/autoskillit/hooks/guards/AGENTS.md
@@ -69,10 +69,16 @@ defense-in-depth measure against privilege escalation:
 | `background_exec_guard.py` | Unrecognized `AUTOSKILLIT_SESSION_TYPE` | Unknown session type should not bypass `run_in_background` prohibition |
 | `github_mutation_guard.py` | Ambiguous or unresolved GitHub mutation command | Unknown mutation scope must not bypass the structured review publisher |
 | `exploration_request_identity_guard.py` | A supported exploration event lacks bounded native identity or its one-shot record cannot be written | A Claude exploration call must not execute without request-correlated authority |
-| `git_ops_guard.py` | Unexpected runtime error during the checked-out-ref preflight (OSError, subprocess.SubprocessError, TypeError, UnicodeDecodeError, ValueError) | An unhandled exception must not silently allow a checked-out ref mutation — use exit 2 + stderr to hard-block |
+| `git_ops_guard.py` | Unexpected runtime error during the checked-out-ref preflight (OSError, subprocess.SubprocessError, TypeError, UnicodeDecodeError, ValueError); or, in the separate headless destructive-op-blocking preflight, an unrecognized global git flag that leaves the real subcommand unresolved | An unhandled exception must not silently allow a checked-out ref mutation — use exit 2 + stderr to hard-block. Separately, `_contains_blocked_git_op` cannot match `_BLOCKED_GIT_OPS`'s literal subcommand tuples against an unresolved subcommand, so it denies unconditionally the moment `extract_git_subcommand_and_flags` reports `"<unresolved>"`, rather than silently falling through to "not blocked" |
 | `pr_create_guard.py` | Hook config unreadable or malformed while the kitchen is open (OSError, JSONDecodeError, AttributeError, TypeError) | An unresolvable `recipe_allows_pr_create` authorization must not be read as permission to bypass the prepare_pr → compose_pr pipeline |
+| `unsafe_install_guard.py` | An unrecognized global pip flag leaves `pip`'s `install` token position unresolved | `_find_pip_install` cannot tell whether the command is a pip install at all; treating that the same as "definitely not an install" would silently skip the editable/system-install checks entirely, so it is threaded through as a distinct `"unresolved-pip-flags"` kind and denied unconditionally, matching the pre-existing `"unresolved-subprocess"` kind's treatment |
 
 **Design principle:** Garbage-in (malformed hook input) = fail-open. Unknown-tier (valid input, unrecognized value) = fail-closed.
+Before adding a fail-closed sentinel for an unresolved case, check what the guard's own
+consumer does with an empty/ambiguous result — if the consumer already treats empty-or-`None`
+as allow (e.g. `write_guard.py`'s `if not targets: sys.exit(0)`), a bolted-on sentinel does not
+fail closed, it silently produces an allow; fix the parse so the case resolves correctly
+instead.
 
 The checked-out-ref check is a preflight, not a repository lock. A concurrent branch
 switch after worktree enumeration leaves a residual race; do not infer stronger

--- a/src/autoskillit/hooks/guards/git_ops_guard.py
+++ b/src/autoskillit/hooks/guards/git_ops_guard.py
@@ -22,9 +22,10 @@ if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
 from _command_classification import (  # type: ignore[import-not-found]  # noqa: E402
-    _GIT_GLOBAL_FLAGS,
-    _GIT_GLOBAL_FLAGS_WITH_VALUE,
+    _GIT_GLOBAL_FLAG_SPEC,
     _SHELL_OPS,
+    _consume_str_flag,
+    _FlagArity,
     command_verb_and_args,
     extract_git_subcommand_and_flags,
     extract_interpreter_command_payloads,
@@ -34,6 +35,9 @@ from _command_classification import (  # type: ignore[import-not-found]  # noqa:
     has_nested_shell,
     tokenize_command_segments,
     tokenize_shell_payload_segments,
+)
+from _github_mutation_analysis import (  # type: ignore[import-not-found]  # noqa: E402
+    _DYNAMIC_SHELL_TOKEN_RE,
 )
 from _hook_payload import (  # type: ignore[import-not-found]  # noqa: E402
     parse_hook_command,
@@ -74,36 +78,97 @@ _EXEMPT_SKILLS: frozenset[str] = frozenset()
 # in hook_registry.py — stdlib-only boundary prevents a shared import.
 _EXEMPT_SESSION_TYPES: frozenset[str] = frozenset({"orchestrator"})
 
-_DYNAMIC_TOKEN_RE = re.compile(r"[$`?\[]")
 _RAW_WRITE_VERBS = frozenset(
     {"cp", "mv", "install", "tee", "truncate", "rm", "unlink", "sed", "dd"}
 )
 
 
-def _extract_git_subcommand_and_remaining(
-    tokens: list[str], start: int
-) -> tuple[str, list[str]] | None:
-    """Starting at tokens[start] (the 'git' token), return (subcommand, remaining).
-
-    Skips global git flags and their value tokens to find the subcommand.
-    Returns None if no subcommand is found.
-    """
-    i = start + 1
-    while i < len(tokens):
-        token = tokens[i]
-        if token in _GIT_GLOBAL_FLAGS_WITH_VALUE:
-            i += 2
-            continue
-        if token in _GIT_GLOBAL_FLAGS:
-            i += 1
-            continue
-        if token.startswith("-"):
-            i += 1
-            continue
-        subcommand = token
-        remaining = tokens[i + 1 :]
-        return (subcommand, remaining)
-    return None
+# git fetch's own flag spec (distinct from _GIT_GLOBAL_FLAG_SPEC, git's
+# top-level global flags), verified against a live `git fetch -h` read.
+# Covers every fetch flag, including its `--no-X` negation form for each
+# boolean flag git itself documents as `--[no-]X`. Used by _classify_fetch
+# to correctly skip past an unrecognized fetch flag's value instead of
+# misreading it as the remote/refspec positional.
+_GIT_FETCH_BOOLEAN_FLAGS: frozenset[str] = frozenset(
+    {
+        "-v",
+        "--verbose",
+        "-q",
+        "--quiet",
+        "--all",
+        "--set-upstream",
+        "-a",
+        "--append",
+        "--atomic",
+        "-f",
+        "--force",
+        "-m",
+        "--multiple",
+        "-t",
+        "--tags",
+        "-n",
+        "--prefetch",
+        "-p",
+        "--prune",
+        "-P",
+        "--prune-tags",
+        "--dry-run",
+        "--porcelain",
+        "--write-fetch-head",
+        "-k",
+        "--keep",
+        "-u",
+        "--update-head-ok",
+        "--progress",
+        "--unshallow",
+        "--refetch",
+        "--update-shallow",
+        "-4",
+        "--ipv4",
+        "-6",
+        "--ipv6",
+        # --recurse-submodules[=<on-demand>] is optional-value; see
+        # _GIT_GLOBAL_FLAG_SPEC's --exec-path precedent for why BOOLEAN is
+        # the correct default (its `=`-form safely fails closed instead).
+        "--recurse-submodules",
+        "--negotiate-only",
+        "--auto-maintenance",
+        "--auto-gc",
+        "--show-forced-updates",
+        "--write-commit-graph",
+        "--stdin",
+    }
+)
+_GIT_FETCH_VALUE_FLAGS: frozenset[str] = frozenset(
+    {
+        "-j",
+        "--jobs",
+        "--depth",
+        "--shallow-since",
+        "--shallow-exclude",
+        "--deepen",
+        "--refmap",
+        "-o",
+        "--server-option",
+        "--negotiation-tip",
+        "--filter",
+        "--upload-pack",
+    }
+)
+_GIT_FETCH_FLAG_SPEC: dict[str, _FlagArity] = {
+    **{flag: _FlagArity.BOOLEAN for flag in _GIT_FETCH_BOOLEAN_FLAGS},
+    **{
+        f"--no-{flag.removeprefix('--')}": _FlagArity.BOOLEAN
+        for flag in _GIT_FETCH_BOOLEAN_FLAGS
+        if flag.startswith("--")
+    },
+    **{flag: _FlagArity.VALUE for flag in _GIT_FETCH_VALUE_FLAGS},
+    **{
+        f"--no-{flag.removeprefix('--')}": _FlagArity.BOOLEAN
+        for flag in _GIT_FETCH_VALUE_FLAGS
+        if flag.startswith("--")
+    },
+}
 
 
 _DELIMITERS_RE = re.compile(r"[\s,\[\]'\"()]+")
@@ -136,10 +201,17 @@ def _contains_blocked_git_op(cmd: str) -> tuple[str, ...] | None:
         # Only treat as a command start at position 0 or after a shell operator.
         if i != 0 and tokens[i - 1] not in _SHELL_OPS:
             continue
-        result = _extract_git_subcommand_and_remaining(tokens, i)
+        result = extract_git_subcommand_and_flags(tokens[i:])
         if result is None:
             continue
         subcommand, remaining = result
+        if subcommand == "<unresolved>":
+            # An unrecognized global git flag means the real subcommand
+            # could not be found at all -- deny unconditionally rather
+            # than matching against _BLOCKED_GIT_OPS's literal tuples,
+            # which "<unresolved>" can never equal (an unhandled case
+            # would silently fall through to "not blocked" here).
+            return (subcommand,)
         for op_tuple in _BLOCKED_GIT_OPS:
             if subcommand != op_tuple[0]:
                 continue
@@ -385,7 +457,7 @@ def _classify_update_ref(args: list[str], cwd: str) -> tuple[str, str, bool] | N
     attempted = "<delete>" if delete else (positional[1] if len(positional) > 1 else "")
     if not attempted:
         return None
-    if _DYNAMIC_TOKEN_RE.search(target) or _DYNAMIC_TOKEN_RE.search(attempted):
+    if _DYNAMIC_SHELL_TOKEN_RE.search(target) or _DYNAMIC_SHELL_TOKEN_RE.search(attempted):
         return ("", "<unresolved>", True)
     if target == "HEAD" and no_deref:
         return ("HEAD", attempted, False)
@@ -434,7 +506,7 @@ def _classify_branch_position(subcommand: str, args: list[str]) -> tuple[str, st
             if index != marker_index + 1 and not token.startswith("-")
         ]
         attempted = other_positionals[0] if other_positionals else "HEAD"
-    if _DYNAMIC_TOKEN_RE.search(target) or _DYNAMIC_TOKEN_RE.search(attempted):
+    if _DYNAMIC_SHELL_TOKEN_RE.search(target) or _DYNAMIC_SHELL_TOKEN_RE.search(attempted):
         return ("", "<unresolved>", True)
     return (_normal_branch_ref(target), attempted, False)
 
@@ -447,7 +519,7 @@ def _classify_reset(args: list[str], cwd: str) -> tuple[str, str, bool] | None:
     if not target:
         # Fail-closed: ambiguous on rev-parse failure — route to _all_threatened.
         return ("", "<unresolved>", True)
-    if _DYNAMIC_TOKEN_RE.search(attempted):
+    if _DYNAMIC_SHELL_TOKEN_RE.search(attempted):
         return ("", "<unresolved>", True)
     old_sha = _git_text(cwd, "rev-parse", target)
     attempted_sha = _resolve_attempted_sha(cwd, attempted)
@@ -466,7 +538,7 @@ def _refspec_targets(refspec: str, owned_refs: list[str]) -> list[str]:
     destination = refspec.split(":", 1)[1]
     if not destination:
         return []
-    if _DYNAMIC_TOKEN_RE.search(destination.replace("*", "")):
+    if _DYNAMIC_SHELL_TOKEN_RE.search(destination.replace("*", "")):
         return owned_refs
     destination = _normal_branch_ref(destination)
     if "*" not in destination:
@@ -491,11 +563,20 @@ def _classify_fetch(
             continue
         if token.startswith("--refmap="):
             refmaps.append(token.split("=", 1)[1])
-        elif token in ("--upload-pack", "-u", "--depth", "--deepen", "--shallow-since"):
-            index += 2
+            index += 1
             continue
-        elif not token.startswith("-"):
-            positional.append(token)
+        if token.startswith("-"):
+            _, next_index, recognized = _consume_str_flag(args, index, _GIT_FETCH_FLAG_SPEC)
+            if not recognized:
+                # An unrecognized fetch flag's value would otherwise be
+                # misread as the remote/refspec positional -- fail closed
+                # into the same ambiguous-deny idiom this function already
+                # uses for --stdin and an unreadable refmap config, rather
+                # than silently misclassifying the fetch destination.
+                return [("", "<unresolved>", True)]
+            index = next_index
+            continue
+        positional.append(token)
         index += 1
     if not positional:
         return []
@@ -562,7 +643,7 @@ def _classify_push(
         # ref if it lands in owned_refs — normalize before classifying.
         normalized = refspec if ":" in refspec else f"{refspec}:{refspec}"
         source, destination = normalized.removeprefix("+").split(":", 1)
-        if _DYNAMIC_TOKEN_RE.search(destination):
+        if _DYNAMIC_SHELL_TOKEN_RE.search(destination):
             return [("", "<unresolved>", True)]
         target = _normal_branch_ref(destination)
         if target in owned_refs:
@@ -577,6 +658,11 @@ def _classify_git_segment(
     if parsed is None:
         return []
     subcommand, args = parsed
+    if subcommand == "<unresolved>":
+        # An unrecognized global git flag means the real subcommand could
+        # not be found -- ambiguous-deny (route through _all_threatened
+        # against every owned ref), not "nothing to check here".
+        return [("", "<unresolved>", True)]
     cwd = str(context["execution_cwd"])
     owners = context["owners"]
     if not isinstance(owners, dict):
@@ -630,7 +716,7 @@ def _raw_write_targets(command: str, segments: list[list[str]]) -> tuple[list[st
         else:
             candidates = args[-1:]
         for candidate in candidates:
-            if _DYNAMIC_TOKEN_RE.search(candidate):
+            if _DYNAMIC_SHELL_TOKEN_RE.search(candidate):
                 ambiguous = True
             elif candidate:
                 targets.append(candidate)
@@ -704,13 +790,14 @@ def _git_segment_cwd(segment: list[str], cwd: str) -> str:
             current = candidate if candidate.is_absolute() else current / candidate
             index += 2
             continue
-        if token in _GIT_GLOBAL_FLAGS_WITH_VALUE:
-            index += 2
-            continue
-        if token in _GIT_GLOBAL_FLAGS or token.startswith("-"):
-            index += 1
-            continue
-        break
+        if not token.startswith("-"):
+            break
+        # -C's own value is captured above (needed to build `current`); every
+        # other global flag is just skipped past, same as before -- an
+        # unrecognized flag advances by one token rather than stopping, this
+        # is cwd-tracking, not the security-critical subcommand parse.
+        _, next_index, recognized = _consume_str_flag(args, index, _GIT_GLOBAL_FLAG_SPEC)
+        index = next_index if recognized else index + 1
     return str(current.resolve())
 
 
@@ -754,7 +841,7 @@ def _preflight_checked_out_ref_mutation(
                 current_cwd = ""
                 continue
             target_args = [arg for arg in args if arg not in ("-P", "--")]
-            if len(target_args) == 1 and not _DYNAMIC_TOKEN_RE.search(target_args[0]):
+            if len(target_args) == 1 and not _DYNAMIC_SHELL_TOKEN_RE.search(target_args[0]):
                 candidate = Path(target_args[0])
                 current_cwd = str(
                     (
@@ -768,7 +855,7 @@ def _preflight_checked_out_ref_mutation(
                 # later git segments classify against a stale cwd.
                 current_cwd = ""
                 continue
-        elif verb == "pushd" and len(args) == 1 and not _DYNAMIC_TOKEN_RE.search(args[0]):
+        elif verb == "pushd" and len(args) == 1 and not _DYNAMIC_SHELL_TOKEN_RE.search(args[0]):
             # pushd swaps cwd into the new dir; track it like cd.
             candidate = Path(args[0])
             current_cwd = str(

--- a/src/autoskillit/hooks/guards/unsafe_install_guard.py
+++ b/src/autoskillit/hooks/guards/unsafe_install_guard.py
@@ -17,6 +17,8 @@ if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
 from _command_classification import (  # type: ignore[import-not-found]  # noqa: E402
+    _PIP_GLOBAL_FLAG_SPEC,
+    _consume_str_flag,
     command_verb_and_args,
     extract_interpreter_command_payloads,
     extract_shell_command_payloads,
@@ -26,6 +28,13 @@ from _command_classification import (  # type: ignore[import-not-found]  # noqa:
 from _hook_payload import parse_hook_command  # type: ignore[import-not-found]  # noqa: E402
 
 UNSAFE_INSTALL_DENY_TRIGGER: str = "Blocked: editable install without --python .venv"
+
+# Sentinel _find_pip_install returns when an unrecognized global pip flag is
+# encountered before `install` could be confirmed either way -- distinguishable
+# from a bare None ("definitely not pip install") so callers can't collapse
+# "ambiguous" into "not pip install" and silently skip an unsafe install
+# (see _classify_install_invocation's "unresolved-pip-flags" kind).
+_PIP_INSTALL_UNRESOLVED = "<unresolved-pip-flags>"
 
 
 def _basename_lower(token: str) -> str:
@@ -97,8 +106,19 @@ def _is_editable_marker(token: str) -> bool:
     )
 
 
-def _find_pip_install(args: list[str]) -> tuple[list[str], list[str]] | None:
-    """Find `pip install` in *args* and return (pre_install, post_install)."""
+def _find_pip_install(
+    args: list[str],
+) -> tuple[list[str], list[str]] | str | None:
+    """Find `pip install` in *args* and return (pre_install, post_install).
+
+    Returns None when this is definitely not a pip-install invocation (no
+    `install` token found after only recognized global flags). Returns the
+    _PIP_INSTALL_UNRESOLVED sentinel when an unrecognized global pip flag
+    is encountered first -- an unrecognized flag's value would otherwise be
+    misread as the `install` token position never being reached, silently
+    treating the command as "not a pip install" (see
+    _classify_install_invocation).
+    """
     i = 0
     while i < len(args):
         token = args[i]
@@ -106,15 +126,10 @@ def _find_pip_install(args: list[str]) -> tuple[list[str], list[str]] | None:
             i += 1
             break
         if token.startswith("-"):
-            if "=" in token:
-                i += 1
-                continue
-            if token in {"-r", "-c", "-t", "-b", "--requirement", "--constraint"} and i + 1 < len(
-                args
-            ):
-                i += 2
-                continue
-            i += 1
+            _, next_i, recognized = _consume_str_flag(args, i, _PIP_GLOBAL_FLAG_SPEC)
+            if not recognized:
+                return _PIP_INSTALL_UNRESOLVED
+            i = next_i
             continue
         break
     if i >= len(args) or args[i] != "install":
@@ -133,6 +148,10 @@ def _classify_install_invocation(
     - python / python3 / python3.X -m pip install ...
     - maturin develop ...
     Returns None when the segment is not a matching install invocation.
+    An unrecognized global pip flag yields ("unresolved-pip-flags", [], [])
+    rather than None -- propagated through _iter_install_segments the same
+    way "unresolved-subprocess" already is, and treated as an unconditional
+    deny by _is_unsafe_editable_install.
     """
     verb, args = command_verb_and_args(segment)
     if not verb:
@@ -141,6 +160,8 @@ def _classify_install_invocation(
         match = _find_pip_install(args)
         if match is None:
             return None
+        if isinstance(match, str):
+            return (_PIP_INSTALL_UNRESOLVED, [], [])
         install_args, post_install = match
         return ("pip", install_args, post_install)
     if _is_uv_executable(verb):
@@ -149,6 +170,8 @@ def _classify_install_invocation(
         match = _find_pip_install(args[1:])
         if match is None:
             return None
+        if isinstance(match, str):
+            return (_PIP_INSTALL_UNRESOLVED, [], [])
         install_args, post_install = match
         return ("uv-pip", install_args, post_install)
     if _is_python_executable(verb):
@@ -157,6 +180,8 @@ def _classify_install_invocation(
         match = _find_pip_install(args[2:])
         if match is None:
             return None
+        if isinstance(match, str):
+            return (_PIP_INSTALL_UNRESOLVED, [], [])
         install_args, post_install = match
         return ("module-pip", install_args, post_install)
     if _is_maturin_executable(verb):
@@ -214,8 +239,10 @@ def _is_unsafe_editable_install(cmd: str) -> bool:
     for kind, _install_args, post_install in _iter_install_segments(cmd):
         if kind == "maturin":
             return True
-        if kind == "unresolved-subprocess":
-            # A matching process-launch call could not be statically resolved.
+        if kind in ("unresolved-subprocess", _PIP_INSTALL_UNRESOLVED):
+            # A matching process-launch call could not be statically resolved,
+            # or an unrecognized global pip flag made the install-args split
+            # ambiguous -- both fail closed the same way.
             return True
         if any(_is_editable_marker(t) for t in post_install):
             python_target = _python_target_value(post_install)

--- a/src/autoskillit/hooks/guards/write_guard.py
+++ b/src/autoskillit/hooks/guards/write_guard.py
@@ -37,8 +37,10 @@ if _HOOKS_DIR not in sys.path:
 
 from _command_classification import (  # type: ignore[import-not-found]  # noqa: E402
     _FD_REDIRECT_RE,
+    _GIT_GLOBAL_FLAG_SPEC,
     _REDIRECT_OP_ONLY_RE,
     _REDIRECT_TOKEN_RE,
+    _FlagArity,
     command_verb,
     extract_interpreter_write_paths,
     extract_redirect_targets,
@@ -76,7 +78,18 @@ _WRITE_VERBS: frozenset[str] = frozenset(
     }
 )
 
-_GIT_FLAG_WITH_VALUE: frozenset[str] = frozenset({"-C", "--git-dir", "--work-tree", "-c"})
+# Every value-taking git global flag, derived at import time from
+# _GIT_GLOBAL_FLAG_SPEC in _command_classification.py. Hook scripts already
+# import from that module via sys.path (same as git_ops_guard.py in this
+# same package) so there is no separate "manual mirror" -- the spec table
+# is the single source of truth and any future addition automatically
+# extends this frozenset. A flag missing from this set is misread by the
+# loop below as a 1-token boolean skip, so its value gets mistaken for
+# the git subcommand -- e.g. `git --namespace refs/foo checkout -- file`
+# previously stopped the loop at `refs/foo`, never reaching `checkout`.
+_GIT_FLAG_WITH_VALUE: frozenset[str] = frozenset(
+    flag for flag, arity in _GIT_GLOBAL_FLAG_SPEC.items() if arity == _FlagArity.VALUE
+)
 
 
 def _extract_segment_targets(segment: list[str], cwd: str) -> list[str] | None:

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -229,6 +229,58 @@ tests/
 temp/                        # Temporary/working files (gitignored)
 ```
 
+## CLI Flag-Spec Coverage Convention
+
+Any guard that parses a CLI's argv by consulting a `{flag: _FlagArity}` spec table
+(e.g. `_GH_API_FLAG_SPEC`/`_CURL_FLAG_SPEC` in `hooks/_github_mutation_analysis.py`;
+`_GIT_GLOBAL_FLAG_SPEC`/`_PIP_GLOBAL_FLAG_SPEC` in `hooks/_command_classification.py`)
+**must** ship with:
+
+1. **A generative parametrized test** covering every flag in the table, parametrized
+   directly from the table's own keys — `@pytest.mark.parametrize("flag",
+   sorted(_MY_SPEC))` — not a hand-maintained flag list. A flag added to the table
+   later is automatically covered with no separate test-list edit; a hand-copied
+   list silently drifts out of sync the moment the table changes. Assert the flag
+   resolves without triggering the guard's own "unrecognized flag" fail-closed
+   outcome (see `tests/hooks/test_command_classification.py`'s
+   `test_every_gh_api_spec_flag_is_recognized`/`test_every_curl_spec_flag_is_recognized`/
+   `test_every_git_global_spec_flag_is_recognized` and
+   `tests/infra/test_unsafe_install_guard.py`'s
+   `test_every_pip_global_spec_flag_is_recognized` for the pattern).
+2. **A `tests/arch/test_guard_flag_spec_coverage.py` entry** — add the table name and
+   its candidate test file(s) to `_SPEC_TABLE_TEST_FILES` so the standing
+   architectural test enforces (1) exists, not just happens to today.
+3. **A live-CLI-`--help` contract test** (see
+   `tests/hooks/test_gh_api_flag_spec_contract.py`) asserting every value-taking flag
+   the installed CLI's `--help` actually lists is present in the spec table with
+   VALUE arity — this is what catches a *future* CLI release adding a flag, which
+   (1) and (2) cannot (they only check today's table against today's tests). Skip
+   gracefully only when the CLI binary is unavailable; never silently pass when the
+   binary is present but the help-text parser extracts zero flags — assert a sanity
+   floor first. If the CLI's flag surface is too large to exhaustively mirror (curl's
+   ~250 flags), scope the contract test explicitly to the flags your change actually
+   needs covered and say so in the test and the spec table's own module comment —
+   never let an exhaustiveness gap go unstated (see
+   `test_curl_flag_spec_covers_this_rectifys_named_flags`'s non-fatal
+   out-of-scope-flag print for the pattern).
+
+Reusable parametrize-matrix constants and builders for `tests/hooks/` test modules
+live in `tests/hooks/_flag_form_matrix.py` (mirroring the
+`tests/infra/_pretty_output_helpers.py` private-helper-module convention):
+`FLAG_FORM_MATRIX = ("space", "equals", "attached-short")` for a value-taking flag's
+three supported forms — not every flag supports every form (e.g. a flag with no short
+alias has no attached-short form); omit inapplicable entries at the call site. Also
+`GRAPHQL_DELIVERY_MATRIX` (the four ways a GraphQL document reaches `gh api graphql`'s
+`-f query=...`: inline-single-quoted, inline-double-quoted, inline-unquoted,
+input-file) and `GRAPHQL_CONTENT_MATRIX` (the four content shapes: plain,
+dollar-variable, list-literal, command-substitution), plus `deliver_graphql_document`/
+`graphql_delivery_is_inherently_safe` builders — crossed exhaustively at the
+classification layer in `test_command_classification.py`'s
+`test_graphql_delivery_content_matrix`, and sampled once per delivery form at the
+guard layer in `test_github_mutation_guard.py`'s
+`test_graphql_delivery_matrix_decision_matches_classification` to prove the guard's
+own decision wiring, not to re-derive the classification layer's own matrix.
+
 ## Retirement Registries
 
 Root `AGENTS.md` § 3.1 states the invariant once; this section is the authoritative

--- a/tests/arch/test_guard_flag_spec_coverage.py
+++ b/tests/arch/test_guard_flag_spec_coverage.py
@@ -1,0 +1,108 @@
+"""Standing invariant: every CLI flag-arity spec table has a generative test.
+
+Each of this rectify's CLI flag-arity spec tables (_GH_API_FLAG_SPEC and
+_CURL_FLAG_SPEC in hooks/_github_mutation_analysis.py; _GIT_GLOBAL_FLAG_SPEC
+and _PIP_GLOBAL_FLAG_SPEC in hooks/_command_classification.py) must have a
+corresponding test parametrized directly from the table's own keys (e.g.
+`@pytest.mark.parametrize("flag", sorted(_GH_API_FLAG_SPEC))`), not a
+hand-maintained flag list a future table update could silently drift out of
+sync with -- adding a flag to the table then automatically extends the
+parametrize's coverage with no separate test-list edit required.
+
+This mirrors tests/arch/test_fail_closed_guard_contract.py's AST-scan and
+batch-report shape: a structural test about the test suite's own
+completeness, not about runtime behavior (the generative tests themselves,
+in tests/hooks/test_command_classification.py and
+tests/infra/test_unsafe_install_guard.py, exercise runtime behavior).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TESTS_ROOT = _REPO_ROOT / "tests"
+
+# spec table name -> candidate test file(s), at least one of which must
+# reference it via a pytest.mark.parametrize(...) call.
+_SPEC_TABLE_TEST_FILES: dict[str, tuple[str, ...]] = {
+    "_GH_API_FLAG_SPEC": ("hooks/test_command_classification.py",),
+    "_CURL_FLAG_SPEC": ("hooks/test_command_classification.py",),
+    "_GIT_GLOBAL_FLAG_SPEC": ("hooks/test_command_classification.py",),
+    "_GIT_FETCH_FLAG_SPEC": ("infra/test_git_ops_guard.py",),
+    "_PIP_GLOBAL_FLAG_SPEC": ("infra/test_unsafe_install_guard.py",),
+}
+
+
+def _references_spec_table_in_parametrize(source: str, table_name: str) -> bool:
+    """Return True if *source* has a pytest.mark.parametrize(...) call whose
+
+    arguments reference *table_name* by name (e.g.
+    `sorted(_GH_API_FLAG_SPEC)`) -- proving the parametrize genuinely
+    iterates the table's own current keys at collection time, rather than a
+    frozen/hand-copied flag list that could silently drift out of sync with
+    the table it was copied from.
+    """
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "parametrize"):
+            continue
+        if any(isinstance(n, ast.Name) and n.id == table_name for n in ast.walk(node)):
+            return True
+    return False
+
+
+def test_parametrize_detection_requires_actual_reference() -> None:
+    """Prove the scanner is live, not vacuous: it must distinguish a
+
+    parametrize that genuinely references the spec table by name from one
+    that merely happens to sit in the same file.
+    """
+    referenced = (
+        "import pytest\n\n"
+        '@pytest.mark.parametrize("flag", sorted(_MY_SPEC))\n'
+        "def test_x(flag):\n    pass\n"
+    )
+    not_referenced = (
+        "import pytest\n\n"
+        '@pytest.mark.parametrize("flag", ["a", "b"])\n'
+        "def test_x(flag):\n    pass\n"
+    )
+
+    assert _references_spec_table_in_parametrize(referenced, "_MY_SPEC")
+    assert not _references_spec_table_in_parametrize(not_referenced, "_MY_SPEC")
+
+
+def test_every_cli_flag_spec_table_has_a_generative_parametrized_test() -> None:
+    """Every table in _SPEC_TABLE_TEST_FILES must have a live parametrize
+
+    reference in at least one of its candidate test files.
+    """
+    missing: list[str] = []
+    for table_name, candidate_paths in _SPEC_TABLE_TEST_FILES.items():
+        found = False
+        for rel_path in candidate_paths:
+            full_path = _TESTS_ROOT / rel_path
+            if not full_path.exists():
+                continue
+            source = full_path.read_text(encoding="utf-8")
+            if _references_spec_table_in_parametrize(source, table_name):
+                found = True
+                break
+        if not found:
+            missing.append(
+                f"{table_name} — no pytest.mark.parametrize(...) referencing it by name "
+                f"found in: {', '.join(candidate_paths)}"
+            )
+    assert not missing, (
+        "CLI flag spec tables missing a generative parametrized test:\n"
+        + "\n".join(f"  {m}" for m in missing)
+    )

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1176,17 +1176,28 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "(issue #4479).",
     ),
     "hooks/_command_classification.py": (
-        1300,
+        1600,
         "REQ-CNST-010-E10: shared command-classification primitive consumed by all "
         "command-inspecting guards — tokenization, shell-payload extraction, "
         "interpreter-write detection, protected-path reads, and recursive payload "
         "segmentation; the stdlib-only hook boundary and shared parser prevent "
         "policy drift across guard processes. Cap reduced to 1300 by #4665's "
         "decomposition of GitHub mutation cardinality/route authority into the "
-        "_github_mutation_analysis.py sibling under E26.",
+        "_github_mutation_analysis.py sibling under E26. Bumped to 1600 for Issue "
+        "#4655's rectify: ArgvToken threads quote provenance through the tokenizer "
+        "(_tokenize_command_segments_with_redirects, _partition_output_redirect_"
+        "indices/_select_executable_argv_tokens, _verb_start_index), and the CLI-"
+        "agnostic _FlagArity/_consume_argv_flag/_consume_str_flag spec-table engine "
+        "(plus _GIT_GLOBAL_FLAG_SPEC and _PIP_GLOBAL_FLAG_SPEC, and "
+        "extract_git_subcommand_and_flags's fail-closed unrecognized-global-flag fix) "
+        "-- these are shared, CLI-agnostic primitives every command-inspecting guard "
+        "consumes (git, curl, pip, and gh's own spec table in "
+        "_github_mutation_analysis.py, which imports this engine rather than "
+        "duplicating it), so they stay adjacent to the tokenizer they extend rather "
+        "than the gh-specific consumer module the split already separated them from.",
     ),
     "hooks/_github_mutation_analysis.py": (
-        1300,
+        1600,
         "REQ-CNST-010-E26: #4665 decomposes the GitHub mutation cardinality/route "
         "analysis out of _command_classification.py into this sibling module — the "
         "gh/curl possible-exec token check, gh issue edit's target/flag grammar, "
@@ -1194,7 +1205,28 @@ _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
         "the recursive cardinality aggregator all share the same mutation authority "
         "and must stay adjacent to one another for test inspection (test_command_"
         "classification.py::TestAnalyzeGitHubMutations). Cap set to 1300 to bound "
-        "the shared mutation authority after decomposition.",
+        "the shared mutation authority after decomposition. Bumped to 1600 for Issue "
+        "#4655's rectify: _GH_API_FLAG_SPEC and _CURL_FLAG_SPEC (this module's own "
+        "gh-api/curl flag tables, consuming _command_classification's shared "
+        "_FlagArity/_consume_argv_flag engine via a module-scope import) replace "
+        "_analyze_gh_api/_analyze_curl_segment's ad-hoc if/elif flag chains so an "
+        "unrecognized flag fails closed with a distinguishable reason code instead of "
+        "being silently misparsed as a second route; and ArgvToken-typed "
+        "_flag_value/_analyze_gh_api/_analyze_curl_segment/_is_dynamic_shell_value/"
+        "_is_static_issue_edit_target/_issue_edit_request_count prove GraphQL "
+        "documents and flag values shell-inert from quote provenance rather than "
+        "content alone -- must stay adjacent to the mutation authority they feed.",
+    ),
+    "hooks/guards/git_ops_guard.py": (
+        1050,
+        "REQ-CNST-010-E28: Issue #4655's rectify moves this guard's checked-out-ref "
+        "dynamic-value check onto the shared _DYNAMIC_SHELL_TOKEN_RE regex, which "
+        "#4665's decomposition relocated to hooks/_github_mutation_analysis.py -- a "
+        "second module-scope import block (alongside the existing "
+        "_command_classification one) is needed since the two symbols now live in "
+        "different sibling modules. Cap bumped from the 1000-line default to give "
+        "this guard's own destructive-op/fetch/checked-out-ref classification room "
+        "without re-tripping the limit on the next small addition.",
     ),
     "session.py": (
         1060,

--- a/tests/core/test_bash_write_targets.py
+++ b/tests/core/test_bash_write_targets.py
@@ -137,6 +137,7 @@ _PARITY_CORPUS: list[tuple[str, str]] = [
     ("cat /source/repo/README.md > /tmp/out.txt", "/workspace"),
     ("echo hello > /tmp/out.txt", "/workspace"),
     ("git checkout branch -- /path/file.txt", "/workspace"),
+    ("git --namespace refs/foo checkout -- /clone/src/main.py", "/workspace"),
     ("git reset --hard HEAD", "/workspace"),
     ("cat /a | grep foo > /b", "/workspace"),
     ("echo x > output.txt", "/workspace"),

--- a/tests/hooks/_flag_form_matrix.py
+++ b/tests/hooks/_flag_form_matrix.py
@@ -1,0 +1,103 @@
+"""Shared parametrize-matrix constants and builders for tests/hooks/ test modules.
+
+Centralizes the reusable ``ids=`` tuples and GraphQL-document command builders
+used across multiple ``tests/hooks/`` test files so a flag-form or
+GraphQL-delivery/content matrix is defined once and consumed everywhere,
+rather than hand-copied per file -- a hand-copied tuple silently drifts the
+moment one copy is edited and the others are not. Introduced by
+``rectify_github_mutation_guard_argv_parsing_immunity`` Part D (REQ-065),
+mirroring the existing ``tests/infra/_pretty_output_helpers.py`` convention
+for a private, same-directory test-helper module.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# A value-taking flag's three distinct syntactic forms this module's tests
+# exercise: space-separated (`--flag value` / `-f value`), `=`-joined long
+# form (`--flag=value`), and a short flag with its value directly attached,
+# no separator (`-fvalue`). Not every flag supports every form (e.g. a flag
+# with no short alias has no attached-short form) -- omit inapplicable
+# entries at the call site.
+#
+# The rectify plan that introduced this matrix (REQ-065) named a 4th
+# "bundled" form alongside "attached-short" as if they were distinct. They
+# are not: the plan's own text (Part B Step 2 item 3 -- "Equals-form... and
+# bundled-form (`-fvalue`)") and `_command_classification.py`'s own comments
+# (":1721", ":299") both use "bundled" as the *name* for the same
+# short-flag-attached-value form already covered here as "attached-short" --
+# gh's CLI grammar has no separate 4th syntactic form for a single
+# value-taking flag to test. A literal 4th tuple element would duplicate
+# "attached-short" under a second label with no new behavior to assert.
+FLAG_FORM_MATRIX: tuple[str, ...] = ("space", "equals", "attached-short")
+
+# The four ways a GraphQL document's text can reach `gh api graphql`'s
+# `-f query=...`: inline and single-quoted end-to-end, inline and
+# double-quoted (or otherwise not fully single-quoted), inline with no
+# quoting at all, or read from a file via `--input`.
+GRAPHQL_DELIVERY_MATRIX: tuple[str, ...] = (
+    "inline-single-quoted",
+    "inline-double-quoted",
+    "inline-unquoted",
+    "input-file",
+)
+
+# The four GraphQL-document content shapes this rectify's investigation
+# named: ordinary text with no dynamic-shell-looking character, a GraphQL
+# `$variable` reference, a GraphQL list literal (`[...]`), and a literal
+# shell command-substitution fragment.
+GRAPHQL_CONTENT_MATRIX: tuple[str, ...] = (
+    "plain",
+    "dollar-variable",
+    "list-literal",
+    "command-substitution",
+)
+
+# One representative, whitespace-free document body per GRAPHQL_CONTENT_MATRIX
+# entry -- whitespace-free so the same body is valid under every delivery
+# form, including "inline-unquoted" (an unquoted argv token ends at the next
+# shell whitespace).
+GRAPHQL_MATRIX_CONTENT_BODIES: dict[str, str] = {
+    "plain": "mutation{addLabels(labelIds:x){clientMutationId}}",
+    "dollar-variable": "mutation($id:ID!){addLabels(id:$id){clientMutationId}}",
+    "list-literal": "mutation{addLabels(labelIds:[1,2]){clientMutationId}}",
+    "command-substitution": "mutation{addLabels(note:`whoami`){clientMutationId}}",
+}
+
+
+def deliver_graphql_document(delivery: str, content_body: str, tmp_path: Path) -> str:
+    """Build a `gh api graphql` command delivering *content_body* via *delivery*.
+
+    *delivery* must be a GRAPHQL_DELIVERY_MATRIX value. For "input-file",
+    writes *content_body* as the query field of tmp_path/graphql.json and
+    returns a command that reads it via `--input graphql.json`; the caller
+    must classify the returned command with `cwd=str(tmp_path)` for the
+    relative path to resolve.
+    """
+    if delivery == "inline-single-quoted":
+        return f"gh api graphql -f query='{content_body}'"
+    if delivery == "inline-double-quoted":
+        return f'gh api graphql -f query="{content_body}"'
+    if delivery == "inline-unquoted":
+        return f"gh api graphql -f query={content_body}"
+    if delivery == "input-file":
+        (tmp_path / "graphql.json").write_text(
+            json.dumps({"query": content_body}), encoding="utf-8"
+        )
+        return "gh api graphql --input graphql.json"
+    raise ValueError(f"unknown delivery form: {delivery!r}")
+
+
+def graphql_delivery_is_inherently_safe(delivery: str, content: str) -> bool:
+    """Whether a (delivery, content) cell should resolve rather than deny.
+
+    True when *delivery* is independently provable "shell could not have
+    altered this" (fully single-quoted, or file content -- see
+    ``_is_dynamic_shell_value`` and the ``query_from_literal_input`` skip
+    condition in ``_command_classification.py``), or when *content* has none
+    of ``_DYNAMIC_SHELL_TOKEN_RE``'s trigger characters (``$`` `` ` `` ``*``
+    ``?`` ``[``) regardless of quoting.
+    """
+    return delivery in ("inline-single-quoted", "input-file") or content == "plain"

--- a/tests/hooks/test_command_classification.py
+++ b/tests/hooks/test_command_classification.py
@@ -12,21 +12,36 @@ import pytest
 import autoskillit.hooks._command_classification as command_classification
 import autoskillit.hooks._github_mutation_analysis as github_mutation_analysis
 from autoskillit.hooks._command_classification import (
+    _GIT_GLOBAL_FLAG_SPEC,
+    _FlagArity,
     command_verb,
+    extract_git_subcommand_and_flags,
     extract_interpreter_write_paths,
     extract_redirect_targets,
     has_interpreter_wrapped_command,
     has_interpreter_write,
     has_nested_shell,
+    is_allowed_protected_path_metadata_command,
     is_gh_command,
     tokenize_command_segments,
 )
 from autoskillit.hooks._github_mutation_analysis import (
+    _CURL_FLAG_SPEC,
+    _GH_API_FLAG_SPEC,
+    _GH_HELP_FLAGS,
     GitHubMutationAnalysis,
     GitHubMutationKind,
     GitHubMutationRecord,
     GitHubMutationStatus,
     analyze_github_mutations,
+)
+from tests.hooks._flag_form_matrix import (
+    FLAG_FORM_MATRIX,
+    GRAPHQL_CONTENT_MATRIX,
+    GRAPHQL_DELIVERY_MATRIX,
+    GRAPHQL_MATRIX_CONTENT_BODIES,
+    deliver_graphql_document,
+    graphql_delivery_is_inherently_safe,
 )
 
 pytestmark = [pytest.mark.layer("infra"), pytest.mark.small]
@@ -935,6 +950,42 @@ def test_strip_heredoc_bodies(command: str, expected_stripped: str) -> None:
     assert strip_heredoc_bodies(command) == expected_stripped
 
 
+class TestIsAllowedProtectedPathMetadataCommand:
+    def test_recognized_git_status_metadata_command_is_allowed(self) -> None:
+        assert is_allowed_protected_path_metadata_command(["git", "status"]) is True
+
+    def test_content_reading_git_subcommand_is_not_allowed(self) -> None:
+        assert is_allowed_protected_path_metadata_command(["git", "show", "HEAD"]) is False
+
+    def test_non_git_command_is_not_allowed(self) -> None:
+        assert is_allowed_protected_path_metadata_command(["cat", "file.py"]) is False
+
+    def test_unrecognized_global_git_flag_shift_is_not_allowed(self) -> None:
+        """Git subcommand shift (Part C, wiring check for the first of
+
+        extract_git_subcommand_and_flags's three callers): a real git
+        global flag absent from the old allowlist, space-separated, must
+        not shift subcommand detection onto the flag's value -- the
+        "<unresolved>" sentinel must be treated identically to None
+        (-> False), not accidentally matched against
+        _PROTECTED_PATH_METADATA_GIT_SUBCOMMANDS.
+        """
+        assert (
+            is_allowed_protected_path_metadata_command(
+                ["git", "--namespace", "refs/foo", "status"]
+            )
+            is True
+        )
+        # A genuinely unrecognized flag (not just one this allowlist predates)
+        # must fail closed to False, not be silently treated as safe metadata.
+        assert (
+            is_allowed_protected_path_metadata_command(
+                ["git", "--this-flag-does-not-exist", "val", "status"]
+            )
+            is False
+        )
+
+
 class TestAnalyzeGitHubMutations:
     def test_read_only_command_has_exact_empty_analysis(self) -> None:
         assert analyze_github_mutations("gh api /repos/o/r/pulls/7/reviews") == (
@@ -1819,6 +1870,472 @@ class TestAnalyzeGitHubMutations:
         assert analysis.status is GitHubMutationStatus.NONE
         assert analysis.request_count == 0
         assert analysis.mutations == ()
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            (
+                "gh api graphql -f query='mutation { addReaction("
+                'input: {subjectId: "abc", content: THUMBS_UP}) '
+                "{ clientMutationId } }' --jq '.data.addReaction.clientMutationId'"
+            ),
+            "gh api /repos/o/r/issues -f title=Bug --template '{{.number}}'",
+            "gh api /repos/o/r/issues -f title=Bug -p custom-preview",
+        ],
+        ids=["jq", "template", "preview"],
+    )
+    def test_previously_unrecognized_gh_api_flags_no_longer_misparse_route(
+        self, command: str
+    ) -> None:
+        """AC1 reproduction (Issue #4655 Defect 1): --jq/--template/-p used to shift
+        the flag's own value into the route slot, tripping a false
+        request_cardinality_unresolved deny. The query bodies above deliberately
+        avoid `$`/`[` so this test isolates Defect 1 from Part B's Defect 2 fix.
+        """
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.status is GitHubMutationStatus.SINGLE_RESOLVED
+        assert analysis.request_count == 1
+        assert analysis.reason_code == ""
+
+    def test_unrecognized_gh_api_flag_has_a_distinguishable_reason_code(self) -> None:
+        """An unrecognized gh api flag must fail closed with its own reason code,
+
+        not the same request_cardinality_unresolved code a genuinely-ambiguous
+        route triggers -- proving the fix is architectural (unknown flags get an
+        honest, distinguishable outcome) rather than three more special-cased
+        branches under the same misleading reason code.
+        """
+        analysis = analyze_github_mutations(
+            "gh api /repos/o/r/issues --this-flag-does-not-exist zzz"
+        )
+
+        assert analysis.status is GitHubMutationStatus.UNRESOLVED
+        assert analysis.reason_code == "unrecognized_gh_api_flag"
+        assert analysis.reason_code != "request_cardinality_unresolved"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            (
+                "gh api /repos/o/r/issues -X POST -F count=1 -f note=hi "
+                "--jq .id --template {{.id}} -p custom"
+            ),
+            (
+                "gh api /repos/o/r/issues --method=POST --field=count=1 "
+                "--raw-field=note=hi --jq=.id --template={{.id}} --preview=custom"
+            ),
+            "gh api /repos/o/r/issues -XPOST -Fcount=1 -fnote=hi -q.id -t{{.id}} -pcustom",
+        ],
+        ids=FLAG_FORM_MATRIX,
+    )
+    def test_gh_api_value_flag_grammar_resolves_identically_across_forms(
+        self, command: str
+    ) -> None:
+        """Extends the gh-issue-edit 5-form precedent to gh api's value-taking
+
+        flags. --method/-X, --field/-F, and --raw-field/-f already supported all
+        three forms via _flag_value (untested before this); --jq/-q, --template/-t,
+        and -p/--preview are newly recognized by this part's spec-driven engine.
+        """
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.status is GitHubMutationStatus.SINGLE_RESOLVED
+        assert analysis.request_count == 1
+        assert analysis.mutations[0].method == "POST"
+
+    @pytest.mark.parametrize("form", ["space", "equals"])
+    def test_gh_api_input_flag_supports_space_and_equals_forms(
+        self, form: str, tmp_path: Path
+    ) -> None:
+        (tmp_path / "body.json").write_text('{"title": "Bug"}', encoding="utf-8")
+        flag = "--input body.json" if form == "space" else "--input=body.json"
+        analysis = analyze_github_mutations(
+            f"gh api /repos/o/r/issues --method POST {flag}",
+            cwd=str(tmp_path),
+        )
+
+        assert analysis.status is GitHubMutationStatus.SINGLE_RESOLVED
+        assert analysis.request_count == 1
+
+    def test_fully_single_quoted_graphql_document_resolves(self) -> None:
+        """AC2/AC3 reproduction (Issue #4655 Defect 2): a GraphQL mutation document
+
+        delivered inline via `-f query='...'`, fully single-quoted end-to-end,
+        legitimately contains `$`/`[` (GraphQL variables, list literals) --
+        this must resolve, not be misclassified as a dynamic shell value.
+        """
+        command = (
+            "gh api graphql -f query='mutation($id: ID!) "
+            "{ addLabels(labelIds: [$id]) { clientMutationId } }'"
+        )
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.status is GitHubMutationStatus.SINGLE_RESOLVED
+        assert analysis.request_count == 1
+        assert analysis.reason_code == ""
+
+    @pytest.mark.parametrize(
+        "suffix",
+        [
+            ";echo done",
+            "|tee /tmp/x",
+            "&echo done",
+        ],
+        ids=["semicolon", "pipe", "ampersand"],
+    )
+    def test_single_quoted_graphql_followed_by_unseparated_shell_operator_resolves(
+        self, suffix: str
+    ) -> None:
+        """Regression pin for _SHELL_OPERATOR_CHARS strip introduced for the
+
+        AC2/AC3 fix above: a fully single-quoted GraphQL document immediately
+        followed by an unseparated shell operator (`, |`, `&`) must still
+        resolve. shlex.shlex(punctuation_chars=True) leaves the operator in
+        the previous token's source range; without the operator-chars strip
+        `fully_single_quoted` would mismatch `'<token>'` and the legitimate
+        mutation would be wrongly denied as dynamic_target.
+        """
+        command = (
+            "gh api graphql -f query='mutation($id: ID!) "
+            "{ addLabels(labelIds: [$id]) { clientMutationId } }'" + suffix
+        )
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.status is GitHubMutationStatus.SINGLE_RESOLVED
+        assert analysis.request_count == 1
+        assert analysis.reason_code == ""
+
+    def test_unquoted_command_substitution_in_graphql_document_remains_denied(self) -> None:
+        """AC4 regression pin: the prior investigation explicitly warned a blanket
+
+        `$`/`[` relaxation would let a real command-substitution fragment through
+        -- this must remain denied as a first-class test, not an afterthought.
+        """
+        command = (
+            'gh api graphql -f query="mutation($id: ID!) '
+            '{ addLabels(labelIds: [`whoami`]) { clientMutationId } }"'
+        )
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.status is GitHubMutationStatus.UNRESOLVED
+        assert analysis.reason_code == "dynamic_target"
+
+    def test_identical_graphql_content_denied_when_not_single_quoted(self) -> None:
+        """Provenance-not-content proof: the exact same `$`/`[` GraphQL content,
+
+        delivered double-quoted instead of single-quoted, must remain denied --
+        proving the fix is provenance-based (quote type of the token), not a
+        character-set relaxation applied to GraphQL content generally.
+        """
+        command = (
+            'gh api graphql -f query="mutation($id: ID!) '
+            '{ addLabels(labelIds: [$id]) { clientMutationId } }"'
+        )
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.status is GitHubMutationStatus.UNRESOLVED
+        assert analysis.reason_code == "dynamic_target"
+
+    def test_partial_single_quote_run_is_not_fully_quoted(self) -> None:
+        """A single-quote run that closes and reopens concatenated with a
+
+        double-quoted segment must remain denied, proving "fully single-quoted
+        end-to-end" is enforced precisely -- not "starts with a quote character".
+        """
+        command = "gh api graphql -f query='mutation'\"($id)\""
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.status is GitHubMutationStatus.UNRESOLVED
+        assert analysis.reason_code == "dynamic_target"
+
+    @pytest.mark.parametrize("content", GRAPHQL_CONTENT_MATRIX)
+    @pytest.mark.parametrize("delivery", GRAPHQL_DELIVERY_MATRIX)
+    def test_graphql_delivery_content_matrix(
+        self, delivery: str, content: str, tmp_path: Path
+    ) -> None:
+        """REQ-065: the full delivery x content cross product the four
+
+        individually-named tests above (single-quoted-resolves,
+        command-substitution-denied, double-quoted-denied,
+        partial-quote-denied) each only sampled one cell of. Resolution
+        depends only on whether *delivery* is inherently safe (fully
+        single-quoted, or file content) or *content* has no dynamic-shell
+        trigger character at all -- see
+        graphql_delivery_is_inherently_safe's own docstring for the exact
+        rule. Every other cell must deny with reason_code ==
+        "dynamic_target".
+        """
+        command = deliver_graphql_document(
+            delivery, GRAPHQL_MATRIX_CONTENT_BODIES[content], tmp_path
+        )
+        analysis = analyze_github_mutations(command, cwd=str(tmp_path))
+
+        if graphql_delivery_is_inherently_safe(delivery, content):
+            assert analysis.status is GitHubMutationStatus.SINGLE_RESOLVED, (
+                f"{delivery}/{content} unexpectedly unresolved: {analysis.reason_code}"
+            )
+            assert analysis.reason_code == ""
+        else:
+            assert analysis.status is GitHubMutationStatus.UNRESOLVED
+            assert analysis.reason_code == "dynamic_target"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh api /repos/o/r/issues -f title=Bug -X 'POST'",
+            "gh api /repos/o/r/issues -f title=Bug --method='POST'",
+            "gh api /repos/o/r/issues -f title=Bug -X'POST'",
+        ],
+        ids=FLAG_FORM_MATRIX,
+    )
+    def test_method_provenance_proof_single_quoted_resolves(self, command: str) -> None:
+        """--method/-X provenance proof (not GraphQL content): a genuinely
+
+        single-quoted method value must resolve -- proving the
+        _flag_value/_consume_argv_flag retyping is real provenance tracing, not
+        a fabricated ArgvToken(value, True) default, since none of the
+        GraphQL-focused tests above exercise the --method/-X extraction path
+        at all.
+        """
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.status is GitHubMutationStatus.SINGLE_RESOLVED
+        assert analysis.mutations[0].method == "POST"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh api /repos/o/r/issues -f title=Bug -X POST$(whoami)",
+            "gh api /repos/o/r/issues -f title=Bug --method=POST$(whoami)",
+            "gh api /repos/o/r/issues -f title=Bug -XPOST$(whoami)",
+        ],
+        ids=FLAG_FORM_MATRIX,
+    )
+    def test_method_provenance_proof_unquoted_substitution_denied(self, command: str) -> None:
+        """Companion to the single-quoted proof above: the same forms, but with
+
+        a real command-substitution fragment appended inside the same
+        quoting (none here), must remain denied.
+        """
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.status is GitHubMutationStatus.UNRESOLVED
+        assert analysis.reason_code == "dynamic_target"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh api /repos/o/r/issues -f title=Bug -X 'PO$ST'",
+            "gh api /repos/o/r/issues -f title=Bug --method='PO$ST'",
+            "gh api /repos/o/r/issues -f title=Bug -X'PO$ST'",
+        ],
+        ids=FLAG_FORM_MATRIX,
+    )
+    def test_method_provenance_proof_quoted_dynamic_looking_content_not_denied(
+        self, command: str
+    ) -> None:
+        """Deep provenance proof: a `$` appearing *inside* a fully single-quoted
+
+        method value must not trigger the dynamic-value check in any form --
+        the equals-form and bundled-form retyping must re-derive the value's
+        own quote provenance (see _argv_token_after_prefix), not inherit the
+        whole token's coarser flag, or a `--method=`/`-X` prefix sitting
+        outside the quotes would wrongly disqualify an otherwise safely
+        quoted value.
+        """
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.reason_code != "dynamic_target"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh api /repos/o/r/issues -f title=Bug -X PO$ST",
+            "gh api /repos/o/r/issues -f title=Bug --method=PO$ST",
+            "gh api /repos/o/r/issues -f title=Bug -XPO$ST",
+        ],
+        ids=FLAG_FORM_MATRIX,
+    )
+    def test_method_provenance_proof_unquoted_dynamic_content_denied(self, command: str) -> None:
+        """Companion regression pin: the identical `$`-bearing content, not
+
+        quoted at all, must still deny in every form.
+        """
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.status is GitHubMutationStatus.UNRESOLVED
+        assert analysis.reason_code == "dynamic_target"
+
+    def test_gh_release_notes_help_spoof_value_does_not_exempt_mutation(self) -> None:
+        """Help-spoof bypass (Part C): --notes is not a curated value-taking
+
+        flag in _GH_KNOWN_VALUE_FLAGS, so under the old "assume boolean,
+        advance 1" default, its own value '--help' would be misread as a
+        bare help flag on the next iteration -- incorrectly exempting the
+        whole command from mutation classification (the code's own comment
+        already named this spoofing risk as the reason the table exists;
+        the table was simply incomplete).
+        """
+        analysis = analyze_github_mutations("gh release create v1 --notes '--help'")
+
+        assert analysis.status is GitHubMutationStatus.SINGLE_RESOLVED
+
+    def test_unrecognized_boolean_flag_before_real_help_still_exempts(self) -> None:
+        """The default-arity flip's trade-off is one-directional and safe: a
+
+        genuinely-boolean unrecognized flag immediately followed by a real
+        --help still classifies as non-mutating (reached via normal
+        classification rather than the help-fast-path -- a missed
+        shortcut, never a bypass).
+        """
+        analysis = analyze_github_mutations("gh pr view --web --help")
+
+        assert analysis.status is GitHubMutationStatus.NONE
+
+    def test_curl_user_agent_flag_does_not_cause_false_cardinality_unresolved(self) -> None:
+        """curl overblock regression pin (Part C): -A/--user-agent is outside
+
+        curl's previously-covered value_flags tuple; its value must not be
+        misread as a second URL and denied as request_cardinality_unresolved.
+        """
+        analysis = analyze_github_mutations(
+            'curl -A "custom-agent/1.0" https://api.github.com/repos/x/y'
+        )
+
+        assert analysis.reason_code != "request_cardinality_unresolved"
+
+    def test_unrecognized_curl_flag_has_a_distinguishable_reason_code(self) -> None:
+        """curl's generalized rewire fails closed on a truly unrecognized flag,
+
+        matching gh api's Part A precedent -- distinguishable from
+        request_cardinality_unresolved.
+        """
+        analysis = analyze_github_mutations(
+            "curl --this-curl-flag-does-not-exist zzz https://api.github.com/repos/x/y"
+        )
+
+        assert analysis.status is GitHubMutationStatus.UNRESOLVED
+        assert analysis.reason_code == "unrecognized_curl_flag"
+        assert analysis.reason_code != "request_cardinality_unresolved"
+
+    @pytest.mark.parametrize("flag", sorted(_GH_API_FLAG_SPEC))
+    def test_every_gh_api_spec_flag_is_recognized(self, flag: str) -> None:
+        """Generative coverage (Part D): every flag in _GH_API_FLAG_SPEC must
+
+        be recognized by _analyze_gh_api's engine, not fall through to
+        unrecognized_gh_api_flag. Parametrized directly from the spec
+        table's own keys (not a hand-maintained flag list) so this test can
+        never silently miss a flag added to the table later -- see
+        tests/arch/test_guard_flag_spec_coverage.py, which verifies this
+        parametrize genuinely iterates the full table.
+
+        -h/--help are routed through a command construction that places them
+        after an unrecognized `-`-prefixed token so _gh_args_have_bare_help_flag
+        treats them as that token's value and does NOT short-circuit
+        analyze_github_mutations before the spec engine sees them. Otherwise
+        the assertion below would vacuously pass for -h/--help because the
+        help exemption returns reason_code="" rather than exercising the spec
+        table at all.
+        """
+        if flag in _GH_HELP_FLAGS:
+            # Construct a command where -h/--help is preceded by an
+            # unrecognized `-`-prefixed token so _gh_args_have_bare_help_flag
+            # classifies -h as that token's value (not a bare help), forcing
+            # analyze_github_mutations down the spec-engine path this test
+            # is meant to cover.
+            command = f"gh api /repos/o/r/issues --header=val {flag}"
+        else:
+            command = f"gh api /repos/o/r/issues -f title=Bug {flag}"
+            if _GH_API_FLAG_SPEC[flag] == _FlagArity.VALUE:
+                command += " someval"
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.reason_code != "unrecognized_gh_api_flag"
+
+    @pytest.mark.parametrize("flag", sorted(_CURL_FLAG_SPEC))
+    def test_every_curl_spec_flag_is_recognized(self, flag: str) -> None:
+        """Generative coverage (Part D): every flag in _CURL_FLAG_SPEC must be
+
+        recognized by _analyze_curl_segment's engine, not fall through to
+        unrecognized_curl_flag.
+        """
+        command = f"curl {flag}"
+        if _CURL_FLAG_SPEC[flag] == _FlagArity.VALUE:
+            command += " someval"
+        command += " https://api.github.com/repos/o/r"
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.reason_code != "unrecognized_curl_flag"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh api -H",
+            "gh api /route -H",
+            "gh api /route --header",
+            "gh api /route --hostname",
+            "gh api /route --cache",
+        ],
+    )
+    def test_gh_api_value_flag_without_value_returns_missing_required_value(
+        self, command: str
+    ) -> None:
+        """Regression pin for the spec-engine dedup (post-validator follow-up):
+
+        dropping the gh api hand-rolled -H/--header/--hostname/--cache skip
+        logic in favor of the spec table engine lost the explicit
+        missing_required_value return -- _consume_argv_flag returns (None,
+        i+1, True) for VALUE-arity with no next token, indistinguishable from
+        BOOLEAN. The call site now re-checks the spec table to surface the
+        distinct missing-value error rather than silently passing.
+        """
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.status is GitHubMutationStatus.UNRESOLVED
+        assert analysis.reason_code == "missing_required_value"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "curl --user-agent",
+            "curl --proxy",
+            "curl --cacert",
+            "curl --connect-timeout",
+        ],
+    )
+    def test_curl_value_flag_without_value_returns_missing_required_value(
+        self, command: str
+    ) -> None:
+        """Regression pin for the spec-engine dedup (post-validator follow-up):
+
+        the curl call site must surface missing-value for VALUE-arity flags
+        similarly to gh api, otherwise `curl --proxy` (no value) silently
+        passes _analyze_curl_segment's unrecognized-flag check and escapes
+        as a missing-required-value smell.
+        """
+        analysis = analyze_github_mutations(command)
+
+        assert analysis.status is GitHubMutationStatus.UNRESOLVED
+        assert analysis.reason_code == "missing_required_value"
+
+
+@pytest.mark.parametrize("flag", sorted(_GIT_GLOBAL_FLAG_SPEC))
+def test_every_git_global_spec_flag_is_recognized(flag: str) -> None:
+    """Generative coverage (Part D): every flag in _GIT_GLOBAL_FLAG_SPEC must
+
+    be recognized by extract_git_subcommand_and_flags, not fall through to
+    the "<unresolved>" fail-closed sentinel.
+    """
+    segment = ["git", flag]
+    if _GIT_GLOBAL_FLAG_SPEC[flag] == _FlagArity.VALUE:
+        segment.append("someval")
+    segment.append("status")
+
+    result = extract_git_subcommand_and_flags(segment)
+
+    assert result is not None
+    assert result[0] != "<unresolved>"
 
 
 class TestSiblingWrappersDelegate:

--- a/tests/hooks/test_gh_api_flag_spec_contract.py
+++ b/tests/hooks/test_gh_api_flag_spec_contract.py
@@ -1,0 +1,312 @@
+"""Live-CLI contract tests for this module's four CLI flag-arity spec tables.
+
+Each test shells out to a CLI's `--help` and asserts every value-taking flag
+it lists is present (with VALUE arity) in the corresponding spec table --
+catching a future CLI release adding a value-taking flag before it can
+silently reintroduce Issue #4655 Defect 1's shape (an unrecognized flag's
+value misread as a second route/positional). One shared diff/assert core
+(`_assert_spec_covers_parsed_flags`) is parameterized by each CLI's own
+help-line-parsing heuristic, since gh/curl/git/pip's `--help` formats are
+structurally different (a per-line FLAGS listing, a bracketed usage
+synopsis, a sectioned options list, ...) -- the parsing can't be shared,
+only the comparison/assertion logic.
+
+curl's flag surface (~250 flags) is deliberately *not* exhaustively covered
+by `_CURL_FLAG_SPEC` (see that table's own module-level comment); its
+contract test is scoped accordingly -- see
+`test_curl_flag_spec_covers_this_rectifys_named_flags` for what it actually
+checks and why.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from collections.abc import Mapping
+
+import pytest
+
+from autoskillit.hooks._command_classification import (
+    _GIT_GLOBAL_FLAG_SPEC,
+    _PIP_GLOBAL_FLAG_SPEC,
+    _FlagArity,
+)
+from autoskillit.hooks._github_mutation_analysis import (
+    _CURL_FLAG_SPEC,
+    _GH_API_FLAG_SPEC,
+)
+
+pytestmark = [pytest.mark.layer("infra"), pytest.mark.small]
+
+
+def _assert_spec_covers_parsed_flags(
+    parsed_flags: set[str],
+    spec: Mapping[str, _FlagArity],
+    *,
+    cli_label: str,
+    sanity_floor: int = 5,
+) -> None:
+    """Shared live-CLI-help-diff assertion.
+
+    Every member of *parsed_flags* (value-taking flags parsed from a live
+    `--help` read) must be present in *spec* with VALUE arity. Fails loudly
+    (never silently passes) if *parsed_flags* is empty or below
+    *sanity_floor* -- that signals a broken parser, not the CLI genuinely
+    having few value-taking flags.
+    """
+    assert len(parsed_flags) >= sanity_floor, (
+        f"{cli_label} --help flag parser extracted only {len(parsed_flags)} value-taking "
+        f"flags ({sorted(parsed_flags)}) -- the parser is likely broken, not {cli_label}'s "
+        "help output actually shrinking below the sanity floor"
+    )
+    spec_value_flags = {flag for flag, arity in spec.items() if arity == _FlagArity.VALUE}
+    missing = parsed_flags - spec_value_flags
+    assert not missing, (
+        f"{cli_label} --help lists value-taking flags absent from its spec table: "
+        f"{sorted(missing)} -- add them in src/autoskillit/hooks/_command_classification.py"
+    )
+
+
+def _parse_help_line_placeholder_flags(help_text: str, *, section_header: str | None) -> set[str]:
+    """Parse a per-line `FLAGS`-style help section (gh, curl, pip's shape).
+
+    A value-taking flag has an extra whitespace-delimited placeholder token
+    (e.g. `string`, `<path>`, `key=value`) between the flag name(s) and the
+    right-padded description column boundary (always >= 2 spaces); a
+    boolean flag does not. If *section_header* is given, only lines after
+    that header (until the next unindented line) are scanned; if None, every
+    indented, flag-shaped line in the text is scanned (curl's `--help all`
+    has no distinct header -- its whole body past the usage line is flags).
+    """
+    value_flags: set[str] = set()
+    in_section = section_header is None
+    for line in help_text.splitlines():
+        stripped = line.strip()
+        if section_header is not None:
+            if stripped == section_header:
+                in_section = True
+                continue
+            if in_section and line and not line[0].isspace():
+                break
+            if not in_section:
+                continue
+        if not stripped or not stripped.startswith("-"):
+            continue
+        flag_part = re.split(r"\s{2,}", stripped, maxsplit=1)[0]
+        tokens = flag_part.replace(",", "").split()
+        flag_names = [t for t in tokens if t.startswith("-")]
+        has_placeholder = len(tokens) > len(flag_names)
+        if has_placeholder:
+            value_flags.update(flag_names)
+    return value_flags
+
+
+def test_gh_api_flag_spec_covers_every_live_value_taking_flag() -> None:
+    if shutil.which("gh") is None:
+        pytest.skip("gh binary not available in this environment")
+
+    result = subprocess.run(
+        ["gh", "api", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, f"gh api --help failed: {result.stderr}"
+
+    parsed_flags = _parse_help_line_placeholder_flags(result.stdout, section_header="FLAGS")
+    _assert_spec_covers_parsed_flags(parsed_flags, _GH_API_FLAG_SPEC, cli_label="gh api")
+
+
+def test_pip_global_flag_spec_covers_every_live_value_taking_flag() -> None:
+    if shutil.which("pip") is None:
+        pytest.skip("pip binary not available in this environment")
+
+    result = subprocess.run(
+        ["pip", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, f"pip --help failed: {result.stderr}"
+
+    parsed_flags = _parse_help_line_placeholder_flags(
+        result.stdout, section_header="General Options:"
+    )
+    _assert_spec_covers_parsed_flags(parsed_flags, _PIP_GLOBAL_FLAG_SPEC, cli_label="pip")
+
+
+def _parse_git_help_value_flags(help_text: str) -> set[str]:
+    """Parse git's top-level usage synopsis for value-taking global flags.
+
+    `git --help`'s usage line uses bracket notation: `[--flag <value>]` or
+    `[--flag=<value>]` for value-taking flags, `[--flag]` (no `<...>`/`=`)
+    for boolean ones, `|` to separate short/long spellings within one
+    bracket group (e.g. `[-v | --version]`), and nested brackets for a
+    flag's own *optional* value (e.g. `[--exec-path[=<path>]]`) -- the
+    latter is excluded from this check entirely (ambiguous, neither
+    definitely boolean nor definitely value-taking; see
+    _GIT_GLOBAL_FLAG_SPEC's own --exec-path comment for why this module
+    treats it as BOOLEAN by default rather than guessing).
+    """
+    value_flags: set[str] = set()
+    match = re.search(r"usage:\s*git\s+(.*?)\s*<command>", help_text, re.DOTALL)
+    if not match:
+        return value_flags
+    usage_text = match.group(1).replace("\n", " ")
+
+    groups: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for char in usage_text:
+        if char == "[":
+            if depth == 0:
+                current = []
+            else:
+                current.append(char)
+            depth += 1
+            continue
+        if char == "]":
+            depth -= 1
+            if depth == 0:
+                groups.append("".join(current))
+            else:
+                current.append(char)
+            continue
+        if depth > 0:
+            current.append(char)
+
+    for group in groups:
+        if "[" in group:
+            continue
+        if "<" not in group and "=" not in group:
+            continue
+        flag_part = re.split(r"[<=]", group, maxsplit=1)[0]
+        for spelling in flag_part.split("|"):
+            spelling = spelling.strip()
+            if spelling.startswith("-"):
+                value_flags.add(spelling)
+    return value_flags
+
+
+def test_git_global_flag_spec_covers_every_live_value_taking_flag() -> None:
+    if shutil.which("git") is None:
+        pytest.skip("git binary not available in this environment")
+
+    result = subprocess.run(
+        ["git", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, f"git --help failed: {result.stderr}"
+
+    parsed_flags = _parse_git_help_value_flags(result.stdout)
+    _assert_spec_covers_parsed_flags(
+        parsed_flags, _GIT_GLOBAL_FLAG_SPEC, cli_label="git", sanity_floor=3
+    )
+
+
+# curl's live surface (~250 flags across `curl --help all`) is deliberately
+# *not* exhaustively mirrored in _CURL_FLAG_SPEC -- see that table's own
+# module comment: an unrecognized curl flag now fails closed, so exhaustive
+# coverage would need to weigh against the availability cost of denying
+# every real-world curl invocation that happens to use one of curl's many
+# rarely-used flags outside this rectify's named set. Rather than silently
+# skip a live-contract check for curl entirely, this test makes the scope
+# limitation explicit: it pins the specific flags this rectify's
+# investigation named (plus curl's own already-covered special-cased
+# flags), not curl's full surface.
+_CURL_FLAGS_THIS_RECTIFY_MUST_COVER: frozenset[str] = frozenset(
+    {
+        "-X",
+        "--request",
+        "--url",
+        "-d",
+        "--data",
+        "--data-raw",
+        "--data-binary",
+        "--data-urlencode",
+        "-F",
+        "--form",
+        "-T",
+        "--upload-file",
+        "-H",
+        "--header",
+        "-u",
+        "--user",
+        "-o",
+        "--output",
+        "-A",
+        "--user-agent",
+        "-b",
+        "--cookie",
+        "-c",
+        "--cookie-jar",
+        "-x",
+        "--proxy",
+        "-w",
+        "--write-out",
+        "-m",
+        "--max-time",
+        "--cacert",
+        "-E",
+        "--cert",
+        "--key",
+        "--connect-timeout",
+        "--retry",
+        "--resolve",
+    }
+)
+
+
+def test_curl_flag_spec_covers_this_rectifys_named_flags() -> None:
+    if shutil.which("curl") is None:
+        pytest.skip("curl binary not available in this environment")
+
+    result = subprocess.run(
+        ["curl", "--help", "all"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, f"curl --help all failed: {result.stderr}"
+
+    parsed_flags = _parse_help_line_placeholder_flags(result.stdout, section_header=None)
+    assert len(parsed_flags) >= 20, (
+        f"curl --help all flag parser extracted only {len(parsed_flags)} value-taking "
+        "flags -- the parser is likely broken, not curl's help output shrinking"
+    )
+
+    named_but_removed = _CURL_FLAGS_THIS_RECTIFY_MUST_COVER - parsed_flags
+    assert not named_but_removed, (
+        "curl --help all no longer lists flags this rectify's investigation named "
+        f"(possibly renamed/removed upstream): {sorted(named_but_removed)} -- update "
+        "_CURL_FLAG_SPEC and this set together in "
+        "src/autoskillit/hooks/_command_classification.py"
+    )
+
+    spec_value_flags = {
+        flag for flag, arity in _CURL_FLAG_SPEC.items() if arity == _FlagArity.VALUE
+    }
+    not_yet_covered = _CURL_FLAGS_THIS_RECTIFY_MUST_COVER - spec_value_flags
+    assert not not_yet_covered, (
+        f"_CURL_FLAG_SPEC is missing flags this rectify's investigation named as VALUE "
+        f"arity: {sorted(not_yet_covered)}"
+    )
+
+    out_of_scope = parsed_flags - spec_value_flags
+    if out_of_scope:
+        # Not a failure -- see the module-level comment on why curl's table
+        # is deliberately bounded. Surfaced here (not silently dropped) so
+        # the scope limitation stays visible in test output.
+        print(
+            f"\ncurl --help all lists {len(out_of_scope)} value-taking flags outside "
+            "_CURL_FLAG_SPEC's deliberately-bounded coverage (an unrecognized curl "
+            "flag now fails closed for these): "
+            f"{sorted(out_of_scope)[:10]}{'...' if len(out_of_scope) > 10 else ''}"
+        )

--- a/tests/hooks/test_github_mutation_guard.py
+++ b/tests/hooks/test_github_mutation_guard.py
@@ -9,6 +9,12 @@ from pathlib import Path
 
 import pytest
 
+from ._flag_form_matrix import (
+    GRAPHQL_DELIVERY_MATRIX,
+    GRAPHQL_MATRIX_CONTENT_BODIES,
+    deliver_graphql_document,
+    graphql_delivery_is_inherently_safe,
+)
 from .conftest import _RUN_CMD_TOOL_DIRECT, make_hook_event
 
 pytestmark = [pytest.mark.layer("infra"), pytest.mark.small]
@@ -664,6 +670,114 @@ def test_unresolved_mutation_denies_with_unresolved_mutation_reason(
     assert "dynamic_target" in reason
     assert "$OWNER" not in reason
     assert "GitHub API route is dynamic" not in reason
+
+
+@pytest.mark.parametrize("event_factory", [_bash_event, _run_cmd_event], ids=["bash", "run-cmd"])
+def test_previously_unrecognized_gh_api_flags_no_longer_deny_at_guard_level(
+    event_factory,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """AC1 reproduction at the guard level: --jq used to shift its own value
+
+    into the route slot, tripping a false request_cardinality_unresolved deny.
+    """
+    command = "gh api /repos/o/r/issues -f title=Bug --jq .id"
+
+    assert _decision(event_factory(command, cwd=str(tmp_path)), monkeypatch) != "deny"
+
+
+def test_unrecognized_gh_api_flag_denies_with_a_distinguishable_reason(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    event = make_hook_event(
+        tool="Bash",
+        command="gh api /repos/o/r/issues --this-flag-does-not-exist zzz",
+        payload_cwd=str(tmp_path),
+    )
+
+    result = _run_hook(event, monkeypatch)
+
+    assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+    reason = result["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "unresolved_mutation" in reason
+    assert "unrecognized_gh_api_flag" in reason
+    assert "request_cardinality_unresolved" not in reason
+
+
+@pytest.mark.parametrize("event_factory", [_bash_event, _run_cmd_event], ids=["bash", "run-cmd"])
+def test_fully_single_quoted_graphql_document_is_not_denied_as_dynamic(
+    event_factory,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """AC2/AC3 reproduction at the guard level: a fully single-quoted GraphQL
+
+    mutation document legitimately containing `$`/`[` must not be denied.
+    """
+    command = (
+        "gh api graphql -f query='mutation($id: ID!) "
+        "{ addLabels(labelIds: [$id]) { clientMutationId } }'"
+    )
+
+    assert _decision(event_factory(command, cwd=str(tmp_path)), monkeypatch) != "deny"
+
+
+def test_unquoted_graphql_command_substitution_remains_denied(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """AC4 regression pin at the guard level: identical-shaped content with a
+
+    real, unquoted command-substitution fragment must remain denied.
+    """
+    event = make_hook_event(
+        tool="Bash",
+        command=(
+            'gh api graphql -f query="mutation($id: ID!) '
+            '{ addLabels(labelIds: [`whoami`]) { clientMutationId } }"'
+        ),
+        payload_cwd=str(tmp_path),
+    )
+
+    result = _run_hook(event, monkeypatch)
+
+    assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+    reason = result["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "dynamic_target" in reason
+
+
+@pytest.mark.parametrize("event_factory", [_bash_event, _run_cmd_event], ids=["bash", "run-cmd"])
+@pytest.mark.parametrize("delivery", GRAPHQL_DELIVERY_MATRIX)
+def test_graphql_delivery_matrix_decision_matches_classification(
+    delivery: str,
+    event_factory,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """REQ-065: every GRAPHQL_DELIVERY_MATRIX form reaches a guard-level deny
+
+    decision that matches analyze_github_mutations's own per-delivery
+    resolution (see the exhaustive delivery x content matrix in
+    test_command_classification.py::TestAnalyzeGitHubMutations) -- filling
+    the one delivery form ("inline-unquoted") neither of this file's two
+    named GraphQL regression tests above happens to exercise. Content is
+    fixed at "dollar-variable" (the two tests above already separately pin
+    "plain"-via-single-quote and "command-substitution"-via-double-quote);
+    the full 16-cell delivery x content cross product is exhaustively
+    checked once, at the classification layer, not duplicated here -- this
+    test only proves the guard's own decision wiring surfaces that result.
+    """
+    content_body = GRAPHQL_MATRIX_CONTENT_BODIES["dollar-variable"]
+    command = deliver_graphql_document(delivery, content_body, tmp_path)
+
+    decision = _decision(event_factory(command, cwd=str(tmp_path)), monkeypatch)
+
+    if graphql_delivery_is_inherently_safe(delivery, "dollar-variable"):
+        assert decision != "deny"
+    else:
+        assert decision == "deny"
 
 
 def test_deny_messages_mapping_is_exhaustive() -> None:

--- a/tests/hooks/test_write_guard.py
+++ b/tests/hooks/test_write_guard.py
@@ -1078,6 +1078,15 @@ class TestExtractBashWriteTargetsNewFamilies:
         assert result is not None
         assert "/clone/src/main.py" in result
 
+    def test_git_namespace_flag_before_checkout_detected(self):
+        from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
+
+        result = _extract_bash_write_targets(
+            "git --namespace refs/foo checkout -- /clone/src/main.py"
+        )
+        assert result is not None
+        assert "/clone/src/main.py" in result
+
     def test_git_with_flag_prefix_reset_hard_detected(self):
         from autoskillit.hooks.guards.write_guard import _extract_bash_write_targets
 

--- a/tests/infra/test_git_ops_guard.py
+++ b/tests/infra/test_git_ops_guard.py
@@ -19,6 +19,12 @@ from pathlib import Path
 
 import pytest
 
+from autoskillit.hooks.guards.git_ops_guard import (
+    _GIT_FETCH_FLAG_SPEC,
+    _classify_fetch,
+    _FlagArity,
+)
+
 pytestmark = [pytest.mark.layer("infra"), pytest.mark.medium]
 
 _TOOL_NAME = "mcp__autoskillit__local__autoskillit__run_cmd"
@@ -203,6 +209,30 @@ class TestGitPushForceDenied:
     def test_denies_full_path_git_push_force(self, tmp_path):
         out = _run_guard("/usr/local/bin/git push --force", kitchen_open=True, tmpdir=tmp_path)
         assert _is_denied(out)
+
+    def test_denies_push_force_with_unresolved_global_flag(self, tmp_path: Path) -> None:
+        """Defense regression for _contains_blocked_git_op's <unresolved>
+
+        short-circuit (git_ops_guard.py:206). An unrecognized git global
+        flag (`--attr-source` -- a genuine git option not yet enumerated in
+        _GIT_GLOBAL_FLAG_SPEC) before `push --force` makes
+        extract_git_subcommand_and_flags return ("<unresolved>", ...). The
+        short-circuit at git_ops_guard.py:206 then must deny unconditionally
+        via the fail-closed sentinel; without it, the sentinel would not
+        match any literal entry in _BLOCKED_GIT_OPS and the destructive
+        `push --force` would slip through undetected.
+        """
+        out = _run_guard(
+            "git --attr-source foo push --force",
+            kitchen_open=True,
+            tmpdir=tmp_path,
+        )
+        assert _is_denied(out)
+        data = json.loads(out)
+        reason = data["hookSpecificOutput"]["permissionDecisionReason"]
+        # Distinguish from the checked-out-ref denial (TestCheckedOutRef*)
+        # and from a no-op exit: this path uses GIT_OPS_DENY_TRIGGER.
+        assert "destructive" in reason.lower() or "blocked" in reason.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -660,6 +690,32 @@ class TestCheckedOutRefMutations:
         assert any(row["target_ref"] == "refs/heads/develop" for row in threatened)
         _assert_ref_unchanged(linked, "refs/heads/develop", str(linked_repo["old_sha"]))
 
+    def test_denies_fetch_with_unrecognized_value_flag_space_separated(
+        self, linked_repo: dict[str, Path | str]
+    ) -> None:
+        """--negotiation-tip <rev> in space-separated form (NOT --flag=value,
+        which is a single self-contained shlex token) previously fell through
+        _classify_fetch's flag parsing as unrecognized, so its value was
+        appended to `positional` and misread as the remote name. The wrong
+        remote.<name>.fetch lookup returned nothing, mappings stayed empty,
+        and the fetch passed through unclassified. See _GIT_FETCH_FLAG_SPEC.
+        """
+        linked = linked_repo["linked"]
+        assert isinstance(linked, Path)
+        old_sha = str(linked_repo["old_sha"])
+        out = _run_guard(
+            f"git fetch origin --negotiation-tip {old_sha} "
+            "+refs/remotes/origin/develop:refs/heads/develop",
+            kitchen_open=True,
+            tmpdir=linked,
+        )
+        assert _is_denied(out)
+        result = _checked_out_ref_result(out)
+        threatened = result["threatened_refs"]
+        assert isinstance(threatened, list)
+        assert any(row["target_ref"] == "refs/heads/develop" for row in threatened)
+        _assert_ref_unchanged(linked, "refs/heads/develop", old_sha)
+
     @pytest.mark.parametrize(
         ("relative_target", "command_builder"),
         [
@@ -708,6 +764,67 @@ class TestCheckedOutRefAmbiguity:
         linked = linked_repo["linked"]
         assert isinstance(linked, Path)
         out = _run_guard(command, kitchen_open=True, tmpdir=linked)
+        assert _is_denied(out)
+        result = _checked_out_ref_result(out)
+        refs = result["threatened_refs"]
+        assert isinstance(refs, list)
+        assert {row["target_ref"] for row in refs} >= {
+            "refs/heads/develop",
+            "refs/heads/review",
+        }
+        assert all(row["old_sha"] == linked_repo["old_sha"] for row in refs)
+
+    def test_literal_asterisk_in_value_is_recognized_as_dynamic(
+        self, linked_repo: dict[str, Path | str]
+    ) -> None:
+        # Regression test: the shared _DYNAMIC_SHELL_TOKEN_RE (imported from
+        # _github_mutation_analysis.py) must include `*`. The guard previously
+        # defined its own local _DYNAMIC_TOKEN_RE for this preflight that
+        # omitted `*`, so a start-point value containing a literal `*` (a
+        # shell-glob-expandable character) was NOT recognized as dynamic and
+        # could slip through as if it were a resolvable literal ref. It must
+        # instead be treated as unresolved/ambiguous, matching the $TARGET
+        # case above.
+        linked = linked_repo["linked"]
+        assert isinstance(linked, Path)
+        out = _run_guard("git branch -f develop br*nch", kitchen_open=True, tmpdir=linked)
+        assert _is_denied(out)
+        result = _checked_out_ref_result(out)
+        refs = result["threatened_refs"]
+        assert isinstance(refs, list)
+        assert {row["target_ref"] for row in refs} >= {
+            "refs/heads/develop",
+            "refs/heads/review",
+        }
+        assert all(row["old_sha"] == linked_repo["old_sha"] for row in refs)
+
+    def test_unresolved_global_flag_before_subcommand_fails_closed_for_all_owners(
+        self, linked_repo: dict[str, Path | str]
+    ) -> None:
+        # Regression test: extract_git_subcommand_and_flags() must return
+        # ("<unresolved>", []) -- not silently misparse -- when a real git
+        # global flag outside the guard's recognized _GIT_GLOBAL_FLAG_SPEC
+        # appears in space-separated form before the subcommand.
+        # --attr-source=<tree-ish> is a genuine git global option (see
+        # `git help git`'s OPTIONS section; `git --attr-source foo status`
+        # runs status normally, proving git itself consumes "foo" as the
+        # flag's value, not a subcommand) that the guard's flag spec does
+        # not recognize. The prior parser advanced its cursor by exactly
+        # one token for any unrecognized `-`-prefixed token, so the flag's
+        # *value* token ("foo") was misread as the subcommand itself: `git
+        # --attr-source foo branch -f develop start` classified
+        # subcommand="foo", which matched none of _classify_git_segment's
+        # dispatch branches, so the real `branch -f` mutation was never
+        # classified at all and slipped through undetected. It must
+        # instead be treated as unresolved/ambiguous, matching the
+        # $TARGET and asterisk cases above.
+        linked = linked_repo["linked"]
+        assert isinstance(linked, Path)
+        out = _run_guard(
+            "git --attr-source foo branch -f develop start",
+            kitchen_open=True,
+            tmpdir=linked,
+        )
         assert _is_denied(out)
         result = _checked_out_ref_result(out)
         refs = result["threatened_refs"]
@@ -821,3 +938,47 @@ class TestCheckedOutRefPreflightOrdering:
         )
         assert _is_denied(out)
         _checked_out_ref_result(out)
+
+
+# ---------------------------------------------------------------------------
+# Spec table coverage: every entry in _GIT_FETCH_FLAG_SPEC must be recognized
+# by _classify_fetch's spec-driven consume loop. Parametrized directly from
+# the table's own keys so a future flag added to the spec extends coverage
+# automatically. Registered with test_guard_flag_spec_coverage.py via
+# _SPEC_TABLE_TEST_FILES so the standing-invariant AST scanner confirms the
+# parametrize genuinely iterates the table rather than a hand-copied list.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("flag", sorted(_GIT_FETCH_FLAG_SPEC))
+def test_every_git_fetch_spec_flag_is_recognized(flag: str) -> None:
+    """Generative coverage (Part D): every flag in _GIT_FETCH_FLAG_SPEC must be
+
+    recognized by _classify_fetch rather than misread as the remote/refspec
+    positional. An unrecognized flag's value would have been misclassified as
+    the fetch's remote URL and silently passed the destructive-op preflight;
+    that must not happen for any spec member.
+
+    --stdin is intentionally short-circuited by _classify_fetch's first
+    special case (it makes destinations ambiguous by design, independent of
+    spec-table recognition), so we assert the SPECIFIC ambiguous result shape
+    for it rather than the generic non-unresolved invariant.
+    """
+    args = [flag]
+    if _GIT_FETCH_FLAG_SPEC[flag] == _FlagArity.VALUE:
+        args.append("someval")
+    args.append("origin")
+
+    result = _classify_fetch(args, cwd="/tmp", owned_refs=[])
+
+    if flag == "--stdin":
+        # --stdin is special-cased at the top of _classify_fetch to return the
+        # ambiguous-deny idiom; the spec table entry exists so the generic
+        # consume loop doesn't misread it as a positional remote, not because
+        # the function's downstream logic actually consumes it.
+        assert result == [("", "<unresolved>", True)]
+    else:
+        # Any presence of an `<unresolved>` entry from the consume loop
+        # means the flag was NOT recognized -- the precise failure mode the
+        # spec table is supposed to prevent.
+        assert not any(entry[1] == "<unresolved>" for entry in result)

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -1166,7 +1166,7 @@ def test_canonical_recipe_responses_fit_independent_registry_ceilings(tmp_path, 
     assert maxima == {
         "get_recipe_section": (179_951, "remediation", "all_truthy"),
         "load_recipe": (179_951, "remediation", "all_truthy"),
-        "open_kitchen": (180_004, "remediation", "all_truthy"),
+        "open_kitchen": (180_005, "remediation", "all_truthy"),
     }
 
 

--- a/tests/infra/test_unsafe_install_guard.py
+++ b/tests/infra/test_unsafe_install_guard.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 
 import pytest
 
+from autoskillit.hooks._command_classification import _PIP_GLOBAL_FLAG_SPEC, _FlagArity
+
 pytestmark = [pytest.mark.layer("infra"), pytest.mark.small]
 
 
@@ -155,6 +157,18 @@ class TestUnsafeInstallGuardAllowed:
         """Non-editable pip install does not create dangling entry points — allowed."""
         assert not _is_denied(_run_guard("pip install requests"))
 
+    def test_pip_install_non_editable_is_allowed_via_empty_output(self):
+        """Same case as above, asserted directly on the guard's raw output
+
+        (empty stdout = allow) rather than through the _is_denied wrapper --
+        this is the fail-closed guard registry's required behavioral
+        allow-test neighbor (see tests/arch/test_fail_closed_guard_contract.py),
+        which AST-scans for an assertion referencing the guard result by
+        name, not through an indirection helper.
+        """
+        result = _run_guard("pip install requests")
+        assert result == ""
+
     def test_task_install_worktree_allowed(self):
         """task install-worktree always uses --python .venv — allowed."""
         assert not _is_denied(_run_guard("task install-worktree"))
@@ -285,6 +299,10 @@ _DIRECT_DENIED: list[tuple[str, str]] = [
     ("stdbuf -o0 pip install -e .", "stdbuf-pip-install-e"),
     # Attached --python=<path> form: must remain unsafe when path is not .venv.
     ("pip install -e . --python=/usr/bin/python3", "attached-system-python"),
+    # Space-separated global *value* flag (--proxy <url>) preceding `install`:
+    # must still be recognized as a pip-install invocation and denied, not
+    # silently skipped (see _find_pip_install's _PIP_GLOBAL_FLAG_SPEC lookup).
+    ("pip --proxy http://example.invalid install -e .", "pip-global-value-flag-proxy-install-e"),
 ]
 
 
@@ -705,3 +723,75 @@ class TestSystemInstallScope:
     )
     def test_bash_guard_denies_scoped_system(self, cmd: str) -> None:
         assert _is_denied(_run_bash_guard(cmd))
+
+
+# --- Unrecognized pip global-flag ambiguity (kind propagation) ---
+# Guard-level coverage for the --proxy bypass regression lives in
+# _DIRECT_DENIED above. This directly unit-tests _is_unsafe_editable_install
+# so a fix that only teaches _find_pip_install to resolve the ambiguity,
+# without wiring that result through _classify_install_invocation and
+# _iter_install_segments to the top-level deny decision, stays caught.
+
+
+class TestPipGlobalFlagAmbiguityPropagation:
+    def test_is_unsafe_editable_install_denies_space_separated_global_value_flag(
+        self,
+    ) -> None:
+        from autoskillit.hooks.guards.unsafe_install_guard import (
+            _is_unsafe_editable_install,
+        )
+
+        assert (
+            _is_unsafe_editable_install("pip --proxy http://example.invalid install -e .") is True
+        )
+
+    def test_truly_unrecognized_pip_flag_yields_unresolved_pip_flags_kind(self) -> None:
+        """--proxy above is now correctly recognized by _PIP_GLOBAL_FLAG_SPEC
+
+        (Part C's table extension), so it never actually reaches the
+        "unresolved-pip-flags" sentinel path itself. This test isolates
+        that path directly with a flag genuinely absent from the spec
+        table, proving the propagation chain
+        _find_pip_install -> _classify_install_invocation ->
+        _iter_install_segments -> _is_unsafe_editable_install is real, not
+        a no-op that stops at _find_pip_install alone.
+        """
+        from autoskillit.hooks.guards.unsafe_install_guard import (
+            _classify_install_invocation,
+            _is_unsafe_editable_install,
+        )
+
+        segment = ["pip", "--this-pip-flag-does-not-exist", "val", "install", "-e", "."]
+        from autoskillit.hooks.guards.unsafe_install_guard import _PIP_INSTALL_UNRESOLVED
+
+        assert _classify_install_invocation(segment) == (_PIP_INSTALL_UNRESOLVED, [], [])
+        assert (
+            _is_unsafe_editable_install("pip --this-pip-flag-does-not-exist val install -e .")
+            is True
+        )
+
+
+class TestPipGlobalFlagSpecGenerativeCoverage:
+    """Generative coverage (Part D): every flag in _PIP_GLOBAL_FLAG_SPEC must
+
+    be recognized by _find_pip_install, not fall through to the
+    _PIP_INSTALL_UNRESOLVED sentinel. Parametrized directly from the spec
+    table's own keys (not a hand-maintained flag list) so this test can
+    never silently miss a flag added to the table later -- see
+    tests/arch/test_guard_flag_spec_coverage.py, which verifies this
+    parametrize genuinely iterates the full table.
+    """
+
+    @pytest.mark.parametrize("flag", sorted(_PIP_GLOBAL_FLAG_SPEC))
+    def test_every_pip_global_spec_flag_is_recognized(self, flag: str) -> None:
+        from autoskillit.hooks.guards.unsafe_install_guard import _find_pip_install
+
+        args = [flag]
+        if _PIP_GLOBAL_FLAG_SPEC[flag] == _FlagArity.VALUE:
+            args.append("someval")
+        args.append("install")
+
+        result = _find_pip_install(args)
+
+        assert result is not None
+        assert not isinstance(result, str)

--- a/tests/server/test_delivery_e2e_verification.py
+++ b/tests/server/test_delivery_e2e_verification.py
@@ -250,9 +250,9 @@ async def test_implementation_bounded_path_counts_automatic_and_advertised_deliv
     totals = normalized_counter.totals()
     # Drift baseline, not a production-safe threshold.
     assert totals == {
-        "raw_chars": 22_318,
-        "utf8_bytes": 22_332,
-        "client_serialized_chars": 24_993,
+        "raw_chars": 22_319,
+        "utf8_bytes": 22_333,
+        "client_serialized_chars": 24_994,
         "estimated_tokens": 5_581,
         "responses": 5,
     }


### PR DESCRIPTION
## Summary

This plan was developed and reviewed as four parts; they are combined here into one document for convenience, but **must still be implemented sequentially in this order** — each part depends on state the previous part establishes:

- **Part A** — flag-arity spec-table engine, applied to `gh api` (closes Issue #4655 Defect 1).
- **Part B** — quote-provenance tokenizer (`ArgvToken`), closing Issue #4655 Defect 2. *Depends on Part A* (retypes the return value of Part A's `_consume_gh_flag`).
- **Part C** — extends Part A's engine to 7 further sites with bypass-direction bugs found during the parallel investigation, including a third independent copy of one bug in `core/bash_write_targets.py`. *Depends on Part A* (reuses its flag-arity-spec engine).
- **Part D** — test-suite-wide architectural enforcement (per-flag/per-form coverage test + live CLI-help drift detection). *Depends on Parts A and C* (audits their spec tables for test coverage).

Each part below retains its own Summary, How Tests Missed This, Related Issues Found, Architectural Analysis, Immunity Plan (failing tests → implementation → wiring check), and Verification — every part must independently pass `task test-all` (this project's configured `test_check.command` in `.autoskillit/config.yaml`) before the next begins, per this project's multi-part plan green-gate convention.

Three rounds of adversarial review (a control-flow Foundation Audit, a variable-provenance Interface Mapping pass, and a Registry/completeness Trace) were run against the full draft of this plan; their findings are already incorporated into the text below, not listed separately.

A subsequent `/audit-impl` pass found two gaps against this plan: REQ-065 (a test-suite parametrize-matrix convention specified in Part D was only partially applied) was fixed directly; REQ-044 (Part C's `_gh_args_have_bare_help_flag` fix) was implemented deliberately narrower than the plan specified, after tracing that the plan's literal default-arity-flip reintroduces a real mutation-guard bypass the project's own pre-existing regression test already pins — filed as a formal deviation and independently confirmed ACCEPT by the project's own deviation-evaluator agent.

Closes https://github.com/TalonT-Org/AutoSkillit/issues/4655

## Implementation Plan

Plan file: `/home/talon/projects/generic_automation_mcp/.autoskillit/temp/rectify/rectify_github_mutation_guard_argv_parsing_immunity_2026-08-17_061427_combined.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
