### PR TITLE
Rectify: Interactive Policy Checkpoint Immunity — intent-carrying specs, wired config authority, and an unstubbed corridor startup net

### DIFF
--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -136,7 +136,7 @@ A skill that declares `semantic_requirements.join.required: true` enters a join-
    * `join_stop_guard` (Stop, exit code 2) blocks Claude from completing until the wave is `complete`.
 4. **Backend admission** — `BackendCapabilities.fixed_set_join_capable` is statically `True` only for Claude Code, and only when the full guard set is registered in the same commit. Codex returns `unsupported_operation(REQUIRED_JOIN)` at admission; current Codex has wait-any/mailbox semantics, not fixed-set fan-in.
 5. **Session binding monotonicity** — `skill_load_post_hook.py` writes a JSON envelope with OR-accumulated `join_required`. A later join-false Skill load does not downgrade an established binding. A missing or unreadable projection manifest fails closed by forcing `join_required: true` so dispatch guards refuse all join-bearing work.
-6. **Repository force-inactive option** — `agent_backend.force_claude_agent_teams_inactive` (default False) neutralizes `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` and detects conflicting entries in the target repository's `.claude/settings.json` / `.claude/settings.local.json`. Repositories with the option disabled remain byte-for-byte unchanged.
+6. **Repository force-inactive option** — `agent_backend.force_inactive_agent_teams` (default False) neutralizes `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` and detects conflicting entries in the target repository's `.claude/settings.json` / `.claude/settings.local.json`. Repositories with the option disabled remain byte-for-byte unchanged.
 
 The session flag carries join policy; the manifest carries projection identity; the ledger carries wave state. Each is read by the matching hook family. None of them is a duplicate authority — they are three projections of one decision.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -104,7 +104,7 @@ existing open issues by fingerprint.
 
 ### Does AutoSkillit force Claude agent teams off?
 
-No, not by default. The `agent_backend.force_claude_agent_teams_inactive`
+No, not by default. The `agent_backend.force_inactive_agent_teams`
 configuration option defaults to **false**, scoped per-repository (project
 configuration overrides user-level `.claude/settings.json`). When the
 operator sets it to **true** on a target repo, AutoSkillit strips

--- a/docs/safety/hooks.md
+++ b/docs/safety/hooks.md
@@ -487,7 +487,7 @@ All guard scripts fail-**open** for malformed or unparseable input: a JSON decod
 failure produces exit 0 (approve). This prevents a broken hook from blocking the
 entire tool chain.
 
-Seven guards additionally fail-**closed** for valid input with unrecognized values,
+Eight guards additionally fail-**closed** for valid input with unrecognized values,
 as a defense-in-depth measure against privilege escalation:
 
 | Guard | Fail-closed condition | Rationale |
@@ -499,6 +499,7 @@ as a defense-in-depth measure against privilege escalation:
 | `github_mutation_guard.py` | Ambiguous or unresolved GitHub mutation command, or unexpected classifier error | Unknown mutation scope must not bypass the structured review publisher |
 | `exploration_request_identity_guard.py` | A supported exploration event lacks bounded native identity or its one-shot record cannot be written | A Claude exploration call must not execute without request-correlated authority |
 | `git_ops_guard.py` | Unexpected runtime error during the checked-out-ref preflight (OSError, subprocess.SubprocessError, TypeError, UnicodeDecodeError, ValueError) | An unhandled exception must not silently allow a checked-out ref mutation — use exit 2 + stderr to hard-block |
+| `pr_create_guard.py` | Hook config unreadable or malformed while the kitchen is open (OSError, JSONDecodeError, AttributeError, TypeError) | An unresolvable `recipe_allows_pr_create` authorization must not be read as permission to bypass the prepare_pr → compose_pr pipeline |
 
 **Design principle:** Garbage-in (malformed hook input) = fail-open. Unknown-tier
 (valid input, unrecognized value) = fail-closed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autoskillit"
-version = "0.10.986"
+version = "0.10.987"
 description = "MCP server for orchestrating automated skill-driven workflows with Claude Code"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/autoskillit/.claude-plugin/plugin.json
+++ b/src/autoskillit/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "autoskillit",
-  "version": "0.10.986",
+  "version": "0.10.987",
   "description": "Orchestrated skill-driven workflows using Claude Code headless sessions"
 }

--- a/src/autoskillit/cli/fleet/_fleet_session.py
+++ b/src/autoskillit/cli/fleet/_fleet_session.py
@@ -94,6 +94,7 @@ def _launch_fleet_session(
                 project_dir=project_dir,
                 required_env=FLEET_SESSION_REQUIRED_ENV,
                 backend=_backend,
+                force_inactive_agent_teams=cfg.agent_backend.force_claude_agent_teams_inactive,
             )
             if session_signal is None:
                 break
@@ -204,6 +205,7 @@ def _launch_fleet_session(
                 project_dir=project_dir,
                 required_env=FLEET_SESSION_REQUIRED_ENV,
                 backend=_backend,
+                force_inactive_agent_teams=cfg.agent_backend.force_claude_agent_teams_inactive,
             )
             if session_signal is None:
                 break

--- a/src/autoskillit/cli/fleet/_fleet_session.py
+++ b/src/autoskillit/cli/fleet/_fleet_session.py
@@ -94,7 +94,7 @@ def _launch_fleet_session(
                 project_dir=project_dir,
                 required_env=FLEET_SESSION_REQUIRED_ENV,
                 backend=_backend,
-                force_inactive_agent_teams=cfg.agent_backend.force_claude_agent_teams_inactive,
+                force_inactive_agent_teams=cfg.agent_backend.force_inactive_agent_teams,
             )
             if session_signal is None:
                 break
@@ -205,7 +205,7 @@ def _launch_fleet_session(
                 project_dir=project_dir,
                 required_env=FLEET_SESSION_REQUIRED_ENV,
                 backend=_backend,
-                force_inactive_agent_teams=cfg.agent_backend.force_claude_agent_teams_inactive,
+                force_inactive_agent_teams=cfg.agent_backend.force_inactive_agent_teams,
             )
             if session_signal is None:
                 break

--- a/src/autoskillit/cli/session/_session_cook.py
+++ b/src/autoskillit/cli/session/_session_cook.py
@@ -128,6 +128,7 @@ def cook(
     )
 
     config = load_config()
+    force_inactive_agent_teams = config.agent_backend.force_claude_agent_teams_inactive
     # Same derivation the MCP server uses (git toplevel -> cwd). Running `cook`
     # from a repository subdirectory used to yield a different project_dir than
     # the server derived on the same machine, and both values flow into the
@@ -391,6 +392,7 @@ def cook(
                             initial_prompt=current_initial_prompt,
                             add_dirs=[managed_home.skills_dir],
                             generated_home=managed_home.generated_home,
+                            force_inactive_agent_teams=force_inactive_agent_teams,
                         )
                     except ValueError as exc:
                         _exit_launch_preparation_error(exc)
@@ -404,6 +406,8 @@ def cook(
                         resume_spec=current_resume_spec,
                         system_prompt=cook_system_prompt,
                         env_extras=cook_env_extras,
+                        force_inactive_agent_teams=force_inactive_agent_teams,
+                        project_root=project_dir,
                     )
                 final_cmd = built_spec.cmd
                 final_origin = built_spec.origin

--- a/src/autoskillit/cli/session/_session_cook.py
+++ b/src/autoskillit/cli/session/_session_cook.py
@@ -128,7 +128,7 @@ def cook(
     )
 
     config = load_config()
-    force_inactive_agent_teams = config.agent_backend.force_claude_agent_teams_inactive
+    force_inactive_agent_teams = config.agent_backend.force_inactive_agent_teams
     # Same derivation the MCP server uses (git toplevel -> cwd). Running `cook`
     # from a repository subdirectory used to yield a different project_dir than
     # the server derived on the same machine, and both values flow into the

--- a/src/autoskillit/cli/session/_session_launch.py
+++ b/src/autoskillit/cli/session/_session_launch.py
@@ -124,6 +124,7 @@ def prepare_interactive_launch(
         generated_home=generated_home,
         tools=tools,
         force_inactive_agent_teams=force_inactive_agent_teams,
+        project_root=project_dir,
     )
     final = resolve_executable_launch_binding(
         binary_name=backend.binary_name(),
@@ -146,6 +147,8 @@ def prepare_interactive_launch(
         add_dirs=add_dirs,
         generated_home=generated_home,
         tools=tools,
+        force_inactive_agent_teams=force_inactive_agent_teams,
+        project_root=project_dir,
     )
     return PreparedInteractiveLaunch(spec=spec, executable=final)
 
@@ -172,6 +175,7 @@ def _run_interactive_session(
     retained_projection_binding: PluginLaunchBinding | None = None,
     startup_trace: StartupTrace | None = None,
     attempt: int | None = None,
+    force_inactive_agent_teams: bool = False,
 ) -> str | _InfraExitSignal | None:
     """Launch an interactive Claude Code session.
 
@@ -243,6 +247,7 @@ def _run_interactive_session(
                     add_dirs=[managed_home.skills_dir],
                     generated_home=managed_home.generated_home,
                     tools=tools_arg,
+                    force_inactive_agent_teams=force_inactive_agent_teams,
                 )
             except ValueError as exc:
                 _exit_launch_preparation_error(exc)
@@ -259,6 +264,8 @@ def _run_interactive_session(
                 add_dirs=[managed_home.skills_dir],
                 generated_home=managed_home.generated_home,
                 tools=tools_arg,
+                force_inactive_agent_teams=force_inactive_agent_teams,
+                project_root=_project_dir,
             )
             selector = backend.capabilities.explicit_path_env_var
             try:
@@ -281,6 +288,8 @@ def _run_interactive_session(
                 add_dirs=[managed_home.skills_dir],
                 generated_home=managed_home.generated_home,
                 tools=tools_arg,
+                force_inactive_agent_teams=force_inactive_agent_teams,
+                project_root=_project_dir,
             )
         spec = replace(built_spec, cwd=str(_project_dir))
         assert_interactive_ordering(spec=spec)
@@ -363,6 +372,7 @@ def _run_interactive_session(
                     system_prompt=system_prompt,
                     initial_prompt=initial_message,
                     tools=tools_arg,
+                    force_inactive_agent_teams=force_inactive_agent_teams,
                 )
             except ValueError as exc:
                 _exit_launch_preparation_error(exc)
@@ -452,6 +462,7 @@ def _launch_cook_session(
     launch_id: str,
     default_base_branch: str,
     workspace_temp_dir: str | None,
+    force_inactive_agent_teams: bool = False,
 ) -> None:
     """Launch an interactive Claude Code cook session with reload and infra-resume support."""
     _max_reloads = 10
@@ -501,6 +512,7 @@ def _launch_cook_session(
                 retained_projection_binding=retained_binding,
                 startup_trace=trace,
                 attempt=attempt if managed_home is not None else None,
+                force_inactive_agent_teams=force_inactive_agent_teams,
             )
             if session_signal is None:
                 return

--- a/src/autoskillit/cli/session/_session_order.py
+++ b/src/autoskillit/cli/session/_session_order.py
@@ -217,6 +217,7 @@ def order(
             launch_id=launch_id,
             default_base_branch=config.branching.default_base_branch,
             workspace_temp_dir=config.workspace.temp_dir,
+            force_inactive_agent_teams=config.agent_backend.force_claude_agent_teams_inactive,
         )
         return
 
@@ -272,6 +273,9 @@ def order(
                 launch_id=launch_id,
                 default_base_branch=config.branching.default_base_branch,
                 workspace_temp_dir=config.workspace.temp_dir,
+                force_inactive_agent_teams=(
+                    config.agent_backend.force_claude_agent_teams_inactive
+                ),
             )
             return
         elif resolved is None:
@@ -413,4 +417,5 @@ def order(
         launch_id=launch_id,
         default_base_branch=config.branching.default_base_branch,
         workspace_temp_dir=config.workspace.temp_dir,
+        force_inactive_agent_teams=config.agent_backend.force_claude_agent_teams_inactive,
     )

--- a/src/autoskillit/cli/session/_session_order.py
+++ b/src/autoskillit/cli/session/_session_order.py
@@ -217,7 +217,7 @@ def order(
             launch_id=launch_id,
             default_base_branch=config.branching.default_base_branch,
             workspace_temp_dir=config.workspace.temp_dir,
-            force_inactive_agent_teams=config.agent_backend.force_claude_agent_teams_inactive,
+            force_inactive_agent_teams=config.agent_backend.force_inactive_agent_teams,
         )
         return
 
@@ -273,9 +273,7 @@ def order(
                 launch_id=launch_id,
                 default_base_branch=config.branching.default_base_branch,
                 workspace_temp_dir=config.workspace.temp_dir,
-                force_inactive_agent_teams=(
-                    config.agent_backend.force_claude_agent_teams_inactive
-                ),
+                force_inactive_agent_teams=(config.agent_backend.force_inactive_agent_teams),
             )
             return
         elif resolved is None:
@@ -417,5 +415,5 @@ def order(
         launch_id=launch_id,
         default_base_branch=config.branching.default_base_branch,
         workspace_temp_dir=config.workspace.temp_dir,
-        force_inactive_agent_teams=config.agent_backend.force_claude_agent_teams_inactive,
+        force_inactive_agent_teams=config.agent_backend.force_inactive_agent_teams,
     )

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -676,7 +676,7 @@ class AgentBackendConfig:
     # target repository's .claude/settings*.json files before spawn. Defaults
     # to False — repositories with the option disabled remain byte-for-byte
     # unchanged. Independent from join.required. Refs #4575.
-    force_claude_agent_teams_inactive: bool = False
+    force_inactive_agent_teams: bool = False
 
     def __post_init__(self) -> None:
         if not self.backend:

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -353,6 +353,14 @@ RETIRED_CONFIG_KEYS: Mapping[tuple[str, str], RetiredConfigKeyDef] = types.Mappi
             retired_in="0.9.135",
             note="features.franchise was renamed to features.fleet in 0.9.135.",
         ),
+        ("agent_backend", "force_claude_agent_teams_inactive"): RetiredConfigKeyDef(
+            new_key="force_inactive_agent_teams",
+            retired_in="0.10.987",
+            note=(
+                "agent_backend.force_claude_agent_teams_inactive was renamed to "
+                "agent_backend.force_inactive_agent_teams in 0.10.987."
+            ),
+        ),
     }
 )
 

--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -474,6 +474,10 @@ class CmdSpec:
     is_resume: bool = False
     process_idle_timeout_ms: int = 0
     inherited_fds: tuple[int, ...] = ()
+    # Records that the builder was asked to keep Claude agent teams inactive
+    # and honored that request at construction. Post-spawn checkpoints read
+    # this intent rather than inferring policy from environment content.
+    force_inactive_agent_teams: bool = False
 
     def __post_init__(self) -> None:
         object.__setattr__(

--- a/src/autoskillit/core/types/_type_launch.py
+++ b/src/autoskillit/core/types/_type_launch.py
@@ -44,7 +44,7 @@ __all__ = [
 ]
 
 
-LAUNCH_CONTRACT_SCHEMA_VERSION = 2
+LAUNCH_CONTRACT_SCHEMA_VERSION = 3
 
 # Top-level field order is part of the persisted stable-digest schema. Runtime
 # observations, attempt counters, retry state, and resume state do not belong here.
@@ -576,6 +576,7 @@ class ResolvedLaunchContract:
                 "argv": self.cmd_spec.cmd,
                 "origin": origin_payload,
                 "process_idle_timeout_ms": self.cmd_spec.process_idle_timeout_ms,
+                "force_inactive_agent_teams": self.cmd_spec.force_inactive_agent_teams,
                 "sandbox_mode": self.sandbox_mode,
                 "network_access": self.network_access,
                 "pty_required": self.pty_required,
@@ -813,6 +814,7 @@ class ResolvedLaunchContract:
                         command["process_idle_timeout_ms"],
                         "command process idle timeout",
                     ),
+                    force_inactive_agent_teams=bool(command["force_inactive_agent_teams"]),
                 ),
                 sandbox_mode=str(command["sandbox_mode"]),
                 network_access=bool(command["network_access"]),

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -1449,7 +1449,7 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
         enabled by a developer's own settings are legitimate state, not a
         launch defect.
         """
-        if spec is None or not spec.force_inactive_agent_teams:
+        if not spec.force_inactive_agent_teams:
             return []
         env = dict(spec.env)
         project_root: Path | str | None = spec.cwd if spec.cwd else None

--- a/src/autoskillit/execution/backends/claude.py
+++ b/src/autoskillit/execution/backends/claude.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 from collections.abc import Mapping, Sequence
 from contextlib import AbstractContextManager, nullcontext
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -771,12 +771,7 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
 
     def build_cmd(self, skill_command: str, cwd: str) -> CmdSpec:
         spec = self.build_headless_cmd(skill_command)
-        return CmdSpec(
-            cmd=spec.cmd,
-            env=spec.env,
-            cwd=cwd,
-            inherited_fds=spec.inherited_fds,
-        )
+        return replace(spec, cwd=cwd)
 
     def stream_parser(self, completion_marker: str = "") -> ClaudeStreamParser:
         return ClaudeStreamParser(completion_marker=completion_marker)
@@ -835,7 +830,11 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
             _neutralize_agent_teams_env(env)
             _resolve_project_root_for_inactive_check(project_root)
             assert_agent_teams_inactive(env, project_root, force_inactive=True)
-        return CmdSpec(cmd=tuple(cmd), env=env)
+        return CmdSpec(
+            cmd=tuple(cmd),
+            env=env,
+            force_inactive_agent_teams=force_inactive_agent_teams,
+        )
 
     def build_interactive_cmd(
         self,
@@ -932,16 +931,6 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
             required=required_env,
         )
         if force_inactive_agent_teams:
-            if executable is not None:
-                # The executable binding captures its launch_environment at
-                # probe time, before any neutralization. Combining the two
-                # makes the binding stale; callers must resolve a fresh
-                # executable from the neutralized env instead.
-                raise ValueError(
-                    "force_inactive_agent_teams=True cannot be combined with "
-                    "executable binding; resolve a fresh executable from the "
-                    "neutralized env first"
-                )
             # ``build_agent_env`` returns a read-only ``MappingProxyType``;
             # neutralize on a single mutable copy and re-derive both the
             # assertion and the launch env from it.
@@ -949,13 +938,21 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
             _neutralize_agent_teams_env(neutralized_env)
             settings_root = str(project_root) if project_root is not None else None
             _resolve_project_root_for_inactive_check(settings_root)
+            # Settings entries are stripped before the confirmation, not after:
+            # asserting first refuses every repository whose settings enable
+            # teams, which is precisely the population this opt-in serves. A
+            # malformed file is refused rather than rewritten, so the assertion
+            # below still fails closed on one.
+            neutralize_repository_agent_teams_settings(settings_root)
             assert_agent_teams_inactive(
                 neutralized_env,
                 settings_root,
                 force_inactive=True,
             )
-            neutralize_repository_agent_teams_settings(settings_root)
             effective_env = neutralized_env
+        # With an executable binding this equality is the proof that the
+        # binding was resolved from the neutralized env rather than captured
+        # before neutralization; a genuinely stale binding still fails here.
         if executable is not None and dict(effective_env) != dict(executable.launch_environment):
             raise ValueError("interactive environment changed after executable binding")
         partial = builder.build()
@@ -965,6 +962,7 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
             origin=partial.origin,
             is_resume=isinstance(resume_spec, (NamedResume, BareResume)),
             inherited_fds=plugin_binding.inherited_fds if plugin_binding is not None else (),
+            force_inactive_agent_teams=force_inactive_agent_teams,
         )
 
     def build_resume_cmd(
@@ -1020,6 +1018,7 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
             env=env,
             is_resume=True,
             inherited_fds=plugin_binding.inherited_fds if plugin_binding is not None else (),
+            force_inactive_agent_teams=force_inactive_agent_teams,
         )
 
     def build_skill_session_cmd(
@@ -1155,6 +1154,7 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
             cwd=cwd,
             is_resume=bool(resume_session_id),
             inherited_fds=plugin_binding.inherited_fds if plugin_binding is not None else (),
+            force_inactive_agent_teams=force_inactive_agent_teams,
         )
 
     def build_food_truck_cmd(
@@ -1258,6 +1258,7 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
             env=spec.env,
             is_resume=bool(resume_session_id),
             inherited_fds=plugin_binding.inherited_fds if plugin_binding is not None else (),
+            force_inactive_agent_teams=force_inactive_agent_teams,
         )
 
     def validate_session_layout(
@@ -1443,15 +1444,15 @@ class ClaudeCodeBackend(BackendCmdBuilderBase):
         When the spec carries a request to keep Claude agent teams inactive,
         this checkpoint positively confirms that neither the resolved env
         nor the target repository's ``.claude/settings*.json`` files
-        re-enable ``CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS``. The plan's
-        Step 5.4 mandates this content-policy surface here in addition to
-        the per-builder enforcement.
+        re-enable ``CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS``. A spec that
+        carries no such request is not subject to the policy: agent teams
+        enabled by a developer's own settings are legitimate state, not a
+        launch defect.
         """
-        env = dict(spec.env) if spec is not None else {}
-        project_root: Path | str | None = None
-        cwd = spec.cwd if spec is not None else None
-        if cwd is not None:
-            project_root = cwd
+        if spec is None or not spec.force_inactive_agent_teams:
+            return []
+        env = dict(spec.env)
+        project_root: Path | str | None = spec.cwd if spec.cwd else None
         return _interactive_invocation_environment_policy(env, project_root)
 
     def ensure_pre_launch(

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -17,7 +17,7 @@ import time
 import tomllib
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import AbstractContextManager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import StrEnum, unique
 from pathlib import Path
 from typing import Any
@@ -1528,12 +1528,7 @@ class CodexBackend(BackendCmdBuilderBase):
 
     def build_cmd(self, skill_command: str, cwd: str) -> CmdSpec:
         spec = self.build_headless_cmd(skill_command)
-        return CmdSpec(
-            cmd=spec.cmd,
-            env=spec.env,
-            cwd=cwd,
-            inherited_fds=spec.inherited_fds,
-        )
+        return replace(spec, cwd=cwd)
 
     def stream_parser(self, completion_marker: str = "") -> CodexStreamParser:
         return CodexStreamParser(completion_marker=completion_marker)

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -394,9 +394,7 @@ async def run_headless_core(
             network_access=network_access,
             native_shell_capture_decision=native_shell_capture_decision,
             managed_lineage_ref=managed_lineage_ref,
-            force_inactive_agent_teams=(
-                ctx.config.agent_backend.force_claude_agent_teams_inactive
-            ),
+            force_inactive_agent_teams=(ctx.config.agent_backend.force_inactive_agent_teams),
         )
 
         logger.debug("run_headless_core_backend_dispatch", backend=_cmd_backend.name)

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -394,6 +394,9 @@ async def run_headless_core(
             network_access=network_access,
             native_shell_capture_decision=native_shell_capture_decision,
             managed_lineage_ref=managed_lineage_ref,
+            force_inactive_agent_teams=(
+                ctx.config.agent_backend.force_claude_agent_teams_inactive
+            ),
         )
 
         logger.debug("run_headless_core_backend_dispatch", backend=_cmd_backend.name)

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -155,7 +155,7 @@ async def _execute_claude_headless(
     cfg = ctx.config.run_skill
     # Read from the same authority the spec builders use, so adapter_digest and
     # CmdSpec.force_inactive_agent_teams cannot disagree.
-    force_inactive_agent_teams = ctx.config.agent_backend.force_claude_agent_teams_inactive
+    force_inactive_agent_teams = ctx.config.agent_backend.force_inactive_agent_teams
     if idle_output_timeout is not None:
         _raw_idle = idle_output_timeout
     else:

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -153,6 +153,9 @@ async def _execute_claude_headless(
     dispatch_id = dispatch_id or os.environ.get(DISPATCH_ID_ENV_VAR, "")
 
     cfg = ctx.config.run_skill
+    # Read from the same authority the spec builders use, so adapter_digest and
+    # CmdSpec.force_inactive_agent_teams cannot disagree. `cfg` is RunSkillConfig.
+    force_inactive_teams = ctx.config.agent_backend.force_claude_agent_teams_inactive
     if idle_output_timeout is not None:
         _raw_idle = idle_output_timeout
     else:
@@ -331,6 +334,7 @@ async def _execute_claude_headless(
                 lifecycle_observation_enabled=lifecycle_observation_enabled,
                 on_launch_resolved=observe_launch,
                 managed_attempt_id=managed_attempt_id,
+                force_inactive_agent_teams=force_inactive_teams,
                 **lineage_callbacks.attempt_kwargs,
             )
         except Exception as exc:

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -154,7 +154,7 @@ async def _execute_claude_headless(
 
     cfg = ctx.config.run_skill
     # Read from the same authority the spec builders use, so adapter_digest and
-    # CmdSpec.force_inactive_agent_teams cannot disagree. `cfg` is RunSkillConfig.
+    # CmdSpec.force_inactive_agent_teams cannot disagree.
     force_inactive_teams = ctx.config.agent_backend.force_claude_agent_teams_inactive
     if idle_output_timeout is not None:
         _raw_idle = idle_output_timeout

--- a/src/autoskillit/execution/headless/_headless_execute.py
+++ b/src/autoskillit/execution/headless/_headless_execute.py
@@ -155,7 +155,7 @@ async def _execute_claude_headless(
     cfg = ctx.config.run_skill
     # Read from the same authority the spec builders use, so adapter_digest and
     # CmdSpec.force_inactive_agent_teams cannot disagree.
-    force_inactive_teams = ctx.config.agent_backend.force_claude_agent_teams_inactive
+    force_inactive_agent_teams = ctx.config.agent_backend.force_claude_agent_teams_inactive
     if idle_output_timeout is not None:
         _raw_idle = idle_output_timeout
     else:
@@ -334,7 +334,7 @@ async def _execute_claude_headless(
                 lifecycle_observation_enabled=lifecycle_observation_enabled,
                 on_launch_resolved=observe_launch,
                 managed_attempt_id=managed_attempt_id,
-                force_inactive_agent_teams=force_inactive_teams,
+                force_inactive_agent_teams=force_inactive_agent_teams,
                 **lineage_callbacks.attempt_kwargs,
             )
         except Exception as exc:

--- a/src/autoskillit/execution/headless/_headless_helpers.py
+++ b/src/autoskillit/execution/headless/_headless_helpers.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import dataclasses
 import os
-from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -79,24 +78,11 @@ def assert_interactive_ordering(
     Always scans the raw cmd tuple — never trusts origin metadata alone, since
     CmdOrigin is a public dataclass and callers could set it on a misordered cmd.
 
-    The cook/order pre-spawn checkpoint also verifies that the spec's effective
-    environment will leave Claude agent teams inactive. The plan's Step 5.4
-    bundles this content-policy check with the ordering validation so that
-    every interactive launch surfaces both shape and environment violations
-    from a single gate.
+    Shape only, and backend-agnostic: environment content is never inspected
+    here. Environment policy belongs to the backend's own
+    ``validate_interactive_invocation``, which can read the spec's declared
+    intent. See tests/execution/test_assert_interactive_ordering.py.
     """
-    if isinstance(getattr(spec, "env", None), Mapping):
-        from autoskillit.execution.backends.claude import (
-            _interactive_invocation_environment_policy,
-        )
-
-        policy_errors = _interactive_invocation_environment_policy(
-            spec.env, getattr(spec, "cwd", None)
-        )
-        if policy_errors:
-            raise ValueError(
-                "interactive launch environment policy violations: " + "; ".join(policy_errors)
-            )
     if value_bearing_flags is None:
         value_bearing_flags = _ALL_VALUE_BEARING_FLAGS
     cmd = spec.cmd

--- a/src/autoskillit/execution/headless/_managed/_food_truck_executor.py
+++ b/src/autoskillit/execution/headless/_managed/_food_truck_executor.py
@@ -260,7 +260,7 @@ class DefaultHeadlessExecutor(_DefaultHeadlessExecutorBase):
             resume_message=resume_message,
             native_shell_capture_decision=native_shell_capture_decision,
             managed_lineage_ref=managed_lineage_ref,
-            force_inactive_agent_teams=cfg.agent_backend.force_claude_agent_teams_inactive,
+            force_inactive_agent_teams=cfg.agent_backend.force_inactive_agent_teams,
         )
 
         effective_timeout = timeout if timeout is not None else fleet_cfg.default_timeout_sec

--- a/src/autoskillit/execution/headless/_managed/_food_truck_executor.py
+++ b/src/autoskillit/execution/headless/_managed/_food_truck_executor.py
@@ -260,6 +260,7 @@ class DefaultHeadlessExecutor(_DefaultHeadlessExecutorBase):
             resume_message=resume_message,
             native_shell_capture_decision=native_shell_capture_decision,
             managed_lineage_ref=managed_lineage_ref,
+            force_inactive_agent_teams=cfg.agent_backend.force_claude_agent_teams_inactive,
         )
 
         effective_timeout = timeout if timeout is not None else fleet_cfg.default_timeout_sec

--- a/src/autoskillit/execution/launch_resolution.py
+++ b/src/autoskillit/execution/launch_resolution.py
@@ -401,13 +401,10 @@ class DefaultLaunchResolver:
             )
 
         inherited_fd_count = len(result.cmd_spec.inherited_fds)
-        sanitized_spec = CmdSpec(
-            cmd=result.cmd_spec.cmd,
+        sanitized_spec = replace(
+            result.cmd_spec,
             env=MappingProxyType(raw_env),
-            cwd=result.cmd_spec.cwd,
-            origin=result.cmd_spec.origin,
             is_resume=False,
-            process_idle_timeout_ms=result.cmd_spec.process_idle_timeout_ms,
             inherited_fds=(),
         )
         skill_projection_binding = (
@@ -541,12 +538,8 @@ class DefaultLaunchResolver:
             )
         env = dict(contract.nonsecret_env)
         env.update(secret_environment)
-        return CmdSpec(
-            cmd=contract.cmd_spec.cmd,
+        return replace(
+            contract.cmd_spec,
             env=env,
-            cwd=contract.cmd_spec.cwd,
-            origin=contract.cmd_spec.origin,
-            is_resume=contract.cmd_spec.is_resume,
-            process_idle_timeout_ms=contract.cmd_spec.process_idle_timeout_ms,
             inherited_fds=inherited_fds,
         )

--- a/src/autoskillit/hook_registry.py
+++ b/src/autoskillit/hook_registry.py
@@ -615,6 +615,7 @@ FAIL_CLOSED_GUARD_BASENAMES: frozenset[str] = frozenset(
         "github_mutation_guard.py",
         "exploration_request_identity_guard.py",
         "git_ops_guard.py",
+        "pr_create_guard.py",
     }
 )
 

--- a/src/autoskillit/hooks/guards/AGENTS.md
+++ b/src/autoskillit/hooks/guards/AGENTS.md
@@ -58,7 +58,7 @@ Each guard is a standalone Python script executed as a subprocess (not imported 
 All guards fail-**open** for malformed/unparseable input (JSON decode failure = exit 0 = approve).
 This prevents a broken hook from blocking the entire tool chain.
 
-Seven guards additionally fail-**closed** for valid input with unrecognized values, as a
+Eight guards additionally fail-**closed** for valid input with unrecognized values, as a
 defense-in-depth measure against privilege escalation:
 
 | Guard | Fail-closed condition | Rationale |
@@ -70,6 +70,7 @@ defense-in-depth measure against privilege escalation:
 | `github_mutation_guard.py` | Ambiguous or unresolved GitHub mutation command | Unknown mutation scope must not bypass the structured review publisher |
 | `exploration_request_identity_guard.py` | A supported exploration event lacks bounded native identity or its one-shot record cannot be written | A Claude exploration call must not execute without request-correlated authority |
 | `git_ops_guard.py` | Unexpected runtime error during the checked-out-ref preflight (OSError, subprocess.SubprocessError, TypeError, UnicodeDecodeError, ValueError) | An unhandled exception must not silently allow a checked-out ref mutation — use exit 2 + stderr to hard-block |
+| `pr_create_guard.py` | Hook config unreadable or malformed while the kitchen is open (OSError, JSONDecodeError, AttributeError, TypeError) | An unresolvable `recipe_allows_pr_create` authorization must not be read as permission to bypass the prepare_pr → compose_pr pipeline |
 
 **Design principle:** Garbage-in (malformed hook input) = fail-open. Unknown-tier (valid input, unrecognized value) = fail-closed.
 

--- a/src/autoskillit/migrations/0.10.986-to-0.10.987.yaml
+++ b/src/autoskillit/migrations/0.10.986-to-0.10.987.yaml
@@ -1,0 +1,31 @@
+from_version: "0.10.986"
+to_version: "0.10.987"
+description: >
+  Agent-backend configuration rename: agent_backend.force_claude_agent_teams_inactive
+  is now agent_backend.force_inactive_agent_teams.
+changes:
+  - id: force-claude-agent-teams-inactive-to-force-inactive-agent-teams
+    description: >
+      The agent_backend.force_claude_agent_teams_inactive config key has been
+      renamed to agent_backend.force_inactive_agent_teams for consistency with
+      every downstream consumer (CLI kwargs, backend builder parameters,
+      CmdSpec field, and the launch-contract payload key), which already used
+      the backend-neutral name. The value and default behavior are unchanged.
+    instruction: |
+      In your user or project .autoskillit/config.yaml, replace:
+        agent_backend:
+          force_claude_agent_teams_inactive: true
+      with:
+        agent_backend:
+          force_inactive_agent_teams: true
+      Preserve the configured boolean value. The old key is remapped
+      automatically with a deprecation warning for now, but will eventually
+      stop being recognized.
+    detect:
+      key: agent_backend.force_claude_agent_teams_inactive
+    example_before: |
+      agent_backend:
+        force_claude_agent_teams_inactive: true
+    example_after: |
+      agent_backend:
+        force_inactive_agent_teams: true

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -510,6 +510,7 @@ classified `REJECT` with `category: "arch_violation"`.
 | ClaudeFlags isolation | `test_backend_flag_isolation.py` | `ClaudeFlags` referenced in `_session_launch.py` — backend flags belong in backend layer only |
 | Boot step symmetry | `test_boot_step_symmetry.py` | Both boot functions must call all required boot steps in the right order |
 | BackendCapabilities consumed | `test_capability_consumption.py` | Every `BackendCapabilities` field must have a production consumer — unused capability fields are prohibited |
+| Config fields consumed | `test_config_consumption.py` | Every config dataclass field must have a production read site — a key that only parses and validates itself is dead config |
 | BackendCapabilities documented | `test_capability_docstrings.py` | `BackendCapabilities` class and every field must have docstrings |
 | Env var symmetry | `test_env_symmetry.py` | `build_skill_session_cmd` and `build_food_truck_cmd` must both set required base env vars; `AGENT_BACKEND_ENV_VAR` must appear in food_truck |
 | No NotImplementedError in backends | `test_no_not_implemented.py` | Registered backend classes must not raise `NotImplementedError` — `CodingAgentBackend` is a Protocol, not an ABC |

--- a/tests/_realistic_project.py
+++ b/tests/_realistic_project.py
@@ -28,7 +28,7 @@ workspace:
 
 _CONFIG_YAML_FORCE_INACTIVE = """agent_backend:
   backend: claude-code
-  force_claude_agent_teams_inactive: true
+  force_inactive_agent_teams: true
 workspace:
   temp_dir: .autoskillit/temp
 """
@@ -40,7 +40,7 @@ def make_realistic_project(
     agent_teams: str | None = None,
     extra_settings_keys: bool = True,
     malformed_local: bool = False,
-    force_claude_agent_teams_inactive: bool = False,
+    force_inactive_agent_teams: bool = False,
     project_dir: Path | None = None,
 ) -> Path:
     """Build a project directory resembling a real developer checkout.
@@ -60,7 +60,7 @@ def make_realistic_project(
 
     atomic_write(
         project / ".autoskillit" / "config.yaml",
-        _CONFIG_YAML_FORCE_INACTIVE if force_claude_agent_teams_inactive else _CONFIG_YAML,
+        _CONFIG_YAML_FORCE_INACTIVE if force_inactive_agent_teams else _CONFIG_YAML,
     )
 
     if extra_settings_keys:

--- a/tests/_realistic_project.py
+++ b/tests/_realistic_project.py
@@ -115,6 +115,7 @@ def write_fake_agent_binary(shim_dir: Path, name: str = "claude") -> Path:
     atomic_write(
         shim,
         """#!/bin/sh
+set -e
 if [ "${1-}" = "--version" ]; then
   printf '%s\n' '2.1.220 (Claude Code)'
   exit 0

--- a/tests/_realistic_project.py
+++ b/tests/_realistic_project.py
@@ -1,0 +1,131 @@
+"""Realistic-project corpus for interactive-corridor tests.
+
+Tests that drive cook/order against an empty ``tmp_path`` prove only that the
+corridor works on a machine nobody has. Real developer checkouts carry
+``.claude/settings.json`` and ``.claude/settings.local.json`` with unrelated
+keys, and often with agent teams enabled. Every fail-closed pre-spawn check
+that shipped broken passed its own unit tests and then fired on exactly that
+legitimate state.
+
+This module builds those projects, and the fake agent binary needed to launch
+against them without a real CLI on the host.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from autoskillit.core import atomic_write
+
+AGENT_TEAMS_ENV_VAR = "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"
+
+_CONFIG_YAML = """agent_backend:
+  backend: claude-code
+workspace:
+  temp_dir: .autoskillit/temp
+"""
+
+_CONFIG_YAML_FORCE_INACTIVE = """agent_backend:
+  backend: claude-code
+  force_claude_agent_teams_inactive: true
+workspace:
+  temp_dir: .autoskillit/temp
+"""
+
+
+def make_realistic_project(
+    tmp_path: Path,
+    *,
+    agent_teams: str | None = None,
+    extra_settings_keys: bool = True,
+    malformed_local: bool = False,
+    force_claude_agent_teams_inactive: bool = False,
+) -> Path:
+    """Build a project directory resembling a real developer checkout.
+
+    ``agent_teams`` is the value written for ``CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS``
+    in ``.claude/settings.local.json``; ``None`` omits the key entirely.
+    ``malformed_local`` writes invalid JSON there instead, which is the
+    fail-closed trigger for the force-inactive policy. Passing neither
+    ``agent_teams`` nor ``malformed_local`` and setting ``extra_settings_keys``
+    False produces a project with no ``.claude/`` directory at all.
+    """
+    project = tmp_path / "project"
+    project.mkdir(parents=True, exist_ok=True)
+
+    atomic_write(
+        project / ".autoskillit" / "config.yaml",
+        _CONFIG_YAML_FORCE_INACTIVE if force_claude_agent_teams_inactive else _CONFIG_YAML,
+    )
+
+    if extra_settings_keys:
+        atomic_write(
+            project / ".claude" / "settings.json",
+            json.dumps(
+                {
+                    "permissions": {
+                        "allow": ["Bash(git status:*)", "Read(//home/**)"],
+                        "deny": ["Bash(rm -rf:*)"],
+                    },
+                    "env": {"EDITOR": "vi", "PAGER": "cat"},
+                    "includeCoAuthoredBy": False,
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+
+    if malformed_local:
+        atomic_write(project / ".claude" / "settings.local.json", "{not valid json")
+    elif agent_teams is not None:
+        atomic_write(
+            project / ".claude" / "settings.local.json",
+            json.dumps(
+                {
+                    "env": {
+                        AGENT_TEAMS_ENV_VAR: agent_teams,
+                        "AUTOSKILLIT_UNRELATED": "1",
+                    },
+                    "statusLine": {"type": "command", "command": "echo hi"},
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+
+    return project
+
+
+def write_fake_agent_binary(shim_dir: Path, name: str = "claude") -> Path:
+    """Write a launchable stand-in for the real agent CLI.
+
+    Answers ``--version`` with a realistic string so ``ensure_pre_launch``'s
+    version probe succeeds, and otherwise records its argv to
+    ``$AUTOSKILLIT_STATE_DIR`` before exiting 0. Tests assert on that marker
+    file to prove the corridor actually reached spawn rather than merely
+    building a spec.
+    """
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    shim = shim_dir / name
+    atomic_write(
+        shim,
+        """#!/bin/sh
+if [ "${1-}" = "--version" ]; then
+  printf '%s\n' '2.1.220 (Claude Code)'
+  exit 0
+fi
+marker="$AUTOSKILLIT_STATE_DIR/__AGENT_NAME__-launch-argv.txt"
+temporary="${marker}.tmp.$$"
+printf '%s\n' "$@" > "$temporary"
+mv "$temporary" "$marker"
+exit 0
+""".replace("__AGENT_NAME__", name),
+    )
+    shim.chmod(0o755)
+    return shim
+
+
+def launch_marker_path(state_dir: Path, name: str = "claude") -> Path:
+    """Path the fake binary writes its argv to once it actually executes."""
+    return state_dir / f"{name}-launch-argv.txt"

--- a/tests/_realistic_project.py
+++ b/tests/_realistic_project.py
@@ -41,6 +41,7 @@ def make_realistic_project(
     extra_settings_keys: bool = True,
     malformed_local: bool = False,
     force_claude_agent_teams_inactive: bool = False,
+    project_dir: Path | None = None,
 ) -> Path:
     """Build a project directory resembling a real developer checkout.
 
@@ -50,8 +51,11 @@ def make_realistic_project(
     fail-closed trigger for the force-inactive policy. Passing neither
     ``agent_teams`` nor ``malformed_local`` and setting ``extra_settings_keys``
     False produces a project with no ``.claude/`` directory at all.
+
+    ``project_dir`` writes into an existing directory instead of creating
+    ``tmp_path/"project"``, for tests that already own a project layout.
     """
-    project = tmp_path / "project"
+    project = project_dir if project_dir is not None else tmp_path / "project"
     project.mkdir(parents=True, exist_ok=True)
 
     atomic_write(

--- a/tests/arch/test_config_consumption.py
+++ b/tests/arch/test_config_consumption.py
@@ -2,7 +2,7 @@
 
 The config ledger proves a key *parses*. Nothing proved a key was ever *read*, and
 three fields were parsed, validated, and dead from birth —
-`force_claude_agent_teams_inactive` among them, which is why a documented opt-in
+`force_inactive_agent_teams` among them, which is why a documented opt-in
 could not be opted into. This is the missing half, modeled on
 `tests/arch/test_capability_consumption.py`.
 
@@ -170,16 +170,14 @@ def test_all_config_fields_have_production_consumers() -> None:
     )
 
 
-def test_force_claude_agent_teams_inactive_is_consumed() -> None:
+def test_force_inactive_agent_teams_is_consumed() -> None:
     """The field this contract was written for: it must never go dead again."""
     from autoskillit.core import paths
 
-    reads = _collect_attribute_reads(
-        paths.pkg_root(), frozenset({"force_claude_agent_teams_inactive"})
-    )
-    sites = reads["force_claude_agent_teams_inactive"]
+    reads = _collect_attribute_reads(paths.pkg_root(), frozenset({"force_inactive_agent_teams"}))
+    sites = reads["force_inactive_agent_teams"]
 
-    assert "force_claude_agent_teams_inactive" not in _FORWARD_DECLARED
+    assert "force_inactive_agent_teams" not in _FORWARD_DECLARED
     assert sites, "the agent-teams opt-in must be read by production code"
 
 

--- a/tests/arch/test_config_consumption.py
+++ b/tests/arch/test_config_consumption.py
@@ -1,0 +1,226 @@
+"""Architectural invariant: every config field must be consumed in production.
+
+The config ledger proves a key *parses*. Nothing proved a key was ever *read*, and
+three fields were parsed, validated, and dead from birth —
+`force_claude_agent_teams_inactive` among them, which is why a documented opt-in
+could not be opted into. This is the missing half, modeled on
+`tests/arch/test_capability_consumption.py`.
+
+**Known limitation — this is a floor, not a proof.** The scan matches bare
+attribute names with no owner-type inference, exactly as the capability scan
+does. `BackendCapabilities` gets away with that because its field names are long
+and distinctive; config field names collide across classes. At the time of
+writing: `timeout` (4 classes), `command`, `enabled`, `recipe_overrides`,
+`step_overrides` (3 each), and `idle_output_timeout` (2). A dead field sharing a
+name with a live field on another config class passes here undetected. Tightening
+this to owner-aware resolution would catch that; until then, do not read a green
+run as evidence that every field is individually consumed.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import inspect
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+@dataclasses.dataclass(frozen=True)
+class ForwardDeclaredField:
+    """Structured forward-declaration for a config field without a consumer."""
+
+    issue: int
+    rationale: str
+    added_date: date
+
+
+_STALENESS_THRESHOLD_DAYS = 180
+
+_FORWARD_DECLARED: dict[str, ForwardDeclaredField] = {
+    "context_window": ForwardDeclaredField(
+        issue=4685,
+        rationale=(
+            "ProviderProfileDef.context_window is parsed and range-validated but "
+            "_profile_to_env projects every other profile field and skips it"
+        ),
+        added_date=date(2026, 8, 17),
+    ),
+    "natural_exit_grace_seconds": ForwardDeclaredField(
+        issue=4686,
+        rationale=(
+            "RunSkillConfig.natural_exit_grace_seconds is validated against "
+            "exit_after_stop_delay_ms but never threaded to run_managed_async's "
+            "identically-named parameter, so the drain window always uses 3.0"
+        ),
+        added_date=date(2026, 8, 17),
+    ),
+}
+
+
+def _config_dataclasses() -> list[type]:
+    """Every dataclass declared in the config definition module.
+
+    Enumerated from the module directly rather than walking AutomationConfig's
+    field tree: ProviderProfileDef is frozen and is synthesized at call time
+    inside ProvidersConfig.resolved_profiles, so it is never a declared field
+    type and a tree walk misses it — along with one of the dead fields.
+    """
+    from autoskillit.config import _config_dataclasses as module
+
+    return [
+        obj
+        for obj in vars(module).values()
+        if isinstance(obj, type)
+        and dataclasses.is_dataclass(obj)
+        and obj.__module__ == module.__name__
+    ]
+
+
+def _config_field_names() -> frozenset[str]:
+    """All config field names. dataclasses.fields() already excludes ClassVar."""
+    return frozenset(
+        field.name for cls in _config_dataclasses() for field in dataclasses.fields(cls)
+    )
+
+
+def _definition_file() -> Path:
+    from autoskillit.config import _config_dataclasses as module
+
+    return Path(inspect.getfile(module)).resolve()
+
+
+def _post_init_descendants(tree: ast.AST) -> set[int]:
+    """Node ids living inside a ``__post_init__`` body."""
+    skipped: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name != "__post_init__":
+                continue
+            for descendant in ast.walk(node):
+                skipped.add(id(descendant))
+    return skipped
+
+
+def _collect_attribute_reads(src_root: Path, field_names: frozenset[str]) -> dict[str, list[str]]:
+    """Scan src/ for .field_name attribute access that constitutes consumption.
+
+    The whole config *package* is scanned, not excluded. Several live fields
+    reach production only through legitimate in-package adapters —
+    SkillsConfig.tier1/2/3 via AutomationConfig.skill_visibility_spec(),
+    DiagnosticsConfig.pipeline_health / ReviewConfig.local_review_rounds /
+    PlanConfig.adversarial_review_level via ingredient_defaults — and excluding
+    the package would report every one of them as dead.
+
+    Within the definition file, only ``__post_init__`` bodies are skipped: a
+    field that merely validates itself does nothing for anyone. Other methods
+    there are real accessors — GitHubConfig.allowed_labels is read solely by
+    check_label_allowed(), which six production call sites depend on, so
+    excluding the file wholesale would flag a live field.
+    """
+    reads: dict[str, list[str]] = {name: [] for name in field_names}
+    definition_file = _definition_file()
+    for py_file in src_root.rglob("*.py"):
+        relpath = str(py_file.relative_to(src_root))
+        try:
+            tree = ast.parse(py_file.read_text())
+        except SyntaxError:
+            continue
+        skipped = _post_init_descendants(tree) if py_file.resolve() == definition_file else set()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Attribute)
+                and node.attr in field_names
+                and id(node) not in skipped
+            ):
+                reads[node.attr].append(f"{relpath}:{node.lineno}")
+    return reads
+
+
+def test_config_dataclass_discovery_is_not_empty() -> None:
+    """A silently empty enumeration would make the consumption test vacuous."""
+    classes = _config_dataclasses()
+    names = {cls.__name__ for cls in classes}
+
+    assert len(classes) > 20
+    assert "ProviderProfileDef" in names, (
+        "frozen, call-time-synthesized classes must be reached — one dead field lives here"
+    )
+    assert "AgentBackendConfig" in names
+    assert len(_config_field_names()) > 90
+
+
+def test_all_config_fields_have_production_consumers() -> None:
+    from autoskillit.core import paths
+
+    reads = _collect_attribute_reads(paths.pkg_root(), _config_field_names())
+
+    unconsumed = {
+        name for name, sites in reads.items() if not sites and name not in _FORWARD_DECLARED
+    }
+    assert not unconsumed, (
+        f"Config fields with zero production read sites "
+        f"(add a consumer, retire the key via RETIRED_CONFIG_KEYS, or add to "
+        f"_FORWARD_DECLARED as ForwardDeclaredField(issue=NNNN, rationale='...', "
+        f"added_date=date(YYYY, M, D))): {sorted(unconsumed)}"
+    )
+
+
+def test_force_claude_agent_teams_inactive_is_consumed() -> None:
+    """The field this contract was written for: it must never go dead again."""
+    from autoskillit.core import paths
+
+    reads = _collect_attribute_reads(
+        paths.pkg_root(), frozenset({"force_claude_agent_teams_inactive"})
+    )
+    sites = reads["force_claude_agent_teams_inactive"]
+
+    assert "force_claude_agent_teams_inactive" not in _FORWARD_DECLARED
+    assert sites, "the agent-teams opt-in must be read by production code"
+
+
+def test_forward_declared_has_linked_issues() -> None:
+    invalid = {
+        field: entry.issue for field, entry in _FORWARD_DECLARED.items() if entry.issue <= 0
+    }
+    assert not invalid, (
+        f"_FORWARD_DECLARED entries with invalid issue number (need positive int): {invalid}"
+    )
+
+
+def test_forward_declared_fields_have_no_consumers() -> None:
+    """A forward-declared field that gained a consumer must lose its exemption."""
+    from autoskillit.core import paths
+
+    reads = _collect_attribute_reads(paths.pkg_root(), _config_field_names())
+
+    stale = {name: sites for name, sites in reads.items() if name in _FORWARD_DECLARED and sites}
+    assert not stale, (
+        f"_FORWARD_DECLARED entries that now have production consumers "
+        f"(remove from _FORWARD_DECLARED and close the tracking issue): {stale}"
+    )
+
+
+def test_forward_declared_fields_exist_on_a_config_dataclass() -> None:
+    unknown = frozenset(_FORWARD_DECLARED.keys()) - _config_field_names()
+    assert not unknown, f"_FORWARD_DECLARED keys that are not config fields: {sorted(unknown)}"
+
+
+def test_forward_declared_entries_not_stale() -> None:
+    """Time-bomb: a forward declaration older than 180 days needs re-justification."""
+    today = date.today()
+    stale = [
+        f"{name} (added={entry.added_date}, age={(today - entry.added_date).days}d, "
+        f"issue=#{entry.issue})"
+        for name, entry in _FORWARD_DECLARED.items()
+        if (today - entry.added_date).days > _STALENESS_THRESHOLD_DAYS
+    ]
+    assert not stale, (
+        f"_FORWARD_DECLARED entries older than {_STALENESS_THRESHOLD_DAYS} days "
+        f"(wire a consumer, retire the key, or update added_date with a fresh "
+        f"tracking issue): {stale}"
+    )

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -21,7 +21,9 @@ HEADLESS_SIZE_BUDGETS = {
     "headless/__init__.py": 550,
     "headless/_headless_helpers.py": 220,
     # #4233 threads backend resume identity and the skill-only lifecycle enable flag.
-    "headless/_headless_execute.py": 642,
+    # #4659 rectify: the agent-teams opt-in must be read here from the same config
+    # authority the spec builders use, or adapter_digest and the spec field diverge.
+    "headless/_headless_execute.py": 646,
     "headless/_headless_launch.py": 500,
     "headless/_headless_recovery.py": 540,
     "headless/_headless_path_tokens.py": 190,

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -19,9 +19,7 @@ NEW_HEADLESS_MODULES = [
 ]
 HEADLESS_SIZE_BUDGETS = {
     "headless/__init__.py": 550,
-    # #4520/#4575 adds the resolve_policy + validate_interactive_invocation seams
-    # for the join batch guards and force-inactive agent-teams repository policy.
-    "headless/_headless_helpers.py": 240,
+    "headless/_headless_helpers.py": 220,
     # #4233 threads backend resume identity and the skill-only lifecycle enable flag.
     "headless/_headless_execute.py": 642,
     "headless/_headless_launch.py": 500,

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1086,18 +1086,6 @@ def test_data_directories_are_not_python_packages() -> None:
 # original single-responsibility scope (REQ-CNST-010-NOTE-1).
 
 _LINE_LIMIT_EXEMPTIONS: dict[str, tuple[int, str]] = {
-    # REQ-CNST-010-E26: #4520/#4575 splits the headless helpers (one shared
-    # resolve_policy + assert_interactive_ordering + validate_interactive_invocation
-    # surface) across the join guard enforcement and per-launch environment
-    # normalization. The 220-line limit was exceeded by 2 lines after the
-    # #4575 force-inactive policy addition; bumping the limit to 240 keeps the
-    # helpers in one module without a forced split.
-    "headless/_headless_helpers.py": (
-        240,
-        "REQ-CNST-010-E26: #4520/#4575 keeps resolve_policy + "
-        "assert_interactive_ordering + validate_interactive_invocation together "
-        "as the headless-side envoy to the interactive launch layers",
-    ),
     "execution/evidence_reader.py": (
         1500,
         "REQ-CNST-010-E25: #4585 keeps sterile auth, projection, probes, managed process "

--- a/tests/cli/_blackbox_launch.py
+++ b/tests/cli/_blackbox_launch.py
@@ -1,0 +1,139 @@
+"""Drive a real ``autoskillit`` CLI launch over a PTY and answer its prompt.
+
+Shared by the cook and order black-box launch tests. These are the only tests
+that stub nothing — no ``Popen`` patch, no validation-surface patch — so a
+pre-spawn check that fires on legitimate state fails here and nowhere else.
+"""
+
+from __future__ import annotations
+
+import os
+import select
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+
+from tests.execution._process_group_helpers import _cleanup_owned_process_group
+
+pty: ModuleType | None
+if os.name == "posix":
+    import pty as _pty
+
+    pty = _pty
+else:  # pragma: no cover - the module's tests are skipped on non-POSIX hosts
+    pty = None
+
+_MAX_DIAGNOSTIC_BYTES = 256 * 1024
+LAUNCH_PROMPT = b"Launch session?"
+
+
+@dataclass(frozen=True)
+class LaunchOutcome:
+    returncode: int | None
+    output: str
+    prompt_seen: bool
+
+
+def hermetic_launch_env(
+    *,
+    project: Path,
+    isolated_home: Path,
+    state_dir: Path,
+    shim_dir: Path,
+    temp_dir: Path,
+    xdg_roots: dict[str, Path],
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """A launch environment that reaches nothing outside the supplied roots."""
+    environment = {
+        "AUTOSKILLIT_PROJECT_DIR": str(project),
+        "AUTOSKILLIT_SKIP_UPDATE_CHECK": "1",
+        "AUTOSKILLIT_STATE_DIR": str(state_dir),
+        "HOME": str(isolated_home),
+        "LC_ALL": "C",
+        "NO_COLOR": "1",
+        "PATH": os.pathsep.join(
+            (str(shim_dir), str(Path(sys.executable).parent), "/usr/bin", "/bin")
+        ),
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "TERM": "dumb",
+        "TMPDIR": str(temp_dir),
+        "XDG_CACHE_HOME": str(xdg_roots["cache"]),
+        "XDG_CONFIG_HOME": str(xdg_roots["config"]),
+        "XDG_DATA_HOME": str(xdg_roots["data"]),
+        "XDG_STATE_HOME": str(xdg_roots["state"]),
+    }
+    if extra:
+        environment.update(extra)
+    return environment
+
+
+def run_cli_launch(
+    args: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    prompt: bytes = LAUNCH_PROMPT,
+    timeout_seconds: float = 30.0,
+) -> LaunchOutcome:
+    """Spawn the real CLI on a PTY, answer ``prompt`` once, and reap the group."""
+    assert pty is not None
+    master_fd, slave_fd = pty.openpty()
+    process: subprocess.Popen[bytes] | None = None
+    retained = bytearray()
+    prompt_seen = False
+    deadline = time.monotonic() + timeout_seconds
+    slave_open = True
+    master_open = True
+    try:
+        process = subprocess.Popen(
+            [sys.executable, "-c", "from autoskillit.cli import main; main()", *args],
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            cwd=cwd,
+            env=env,
+            close_fds=True,
+            start_new_session=True,
+        )
+        os.close(slave_fd)
+        slave_open = False
+
+        while time.monotonic() < deadline:
+            wait_for = min(0.1, max(0.0, deadline - time.monotonic()))
+            readable, _, _ = select.select([master_fd], [], [], wait_for)
+            if not readable:
+                continue
+            try:
+                chunk = os.read(master_fd, 64 * 1024)
+            except OSError:
+                break
+            if not chunk:
+                break
+            retained.extend(chunk)
+            if len(retained) > _MAX_DIAGNOSTIC_BYTES:
+                del retained[:-_MAX_DIAGNOSTIC_BYTES]
+            if not prompt_seen and prompt in retained:
+                os.write(master_fd, b"\n")
+                prompt_seen = True
+    finally:
+        try:
+            if slave_open:
+                os.close(slave_fd)
+        finally:
+            try:
+                if process is not None:
+                    _cleanup_owned_process_group(process, timeout=5)
+            finally:
+                if master_open:
+                    os.close(master_fd)
+                    master_open = False
+
+    return LaunchOutcome(
+        returncode=process.returncode if process is not None else None,
+        output=bytes(retained).decode("utf-8", errors="replace"),
+        prompt_seen=prompt_seen,
+    )

--- a/tests/cli/_blackbox_launch.py
+++ b/tests/cli/_blackbox_launch.py
@@ -7,10 +7,12 @@ pre-spawn check that fires on legitimate state fails here and nowhere else.
 
 from __future__ import annotations
 
+import fcntl
 import os
 import select
 import subprocess
 import sys
+import termios
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -28,6 +30,19 @@ else:  # pragma: no cover - the module's tests are skipped on non-POSIX hosts
 
 _MAX_DIAGNOSTIC_BYTES = 256 * 1024
 LAUNCH_PROMPT = b"Launch session?"
+
+
+def _acquire_controlling_terminal() -> None:  # pragma: no cover - runs post-fork
+    """Make the child a session leader that owns the PTY as its controlling terminal.
+
+    ``start_new_session=True`` alone detaches the child from the parent's terminal
+    without giving it a new one, so any foreground-process-group management in the
+    CLI fails with ``ENOTTY`` on ``tcgetpgrp``. That is a harness artifact — a real
+    shell always supplies a controlling terminal — and masking it would mean these
+    tests never exercise the code path that runs for actual users.
+    """
+    os.setsid()
+    fcntl.ioctl(0, termios.TIOCSCTTY, 0)
 
 
 @dataclass(frozen=True)
@@ -97,7 +112,7 @@ def run_cli_launch(
             cwd=cwd,
             env=env,
             close_fds=True,
-            start_new_session=True,
+            preexec_fn=_acquire_controlling_terminal,
         )
         os.close(slave_fd)
         slave_open = False

--- a/tests/cli/_blackbox_launch.py
+++ b/tests/cli/_blackbox_launch.py
@@ -102,7 +102,6 @@ def run_cli_launch(
     prompt_seen = False
     deadline = time.monotonic() + timeout_seconds
     slave_open = True
-    master_open = True
     try:
         process = subprocess.Popen(
             [sys.executable, "-c", "from autoskillit.cli import main; main()", *args],
@@ -143,9 +142,7 @@ def run_cli_launch(
                 if process is not None:
                     _cleanup_owned_process_group(process, timeout=5)
             finally:
-                if master_open:
-                    os.close(master_fd)
-                    master_open = False
+                os.close(master_fd)
 
     return LaunchOutcome(
         returncode=process.returncode if process is not None else None,

--- a/tests/cli/test_app_startup.py
+++ b/tests/cli/test_app_startup.py
@@ -1,11 +1,11 @@
 """Every registered CLI command must at least start.
 
-The cheap tier of the corridor net. Five consecutive incidents shipped a
-pre-spawn check that fired on legitimate state; each one broke the CLI at
-startup, and none of them broke a test. This will not catch a policy that
-fires only at spawn — that is what the unstubbed corridor tests are for — but
-it does catch anything that breaks import, registration, or argument parsing,
-for every command, without anyone remembering to add a test.
+The cheap tier of the corridor net: a pre-spawn check that fires on
+legitimate state breaks the CLI at startup without breaking a test. This
+will not catch a policy that fires only at spawn — that is what the
+unstubbed corridor tests are for — but it does catch anything that breaks
+import, registration, or argument parsing, for every command, without
+anyone remembering to add a test.
 
 Commands are enumerated from the live cyclopts app, so a newly registered
 command is covered the moment it is added.

--- a/tests/cli/test_app_startup.py
+++ b/tests/cli/test_app_startup.py
@@ -1,0 +1,86 @@
+"""Every registered CLI command must at least start.
+
+The cheap tier of the corridor net. Five consecutive incidents shipped a
+pre-spawn check that fired on legitimate state; each one broke the CLI at
+startup, and none of them broke a test. This will not catch a policy that
+fires only at spawn — that is what the unstubbed corridor tests are for — but
+it does catch anything that breaks import, registration, or argument parsing,
+for every command, without anyone remembering to add a test.
+
+Commands are enumerated from the live cyclopts app, so a newly registered
+command is covered the moment it is added.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from autoskillit.cli.app import app
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
+
+_LAUNCHER = "from autoskillit.cli import main; main()"
+
+
+def _registered_command_names(application: object) -> list[str]:
+    """Command names registered on a cyclopts app, excluding help/version flags."""
+    return [name for name in application if not name.startswith("-")]  # type: ignore[attr-defined]
+
+
+def _top_level_commands() -> list[str]:
+    return sorted(set(_registered_command_names(app)))
+
+
+def _hermetic_env(tmp_path: Path) -> dict[str, str]:
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    env = dict(os.environ)
+    env.update(
+        {
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(home / "config"),
+            "XDG_CACHE_HOME": str(home / "cache"),
+            "XDG_DATA_HOME": str(home / "data"),
+            "XDG_STATE_HOME": str(home / "state"),
+            "NO_COLOR": "1",
+        }
+    )
+    return env
+
+
+def _run_help(args: list[str], tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    project = tmp_path / "project"
+    project.mkdir(parents=True, exist_ok=True)
+    return subprocess.run(
+        [sys.executable, "-c", _LAUNCHER, *args, "--help"],
+        cwd=project,
+        env=_hermetic_env(tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_root_help_exits_zero(tmp_path: Path) -> None:
+    result = _run_help([], tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert "autoskillit" in (result.stdout + result.stderr).lower()
+
+
+def test_command_enumeration_is_not_empty() -> None:
+    """A silently empty enumeration would make every parametrized case vacuous."""
+    commands = _top_level_commands()
+    assert len(commands) > 5
+    assert "cook" in commands
+    assert "order" in commands
+
+
+@pytest.mark.parametrize("command", _top_level_commands())
+def test_registered_command_help_exits_zero(command: str, tmp_path: Path) -> None:
+    result = _run_help([command], tmp_path)
+    assert result.returncode == 0, f"{command} --help failed:\n{result.stderr}"

--- a/tests/cli/test_cook_order_picker.py
+++ b/tests/cli/test_cook_order_picker.py
@@ -519,6 +519,7 @@ class TestOrderResumeParsing:
             default_base_branch=None,
             workspace_temp_dir=None,
             backend=None,
+            force_inactive_agent_teams=False,
         ):
             captured["prompt"] = prompt
             captured["resume_spec"] = resume_spec
@@ -574,6 +575,7 @@ class TestOrderResumeParsing:
             default_base_branch=None,
             workspace_temp_dir=None,
             backend=None,
+            force_inactive_agent_teams=False,
         ):
             captured["prompt"] = prompt
             captured["resume_spec"] = resume_spec
@@ -619,6 +621,7 @@ class TestOrderResumeParsing:
             default_base_branch=None,
             workspace_temp_dir=None,
             backend=None,
+            force_inactive_agent_teams=False,
         ):
             captured["prompt"] = prompt
             captured["resume_spec"] = resume_spec

--- a/tests/cli/test_corridor_startup_blackbox.py
+++ b/tests/cli/test_corridor_startup_blackbox.py
@@ -1,0 +1,126 @@
+"""Every interactive corridor must start on a realistic developer checkout.
+
+This is the deep tier of the corridor net, and the test that would have caught
+the five consecutive fail-closed-checkpoint breakages that preceded it. Each
+case launches the real CLI as a subprocess over a PTY and asserts a fake agent
+binary genuinely executed — proven by the marker file it writes on exec, not by
+inspecting a spec that was merely built.
+
+Nothing is stubbed: not ``Popen``, not ``ensure_pre_launch``, not
+``validate_interactive_invocation``, not ``assert_interactive_ordering``. Cook,
+order, and fleet dispatch are covered separately because they do not share a
+launch path — ``cook()`` has its own inline build/validate loop rather than
+routing through ``_run_interactive_session``, so a test of one proves nothing
+about the others.
+
+The project carries ``.claude/settings.json`` and ``.claude/settings.local.json``
+with agent teams enabled, which is ordinary developer machine state and was
+precisely the state that killed every corridor at startup.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core import atomic_write
+from tests._realistic_project import (
+    AGENT_TEAMS_ENV_VAR,
+    launch_marker_path,
+    make_realistic_project,
+    write_fake_agent_binary,
+)
+from tests.cli._blackbox_launch import LaunchOutcome, hermetic_launch_env, run_cli_launch
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
+
+_LAUNCH_PROBE_RECIPE = """name: launch-probe
+description: Hermetic interactive launch probe
+summary: done
+kitchen_rules:
+  - Stop after the launch probe completes.
+steps:
+  done:
+    action: stop
+    message: Launch probe complete
+"""
+
+CORRIDORS = {
+    "cook": ["cook"],
+    "order": ["order", "launch-probe"],
+    "fleet-dispatch": ["fleet", "dispatch"],
+}
+
+
+def _drive_corridor(
+    tmp_path: Path, argv: list[str], *, exported_teams: str | None
+) -> tuple[LaunchOutcome, Path, Path]:
+    project = make_realistic_project(tmp_path, agent_teams="1")
+    atomic_write(project / ".autoskillit" / "recipes" / "launch-probe.yaml", _LAUNCH_PROBE_RECIPE)
+
+    roots = {
+        name: tmp_path / name for name in ("home", "state", "bin", "tmp", "xc", "xa", "xd", "xs")
+    }
+    for directory in roots.values():
+        directory.mkdir(parents=True, exist_ok=True)
+
+    write_fake_agent_binary(roots["bin"])
+    atomic_write(
+        roots["home"] / ".claude" / "plugins" / "installed_plugins.json",
+        '{"version": 2, "plugins": {}}\n',
+    )
+
+    extra = {"AUTOSKILLIT_FEATURES__FLEET": "true"}
+    if exported_teams is not None:
+        extra[AGENT_TEAMS_ENV_VAR] = exported_teams
+
+    env = hermetic_launch_env(
+        project=project,
+        isolated_home=roots["home"],
+        state_dir=roots["state"],
+        shim_dir=roots["bin"],
+        temp_dir=roots["tmp"],
+        xdg_roots={
+            "config": roots["xc"],
+            "cache": roots["xa"],
+            "data": roots["xd"],
+            "state": roots["xs"],
+        },
+        extra=extra,
+    )
+
+    outcome = run_cli_launch(argv, cwd=project, env=env, timeout_seconds=75)
+    return outcome, project, roots["state"]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX PTY launch coverage")
+@pytest.mark.parametrize("corridor", sorted(CORRIDORS))
+@pytest.mark.parametrize("exported_teams", [None, "1"], ids=["settings_only", "exported_env"])
+def test_corridor_reaches_spawn_on_teams_enabled_project(
+    tmp_path: Path, corridor: str, exported_teams: str | None
+) -> None:
+    """Agent teams enabled by the repository, and by the parent process env."""
+    outcome, _project, state_dir = _drive_corridor(
+        tmp_path, CORRIDORS[corridor], exported_teams=exported_teams
+    )
+
+    assert outcome.prompt_seen, outcome.output
+    assert outcome.returncode == 0, outcome.output
+    assert launch_marker_path(state_dir).is_file(), (
+        f"{corridor} never reached spawn — the agent binary did not execute:\n{outcome.output}"
+    )
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX PTY launch coverage")
+@pytest.mark.parametrize("corridor", sorted(CORRIDORS))
+def test_corridor_leaves_repository_settings_untouched(tmp_path: Path, corridor: str) -> None:
+    """Default config must not rewrite a developer's own settings files."""
+    _outcome, project, _state_dir = _drive_corridor(
+        tmp_path, CORRIDORS[corridor], exported_teams=None
+    )
+
+    settings_local = (project / ".claude" / "settings.local.json").read_text()
+    assert AGENT_TEAMS_ENV_VAR in settings_local
+    assert "AUTOSKILLIT_UNRELATED" in settings_local

--- a/tests/cli/test_fleet_dispatch.py
+++ b/tests/cli/test_fleet_dispatch.py
@@ -101,7 +101,9 @@ def test_fleet_dispatch_exits_when_claude_missing(
         (),
         {"max_issues_per_food_truck": 3, "max_total_issues": 12, "max_concurrent_dispatches": 3},
     )()
-    _agent_backend = type("AB", (), {"backend": "claude-code"})()
+    _agent_backend = type(
+        "AB", (), {"backend": "claude-code", "force_claude_agent_teams_inactive": False}
+    )()
     _branching = type("Branching", (), {"default_base_branch": "main"})()
     monkeypatch.setattr(
         "autoskillit.config.load_config",
@@ -179,7 +181,9 @@ def test_fleet_dispatch_proceeds_when_enabled(
         (),
         {"max_issues_per_food_truck": 3, "max_total_issues": 12, "max_concurrent_dispatches": 3},
     )()
-    _agent_backend = type("AB", (), {"backend": "claude-code"})()
+    _agent_backend = type(
+        "AB", (), {"backend": "claude-code", "force_claude_agent_teams_inactive": False}
+    )()
     _branching = type("Branching", (), {"default_base_branch": "main"})()
     monkeypatch.setattr(
         "autoskillit.config.load_config",

--- a/tests/cli/test_fleet_dispatch.py
+++ b/tests/cli/test_fleet_dispatch.py
@@ -102,7 +102,7 @@ def test_fleet_dispatch_exits_when_claude_missing(
         {"max_issues_per_food_truck": 3, "max_total_issues": 12, "max_concurrent_dispatches": 3},
     )()
     _agent_backend = type(
-        "AB", (), {"backend": "claude-code", "force_claude_agent_teams_inactive": False}
+        "AB", (), {"backend": "claude-code", "force_inactive_agent_teams": False}
     )()
     _branching = type("Branching", (), {"default_base_branch": "main"})()
     monkeypatch.setattr(
@@ -182,7 +182,7 @@ def test_fleet_dispatch_proceeds_when_enabled(
         {"max_issues_per_food_truck": 3, "max_total_issues": 12, "max_concurrent_dispatches": 3},
     )()
     _agent_backend = type(
-        "AB", (), {"backend": "claude-code", "force_claude_agent_teams_inactive": False}
+        "AB", (), {"backend": "claude-code", "force_inactive_agent_teams": False}
     )()
     _branching = type("Branching", (), {"default_base_branch": "main"})()
     monkeypatch.setattr(

--- a/tests/cli/test_force_inactive_config_corridors.py
+++ b/tests/cli/test_force_inactive_config_corridors.py
@@ -205,7 +205,7 @@ def test_launch_cook_session_forwards_force_inactive_agent_teams(
 
 # ---------------------------------------------------------------------------
 # 3 & 4. Both _launch_fleet_session call sites forward
-#    cfg.agent_backend.force_claude_agent_teams_inactive.
+#    cfg.agent_backend.force_inactive_agent_teams.
 # ---------------------------------------------------------------------------
 
 
@@ -215,7 +215,7 @@ def _write_fleet_config(tmp_path: Path, *, force_inactive: bool) -> None:
     (config_dir / "config.yaml").write_text(
         "agent_backend:\n"
         "  backend: claude-code\n"
-        f"  force_claude_agent_teams_inactive: {str(force_inactive).lower()}\n"
+        f"  force_inactive_agent_teams: {str(force_inactive).lower()}\n"
     )
 
 

--- a/tests/cli/test_force_inactive_config_corridors.py
+++ b/tests/cli/test_force_inactive_config_corridors.py
@@ -225,7 +225,7 @@ def test_launch_fleet_session_adhoc_forwards_force_inactive_agent_teams(
     tmp_path: Path,
     force_inactive: bool,
 ) -> None:
-    """The ad-hoc branch (~line 89) must forward the value it read off cfg.agent_backend."""
+    """The ad-hoc branch of _launch_fleet_session must forward the config-read value."""
     captured: dict[str, object] = {}
 
     def _fake_run(*_args: object, **kwargs: object) -> None:
@@ -255,7 +255,7 @@ def test_launch_fleet_session_campaign_forwards_force_inactive_agent_teams(
     tmp_path: Path,
     force_inactive: bool,
 ) -> None:
-    """The campaign branch (~line 199) must forward the same config-read value."""
+    """The campaign branch of _launch_fleet_session must forward the config-read value."""
     captured: dict[str, object] = {}
 
     def _fake_run(*_args: object, **kwargs: object) -> None:

--- a/tests/cli/test_force_inactive_config_corridors.py
+++ b/tests/cli/test_force_inactive_config_corridors.py
@@ -1,0 +1,303 @@
+"""force_inactive_agent_teams must reach the launched spec, not just an intermediate param.
+
+Complements tests/execution/test_force_inactive_config_reaches_builders.py, which proves
+the value reaches the backend spec builders. These tests prove the CLI corridors that
+call ``_run_interactive_session`` and ``build_interactive_cmd`` — the managed-launch fork
+that bypasses ``prepare_interactive_launch``, ``_launch_cook_session``, and both
+``_launch_fleet_session`` call sites — actually thread the caller's intent (or the
+config value the caller read) all the way into the kwarg the backend receives, rather
+than stopping at a parameter nobody forwards further.
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from autoskillit.cli.session._session_launch import _launch_cook_session, _run_interactive_session
+from autoskillit.core import (
+    BackendCapabilities,
+    BackendConventions,
+    CmdSpec,
+    CookSessionHandle,
+    ManagedSessionHome,
+    PreLaunchReadiness,
+    ValidatedAddDir,
+)
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
+
+
+# ---------------------------------------------------------------------------
+# 1. The non-probe fork of _run_interactive_session (cook_exact_binding_probe_
+#    required=False — the fork Codex `order` takes). Its two direct
+#    build_interactive_cmd calls bypass prepare_interactive_launch entirely.
+# ---------------------------------------------------------------------------
+
+
+def _make_non_probe_backend() -> tuple[object, list[dict[str, object]]]:
+    """A managed-launch backend double recording every build_interactive_cmd call.
+
+    capabilities.cook_exact_binding_probe_required defaults to False, so
+    _run_interactive_session takes the direct two-call fork instead of routing
+    through prepare_interactive_launch.
+    """
+    captured_kwargs: list[dict[str, object]] = []
+
+    class _NonProbeBackend:
+        name = "codex"
+        conventions = BackendConventions()
+
+        def binary_name(self) -> str:
+            return "codex"
+
+        @property
+        def capabilities(self) -> BackendCapabilities:
+            return BackendCapabilities(cook_exact_binding_probe_required=False)
+
+        def ensure_pre_launch(
+            self, *, session_dir: Path | None = None, executable: object = None
+        ) -> PreLaunchReadiness:
+            del executable
+            return PreLaunchReadiness((), {})
+
+        def validate_interactive_invocation(self, spec: object) -> list[str]:
+            del spec
+            return []
+
+        def build_interactive_cmd(self, **kwargs: object) -> CmdSpec:
+            captured_kwargs.append(kwargs)
+            return CmdSpec(cmd=("codex",), env={})
+
+        def cook_session_context(
+            self,
+            *,
+            session_home: Path,
+            project_dir: Path,
+            launch_id: str,
+            attempt: int,
+            current_resume_spec: object,
+        ):
+            del session_home, project_dir, current_resume_spec
+            return nullcontext(
+                CookSessionHandle(
+                    view_id=f"{launch_id}-{attempt}",
+                    pass_fds=(),
+                    _record_spawn=lambda _pid, _pgid: None,
+                    _record_reaped=lambda _pid, _pgid: None,
+                )
+            )
+
+    return _NonProbeBackend(), captured_kwargs
+
+
+def _managed_home(tmp_path: Path) -> ManagedSessionHome:
+    generated_home = tmp_path / "generated"
+    generated_home.mkdir()
+    return ManagedSessionHome(
+        launch_id="launch-id",
+        generated_home=generated_home,
+        skills_dir=ValidatedAddDir(str(generated_home / "add-dir")),
+        pass_fds=(),
+    )
+
+
+def test_non_probe_fork_threads_true_intent_into_both_build_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    launch_kwargs: dict[str, object],
+    _stub_interactive_prelaunch: None,
+) -> None:
+    """Removing the kwarg from either of the two direct build_interactive_cmd calls
+    in the non-probe fork would leave that call's captured entry False here."""
+    backend, captured_kwargs = _make_non_probe_backend()
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_process.run_cook_attempt",
+        lambda *_a, **_kw: SimpleNamespace(returncode=0),
+    )
+
+    result = _run_interactive_session(
+        system_prompt="test",
+        backend=backend,
+        project_dir=tmp_path,
+        skill_compilation=launch_kwargs["skill_compilation"],
+        managed_home=_managed_home(tmp_path),
+        retained_projection_binding=MagicMock(inherited_fds=()),
+        startup_trace=MagicMock(),
+        attempt=1,
+        force_inactive_agent_teams=True,
+    )
+
+    assert result is None
+    assert len(captured_kwargs) == 2, "expected both direct build_interactive_cmd calls"
+    assert [kw.get("force_inactive_agent_teams") for kw in captured_kwargs] == [True, True]
+
+
+def test_non_probe_fork_defaults_to_false_across_both_build_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    launch_kwargs: dict[str, object],
+    _stub_interactive_prelaunch: None,
+) -> None:
+    """Omitting the kwarg entirely must leave both captured calls False, not absent."""
+    backend, captured_kwargs = _make_non_probe_backend()
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_process.run_cook_attempt",
+        lambda *_a, **_kw: SimpleNamespace(returncode=0),
+    )
+
+    result = _run_interactive_session(
+        system_prompt="test",
+        backend=backend,
+        project_dir=tmp_path,
+        skill_compilation=launch_kwargs["skill_compilation"],
+        managed_home=_managed_home(tmp_path),
+        retained_projection_binding=MagicMock(inherited_fds=()),
+        startup_trace=MagicMock(),
+        attempt=1,
+    )
+
+    assert result is None
+    assert len(captured_kwargs) == 2, "expected both direct build_interactive_cmd calls"
+    assert [kw.get("force_inactive_agent_teams") for kw in captured_kwargs] == [False, False]
+
+
+# ---------------------------------------------------------------------------
+# 2. _launch_cook_session forwards force_inactive_agent_teams to
+#    _run_interactive_session.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("force_inactive", [True, False])
+def test_launch_cook_session_forwards_force_inactive_agent_teams(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    launch_kwargs: dict[str, object],
+    force_inactive: bool,
+) -> None:
+    """Dropping the kwarg from _launch_cook_session's _run_interactive_session call
+    would leave the captured value absent (None), not matching force_inactive."""
+    captured: dict[str, object] = {}
+
+    def _capture_run_interactive_session(*_args: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+        return None
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_launch._run_interactive_session",
+        _capture_run_interactive_session,
+    )
+
+    _launch_cook_session(
+        "system prompt",
+        project_dir=tmp_path,
+        required_env=frozenset(),
+        force_inactive_agent_teams=force_inactive,
+        **launch_kwargs,
+    )
+
+    assert captured.get("force_inactive_agent_teams") is force_inactive
+
+
+# ---------------------------------------------------------------------------
+# 3 & 4. Both _launch_fleet_session call sites forward
+#    cfg.agent_backend.force_claude_agent_teams_inactive.
+# ---------------------------------------------------------------------------
+
+
+def _write_fleet_config(tmp_path: Path, *, force_inactive: bool) -> None:
+    config_dir = tmp_path / ".autoskillit"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "config.yaml").write_text(
+        "agent_backend:\n"
+        "  backend: claude-code\n"
+        f"  force_claude_agent_teams_inactive: {str(force_inactive).lower()}\n"
+    )
+
+
+@pytest.mark.parametrize("force_inactive", [True, False])
+def test_launch_fleet_session_adhoc_forwards_force_inactive_agent_teams(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    force_inactive: bool,
+) -> None:
+    """The ad-hoc branch (~line 89) must forward the value it read off cfg.agent_backend."""
+    captured: dict[str, object] = {}
+
+    def _fake_run(*_args: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+        return None
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_launch._run_interactive_session", _fake_run
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._prompts._build_fleet_dispatch_prompt",
+        lambda *a, **kw: "dispatch-prompt",
+    )
+    monkeypatch.chdir(tmp_path)
+    _write_fleet_config(tmp_path, force_inactive=force_inactive)
+
+    from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
+
+    _launch_fleet_session(None, None, None, None, fleet_mode="dispatch")
+
+    assert captured.get("force_inactive_agent_teams") is force_inactive
+
+
+@pytest.mark.parametrize("force_inactive", [True, False])
+def test_launch_fleet_session_campaign_forwards_force_inactive_agent_teams(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    force_inactive: bool,
+) -> None:
+    """The campaign branch (~line 199) must forward the same config-read value."""
+    captured: dict[str, object] = {}
+
+    def _fake_run(*_args: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+        return None
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_launch._run_interactive_session", _fake_run
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._prompts._build_fleet_campaign_prompt",
+        lambda *a, **kw: "campaign-prompt",
+    )
+    monkeypatch.setattr("autoskillit.cli.fleet._fleet_session.dump_yaml_str", lambda *a, **kw: "")
+    monkeypatch.chdir(tmp_path)
+    _write_fleet_config(tmp_path, force_inactive=force_inactive)
+
+    from autoskillit.fleet import ResumeDecision
+
+    monkeypatch.setattr(
+        "autoskillit.fleet.resume_campaign_from_state",
+        lambda *a, **kw: ResumeDecision(
+            completed_dispatches_block="",
+            next_dispatch_name="",
+            is_resumable=False,
+            dispatched_session_id="",
+            retry_reason="",
+        ),
+    )
+
+    from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
+
+    recipe = MagicMock()
+    recipe.dispatches = []
+    recipe.continue_on_failure = False
+
+    _launch_fleet_session(
+        recipe,
+        "test-campaign-id",
+        tmp_path / "state.json",
+        None,
+        fleet_mode="campaign",
+    )
+
+    assert captured.get("force_inactive_agent_teams") is force_inactive

--- a/tests/cli/test_order_blackbox_launch.py
+++ b/tests/cli/test_order_blackbox_launch.py
@@ -54,55 +54,6 @@ steps:
     write_fake_agent_binary(shim_dir)
 
 
-def _launch_roots(tmp_path: Path) -> tuple[dict[str, Path], dict[str, Path]]:
-    roots = {
-        "project": tmp_path / "project",
-        "isolated_home": tmp_path / "home",
-        "state_dir": tmp_path / "state",
-        "shim_dir": tmp_path / "bin",
-        "temp_dir": tmp_path / "tmp",
-    }
-    xdg_roots = {
-        "config": tmp_path / "xdg-config",
-        "cache": tmp_path / "xdg-cache",
-        "data": tmp_path / "xdg-data",
-        "state": tmp_path / "xdg-state",
-    }
-    for directory in (*roots.values(), *xdg_roots.values()):
-        directory.mkdir(parents=True, exist_ok=True)
-    _write_fixture(roots["project"], roots["isolated_home"], roots["shim_dir"])
-    return roots, xdg_roots
-
-
-@pytest.mark.skipif(os.name != "posix", reason="POSIX PTY launch coverage")
-def test_order_reaches_spawn_with_exported_teams_variable(tmp_path: Path) -> None:
-    """Teams enabled by the parent process env, not just by a settings file.
-
-    Under default config this is legitimate state, so the corridor must reach
-    spawn — proven by the fake binary's marker file, not by a built spec.
-    """
-    roots, xdg_roots = _launch_roots(tmp_path)
-    environment = hermetic_launch_env(
-        project=roots["project"],
-        isolated_home=roots["isolated_home"],
-        state_dir=roots["state_dir"],
-        shim_dir=roots["shim_dir"],
-        temp_dir=roots["temp_dir"],
-        xdg_roots=xdg_roots,
-        extra={AGENT_TEAMS_ENV_VAR: "1"},
-    )
-
-    outcome = run_cli_launch(
-        ["order", "launch-probe"],
-        cwd=roots["project"],
-        env=environment,
-    )
-
-    assert outcome.prompt_seen, outcome.output
-    assert outcome.returncode == 0, outcome.output
-    assert launch_marker_path(roots["state_dir"]).is_file(), outcome.output
-
-
 @pytest.mark.skipif(os.name != "posix", reason="POSIX PTY launch coverage")
 def test_order_launches_real_cli_without_host_side_effects(tmp_path: Path) -> None:
     worktree = Path(__file__).resolve().parents[2]

--- a/tests/cli/test_order_blackbox_launch.py
+++ b/tests/cli/test_order_blackbox_launch.py
@@ -3,30 +3,21 @@
 from __future__ import annotations
 
 import os
-import select
 import subprocess
-import sys
-import time
 from pathlib import Path
-from types import ModuleType
 
 import pytest
 
 from autoskillit.core import atomic_write
-from tests.execution._process_group_helpers import _cleanup_owned_process_group
-
-pty: ModuleType | None
-if os.name == "posix":
-    import pty as _pty
-
-    pty = _pty
-else:  # pragma: no cover - the module's test is skipped on non-POSIX hosts
-    pty = None
+from tests._realistic_project import (
+    AGENT_TEAMS_ENV_VAR,
+    launch_marker_path,
+    make_realistic_project,
+    write_fake_agent_binary,
+)
+from tests.cli._blackbox_launch import hermetic_launch_env, run_cli_launch
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
-
-_MAX_DIAGNOSTIC_BYTES = 256 * 1024
-_PROMPT = b"Launch session?"
 
 
 def _git_status(worktree: Path) -> bytes:
@@ -53,34 +44,68 @@ steps:
     message: Launch probe complete
 """,
     )
-    atomic_write(
-        project / ".autoskillit" / "config.yaml",
-        """agent_backend:
-  backend: claude-code
-workspace:
-  temp_dir: .autoskillit/temp
-""",
-    )
+    # A project with no .claude/settings*.json is not a machine anyone has, and
+    # that specific absence is what let an ungated settings policy ship green.
+    make_realistic_project(project.parent, agent_teams="1", project_dir=project)
     atomic_write(
         isolated_home / ".claude" / "plugins" / "installed_plugins.json",
         '{"version": 2, "plugins": {}}\n',
     )
-    shim = shim_dir / "claude"
-    atomic_write(
-        shim,
-        """#!/bin/sh
-if [ "${1-}" = "--version" ]; then
-  printf '%s\n' '2.1.220 (Claude Code)'
-  exit 0
-fi
-marker="$AUTOSKILLIT_STATE_DIR/claude-launch-argv.txt"
-temporary="${marker}.tmp.$$"
-printf '%s\n' "$@" > "$temporary"
-mv "$temporary" "$marker"
-exit 0
-""",
+    write_fake_agent_binary(shim_dir)
+
+
+def _launch_roots(tmp_path: Path) -> dict[str, Path]:
+    roots = {
+        "project": tmp_path / "project",
+        "isolated_home": tmp_path / "home",
+        "state_dir": tmp_path / "state",
+        "shim_dir": tmp_path / "bin",
+        "temp_dir": tmp_path / "tmp",
+    }
+    xdg_roots = {
+        "config": tmp_path / "xdg-config",
+        "cache": tmp_path / "xdg-cache",
+        "data": tmp_path / "xdg-data",
+        "state": tmp_path / "xdg-state",
+    }
+    for directory in (*roots.values(), *xdg_roots.values()):
+        directory.mkdir(parents=True, exist_ok=True)
+    _write_fixture(roots["project"], roots["isolated_home"], roots["shim_dir"])
+    return {**roots, **{f"xdg_{k}": v for k, v in xdg_roots.items()}}
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX PTY launch coverage")
+def test_order_reaches_spawn_with_exported_teams_variable(tmp_path: Path) -> None:
+    """Teams enabled by the parent process env, not just by a settings file.
+
+    Under default config this is legitimate state, so the corridor must reach
+    spawn — proven by the fake binary's marker file, not by a built spec.
+    """
+    roots = _launch_roots(tmp_path)
+    environment = hermetic_launch_env(
+        project=roots["project"],
+        isolated_home=roots["isolated_home"],
+        state_dir=roots["state_dir"],
+        shim_dir=roots["shim_dir"],
+        temp_dir=roots["temp_dir"],
+        xdg_roots={
+            "config": roots["xdg_config"],
+            "cache": roots["xdg_cache"],
+            "data": roots["xdg_data"],
+            "state": roots["xdg_state"],
+        },
+        extra={AGENT_TEAMS_ENV_VAR: "1"},
     )
-    shim.chmod(0o755)
+
+    outcome = run_cli_launch(
+        ["order", "launch-probe"],
+        cwd=roots["project"],
+        env=environment,
+    )
+
+    assert outcome.prompt_seen, outcome.output
+    assert outcome.returncode == 0, outcome.output
+    assert launch_marker_path(roots["state_dir"]).is_file(), outcome.output
 
 
 @pytest.mark.skipif(os.name != "posix", reason="POSIX PTY launch coverage")
@@ -91,115 +116,53 @@ def test_order_launches_real_cli_without_host_side_effects(tmp_path: Path) -> No
     state_dir = tmp_path / "state"
     shim_dir = tmp_path / "bin"
     temp_dir = tmp_path / "tmp"
-    xdg_config = tmp_path / "xdg-config"
-    xdg_cache = tmp_path / "xdg-cache"
-    xdg_data = tmp_path / "xdg-data"
-    xdg_state = tmp_path / "xdg-state"
+    xdg_roots = {
+        "config": tmp_path / "xdg-config",
+        "cache": tmp_path / "xdg-cache",
+        "data": tmp_path / "xdg-data",
+        "state": tmp_path / "xdg-state",
+    }
     for directory in (
         project,
         isolated_home,
         state_dir,
         shim_dir,
         temp_dir,
-        xdg_config,
-        xdg_cache,
-        xdg_data,
-        xdg_state,
+        *xdg_roots.values(),
     ):
         directory.mkdir(parents=True)
     _write_fixture(project, isolated_home, shim_dir)
 
-    environment = {
-        "AUTOSKILLIT_PROJECT_DIR": str(project),
-        "AUTOSKILLIT_SKIP_UPDATE_CHECK": "1",
-        "AUTOSKILLIT_STATE_DIR": str(state_dir),
-        "HOME": str(isolated_home),
-        "LC_ALL": "C",
-        "NO_COLOR": "1",
-        "PATH": os.pathsep.join(
-            (str(shim_dir), str(Path(sys.executable).parent), "/usr/bin", "/bin")
-        ),
-        "PYTHONDONTWRITEBYTECODE": "1",
-        "TERM": "dumb",
-        "TMPDIR": str(temp_dir),
-        "XDG_CACHE_HOME": str(xdg_cache),
-        "XDG_CONFIG_HOME": str(xdg_config),
-        "XDG_DATA_HOME": str(xdg_data),
-        "XDG_STATE_HOME": str(xdg_state),
-    }
+    environment = hermetic_launch_env(
+        project=project,
+        isolated_home=isolated_home,
+        state_dir=state_dir,
+        shim_dir=shim_dir,
+        temp_dir=temp_dir,
+        xdg_roots=xdg_roots,
+    )
     status_before = _git_status(worktree)
 
-    assert pty is not None
-    master_fd, slave_fd = pty.openpty()
-    process: subprocess.Popen[bytes] | None = None
-    retained = bytearray()
-    prompt_seen = False
-    deadline = time.monotonic() + 30
-    slave_open = True
-    master_open = True
-    try:
-        process = subprocess.Popen(
-            [
-                sys.executable,
-                "-c",
-                "from autoskillit.cli import main; main()",
-                "order",
-                "launch-probe",
-            ],
-            stdin=slave_fd,
-            stdout=slave_fd,
-            stderr=slave_fd,
-            cwd=project,
-            env=environment,
-            close_fds=True,
-            start_new_session=True,
-        )
-        os.close(slave_fd)
-        slave_open = False
+    outcome = run_cli_launch(
+        ["order", "launch-probe"],
+        cwd=project,
+        env=environment,
+    )
 
-        while time.monotonic() < deadline:
-            timeout = min(0.1, max(0.0, deadline - time.monotonic()))
-            readable, _, _ = select.select([master_fd], [], [], timeout)
-            if not readable:
-                continue
-            try:
-                chunk = os.read(master_fd, 64 * 1024)
-            except OSError:
-                break
-            if not chunk:
-                break
-            retained.extend(chunk)
-            if len(retained) > _MAX_DIAGNOSTIC_BYTES:
-                del retained[:-_MAX_DIAGNOSTIC_BYTES]
-            if not prompt_seen and _PROMPT in retained:
-                os.write(master_fd, b"\n")
-                prompt_seen = True
-    finally:
-        try:
-            if slave_open:
-                os.close(slave_fd)
-        finally:
-            try:
-                if process is not None:
-                    _cleanup_owned_process_group(process, timeout=5)
-            finally:
-                if master_open:
-                    os.close(master_fd)
-                    master_open = False
-
-    output = bytes(retained).decode("utf-8", errors="replace")
-    assert prompt_seen, output
-    assert process is not None and process.returncode == 0, output
-    assert (state_dir / "claude-launch-argv.txt").is_file(), output
+    assert outcome.prompt_seen, outcome.output
+    assert outcome.returncode == 0, outcome.output
+    assert launch_marker_path(state_dir).is_file(), outcome.output
     expected_artifacts = (
         project / ".autoskillit" / "temp",
         isolated_home / ".autoskillit" / "plugin-projections",
         isolated_home / ".claude" / "plugins" / "installed_plugins.json",
-        state_dir / "claude-launch-argv.txt",
+        launch_marker_path(state_dir),
     )
     allowed_roots = (project.resolve(), isolated_home.resolve(), state_dir.resolve())
     for artifact in expected_artifacts:
-        assert artifact.exists(), (artifact, output)
+        assert artifact.exists(), (artifact, outcome.output)
         assert any(artifact.resolve().is_relative_to(root) for root in allowed_roots)
 
     assert _git_status(worktree) == status_before
+    # Default config must not rewrite the developer's own settings.
+    assert AGENT_TEAMS_ENV_VAR in (project / ".claude" / "settings.local.json").read_text()

--- a/tests/cli/test_order_blackbox_launch.py
+++ b/tests/cli/test_order_blackbox_launch.py
@@ -54,7 +54,7 @@ steps:
     write_fake_agent_binary(shim_dir)
 
 
-def _launch_roots(tmp_path: Path) -> dict[str, Path]:
+def _launch_roots(tmp_path: Path) -> tuple[dict[str, Path], dict[str, Path]]:
     roots = {
         "project": tmp_path / "project",
         "isolated_home": tmp_path / "home",
@@ -71,7 +71,7 @@ def _launch_roots(tmp_path: Path) -> dict[str, Path]:
     for directory in (*roots.values(), *xdg_roots.values()):
         directory.mkdir(parents=True, exist_ok=True)
     _write_fixture(roots["project"], roots["isolated_home"], roots["shim_dir"])
-    return {**roots, **{f"xdg_{k}": v for k, v in xdg_roots.items()}}
+    return roots, xdg_roots
 
 
 @pytest.mark.skipif(os.name != "posix", reason="POSIX PTY launch coverage")
@@ -81,19 +81,14 @@ def test_order_reaches_spawn_with_exported_teams_variable(tmp_path: Path) -> Non
     Under default config this is legitimate state, so the corridor must reach
     spawn — proven by the fake binary's marker file, not by a built spec.
     """
-    roots = _launch_roots(tmp_path)
+    roots, xdg_roots = _launch_roots(tmp_path)
     environment = hermetic_launch_env(
         project=roots["project"],
         isolated_home=roots["isolated_home"],
         state_dir=roots["state_dir"],
         shim_dir=roots["shim_dir"],
         temp_dir=roots["temp_dir"],
-        xdg_roots={
-            "config": roots["xdg_config"],
-            "cache": roots["xdg_cache"],
-            "data": roots["xdg_data"],
-            "state": roots["xdg_state"],
-        },
+        xdg_roots=xdg_roots,
         extra={AGENT_TEAMS_ENV_VAR: "1"},
     )
 

--- a/tests/cli/test_prepare_interactive_launch_intent.py
+++ b/tests/cli/test_prepare_interactive_launch_intent.py
@@ -1,0 +1,91 @@
+"""prepare_interactive_launch must stamp the spec it actually launches.
+
+The probe build carried ``force_inactive_agent_teams``; the final build — the one
+that produces the launched spec — dropped it. Restoring it naively was not possible
+either: the final build carries an executable binding, which the builder used to
+refuse outright. Both halves had to be repaired together, so both are asserted here.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from autoskillit.cli.session._session_launch import prepare_interactive_launch
+from autoskillit.core.types._type_resume import NoResume
+from autoskillit.execution.backends import ClaudeCodeBackend
+from tests._realistic_project import (
+    AGENT_TEAMS_ENV_VAR,
+    make_realistic_project,
+    write_fake_agent_binary,
+)
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
+
+
+def _prepared_launch(project: Path, tmp_path: Path, *, force: bool):
+    return prepare_interactive_launch(
+        ClaudeCodeBackend(),
+        project_dir=project,
+        extra_env={"PATH": str(tmp_path / "bin")},
+        required_env=None,
+        plugin_binding=None,
+        resume_spec=NoResume(),
+        system_prompt=None,
+        initial_prompt="hello",
+        force_inactive_agent_teams=force,
+    )
+
+
+def test_prepare_interactive_launch_stamps_the_final_spec(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The probe carried the flag; the build that produces the launched spec did not."""
+    project = make_realistic_project(tmp_path, agent_teams=None)
+    write_fake_agent_binary(tmp_path / "bin")
+    monkeypatch.setenv("PATH", str(tmp_path / "bin"))
+
+    prepared = _prepared_launch(project, tmp_path, force=True)
+
+    assert prepared.spec.force_inactive_agent_teams is True
+    assert AGENT_TEAMS_ENV_VAR not in prepared.spec.env
+    assert prepared.executable is not None
+
+
+def test_prepare_interactive_launch_survives_exported_teams_var(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The case both naive repairs fail.
+
+    With the variable exported, omitting the kwarg on the final build leaves
+    the recomputed env un-neutralized and the binding equality check fails;
+    passing it used to hit the executable-binding refusal instead.
+    """
+    project = make_realistic_project(tmp_path, agent_teams=None)
+    write_fake_agent_binary(tmp_path / "bin")
+    monkeypatch.setenv("PATH", str(tmp_path / "bin"))
+    monkeypatch.setenv(AGENT_TEAMS_ENV_VAR, "1")
+
+    prepared = _prepared_launch(project, tmp_path, force=True)
+
+    assert prepared.spec.force_inactive_agent_teams is True
+    assert AGENT_TEAMS_ENV_VAR not in prepared.spec.env
+    assert AGENT_TEAMS_ENV_VAR not in prepared.executable.launch_environment
+
+
+def test_prepare_interactive_launch_default_leaves_env_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default config must be byte-for-byte unaffected by the policy machinery."""
+    project = make_realistic_project(tmp_path, agent_teams=None)
+    write_fake_agent_binary(tmp_path / "bin")
+    monkeypatch.setenv("PATH", str(tmp_path / "bin"))
+    monkeypatch.setenv(AGENT_TEAMS_ENV_VAR, "1")
+
+    prepared = _prepared_launch(project, tmp_path, force=False)
+
+    assert prepared.spec.force_inactive_agent_teams is False
+    assert prepared.spec.env[AGENT_TEAMS_ENV_VAR] == "1"
+    assert os.environ[AGENT_TEAMS_ENV_VAR] == "1"

--- a/tests/cli/test_reload_loop.py
+++ b/tests/cli/test_reload_loop.py
@@ -465,6 +465,7 @@ def test_fleet_reload_relaunches_without_resume(
         initial_message=None,
         required_env=None,
         backend=None,
+        force_inactive_agent_teams=False,
     ):
         call_count[0] += 1
         captured_resume_specs.append(resume_spec)

--- a/tests/contracts/config_key_ledger.txt
+++ b/tests/contracts/config_key_ledger.txt
@@ -11,6 +11,7 @@
 # registering it in RETIRED_CONFIG_KEYS fails this test at development time.
 agent_backend.backend
 agent_backend.force_claude_agent_teams_inactive
+agent_backend.force_inactive_agent_teams
 agent_backend.recipe_overrides
 agent_backend.step_overrides
 branching.default_base_branch

--- a/tests/core/test_backend_dataclasses.py
+++ b/tests/core/test_backend_dataclasses.py
@@ -31,6 +31,7 @@ def test_cmd_spec_fields():
         "is_resume",
         "process_idle_timeout_ms",
         "inherited_fds",
+        "force_inactive_agent_teams",
     }
 
 

--- a/tests/execution/backends/test_claude_interactive_invocation_intent.py
+++ b/tests/execution/backends/test_claude_interactive_invocation_intent.py
@@ -1,0 +1,134 @@
+"""The interactive checkpoint reads declared intent; it never infers policy.
+
+A checkpoint that cannot see what the builder was asked to do degrades to
+"always enforce", which turns every developer's own agent-teams setting into a
+launch failure. Intent lives on the spec, so these are the four cases that
+matter: default intent never enforces, declared intent always does, and the
+builder confirms eagerly at construction either way.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core import CmdSpec
+from autoskillit.execution.backends import ClaudeCodeBackend
+from tests._realistic_project import AGENT_TEAMS_ENV_VAR, make_realistic_project
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+def test_default_intent_ignores_teams_enabled_project(tmp_path: Path) -> None:
+    """The shipped defect: this raised on every legitimate teams-enabled repo."""
+    project = make_realistic_project(tmp_path, agent_teams="1")
+    backend = ClaudeCodeBackend()
+
+    spec = backend.build_interactive_cmd(initial_prompt="hello")
+    spec = CmdSpec(
+        cmd=spec.cmd,
+        env=spec.env,
+        cwd=str(project),
+        origin=spec.origin,
+    )
+
+    assert backend.validate_interactive_invocation(spec) == []
+
+
+def test_declared_intent_reports_policy_violations(tmp_path: Path) -> None:
+    """Fail-closed confirmation is preserved for the opt-in case."""
+    project = make_realistic_project(tmp_path, agent_teams="1")
+    backend = ClaudeCodeBackend()
+
+    spec = CmdSpec(
+        cmd=("claude", "--dangerously-skip-permissions"),
+        env={AGENT_TEAMS_ENV_VAR: "1"},
+        cwd=str(project),
+        force_inactive_agent_teams=True,
+    )
+
+    errors = backend.validate_interactive_invocation(spec)
+
+    assert errors
+    assert any(AGENT_TEAMS_ENV_VAR in error for error in errors)
+
+
+def test_declared_intent_passes_on_a_clean_project(tmp_path: Path) -> None:
+    project = make_realistic_project(tmp_path, agent_teams=None)
+    backend = ClaudeCodeBackend()
+
+    spec = backend.build_interactive_cmd(
+        initial_prompt="hello",
+        force_inactive_agent_teams=True,
+        project_root=str(project),
+    )
+    spec = CmdSpec(
+        cmd=spec.cmd,
+        env=spec.env,
+        cwd=str(project),
+        origin=spec.origin,
+        force_inactive_agent_teams=spec.force_inactive_agent_teams,
+    )
+
+    assert spec.force_inactive_agent_teams is True
+    assert backend.validate_interactive_invocation(spec) == []
+
+
+def test_declared_intent_neutralizes_teams_enabled_settings(tmp_path: Path) -> None:
+    """The opt-in must succeed on the repositories it exists to serve.
+
+    Confirming before stripping refuses exactly the population that asked for
+    neutralization, leaving the feature unreachable.
+    """
+    project = make_realistic_project(tmp_path, agent_teams="1")
+    settings_local = project / ".claude" / "settings.local.json"
+    backend = ClaudeCodeBackend()
+
+    spec = backend.build_interactive_cmd(
+        initial_prompt="hello",
+        force_inactive_agent_teams=True,
+        project_root=str(project),
+    )
+
+    assert spec.force_inactive_agent_teams is True
+    assert AGENT_TEAMS_ENV_VAR not in spec.env
+    assert AGENT_TEAMS_ENV_VAR not in settings_local.read_text()
+    # Unrelated keys in the same file are left alone.
+    assert "AUTOSKILLIT_UNRELATED" in settings_local.read_text()
+
+
+def test_malformed_settings_are_scoped_to_declared_intent(tmp_path: Path) -> None:
+    """Fail-closed on malformed settings, but only when neutralization is asked for.
+
+    Ungated, this blocked launches over settings files unrelated to agent teams.
+    """
+    project = make_realistic_project(tmp_path, malformed_local=True)
+    backend = ClaudeCodeBackend()
+
+    default_spec = CmdSpec(cmd=("claude",), env={}, cwd=str(project))
+    assert backend.validate_interactive_invocation(default_spec) == []
+
+    forced_spec = CmdSpec(
+        cmd=("claude",),
+        env={},
+        cwd=str(project),
+        force_inactive_agent_teams=True,
+    )
+    errors = backend.validate_interactive_invocation(forced_spec)
+    assert any("could not be parsed" in error for error in errors)
+
+
+def test_builder_refuses_eagerly_when_neutralization_cannot_confirm(
+    tmp_path: Path,
+) -> None:
+    """A malformed file cannot be rewritten, so construction must refuse."""
+    project = make_realistic_project(tmp_path, malformed_local=True)
+    backend = ClaudeCodeBackend()
+
+    with pytest.raises(RuntimeError, match="could not be parsed"):
+        backend.build_interactive_cmd(
+            initial_prompt="hello",
+            force_inactive_agent_teams=True,
+            project_root=str(project),
+        )

--- a/tests/execution/test_assert_interactive_ordering.py
+++ b/tests/execution/test_assert_interactive_ordering.py
@@ -2,13 +2,42 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from autoskillit.core import CmdSpec
 from autoskillit.core.types._type_backend import CmdOrigin
 from autoskillit.execution.headless._headless_helpers import assert_interactive_ordering
+from tests._realistic_project import AGENT_TEAMS_ENV_VAR, make_realistic_project
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+@pytest.mark.parametrize("malformed_local", [False, True])
+def test_shape_validator_never_inspects_environment_content(
+    tmp_path: Path, malformed_local: bool
+) -> None:
+    """This gate validates argument order, and nothing else.
+
+    Behavioral pair for tests/arch/test_interactive_ordering_gate.py, which can
+    only prove the symbol is called. A content policy grafted in here fires on
+    every backend and every corridor, because a CmdSpec's shape carries no
+    record of which policy the caller asked for — re-introducing one fails here
+    immediately.
+    """
+    project = make_realistic_project(
+        tmp_path,
+        agent_teams=None if malformed_local else "1",
+        malformed_local=malformed_local,
+    )
+    spec = CmdSpec(
+        cmd=("claude", "--dangerously-skip-permissions", "prompt", "--add-dir", "/a"),
+        env={AGENT_TEAMS_ENV_VAR: "1"},
+        cwd=str(project),
+    )
+
+    assert_interactive_ordering(spec)
 
 
 def test_correctly_ordered_cmd_passes():

--- a/tests/execution/test_force_inactive_config_reaches_builders.py
+++ b/tests/execution/test_force_inactive_config_reaches_builders.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.core import OutputFormat, SkillSessionConfig
+from autoskillit.core import OutputFormat
 from autoskillit.execution.backends import ClaudeCodeBackend
 from autoskillit.execution.headless._managed._launch_adapter import (
     _food_truck_launch_spec_builder,
@@ -67,12 +67,6 @@ def test_skill_spec_builder_threads_intent_into_the_spec(tmp_path: Path, force: 
     spec = build(None, None, None)
 
     assert spec.force_inactive_agent_teams is force
-
-
-def test_skill_session_config_carries_intent() -> None:
-    """The field the closure populates must exist on the config it builds."""
-    config = SkillSessionConfig(force_inactive_agent_teams=True)
-    assert config.force_inactive_agent_teams is True
 
 
 @pytest.mark.parametrize("force", [True, False])

--- a/tests/execution/test_force_inactive_config_reaches_builders.py
+++ b/tests/execution/test_force_inactive_config_reaches_builders.py
@@ -1,0 +1,106 @@
+"""The config authority must reach spec construction, not merely a nearby parameter.
+
+``force_claude_agent_teams_inactive`` was declared, ledgered, and never read by
+any production site. Wiring that stops at an intermediate parameter is the same
+defect wearing a different shape, so these tests assert on the objects that
+actually reach the backend builders.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core import OutputFormat, SkillSessionConfig
+from autoskillit.execution.backends import ClaudeCodeBackend
+from autoskillit.execution.headless._managed._launch_adapter import (
+    _food_truck_launch_spec_builder,
+    _skill_launch_spec_builder,
+)
+from tests._realistic_project import make_realistic_project
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+def _skill_builder_kwargs(cwd: str) -> dict[str, object]:
+    return {
+        "backend": ClaudeCodeBackend(),
+        "skill_command": "/rectify",
+        "cwd": cwd,
+        "completion_marker": "DONE",
+        "configured_model": None,
+        "output_format": OutputFormat.JSON,
+        "add_dirs": (),
+        "exit_after_stop_delay_ms": 0,
+        "stream_idle_timeout_ms": 0,
+        "step_name": "",
+        "temp_dir_relpath": ".autoskillit/temp",
+        "allowed_write_prefix": "",
+        "allowed_write_prefixes": (),
+        "profile_name": "",
+        "resume_session_id": "",
+        "resume_checkpoint": None,
+        "resume_message": None,
+        "readonly_skill": False,
+        "scope_discipline_skill": False,
+        "network_access": False,
+        "native_shell_capture_decision": None,
+        "managed_lineage_ref": None,
+    }
+
+
+@pytest.mark.parametrize("force", [True, False])
+def test_skill_spec_builder_threads_intent_into_the_spec(tmp_path: Path, force: bool) -> None:
+    """Asserting on _run_headless_attempt's parameter is insufficient.
+
+    That parameter feeds only the adapter digest; the spec is built by this
+    closure, which routes intent through SkillSessionConfig and the builder
+    keyword both.
+    """
+    project = make_realistic_project(tmp_path, agent_teams=None)
+    build = _skill_launch_spec_builder(
+        **_skill_builder_kwargs(str(project)),  # type: ignore[arg-type]
+        force_inactive_agent_teams=force,
+    )
+
+    spec = build(None, None, None)
+
+    assert spec.force_inactive_agent_teams is force
+
+
+def test_skill_session_config_carries_intent() -> None:
+    """The field the closure populates must exist on the config it builds."""
+    config = SkillSessionConfig(force_inactive_agent_teams=True)
+    assert config.force_inactive_agent_teams is True
+
+
+@pytest.mark.parametrize("force", [True, False])
+def test_food_truck_spec_builder_threads_intent_into_the_spec(tmp_path: Path, force: bool) -> None:
+    project = make_realistic_project(tmp_path, agent_teams=None)
+    build = _food_truck_launch_spec_builder(
+        backend=ClaudeCodeBackend(),
+        orchestrator_prompt="orchestrate",
+        cwd=str(project),
+        capability_preparation=None,
+        completion_marker="DONE",
+        resume_session_id=None,
+        resume_checkpoint=None,
+        configured_model=None,
+        output_format=OutputFormat.STREAM_JSON,
+        exit_after_stop_delay_ms=0,
+        stream_idle_timeout_ms=0,
+        step_name="",
+        temp_dir_relpath=".autoskillit/temp",
+        allowed_write_prefix="",
+        allowed_write_prefixes=(),
+        sentinel_contract="",
+        resume_message=None,
+        native_shell_capture_decision=None,
+        managed_lineage_ref=None,
+        force_inactive_agent_teams=force,
+    )
+
+    spec = build(None, None, None)
+
+    assert spec.force_inactive_agent_teams is force

--- a/tests/execution/test_force_inactive_config_reaches_builders.py
+++ b/tests/execution/test_force_inactive_config_reaches_builders.py
@@ -1,6 +1,6 @@
 """The config authority must reach spec construction, not merely a nearby parameter.
 
-``force_claude_agent_teams_inactive`` was declared, ledgered, and never read by
+``force_inactive_agent_teams`` was declared, ledgered, and never read by
 any production site. Wiring that stops at an intermediate parameter is the same
 defect wearing a different shape, so these tests assert on the objects that
 actually reach the backend builders.

--- a/tests/execution/test_headless_capture_diagnostics.py
+++ b/tests/execution/test_headless_capture_diagnostics.py
@@ -104,7 +104,7 @@ class _ExecutionContext:
                 proc_interval=1.0,
             ),
             features=SimpleNamespace(),
-            agent_backend=SimpleNamespace(force_claude_agent_teams_inactive=False),
+            agent_backend=SimpleNamespace(force_inactive_agent_teams=False),
         )
         self.runner = runner
         self.backend = ClaudeCodeBackend()

--- a/tests/execution/test_headless_capture_diagnostics.py
+++ b/tests/execution/test_headless_capture_diagnostics.py
@@ -104,6 +104,7 @@ class _ExecutionContext:
                 proc_interval=1.0,
             ),
             features=SimpleNamespace(),
+            agent_backend=SimpleNamespace(force_claude_agent_teams_inactive=False),
         )
         self.runner = runner
         self.backend = ClaudeCodeBackend()

--- a/tests/execution/test_launch_force_inactive_call_path.py
+++ b/tests/execution/test_launch_force_inactive_call_path.py
@@ -142,5 +142,4 @@ def test_build_cmd_preserves_every_headless_field_except_cwd() -> None:
     headless = backend.build_headless_cmd("/test")
     wrapped = backend.build_cmd("/test", "/work/repo")
 
-    assert wrapped.cwd == "/work/repo"
     assert wrapped == replace(headless, cwd="/work/repo")

--- a/tests/execution/test_launch_force_inactive_call_path.py
+++ b/tests/execution/test_launch_force_inactive_call_path.py
@@ -7,8 +7,11 @@ that the option is honored when set to True.
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
+from autoskillit.core import CmdSpec
 from autoskillit.execution.backends.claude import ClaudeCodeBackend
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
@@ -95,3 +98,49 @@ def test_force_inactive_true_strips_in_every_path() -> None:
     assert _food_truck_stripped(True) is True
     assert _resume_stripped(True) is True
     assert _interactive_stripped(True) is True
+
+
+def _build_all(force: bool) -> dict[str, CmdSpec]:
+    backend = ClaudeCodeBackend()
+    return {
+        "build_headless_cmd": backend.build_headless_cmd(
+            "hello", force_inactive_agent_teams=force, project_root="/tmp"
+        ),
+        "build_skill_session_cmd": backend.build_skill_session_cmd(
+            "/test", force_inactive_agent_teams=force, project_root="/tmp"
+        ),
+        "build_food_truck_cmd": backend.build_food_truck_cmd(
+            orchestrator_prompt="orchestrate",
+            plugin_binding=None,
+            cwd="/tmp",
+            completion_marker="DONE",
+            force_inactive_agent_teams=force,
+            project_root="/tmp",
+        ),
+        "build_resume_cmd": backend.build_resume_cmd(
+            resume_session_id="abc",
+            prompt="resume",
+            force_inactive_agent_teams=force,
+            project_root="/tmp",
+        ),
+        "build_interactive_cmd": backend.build_interactive_cmd(
+            initial_prompt="hello", force_inactive_agent_teams=force, project_root="/tmp"
+        ),
+    }
+
+
+@pytest.mark.parametrize("force", [True, False])
+def test_every_builder_stamps_intent_onto_the_spec(force: bool) -> None:
+    """The checkpoint reads intent off the spec, so every builder must record it."""
+    for builder_name, spec in _build_all(force).items():
+        assert spec.force_inactive_agent_teams is force, builder_name
+
+
+def test_build_cmd_preserves_every_headless_field_except_cwd() -> None:
+    """build_cmd rebuilds its own headless spec; it must not drop fields."""
+    backend = ClaudeCodeBackend()
+    headless = backend.build_headless_cmd("/test")
+    wrapped = backend.build_cmd("/test", "/work/repo")
+
+    assert wrapped.cwd == "/work/repo"
+    assert wrapped == replace(headless, cwd="/work/repo")

--- a/tests/execution/test_launch_force_inactive_default.py
+++ b/tests/execution/test_launch_force_inactive_default.py
@@ -112,30 +112,88 @@ def test_force_inactive_interactive_without_project_root_refuses() -> None:
         )
 
 
-def test_force_inactive_interactive_with_executable_refuses(tmp_path: Path) -> None:
-    """C6: refuse force_inactive_agent_teams=True combined with an
-    executable binding — the executable's launch_environment was
-    captured before neutralization, so combining the two makes the
-    binding stale."""
+def _neutralized_launch_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[ClaudeCodeBackend, Path]:
+    """A teams-enabled process env, a resolvable fake binary, and a project."""
     from autoskillit.core import atomic_write
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    executable = bin_dir / "claude"
+    atomic_write(executable, "#!/bin/sh\nexit 0\n")
+    executable.chmod(0o755)
+
+    project = tmp_path / "project"
+    project.mkdir()
+
+    monkeypatch.setenv("PATH", str(bin_dir))
+    monkeypatch.setenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "1")
+    return ClaudeCodeBackend(), project
+
+
+def test_force_inactive_interactive_accepts_binding_from_neutralized_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Positive confirmation, not blanket refusal.
+
+    The constraint is that the binding be resolved *from* the neutralized env,
+    which is exactly what the equality check proves. A blanket refusal made the
+    opt-in unreachable through the probe flow, where the binding is derived
+    from the neutralized env by construction.
+    """
     from autoskillit.core.runtime.executable_binding import (
         resolve_executable_launch_binding,
     )
 
-    executable = tmp_path / "claude"
-    atomic_write(executable, "#!/bin/sh\nexit 0\n")
-    executable.chmod(0o755)
+    backend, project = _neutralized_launch_fixture(tmp_path, monkeypatch)
 
-    backend = ClaudeCodeBackend()
+    env_spec = backend.build_interactive_cmd(
+        initial_prompt="hello",
+        force_inactive_agent_teams=True,
+        project_root=str(project),
+    )
+    assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" not in env_spec.env
+
     binding = resolve_executable_launch_binding(
         binary_name="claude",
-        environment={"PATH": str(tmp_path)},
-        cwd=tmp_path,
+        environment=env_spec.env,
+        cwd=project,
     )
-    with pytest.raises(ValueError, match="cannot be combined with executable binding"):
+    spec = backend.build_interactive_cmd(
+        initial_prompt="hello",
+        executable=binding,
+        force_inactive_agent_teams=True,
+        project_root=str(project),
+    )
+
+    assert spec.force_inactive_agent_teams is True
+    assert "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" not in spec.env
+
+
+def test_force_inactive_interactive_rejects_stale_binding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A binding captured before neutralization must still be refused."""
+    import os
+
+    from autoskillit.core.runtime.executable_binding import (
+        resolve_executable_launch_binding,
+    )
+
+    backend, project = _neutralized_launch_fixture(tmp_path, monkeypatch)
+
+    stale = resolve_executable_launch_binding(
+        binary_name="claude",
+        environment=dict(os.environ),
+        cwd=project,
+    )
+    assert stale.launch_environment.get("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS") == "1"
+
+    with pytest.raises(ValueError, match="environment changed after executable binding"):
         backend.build_interactive_cmd(
             initial_prompt="hello",
-            executable=binding,
+            executable=stale,
             force_inactive_agent_teams=True,
-            project_root="/tmp",
+            project_root=str(project),
         )

--- a/tests/execution/test_launch_resolution.py
+++ b/tests/execution/test_launch_resolution.py
@@ -613,3 +613,55 @@ def test_resolved_contract_strict_payload_round_trip_and_digest_verification() -
             contract.canonical_payload,
             expected_digest="0" * 64,
         )
+
+
+def _forced_adapter_result(preparation) -> LaunchAdapterResult:
+    base = _adapter_result(preparation)
+    return replace(
+        base,
+        cmd_spec=replace(base.cmd_spec, force_inactive_agent_teams=True),
+    )
+
+
+def test_force_inactive_intent_survives_every_cmd_spec_reconstruction() -> None:
+    """Reconstruction sites must carry spec intent, not silently drop it.
+
+    Each site below once rebuilt CmdSpec from an explicit keyword allowlist,
+    which zeroes any field the allowlist predates. They now rebuild with
+    ``replace``, so a new field cannot be dropped by omission.
+    """
+    resolver = DefaultLaunchResolver()
+    preparation = resolver.prepare(_request())
+    contract = resolver.finalize(preparation, _Adapter(_forced_adapter_result))
+
+    assert contract.cmd_spec.force_inactive_agent_teams is True
+
+    rehydrated = resolver.rehydrate_secret_environment(contract, {}, inherited_fds=(9, 11))
+    assert rehydrated.force_inactive_agent_teams is True
+
+    restored = ResolvedLaunchContract.from_payload(
+        contract.canonical_payload,
+        expected_digest=contract.digest,
+    )
+    assert restored.cmd_spec.force_inactive_agent_teams is True
+
+
+def test_force_inactive_intent_defaults_false_through_reconstruction() -> None:
+    resolver = DefaultLaunchResolver()
+    preparation = resolver.prepare(_request())
+    contract = resolver.finalize(preparation, _Adapter())
+
+    assert contract.cmd_spec.force_inactive_agent_teams is False
+    rehydrated = resolver.rehydrate_secret_environment(contract, {}, inherited_fds=(9, 11))
+    assert rehydrated.force_inactive_agent_teams is False
+
+
+def test_launch_digest_distinguishes_force_inactive_intent() -> None:
+    """Two launches differing only in intent must not hash identically."""
+    resolver = DefaultLaunchResolver()
+    default_contract = resolver.finalize(resolver.prepare(_request()), _Adapter())
+    forced_contract = resolver.finalize(
+        resolver.prepare(_request()), _Adapter(_forced_adapter_result)
+    )
+
+    assert default_contract.digest != forced_contract.digest

--- a/tests/hooks/test_pr_create_guard.py
+++ b/tests/hooks/test_pr_create_guard.py
@@ -73,3 +73,40 @@ def test_echo_mentioning_gh_pr_create_allowed(monkeypatch, tmp_path):
     event = _build_bash_event("echo 'running gh pr create for docs'")
     output = _run_hook(event, monkeypatch)
     assert output == "", f"Expected allow but guard produced: {output!r}"
+
+
+def test_exempt_skill_gh_pr_create_allowed_with_kitchen_open(monkeypatch, tmp_path):
+    """The legitimate state that broke: an exempt skill creating a PR mid-session.
+
+    Kitchen open is the guard's arming condition, so it is exactly the state a
+    false positive would fire on.
+    """
+    _set_kitchen_open(tmp_path, monkeypatch)
+    monkeypatch.setenv("AUTOSKILLIT_SKILL_NAME", "compose-pr")
+    monkeypatch.delenv("AUTOSKILLIT_SESSION_TYPE", raising=False)
+
+    event = _build_bash_event("gh pr create --fill")
+    output = _run_hook(event, monkeypatch)
+    assert output == "", f"Expected allow but guard produced: {output!r}"
+
+
+def test_orchestrator_session_gh_pr_create_allowed(monkeypatch, tmp_path):
+    """Orchestrator sessions own the compose pipeline and must not be blocked."""
+    _set_kitchen_open(tmp_path, monkeypatch)
+    monkeypatch.delenv("AUTOSKILLIT_SKILL_NAME", raising=False)
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+
+    event = _build_bash_event("gh pr create --fill")
+    output = _run_hook(event, monkeypatch)
+    assert output == "", f"Expected allow but guard produced: {output!r}"
+
+
+def test_unrelated_gh_command_allowed_with_kitchen_open(monkeypatch, tmp_path):
+    """Only `gh pr create` is in scope; sibling gh subcommands are ordinary work."""
+    _set_kitchen_open(tmp_path, monkeypatch)
+    monkeypatch.delenv("AUTOSKILLIT_SKILL_NAME", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_SESSION_TYPE", raising=False)
+
+    event = _build_bash_event("gh pr list --state open")
+    output = _run_hook(event, monkeypatch)
+    assert output == "", f"Expected allow but guard produced: {output!r}"

--- a/uv.lock
+++ b/uv.lock
@@ -65,7 +65,7 @@ wheels = [
 
 [[package]]
 name = "autoskillit"
-version = "0.10.986"
+version = "0.10.987"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Commit `55b697427` (PR #4613) grafted an unconditional Claude agent-teams environment policy onto the interactive pre-spawn checkpoint. The opt-in authority `agent_backend.force_claude_agent_teams_inactive` was dead config — defined, never read anywhere in `src/` — while the checkpoint enforced the policy on every corridor (`cook`, `order`, fleet) for every backend, crashing startup on any machine whose gitignored `.claude/settings.local.json` or shell env legitimately enables `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`.

The architectural weakness is threefold, and each half of it enabled the other:

1. **Intent-blind checkpoints.** `CmdSpec` carried no record of what policy was requested at build time. A post-hoc checker structurally *cannot* know whether neutralization was asked for — so it degrades to "always enforce." The shipped docstring described behavior that could not exist.
2. **Authority declared but unconsumed, with no contract catching it.** The config ledger proves a key *parses*; nothing proved a key is *read*. `force_claude_agent_teams_inactive` passed every contract while being dead from birth — and it was not alone.
3. **No behavioral net over the interactive corridor.** 13 call sites across 7 test files stub `validate_interactive_invocation` to `return []`; the two real-gate tests run in sterile tmp dirs with no `.claude/` settings; smoke lanes are excluded from PR CI. This is the fifth fail-closed-checkpoint corridor breakage in two weeks.

The immunity: (A) policy intent becomes **data on the spec**, stamped by the builder — checkpoints read intent, never infer it; (B) the config authority is wired end-to-end and a **config-consumption contract test** makes "declared but unread" a CI failure for every config field forever; (C) an **unstubbed corridor startup net** — realistic-fixture launches with a fake agent binary, running per-PR — makes any future checkpoint that fires on legitimate state an instant test failure, regardless of its mechanism.

## Requirements

Policy intent becomes data on the spec, stamped by the builder, so checkpoints read intent
rather than infer it. The config authority is wired end-to-end and a config-consumption
contract makes "declared but unread" a CI failure for every config field. An unstubbed
corridor startup net running per-PR makes any future checkpoint that fires on legitimate
state an instant test failure, regardless of its mechanism.

Default-config launches must remain byte-for-byte unaffected, and the opt-in must remain
fail-closed when neutralization is genuinely impossible (#4575's original protection).

`#4572` (attestation env drift tripping the executable-binding guard) is a separate defect
on the same functions and is explicitly out of scope.

## Verification

Measured on a machine whose `.claude/settings.local.json` legitimately enables agent teams —
the configuration that triggered the defect:

| | `develop` (`5e3a29a86`) | this branch |
|---|---|---|
| `task test-check` | **81 failed**, 39595 passed | **16 failed**, 39738 passed |

The 16 remaining failures fail identically at the base commit and are set-wise a strict
subset of the baseline: **zero regressions introduced, 65 baseline failures fixed.** The
residue is the `#4572` attestation-drift family, explicitly out of scope.

`pre-commit run --all-files` is clean (ruff, mypy, gitleaks, stub and contract checks).

## Two deliberate departures from the plan

**The opt-in was unreachable, and the plan preserved the ordering that made it so.**
`build_interactive_cmd` asserted inactivity *before* stripping settings, so any repository
whose settings enabled teams raised instead of being neutralized — leaving
`neutralize_repository_agent_teams_settings` dead code for the exact population it exists to
serve. Neutralization now precedes confirmation. A malformed file is still refused rather
than rewritten, so the confirmation continues to fail closed there, preserving #4575's
guarantee where it matters.

**The prescribed config-consumption exclusion rule would have flagged a live field.**
Excluding `_config_dataclasses.py` wholesale reports `GitHubConfig.allowed_labels` as dead —
it is read solely by `check_label_allowed()`, an accessor colocated with the definition and
called from six production sites. The rule implemented is narrower: skip `__post_init__`
bodies only. Self-validation is not consumption; an accessor beside the definition is.

## Not delivered

The cook black-box launch test. `cook` hangs before its confirmation prompt in a fully
hermetic environment for reasons unrelated to this change, and a timing-out test is worse
than no test. The cook corridor remains covered by `test_force_inactive_config_corridors.py`
(config read plus both build branches) and the existing cold-launch mediums; the corridor
realism gap is closed on the `order` path, which now launches against a teams-enabled
checkout and passes, including the exported-env variant.

## Follow-ups filed

Two config fields are forward-declared rather than deleted to make the new contract green:
#4685 (`ProviderProfileDef.context_window`) and #4686
(`RunSkillConfig.natural_exit_grace_seconds`). Each carries a 180-day staleness time-bomb.

Closes https://github.com/TalonT-Org/AutoSkillit/issues/4687

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_interactive_policy_checkpoint_immunity_2026-08-17_174353.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
