### PR TITLE
ci: fetch ripgrep from GitHub Releases instead of apt (hotfix)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,8 +90,19 @@ jobs:
           fi
           case "$RUNNER_OS" in
             Linux)
-              sudo apt-get update
-              sudo apt-get install --yes ripgrep
+              # Fetched directly from ripgrep's GitHub Releases (verified against a
+              # pinned SHA256) instead of via apt/azure.archive.ubuntu.com, which has a
+              # known, chronic upstream throughput instability that has repeatedly
+              # stalled this step for 10+ minutes — see issue #4697.
+              RG_VERSION="14.1.0"
+              RG_SHA256="f84757b07f425fe5cf11d87df6644691c644a5cd2348a2c670894272999d3ba7"
+              RG_TARBALL="ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+              curl -fsSL -o "${RG_TARBALL}" \
+                "https://github.com/BurntSushi/ripgrep/releases/download/${RG_VERSION}/${RG_TARBALL}"
+              echo "${RG_SHA256}  ${RG_TARBALL}" | sha256sum -c -
+              tar -xzf "${RG_TARBALL}" "ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl/rg"
+              sudo install -m 0755 "ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl/rg" /usr/local/bin/rg
+              rm -rf "${RG_TARBALL}" "ripgrep-${RG_VERSION}-x86_64-unknown-linux-musl"
               ;;
             macOS)
               brew install ripgrep

--- a/tests/infra/test_ci_workflow.py
+++ b/tests/infra/test_ci_workflow.py
@@ -481,7 +481,13 @@ def test_workflow_consumes_one_target_policy_authority() -> None:
     assert test_job["steps"].index(install_rg) < test_job["steps"].index(run_tests)
     assert install_rg["shell"] == "bash"
     assert "command -v rg" in install_rg["run"]
-    assert "sudo apt-get install --yes ripgrep" in install_rg["run"]
+    # Linux installs ripgrep from a pinned, SHA256-verified GitHub Releases asset rather
+    # than apt: azure.archive.ubuntu.com has a known, chronic throughput instability that
+    # repeatedly stalled this step for 10+ minutes in production (issue #4697). Assert the
+    # apt path is gone so it can't silently regress back in.
+    assert "sudo apt-get install --yes ripgrep" not in install_rg["run"]
+    assert "github.com/BurntSushi/ripgrep/releases/download/" in install_rg["run"]
+    assert "sha256sum -c" in install_rg["run"]
     assert "brew install ripgrep" in install_rg["run"]
     assert 'case "$RUNNER_OS" in' in install_rg["run"]
     assert run_tests["env"]["AUTOSKILLIT_TEST_FILTER"] == (


### PR DESCRIPTION
## Problem

The `Test` job's "Install ripgrep" step has repeatedly hung for 10-28+ minutes across
multiple concurrent runs today (two unrelated PR branches plus a merge-queue re-entry —
7 of 9 matrix legs stuck simultaneously at one point), repeatedly blocking the merge
queue.

## Root cause

Not the apt "interactive prompt" theory originally floated in #4697 — full logs from legs
that did complete show `needrestart` running and exiting cleanly, non-interactively.

The actual cause: `apt-get update`/`install` against `azure.archive.ubuntu.com` /
`packages.microsoft.com` running at a fraction of normal throughput — confirmed in two
different Azure regions (`eastus`: 255 kB/s, `centralus`: 41-109 kB/s, vs. a same-day
baseline of 7-31s total for the whole step). This is a known, chronic, externally
unresolved instability in that mirror:

- [actions/runner-images#7048](https://github.com/actions/runner-images/issues/7048)
- [actions/runner-images#12949](https://github.com/actions/runner-images/issues/12949)
- [community discussion #172048](https://github.com/orgs/community/discussions/172048)

Ruled out: GitHub Actions platform outage (githubstatus.com all-green throughout), a
single bad datacenter (two regions affected), and a regression in our own workflow (no
apt/mirror-related changes to `tests.yml` since Aug 9).

## Fix

Fetch the `ripgrep` Linux binary directly from its own GitHub Releases
(`release-assets.githubusercontent.com`) instead of via apt — the same distribution
channel already used successfully and fast throughout today's incident by `uv`,
`go-task`, and the Rust toolchain steps in this same job. Verified against a SHA256
pinned in the workflow (not trusted from a same-request checksum file, so integrity holds
even if the release host were independently compromised). `macOS` (`brew`) is untouched.

**Verified locally before opening this PR:** downloaded the exact pinned URL, confirmed
`sha256sum -c` passes, extracted, and ran the binary — output matches the version
currently installed via apt (`ripgrep 14.1.0`).

## Related

- #4697 — original tracking issue; its root-cause write-up has been corrected in place
  and its `timeout-minutes` guard proposal remains open as a separate, still-needed
  follow-up (not included in this change — kept this PR scoped to the mirror bypass only).

## Note on merge urgency

This is a hotfix for an active incident (CI hangs blocking multiple PRs and the merge
queue right now). If this PR's own CI run completes normally, that's direct confirmation
the fix works and it should merge through the normal queue. If it's still affected, we may
need a manual/admin merge to get it in — flagging that possibility rather than doing it
preemptively.
