### PR TITLE
Implementation Plan: Pre-Launch Model↔Backend Compatibility Gate (#4238)

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -918,6 +918,7 @@ from .types import MergeState as MergeState
 from .types import MigrationService as MigrationService
 from .types import ModelIdentity as ModelIdentity
 from .types import ModelItemId as ModelItemId
+from .types import ModelPinResolution as ModelPinResolution
 from .types import ModelTotalEntry as ModelTotalEntry
 from .types import ModelTranslation as ModelTranslation
 from .types import NamedResume as NamedResume

--- a/src/autoskillit/core/types/_type_backend.py
+++ b/src/autoskillit/core/types/_type_backend.py
@@ -246,6 +246,15 @@ class BackendCapabilities:
     # cannot realize exact-set fixed membership, so its `fixed_set_join_capable`
     # must remain False until the active harness exposes a real fixed-set primitive.
     fixed_set_join_capable: bool = False
+    # Raw model identifiers only this backend can serve. Empty means the backend
+    # publishes no enumerable allowlist, so foreign-model detection is not
+    # decidable for it (no Claude-side native-id allowlist exists — see #4238).
+    # Read by DefaultLaunchResolver.prepare() to refuse a backend-foreign model
+    # pre-launch. An id owned by no backend is accepted: the gate degrades open,
+    # which is what keeps provider-profile models working, and which makes this
+    # set's freshness part of the gate's coverage — see
+    # CODEX_MODEL_ALIASES_LAST_VERIFIED.
+    native_model_ids: frozenset[str] = field(default_factory=frozenset)
 
 
 ALL_PROJECT_LOCAL_SKILL_SEARCH_DIRS: tuple[str, ...] = (
@@ -417,6 +426,7 @@ CLAUDE_CODE_CAPABILITIES: BackendCapabilities = BackendCapabilities(
     recipe_delivery_budget=None,
     hook_trust_policy=HookTrustPolicy.AUTOMATED,
     fixed_set_join_capable=True,
+    native_model_ids=frozenset(),
 )
 
 

--- a/src/autoskillit/core/types/_type_launch.py
+++ b/src/autoskillit/core/types/_type_launch.py
@@ -36,6 +36,7 @@ __all__ = [
     "LaunchSurface",
     "LaunchValueSource",
     "LaunchValueSourceKind",
+    "ModelPinResolution",
     "ProviderBinding",
     "ResolvedLaunchContract",
     "SecretEnvironmentBinding",
@@ -195,6 +196,19 @@ class LaunchValueSource:
 
     def to_payload(self) -> Mapping[str, str]:
         return MappingProxyType({"kind": self.kind.value, "key_path": self.key_path})
+
+
+@dataclass(frozen=True, slots=True)
+class ModelPinResolution:
+    """One resolved model value with its typed config origin.
+
+    Gives the model axis the provenance the backend axis already carries,
+    reusing the LaunchValueSource wrapper defined beside it rather than
+    BackendPinResolution's flat NamedTuple shape.
+    """
+
+    model: str
+    source: LaunchValueSource
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/autoskillit/execution/backends/codex.py
+++ b/src/autoskillit/execution/backends/codex.py
@@ -24,6 +24,7 @@ from autoskillit.core import (
     CODEX_MCP_ENV_FORWARD_VARS,
     CODEX_MODEL_ALIASES,
     CODEX_SESSIONS_SUBDIR,
+    CODEX_VALID_MODEL_IDS,
     FLEET_INSPECTOR_MODEL_ENV_VAR,
     FOOD_TRUCK_TOOL_TAGS_ENV_VAR,
     LAUNCH_ID_ENV_VAR,
@@ -276,6 +277,7 @@ class CodexBackend(BackendCmdBuilderBase):
             recipe_delivery_budget=CODEX_RECIPE_DELIVERY_BUDGET,
             hook_trust_policy=HookTrustPolicy.REVIEW_EACH_SESSION,
             fixed_set_join_capable=False,
+            native_model_ids=CODEX_VALID_MODEL_IDS,
         )
 
     @property

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -57,13 +57,13 @@ from autoskillit.execution.headless._headless_helpers import (
     PostSessionMetrics,
     _compute_post_session_metrics,  # noqa: F401
     _derive_step_name_from_skill_command,
-    _resolve_model,  # noqa: F401
     _resolve_pty_mode,  # noqa: F401
     _resolve_session_log_dir,  # noqa: F401
     _session_log_dir,  # noqa: F401
     _stat_snapshot,  # noqa: F401
     assert_interactive_ordering,
     resolve_model_identity,
+    resolve_model_pin,
 )
 from autoskillit.execution.headless._headless_launch import (
     _NUDGE_TIMEOUT,  # noqa: F401
@@ -197,13 +197,10 @@ async def run_headless_core(
         skill_command=original_skill_command[:SKILL_COMMAND_DISPLAY_MAX],
         step_name=step_name or None,
     ):
-        model_identity = resolve_model_identity(
-            model,
-            ctx.config,
-            step_name=step_name,
-            recipe_name=recipe_name,
-            profile_name=profile_name,
+        model_pin = resolve_model_pin(
+            model, ctx.config, step_name=step_name, recipe_name=recipe_name
         )
+        model_identity = resolve_model_identity(model_pin, profile_name=profile_name)
         add_dirs_tuple = tuple(add_dirs)
         if backend_authority is None:
             if ctx.backend is None:
@@ -290,11 +287,15 @@ async def run_headless_core(
             arguments=(),
             cwd=cwd,
             requested_model=model or None,
-            requested_model_source=authority_source if model else default_source,
+            requested_model_source=(
+                LaunchValueSource(LaunchValueSourceKind.CALLER, "run_skill.model")
+                if model
+                else default_source
+            ),
             configured_model=model_identity.configured_model or None,
-            configured_model_source=authority_source
-            if model_identity.configured_model
-            else default_source,
+            configured_model_source=(
+                model_pin.source if model_identity.configured_model else default_source
+            ),
             effort=None,
             effort_source=default_source,
             sandbox_mode="pending-adapter",

--- a/src/autoskillit/execution/headless/_headless_helpers.py
+++ b/src/autoskillit/execution/headless/_headless_helpers.py
@@ -12,7 +12,10 @@ from autoskillit.core import (
     ClaudeFlags,
     CmdSpec,
     CodingAgentBackend,
+    LaunchValueSource,
+    LaunchValueSourceKind,
     ModelIdentity,
+    ModelPinResolution,
     SkillResult,
     get_logger,
 )
@@ -112,52 +115,68 @@ def _resolve_session_log_dir(cwd: str, backend: CodingAgentBackend) -> Path | No
     return _session_log_dir(cwd, backend)
 
 
-def _resolve_model(
+def resolve_model_pin(
     step_model: str,
     config: AutomationConfig,
     *,
     step_name: str = "",
     recipe_name: str = "",
-) -> str | None:
+) -> ModelPinResolution:
     if config.model.model_override:
         logger.debug("model_resolved", tier="override", model=config.model.model_override)
-        return config.model.model_override
+        return ModelPinResolution(
+            config.model.model_override,
+            LaunchValueSource(LaunchValueSourceKind.GLOBAL, "model.model_override"),
+        )
     if recipe_name and step_name:
         recipe_model = config.model.recipe_overrides.get(recipe_name, {}).get(step_name)
         if recipe_model:
             logger.debug("model_resolved", tier="recipe_override", model=recipe_model)
-            return recipe_model
+            return ModelPinResolution(
+                recipe_model,
+                LaunchValueSource(
+                    LaunchValueSourceKind.RECIPE,
+                    f"model.recipe_overrides.{recipe_name}.{step_name}",
+                ),
+            )
     if step_name:
         step_override = config.model.step_overrides.get(step_name)
         if step_override:
             logger.debug("model_resolved", tier="step_override", model=step_override)
-            return step_override
+            return ModelPinResolution(
+                step_override,
+                LaunchValueSource(LaunchValueSourceKind.STEP, f"model.step_overrides.{step_name}"),
+            )
     if step_model:
         logger.debug("model_resolved", tier="step", model=step_model)
-        return step_model
+        return ModelPinResolution(
+            step_model,
+            LaunchValueSource(LaunchValueSourceKind.CALLER, "run_skill.model"),
+        )
     if config.model.default_model:
         logger.debug("model_resolved", tier="default", model=config.model.default_model)
-        return config.model.default_model
+        return ModelPinResolution(
+            config.model.default_model,
+            LaunchValueSource(LaunchValueSourceKind.DEFAULT, "model.default_model"),
+        )
     logger.debug("model_resolved", tier="none", model=None)
-    return None
+    return ModelPinResolution(
+        "", LaunchValueSource(LaunchValueSourceKind.DEFAULT, "run_skill.defaults")
+    )
 
 
 def resolve_model_identity(
-    step_model: str,
-    config: AutomationConfig,
+    pin: ModelPinResolution,
     *,
-    step_name: str = "",
-    recipe_name: str = "",
     profile_name: str = "",
 ) -> ModelIdentity:
-    """Wrap _resolve_model() with provider awareness.
+    """Wrap resolve_model_pin() with provider awareness.
 
     For non-Anthropic providers, effective_model is left empty so the downstream
     argmax fallback in flush_session_log fires and extracts the real provider model
     from model_breakdown.
     """
-    resolved = _resolve_model(step_model, config, step_name=step_name, recipe_name=recipe_name)
-    configured = resolved or ""
+    configured = pin.model
     if profile_name and profile_name != "anthropic":
         return ModelIdentity.for_provider(
             configured=configured, effective="", profile=profile_name

--- a/src/autoskillit/execution/headless/_managed/_food_truck_executor.py
+++ b/src/autoskillit/execution/headless/_managed/_food_truck_executor.py
@@ -32,7 +32,10 @@ from autoskillit.core import (
     SkillResult,
     temp_dir_display_str,
 )
-from autoskillit.execution.headless._headless_helpers import resolve_model_identity
+from autoskillit.execution.headless._headless_helpers import (
+    resolve_model_identity,
+    resolve_model_pin,
+)
 from autoskillit.execution.headless._headless_outcome import validated_dispatch_cwd
 from autoskillit.execution.headless._managed._attempt import (
     _headless_plugin_load_mode,
@@ -128,9 +131,8 @@ class DefaultHeadlessExecutor(_DefaultHeadlessExecutorBase):
                     f"{dispatch_backend.name!r}: {'; '.join(readiness.errors)}"
                 )
         cfg = self._ctx.config
-        model_identity = resolve_model_identity(
-            model, cfg, step_name=step_name, profile_name=profile_name
-        )
+        model_pin = resolve_model_pin(model, cfg, step_name=step_name)
+        model_identity = resolve_model_identity(model_pin, profile_name=profile_name)
         fleet_cfg = cfg.fleet
         merged_extras: dict[str, str] = dict(env_extras) if env_extras else {}
         if requires_packs:
@@ -187,10 +189,14 @@ class DefaultHeadlessExecutor(_DefaultHeadlessExecutorBase):
                 arguments=(),
                 cwd=cwd,
                 requested_model=model or None,
-                requested_model_source=authority_source if model else default_source,
+                requested_model_source=(
+                    LaunchValueSource(LaunchValueSourceKind.CALLER, "fleet.model")
+                    if model
+                    else default_source
+                ),
                 configured_model=model_identity.configured_model or None,
                 configured_model_source=(
-                    authority_source if model_identity.configured_model else default_source
+                    model_pin.source if model_identity.configured_model else default_source
                 ),
                 effort=None,
                 effort_source=default_source,

--- a/src/autoskillit/execution/launch_resolution.py
+++ b/src/autoskillit/execution/launch_resolution.py
@@ -22,6 +22,7 @@ from autoskillit.core import (
     ResolvedLaunchContract,
     SecretEnvironmentBinding,
     SemanticLaunchPlan,
+    strip_context_window_suffix,
 )
 
 __all__ = ["DefaultLaunchResolver"]
@@ -170,6 +171,17 @@ class DefaultLaunchResolver:
                 )
             fallback_routes.append(replace(route, backend=route_backend))
 
+        for model_value, model_source in (
+            (request.configured_model, request.configured_model_source),
+            (request.requested_model, request.requested_model_source),
+        ):
+            self._reject_backend_foreign_model(
+                model_value,
+                model_source,
+                selected_backend=selected_backend,
+                authority_key_path=selected_candidate.key_path,
+            )
+
         return LaunchPreparation(
             surface=request.surface,
             selected_backend=selected_backend,
@@ -279,6 +291,38 @@ class DefaultLaunchResolver:
 
         backend = self._canonical_backend(authority.backend, key_path=authority.key_path)
         return get_backend(backend)
+
+    @staticmethod
+    def _native_model_owners(model: str) -> tuple[str, ...]:
+        """Backends declaring ``model`` as one of their own native ids."""
+        from autoskillit.execution.backends import BACKEND_REGISTRY, get_backend
+
+        base = strip_context_window_suffix(model)
+        return tuple(
+            name
+            for name in sorted(BACKEND_REGISTRY)
+            if base in get_backend(name).capabilities.native_model_ids
+        )
+
+    def _reject_backend_foreign_model(
+        self,
+        model: str | None,
+        source: LaunchValueSource,
+        *,
+        selected_backend: str,
+        authority_key_path: str,
+    ) -> None:
+        if not model:
+            return
+        owners = self._native_model_owners(model)
+        if not owners or selected_backend in owners:
+            return
+        raise LaunchContractError(
+            f"model {model!r} resolved from {source.key_path} is native to backend "
+            f"{'/'.join(owners)}, but backend authority {authority_key_path} selected "
+            f"{selected_backend!r}; pin the backend and the model to the same target — "
+            f"a model may never change the selected backend"
+        )
 
     @staticmethod
     def _require_equal(field_name: str, expected: object, observed: object) -> None:

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -19,7 +19,9 @@ NEW_HEADLESS_MODULES = [
 ]
 HEADLESS_SIZE_BUDGETS = {
     "headless/__init__.py": 550,
-    "headless/_headless_helpers.py": 220,
+    # #4238 threads typed model provenance: each resolution tier now returns a
+    # ModelPinResolution carrying its own LaunchValueSource key path.
+    "headless/_headless_helpers.py": 270,
     # #4233 threads backend resume identity and the skill-only lifecycle enable flag.
     # #4659 rectify: the agent-teams opt-in must be read here from the same config
     # authority the spec builders use, or adapter_digest and the spec field diverge.
@@ -96,7 +98,7 @@ def test_headless_facade_does_not_define_helpers():
         "def _session_log_dir",
         "def _resolve_pty_mode",
         "def _resolve_session_log_dir",
-        "def _resolve_model",
+        "def resolve_model_pin",
         "def _derive_step_name_from_skill_command",
         "def _stat_snapshot",
         "class PostSessionMetrics",

--- a/tests/core/test_backend_capabilities.py
+++ b/tests/core/test_backend_capabilities.py
@@ -124,6 +124,7 @@ def test_backend_capabilities_field_count():
         "mcp_env_forward_vars",
         "write_guard_tool_names",
         "process_name_aliases",
+        "native_model_ids",
     }
     assert str_fields == {
         "min_version",
@@ -200,6 +201,7 @@ def test_backend_capabilities_field_names_locked():
         "recipe_delivery_budget",
         "hook_trust_policy",
         "fixed_set_join_capable",
+        "native_model_ids",
     }
     actual = {f.name for f in dataclasses.fields(BackendCapabilities)}
     assert actual == expected

--- a/tests/core/test_backend_dataclasses.py
+++ b/tests/core/test_backend_dataclasses.py
@@ -339,6 +339,12 @@ def test_backend_module_all_exhaustive():
     }
 
 
+def test_native_model_ids_defaults_to_empty_frozenset():
+    from autoskillit.core import BackendCapabilities
+
+    assert BackendCapabilities().native_model_ids == frozenset()
+
+
 def test_backend_conventions_frozen_slots_fields():
     import typing
     from dataclasses import FrozenInstanceError

--- a/tests/execution/backends/test_coding_agent_backend_conformance.py
+++ b/tests/execution/backends/test_coding_agent_backend_conformance.py
@@ -66,6 +66,7 @@ CAPABILITY_CLASSIFICATION: dict[str, Literal["REQUIRED", "OPTIONAL"]] = {
     "mcp_config_capable": "OPTIONAL",
     "mcp_env_forward_vars": "OPTIONAL",
     "min_version": "OPTIONAL",
+    "native_model_ids": "REQUIRED",
     "patch_format": "OPTIONAL",
     "plugin_install_capable": "OPTIONAL",
     "protected_recipe_delivery_capable": "OPTIONAL",
@@ -152,6 +153,24 @@ class TestCodingAgentBackendConformance(BackendContractBase):
         supports_tool_list_changed, triage_capable, write_detection_strategy.
         """
         assert isinstance(self.backend.capabilities, BackendCapabilities)
+
+    def test_native_model_ids_declares_backend_owned_ids(self) -> None:
+        """Exercises native_model_ids: Codex declares CODEX_VALID_MODEL_IDS, Claude Code
+        declares an empty set."""
+        from autoskillit.core import CODEX_VALID_MODEL_IDS
+
+        if self.backend.name == "codex":
+            assert self.backend.capabilities.native_model_ids == CODEX_VALID_MODEL_IDS
+        elif self.backend.name == "claude-code":
+            assert self.backend.capabilities.native_model_ids == frozenset()
+        else:
+            # Intentional sentinel: when a new backend is added to BACKEND_REGISTRY,
+            # add an elif branch above with explicit native_model_ids coverage rather
+            # than removing this guard.
+            pytest.fail(
+                f"test_native_model_ids_declares_backend_owned_ids has no coverage"
+                f" for backend {self.backend.name!r}"
+            )
 
     def test_hook_trust_policy_is_typed(self) -> None:
         """BackendCapabilities.hook_trust_policy — interactive hook review policy."""

--- a/tests/execution/backends/test_model_translation.py
+++ b/tests/execution/backends/test_model_translation.py
@@ -29,7 +29,13 @@ class TestCodexTranslateModel:
         assert CodexBackend().translate_model(model_id) == model_id
 
     def test_unknown_passthrough(self) -> None:
+        """translate_model is an alias mapper, not a validator; on the headless dispatch
+        path, backend-foreign model ids are refused pre-launch by
+        DefaultLaunchResolver.prepare() (#4238)."""
         assert CodexBackend().translate_model("custom-model-xyz") == "custom-model-xyz"
+
+    def test_codex_backend_passes_claude_native_id_through_untranslated(self) -> None:
+        assert CodexBackend().translate_model("claude-opus-5") == "claude-opus-5"
 
     def test_haiku_alias(self) -> None:
         assert CodexBackend().translate_model("haiku") == CODEX_MODEL_ALIASES["haiku"]
@@ -49,7 +55,13 @@ class TestClaudeTranslateModel:
         )
 
     def test_unknown_passthrough(self) -> None:
+        """translate_model is an alias mapper, not a validator; on the headless dispatch
+        path, backend-foreign model ids are refused pre-launch by
+        DefaultLaunchResolver.prepare() (#4238)."""
         assert ClaudeCodeBackend().translate_model("custom-model-xyz") == "custom-model-xyz"
+
+    def test_claude_backend_passes_codex_native_id_through_untranslated(self) -> None:
+        assert ClaudeCodeBackend().translate_model("gpt-5.6-sol") == "gpt-5.6-sol"
 
     def test_haiku_identity(self) -> None:
         assert ClaudeCodeBackend().translate_model("haiku") == "haiku"

--- a/tests/execution/headless/test_headless_helpers_execute_split_integrity.py
+++ b/tests/execution/headless/test_headless_helpers_execute_split_integrity.py
@@ -27,10 +27,10 @@ class TestHeadlessHelpersModuleExists:
 
         assert callable(_resolve_session_log_dir)
 
-    def test_resolve_model_importable(self):
-        from autoskillit.execution.headless._headless_helpers import _resolve_model
+    def test_resolve_model_pin_importable(self):
+        from autoskillit.execution.headless._headless_helpers import resolve_model_pin
 
-        assert callable(_resolve_model)
+        assert callable(resolve_model_pin)
 
     def test_derive_step_name_importable(self):
         from autoskillit.execution.headless._headless_helpers import (

--- a/tests/execution/test_headless_debug_logging.py
+++ b/tests/execution/test_headless_debug_logging.py
@@ -88,7 +88,7 @@ class TestBuildSkillResultLogging:
 
 
 class TestResolveModelLogging:
-    """Verify _resolve_model logs which priority tier resolved the model."""
+    """Verify resolve_model_pin logs which priority tier resolved the model."""
 
     def _make_config(self, *, override=None, default=None):
         from tests._helpers import make_model_config, make_test_config
@@ -98,99 +98,131 @@ class TestResolveModelLogging:
         return cfg
 
     def test_logs_override_tier(self):
-        from autoskillit.execution.headless import _resolve_model
+        from autoskillit.core import LaunchValueSourceKind
+        from autoskillit.execution.headless import resolve_model_pin
 
         with structlog.testing.capture_logs() as logs:
-            result = _resolve_model("sonnet", self._make_config(override="opus"))
-        assert result == "opus"
+            pin = resolve_model_pin("sonnet", self._make_config(override="opus"))
+        assert pin.model == "opus"
+        assert pin.source.kind == LaunchValueSourceKind.GLOBAL
+        assert pin.source.key_path == "model.model_override"
         model_logs = [r for r in logs if r.get("event") == "model_resolved"]
         assert model_logs
         assert model_logs[0]["tier"] == "override"
         assert model_logs[0]["model"] == "opus"
 
     def test_logs_step_tier(self):
-        from autoskillit.execution.headless import _resolve_model
+        from autoskillit.core import LaunchValueSourceKind
+        from autoskillit.execution.headless import resolve_model_pin
 
         with structlog.testing.capture_logs() as logs:
-            result = _resolve_model("sonnet", self._make_config())
-        assert result == "sonnet"
+            pin = resolve_model_pin("sonnet", self._make_config())
+        assert pin.model == "sonnet"
+        assert pin.source.kind == LaunchValueSourceKind.CALLER
+        assert pin.source.key_path == "run_skill.model"
         model_logs = [r for r in logs if r.get("event") == "model_resolved"]
         assert model_logs
         assert model_logs[0]["tier"] == "step"
 
     def test_logs_default_tier(self):
-        from autoskillit.execution.headless import _resolve_model
+        from autoskillit.core import LaunchValueSourceKind
+        from autoskillit.execution.headless import resolve_model_pin
 
         with structlog.testing.capture_logs() as logs:
-            result = _resolve_model("", self._make_config(default="haiku"))
-        assert result == "haiku"
+            pin = resolve_model_pin("", self._make_config(default="haiku"))
+        assert pin.model == "haiku"
+        assert pin.source.kind == LaunchValueSourceKind.DEFAULT
+        assert pin.source.key_path == "model.default_model"
         model_logs = [r for r in logs if r.get("event") == "model_resolved"]
         assert model_logs
         assert model_logs[0]["tier"] == "default"
 
     def test_logs_none_tier(self):
-        from autoskillit.execution.headless import _resolve_model
+        from autoskillit.core import LaunchValueSourceKind
+        from autoskillit.execution.headless import resolve_model_pin
 
         with structlog.testing.capture_logs() as logs:
-            result = _resolve_model("", self._make_config())
-        assert result is None
+            pin = resolve_model_pin("", self._make_config())
+        assert pin.model == ""
+        assert pin.source.kind == LaunchValueSourceKind.DEFAULT
+        assert pin.source.key_path == "run_skill.defaults"
         model_logs = [r for r in logs if r.get("event") == "model_resolved"]
         assert model_logs
         assert model_logs[0]["tier"] == "none"
 
     def test_logs_recipe_override_tier(self):
-        from autoskillit.execution.headless import _resolve_model
+        from autoskillit.core import LaunchValueSourceKind
+        from autoskillit.execution.headless import resolve_model_pin
 
         cfg = self._make_config()
         cfg.model.recipe_overrides = {"impl": {"plan": "opus"}}
         with structlog.testing.capture_logs() as logs:
-            result = _resolve_model("", cfg, step_name="plan", recipe_name="impl")
-        assert result == "opus"
+            pin = resolve_model_pin("", cfg, step_name="plan", recipe_name="impl")
+        assert pin.model == "opus"
+        assert pin.source.kind == LaunchValueSourceKind.RECIPE
+        assert pin.source.key_path == "model.recipe_overrides.impl.plan"
         model_logs = [r for r in logs if r.get("event") == "model_resolved"]
         assert model_logs
         assert model_logs[0]["tier"] == "recipe_override"
 
     def test_logs_step_override_tier(self):
-        from autoskillit.execution.headless import _resolve_model
+        from autoskillit.core import LaunchValueSourceKind
+        from autoskillit.execution.headless import resolve_model_pin
 
         cfg = self._make_config()
         cfg.model.step_overrides = {"plan": "opus"}
         with structlog.testing.capture_logs() as logs:
-            result = _resolve_model("", cfg, step_name="plan")
-        assert result == "opus"
+            pin = resolve_model_pin("", cfg, step_name="plan")
+        assert pin.model == "opus"
+        assert pin.source.kind == LaunchValueSourceKind.STEP
+        assert pin.source.key_path == "model.step_overrides.plan"
         model_logs = [r for r in logs if r.get("event") == "model_resolved"]
         assert model_logs
         assert model_logs[0]["tier"] == "step_override"
 
     def test_recipe_override_beats_step_override(self):
-        from autoskillit.execution.headless import _resolve_model
+        from autoskillit.execution.headless import resolve_model_pin
 
         cfg = self._make_config()
         cfg.model.step_overrides = {"plan": "haiku"}
         cfg.model.recipe_overrides = {"impl": {"plan": "opus"}}
-        result = _resolve_model("", cfg, step_name="plan", recipe_name="impl")
-        assert result == "opus"
+        pin = resolve_model_pin("", cfg, step_name="plan", recipe_name="impl")
+        assert pin.model == "opus"
 
     def test_step_override_beats_step_model(self):
-        from autoskillit.execution.headless import _resolve_model
+        from autoskillit.execution.headless import resolve_model_pin
 
         cfg = self._make_config()
         cfg.model.step_overrides = {"plan": "opus"}
-        result = _resolve_model("sonnet", cfg, step_name="plan")
-        assert result == "opus"
+        pin = resolve_model_pin("sonnet", cfg, step_name="plan")
+        assert pin.model == "opus"
 
     def test_override_beats_recipe_override(self):
-        from autoskillit.execution.headless import _resolve_model
+        from autoskillit.execution.headless import resolve_model_pin
 
         cfg = self._make_config(override="haiku")
         cfg.model.recipe_overrides = {"impl": {"plan": "opus"}}
-        result = _resolve_model("", cfg, step_name="plan", recipe_name="impl")
-        assert result == "haiku"
+        pin = resolve_model_pin("", cfg, step_name="plan", recipe_name="impl")
+        assert pin.model == "haiku"
 
     def test_recipe_override_no_leak(self):
-        from autoskillit.execution.headless import _resolve_model
+        from autoskillit.execution.headless import resolve_model_pin
 
         cfg = self._make_config(default="sonnet")
         cfg.model.recipe_overrides = {"impl": {"plan": "opus"}}
-        result = _resolve_model("", cfg, step_name="plan", recipe_name="other")
-        assert result == "sonnet"
+        pin = resolve_model_pin("", cfg, step_name="plan", recipe_name="other")
+        assert pin.model == "sonnet"
+
+    def test_recipe_override_miss_falls_through_to_default(self):
+        """A recipe-name hit with a step-key miss does not jump straight to
+        default_model — resolution still falls through the step_overrides
+        and step_model (caller-arg) tiers first. This case only lands on
+        default_model because the fixture leaves both of those tiers empty.
+        """
+        from autoskillit.execution.headless import resolve_model_pin
+
+        cfg = self._make_config(default="haiku")
+        cfg.model.recipe_overrides = {"impl": {"plan": "opus"}}
+        pin = resolve_model_pin("", cfg, step_name="other-step", recipe_name="impl")
+        assert pin.model == "haiku"
+        assert pin.source.key_path == "model.default_model"

--- a/tests/execution/test_launch_resolution.py
+++ b/tests/execution/test_launch_resolution.py
@@ -10,6 +10,7 @@ import pytest
 
 from autoskillit.core import (
     CANONICAL_LAUNCH_DIGEST_FIELDS,
+    CODEX_VALID_MODEL_IDS,
     BackendAuthority,
     BackendAuthorityKind,
     BackendAuthorityTier,
@@ -28,6 +29,7 @@ from autoskillit.core import (
     SkillProjectionBinding,
 )
 from autoskillit.execution import DefaultLaunchResolver
+from autoskillit.execution.backends import all_backends, get_backend
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -665,3 +667,141 @@ def test_launch_digest_distinguishes_force_inactive_intent() -> None:
     )
 
     assert default_contract.digest != forced_contract.digest
+
+
+def test_codex_native_model_on_claude_backend_is_rejected() -> None:
+    request = _request(
+        configured_model="gpt-5.6-sol",
+        configured_model_source=LaunchValueSource(
+            LaunchValueSourceKind.RECIPE,
+            "model.recipe_overrides.implementation.review_pr",
+        ),
+    )
+
+    with pytest.raises(
+        LaunchContractError,
+        match=(
+            "model.*gpt-5.6-sol.*model.recipe_overrides.implementation.review_pr"
+            ".*codex.*agent_backend.backend.*claude-code"
+        ),
+    ):
+        DefaultLaunchResolver().prepare(request)
+
+
+def test_codex_native_model_on_codex_backend_is_accepted() -> None:
+    candidate = _authority(
+        "codex",
+        BackendAuthorityKind.GLOBAL,
+        BackendAuthorityTier.GLOBAL,
+        "agent_backend.backend",
+    )
+    request = _request(
+        authority_candidates=(candidate,),
+        configured_model="gpt-5.6-sol",
+        configured_model_source=LaunchValueSource(
+            LaunchValueSourceKind.RECIPE,
+            "model.recipe_overrides.implementation.review_pr",
+        ),
+    )
+
+    preparation = DefaultLaunchResolver().prepare(request)
+
+    assert preparation.selected_backend == "codex"
+    assert preparation.configured_model == "gpt-5.6-sol"
+
+
+@pytest.mark.parametrize("backend", ["claude-code", "codex"])
+@pytest.mark.parametrize("alias", ["sonnet", "opus", "haiku"])
+def test_canonical_aliases_are_accepted_on_every_backend(alias: str, backend: str) -> None:
+    candidate = _authority(
+        backend,
+        BackendAuthorityKind.GLOBAL,
+        BackendAuthorityTier.GLOBAL,
+        "agent_backend.backend",
+    )
+    request = _request(authority_candidates=(candidate,), configured_model=alias)
+
+    preparation = DefaultLaunchResolver().prepare(request)
+
+    assert preparation.selected_backend == backend
+    assert preparation.configured_model == alias
+
+
+def test_context_window_suffix_does_not_evade_the_gate() -> None:
+    request = _request(configured_model="gpt-5.6-sol[1m]")
+
+    with pytest.raises(LaunchContractError, match="is native to backend codex"):
+        DefaultLaunchResolver().prepare(request)
+
+
+def test_requested_model_is_gated_with_its_own_key_path() -> None:
+    request = _request(
+        configured_model=None,
+        configured_model_source=STEP,
+        requested_model="gpt-5.6-sol",
+        requested_model_source=LaunchValueSource(LaunchValueSourceKind.CALLER, "run_skill.model"),
+    )
+
+    with pytest.raises(LaunchContractError, match="run_skill.model"):
+        DefaultLaunchResolver().prepare(request)
+
+
+def test_claude_model_id_on_codex_backend_is_accepted() -> None:
+    """Documents the gate's one-directional decidability limit.
+
+    No Claude-side native-id allowlist exists, so a Claude model pinned onto
+    the Codex backend (the mirrored incident to the one this gate closes) is
+    knowingly out of the gate's reach.
+    """
+    candidate = _authority(
+        "codex",
+        BackendAuthorityKind.GLOBAL,
+        BackendAuthorityTier.GLOBAL,
+        "agent_backend.backend",
+    )
+    request = _request(authority_candidates=(candidate,), configured_model="claude-opus-5")
+
+    preparation = DefaultLaunchResolver().prepare(request)
+
+    assert preparation.selected_backend == "codex"
+    assert preparation.configured_model == "claude-opus-5"
+
+
+@pytest.mark.parametrize("backend", ["claude-code", "codex"])
+@pytest.mark.parametrize("model", ["MiniMax-M3", "gpt-9.9-unreleased"])
+def test_model_owned_by_no_backend_is_accepted(model: str, backend: str) -> None:
+    """An id absent from every backend's native_model_ids has no owner.
+
+    This is deliberately fail-open: refusing an unowned id would wrongly
+    reject provider-profile models and future-dated ids the gate cannot know
+    about yet.
+    """
+    candidate = _authority(
+        backend,
+        BackendAuthorityKind.GLOBAL,
+        BackendAuthorityTier.GLOBAL,
+        "agent_backend.backend",
+    )
+    request = _request(authority_candidates=(candidate,), configured_model=model)
+
+    preparation = DefaultLaunchResolver().prepare(request)
+
+    assert preparation.selected_backend == backend
+    assert preparation.configured_model == model
+
+
+def test_every_registered_backend_declares_native_model_ids() -> None:
+    for backend in all_backends():
+        assert isinstance(backend.capabilities.native_model_ids, frozenset)
+
+    assert get_backend("codex").capabilities.native_model_ids == CODEX_VALID_MODEL_IDS
+    assert get_backend("claude-code").capabilities.native_model_ids == frozenset()
+
+
+def test_no_model_never_triggers_the_gate() -> None:
+    request = _request(configured_model=None, requested_model=None)
+
+    preparation = DefaultLaunchResolver().prepare(request)
+
+    assert preparation.configured_model is None
+    assert preparation.requested_model is None

--- a/tests/execution/test_model_backend_launch_contract.py
+++ b/tests/execution/test_model_backend_launch_contract.py
@@ -1,0 +1,149 @@
+"""End-to-end tests for the pre-launch model<->backend compatibility gate (#4238).
+
+A model native to one backend (e.g. a Codex-only model id) must never silently
+redirect the backend selected by ``authority_candidates`` — and the model's own
+config provenance (its key path, not the backend authority's) must be what
+reaches ``LaunchPreparation``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from autoskillit.core import LaunchPreparation, LaunchValueSourceKind
+from autoskillit.core.types import LaunchContractError, RetryReason, SkillResult
+
+from .conftest import _backend_authority, _mock_backend
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+_CODEX_NATIVE_MODEL = "gpt-5.6-sol"
+_RECIPE_OVERRIDES = {"implementation": {"review_pr": _CODEX_NATIVE_MODEL}}
+_MODEL_KEY_PATH = "model.recipe_overrides.implementation.review_pr"
+_MODEL_KEY_PATH_RE = _MODEL_KEY_PATH.replace(".", r"\.")
+
+
+def _skill_result_success() -> SkillResult:
+    return SkillResult(
+        success=True,
+        result="",
+        session_id="test-session",
+        subtype="success",
+        is_error=False,
+        exit_code=0,
+        needs_retry=False,
+        retry_reason=RetryReason.NONE,
+        stderr="",
+    )
+
+
+@pytest.mark.anyio
+async def test_codex_model_pinned_without_backend_pin_fails_before_launch(minimal_ctx):
+    """A Codex-native model pinned via recipe_overrides, with no backend pin,
+    must fail closed before any subprocess is spawned — the global Claude Code
+    authority wins and a foreign-backend model may never redirect it."""
+    minimal_ctx.config.model.recipe_overrides = _RECIPE_OVERRIDES
+    minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
+    minimal_ctx.runner = AsyncMock()
+
+    from autoskillit.execution.headless import run_headless_core
+
+    with pytest.raises(
+        LaunchContractError,
+        match=rf"{_MODEL_KEY_PATH_RE}.*agent_backend\.backend",
+    ):
+        await run_headless_core(
+            "/autoskillit:test",
+            "/tmp/cwd",
+            minimal_ctx,
+            completion_marker="%%DONE%%",
+            step_name="review_pr",
+            recipe_name="implementation",
+        )
+
+    minimal_ctx.runner.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_codex_model_with_matching_backend_pin_launches(minimal_ctx):
+    """The same Codex-native model, paired with an explicit codex
+    backend_authority pin, proceeds past resolution with no model/backend
+    drift error."""
+    minimal_ctx.config.model.recipe_overrides = _RECIPE_OVERRIDES
+    minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
+    minimal_ctx.runner = AsyncMock()
+
+    codex_backend = _mock_backend(
+        pty_required=False, channel_b_capable=False, process_name="codex"
+    )
+    codex_backend.name = "codex"
+    authority = _backend_authority("codex")
+
+    with (
+        patch.object(minimal_ctx.launch_resolver, "backend_for", return_value=codex_backend),
+        patch("autoskillit.execution.headless._execute_claude_headless") as mock_exec,
+    ):
+        mock_exec.return_value = _skill_result_success()
+        from autoskillit.execution.headless import run_headless_core
+
+        result = await run_headless_core(
+            "/autoskillit:test",
+            "/tmp/cwd",
+            minimal_ctx,
+            completion_marker="%%DONE%%",
+            step_name="review_pr",
+            recipe_name="implementation",
+            backend_authority=authority,
+        )
+
+    assert result.success is True
+    mock_exec.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_model_key_path_reaches_launch_preparation(minimal_ctx):
+    """Provenance of the resolved model must be the model's own config key path
+    (model.recipe_overrides.<recipe>.<step>), not the backend authority's key
+    path (agent_backend.backend) — the real-provenance fix behind #4238."""
+    minimal_ctx.config.model.recipe_overrides = _RECIPE_OVERRIDES
+    minimal_ctx.backend = _mock_backend(pty_required=True, channel_b_capable=True)
+    minimal_ctx.runner = AsyncMock()
+
+    codex_backend = _mock_backend(
+        pty_required=False, channel_b_capable=False, process_name="codex"
+    )
+    codex_backend.name = "codex"
+    authority = _backend_authority("codex")
+
+    original_prepare = minimal_ctx.launch_resolver.prepare
+    captured: list[LaunchPreparation] = []
+
+    def _spy_prepare(request):
+        preparation = original_prepare(request)
+        captured.append(preparation)
+        return preparation
+
+    with (
+        patch.object(minimal_ctx.launch_resolver, "prepare", side_effect=_spy_prepare),
+        patch.object(minimal_ctx.launch_resolver, "backend_for", return_value=codex_backend),
+        patch("autoskillit.execution.headless._execute_claude_headless") as mock_exec,
+    ):
+        mock_exec.return_value = _skill_result_success()
+        from autoskillit.execution.headless import run_headless_core
+
+        await run_headless_core(
+            "/autoskillit:test",
+            "/tmp/cwd",
+            minimal_ctx,
+            completion_marker="%%DONE%%",
+            step_name="review_pr",
+            recipe_name="implementation",
+            backend_authority=authority,
+        )
+
+    assert len(captured) == 1
+    preparation = captured[0]
+    assert preparation.configured_model_source.key_path == _MODEL_KEY_PATH
+    assert preparation.configured_model_source.kind is LaunchValueSourceKind.RECIPE

--- a/tests/server/test_run_skill_execution_tuning_fallbacks.py
+++ b/tests/server/test_run_skill_execution_tuning_fallbacks.py
@@ -55,7 +55,7 @@ async def test_both_model_sources_empty_does_not_crash(
     tool_ctx_kitchen_open, monkeypatch, tmp_path
 ) -> None:
     """Neither caller nor recipe step declares model -> "" reaches the executor
-    (downstream _resolve_model's tier-5 default_model applies from there; this
+    (downstream resolve_model_pin's tier-5 default_model applies from there; this
     only pins that the vacancy is left alone, not what the eventual default is)."""
     executor = InMemoryHeadlessExecutor()
     tool_ctx_kitchen_open.executor = executor

--- a/tests/server/test_tools_config.py
+++ b/tests/server/test_tools_config.py
@@ -138,7 +138,10 @@ def test_behavior_cases_cover_exact_public_and_registered_parameters() -> None:
 async def test_partial_updates_accumulate_in_live_config_and_snapshot(
     tmp_path, monkeypatch
 ) -> None:
-    from autoskillit.execution.headless._headless_helpers import resolve_model_identity
+    from autoskillit.execution.headless._headless_helpers import (
+        resolve_model_identity,
+        resolve_model_pin,
+    )
     from autoskillit.server import _state
     from autoskillit.server.tools.tools_config import configure_order
 
@@ -150,14 +153,17 @@ async def test_partial_updates_accumulate_in_live_config_and_snapshot(
     observed = await _observe_headless_defaults(ctx, monkeypatch)
 
     assert observed["timeout"] == 400
-    assert resolve_model_identity("", ctx.config).configured_model == "opus"
+    assert resolve_model_identity(resolve_model_pin("", ctx.config)).configured_model == "opus"
     assert payload["config"]["order"]["timeout"] == 400
     assert payload["config"]["core"]["default_model"] == "opus"
 
 
 @pytest.mark.anyio
 async def test_shared_default_model_is_last_write_wins(tmp_path, monkeypatch) -> None:
-    from autoskillit.execution.headless._headless_helpers import resolve_model_identity
+    from autoskillit.execution.headless._headless_helpers import (
+        resolve_model_identity,
+        resolve_model_pin,
+    )
     from autoskillit.server import _state
     from autoskillit.server.tools.tools_config import configure_fleet, configure_order
 
@@ -169,8 +175,11 @@ async def test_shared_default_model_is_last_write_wins(tmp_path, monkeypatch) ->
 
     assert ctx.config.model.default_model == "haiku"
     assert payload["config"]["core"]["default_model"] == "haiku"
-    assert resolve_model_identity("", ctx.config).configured_model == "haiku"
-    assert resolve_model_identity("explicit", ctx.config).configured_model == "explicit"
+    assert resolve_model_identity(resolve_model_pin("", ctx.config)).configured_model == "haiku"
+    assert (
+        resolve_model_identity(resolve_model_pin("explicit", ctx.config)).configured_model
+        == "explicit"
+    )
 
 
 @pytest.mark.anyio
@@ -178,7 +187,10 @@ async def test_same_worktree_contexts_do_not_import_each_others_overrides(
     tmp_path,
     monkeypatch,
 ) -> None:
-    from autoskillit.execution.headless._headless_helpers import resolve_model_identity
+    from autoskillit.execution.headless._headless_helpers import (
+        resolve_model_identity,
+        resolve_model_pin,
+    )
     from autoskillit.server import _state
     from autoskillit.server.tools.tools_config import configure_order
 
@@ -194,9 +206,12 @@ async def test_same_worktree_contexts_do_not_import_each_others_overrides(
     observed_a = await _observe_headless_defaults(ctx_a, monkeypatch)
     observed_b = await _observe_headless_defaults(ctx_b, monkeypatch)
     assert observed_a["timeout"] == 401
-    assert resolve_model_identity("", ctx_a.config).configured_model == baseline_model
+    assert (
+        resolve_model_identity(resolve_model_pin("", ctx_a.config)).configured_model
+        == baseline_model
+    )
     assert observed_b["timeout"] == 7200
-    assert resolve_model_identity("", ctx_b.config).configured_model == "haiku"
+    assert resolve_model_identity(resolve_model_pin("", ctx_b.config)).configured_model == "haiku"
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_execution_command.py
+++ b/tests/server/test_tools_execution_command.py
@@ -251,7 +251,7 @@ class TestRunSkillModel:
         # Direct assignment bypasses CoreRunConfig.__post_init__ (which rejects empty
         # default_model). Production config is always non-empty; this simulates the
         # path where both the caller-supplied model param and the config default are
-        # empty, so _resolve_model returns "" and no --model flag is emitted.
+        # empty, so resolve_model_pin returns "" and no --model flag is emitted.
         tool_ctx_kitchen_open.config.model.default_model = ""
         tool_ctx_kitchen_open.runner.push(_make_result(returncode=1))  # clone guard snapshot
         tool_ctx_kitchen_open.runner.push(_make_result(0, self._MOCK_STDOUT, ""))


### PR DESCRIPTION
## Summary

A backend-native model id resolved onto a foreign backend reaches the provider API and fails
there (`claude --model gpt-5.6-sol` → Anthropic HTTP 404). Model resolution
(`_resolve_model`, `execution/headless/_headless_helpers.py:115-142`) and backend resolution
(`_resolve_backend_override`, `server/_guards.py:468-549`) never consult each other, and
`DefaultLaunchResolver.prepare()` (`execution/launch_resolution.py:82-210`) — the deepest
pre-launch point where both are known — threads the model through untouched at lines 188-191.

This implements the second, unshipped half of #4269's acceptance criteria: *"Model selection
never changes backend or provider. `run_skill(model=...)`, model aliases, and inner child-model
requests resolve within the effective backend **or fail with a model/capability diagnostic**."*

Three changes, in dependency order:

1. **Per-backend native model vocabulary.** `BackendCapabilities` gains
   `native_model_ids: frozenset[str]` — the raw model identifiers only this backend can serve.
   Codex declares `CODEX_VALID_MODEL_IDS`; Claude Code declares `frozenset()`. This is the
   "per-backend valid-set on `BackendCapabilities`" branch of the issue's first implementation
   blocker, and follows `execution/backends/AGENTS.md` step 4 ("declare via capability fields",
   not new per-backend conditionals), so a future backend declares its own set at its single
   construction site rather than joining a hardcoded table.

2. **Real model provenance.** `_resolve_model` computes which config tier won and discards it.
   `run_headless_core` (`execution/headless/__init__.py:292-297`) then fills
   `configured_model_source` / `requested_model_source` with the **backend authority's**
   `key_path` — a misattribution that makes the model's own config key unavailable at the gate.
   `_resolve_model` is replaced by `resolve_model_pin`, returning a typed
   `ModelPinResolution(model, source)` mirroring the existing `BackendPinResolution`
   (`core/types/_type_execution_identity.py:33-39`), so the gate can name
   `model.recipe_overrides.<recipe>.<step>` exactly.

3. **The gate.** `DefaultLaunchResolver.prepare()` raises `LaunchContractError` when a resolved
   model is native to a backend other than the selected one — the same shape as its existing
   provider↔backend check (lines 144-152) and cross-backend fallback prohibition (lines 163-171).

**Refuse; never reroute and never substitute.** Auto-routing "Codex id ⇒ Codex backend" is
backend inference by another name, already retired under `_RETIRED_SEMANTIC_DECLARATIONS`
(`workspace/skill_capabilities.py:841-845`, reason *"backend selection outside skill
declarations"*) and contradicted by the invariant comment at
`server/tools/tools_execution.py:1765-1767`. Substituting `default_model = ""` is the silent
behavior #4269 forbids and would record a session whose model does not match what ran.

**Decidability is deliberately one-directional.** No Claude-side native-id allowlist exists anywhere
in `src/`. The only related constant is test-local and differently named — `VALID_CLAUDE_MODEL_IDS`
(note the reversed word order) at `tests/execution/test_model_alias_registry.py:9`, unused outside
that file. "This id is native to backend X and X is not selected" is decidable; "this string is not
a Claude model" is not. Claude Code therefore declares an empty `native_model_ids`, and a Claude model id on
the Codex backend is **not** rejected. The asymmetry is a property of the available vocabulary; it
is asserted by test and documented on the field.

**This closes half the defect class, and the plan should not be read as closing more.** The mirrored
incident — a Claude model id pinned onto a Codex-selected step — still reaches the provider and
fails there, exactly as `gpt-5.6-sol` on Claude does today. Refusing that direction requires a
Claude-side native-id allowlist that does not exist in `src/` and that this change does not create.
The gate is sound (it never refuses a legal pairing) but deliberately incomplete. Canonical aliases are unaffected either way:
`sonnet` / `opus` / `haiku` are model *classes*, appear in no backend's `native_model_ids`, and
translate per backend through `CLAUDE_MODEL_ALIASES` / `CODEX_MODEL_ALIASES`.

**`translate_model` stays a pure transform.** Rejection is not moved into
`ClaudeCodeBackend.translate_model` / `CodexBackend.translate_model`: those run at argv-build time,
after resolution, with no config provenance in scope, and #4269 requires failure *before* launch.
The two existing `test_unknown_passthrough` tests
(`tests/execution/backends/test_model_translation.py:31-32, 51-52`) therefore remain correct and
are kept — updated deliberately, per the issue's second implementation blocker, to state the
division of responsibility and cover the backend-foreign case they never exercised.

**Scope boundary — the interactive launch surface.** `build_interactive_cmd`
(`execution/backends/claude.py:552-627`, `codex.py:693-741`) also applies `translate_model` to a
`model` argument and writes it to argv, but its callers
(`cli/session/_session_launch.py:118,142`, `cli/session/_session_cook.py:411`) build no
`LaunchResolutionRequest` and never call `prepare()` — that surface is parallel to launch
resolution, not downstream of it. Verified: **no production caller passes `model=`**, and the
interactive path reads none of `model.model_override` / `model.recipe_overrides` /
`model.step_overrides`, so it cannot reproduce this defect. It is out of scope, and every claim
here about the gate's reach says "on the headless dispatch path" rather than universally.

Closes https://github.com/TalonT-Org/AutoSkillit/issues/4238

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/model_backend_launch_gate_4238_plan_2026-08-19_193029.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
